### PR TITLE
images: Align base images

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.2.1511
+FROM centos:7
 
 RUN curl -OL https://github.com/swagger-api/swagger-ui/archive/v2.2.6.tar.gz && tar xf v2.2.6.tar.gz \
     && mkdir /third_party \

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.2.1511
+FROM centos:7
 
 COPY virt-controller /virt-controller
 

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.2.1511
+FROM centos:7
 
 COPY virt-launcher /virt-launcher
 


### PR DESCRIPTION
Previously different base image tags were used, now we use the same where
possible to increase the probability to share the same base.