### PR TITLE
Change core manifests from pod to deployment

### DIFF
--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -11,18 +11,21 @@ spec:
   selector:
     app: haproxy
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: haproxy
-  labels:
-    app: haproxy
 spec:
-  containers:
-  - name: haproxy
-    image: {{ docker_prefix }}/haproxy:{{ docker_tag }}
-    imagePullPolicy: IfNotPresent
-    ports:
-      - containerPort: 8184
-        name: "haproxy"
-        protocol: "TCP"
+  template:
+    metadata:
+      labels:
+        app: haproxy
+    spec:
+      containers:
+      - name: haproxy
+        image: {{ docker_prefix }}/haproxy:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8184
+            name: "haproxy"
+            protocol: "TCP"

--- a/manifests/squid.yaml.in
+++ b/manifests/squid.yaml.in
@@ -11,18 +11,21 @@ spec:
   selector:
     app: spice-proxy
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: spice-proxy
-  labels:
-    app: spice-proxy
 spec:
-  containers:
-  - name: spice-proxy
-    image: rmohr/spice-squid:latest
-    imagePullPolicy: IfNotPresent
-    ports:
-      - containerPort: 3128
-        name: "spice-proxy"
-        protocol: "TCP"
+  template:
+    metadata:
+      labels:
+        app: spice-proxy
+    spec:
+      containers:
+        - name: spice-proxy
+          image: rmohr/spice-squid:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3128
+              name: "spice-proxy"
+              protocol: "TCP"

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -11,24 +11,27 @@ spec:
   selector:
     app: virt-api
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: virt-api
-  labels:
-    app: virt-api
 spec:
-  containers:
-  - name: virt-api
-    image: {{ docker_prefix }}/virt-api:{{ docker_tag }}
-    imagePullPolicy: IfNotPresent
-    command:
-        - "/virt-api"
-        - "--port"
-        - "8183"
-        - "--spice-proxy"
-        - "{{ master_ip }}:3128"
-    ports:
-      - containerPort: 8183
-        name: "virt-api"
-        protocol: "TCP"
+  template:
+    metadata:
+      labels:
+        app: virt-api
+    spec:
+      containers:
+      - name: virt-api
+        image: {{ docker_prefix }}/virt-api:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        command:
+            - "/virt-api"
+            - "--port"
+            - "8183"
+            - "--spice-proxy"
+            - "{{ master_ip }}:3128"
+        ports:
+          - containerPort: 8183
+            name: "virt-api"
+            protocol: "TCP"

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -11,24 +11,27 @@ spec:
   selector:
     app: virt-controller
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: virt-controller
-  labels:
-    app: virt-controller
 spec:
-  containers:
-  - name: virt-controller
-    image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
-    imagePullPolicy: IfNotPresent
-    command:
-        - "/virt-controller"
-        - "--launcher-image"
-        - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
-        - "--port"
-        - "8182"
-    ports:
-      - containerPort: 8182
-        name: "virt-controller"
-        protocol: "TCP"
+  template:
+    metadata:
+      labels:
+        app: virt-controller
+    spec:
+      containers:
+      - name: virt-controller
+        image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        command:
+            - "/virt-controller"
+            - "--launcher-image"
+            - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
+            - "--port"
+            - "8182"
+        ports:
+          - containerPort: 8182
+            name: "virt-controller"
+            protocol: "TCP"


### PR DESCRIPTION
As stated in issue #115, following manifests should be changed from pod to deployment.

 - [X] squid proxy (squid.yaml.in)
 - [x] haproxy (haproxy.yaml.in)
 - [x] virt-api (virt-api.yaml.in)
 - [x] virt-controller (virt-controller.yaml.in)

