### PR TITLE
Upate dock, to use forked mockgen until mockgen is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
  - go get github.com/mattn/goveralls
  - go get -u github.com/kardianos/govendor
  - go get -u github.com/golang/mock/gomock
- - go get -u github.com/golang/mock/mockgen
+ - go get -u github.com/rmohr/mock/mockgen
  - go get -u github.com/rmohr/go-swagger-utils/swagger-doc
  - sudo apt-get install libvirt-dev make
  - make sync

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,7 @@ First install the generator tools:
 
 ```bash
 go get -u github.com/golang/mock/gomock
-go get -u github.com/golang/mock/mockgen
+go get -u github.com/rmohr/mock/mockgen
 go get -u github.com/rmohr/go-swagger-utils/swagger-doc
 ```
 


### PR DESCRIPTION
PR to mockgen is sent, until it is merged we can use rmohr/mock/mockgen.