### PR TITLE
drop XML tags from cluster-wide schema

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -12,63 +12,63 @@ import (
 )
 
 type DomainSpec struct {
-	XMLName xml.Name `xml:"domain" json:"-"`
-	Name    string   `xml:"name" json:"name"`
-	UUID    string   `xml:"uuid,omitempty" json:"uuid,omitempty"`
-	Memory  Memory   `xml:"memory" json:"memory"`
-	Type    string   `xml:"type,attr" json:"type"`
-	OS      OS       `xml:"os" json:"os"`
-	SysInfo *SysInfo `xml:"sysinfo,omitempty" json:"sysInfo,omitempty"`
-	Devices Devices  `xml:"devices" json:"devices"`
-	Clock   *Clock   `xml:"clock,omitempty" json:"clock,omitempty"`
+	XMLName xml.Name `json:"-"`
+	Name    string   `json:"name"`
+	UUID    string   `json:"uuid,omitempty"`
+	Memory  Memory   `json:"memory"`
+	Type    string   `json:"type"`
+	OS      OS       `json:"os"`
+	SysInfo *SysInfo `json:"sysInfo,omitempty"`
+	Devices Devices  `json:"devices"`
+	Clock   *Clock   `json:"clock,omitempty"`
 }
 
 type Memory struct {
-	Value uint   `xml:",chardata" json:"value"`
-	Unit  string `xml:"unit,attr" json:"unit"`
+	Value uint   `json:"value"`
+	Unit  string `json:"unit"`
 }
 
 type Devices struct {
-	Emulator   string      `xml:"emulator" json:"emulator"`
-	Interfaces []Interface `xml:"interface" json:"interfaces,omitempty"`
-	Channels   []Channel   `xml:"channel" json:"channels,omitempty"`
-	Video      []Video     `xml:"video" json:"video,omitempty"`
-	Graphics   []Graphics  `xml:"graphics" json:"graphics,omitempty"`
-	Ballooning *Ballooning `xml:"memballoon,omitempty" json:"memballoon,omitempty"`
-	Disks      []Disk      `xml:"disk" json:"disks,omitempty"`
+	Emulator   string      `json:"emulator"`
+	Interfaces []Interface `json:"interfaces,omitempty"`
+	Channels   []Channel   `json:"channels,omitempty"`
+	Video      []Video     `json:"video,omitempty"`
+	Graphics   []Graphics  `json:"graphics,omitempty"`
+	Ballooning *Ballooning `json:"memballoon,omitempty"`
+	Disks      []Disk      `json:"disks,omitempty"`
 }
 
 // BEGIN Disk -----------------------------
 
 type Disk struct {
-	Device     string      `xml:"device,attr" json:"device"`
-	Snapshot   string      `xml:"snapshot,attr" json:"shapshot"`
-	Type       string      `xml:"type,attr" json:"type"`
-	DiskSource DiskSource  `xml:"source" json:"diskSource"`
-	DiskTarget DiskTarget  `xml:"target" json:"diskTarget"`
-	Serial     string      `xml:"serial,omitempty" json:"serial,omitempty"`
-	Driver     *DiskDriver `xml:"driver,omitempty" json:"driver,omitempty"`
-	ReadOnly   *ReadOnly   `xml:"readonly,omitempty" json:"readOnly,omitempty"`
+	Device     string      `json:"device"`
+	Snapshot   string      `json:"shapshot"`
+	Type       string      `json:"type"`
+	DiskSource DiskSource  `json:"diskSource"`
+	DiskTarget DiskTarget  `json:"diskTarget"`
+	Serial     string      `json:"serial,omitempty"`
+	Driver     *DiskDriver `json:"driver,omitempty"`
+	ReadOnly   *ReadOnly   `json:"readOnly,omitempty"`
 }
 
 type ReadOnly struct{}
 
 type DiskSource struct {
-	File          string `xml:"file,attr" json:"file"`
-	StartupPolicy string `xml:"startupPolicy,attr,omitempty" json:"startupPolicy,omitempty"`
+	File          string `json:"file"`
+	StartupPolicy string `json:"startupPolicy,omitempty"`
 }
 
 type DiskTarget struct {
-	Bus    string `xml:"bus,attr" json:"bus"`
-	Device string `xml:"dev,attr" json:"dev"`
+	Bus    string `json:"bus"`
+	Device string `json:"dev"`
 }
 
 type DiskDriver struct {
-	Cache       string `xml:"cache,attr,omitempty" json:"cache,omitempty"`
-	ErrorPolicy string `xml:"error_policy,attr,omitempty" json:"errorPolicy,omitempty"`
-	IO          string `xml:"io,attr,omitempty" json:"io,omitempty"`
-	Name        string `xml:"name,attr" json:"name"`
-	Type        string `xml:"type,attr" json:"type"`
+	Cache       string `json:"cache,omitempty"`
+	ErrorPolicy string `json:"errorPolicy,omitempty"`
+	IO          string `json:"io,omitempty"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
 }
 
 // END Disk -----------------------------
@@ -76,89 +76,89 @@ type DiskDriver struct {
 // BEGIN Inteface -----------------------------
 
 type Interface struct {
-	Address   *Address         `xml:"address,omitempty" json:"address,omitempty"`
-	Type      string           `xml:"type,attr" json:"type"`
-	Source    InterfaceSource  `xml:"source" json:"source"`
-	Target    *InterfaceTarget `xml:"target,omitempty" json:"target,omitempty"`
-	Model     *Model           `xml:"model,omitempty" json:"model,omitempty"`
-	MAC       *MAC             `xml:"mac,omitempty" json:"mac,omitempty"`
-	BandWidth *BandWidth       `xml:"bandwidth,omitempty" json:"bandwidth,omitempty"`
-	BootOrder *BootOrder       `xml:"boot,omitempty" json:"boot,omitempty"`
-	LinkState *LinkState       `xml:"link,omitempty" json:"link,omitempty"`
-	FilterRef *FilterRef       `xml:"filterref,omitempty" json:"filterRef,omitempty"`
-	Alias     *Alias           `xml:"alias,omitempty" json:"alias,omitempty"`
+	Address   *Address         `json:"address,omitempty"`
+	Type      string           `json:"type"`
+	Source    InterfaceSource  `json:"source"`
+	Target    *InterfaceTarget `json:"target,omitempty"`
+	Model     *Model           `json:"model,omitempty"`
+	MAC       *MAC             `json:"mac,omitempty"`
+	BandWidth *BandWidth       `json:"bandwidth,omitempty"`
+	BootOrder *BootOrder       `json:"boot,omitempty"`
+	LinkState *LinkState       `json:"link,omitempty"`
+	FilterRef *FilterRef       `json:"filterRef,omitempty"`
+	Alias     *Alias           `json:"alias,omitempty"`
 }
 
 type LinkState struct {
-	State string `xml:"state,attr" json:"state"`
+	State string `json:"state"`
 }
 
 type BandWidth struct {
 }
 
 type BootOrder struct {
-	Order uint `xml:"order,attr" json:"order"`
+	Order uint `json:"order"`
 }
 
 type MAC struct {
-	MAC string `xml:"address,attr" json:"address"`
+	MAC string `json:"address"`
 }
 
 type FilterRef struct {
-	Filter string `xml:"filter,attr" json:"filter"`
+	Filter string `json:"filter"`
 }
 
 type InterfaceSource struct {
-	Network string `xml:"network,attr,omitempty" json:"network,omitempty"`
-	Device  string `xml:"dev,attr,omitempty" json:"device,omitempty"`
-	Bridge  string `xml:"bridge,attr,omitempty" json:"bridge,omitempty"`
+	Network string `json:"network,omitempty"`
+	Device  string `json:"device,omitempty"`
+	Bridge  string `json:"bridge,omitempty"`
 }
 
 type Model struct {
-	Type string `xml:"type,attr" json:"type"`
+	Type string `json:"type"`
 }
 
 type InterfaceTarget struct {
-	Device string `xml:"dev,attr" json:"dev"`
+	Device string `json:"dev"`
 }
 
 type Alias struct {
-	Name string `xml:"name,attr" json:"name"`
+	Name string `json:"name"`
 }
 
 // END Inteface -----------------------------
 //BEGIN OS --------------------
 
 type OS struct {
-	Type      OSType    `xml:"type" json:"type"`
-	SMBios    *SMBios   `xml:"smbios,omitempty" json:"smBIOS,omitempty"`
-	BootOrder []Boot    `xml:"boot" json:"bootOrder"`
-	BootMenu  *BootMenu `xml:"bootmenu,omitempty" json:"bootMenu,omitempty"`
-	BIOS      *BIOS     `xml:"bios,omitempty" json:"bios,omitempty"`
+	Type      OSType    `json:"type"`
+	SMBios    *SMBios   `json:"smBIOS,omitempty"`
+	BootOrder []Boot    `json:"bootOrder"`
+	BootMenu  *BootMenu `json:"bootMenu,omitempty"`
+	BIOS      *BIOS     `json:"bios,omitempty"`
 }
 
 type OSType struct {
-	OS      string `xml:",chardata" json:"os"`
-	Arch    string `xml:"arch,attr,omitempty" json:"arch,omitempty"`
-	Machine string `xml:"machine,attr,omitempty" json:"machine,omitempty"`
+	OS      string `json:"os"`
+	Arch    string `json:"arch,omitempty"`
+	Machine string `json:"machine,omitempty"`
 }
 
 type SMBios struct {
-	Mode string `xml:"mode,attr" json:"mode"`
+	Mode string `json:"mode"`
 }
 
 type NVRam struct {
-	NVRam    string `xml:",chardata,omitempty" json:"nvRam,omitempty"`
-	Template string `xml:"template,attr,omitempty" json:"template,omitempty"`
+	NVRam    string `json:"nvRam,omitempty"`
+	Template string `json:"template,omitempty"`
 }
 
 type Boot struct {
-	Dev string `xml:"dev,attr" json:"dev"`
+	Dev string `json:"dev"`
 }
 
 type BootMenu struct {
-	Enabled bool  `xml:"enabled,attr" json:"enabled,omitempty"`
-	Timeout *uint `xml:"timeout,attr,omitempty" json:"timeout,omitempty"`
+	Enabled bool  `json:"enabled,omitempty"`
+	Timeout *uint `json:"timeout,omitempty"`
 }
 
 // TODO <loader readonly='yes' secure='no' type='rom'>/usr/lib/xen/boot/hvmloader</loader>
@@ -170,15 +170,15 @@ type Loader struct {
 }
 
 type SysInfo struct {
-	Type      string  `xml:"type,attr" json:"type"`
-	System    []Entry `xml:"system>entry" json:"system"`
-	BIOS      []Entry `xml:"bios>entry" json:"bios"`
-	BaseBoard []Entry `xml:"baseBoard>entry" json:"baseBoard"`
+	Type      string  `json:"type"`
+	System    []Entry `json:"system"`
+	BIOS      []Entry `json:"bios"`
+	BaseBoard []Entry `json:"baseBoard"`
 }
 
 type Entry struct {
-	Name  string `xml:"name" json:"name"`
-	Value string `xml:",chardata" json:"value"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 //END OS --------------------
@@ -189,9 +189,9 @@ type Clock struct {
 }
 
 type Timer struct {
-	Name       string `xml:"name,attr" json:"name"`
-	TickPolicy string `xml:"tickpolicy,attr,omitempty" json:"tickPolicy,omitempty"`
-	Present    string `xml:"present,attr,omitempty" json:"present,omitempty"`
+	Name       string `json:"name"`
+	TickPolicy string `json:"tickPolicy,omitempty"`
+	Present    string `json:"present,omitempty"`
 }
 
 //END Clock --------------------
@@ -199,21 +199,21 @@ type Timer struct {
 //BEGIN Channel --------------------
 
 type Channel struct {
-	Type   string         `xml:"type,attr" json:"type"`
-	Source ChannelSource  `xml:"source,omitempty" json:"source,omitempty"`
-	Target *ChannelTarget `xml:"target,omitempty" json:"target,omitempty"`
+	Type   string         `json:"type"`
+	Source ChannelSource  `json:"source,omitempty"`
+	Target *ChannelTarget `json:"target,omitempty"`
 }
 
 type ChannelTarget struct {
-	Name    string `xml:"name,attr,omitempty" json:"name,omitempty"`
-	Type    string `xml:"type,attr" json:"type"`
-	Address string `xml:"address,attr,omitempty" json:"address,omitempty"`
-	Port    uint   `xml:"port,attr,omitempty" json:"port,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Type    string `json:"type"`
+	Address string `json:"address,omitempty"`
+	Port    uint   `json:"port,omitempty"`
 }
 
 type ChannelSource struct {
-	Mode string `xml:"mode,attr" json:"mode"`
-	Path string `xml:"path,attr" json:"path"`
+	Mode string `json:"mode"`
+	Path string `json:"path"`
 }
 
 //END Channel --------------------
@@ -228,41 +228,41 @@ type Video struct {
 }
 
 type VideoModel struct {
-	Type   string `xml:"type,attr" json:"type"`
-	Heads  uint   `xml:"heads,attr,omitempty" json:"heads,omitempty"`
-	Ram    uint   `xml:"ram,attr,omitempty" json:"ram,omitempty"`
-	VRam   uint   `xml:"vram,attr,omitempty" json:"vram,omitempty"`
-	VGAMem uint   `xml:"vgamem,attr,omitempty" vgamem:"vram,omitempty"`
+	Type   string `json:"type"`
+	Heads  uint   `json:"heads,omitempty"`
+	Ram    uint   `json:"ram,omitempty"`
+	VRam   uint   `json:"vram,omitempty"`
+	VGAMem uint   `vgamem:"vram,omitempty"`
 }
 
 type Graphics struct {
-	AutoPort      string `xml:"autoPort,attr,omitempty" json:"autoPort,omitempty"`
-	DefaultMode   string `xml:"defaultMode,attr,omitempty" json:"defaultMode,omitempty"`
-	Listen        Listen `xml:"listen,omitempty" json:"listen,omitempty"`
-	PasswdValidTo string `xml:"passwdValidTo,attr,omitempty" json:"passwdValidTo,omitempty"`
-	Port          int32  `xml:"port,attr,omitempty" json:"port,omitempty"`
-	TLSPort       int    `xml:"tlsPort,attr,omitempty" json:"tlsPort,omitempty"`
-	Type          string `xml:"type,attr" json:"type"`
+	AutoPort      string `json:"autoPort,omitempty"`
+	DefaultMode   string `json:"defaultMode,omitempty"`
+	Listen        Listen `json:"listen,omitempty"`
+	PasswdValidTo string `json:"passwdValidTo,omitempty"`
+	Port          int32  `json:"port,omitempty"`
+	TLSPort       int    `json:"tlsPort,omitempty"`
+	Type          string `json:"type"`
 }
 
 type Listen struct {
-	Type    string `xml:"type,attr" json:"type"`
-	Address string `xml:"address,attr,omitempty" json:"address,omitempty"`
-	Network string `xml:"newtork,attr,omitempty" json:"network,omitempty"`
+	Type    string `json:"type"`
+	Address string `json:"address,omitempty"`
+	Network string `json:"network,omitempty"`
 }
 
 type Address struct {
-	Type     string `xml:"type,attr" json:"type"`
-	Domain   string `xml:"domain,attr" json:"domain"`
-	Bus      string `xml:"bus,attr" json:"bus"`
-	Slot     string `xml:"slot,attr" json:"slot"`
-	Function string `xml:"function,attr" json:"function"`
+	Type     string `json:"type"`
+	Domain   string `json:"domain"`
+	Bus      string `json:"bus"`
+	Slot     string `json:"slot"`
+	Function string `json:"function"`
 }
 
 //END Video -------------------
 
 type Ballooning struct {
-	Model string `xml:"model,attr" json:"model"`
+	Model string `json:"model"`
 }
 
 type RandomGenerator struct {

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -3,6 +3,7 @@ package virtwrap
 import (
 	"encoding/xml"
 	"github.com/golang/mock/gomock"
+	"github.com/jeevatkm/go-model"
 	"github.com/libvirt/libvirt-go"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -29,7 +30,12 @@ var _ = Describe("Manager", func() {
 		It("should define and start a new VM", func() {
 			vm := newVM("testvm")
 			mockConn.EXPECT().LookupDomainByName("testvm").Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
-			xml, err := xml.Marshal(vm.Spec.Domain)
+
+			// we have to make sure that we use correct DomainSpec (from virtwrap)
+			var domainSpec DomainSpec
+			Expect(model.Copy(&domainSpec, vm.Spec.Domain)).To(BeEmpty())
+
+			xml, err := xml.Marshal(domainSpec)
 			Expect(err).To(BeNil())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)


### PR DESCRIPTION
Also, virtwrap.manager_test.go used wrong DomainSpec -- we first have to fix that, and then we can easily drop the xml tags. Fixes #70 