### PR TITLE
Seamless spice

### DIFF
--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -6,8 +6,12 @@ FROM centos:7
 RUN yum -y install wget && \
     wget -P /etc/yum.repos.d https://copr.fedorainfracloud.org/coprs/jmliger/virt7-upstream/repo/epel-7/jmliger-virt7-upstream-epel-7.repo  \
     && yum -y install libvirt-client \
+    && wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+    && yum -y install epel-release-latest-7.noarch.rpm \
+    && yum -y install xmlstarlet \
     && yum -y clean all
 
+COPY migrate /migrate
 COPY virt-handler /virt-handler
 
 ENTRYPOINT [ "/virt-handler" ]

--- a/cmd/virt-handler/migrate
+++ b/cmd/virt-handler/migrate
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -p|--pod-ip)
+    POD_IP="$2"
+    shift
+    ;;
+    -s|--source)
+    SOURCE="$2"
+    shift
+    ;;
+    -d|--dest)
+    DEST="$2"
+    shift
+    ;;
+    *)
+      VM=$1
+    ;;
+esac
+shift
+done
+
+if [ -z $POD_IP ] || [ -z $DEST ] || [ -z $SOURCE ] || [ -z $VM ] ; then
+echo "Usage: migrate DOMAIN --source SOURCE --dest DESTINATION --pod-ip POD_IP"        
+exit 1
+fi 
+
+# Tell libvirt where qemu will listen for spice connections on the new host
+virsh -c $SOURCE dumpxml $VM > $VM.xml
+xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/@listen" -v $POD_IP $VM.xml
+xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/listen/@address" -v $POD_IP $VM.xml
+
+# Migrate
+virsh -c $SOURCE migrate --xml $VM.xml $VM $DEST tcp://$POD_IP

--- a/pkg/virt-controller/services/generated_mock_vm.go
+++ b/pkg/virt-controller/services/generated_mock_vm.go
@@ -126,14 +126,14 @@ func (_mr *_MockVMServiceRecorder) FetchMigration(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FetchMigration", arg0)
 }
 
-func (_m *MockVMService) StartMigration(migration *v10.Migration, vm *v10.VM, sourceNode *v1.Node, targetNode *v1.Node) error {
-	ret := _m.ctrl.Call(_m, "StartMigration", migration, vm, sourceNode, targetNode)
+func (_m *MockVMService) StartMigration(migration *v10.Migration, vm *v10.VM, sourceNode *v1.Node, targetNode *v1.Node, targetPod *v1.Pod) error {
+	ret := _m.ctrl.Call(_m, "StartMigration", migration, vm, sourceNode, targetNode, targetPod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVMServiceRecorder) StartMigration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartMigration", arg0, arg1, arg2, arg3)
+func (_mr *_MockVMServiceRecorder) StartMigration(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartMigration", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockVMService) GetMigrationJob(migration *v10.Migration) (*v1.Pod, bool, error) {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -110,7 +110,7 @@ func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node,
 					Name:  "virt-migration",
 					Image: "kubevirt/virt-handler:devel",
 					Command: []string{
-						"virsh", "-c", srcUri, "migrate", vm.Spec.Domain.Name, destUri, "tcp://" + targetPod.Status.PodIP,
+						"/migrate", vm.Spec.Domain.Name, "--source", srcUri, "--dest", destUri, "--pod-ip", targetPod.Status.PodIP,
 					},
 				},
 			},

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -13,7 +13,7 @@ import (
 
 type TemplateService interface {
 	RenderLaunchManifest(*v1.VM) (*kubev1.Pod, error)
-	RenderMigrationJob(*v1.VM, *kubev1.Node, *kubev1.Node) (*kubev1.Pod, error)
+	RenderMigrationJob(*v1.VM, *kubev1.Node, *kubev1.Node, *kubev1.Pod) (*kubev1.Pod, error)
 }
 
 type templateService struct {
@@ -66,7 +66,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VM) (*kubev1.Pod, error) {
 	return &pod, nil
 }
 
-func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node, targetNode *kubev1.Node) (*kubev1.Pod, error) {
+func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node, targetNode *kubev1.Node, targetPod *kubev1.Pod) (*kubev1.Pod, error) {
 	srcAddr := ""
 	dstAddr := ""
 	for _, addr := range sourceNode.Status.Addresses {
@@ -110,7 +110,7 @@ func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node,
 					Name:  "virt-migration",
 					Image: "kubevirt/virt-handler:devel",
 					Command: []string{
-						"virsh", "-c", srcUri, "migrate", "--tunnelled", "--p2p", vm.Spec.Domain.Name, destUri,
+						"virsh", "-c", srcUri, "migrate", vm.Spec.Domain.Name, destUri, "tcp://" + targetPod.Status.PodIP,
 					},
 				},
 			},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/util/uuid"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
 )
