### PR TITLE
Fix vagrant dns problems

### DIFF
--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -8,7 +8,7 @@ yum install -y cockpit cockpit-kubernetes
 systemctl enable cockpit.socket && systemctl start cockpit.socket
 
 # Create the master
-kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --use-kubernetes-version v1.4.5
+kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --use-kubernetes-version v1.5.4
 
 set +e
 
@@ -22,7 +22,7 @@ done
 set -e
 
 if [ "$NETWORK_PROVIDER" == "weave" ]; then 
-  kubectl apply -s 127.0.0.1:8080 -f https://github.com/weaveworks/weave/releases/download/v1.9.0/weave-daemonset.yaml
+  kubectl apply -s 127.0.0.1:8080 -f https://github.com/weaveworks/weave/releases/download/v1.9.3/weave-daemonset.yaml
 else
   kubectl create -s 127.0.0.1:8080 -f kube-$NETWORK_PROVIDER.yaml
 fi

--- a/cluster/vagrant/setup_kubernetes_node.sh
+++ b/cluster/vagrant/setup_kubernetes_node.sh
@@ -2,8 +2,6 @@
 
 bash ./setup_kubernetes_common.sh
 
-ADVERTISED_MASTER_IP=`dig +short master`
-
 set +e
 
 echo 'Trying to register myself...'

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,5 +1,5 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api"
-docker_images="$binaries images/haproxy images/libvirtd images/iscsi-demo-target-tgtd"
+docker_images="$binaries images/haproxy images/iscsi-demo-target-tgtd"
 docker_prefix=kubevirt
 docker_tag=${DOCKER_TAG:-latest}
 manifest_templates="`ls manifests/*.in`"

--- a/tests/vm_migration_test.go
+++ b/tests/vm_migration_test.go
@@ -154,7 +154,7 @@ var _ = Describe("VmMigration", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			thisMigration := obj.(*v1.Migration)
-			labelSelector, err := labels.Parse(v1.DomainLabel + "," + v1.AppLabel + "=migration" + "," + v1.MigrationUIDLabel + "=" + string(thisMigration.GetObjectMeta().GetUID()), )
+			labelSelector, err := labels.Parse(v1.DomainLabel + "," + v1.AppLabel + "=migration" + "," + v1.MigrationUIDLabel + "=" + string(thisMigration.GetObjectMeta().GetUID()))
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() int {


### PR DESCRIPTION
 * Bump to Kubernetes 1.5.4 and Weave 1.9.3
 * Use eth1 with well known IPs to wire Kubernetes masters and nodes
 * Swich to proxy mode `userspace`, to work around https://github.com/kubernetes/kubernetes/issues/34101

This solves two things:
 * works around the glitches people were sometimes seeing, like the node not being able to resolve `master`, or that the node can't reach the master ip.
 * We can now distribute a pre-deployed vagrant image to atlas (e.g. for demoing migrations), since the certificates generated by kubeadm, are now bound to the well known IP of eth1

