### PR TITLE
Added fields to OS struct

### DIFF
--- a/pkg/virt-handler/libvirt/schema.go
+++ b/pkg/virt-handler/libvirt/schema.go
@@ -211,11 +211,14 @@ type Alias struct {
 //BEGIN OS --------------------
 
 type OS struct {
-	Type      OSType    `xml:"type" json:"type"`
-	SMBios    *SMBios   `xml:"smbios,omitempty" json:"smBIOS,omitempty"`
-	BootOrder []Boot    `xml:"boot" json:"bootOrder"`
-	BootMenu  *BootMenu `xml:"bootmenu,omitempty" json:"bootMenu,omitempty"`
-	BIOS      *BIOS     `xml:"bios,omitempty" json:"bios,omitempty"`
+	Type       OSType    `xml:"type" json:"type"`
+	SMBios     *SMBios   `xml:"smbios,omitempty" json:"smBIOS,omitempty"`
+	BootOrder  []Boot    `xml:"boot" json:"bootOrder"`
+	BootMenu   *BootMenu `xml:"bootmenu,omitempty" json:"bootMenu,omitempty"`
+	BIOS       *BIOS     `xml:"bios,omitempty" json:"bios,omitempty"`
+	Kernel     string    `xml:"kernel,omitempty" json:"kernel,omitempty"`
+	Initrd     string    `xml:"initrd,omitempty" json:"initrd,omitempty"`
+	KernelArgs string    `xml:"cmdline,omitempty" json:"cmdline,omitempty"`
 }
 
 type OSType struct {


### PR DESCRIPTION
Hi!

I've just realized I did the same work which is done here in kubevirt the same way (libvirt schema) :) But there were no fields for os's kernel, it's cmdline and initrd.

I need these ones so I've thought it's a good idea to add these to kubevirt.

Thank you.

Signed-off-by: Alexey Slaykovsky <aslaikov@redhat.com>