### PR TITLE
Delete all pods and deployments before running functional tests

### DIFF
--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -44,6 +44,11 @@ make
 # Run unit tests
 # make test
 
+# Delete traces from old deployments
+cluster/kubectl.sh --init
+cluster/kubectl.sh --core delete deployments --all
+cluster/kubectl.sh --core delete pods --all
+
 # Deploy kubevirt
 cluster/sync.sh
 


### PR DESCRIPTION
In the CI environment, delete all existing pods and deployments, to make
the CI job more resilient agains manifest changes.