### PR TITLE
manifests: Add a manifest for deploying the Cockpit Demo

### DIFF
--- a/manifests/cockpit-demo.yaml.in
+++ b/manifests/cockpit-demo.yaml.in
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubevirt-cockpit-demo
+spec:
+  ports:
+  - protocol: TCP
+    port: 9091
+    targetPort: 9090
+  externalIPs:
+  - "{{ master_ip }}"
+  selector:
+    name: kubevirt-cockpit-demo
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubevirt-cockpit-demo
+spec:
+  template:
+    metadata:
+      labels:
+        name: kubevirt-cockpit-demo
+    spec:
+      containers:
+      - name: cockpit
+        image: kubevirt/cockpit-demo
+        ports:
+        - containerPort: 9090
+          protocol: TCP


### PR DESCRIPTION
The cockpit demo is hosted outisde of the core repository, but for
demonstration purpose it is still valuable to deploy it.

See also https://github.com/kubevirt/cockpit-demo