### PR TITLE
Fix virt-api responses

### DIFF
--- a/pkg/rest/endpoints/encoders.go
+++ b/pkg/rest/endpoints/encoders.go
@@ -3,40 +3,47 @@ package endpoints
 import (
 	"encoding/json"
 	"golang.org/x/net/context"
+	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"net/http"
+	"reflect"
 )
 
 func encodeApplicationErrors(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", "text/plain")
+	var err error
 	switch t := response.(type) {
 	// More specific AppErrors  like 404 must be handled before the AppError case
-	case middleware.ResourceNotFoundError:
+	case *middleware.KubernetesError:
+		w.WriteHeader(t.StatusCode())
+		_, err = w.Write(t.Body())
+	case *middleware.ResourceNotFoundError:
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(t.Cause().Error()))
+		_, err = w.Write([]byte(t.Cause().Error()))
 	case middleware.ResourceExistsError:
 		w.WriteHeader(http.StatusConflict)
-		w.Write([]byte(t.Cause().Error()))
+		_, err = w.Write([]byte(t.Cause().Error()))
 	case middleware.AppError:
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(t.Cause().Error()))
+		_, err = w.Write([]byte(t.Cause().Error()))
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
 		// TODO log the error but don't send it along
-		w.Write([]byte("Error handling failed, that should never happen."))
+		_, err = w.Write([]byte("Error handling failed, that should never happen."))
 	}
-	return json.NewEncoder(w).Encode(response)
+	return err
 }
 
 func EncodePostResponse(context context.Context, w http.ResponseWriter, response interface{}) error {
-	if _, ok := response.(middleware.AppError); ok != false {
+	logging.DefaultLogger().Info().Msg(reflect.TypeOf(response).Name())
+	if _, ok := response.(middleware.AppError); ok {
 		return encodeApplicationErrors(context, w, response)
 	}
 	return encodeJsonResponse(w, response, http.StatusCreated)
 }
 
 func EncodeGetResponse(context context.Context, w http.ResponseWriter, response interface{}) error {
-	if _, ok := response.(middleware.AppError); ok != false {
+	if _, ok := response.(middleware.AppError); ok {
 		return encodeApplicationErrors(context, w, response)
 	}
 	return encodeJsonResponse(w, response, http.StatusOK)


### PR DESCRIPTION
Instead of proxying apiserver errors, virt-api translated them to
internal server errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/55)
<!-- Reviewable:end -->
