### PR TITLE
add tags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ cluster/vagrant/.kubeconfig
 cluster/vagrant/.kubectl
 cluster/.console.vv
 build-tools/desc/desc
+tags


### PR DESCRIPTION
The tags are critical for vim users. It's possible to generate the
tags using https://github.com/jstemmer/gotags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/67)
<!-- Reviewable:end -->
