### PR TITLE
Don't set advertise address on kubernetes deployment

### DIFF
--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -7,10 +7,8 @@ bash ./setup_kubernetes_common.sh
 yum install -y cockpit cockpit-kubernetes
 systemctl enable cockpit.socket && systemctl start cockpit.socket
 
-ADVERTISED_MASTER_IP=`dig +short master`
-
 # Create the master
-kubeadm init --api-advertise-addresses=$ADVERTISED_MASTER_IP --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --use-kubernetes-version v1.4.5
+kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --use-kubernetes-version v1.4.5
 
 set +e
 
@@ -23,10 +21,6 @@ done
 
 set -e
 
-# Fix proxy definition
-# https://github.com/kubernetes/kubeadm/issues/66#issuecomment-262394822
-#kubectl -n kube-system get ds -l 'component=kube-proxy' -o json   | jq '.items[0].spec.template.spec.containers[0].command |= .+ ["--proxy-mode=userspace"]'   |   kubectl apply -f - && kubectl -n kube-system delete pods -l 'component=kube-proxy'
-
 if [ "$NETWORK_PROVIDER" == "weave" ]; then 
   kubectl apply -s 127.0.0.1:8080 -f https://git.io/weave-kube
 else
@@ -34,7 +28,7 @@ else
 fi
 
 # Allow scheduling pods on master
-# Ignore retval because it might not be dedicated
+# Ignore retval because it might not be dedicated already
 kubectl -s 127.0.0.1:8080 taint nodes --all dedicated- || :
 
 mkdir -p /exports/share1


### PR DESCRIPTION
kubeadm uses the address from eth0 anyway and a lot of people have the
problem that "dig +short master" does not resolve to the master ip inside their VMs.
Works around #43

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/50)
<!-- Reviewable:end -->
