### PR TITLE
Use goimports instead of gofmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
  - git reset --hard # we are caching the vendor folder, make sure we see the new vendor.json file
  - go get github.com/mattn/goveralls
  - go get -u github.com/kardianos/govendor
+ - go get golang.org/x/tools/cmd/goimports
  - go get -u github.com/golang/mock/gomock
  - go get -u github.com/rmohr/mock/mockgen
  - go get -u github.com/rmohr/go-swagger-utils/swagger-doc
@@ -27,7 +28,10 @@ install:
  - make sync
 
 script:
+ - make fmt
+ - if git diff --name-only | grep '.*.go'; then echo "It seems like you did not run `make fmt`. Please run it and commit the changes"; false; fi
  - make generate
+ - make fmt
  - if git diff --name-only | grep 'generated.*.go'; then echo "Content of generated files changed. Please regenerate and commit them."; false; fi
  - if diff <(git grep -c '') <(git grep -cI '') | grep -v 'swagger-ui' | grep '^<'; then echo "Binary files are present in git repostory."; false; fi
  - make check

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ vet:
 	./hack/build-go.sh vet ${WHAT}
 
 fmt:
-	./hack/build-go.sh fmt ${WHAT}
+	goimports -w -local kubevirt.io cmd/ pkg/ tests/
 
 test: build
 	./hack/build-go.sh test ${WHAT}

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"flag"
+	"log"
+	"net/http"
+	"strconv"
+
 	"github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful/swagger"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/pkg/runtime/schema"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/healthz"
 	"kubevirt.io/kubevirt/pkg/kubecli"
@@ -15,9 +20,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/rest/endpoints"
 	"kubevirt.io/kubevirt/pkg/rest/filter"
 	"kubevirt.io/kubevirt/pkg/virt-api/rest"
