### PR TITLE
Add serial and console schemas

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -36,6 +36,8 @@ type Devices struct {
 	Graphics   []Graphics  `json:"graphics,omitempty"`
 	Ballooning *Ballooning `json:"memballoon,omitempty"`
 	Disks      []Disk      `json:"disks,omitempty"`
+	Serials    []Serial    `json:"serials,omitempty"`
+	Consoles   []Console   `json:"consoles,omitempty"`
 }
 
 // BEGIN Disk -----------------------------
@@ -80,6 +82,33 @@ type DiskSourceHost struct {
 }
 
 // END Disk -----------------------------
+
+// BEGIN Serial -----------------------------
+
+type Serial struct {
+	Type         string       `json:"type"`
+	SerialTarget SerialTarget `json:"serialTarget"`
+}
+
+type SerialTarget struct {
+	Port string `json:"port"`
+}
+
+// END Serial -----------------------------
+
+// BEGIN Console -----------------------------
+
+type Console struct {
+	Type          string        `json:"type"`
+	ConsoleTarget ConsoleTarget `json:"consoleTarget"`
+}
+
+type ConsoleTarget struct {
+	Type string `json:"type"`
+	Port string `json:"port"`
+}
+
+// END Serial -----------------------------
 
 // BEGIN Inteface -----------------------------
 

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -86,12 +86,12 @@ type DiskSourceHost struct {
 // BEGIN Serial -----------------------------
 
 type Serial struct {
-	Type         string       `json:"type"`
-	SerialTarget SerialTarget `json:"serialTarget"`
+	Type   string       `json:"type"`
+	Target SerialTarget `json:"target"`
 }
 
 type SerialTarget struct {
-	Port string `json:"port"`
+	Port uint `json:"port"`
 }
 
 // END Serial -----------------------------
@@ -99,13 +99,13 @@ type SerialTarget struct {
 // BEGIN Console -----------------------------
 
 type Console struct {
-	Type          string        `json:"type"`
-	ConsoleTarget ConsoleTarget `json:"consoleTarget"`
+	Type   string        `json:"type"`
+	Target ConsoleTarget `json:"target"`
 }
 
 type ConsoleTarget struct {
 	Type string `json:"type"`
-	Port string `json:"port"`
+	Port *uint  `json:"port,omitempty"`
 }
 
 // END Serial -----------------------------

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -38,6 +38,22 @@ func (DiskSourceHost) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }
 
+func (Serial) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
+func (SerialTarget) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
+func (Console) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
+func (ConsoleTarget) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }

--- a/pkg/virt-handler/virtwrap/schema.go
+++ b/pkg/virt-handler/virtwrap/schema.go
@@ -33,6 +33,10 @@ func init() {
 	mapper.AddPtrConversion((**DiskDriver)(nil), (**v1.DiskDriver)(nil))
 	mapper.AddPtrConversion((**ReadOnly)(nil), (**v1.ReadOnly)(nil))
 	mapper.AddPtrConversion((**Address)(nil), (**v1.Address)(nil))
+	mapper.AddConversion(&Serial{}, &v1.Serial{})
+	mapper.AddConversion(&SerialTarget{}, &v1.SerialTarget{})
+	mapper.AddConversion(&Console{}, &v1.Console{})
+	mapper.AddConversion(&ConsoleTarget{}, &v1.ConsoleTarget{})
 	mapper.AddConversion(&InterfaceSource{}, &v1.InterfaceSource{})
 	mapper.AddPtrConversion((**InterfaceTarget)(nil), (**v1.InterfaceTarget)(nil))
 	mapper.AddPtrConversion((**Model)(nil), (**v1.Model)(nil))
@@ -118,6 +122,8 @@ type Devices struct {
 	Graphics   []Graphics  `xml:"graphics"`
 	Ballooning *Ballooning `xml:"memballoon,omitempty"`
 	Disks      []Disk      `xml:"disk"`
+	Serials    []Serial    `xml:"serial"`
+	Consoles   []Console   `xml:"console"`
 }
 
 // BEGIN Disk -----------------------------
@@ -162,6 +168,33 @@ type DiskSourceHost struct {
 }
 
 // END Disk -----------------------------
+
+// BEGIN Serial -----------------------------
+
+type Serial struct {
+	Type         string       `xml:"type,attr"`
+	SerialTarget SerialTarget `xml:"serialTarget"`
+}
+
+type SerialTarget struct {
+	Port string `xml:"port,attr"`
+}
+
+// END Serial -----------------------------
+
+// BEGIN Console -----------------------------
+
+type Console struct {
+	Type          string        `xml:"type,attr"`
+	ConsoleTarget ConsoleTarget `xml:"consoleTarget"`
+}
+
+type ConsoleTarget struct {
+	Type string `xml:"type,attr"`
+	Port string `xml:"port,attr"`
+}
+
+// END Serial -----------------------------
 
 // BEGIN Inteface -----------------------------
 

--- a/pkg/virt-handler/virtwrap/schema.go
+++ b/pkg/virt-handler/virtwrap/schema.go
@@ -172,12 +172,12 @@ type DiskSourceHost struct {
 // BEGIN Serial -----------------------------
 
 type Serial struct {
-	Type         string       `xml:"type,attr"`
-	SerialTarget SerialTarget `xml:"serialTarget"`
+	Type   string       `xml:"type,attr"`
+	Target SerialTarget `xml:"target"`
 }
 
 type SerialTarget struct {
-	Port string `xml:"port,attr"`
+	Port uint `xml:"port,attr"`
 }
 
 // END Serial -----------------------------
@@ -185,13 +185,13 @@ type SerialTarget struct {
 // BEGIN Console -----------------------------
 
 type Console struct {
-	Type          string        `xml:"type,attr"`
-	ConsoleTarget ConsoleTarget `xml:"consoleTarget"`
+	Type   string        `xml:"type,attr"`
+	Target ConsoleTarget `xml:"target"`
 }
 
 type ConsoleTarget struct {
 	Type string `xml:"type,attr"`
-	Port string `xml:"port,attr"`
+	Port *uint  `xml:"port,attr,omitempty"`
 }
 
 // END Serial -----------------------------


### PR DESCRIPTION
VM spec needs "serials" and "consoles" elements to set up
a serial console in a guest VM.

Resolves #102 