### PR TITLE
Only close libvirt connection when it is open

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -51,10 +51,10 @@ func main() {
 	}()
 	// TODO we need to handle disconnects
 	domainConn, err := libvirt.NewConnection(*libvirtUri, *libvirtUser, *libvirtPass)
-	defer domainConn.CloseConnection()
 	if err != nil {
 		panic(err)
 	}
+	defer domainConn.CloseConnection()
 
 	// Create event recorder
 	coreClient, err := kubecli.Get()


### PR DESCRIPTION
First check if the libvirt connection is established before adding the
defer for closing the connection. Fixes #32 