### PR TITLE
Libvirtd container support

### DIFF
--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,5 +1,5 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api"
-docker_images="$binaries images/haproxy"
+docker_images="$binaries images/haproxy images/libvirtd"
 docker_prefix=kubevirt
 docker_tag=latest
 manifest_templates="`ls manifests/*.in`"

--- a/images/libvirtd/Dockerfile
+++ b/images/libvirtd/Dockerfile
@@ -13,6 +13,8 @@ RUN yum install -y \
 COPY augconf /augconf
 RUN augtool -f /augconf
 
+RUN echo -n shibboleth | saslpasswd2 -p -a libvirt vdsm@ovirt
+
 COPY libvirtd.sh /libvirtd.sh
 RUN chmod a+x /libvirtd.sh
 #EXPOSE 16509

--- a/images/libvirtd/augconf
+++ b/images/libvirtd/augconf
@@ -1,7 +1,7 @@
 # Enable unauthenticated tcp
 set /files/etc/libvirt/libvirtd.conf/listen_tls 0
 set /files/etc/libvirt/libvirtd.conf/listen_tcp 1
-set /files/etc/libvirt/libvirtd.conf/auth_tcp none
+set /files/etc/libvirt/libvirtd.conf/auth_tcp sasl
 
 # Listen on all interfaces for now
 set /files/etc/libvirt/qemu.conf/spice_listen 0.0.0.0

--- a/images/libvirtd/libvirtd-ds.yaml
+++ b/images/libvirtd/libvirtd-ds.yaml
@@ -16,7 +16,7 @@ spec:
         runAsUser: 0
       containers:
         - name: daemon
-          image: fabiand/libvirt:latest
+          image: kubevirt/libvirtd:latest
           ports:
             - containerPort: 16509
           securityContext:
@@ -47,4 +47,5 @@ spec:
           hostPath:
             path: /var/log/libvirt
         - name: host
+          hostPath:
             path: /

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -19,6 +19,8 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
           - "/virt-handler"
+          - "--libvirt-uri"
+          - "qemu:///system"
           - "--hostname-override"
           - "$(NODE_NAME)"
         securityContext:


### PR DESCRIPTION
This small series of patches will enable libvirtd image builds, and allows us to start using (experimenting) with the containerized libvirtd as the runtime for the domains.