### PR TITLE
Move all rest endpoints in the project a common prefix

### DIFF
--- a/pkg/virt-api/rest/rest.go
+++ b/pkg/virt-api/rest/rest.go
@@ -13,5 +13,5 @@ func init() {
 	WebService.Path("/").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
 	WebService.ApiVersion(v1.GroupVersion.String()).Doc("help")
 	restful.Add(WebService)
-	WebService.Route(WebService.GET("/api/v1/healthz").To(healthz.KubeConnectionHealthzFunc).Doc("Health endpoint"))
+	WebService.Route(WebService.GET("/apis/" + v1.GroupVersion.String() + "/healthz").To(healthz.KubeConnectionHealthzFunc).Doc("Health endpoint"))
 }

--- a/pkg/virt-controller/rest/rest.go
+++ b/pkg/virt-controller/rest/rest.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"github.com/emicklei/go-restful"
+	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/healthz"
 )
 
@@ -9,6 +10,6 @@ var WebService *restful.WebService
 
 func init() {
 	WebService = new(restful.WebService)
-	WebService.Path("/api/v1").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
-	WebService.Route(WebService.GET("healthz").To(healthz.KubeConnectionHealthzFunc))
+	WebService.Path("/").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
+	WebService.Route(WebService.GET("/apis/" + v1.GroupVersion.String() + "/healthz").To(healthz.KubeConnectionHealthzFunc).Doc("Health endpoint"))
 }


### PR DESCRIPTION
Health endpoints were at api/v1 but they have to be at
'apis/kubevirt.io/v1alpha1' like everything else.