### PR TITLE
Do a git reset --hard on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
   - tip
 
 install:
+ - git reset --hard # we are caching the vendor folder, make sure we see the new vendor.json file
  - go get -u github.com/kardianos/govendor
  - go get -u github.com/golang/mock/gomock
  - go get -u github.com/golang/mock/mockgen


### PR DESCRIPTION
We are caching the vendor folder. This can lead to a situation where we
miss changes in the vendor.json file. By doing a reset before "make
sync", we make sure that we see the updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/58)
<!-- Reviewable:end -->
