### PR TITLE
handler: Throw a connection error

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -53,7 +53,7 @@ func main() {
 	// TODO we need to handle disconnects
 	domainConn, err := virtwrap.NewConnection(*libvirtUri, *libvirtUser, *libvirtPass)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("failed to connect to libvirtd: %s", err))
 	}
 	defer domainConn.Close()
 


### PR DESCRIPTION
Previously it was a cryptic panic, now we at least say that the libvirt
connection failed.