### PR TITLE
update VM phase by checking domain status and reason

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -89,7 +89,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	domainStore, domainController := virthandler.NewDomainController(vmQueue, vmStore, domainSharedInformer)
+	domainStore, domainController := virthandler.NewDomainController(vmQueue, vmStore, domainSharedInformer, *restClient)
 
 	if err != nil {
 		panic(err)

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,5 +1,5 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api"
-docker_images="$binaries images/haproxy images/iscsi-demo-target-tgtd"
+docker_images="$binaries images/haproxy images/iscsi-demo-target-tgtd images/vm-killer"
 docker_prefix=kubevirt
 docker_tag=${DOCKER_TAG:-latest}
 manifest_templates="`ls manifests/*.in`"

--- a/images/vm-killer/Dockerfile
+++ b/images/vm-killer/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos
+
+ENV container docker
+
+RUN yum install -y psmisc
+
+COPY vm-killer.sh /vm-killer.sh
+RUN chmod a+x /vm-killer.sh

--- a/images/vm-killer/vm-killer.sh
+++ b/images/vm-killer/vm-killer.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+pkill -9 qemu

--- a/pkg/virt-handler/domain.go
+++ b/pkg/virt-handler/domain.go
@@ -1,7 +1,9 @@
 package virthandler
 
 import (
+	kubeapi "k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/util/workqueue"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
@@ -15,20 +17,22 @@ TODO: Define the exact scope of this controller.
 For now it looks like we should use domain events to detect unexpected domain changes like crashes or vms going
 into pause mode because of resource shortage or cut off connections to storage.
 */
-func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedInformer) (cache.Store, *kubecli.Controller) {
+func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedInformer, restClient rest.RESTClient) (cache.Store, *kubecli.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	informer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForQorkqueue(queue))
 
 	dispatch := DomainDispatch{
-		vmQueue: vmQueue,
-		vmStore: vmStore,
+		vmQueue:    vmQueue,
+		vmStore:    vmStore,
+		restClient: restClient,
 	}
 	return kubecli.NewControllerFromInformer(informer.GetStore(), informer, queue, &dispatch)
 }
 
 type DomainDispatch struct {
-	vmQueue workqueue.RateLimitingInterface
-	vmStore cache.Store
+	vmQueue    workqueue.RateLimitingInterface
+	vmStore    cache.Store
+	restClient rest.RESTClient
 }
 
 func (d *DomainDispatch) Execute(indexer cache.Store, queue workqueue.RateLimitingInterface, key interface{}) {
@@ -56,6 +60,33 @@ func (d *DomainDispatch) Execute(indexer cache.Store, queue workqueue.RateLimiti
 	} else if !vmExists || obj.(*v1.VM).GetObjectMeta().GetUID() != domain.GetObjectMeta().GetUID() {
 		// The VM is not in the vm cache, or is a VM with a differend uuid, tell the VM controller to investigate it
 		d.vmQueue.Add(key)
+	} else {
+		err = setVmPhaseForStatusReason(domain, obj.(*v1.VM), d.restClient)
+		if err != nil {
+			queue.AddRateLimited(key)
+		}
 	}
+
 	return
+}
+
+func setVmPhaseForStatusReason(domain *virtwrap.Domain, vm *v1.VM, restClient rest.RESTClient) error {
+	flag := false
+	if domain.Status.Status == virtwrap.Shutoff {
+		switch domain.Status.Reason {
+		case virtwrap.ReasonFailed, virtwrap.ReasonCrashed:
+			vm.Status.Phase = v1.Failed
+			flag = true
+		case virtwrap.ReasonShutdown, virtwrap.ReasonDestroyed, virtwrap.ReasonMigrated, virtwrap.ReasonSaved, virtwrap.ReasonFromSnapshot:
+			vm.Status.Phase = v1.Succeeded
+			flag = true
+		}
+	}
+
+	if flag {
+		logging.DefaultLogger().Info().Object(vm).Msgf("Changing VM phase to %s", vm.Status.Phase)
+		return restClient.Put().Resource("vms").Body(vm).Name(vm.ObjectMeta.Name).Namespace(kubeapi.NamespaceDefault).Do().Error()
+	}
+
+	return nil
 }

--- a/pkg/virt-handler/domain.go
+++ b/pkg/virt-handler/domain.go
@@ -52,7 +52,7 @@ func (d *DomainDispatch) Execute(indexer cache.Store, queue workqueue.RateLimiti
 		logging.DefaultLogger().Info().Object(domain).Msgf("Domain deleted")
 	} else {
 		domain = obj.(*virtwrap.Domain)
-		logging.DefaultLogger().Info().Object(domain).Msgf("Domain is in state %s", domain.Status.Status)
+		logging.DefaultLogger().Info().Object(domain).Msgf("Domain is in state %s reason %s", domain.Status.Status, domain.Status.Reason)
 	}
 	obj, vmExists, err := d.vmStore.GetByKey(key.(string))
 	if err != nil {

--- a/pkg/virt-handler/domain_test.go
+++ b/pkg/virt-handler/domain_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/pkg/types"
 	"k8s.io/client-go/pkg/util/workqueue"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/cache/testing"
 	"kubevirt.io/kubevirt/pkg/api/v1"
@@ -18,6 +19,7 @@ var _ = Describe("Domain", func() {
 	var fakeWatcher *framework.FakeControllerSource
 	var vmStore cache.Store
 	var vmQueue workqueue.RateLimitingInterface
+	var restClient rest.RESTClient
 
 	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
 
@@ -28,7 +30,7 @@ var _ = Describe("Domain", func() {
 		vmStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 		vmQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 		informer := cache.NewSharedInformer(fakeWatcher, &virtwrap.Domain{}, 0)
-		_, controller := NewDomainController(vmQueue, vmStore, informer)
+		_, controller := NewDomainController(vmQueue, vmStore, informer, restClient)
 		controller.StartInformer(stopChan)
 		controller.WaitForSync(stopChan)
 		go controller.Run(1, stopChan)


### PR DESCRIPTION
Second attempt since the event changes. The only way to really see the phase change is to actually crash the domain - there is no phase change when VM TPR is deleted (so is the domain, but at that point there is nothing to update). 

@rmohr Any idea how to nicely test this? Currently experimenting with pkill -9 qemu, which may be a *bit* strong. Pretty much need anything to send kill -9 or equivalent.

Closes #75 