### PR TITLE
Downgrade weave to 1.9.0

### DIFF
--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -22,7 +22,7 @@ done
 set -e
 
 if [ "$NETWORK_PROVIDER" == "weave" ]; then 
-  kubectl apply -s 127.0.0.1:8080 -f https://git.io/weave-kube
+  kubectl apply -s 127.0.0.1:8080 -f https://github.com/weaveworks/weave/releases/download/v1.9.0/weave-daemonset.yaml
 else
   kubectl create -s 127.0.0.1:8080 -f kube-$NETWORK_PROVIDER.yaml
 fi


### PR DESCRIPTION
Version 1.9.1 breaks when br_filters are built into the kernel and not
modules.

See https://github.com/weaveworks/weave/issues/2820 for details.

Fixes #111 