-	"log"
-	"net/http"
-	"strconv"
 )
 
 func main() {

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 
+	"time"
+
 	"github.com/emicklei/go-restful"
 	"github.com/libvirt/libvirt-go"
 	kubecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/client-go/pkg/fields"
 	"k8s.io/client-go/pkg/labels"
 	"k8s.io/client-go/tools/record"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
@@ -23,7 +26,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 	virt_api "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cache"
-	"time"
 )
 
 func main() {

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -11,9 +11,10 @@ import (
 	"syscall"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/logging"
 	"strconv"
 	"strings"
+
+	"kubevirt.io/kubevirt/pkg/logging"
 )
 
 type Monitor struct {

--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -4,12 +4,14 @@ import (
 	"os"
 
 	"fmt"
+	"log"
+
 	flag "github.com/spf13/pflag"
+
 	"kubevirt.io/kubevirt/pkg/virtctl"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/convert"
 	"kubevirt.io/kubevirt/pkg/virtctl/spice"
-	"log"
 )
 
 func main() {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,9 @@ to install a few build requirements:
 
 
     cd $GOPATH
-    # First we setup govendor which is used to track dependencies
+    # Use goimports for package import ordering
+    go get golang.org/x/tools/cmd/goimports
+    # Setup govendor which is used to track dependencies
     go get -u github.com/kardianos/govendor
 ```
 

--- a/pkg/api/v1/mapper_test.go
+++ b/pkg/api/v1/mapper_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/satori/go.uuid"

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 	"k8s.io/client-go/pkg/runtime/schema"
 	"k8s.io/client-go/pkg/types"
+
 	"kubevirt.io/kubevirt/pkg/mapper"
 	"kubevirt.io/kubevirt/pkg/precond"
 )

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -2,10 +2,12 @@ package healthz
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/emicklei/go-restful"
 	"k8s.io/client-go/pkg/util/json"
+
 	"kubevirt.io/kubevirt/pkg/kubecli"
-	"net/http"
 )
 
 func KubeConnectionHealthzFunc(_ *restful.Request, response *restful.Response) {

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -7,6 +7,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	v10 "k8s.io/client-go/pkg/apis/meta/v1"
+
 	v11 "kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/kubecli/kubecli.go
+++ b/pkg/kubecli/kubecli.go
@@ -2,6 +2,9 @@ package kubecli
 
 import (
 	"flag"
+	"runtime/debug"
+	"time"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
@@ -15,10 +18,9 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
-	"runtime/debug"
-	"time"
 )
 
 var (

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -7,13 +7,15 @@ package kubecli
 */
 
 import (
+	"net/http"
+
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/errors"
 	k8sv1 "k8s.io/client-go/pkg/api/v1"
 	k8smetav1 "k8s.io/client-go/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
-	"net/http"
 )
 
 type KubevirtClient interface {

--- a/pkg/kubecli/kubevirt_test.go
+++ b/pkg/kubecli/kubevirt_test.go
@@ -1,13 +1,15 @@
 package kubecli
 
 import (
+	"net/http"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	k8sv1 "k8s.io/client-go/pkg/api/v1"
 	k8smetav1 "k8s.io/client-go/pkg/apis/meta/v1"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
-	"net/http"
 )
 
 var _ = Describe("Kubevirt", func() {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -4,15 +4,16 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/go-kit/kit/log"
 	"io"
-	"k8s.io/client-go/pkg/api/meta"
-	k8sruntime "k8s.io/client-go/pkg/runtime"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/go-kit/kit/log"
+	"k8s.io/client-go/pkg/api/meta"
+	k8sruntime "k8s.io/client-go/pkg/runtime"
 )
 
 type logLevel int

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -3,11 +3,12 @@ package logging
 import (
 	"errors"
 	"fmt"
-	"kubevirt.io/kubevirt/pkg/api/v1"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 
 var logCalled bool = false

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -1,8 +1,9 @@
 package mapper
 
 import (
-	"github.com/jeevatkm/go-model"
 	"reflect"
+
+	"github.com/jeevatkm/go-model"
 )
 
 func AddConversion(inPtr interface{}, outPtr interface{}) {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -3,15 +3,18 @@ package middleware
 import (
 	"errors"
 	"fmt"
-	"github.com/go-kit/kit/endpoint"
-	"golang.org/x/net/context"
 	"runtime/debug"
 
+	"github.com/go-kit/kit/endpoint"
+	"golang.org/x/net/context"
+
 	"encoding/json"
+
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/levels"
 	"k8s.io/client-go/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -2,10 +2,12 @@ package middleware
 
 import (
 	"errors"
+
 	"github.com/go-kit/kit/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
+
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 

--- a/pkg/rest/endpoints/builder.go
+++ b/pkg/rest/endpoints/builder.go
@@ -3,11 +3,13 @@ package endpoints
 import (
 	"golang.org/x/net/context"
 
+	"net/http"
+
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
+
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/rest"
-	"net/http"
 )
 
 type HandlerBuilder interface {

--- a/pkg/rest/endpoints/decoders.go
+++ b/pkg/rest/endpoints/decoders.go
@@ -4,19 +4,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/asaskevich/govalidator"
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"
 	gokithttp "github.com/go-kit/kit/transport/http"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/pkg/api"
+
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/rest"
-	"net/http"
-	"reflect"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 type PutObject struct {

--- a/pkg/rest/endpoints/delete_test.go
+++ b/pkg/rest/endpoints/delete_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 
 	"encoding/json"
-	"github.com/emicklei/go-restful"
-	"golang.org/x/net/context"
-	"kubevirt.io/kubevirt/pkg/rest"
 	"net/http/httptest"
 	"net/url"
+
+	"github.com/emicklei/go-restful"
+	"golang.org/x/net/context"
+
+	"kubevirt.io/kubevirt/pkg/rest"
 )
 
 func newValidDeleteRequest() *http.Request {

--- a/pkg/rest/endpoints/encoders.go
+++ b/pkg/rest/endpoints/encoders.go
@@ -2,14 +2,16 @@ package endpoints
 
 import (
 	"encoding/json"
+	"net/http"
+	"strings"
+
 	"github.com/ghodss/yaml"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"golang.org/x/net/context"
 	"gopkg.in/ini.v1"
+
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/rest"
-	"net/http"
-	"strings"
 )
 
 func encodeApplicationErrors(_ context.Context, w http.ResponseWriter, response interface{}) error {

--- a/pkg/rest/endpoints/get_test.go
+++ b/pkg/rest/endpoints/get_test.go
@@ -4,17 +4,20 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	kithttp "github.com/go-kit/kit/transport/http"
 	"net/http"
 
+	kithttp "github.com/go-kit/kit/transport/http"
+
 	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"
 	"golang.org/x/net/context"
 	"gopkg.in/ini.v1"
+
 	"kubevirt.io/kubevirt/pkg/rest"
-	"net/http/httptest"
-	"net/url"
 )
 
 func newValidGetRequest() *http.Request {

--- a/pkg/rest/endpoints/patch_test.go
+++ b/pkg/rest/endpoints/patch_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
+
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/rest"
 )

--- a/pkg/rest/endpoints/post_test.go
+++ b/pkg/rest/endpoints/post_test.go
@@ -7,14 +7,16 @@ import (
 	"net/http"
 
 	"encoding/json"
-	"github.com/emicklei/go-restful"
-	"github.com/ghodss/yaml"
-	"golang.org/x/net/context"
 	"io/ioutil"
-	"kubevirt.io/kubevirt/pkg/rest"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+
+	"github.com/emicklei/go-restful"
+	"github.com/ghodss/yaml"
+	"golang.org/x/net/context"
+
+	"kubevirt.io/kubevirt/pkg/rest"
 )
 
 func newValidJSONPostRequest() *http.Request {

--- a/pkg/rest/endpoints/put_test.go
+++ b/pkg/rest/endpoints/put_test.go
@@ -8,15 +8,17 @@ import (
 
 	"bytes"
 	"encoding/json"
-	"github.com/emicklei/go-restful"
-	"golang.org/x/net/context"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
-	"kubevirt.io/kubevirt/pkg/rest"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+
+	"github.com/emicklei/go-restful"
+	"golang.org/x/net/context"
+	"gopkg.in/yaml.v2"
+
+	"kubevirt.io/kubevirt/pkg/rest"
 )
 
 func marshalToJSON(payload interface{}) io.ReadCloser {

--- a/pkg/rest/filter/filter.go
+++ b/pkg/rest/filter/filter.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/go-restful"
+
 	"kubevirt.io/kubevirt/pkg/logging"
 )
 

--- a/pkg/virt-api/rest/console.go
+++ b/pkg/virt-api/rest/console.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
 	"github.com/emicklei/go-restful"
 	"github.com/gorilla/websocket"
-	"io"
 	k8scorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	k8sv1meta "k8s.io/client-go/pkg/apis/meta/v1"
+
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
-	"net/http"
-	"net/url"
 )
 
 var upgrader = websocket.Upgrader{

--- a/pkg/virt-api/rest/console_test.go
+++ b/pkg/virt-api/rest/console_test.go
@@ -2,22 +2,24 @@ package rest
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
 	"github.com/emicklei/go-restful"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 	fake2 "k8s.io/client-go/kubernetes/fake"
 	k8scorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	k8sv1 "k8s.io/client-go/pkg/api/v1"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"strings"
 )
 
 var _ = Describe("Console", func() {

--- a/pkg/virt-api/rest/kubeproxy.go
+++ b/pkg/virt-api/rest/kubeproxy.go
@@ -3,6 +3,11 @@ package rest
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
 	"github.com/asaskevich/govalidator"
 	"github.com/emicklei/go-restful"
 	"github.com/evanphx/json-patch"
@@ -15,14 +20,11 @@ import (
 	"k8s.io/client-go/pkg/runtime"
 	"k8s.io/client-go/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/middleware"
 	mime "kubevirt.io/kubevirt/pkg/rest"
 	"kubevirt.io/kubevirt/pkg/rest/endpoints"
-	"net/http"
-	"reflect"
-	"strings"
-	"time"
 )
 
 type ResponseHandlerFunc func(rest.Result) (interface{}, error)

--- a/pkg/virt-api/rest/kubeproxy_test.go
+++ b/pkg/virt-api/rest/kubeproxy_test.go
@@ -7,6 +7,8 @@ import (
 
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
@@ -14,12 +16,12 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	"golang.org/x/net/context"
-	"io/ioutil"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/errors"
 	v12 "k8s.io/client-go/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virt-api/rest/spice.go
+++ b/pkg/virt-api/rest/spice.go
@@ -3,6 +3,8 @@ package rest
 import (
 	"flag"
 	"fmt"
+	"strings"
+
 	"github.com/go-kit/kit/endpoint"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/kubernetes"
@@ -12,10 +14,10 @@ import (
 	"k8s.io/client-go/pkg/labels"
 	"k8s.io/client-go/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/rest/endpoints"
-	"strings"
 )
 
 var spiceProxy string

--- a/pkg/virt-controller/rest/rest.go
+++ b/pkg/virt-controller/rest/rest.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"github.com/emicklei/go-restful"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/healthz"
 )

--- a/pkg/virt-controller/services/generated_mock_vm.go
+++ b/pkg/virt-controller/services/generated_mock_vm.go
@@ -6,6 +6,7 @@ package services
 import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/client-go/pkg/api/v1"
+
 	v10 "kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	kubev1 "k8s.io/client-go/pkg/api/v1"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/precond"

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/util/uuid"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
 )

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -3,6 +3,8 @@ package services_test
 import (
 	"encoding/json"
 	"flag"
+	"net/http"
+
 	"github.com/facebookgo/inject"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,10 +13,10 @@ import (
 	corev1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/util/uuid"
 	"k8s.io/client-go/rest"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	. "kubevirt.io/kubevirt/pkg/virt-controller/services"
-	"net/http"
 )
 
 var _ = Describe("VM", func() {

--- a/pkg/virt-controller/watch/job.go
+++ b/pkg/virt-controller/watch/job.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+
 	kvirtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virt-controller/watch/job_test.go
+++ b/pkg/virt-controller/watch/job_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/pkg/util/workqueue"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+
 	kvirtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	kubev1 "k8s.io/client-go/pkg/api/v1"
+
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virt-handler/domain.go
+++ b/pkg/virt-handler/domain.go
@@ -8,6 +8,7 @@ import (
 
 	k8sv1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/record"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virt-handler/domain_test.go
+++ b/pkg/virt-handler/domain_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -1,15 +1,17 @@
 package rest
 
 import (
+	"io"
+	"net/http"
+
 	"github.com/emicklei/go-restful"
 	"github.com/gorilla/websocket"
 	"github.com/libvirt/libvirt-go"
-	"io"
 	"k8s.io/client-go/pkg/types"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
-	"net/http"
 )
 
 var upgrader = websocket.Upgrader{

--- a/pkg/virt-handler/rest/console_test.go
+++ b/pkg/virt-handler/rest/console_test.go
@@ -2,6 +2,10 @@ package rest
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
 	"github.com/emicklei/go-restful"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
@@ -10,11 +14,9 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/util/uuid"
 	"k8s.io/client-go/tools/record"
+
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 )
 
 var _ = Describe("Console", func() {

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -2,15 +2,17 @@ package api
 
 import (
 	"encoding/xml"
+	"reflect"
+
 	"github.com/jeevatkm/go-model"
 	"k8s.io/client-go/pkg/api/meta"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/runtime/schema"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/mapper"
 	"kubevirt.io/kubevirt/pkg/precond"
-	"reflect"
 )
 
 type LifeCycle string

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/xml"
+
 	"github.com/jeevatkm/go-model"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/virt-handler/virtwrap/cache/cache.go
+++ b/pkg/virt-handler/virtwrap/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"encoding/xml"
+
 	"github.com/libvirt/libvirt-go"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/meta/v1"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/client-go/pkg/types"
 	"k8s.io/client-go/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"

--- a/pkg/virt-handler/virtwrap/cache/cache_test.go
+++ b/pkg/virt-handler/virtwrap/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"encoding/xml"
+
 	"github.com/golang/mock/gomock"
 	"github.com/libvirt/libvirt-go"
 	. "github.com/onsi/ginkgo"
@@ -9,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -6,6 +6,7 @@ package virtwrap
 import (
 	gomock "github.com/golang/mock/gomock"
 	libvirt_go "github.com/libvirt/libvirt-go"
+
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -2,6 +2,7 @@ package virtwrap
 
 import (
 	"encoding/xml"
+
 	"github.com/golang/mock/gomock"
 	"github.com/jeevatkm/go-model"
 	"github.com/libvirt/libvirt-go"
@@ -10,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/record"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -3,18 +3,19 @@ package console
 import (
 	"bytes"
 	"fmt"
-	"github.com/gorilla/websocket"
-	flag "github.com/spf13/pflag"
-	"golang.org/x/crypto/ssh/terminal"
 	"io"
-	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/tools/clientcmd"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/gorilla/websocket"
+	flag "github.com/spf13/pflag"
+	"golang.org/x/crypto/ssh/terminal"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type Console struct {

--- a/pkg/virtctl/convert/convert.go
+++ b/pkg/virtctl/convert/convert.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"fmt"
+
 	flag "github.com/spf13/pflag"
 )
 

--- a/pkg/virtctl/convert/convert_test.go
+++ b/pkg/virtctl/convert/convert_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	"github.com/spf13/pflag"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/virtctl/convert/converter.go
+++ b/pkg/virtctl/convert/converter.go
@@ -3,10 +3,12 @@ package convert
 import (
 	"encoding/json"
 	"encoding/xml"
+	"io"
+
 	ghodss_yaml "github.com/ghodss/yaml"
 	"github.com/jeevatkm/go-model"
-	"io"
 	"k8s.io/client-go/pkg/util/yaml"
+
 	virt "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )

--- a/pkg/virtctl/convert/converter_test.go
+++ b/pkg/virtctl/convert/converter_test.go
@@ -2,9 +2,11 @@ package convert
 
 import (
 	"bytes"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/virtctl/convert/guess_test.go
+++ b/pkg/virtctl/convert/guess_test.go
@@ -4,10 +4,11 @@ import (
 	. "kubevirt.io/kubevirt/pkg/virtctl/convert"
 
 	"bytes"
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
 )
 
 var _ = Describe("Guess", func() {

--- a/pkg/virtctl/spice/spice.go
+++ b/pkg/virtctl/spice/spice.go
@@ -3,14 +3,16 @@ package spice
 import (
 	"errors"
 	"fmt"
-	flag "github.com/spf13/pflag"
 	"io/ioutil"
-	kubev1 "k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/rest"
-	"kubevirt.io/kubevirt/pkg/kubecli"
 	"log"
 	"os"
 	"os/exec"
+
+	flag "github.com/spf13/pflag"
+	kubev1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
 )
 
 const FLAG = "spice"

--- a/pkg/virtctl/virtctl.go
+++ b/pkg/virtctl/virtctl.go
@@ -2,8 +2,9 @@ package virtctl
 
 import (
 	"fmt"
-	flag "github.com/spf13/pflag"
 	"os"
+
+	flag "github.com/spf13/pflag"
 )
 
 type App interface {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -4,15 +4,17 @@ import (
 	"flag"
 	"net/url"
 
+	"strings"
+	"time"
+
 	"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/api"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
-	"strings"
-	"time"
 )
 
 var _ = Describe("Vmlifecycle", func() {

--- a/tests/spice_test.go
+++ b/tests/spice_test.go
@@ -6,19 +6,21 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/ini.v1"
-	"io"
 	"k8s.io/client-go/pkg/api"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/rest"
 	"kubevirt.io/kubevirt/tests"
-	"math/rand"
-	"net"
-	"strings"
 )
 
 var _ = Describe("Vmlifecycle", func() {

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -3,15 +3,17 @@ package tests_test
 import (
 	"flag"
 	"fmt"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/api"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/tests"
-	"time"
 )
 
 var _ = Describe("Storage", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2,6 +2,9 @@ package tests
 
 import (
 	"fmt"
+	"reflect"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/api"
@@ -11,10 +14,9 @@ import (
 	"k8s.io/client-go/pkg/labels"
 	"k8s.io/client-go/pkg/runtime"
 	"k8s.io/client-go/pkg/util/rand"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
-	"reflect"
-	"time"
 )
 
 type EventType string

--- a/tests/vm_migration_test.go
+++ b/tests/vm_migration_test.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/labels"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -2,6 +2,9 @@ package tests_test
 
 import (
 	"flag"
+	"net/http"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes"
@@ -11,11 +14,10 @@ import (
 	"k8s.io/client-go/pkg/fields"
 	"k8s.io/client-go/pkg/labels"
 	"k8s.io/client-go/pkg/util/json"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
-	"net/http"
-	"time"
 )
 
 var _ = Describe("Vmlifecycle", func() {


### PR DESCRIPTION
Everything except imports should be the same like with a direct call of
gofmt.

Imports will now be grouped into system packages, vendor packages and
kubevirt packages when calling "make fmt".

Resolves #79 