### PR TITLE
Add Reason(err error) to logger

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -44,6 +44,7 @@ type FilteredLogger struct {
 	currentLogLevel       logLevel
 	verbosityLevel        int
 	currentVerbosityLevel int
+	err                   error
 }
 
 func InitializeLogging(comp string) {
@@ -136,6 +137,9 @@ func (l FilteredLogger) log(skipFrames int, params ...interface{}) error {
 			"pos", fmt.Sprintf("%s:%d", filepath.Base(fileName), lineNumber),
 			"component", l.component,
 		)
+		if l.err != nil {
+			l.logContext = l.logContext.With("reason", l.err)
+		}
 		return l.logContext.WithPrefix(logParams...).Log(params...)
 	}
 	return nil
@@ -214,5 +218,10 @@ func (l FilteredLogger) Error() *FilteredLogger {
 
 func (l FilteredLogger) Critical() *FilteredLogger {
 	l.currentLogLevel = CRITICAL
+	return &l
+}
+
+func (l FilteredLogger) Reason(err error) *FilteredLogger {
+	l.err = err
 	return &l
 }

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"errors"
+	"fmt"
 	"kubevirt.io/kubevirt/pkg/api"
 	"path/filepath"
 	"runtime"
@@ -369,5 +370,18 @@ func TestMsgfVerbosity(t *testing.T) {
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[4].(string) == "pos", "Logged line did not contain pos")
 	assert(t, strings.HasPrefix(logEntry[5].(string), "logging_test.go"), "Logged line referenced wrong module")
+	tearDown()
+}
+
+func TestErrWithMsgf(t *testing.T) {
+	setUp()
+	log := MakeLogger(MockLogger{})
+	log.Reason(fmt.Errorf("testerror")).Msgf("%s", "test")
+
+	logEntry := logParams[0].([]interface{})
+	assert(t, logEntry[8].(string) == "reason", "Logged line did not contain message header")
+	assert(t, logEntry[9].(error).Error() == "testerror", "Logged line did not contain message header")
+	assert(t, logEntry[10].(string) == "msg", "Logged line did not contain message header")
+	assert(t, logEntry[11].(string) == "test", "Logged line did not contain message")
 	tearDown()
 }

--- a/pkg/virt-controller/watch/pod.go
+++ b/pkg/virt-controller/watch/pod.go
@@ -81,7 +81,7 @@ func processPod(p *podResourceEventHandler, pod *v1.Pod) error {
 		vm.ObjectMeta.Labels[corev1.NodeNameLabel] = pod.Spec.NodeName
 		// Update the VM
 		if err := p.restCli.Put().Resource("vms").Body(&vm).Name(vm.ObjectMeta.Name).Namespace(kubeapi.NamespaceDefault).Do().Error(); err != nil {
-			logger.Error().Msgf("Setting the VM to pending failed with: %s", err)
+			logger.Error().Reason(err).Msg("Setting the VM to pending failed.")
 			if e, ok := err.(*errors.StatusError); ok {
 				if e.Status().Reason == metav1.StatusReasonNotFound {
 					// VM does not exist anymore, we don't have to retry


### PR DESCRIPTION
Very often the only reason why string formatting is needed, is to embed
an error. New Instead of

  logging.DefaultLogger().Error().Msgf("Something failed with %s." err)

do

  logging.DefaultLogger().Error().Reason(err).Msgf("Something failed.")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/47)
<!-- Reviewable:end -->
