### PR TITLE
README typo: setup -> set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ curl run.kubevirt.io/demo.sh | bash
 ```
 on a recent Fedora or Ubuntu and follow [these steps](https://github.com/kubevirt/demo).
 
-**Developer** To setup a development environment please read our
+**Developer** To set up a development environment please read our
 [Getting Started Guide](docs/getting-started.md).
 
 


### PR DESCRIPTION
Fix a typo in README.md. "Setup" is a noun, while "set up" is a verb.