### PR TITLE
Add first VM lifecycle events

### DIFF
--- a/cluster/vm.json
+++ b/cluster/vm.json
@@ -5,6 +5,28 @@
    "apiVersion": "kubevirt.io/v1alpha1",
    "kind": "VM",
    "spec": {
-           "nodeSelector": {"kubernetes.io/hostname":"master"}
+        "nodeSelector": {"kubernetes.io/hostname":"master"},
+        "domain": {
+          "devices": {
+            "interfaces": [
+              {
+                "source": {
+                  "network": "default"
+                },
+                "type": "network"
+              }
+            ]
+          },
+          "memory": {
+            "unit": "KiB",
+            "value": 8192
+          },
+          "os": {
+            "type": {
+              "os": "hvm"
+            }
+          },
+          "type": "qemu"
+        }
    }
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/1.5/pkg/api/v1"
 	"k8s.io/client-go/1.5/pkg/apimachinery/announced"
 	"k8s.io/client-go/1.5/pkg/runtime"
+	"k8s.io/client-go/1.5/pkg/types"
 	"kubevirt.io/kubevirt/pkg/api"
 	"reflect"
 )
@@ -243,3 +244,34 @@ const (
 	UIDLabel      string = "kubevirt.io/vmUID"
 	NodeNameLabel string = "kubevirt.io/nodeName"
 )
+
+func NewVM(name string, uid types.UID) *VM {
+	return &VM{
+		Spec: VMSpec{},
+		ObjectMeta: kubeapi.ObjectMeta{
+			Name:      name,
+			UID:       uid,
+			Namespace: kubeapi.NamespaceDefault,
+		},
+		Status: VMStatus{},
+		TypeMeta: unversioned.TypeMeta{
+			APIVersion: GroupVersion.String(),
+			Kind:       "VM",
+		},
+	}
+}
+
+type SyncEvent string
+
+const (
+	Created    SyncEvent = "Created"
+	Deleted    SyncEvent = "Deleted"
+	Started    SyncEvent = "Started"
+	Stopped    SyncEvent = "Stopped"
+	SyncFailed SyncEvent = "SyncFailed"
+	Resumed    SyncEvent = "Resumed"
+)
+
+func (s SyncEvent) String() string {
+	return string(s)
+}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -74,6 +74,7 @@ func processVM(v *vmResourceEventHandler, obj *v1.VM) error {
 		}
 		vm.Spec.Domain.UUID = string(vm.GetObjectMeta().GetUID())
 		vm.Spec.Domain.Devices.Emulator = "/usr/local/bin/qemu-x86_64"
+		vm.Spec.Domain.Name = vm.GetObjectMeta().GetName()
 
 		// TODO get rid of these service calls
 		if err := v.VMService.StartVM(&vm); err != nil {

--- a/pkg/virt-handler/libvirt/cache/cache.go
+++ b/pkg/virt-handler/libvirt/cache/cache.go
@@ -176,7 +176,7 @@ func NewDomain(dom kubevirt.VirDomain) (*kubevirt.Domain, error) {
 		Status: kubevirt.DomainStatus{},
 		TypeMeta: unversioned.TypeMeta{
 			APIVersion: "1.2.2",
-			Kind:       "domains",
+			Kind:       "Domain",
 		},
 	}, nil
 }


### PR DESCRIPTION
Send first VM events from virt-handler to kubernetes event stream.
The events can be watched like every other kubernetes event with

  kubectl get events --watch