@@ -99,38 +100,45 @@ var _ = Describe("Template", func() {
 				}
 			})
 
-			Context("migration template with correct parameters", func() {
-				It("should never restart", func() {
-					vm := v1.NewMinimalVM("testvm")
+			Context("migration template", func() {
+				var vm *v1.VM
+				var destPod *kubev1.Pod
+				BeforeEach(func() {
+					vm = v1.NewMinimalVM("testvm")
+					vm.GetObjectMeta().SetUID(uuid.NewUUID())
+					destPod, err = svc.RenderLaunchManifest(vm)
+					Expect(err).ToNot(HaveOccurred())
+					destPod.Status.PodIP = "127.0.0.1"
+				})
+				Context("with correct parameters", func() {
 
-					job, err := svc.RenderMigrationJob(vm, &srcNodeIp, &destNodeIp)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(job.Spec.RestartPolicy).To(Equal(kubev1.RestartPolicyNever))
+					It("should never restart", func() {
+						job, err := svc.RenderMigrationJob(vm, &srcNodeIp, &destNodeIp, destPod)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(job.Spec.RestartPolicy).To(Equal(kubev1.RestartPolicyNever))
+					})
+					It("should use the first ip it finds", func() {
+						job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode, destPod)
+						Expect(err).ToNot(HaveOccurred())
+						refCommand := []string{
+							"virsh", "-c", "qemu+tcp://127.0.0.2/system", "migrate", "testvm",
+							"qemu+tcp://127.0.0.3/system", "tcp://127.0.0.1"}
+						Expect(job.Spec.Containers[0].Command).To(Equal(refCommand))
+					})
 				})
-				It("should use the first ip it finds", func() {
-					vm := v1.NewMinimalVM("testvm")
-					job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode)
-					Expect(err).ToNot(HaveOccurred())
-					refCommand := []string{
-						"virsh", "-c", "qemu+tcp://127.0.0.2/system", "migrate", "--tunnelled", "--p2p", "testvm",
-						"qemu+tcp://127.0.0.3/system"}
-					Expect(job.Spec.Containers[0].Command).To(Equal(refCommand))
-				})
-			})
-			Context("migration template with incorrect parameters", func() {
-				It("should error on missing source address", func() {
-					vm := v1.NewMinimalVM("testvm")
-					srcNode.Status.Addresses = []kubev1.NodeAddress{}
-					job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode)
-					Expect(err).To(HaveOccurred())
-					Expect(job).To(BeNil())
-				})
-				It("should error on missing destination address", func() {
-					vm := v1.NewMinimalVM("testvm")
-					targetNode.Status.Addresses = []kubev1.NodeAddress{}
-					job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode)
-					Expect(err).To(HaveOccurred())
-					Expect(job).To(BeNil())
+				Context("with incorrect parameters", func() {
+					It("should error on missing source address", func() {
+						srcNode.Status.Addresses = []kubev1.NodeAddress{}
+						job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode, destPod)
+						Expect(err).To(HaveOccurred())
+						Expect(job).To(BeNil())
+					})
+					It("should error on missing destination address", func() {
+						targetNode.Status.Addresses = []kubev1.NodeAddress{}
+						job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode, destPod)
+						Expect(err).To(HaveOccurred())
+						Expect(job).To(BeNil())
+					})
 				})
 			})
 		})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -121,8 +121,9 @@ var _ = Describe("Template", func() {
 						job, err := svc.RenderMigrationJob(vm, &srcNode, &targetNode, destPod)
 						Expect(err).ToNot(HaveOccurred())
 						refCommand := []string{
-							"virsh", "-c", "qemu+tcp://127.0.0.2/system", "migrate", "testvm",
-							"qemu+tcp://127.0.0.3/system", "tcp://127.0.0.1"}
+							"/migrate", "testvm", "--source", "qemu+tcp://127.0.0.2/system",
+							"--dest", "qemu+tcp://127.0.0.3/system",
+							"--pod-ip", "127.0.0.1"}
 						Expect(job.Spec.Containers[0].Command).To(Equal(refCommand))
 					})
 				})

