### PR TITLE
By default only create master VM when using vagrant

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,17 @@ Vagrant environment:
     cluster/sync.sh
 ```
 
+This will create a VM called `master` which acts as Kubernetes master and then
+deploy Kubevirt there. To create one or more nodes which will register
+themselves on master, you can use the `VAGRANT_NUM_NODES` environment variable.
+This would create a master and two nodes:
+
+```bash
+    VAGRANT_NUM_NODES=2 vagrant up
+```
+
+However, just running `master` is enough for most development tasks.
+
 You could also run some build steps individually:
 
 ```bash
@@ -134,8 +145,8 @@ Finally start a VM called `testvm`:
     ./cluster/kubectl.sh get pods
 ```
 
-This will start a VM on master or node with a macvtap and a tap networking
-device attached.
+This will start a VM on master or one of the running nodes with a macvtap and a
+tap networking device attached.
 
 Basic verification is possible by running
 
@@ -184,8 +195,3 @@ $ ./cluster/kubectl.sh get vms -o json
             "spec": {
     ...
 ```
-
-
-
-
-


### PR DESCRIPTION
One or more nodes can be created by setting the environment variable
VAGRANT_NUM_NODES. They will all register automatically at the apiserver
on master.

Change-Id: I97be438be4f77fa7a8cc6de926e6f0fd8a2ff50c