### PR TITLE
Check if go files pass "fmt" and "vet" on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 script:
  - make generate
  - if git diff --name-only | grep 'generated.*.go'; then echo "Content of generated files changed. Please regenerate and commit them."; false; fi
+ - make check
  - make test
 
 cache:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ publish: docker
 manifests: $(wildcard manifests/*.in)
 	./hack/build-manifests.sh
 
-check: check-bash
+check: check-bash vet
+	test -z "`./hack/build-go.sh fmt`"
 
 check-bash:
 	find . -name \*.sh -exec bash -n \{\} \;


### PR DESCRIPTION
The "fmt" check is a little bit hacky since it checks if "go fmt"
returns a file to format. Since this involves a normal format run, after
that the file is formated. It would be cleaner to wrap "gofmt -l" in a
script and run it on all scripts to not modify wrong formatted files
while checking.