### PR TITLE
Supress spurious vagrant status output

### DIFF
--- a/cluster/sync.sh
+++ b/cluster/sync.sh
@@ -5,7 +5,7 @@ cluster/vagrant/sync_config.sh
 
 make all
 
-for VM in `vagrant status | grep running | cut -d " " -f1`; do
+for VM in `vagrant status | grep -v "^The Libvirt domain is running." | grep running | cut -d " " -f1`; do
   vagrant rsync $VM # if you do not use NFS
   vagrant ssh $VM -c "cd /vagrant && sudo hack/build-docker.sh"
 done


### PR DESCRIPTION
Vagrant can issue chatty output in response to "vagrant status",
which in some cases can break the cluster/sync.sh script.

Signed-off-by: Stu Gott <sgott@redhat.com>