### PR TITLE
REST and Swagger improvements Part 1

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -32,7 +32,7 @@ func main() {
 	gvk := schema.GroupVersionKind{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Kind: "VM"}
 
 	// FIXME the whole NewResponseHandler is just a hack, see the method itself for details
-	err := rest.AddGenericResourceProxy(rest.WebService, ctx, vmGVR, &v1.VM{}, rest.NewResponseHandler(gvk, &v1.VM{}))
+	err := rest.AddGenericResourceProxy(rest.WebService, ctx, vmGVR, &v1.VM{}, &v1.VMList{}, rest.NewResponseHandler(gvk, &v1.VM{}))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func main() {
 		WebServices:     restful.RegisteredWebServices(), // you control what services are visible
 		WebServicesUrl:  "http://localhost:8183",
 		ApiPath:         "/swaggerapi",
-		SwaggerPath:     "/apidocs/",
+		SwaggerPath:     "/swagger-ui/",
 		SwaggerFilePath: *swaggerui,
 	}
 	swagger.InstallSwaggerService(config)

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -28,10 +28,9 @@ func main() {
 
 	ctx := context.Background()
 	vmGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "vms"}
-	gvk := schema.GroupVersionKind{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Kind: "VM"}
 
-	// FIXME the whole NewResponseHandler is just a hack, see the method itself for details
-	err := rest.AddGenericResourceProxy(rest.WebService, ctx, vmGVR, &v1.VM{}, &v1.VMList{}, rest.NewResponseHandler(gvk, &v1.VM{}))
+	// FIXME the whole newResponseHandler is just a hack, see the method itself for details
+	err := rest.AddGenericResourceProxy(rest.WebService, ctx, vmGVR, &v1.VM{}, v1.GroupVersionKind.Kind, &v1.VMList{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -28,7 +28,6 @@ func main() {
 
 	ctx := context.Background()
 	vmGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "vms"}
-	spiceGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "spices"}
 	gvk := schema.GroupVersionKind{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Kind: "VM"}
 
 	// FIXME the whole NewResponseHandler is just a hack, see the method itself for details
@@ -56,11 +55,8 @@ func main() {
 			})).Build(ctx))
 
 	rest.WebService.Route(rest.WebService.GET(rest.ResourcePath(vmGVR)+rest.SubResourcePath("spice")).
-		To(spice).Produces("text/plain", "application/json", "application/yaml").
+		To(spice).Produces(mime.MIME_INI, mime.MIME_JSON, mime.MIME_YAML).
 		Doc("Returns a remote-viewer configuration file. Run `man 1 remote-viewer` to learn more about the configuration format."))
-	rest.WebService.Route(rest.WebService.GET(rest.ResourcePath(spiceGVR)).
-		To(spice).Produces("application/json", "text/plain", "application/yaml").
-		Doc("Returns SPICE connection details as JSON."))
 
 	config := swagger.Config{
 		WebServices:     restful.RegisteredWebServices(), // you control what services are visible

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -56,6 +56,7 @@ func main() {
 
 	rest.WebService.Route(rest.WebService.GET(rest.ResourcePath(vmGVR)+rest.SubResourcePath("spice")).
 		To(spice).Produces(mime.MIME_INI, mime.MIME_JSON, mime.MIME_YAML).
+		Param(rest.NamespaceParam(rest.WebService)).Param(rest.NameParam(rest.WebService)).
 		Doc("Returns a remote-viewer configuration file. Run `man 1 remote-viewer` to learn more about the configuration format."))
 
 	config := swagger.Config{

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -55,7 +55,7 @@ func main() {
 				mime.MIME_YAML: endpoints.NewEncodeYamlResponse(http.StatusOK),
 			})).Build(ctx))
 
