### PR TITLE
Let virt-api use a working swagger-ui version

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -1,11 +1,11 @@
 FROM centos:7
 
-RUN curl -OL https://github.com/swagger-api/swagger-ui/archive/v2.2.6.tar.gz && tar xf v2.2.6.tar.gz \
+RUN curl -OL https://github.com/swagger-api/swagger-ui/tarball/38f74164a7062edb5dc80ef2fdddda24f3f6eb85/swagger-ui.tar.gz \
+    && mkdir swagger-ui && tar xf swagger-ui.tar.gz -C swagger-ui --strip-components 1 \
     && mkdir /third_party \
-    && mv swagger-ui-2.2.6/dist /third_party/swagger-ui && rm -rf swagger-ui-2.2.6 \
-    && sed -e 's@url = "http://petstore.swagger.io/v2/swagger.json";@url = "/apidocs.json";@' -i  /third_party/swagger-ui/index.html \
-    && rm v2.2.6.tar.gz && rm -rf swagger-ui*
-
+    && mv swagger-ui/dist /third_party/swagger-ui && rm -rf swagger-ui \
+    && sed -e 's@"http://petstore.swagger.io/v2/swagger.json"@"/swaggerapi/"@' -i  /third_party/swagger-ui/index.html \
+    && rm swagger-ui.tar.gz && rm -rf swagger-ui
 
 COPY virt-api /virt-api
 


### PR DESCRIPTION
Taken from latest master. All released versions do not work with our
swagger spec.

Fixes #28 