--- a/pkg/virt-controller/services/vm.go
+++ b/pkg/virt-controller/services/vm.go
@@ -30,7 +30,7 @@ type VMService interface {
 	UpdateMigration(migration *corev1.Migration) error
 	FetchVM(vmName string) (*corev1.VM, bool, error)
 	FetchMigration(migrationName string) (*corev1.Migration, bool, error)
-	StartMigration(migration *corev1.Migration, vm *corev1.VM, sourceNode *v1.Node, targetNode *v1.Node) error
+	StartMigration(migration *corev1.Migration, vm *corev1.VM, sourceNode *v1.Node, targetNode *v1.Node, targetPod *v1.Pod) error
 	GetMigrationJob(migration *corev1.Migration) (*v1.Pod, bool, error)
 }
 
@@ -161,8 +161,8 @@ func (v *vmService) GetRunningMigrationPods(migration *corev1.Migration) (*v1.Po
 	return podList, nil
 }
 
-func (v *vmService) StartMigration(migration *corev1.Migration, vm *corev1.VM, sourceNode *v1.Node, targetNode *v1.Node) error {
-	job, err := v.TemplateService.RenderMigrationJob(vm, sourceNode, targetNode)
+func (v *vmService) StartMigration(migration *corev1.Migration, vm *corev1.VM, sourceNode *v1.Node, targetNode *v1.Node, targetPod *v1.Pod) error {
+	job, err := v.TemplateService.RenderMigrationJob(vm, sourceNode, targetNode, targetPod)
 	job.ObjectMeta.Labels[corev1.MigrationLabel] = migration.GetObjectMeta().GetName()
 	job.ObjectMeta.Labels[corev1.MigrationUIDLabel] = string(migration.GetObjectMeta().GetUID())
 	if err != nil {

--- a/pkg/virt-controller/watch/pod.go
+++ b/pkg/virt-controller/watch/pod.go
@@ -153,7 +153,7 @@ func NewPodControllerFunc(vmCache cache.Store, restClient *rest.RESTClient, vmSe
 					return true
 				}
 
-				if err := vmService.StartMigration(migration, vmCopy, sourceNode, targetNode); err != nil {
+				if err := vmService.StartMigration(migration, vmCopy, sourceNode, targetNode, pod); err != nil {
 					logger.Error().Reason(err).Msg("Starting the migration job failed.")
 					queue.AddRateLimited(key)
 					return true

--- a/pkg/virt-controller/watch/pod_test.go
+++ b/pkg/virt-controller/watch/pod_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Pod", func() {
 			)
 
 			mockVMService.EXPECT().GetMigrationJob(gomock.Any()).Return(nil, false, nil)
-			mockVMService.EXPECT().StartMigration(gomock.Any(), gomock.Any(), &srcNode, &targetNode).Return(nil)
+			mockVMService.EXPECT().StartMigration(gomock.Any(), gomock.Any(), &srcNode, &targetNode, gomock.Any()).Return(nil)
 
 			// Tell the controller that there is a new running Pod
 			lw.Add(pod)


### PR DESCRIPTION
Switch to direct migration and make sure that we set the correct pod IP for spice connections for the migration. This ensures that libvirt knows where to forward active spice traffic during and after a migration.