-	rest.WebService.Route(rest.WebService.GET(rest.SubResourcePath(vmGVR, "spice")).
+	rest.WebService.Route(rest.WebService.GET(rest.ResourcePath(vmGVR)+rest.SubResourcePath("spice")).
 		To(spice).Produces("text/plain", "application/json", "application/yaml").
 		Doc("Returns a remote-viewer configuration file. Run `man 1 remote-viewer` to learn more about the configuration format."))
 	rest.WebService.Route(rest.WebService.GET(rest.ResourcePath(spiceGVR)).
@@ -65,7 +65,7 @@ func main() {
 	config := swagger.Config{
 		WebServices:     restful.RegisteredWebServices(), // you control what services are visible
 		WebServicesUrl:  "http://localhost:8183",
-		ApiPath:         "/apidocs.json",
+		ApiPath:         "/swaggerapi",
 		SwaggerPath:     "/apidocs/",
 		SwaggerFilePath: *swaggerui,
 	}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -261,29 +261,3 @@ curl $HOST/apis/kubevirt.io/v1alpha1/namespaces/default/vms/testvm/spice -H"Acce
 ### Accessing the Domain via the SPICE primary resource
 
 Since `kubectl` does not support TPR subresources yet, the above `cluster/kubectl.sh spice` magic is just a wrapper.
-As an alternative way to get the SPICE connection details through native `kubectl` commands, run
-
-```bash
-cluster/kubectl.sh get spices testvm
-```
-
-That will return a JSON which looks like this:
-
-```json
-{
-  "kind": "Spice",
-  "apiVersion": "kubevirt.io/v1alpha1",
-  "metadata": {
-    "Name": "testvm",
-    "GenerateName": "",
-    "Namespace": "default",
-    [...]
-  },
-  "info": {
-    "type": "spice",
-    "host": "10.32.0.9",
-    "port": 4000,
-    "proxy": "http://192.168.200.2:3128"
-  }
-}
-```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -255,9 +255,14 @@ cluster/kubectl.sh spice testvm --details
 To directly query the config, do
 
 ```bash
-curl $HOST/apis/kubevirt.io/v1alpha1/namespaces/default/vms/testvm/spice -H"Accept:text/plain"
+curl 192.168.200.2:8184/apis/kubevirt.io/v1alpha1/namespaces/default/vms/testvm/spice -H"Accept:text/plain"
 ```
 
 ### Accessing the Domain via the SPICE primary resource
 
 Since `kubectl` does not support TPR subresources yet, the above `cluster/kubectl.sh spice` magic is just a wrapper.
+
+## API Documentation
+
+The combined swagger documentation of Kubernetes and KubeVirt can be accessed under [/swaggerapi](http://192.168.200.2:8184/swaggerapi).
+There is also an embedded swagger-ui instance running inside the cluster. It can be accessed via [/swagger-ui](http://192.168.200.2:8184/swaggerapi).

--- a/images/haproxy/haproxy.cfg
+++ b/images/haproxy/haproxy.cfg
@@ -9,7 +9,7 @@ frontend virt_api
   mode http
   acl is_post_or_put method POST PUT
   acl is_get method GET
-  acl is_swagger_api path_beg /apidocs
+  acl is_swagger_api path_beg /swagger-ui
   acl is_swagger_spec path_beg /swaggerapi/apis/kubevirt.io/
   acl is_kubevirt_vm path_reg ^/apis/kubevirt.io/v1alpha1/namespaces/[^/]+/vms/.+$
   acl is_kubevirt_spice path_reg  ^/apis/kubevirt.io/v1alpha1/namespaces/[^/]+/spices/.+$

--- a/images/haproxy/haproxy.cfg
+++ b/images/haproxy/haproxy.cfg
@@ -9,6 +9,8 @@ frontend virt_api
   mode http
   acl is_post_or_put method POST PUT
   acl is_get method GET
+  acl is_swagger_api path_beg /apidocs
+  acl is_swagger_spec path_beg /swaggerapi/apis/kubevirt.io/
   acl is_kubevirt_vm path_reg ^/apis/kubevirt.io/v1alpha1/namespaces/[^/]+/vms/.+$
   acl is_kubevirt_spice path_reg  ^/apis/kubevirt.io/v1alpha1/namespaces/[^/]+/spices/.+$
   acl is_kubevirt_vm_spice path_reg  ^/apis/kubevirt.io/v1alpha1/namespaces/[^/]+/vms/[^/]+/spice$
@@ -17,6 +19,8 @@ frontend virt_api
   use_backend srvs_kubevirt if is_post_or_put is_kubevirt_vm
   use_backend srvs_kubevirt if is_get is_kubevirt_vm_spice
   use_backend srvs_kubevirt if is_kubevirt_spice
+  use_backend srvs_kubevirt if is_swagger_api
+  use_backend srvs_kubevirt if is_swagger_spec
   default_backend srvs_apiserver
 
 backend srvs_kubevirt

--- a/manifests/vm-resource.yaml.in
+++ b/manifests/vm-resource.yaml.in
@@ -5,11 +5,3 @@ kind: ThirdPartyResource
 description: "VM management"
 versions:
   - name: v1alpha1
----
-metadata:
-  name: spice.kubevirt.io
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-description: "VM spice connection info"
-versions:
-  - name: v1alpha1

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -31,6 +31,9 @@ const GroupName = "kubevirt.io"
 // GroupVersion is group version used to register these objects
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
+// GroupVersionKind
+var GroupVersionKind = schema.GroupVersionKind{Group: GroupName, Version: GroupVersion.Version, Kind: "VM"}
+
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(GroupVersion,
@@ -212,7 +215,7 @@ func NewVM(name string, uid types.UID) *VM {
 		Status: VMStatus{},
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: GroupVersion.String(),
-			Kind:       "VM",
+			Kind:       GroupVersionKind.Kind,
 		},
 	}
 }

--- a/pkg/rest/endpoints/decoders.go
+++ b/pkg/rest/endpoints/decoders.go
@@ -15,7 +15,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 )
 
 type PutObject struct {
@@ -36,7 +35,7 @@ type MetadataHeader struct {
 	LabelSelector   string
 	FieldSelector   string
 	ResourceVersion string
-	Timeout         time.Duration
+	TimeoutSeconds  int64
 }
 
 const (
@@ -95,7 +94,7 @@ func queryExtractor(ctx context.Context, r *http.Request) (*MetadataHeader, erro
 	meta.LabelSelector = rest.QueryParameter("labelSelector")
 	meta.ResourceVersion = rest.QueryParameter("resourceVersion")
 
-	if err := extractDuration(rest.QueryParameter("timeoutSeconds"), &(meta.Timeout)); err != nil {
+	if err := extractDuration(rest.QueryParameter("timeoutSeconds"), &(meta.TimeoutSeconds)); err != nil {
 		return nil, err
 	}
 	return meta, nil
@@ -112,14 +111,14 @@ func extractBool(header string, target *bool) error {
 	return nil
 }
 
-func extractDuration(header string, target *time.Duration) error {
+func extractDuration(header string, target *int64) error {
 	if header != "" {
 		f, err := strconv.Atoi(header)
 		if err != nil {
 			return err
 		}
-		t := time.Second * time.Duration(f)
-		target = &t
+		f64 := int64(f)
+		target = &f64
 	}
 	return nil
 }

--- a/pkg/rest/endpoints/put_test.go
+++ b/pkg/rest/endpoints/put_test.go
@@ -36,8 +36,9 @@ func marshalToYAML(payload interface{}) io.ReadCloser {
 }
 
 type payload struct {
-	Name  string `json:"name" valid:"required"`
-	Email string `json:"email" valid:"email"`
+	Name     string   `json:"name" valid:"required"`
+	Email    string   `json:"email" valid:"email"`
+	Metadata Metadata `json:"metadata"`
 }
 
 func newValidPutRequest() *http.Request {

--- a/pkg/virt-api/rest/rest.go
+++ b/pkg/virt-api/rest/rest.go
@@ -25,10 +25,10 @@ var spiceProxy string
 
 func init() {
 	WebService = new(restful.WebService)
-	WebService.Path("/").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
+	WebService.Path(ResourcePathBase(v1.GroupVersion)).Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
 	WebService.ApiVersion(v1.GroupVersion.String()).Doc("help")
 	restful.Add(WebService)
-	WebService.Route(WebService.GET("/apis/" + v1.GroupVersion.String() + "/healthz").To(healthz.KubeConnectionHealthzFunc).Doc("Health endpoint"))
+	WebService.Route(WebService.GET("/healthz").To(healthz.KubeConnectionHealthzFunc).Doc("Health endpoint"))
 	// TODO should be reloadable, use configmaps and update on every access? Watch a config file and reload?
 	flag.StringVar(&spiceProxy, "spice-proxy", "", "Spice proxy to use when spice access is requested")
 }

--- a/pkg/virt-api/rest/rest.go
+++ b/pkg/virt-api/rest/rest.go
@@ -25,7 +25,7 @@ var spiceProxy string
 
 func init() {
 	WebService = new(restful.WebService)
-	WebService.Path(ResourcePathBase(v1.GroupVersion)).Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
+	WebService.Path(GroupVersionBasePath(v1.GroupVersion)).Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
 	WebService.ApiVersion(v1.GroupVersion.String()).Doc("help")
 	restful.Add(WebService)
 	WebService.Route(WebService.GET("/healthz").To(healthz.KubeConnectionHealthzFunc).Doc("Health endpoint"))

--- a/tests/spice_test.go
+++ b/tests/spice_test.go
@@ -14,6 +14,7 @@ import (
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/rest"
 	"kubevirt.io/kubevirt/tests"
 	"math/rand"
 	"net"
@@ -55,7 +56,7 @@ var _ = Describe("Vmlifecycle", func() {
 				}
 				return false
 			}).Watch()
-			raw, err := restClient.Get().Resource("vms").SetHeader("Accept", "text/plain").SubResource("spice").Namespace(kubev1.NamespaceDefault).Name(vm.GetObjectMeta().GetName()).Do().Raw()
+			raw, err := restClient.Get().Resource("vms").SetHeader("Accept", rest.MIME_INI).SubResource("spice").Namespace(kubev1.NamespaceDefault).Name(vm.GetObjectMeta().GetName()).Do().Raw()
 			spice, err := ini.Load(raw)
 			Expect(err).To(Not(HaveOccurred()))
 
@@ -83,7 +84,7 @@ var _ = Describe("Vmlifecycle", func() {
 				}
 				return false
 			}).Watch()
-			obj, err = restClient.Get().Resource("spices").Namespace(kubev1.NamespaceDefault).Name(vm.GetObjectMeta().GetName()).Do().Get()
+			obj, err = restClient.Get().Resource("vms").SetHeader("Accept", rest.MIME_JSON).SubResource("spice").Namespace(kubev1.NamespaceDefault).Name(vm.GetObjectMeta().GetName()).Do().Get()
 			Expect(err).To(BeNil())
 			spice := obj.(*v1.Spice).Info
 			Expect(spice.Type).To(Equal("spice"))
@@ -105,7 +106,7 @@ var _ = Describe("Vmlifecycle", func() {
 				}
 				return false
 			}).Watch()
-			raw, err := restClient.Get().Resource("vms").SetHeader("Accept", "text/plain").SubResource("spice").Namespace(kubev1.NamespaceDefault).Name(vm.GetObjectMeta().GetName()).Do().Raw()
+			raw, err := restClient.Get().Resource("vms").SetHeader("Accept", rest.MIME_INI).SubResource("spice").Namespace(kubev1.NamespaceDefault).Name(vm.GetObjectMeta().GetName()).Do().Raw()
 			Expect(err).To(BeNil())
 			spiceINI, err := ini.Load(raw)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
 - [x] Merge Kubernetes ad KubeVirt Swagger documentation
 - [x] Document all TPR paths and methods
 - [x] Document all supported query parameters
 - [x] Document path parameters
 - [x] Document the existence of the swagger docs
 - [ ] Proxy watches
 - [x] Proxy Get calls for collections of VMs
 - [x] Proxy Deletes for VM collections
 - [ ] Support export query param
 - [x] Remove SPICE TPR, only keep it as subresource
 - [ ] Support fieldSelector for `status.phase` and `status.NodeName`
 - [ ] Support proxying the registered group (`apis/kubevirt.io`), to allow kubectl autodiscovering our TPRs
 - [ ] Name TPR "VirtualMachine" and register a shortcute "VM" in the autodiscovery
 - [ ] Support https://github.com/evanphx/json-patch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/64)
<!-- Reviewable:end -->
