### PR TITLE
[WIP] Connect VMs to Kubernetes network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
  - go get -u github.com/golang/mock/gomock
  - go get -u github.com/rmohr/mock/mockgen
  - go get -u github.com/rmohr/go-swagger-utils/swagger-doc
+ - go get -u github.com/ugorji/go/codec
  - sudo apt-get install libvirt-dev make
  - make sync
 

--- a/cluster/vagrant/calico-dhcp-agent.yaml
+++ b/cluster/vagrant/calico-dhcp-agent.yaml
@@ -1,0 +1,57 @@
+# This ConfigMap is used to configure a subnet in calico etcd store for calico-dhcp-agent.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: calico-dhcp-config
+data:
+  # This subnet configuration should be equal to the calico network configuration.
+  dhcp_subnet_config: |-
+    {
+        "cidr": "192.168.0.0/16",
+        "gateway_ip": "192.168.0.1",
+        "dns_servers": ["10.32.192.11"]
+    }
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-calico-dhcp
+spec:
+  template:
+    metadata:
+      name: configure-calico-dhcp
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: configure-calico-dhcp
+        image: sungwon/curl:latest
+        command: ["/start.sh"]
+        env:
+          - name: DHCP_SUBNET_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: calico-dhcp-config
+                key: dhcp_subnet_config
+
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: calico-dhcp-agent
+spec:
+  template:
+    metadata:
+      name: calico-dhcp-agent
+      labels:
+        daemon: calico-dhcp-agent
+    spec:
+      hostNetwork: true
+      containers:
+      - name: calico-dhcp-agent
+        image: sungwon/calico-dhcp-agent:latest
+        imagePullPolicy: Always
+        command: ["calico-dhcp-agent", "--config-file", "/etc/neutron/plugins/ml2/ml2.ini"]
+        securityContext:
+          privileged: true
+

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -29,6 +29,8 @@ kubectl -s 127.0.0.1:8080 -n kube-system get ds -l 'component=kube-proxy' -o jso
 
 if [ "$NETWORK_PROVIDER" == "weave" ]; then 
   kubectl apply -s 127.0.0.1:8080 -f https://github.com/weaveworks/weave/releases/download/v1.9.3/weave-daemonset.yaml
+elif [ "$NETWORK_PROVIDER" == "calico"]; then
+  kubectl apply -s 127.0.0.1:8080 -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 else
   kubectl create -s 127.0.0.1:8080 -f kube-$NETWORK_PROVIDER.yaml
 fi

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -21,16 +21,15 @@ done
 
 set -e
 
-# Work around https://github.com/kubernetes/kubernetes/issues/34101
-# Weave otherwise the network provider does not work
-kubectl -s 127.0.0.1:8080 -n kube-system get ds -l 'component=kube-proxy' -o json \
+if [ "$NETWORK_PROVIDER" == "weave" ]; then
+  # Work around https://github.com/kubernetes/kubernetes/issues/34101
+  # Weave otherwise the network provider does not work
+  kubectl -s 127.0.0.1:8080 -n kube-system get ds -l 'component=kube-proxy' -o json \
         | jq '.items[0].spec.template.spec.containers[0].command |= .+ ["--proxy-mode=userspace"]' \
-        |   kubectl -s 127.0.0.1:8080 apply -f - && kubectl -s 127.0.0.1:8080 -n kube-system delete pods -l 'component=kube-proxy'
-
-if [ "$NETWORK_PROVIDER" == "weave" ]; then 
+        |   kubectl -s 127.0.0.1:8080 apply -f - && kubectl -s 127.0.0.1:8080 -n kube-system delete pods -l 'component=kube-proxy' 
   kubectl apply -s 127.0.0.1:8080 -f https://github.com/weaveworks/weave/releases/download/v1.9.3/weave-daemonset.yaml
-elif [ "$NETWORK_PROVIDER" == "calico"]; then
-  kubectl apply -s 127.0.0.1:8080 -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+elif [ "$NETWORK_PROVIDER" == "calico" ]; then
+  kubectl apply -s 127.0.0.1:8080 -f http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
 else
   kubectl create -s 127.0.0.1:8080 -f kube-$NETWORK_PROVIDER.yaml
 fi

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -6,3 +6,5 @@ manifest_templates="`ls manifests/*.in`"
 master_ip=192.168.200.2
 master_port=8184
 network_provider=weave
+cni_bin_path=/opt/cni/bin
+cni_conf_path=/etc/cni/net.d

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -20,7 +20,6 @@ spec:
       - name: cni-bin-dir
         hostPath:
           path: /opt/cni/bin
-      hostNetwork: true
       containers:
       - name: virt-handler
         ports:

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -17,6 +17,10 @@ spec:
       - name: cni-net-dir
         hostPath:
           path: /etc/cni/net.d
+      - name: cni-bin-dir
+        hostPath:
+          path: /opt/cni/bin
+      hostNetwork: true
       containers:
       - name: virt-handler
         ports:
@@ -39,8 +43,14 @@ spec:
           mountPath: /var/run/libvirt
         - name: cni-net-dir
           mountPath: /etc/cni/net.d
+        - name: cni-bin-dir
+          mountPath: /opt/cni/bin
         env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: CNI_PATH
+            value: {{ cni_bin_path }}
+          - name: CNI_CONF
+            value: {{ cni_conf_path }}

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -14,6 +14,9 @@ spec:
       - name: var-run-virt
         hostPath:
           path: /var/run/libvirt
+      - name: cni-net-dir
+        hostPath:
+          path: /etc/cni/net.d
       containers:
       - name: virt-handler
         ports:
@@ -34,6 +37,8 @@ spec:
         volumeMounts:
         - name: var-run-virt
           mountPath: /var/run/libvirt
+        - name: cni-net-dir
+          mountPath: /etc/cni/net.d
         env:
           - name: NODE_NAME
             valueFrom:

--- a/pkg/virt-handler/network/network.go
+++ b/pkg/virt-handler/network/network.go
@@ -1,0 +1,319 @@
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/jeevatkm/go-model"
+	. "github.com/projectcalico/cni-plugin/utils"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/vishvananda/netlink"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/logging"
+)
+
+// This function creates a virtual interface on the Kubernetes cluster network
+// and binds the VM to it.
+func AddToNetwork(vm *v1.VM, namespace string) (*v1.VM, error) {
+	vmCopy := &v1.VM{}
+	model.Copy(vmCopy, vm)
+
+	for idx, iface := range vmCopy.Spec.Domain.Devices.Interfaces {
+		if iface.Type == "cni" {
+			logging.DefaultLogger().V(3).Info().Object(vm).Msg("Mapping Interface")
+
+			// Load a network configuration file
+			netConfDir := os.Getenv("CNI_CONF")
+			pluginDir := os.Getenv("CNI_PATH")
+
+			files, err := libcni.ConfFiles(netConfDir)
+			switch {
+			case err != nil:
+				return vm, err
+			case len(files) == 0:
+				return vm, fmt.Errorf("No networks found in %s", netConfDir)
+			}
+			sort.Strings(files)
+			for _, file := range files {
+				conf, err := libcni.ConfFromFile(file)
+				if err != nil {
+					return vm, fmt.Errorf("Error loading CNI config file %s: %v", file, err)
+				}
+
+				logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
+
+				// network plugin specific code
+				switch conf.Network.Type {
+				case "calico":
+					workload := vmCopy.Spec.Domain.Name
+					orchestrator := "k8s"
+					hostname, _ := os.Hostname()
+
+					logger := CreateContextLogger(workload)
+
+					// Get an IP address from calico-ipam
+					// Collect the result in this variable - this is ultimately what gets "returned" by this function by printing
+					// it to stdout.
+					var result *types.Result
+
+					// Set env variables to call calico-ipam
+					os.Setenv("CNI_COMMAND", "ADD")
+					os.Setenv("CNI_NETNS", "nil")
+					os.Setenv("CNI_IFNAME", "nil")
+					cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
+					os.Setenv("CNI_ARGS", cniArgs)
+
+					result, err = ipam.ExecAdd(conf.Network.IPAM.Type, conf.Bytes)
+					if err != nil {
+						return vm, err
+					}
+					logging.DefaultLogger().Object(vm).Info().Msgf("Got result from IPAM plugin: %v", result)
+
+					cniConf := NetConf{}
+					if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
+						return vm, fmt.Errorf("failed to load netconf: %v", err)
+					}
+
+					calicoClient, err := CreateClient(cniConf)
+					if err != nil {
+						return vm, err
+					}
+
+					// Create the endpoint object and configure it.
+					var endpoint *api.WorkloadEndpoint
+					endpoint = api.NewWorkloadEndpoint()
+					endpoint.Metadata.Name = "eth0"
+					endpoint.Metadata.Node = hostname
+					endpoint.Metadata.Orchestrator = orchestrator
+					endpoint.Metadata.Workload = workload
+					//endpoint.Metadata.Labels = labels
+
+					// Set the profileID according to whether Kubernetes policy is required.
+					// If it's not, then just use the network name (which is the normal behavior)
+					// otherwise use one based on the Kubernetes pod's Namespace.
+					if cniConf.Policy.PolicyType == "k8s" {
+						endpoint.Spec.Profiles = []string{fmt.Sprintf("k8s_ns.%s", namespace)}
+					} else {
+						endpoint.Spec.Profiles = []string{cniConf.Name}
+					}
+
+					// Populate the endpoint with the output from the IPAM plugin.
+					if err = PopulateEndpointNets(endpoint, result); err != nil {
+						// Cleanup IP allocation and return the error.
+						ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
+						return vm, err
+					}
+					logging.DefaultLogger().Object(vm).Info().Msgf("Populated endpoint: %v", endpoint)
+
+					// create a tap device
+					//nameTemplate := fmt.Sprintf("tap-%s-%%d", vmCopy.Spec.Domain.UUID[0:8])
+					//ifName, err := tuntap.CreatePersistentIface(nameTemplate, tuntap.Tap)
+					ifName := fmt.Sprintf("tap-%s", vmCopy.Spec.Domain.UUID[0:8])
+					tap := &netlink.Tuntap{
+						LinkAttrs: netlink.LinkAttrs{Name: ifName},
+						Mode:      netlink.TUNTAP_MODE_TAP,
+					}
+					if err := netlink.LinkAdd(tap); err != nil {
+						return vm, fmt.Errorf("Failed to create a tap device: %v", err)
+					}
+					//if err != nil {
+					//	return vm, fmt.Errorf("Failed to create a tap device: %v", err)
+					//}
+
+					link, err := netlink.LinkByName(ifName)
+					if err != nil {
+						return vm, fmt.Errorf("cannot find link %q", ifName)
+					}
+					logging.DefaultLogger().Object(vm).Info().Msgf("Link(tap) %v created", link)
+
+					if err = netlink.LinkSetUp(link); err != nil {
+						return nil, fmt.Errorf("cannot set link up %q", ifName)
+					}
+
+					// From calico endpoint manager
+					//(https://github.com/projectcalico/felix/blob/master/intdataplane/endpoint_mgr.go)
+					// Enable strict reverse-path filtering.  This prevents a workload from spoofing its
+					// IP address.  Non-privileged containers have additional anti-spoofing protection
+					// but VM workloads, for example, can easily spoof their IP.
+					err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", ifName), "1")
+					if err != nil {
+						return vm, err
+					}
+					// Enable routing to localhost.  This is required to allow for NAT to the local
+					// host.
+					err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/route_localnet", ifName), "1")
+					if err != nil {
+						return vm, err
+					}
+					// Enable proxy ARP, this makes the host respond to all ARP requests with its own
+					// MAC.  This has a couple of advantages:
+					//
+					// - In OpenStack, we're forced to configure the guest's networking using DHCP.
+					//   Since DHCP requires a subnet and gateway, representing the Calico network
+					//   in the natural way would lose a lot of IP addresses.  For IPv4, we'd have to
+					//   advertise a distinct /30 to each guest, which would use up 4 IPs per guest.
+					//   Using proxy ARP, we can advertise the whole pool to each guest as its subnet
+					//   but have the host respond to all ARP requests and route all the traffic whether
+					//   it is on or off subnet.
+					//
+					// - For containers, we install explicit routes into the containers network
+					//   namespace and we use a link-local address for the gateway.  Turing on proxy ARP
+					//   means that we don't need to assign the link local address explicitly to each
+					//   host side of the veth, which is one fewer thing to maintain and one fewer
+					//   thing we may clash over.
+					err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", ifName), "1")
+					if err != nil {
+						return vm, err
+					}
+					// Normally, the kernel has a delay before responding to proxy ARP but we know
+					// that's not needed in a Calico network so we disable it.
+					err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", ifName), "0")
+					if err != nil {
+						return vm, err
+					}
+					// Enable IP forwarding of packets coming _from_ this interface.  For packets to
+					// be forwarded in both directions we need this flag to be set on the fabric-facing
+					// interface too (or for the global default to be set).
+					err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", ifName), "1")
+					if err != nil {
+						return vm, err
+					}
+
+					mac := link.Attrs().HardwareAddr
+					endpoint.Spec.MAC = &cnet.MAC{HardwareAddr: mac}
+					endpoint.Spec.InterfaceName = ifName
+					logger.WithField("endpoint", endpoint).Info("Added Mac and interface name to endpoint")
+
+					// Write the endpoint object (either the newly created one, or the updated one)
+					if _, err := calicoClient.WorkloadEndpoints().Apply(endpoint); err != nil {
+						// Cleanup IP allocation and return the error.
+						ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
+						return vm, err
+					}
+					logger.Info("Wrote updated endpoint to datastore")
+
+					logging.DefaultLogger().Object(vm).Info().Msgf("Mapping %s", ifName)
+					newIface := v1.Interface{}
+
+					newIface.Type = "ethernet"
+					newIface.MAC = new(v1.MAC)
+					newIface.MAC.MAC = mac.String()
+					newIface.Target = new(v1.InterfaceTarget)
+					newIface.Target.Device = ifName
+					newIface.Model = new(v1.Model)
+					newIface.Model.Type = "virtio"
+
+					vmCopy.Spec.Domain.Devices.Interfaces[idx] = newIface
+					return vmCopy, nil
+				}
+			}
+			return vm, fmt.Errorf("No %s network provider found in %s", iface.Source.Network, pluginDir)
+		}
+	}
+	return vmCopy, nil
+}
+
+func DeleteFromNetwork(vm *v1.VM, namespace string) error {
+	netConfDir := os.Getenv("CNI_CONF")
+	files, err := libcni.ConfFiles(netConfDir)
+	switch {
+	case err != nil:
+		return err
+	case len(files) == 0:
+		return fmt.Errorf("No networks found in %s", netConfDir)
+	}
+	sort.Strings(files)
+	for _, file := range files {
+		conf, err := libcni.ConfFromFile(file)
+		if err != nil {
+			return fmt.Errorf("Error loading CNI config file %s: %v", file, err)
+		}
+
+		logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
+
+		// network plugin specific code
+		switch conf.Network.Type {
+		case "calico":
+			// Release IP address
+			workload := vm.GetObjectMeta().GetName()
+			logging.DefaultLogger().Object(vm).Info().Msgf("VM spec when del %+v", vm.GetObjectMeta())
+			orchestrator := "k8s"
+			hostname, _ := os.Hostname()
+			os.Setenv("CNI_COMMAND", "DEL")
+			os.Setenv("CNI_NETNS", "nil")
+			os.Setenv("CNI_IFNAME", "nil")
+			cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
+			os.Setenv("CNI_ARGS", cniArgs)
+
+			ipamErr := ipam.ExecDel(conf.Network.IPAM.Type, conf.Bytes)
+
+			if ipamErr != nil {
+				logging.DefaultLogger().Object(vm).Info().Msgf("IPAM error %v", ipamErr)
+			}
+
+			cniConf := NetConf{}
+			if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
+				return fmt.Errorf("failed to load netconf: %v", err)
+			}
+			calicoClient, err := CreateClient(cniConf)
+			if err != nil {
+				return err
+			}
+
+			// Get tap interface name
+			endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{
+				Node:         hostname,
+				Orchestrator: orchestrator,
+				Workload:     workload})
+			if err != nil {
+				return err
+			}
+
+			if len(endpoints.Items) == 1 {
+				var endpoint *api.WorkloadEndpoint
+				endpoint = &endpoints.Items[0]
+				// Delete tap interface
+				//tuntap.RemovePersistentIface(endpoint.Spec.InterfaceName, tuntap.Tap)
+				link, err := netlink.LinkByName(endpoint.Spec.InterfaceName)
+				if err != nil {
+					return fmt.Errorf("cannot find link %q", endpoint.Spec.InterfaceName)
+				}
+				netlink.LinkDel(link)
+			}
+
+			// Delete endpoint in calico data store
+			if err := calicoClient.WorkloadEndpoints().Delete(api.WorkloadEndpointMetadata{
+				Name:         "eth0",
+				Node:         hostname,
+				Orchestrator: orchestrator,
+				Workload:     workload}); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func writeProcSys(path, value string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write([]byte(value))
+	if err == nil && n < len(value) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
+}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -259,109 +259,113 @@ func MapInterfaces(vm *v1.VM, namespace string) (*v1.VM, error) {
 
 				logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
 
-				workload := vmCopy.Spec.Domain.Name
-				orchestrator := "k8s"
-				hostname, _ := os.Hostname()
+				// network plugin specific code
+				switch conf.Network.Type {
+				case "calico":
+					workload := vmCopy.Spec.Domain.Name
+					orchestrator := "k8s"
+					hostname, _ := os.Hostname()
 
-				logger := CreateContextLogger(workload)
+					logger := CreateContextLogger(workload)
 
-				// Get an IP address from calico-ipam
-				// Collect the result in this variable - this is ultimately what gets "returned" by this function by printing
-				// it to stdout.
-				var result *types.Result
+					// Get an IP address from calico-ipam
+					// Collect the result in this variable - this is ultimately what gets "returned" by this function by printing
+					// it to stdout.
+					var result *types.Result
 
-				// Set env variables to call calico-ipam
-				os.Setenv("CNI_COMMAND", "ADD")
-				os.Setenv("CNI_NETNS", "nil")
-				os.Setenv("CNI_IFNAME", "nil")
-				cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
-				os.Setenv("CNI_ARGS", cniArgs)
+					// Set env variables to call calico-ipam
+					os.Setenv("CNI_COMMAND", "ADD")
+					os.Setenv("CNI_NETNS", "nil")
+					os.Setenv("CNI_IFNAME", "nil")
+					cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
+					os.Setenv("CNI_ARGS", cniArgs)
 
-				result, err = ipam.ExecAdd(conf.Network.IPAM.Type, conf.Bytes)
-				if err != nil {
-					return vm, err
+					result, err = ipam.ExecAdd(conf.Network.IPAM.Type, conf.Bytes)
+					if err != nil {
+						return vm, err
+					}
+					logging.DefaultLogger().Object(vm).Info().Msgf("Got result from IPAM plugin: %v", result)
+
+					cniConf := NetConf{}
+					if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
+						return vm, fmt.Errorf("failed to load netconf: %v", err)
+					}
+
+					calicoClient, err := CreateClient(cniConf)
+					if err != nil {
+						return vm, err
+					}
+
+					// Create the endpoint object and configure it.
+					var endpoint *api.WorkloadEndpoint
+					endpoint = api.NewWorkloadEndpoint()
+					endpoint.Metadata.Name = "eth0"
+					endpoint.Metadata.Node = hostname
+					endpoint.Metadata.Orchestrator = orchestrator
+					endpoint.Metadata.Workload = workload
+					//endpoint.Metadata.Labels = labels
+
+					// Set the profileID according to whether Kubernetes policy is required.
+					// If it's not, then just use the network name (which is the normal behavior)
+					// otherwise use one based on the Kubernetes pod's Namespace.
+					if cniConf.Policy.PolicyType == "k8s" {
+						endpoint.Spec.Profiles = []string{fmt.Sprintf("k8s_ns.%s", namespace)}
+					} else {
+						endpoint.Spec.Profiles = []string{cniConf.Name}
+					}
+
+					// Populate the endpoint with the output from the IPAM plugin.
+					if err = PopulateEndpointNets(endpoint, result); err != nil {
+						// Cleanup IP allocation and return the error.
+						ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
+						return vm, err
+					}
+					logging.DefaultLogger().Object(vm).Info().Msgf("Populated endpoint: %v", endpoint)
+
+					// create a tap device
+					nameTemplate := fmt.Sprintf("tap-%s-%%d", vmCopy.Spec.Domain.UUID[0:8])
+					ifName, err := tuntap.CreatePersistentIface(nameTemplate, tuntap.Tap)
+					if err != nil {
+						return vm, fmt.Errorf("Failed to create a tap device: %v", err)
+					}
+
+					link, err := netlink.LinkByName(ifName)
+					if err != nil {
+						return vm, fmt.Errorf("cannot find link %q", ifName)
+					}
+					logging.DefaultLogger().Object(vm).Info().Msgf("Link(tap) %v created", link)
+
+					if err = netlink.LinkSetUp(link); err != nil {
+						return nil, fmt.Errorf("cannot set link up %q", ifName)
+					}
+
+					mac := link.Attrs().HardwareAddr
+					endpoint.Spec.MAC = &cnet.MAC{HardwareAddr: mac}
+					endpoint.Spec.InterfaceName = ifName
+					logger.WithField("endpoint", endpoint).Info("Added Mac and interface name to endpoint")
+
+					// Write the endpoint object (either the newly created one, or the updated one)
+					if _, err := calicoClient.WorkloadEndpoints().Apply(endpoint); err != nil {
+						// Cleanup IP allocation and return the error.
+						ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
+						return vm, err
+					}
+					logger.Info("Wrote updated endpoint to datastore")
+
+					logging.DefaultLogger().Object(vm).Info().Msgf("Mapping %s", ifName)
+					newIface := v1.Interface{}
+
+					newIface.Type = "ethernet"
+					newIface.MAC = new(v1.MAC)
+					newIface.MAC.MAC = mac.String()
+					newIface.Target = new(v1.InterfaceTarget)
+					newIface.Target.Device = ifName
+					newIface.Model = new(v1.Model)
+					newIface.Model.Type = "virtio"
+
+					vmCopy.Spec.Domain.Devices.Interfaces[idx] = newIface
+					return vmCopy, nil
 				}
-				logging.DefaultLogger().Object(vm).Info().Msgf("Got result from IPAM plugin: %v", result)
-
-				cniConf := NetConf{}
-				if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
-					return vm, fmt.Errorf("failed to load netconf: %v", err)
-				}
-
-				calicoClient, err := CreateClient(cniConf)
-				if err != nil {
-					return vm, err
-				}
-
-				// Create the endpoint object and configure it.
-				var endpoint *api.WorkloadEndpoint
-				endpoint = api.NewWorkloadEndpoint()
-				endpoint.Metadata.Name = "eth0"
-				endpoint.Metadata.Node = hostname
-				endpoint.Metadata.Orchestrator = orchestrator
-				endpoint.Metadata.Workload = workload
-				//endpoint.Metadata.Labels = labels
-
-				// Set the profileID according to whether Kubernetes policy is required.
-				// If it's not, then just use the network name (which is the normal behavior)
-				// otherwise use one based on the Kubernetes pod's Namespace.
-				if cniConf.Policy.PolicyType == "k8s" {
-					endpoint.Spec.Profiles = []string{fmt.Sprintf("k8s_ns.%s", namespace)}
-				} else {
-					endpoint.Spec.Profiles = []string{cniConf.Name}
-				}
-
-				// Populate the endpoint with the output from the IPAM plugin.
-				if err = PopulateEndpointNets(endpoint, result); err != nil {
-					// Cleanup IP allocation and return the error.
-					ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
-					return vm, err
-				}
-				logging.DefaultLogger().Object(vm).Info().Msgf("Populated endpoint: %v", endpoint)
-
-				// create a tap device
-				nameTemplate := fmt.Sprintf("tap-%s-%%d", vmCopy.Spec.Domain.UUID[0:8])
-				ifName, err := tuntap.CreatePersistentIface(nameTemplate, tuntap.Tap)
-				if err != nil {
-					return vm, fmt.Errorf("Failed to create a tap device: %v", err)
-				}
-
-				link, err := netlink.LinkByName(ifName)
-				if err != nil {
-					return vm, fmt.Errorf("cannot find link %q", ifName)
-				}
-				logging.DefaultLogger().Object(vm).Info().Msgf("Link(tap) %v created", link)
-
-				if err = netlink.LinkSetUp(link); err != nil {
-					return nil, fmt.Errorf("cannot set link up %q", ifName)
-				}
-
-				mac := link.Attrs().HardwareAddr
-				endpoint.Spec.MAC = &cnet.MAC{HardwareAddr: mac}
-				endpoint.Spec.InterfaceName = ifName
-				logger.WithField("endpoint", endpoint).Info("Added Mac and interface name to endpoint")
-
-				// Write the endpoint object (either the newly created one, or the updated one)
-				if _, err := calicoClient.WorkloadEndpoints().Apply(endpoint); err != nil {
-					// Cleanup IP allocation and return the error.
-					ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
-					return vm, err
-				}
-				logger.Info("Wrote updated endpoint to datastore")
-
-				logging.DefaultLogger().Object(vm).Info().Msgf("Mapping %s", ifName)
-				newIface := v1.Interface{}
-
-				newIface.Type = "ethernet"
-				newIface.MAC = new(v1.MAC)
-				newIface.MAC.MAC = mac.String()
-				newIface.Target = new(v1.InterfaceTarget)
-				newIface.Target.Device = ifName
-				newIface.Model = new(v1.Model)
-				newIface.Model.Type = "virtio"
-
-				vmCopy.Spec.Domain.Devices.Interfaces[idx] = newIface
-				return vmCopy, nil
 			}
 			return vm, fmt.Errorf("No %s network provider found in %s", iface.Source.Network, pluginDir)
 		}
@@ -387,55 +391,60 @@ func DeleteInterfaces(vm *v1.VM, namespace string) error {
 
 		logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
 
-		// Release IP address
-		workload := vm.GetObjectMeta().GetName()
-		logging.DefaultLogger().Object(vm).Info().Msgf("VM spec when del %+v", vm.GetObjectMeta())
-		orchestrator := "k8s"
-		hostname, _ := os.Hostname()
-		os.Setenv("CNI_COMMAND", "DEL")
-		os.Setenv("CNI_NETNS", "nil")
-		os.Setenv("CNI_IFNAME", "nil")
-		cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
-		os.Setenv("CNI_ARGS", cniArgs)
+		// network plugin specific code
+		switch conf.Network.Type {
+		case "calico":
+			// Release IP address
+			workload := vm.GetObjectMeta().GetName()
+			logging.DefaultLogger().Object(vm).Info().Msgf("VM spec when del %+v", vm.GetObjectMeta())
+			orchestrator := "k8s"
+			hostname, _ := os.Hostname()
+			os.Setenv("CNI_COMMAND", "DEL")
+			os.Setenv("CNI_NETNS", "nil")
+			os.Setenv("CNI_IFNAME", "nil")
+			cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
+			os.Setenv("CNI_ARGS", cniArgs)
 
-		ipamErr := ipam.ExecDel(conf.Network.IPAM.Type, conf.Bytes)
+			ipamErr := ipam.ExecDel(conf.Network.IPAM.Type, conf.Bytes)
 
-		if ipamErr != nil {
-			logging.DefaultLogger().Object(vm).Info().Msgf("IPAM error %v", ipamErr)
-		}
+			if ipamErr != nil {
+				logging.DefaultLogger().Object(vm).Info().Msgf("IPAM error %v", ipamErr)
+			}
 
-		cniConf := NetConf{}
-		if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
-			return fmt.Errorf("failed to load netconf: %v", err)
-		}
-		calicoClient, err := CreateClient(cniConf)
-		if err != nil {
-			return err
-		}
+			cniConf := NetConf{}
+			if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
+				return fmt.Errorf("failed to load netconf: %v", err)
+			}
+			calicoClient, err := CreateClient(cniConf)
+			if err != nil {
+				return err
+			}
 
-		// Get tap interface name
-		endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{
-			Node:         hostname,
-			Orchestrator: orchestrator,
-			Workload:     workload})
-		if err != nil {
-			return err
-		}
+			// Get tap interface name
+			endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{
+				Node:         hostname,
+				Orchestrator: orchestrator,
+				Workload:     workload})
+			if err != nil {
+				return err
+			}
 
-		if len(endpoints.Items) == 1 {
-			var endpoint *api.WorkloadEndpoint
-			endpoint = &endpoints.Items[0]
-			// Delete tap interface
-			tuntap.RemovePersistentIface(endpoint.Spec.InterfaceName, tuntap.Tap)
-		}
+			if len(endpoints.Items) == 1 {
+				var endpoint *api.WorkloadEndpoint
+				endpoint = &endpoints.Items[0]
+				// Delete tap interface
+				tuntap.RemovePersistentIface(endpoint.Spec.InterfaceName, tuntap.Tap)
+			}
 
-		// Delete endpoint in calico data store
-		if err := calicoClient.WorkloadEndpoints().Delete(api.WorkloadEndpointMetadata{
-			Name:         "eth0",
-			Node:         hostname,
-			Orchestrator: orchestrator,
-			Workload:     workload}); err != nil {
-			return err
+			// Delete endpoint in calico data store
+			if err := calicoClient.WorkloadEndpoints().Delete(api.WorkloadEndpointMetadata{
+				Name:         "eth0",
+				Node:         hostname,
+				Orchestrator: orchestrator,
+				Workload:     workload}); err != nil {
+				return err
+			}
+			return nil
 		}
 	}
 	return nil

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1,11 +1,22 @@
 package virthandler
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"sort"
 	"strings"
 
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/coreos/rkt/networking/tuntap"
 	"github.com/jeevatkm/go-model"
+	. "github.com/projectcalico/cni-plugin/utils"
+	"github.com/projectcalico/libcalico-go/lib/api"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/vishvananda/netlink"
 	"k8s.io/client-go/kubernetes"
 	kubeapi "k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/errors"
@@ -89,6 +100,7 @@ func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimit
 			queue.AddRateLimited(key)
 			return
 		}
+<<<<<<< 8f5c4f8e474e665696dd1a0f5d9d7b4dfbbb4ca4
 		// The VM is deleted on the cluster, let's go on with the deletion on the host
 	} else {
 		vm = obj.(*v1.VM)
@@ -98,10 +110,15 @@ func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimit
 	// Process the VM
 	if !exists {
 		// Since the VM was not in the cache, we delete it
+		DeleteInterfaces(vm, kubeapi.NamespaceDefault)
 		err = d.domainManager.KillVM(vm)
 	} else if isWorthSyncing(vm) {
 		// Synchronize the VM state
 		vm, err = MapPersistentVolumes(vm, d.clientset.CoreV1().RESTClient(), kubeapi.NamespaceDefault)
+
+		if err == nil {
+				vm, err = MapInterfaces(vm, kubeapi.NamespaceDefault)
+		}
 
 		if err == nil {
 			// TODO check if found VM has the same UID like the domain, if not, delete the Domain first
@@ -207,6 +224,219 @@ func MapPersistentVolumes(vm *v1.VM, restClient cache.Getter, namespace string) 
 	return vmCopy, nil
 }
 
+
 func isWorthSyncing(vm *v1.VM) bool {
 	return vm.Status.Phase != v1.Succeeded && vm.Status.Phase != v1.Failed
+}
+
+// This function creates a virtual interface on the Kubernetes cluster network
+// and binds the VM to it.
+func MapInterfaces(vm *v1.VM, namespace string) (*v1.VM, error) {
+	vmCopy := &v1.VM{}
+	model.Copy(vmCopy, vm)
+
+	for idx, iface := range vmCopy.Spec.Domain.Devices.Interfaces {
+		if iface.Type == "cni" {
+			logging.DefaultLogger().V(3).Info().Object(vm).Msg("Mapping Interface")
+
+			// Load a network configuration file
+			netConfDir := os.Getenv("CNI_CONF")
+			pluginDir := os.Getenv("CNI_PATH")
+
+			files, err := libcni.ConfFiles(netConfDir)
+			switch {
+			case err != nil:
+				return vm, err
+			case len(files) == 0:
+				return vm, fmt.Errorf("No networks found in %s", netConfDir)
+			}
+			sort.Strings(files)
+			for _, file := range files {
+				conf, err := libcni.ConfFromFile(file)
+				if err != nil {
+					return vm, fmt.Errorf("Error loading CNI config file %s: %v", file, err)
+				}
+
+				logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
+
+				workload := vmCopy.Spec.Domain.Name
+				orchestrator := "k8s"
+				hostname, _ := os.Hostname()
+
+				logger := CreateContextLogger(workload)
+
+				// Get an IP address from calico-ipam
+				// Collect the result in this variable - this is ultimately what gets "returned" by this function by printing
+				// it to stdout.
+				var result *types.Result
+
+				// Set env variables to call calico-ipam
+				os.Setenv("CNI_COMMAND", "ADD")
+				os.Setenv("CNI_NETNS", "nil")
+				os.Setenv("CNI_IFNAME", "nil")
+				cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
+				os.Setenv("CNI_ARGS", cniArgs)
+
+				result, err = ipam.ExecAdd(conf.Network.IPAM.Type, conf.Bytes)
+				if err != nil {
+					return vm, err
+				}
+				logging.DefaultLogger().Object(vm).Info().Msgf("Got result from IPAM plugin: %v", result)
+
+				cniConf := NetConf{}
+				if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
+					return vm, fmt.Errorf("failed to load netconf: %v", err)
+				}
+
+				calicoClient, err := CreateClient(cniConf)
+				if err != nil {
+					return vm, err
+				}
+
+				// Create the endpoint object and configure it.
+				var endpoint *api.WorkloadEndpoint
+				endpoint = api.NewWorkloadEndpoint()
+				endpoint.Metadata.Name = "eth0"
+				endpoint.Metadata.Node = hostname
+				endpoint.Metadata.Orchestrator = orchestrator
+				endpoint.Metadata.Workload = workload
+				//endpoint.Metadata.Labels = labels
+
+				// Set the profileID according to whether Kubernetes policy is required.
+				// If it's not, then just use the network name (which is the normal behavior)
+				// otherwise use one based on the Kubernetes pod's Namespace.
+				if cniConf.Policy.PolicyType == "k8s" {
+					endpoint.Spec.Profiles = []string{fmt.Sprintf("k8s_ns.%s", namespace)}
+				} else {
+					endpoint.Spec.Profiles = []string{cniConf.Name}
+				}
+
+				// Populate the endpoint with the output from the IPAM plugin.
+				if err = PopulateEndpointNets(endpoint, result); err != nil {
+					// Cleanup IP allocation and return the error.
+					ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
+					return vm, err
+				}
+				logging.DefaultLogger().Object(vm).Info().Msgf("Populated endpoint: %v", endpoint)
+
+				// create a tap device
+				nameTemplate := fmt.Sprintf("tap-%s-%%d", vmCopy.Spec.Domain.UUID[0:8])
+				ifName, err := tuntap.CreatePersistentIface(nameTemplate, tuntap.Tap)
+				if err != nil {
+					return vm, fmt.Errorf("Failed to create a tap device: %v", err)
+				}
+
+				link, err := netlink.LinkByName(ifName)
+				if err != nil {
+					return vm, fmt.Errorf("cannot find link %q", ifName)
+				}
+				logging.DefaultLogger().Object(vm).Info().Msgf("Link(tap) %v created", link)
+
+				if err = netlink.LinkSetUp(link); err != nil {
+					return nil, fmt.Errorf("cannot set link up %q", ifName)
+				}
+
+				mac := link.Attrs().HardwareAddr
+				endpoint.Spec.MAC = &cnet.MAC{HardwareAddr: mac}
+				endpoint.Spec.InterfaceName = ifName
+				logger.WithField("endpoint", endpoint).Info("Added Mac and interface name to endpoint")
+
+				// Write the endpoint object (either the newly created one, or the updated one)
+				if _, err := calicoClient.WorkloadEndpoints().Apply(endpoint); err != nil {
+					// Cleanup IP allocation and return the error.
+					ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
+					return vm, err
+				}
+				logger.Info("Wrote updated endpoint to datastore")
+
+				logging.DefaultLogger().Object(vm).Info().Msgf("Mapping %s", ifName)
+				newIface := v1.Interface{}
+
+				newIface.Type = "ethernet"
+				newIface.MAC = new(v1.MAC)
+				newIface.MAC.MAC = mac.String()
+				newIface.Target = new(v1.InterfaceTarget)
+				newIface.Target.Device = ifName
+				newIface.Model = new(v1.Model)
+				newIface.Model.Type = "virtio"
+
+				vmCopy.Spec.Domain.Devices.Interfaces[idx] = newIface
+				return vmCopy, nil
+			}
+			return vm, fmt.Errorf("No %s network provider found in %s", iface.Source.Network, pluginDir)
+		}
+	}
+	return vmCopy, nil
+}
+
+func DeleteInterfaces(vm *v1.VM, namespace string) error {
+	netConfDir := os.Getenv("CNI_CONF")
+	files, err := libcni.ConfFiles(netConfDir)
+	switch {
+	case err != nil:
+		return err
+	case len(files) == 0:
+		return fmt.Errorf("No networks found in %s", netConfDir)
+	}
+	sort.Strings(files)
+	for _, file := range files {
+		conf, err := libcni.ConfFromFile(file)
+		if err != nil {
+			return fmt.Errorf("Error loading CNI config file %s: %v", file, err)
+		}
+
+		logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
+
+		// Release IP address
+		workload := vm.GetObjectMeta().GetName()
+		logging.DefaultLogger().Object(vm).Info().Msgf("VM spec when del %+v", vm.GetObjectMeta())
+		orchestrator := "k8s"
+		hostname, _ := os.Hostname()
+		os.Setenv("CNI_COMMAND", "DEL")
+		os.Setenv("CNI_NETNS", "nil")
+		os.Setenv("CNI_IFNAME", "nil")
+		cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
+		os.Setenv("CNI_ARGS", cniArgs)
+
+		ipamErr := ipam.ExecDel(conf.Network.IPAM.Type, conf.Bytes)
+
+		if ipamErr != nil {
+			logging.DefaultLogger().Object(vm).Info().Msgf("IPAM error %v", ipamErr)
+		}
+
+		cniConf := NetConf{}
+		if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
+			return fmt.Errorf("failed to load netconf: %v", err)
+		}
+		calicoClient, err := CreateClient(cniConf)
+		if err != nil {
+			return err
+		}
+
+		// Get tap interface name
+		endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{
+			Node:         hostname,
+			Orchestrator: orchestrator,
+			Workload:     workload})
+		if err != nil {
+			return err
+		}
+
+		if len(endpoints.Items) == 1 {
+			var endpoint *api.WorkloadEndpoint
+			endpoint = &endpoints.Items[0]
+			// Delete tap interface
+			tuntap.RemovePersistentIface(endpoint.Spec.InterfaceName, tuntap.Tap)
+		}
+
+		// Delete endpoint in calico data store
+		if err := calicoClient.WorkloadEndpoints().Delete(api.WorkloadEndpointMetadata{
+			Name:         "eth0",
+			Node:         hostname,
+			Orchestrator: orchestrator,
+			Workload:     workload}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1,22 +1,11 @@
 package virthandler
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
-	"sort"
 	"strings"
 
-	"github.com/containernetworking/cni/libcni"
-	"github.com/containernetworking/cni/pkg/ipam"
-	"github.com/containernetworking/cni/pkg/types"
-	"github.com/coreos/rkt/networking/tuntap"
 	"github.com/jeevatkm/go-model"
-	. "github.com/projectcalico/cni-plugin/utils"
-	"github.com/projectcalico/libcalico-go/lib/api"
-	cnet "github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/vishvananda/netlink"
 	"k8s.io/client-go/kubernetes"
 	kubeapi "k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/errors"
@@ -29,6 +18,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/virt-handler/network"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 )
 
@@ -100,7 +90,6 @@ func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimit
 			queue.AddRateLimited(key)
 			return
 		}
-<<<<<<< 8f5c4f8e474e665696dd1a0f5d9d7b4dfbbb4ca4
 		// The VM is deleted on the cluster, let's go on with the deletion on the host
 	} else {
 		vm = obj.(*v1.VM)
@@ -110,14 +99,14 @@ func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimit
 	// Process the VM
 	if !exists {
 		// Since the VM was not in the cache, we delete it
-		DeleteInterfaces(vm, kubeapi.NamespaceDefault)
+		network.DeleteFromNetwork(vm, kubeapi.NamespaceDefault)
 		err = d.domainManager.KillVM(vm)
 	} else if isWorthSyncing(vm) {
 		// Synchronize the VM state
 		vm, err = MapPersistentVolumes(vm, d.clientset.CoreV1().RESTClient(), kubeapi.NamespaceDefault)
 
 		if err == nil {
-				vm, err = MapInterfaces(vm, kubeapi.NamespaceDefault)
+			vm, err = network.AddToNetwork(vm, kubeapi.NamespaceDefault)
 		}
 
 		if err == nil {
@@ -224,228 +213,6 @@ func MapPersistentVolumes(vm *v1.VM, restClient cache.Getter, namespace string) 
 	return vmCopy, nil
 }
 
-
 func isWorthSyncing(vm *v1.VM) bool {
 	return vm.Status.Phase != v1.Succeeded && vm.Status.Phase != v1.Failed
-}
-
-// This function creates a virtual interface on the Kubernetes cluster network
-// and binds the VM to it.
-func MapInterfaces(vm *v1.VM, namespace string) (*v1.VM, error) {
-	vmCopy := &v1.VM{}
-	model.Copy(vmCopy, vm)
-
-	for idx, iface := range vmCopy.Spec.Domain.Devices.Interfaces {
-		if iface.Type == "cni" {
-			logging.DefaultLogger().V(3).Info().Object(vm).Msg("Mapping Interface")
-
-			// Load a network configuration file
-			netConfDir := os.Getenv("CNI_CONF")
-			pluginDir := os.Getenv("CNI_PATH")
-
-			files, err := libcni.ConfFiles(netConfDir)
-			switch {
-			case err != nil:
-				return vm, err
-			case len(files) == 0:
-				return vm, fmt.Errorf("No networks found in %s", netConfDir)
-			}
-			sort.Strings(files)
-			for _, file := range files {
-				conf, err := libcni.ConfFromFile(file)
-				if err != nil {
-					return vm, fmt.Errorf("Error loading CNI config file %s: %v", file, err)
-				}
-
-				logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
-
-				// network plugin specific code
-				switch conf.Network.Type {
-				case "calico":
-					workload := vmCopy.Spec.Domain.Name
-					orchestrator := "k8s"
-					hostname, _ := os.Hostname()
-
-					logger := CreateContextLogger(workload)
-
-					// Get an IP address from calico-ipam
-					// Collect the result in this variable - this is ultimately what gets "returned" by this function by printing
-					// it to stdout.
-					var result *types.Result
-
-					// Set env variables to call calico-ipam
-					os.Setenv("CNI_COMMAND", "ADD")
-					os.Setenv("CNI_NETNS", "nil")
-					os.Setenv("CNI_IFNAME", "nil")
-					cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
-					os.Setenv("CNI_ARGS", cniArgs)
-
-					result, err = ipam.ExecAdd(conf.Network.IPAM.Type, conf.Bytes)
-					if err != nil {
-						return vm, err
-					}
-					logging.DefaultLogger().Object(vm).Info().Msgf("Got result from IPAM plugin: %v", result)
-
-					cniConf := NetConf{}
-					if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
-						return vm, fmt.Errorf("failed to load netconf: %v", err)
-					}
-
-					calicoClient, err := CreateClient(cniConf)
-					if err != nil {
-						return vm, err
-					}
-
-					// Create the endpoint object and configure it.
-					var endpoint *api.WorkloadEndpoint
-					endpoint = api.NewWorkloadEndpoint()
-					endpoint.Metadata.Name = "eth0"
-					endpoint.Metadata.Node = hostname
-					endpoint.Metadata.Orchestrator = orchestrator
-					endpoint.Metadata.Workload = workload
-					//endpoint.Metadata.Labels = labels
-
-					// Set the profileID according to whether Kubernetes policy is required.
-					// If it's not, then just use the network name (which is the normal behavior)
-					// otherwise use one based on the Kubernetes pod's Namespace.
-					if cniConf.Policy.PolicyType == "k8s" {
-						endpoint.Spec.Profiles = []string{fmt.Sprintf("k8s_ns.%s", namespace)}
-					} else {
-						endpoint.Spec.Profiles = []string{cniConf.Name}
-					}
-
-					// Populate the endpoint with the output from the IPAM plugin.
-					if err = PopulateEndpointNets(endpoint, result); err != nil {
-						// Cleanup IP allocation and return the error.
-						ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
-						return vm, err
-					}
-					logging.DefaultLogger().Object(vm).Info().Msgf("Populated endpoint: %v", endpoint)
-
-					// create a tap device
-					nameTemplate := fmt.Sprintf("tap-%s-%%d", vmCopy.Spec.Domain.UUID[0:8])
-					ifName, err := tuntap.CreatePersistentIface(nameTemplate, tuntap.Tap)
-					if err != nil {
-						return vm, fmt.Errorf("Failed to create a tap device: %v", err)
-					}
-
-					link, err := netlink.LinkByName(ifName)
-					if err != nil {
-						return vm, fmt.Errorf("cannot find link %q", ifName)
-					}
-					logging.DefaultLogger().Object(vm).Info().Msgf("Link(tap) %v created", link)
-
-					if err = netlink.LinkSetUp(link); err != nil {
-						return nil, fmt.Errorf("cannot set link up %q", ifName)
-					}
-
-					mac := link.Attrs().HardwareAddr
-					endpoint.Spec.MAC = &cnet.MAC{HardwareAddr: mac}
-					endpoint.Spec.InterfaceName = ifName
-					logger.WithField("endpoint", endpoint).Info("Added Mac and interface name to endpoint")
-
-					// Write the endpoint object (either the newly created one, or the updated one)
-					if _, err := calicoClient.WorkloadEndpoints().Apply(endpoint); err != nil {
-						// Cleanup IP allocation and return the error.
-						ReleaseIPAllocation(logger, cniConf.IPAM.Type, conf.Bytes)
-						return vm, err
-					}
-					logger.Info("Wrote updated endpoint to datastore")
-
-					logging.DefaultLogger().Object(vm).Info().Msgf("Mapping %s", ifName)
-					newIface := v1.Interface{}
-
-					newIface.Type = "ethernet"
-					newIface.MAC = new(v1.MAC)
-					newIface.MAC.MAC = mac.String()
-					newIface.Target = new(v1.InterfaceTarget)
-					newIface.Target.Device = ifName
-					newIface.Model = new(v1.Model)
-					newIface.Model.Type = "virtio"
-
-					vmCopy.Spec.Domain.Devices.Interfaces[idx] = newIface
-					return vmCopy, nil
-				}
-			}
-			return vm, fmt.Errorf("No %s network provider found in %s", iface.Source.Network, pluginDir)
-		}
-	}
-	return vmCopy, nil
-}
-
-func DeleteInterfaces(vm *v1.VM, namespace string) error {
-	netConfDir := os.Getenv("CNI_CONF")
-	files, err := libcni.ConfFiles(netConfDir)
-	switch {
-	case err != nil:
-		return err
-	case len(files) == 0:
-		return fmt.Errorf("No networks found in %s", netConfDir)
-	}
-	sort.Strings(files)
-	for _, file := range files {
-		conf, err := libcni.ConfFromFile(file)
-		if err != nil {
-			return fmt.Errorf("Error loading CNI config file %s: %v", file, err)
-		}
-
-		logging.DefaultLogger().Object(vm).Info().Msgf("Found %s network provider", conf.Network.Type)
-
-		// network plugin specific code
-		switch conf.Network.Type {
-		case "calico":
-			// Release IP address
-			workload := vm.GetObjectMeta().GetName()
-			logging.DefaultLogger().Object(vm).Info().Msgf("VM spec when del %+v", vm.GetObjectMeta())
-			orchestrator := "k8s"
-			hostname, _ := os.Hostname()
-			os.Setenv("CNI_COMMAND", "DEL")
-			os.Setenv("CNI_NETNS", "nil")
-			os.Setenv("CNI_IFNAME", "nil")
-			cniArgs := fmt.Sprintf("IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s", namespace, workload)
-			os.Setenv("CNI_ARGS", cniArgs)
-
-			ipamErr := ipam.ExecDel(conf.Network.IPAM.Type, conf.Bytes)
-
-			if ipamErr != nil {
-				logging.DefaultLogger().Object(vm).Info().Msgf("IPAM error %v", ipamErr)
-			}
-
-			cniConf := NetConf{}
-			if err := json.Unmarshal(conf.Bytes, &cniConf); err != nil {
-				return fmt.Errorf("failed to load netconf: %v", err)
-			}
-			calicoClient, err := CreateClient(cniConf)
-			if err != nil {
-				return err
-			}
-
-			// Get tap interface name
-			endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{
-				Node:         hostname,
-				Orchestrator: orchestrator,
-				Workload:     workload})
-			if err != nil {
-				return err
-			}
-
-			if len(endpoints.Items) == 1 {
-				var endpoint *api.WorkloadEndpoint
-				endpoint = &endpoints.Items[0]
-				// Delete tap interface
-				tuntap.RemovePersistentIface(endpoint.Spec.InterfaceName, tuntap.Tap)
-			}
-
-			// Delete endpoint in calico data store
-			if err := calicoClient.WorkloadEndpoints().Delete(api.WorkloadEndpointMetadata{
-				Name:         "eth0",
-				Node:         hostname,
-				Orchestrator: orchestrator,
-				Workload:     workload}); err != nil {
-				return err
-			}
-			return nil
-		}
-	}
-	return nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,12 +123,6 @@
 			"revisionTime": "2017-02-09T20:17:57Z"
 		},
 		{
-			"checksumSHA1": "p/xmG/9OavaNaNT++tI920qIriI=",
-			"path": "github.com/coreos/rkt/networking/tuntap",
-			"revision": "846588be077c9ee68cdc47d1f5745b322905f61c",
-			"revisionTime": "2017-03-15T15:59:46Z"
-		},
-		{
 			"checksumSHA1": "sFhTgIss9Kw8kIf2hp7ojxedznA=",
 			"path": "github.com/emicklei/go-restful",
 			"revision": "858e58f98abd32bc4d164a08e8d7ac169ae876e2",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "ZKxETlJdB2XubMrZnXB0FQimVA8=",
+			"path": "github.com/Sirupsen/logrus",
+			"revision": "10f801ebc38b33738c9d17d50860f484a0988ff5",
+			"revisionTime": "2017-03-17T14:32:14Z"
+		},
+		{
 			"checksumSHA1": "CDOphCxF7dup+hBBVRpFeQhM9Jw=",
 			"path": "github.com/asaskevich/govalidator",
 			"revision": "593d64559f7600f29581a3ee42177f5dbded27a9",
@@ -51,10 +57,28 @@
 			"revisionTime": "2016-09-06T03:24:42Z"
 		},
 		{
+			"checksumSHA1": "8rJLO5vv9q+KlPwkS1mnNm9zxxY=",
+			"path": "github.com/containernetworking/cni/pkg/utils/hwaddr",
+			"revision": "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff",
+			"revisionTime": "2017-03-22T16:47:29Z"
+		},
+		{
 			"checksumSHA1": "1qdja4KM2KRpw9Rt6pyid36OQXA=",
 			"path": "github.com/containernetworking/cni/pkg/version",
 			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
 			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "8s6lHDs2cnGicy0zrJW4ybIYtgI=",
+			"path": "github.com/coreos/go-iptables/iptables",
+			"revision": "5463fbac3bcc6b990663941c2e12660d19f6b36d",
+			"revisionTime": "2016-09-07T22:01:51Z"
+		},
+		{
+			"checksumSHA1": "p/xmG/9OavaNaNT++tI920qIriI=",
+			"path": "github.com/coreos/rkt/networking/tuntap",
+			"revision": "846588be077c9ee68cdc47d1f5745b322905f61c",
+			"revisionTime": "2017-03-15T15:59:46Z"
 		},
 		{
 			"checksumSHA1": "sFhTgIss9Kw8kIf2hp7ojxedznA=",
@@ -373,6 +397,24 @@
 			"revisionTime": "2016-11-27T22:05:27Z"
 		},
 		{
+			"checksumSHA1": "qMinAfqJy8VjdutrdWfuP6+NqsU=",
+			"path": "github.com/projectcalico/libcalico-go/lib/api",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "k0uPDeqmc8skXN5pS8IqkId9srY=",
+			"path": "github.com/projectcalico/libcalico-go/lib/client",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "2KWpuPSsNfF1etjr3MsGZvodkkw=",
+			"path": "github.com/projectcalico/libcalico-go/lib/net",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
 			"path": "github.com/satori/go.uuid",
 			"revision": "b061729afc07e77a8aa4fad0a2fd840958f1942a",
@@ -389,6 +431,12 @@
 			"path": "golang.org/x/crypto/ssh/terminal",
 			"revision": "459e26527287adbc2adcc5d0d49abff9a5f315a7",
 			"revisionTime": "2017-03-17T13:29:17Z"
+        },
+        {
+			"checksumSHA1": "za9USB8saUAWhTBC1InRZx8XaNQ=",
+			"path": "github.com/vishvananda/netlink",
+			"revision": "6c782366d2d5d98d4a70eea226ec10beab397af0",
+			"revisionTime": "2017-03-20T23:05:07Z"
 		},
 		{
 			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2016-07-15T17:06:12Z"
 		},
 		{
+			"checksumSHA1": "7S7iBoQO6v+dOzL0hUNbBmX4LVA=",
+			"path": "github.com/containernetworking/cni/libcni",
+			"revision": "b87126377a207a00ce32bcf67ea059ab8b9f6ba6",
+			"revisionTime": "2017-03-17T02:20:40Z"
+		},
+		{
 			"checksumSHA1": "sFhTgIss9Kw8kIf2hp7ojxedznA=",
 			"path": "github.com/emicklei/go-restful",
 			"revision": "858e58f98abd32bc4d164a08e8d7ac169ae876e2",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,52 @@
 			"revisionTime": "2016-07-15T17:06:12Z"
 		},
 		{
-			"checksumSHA1": "7S7iBoQO6v+dOzL0hUNbBmX4LVA=",
+			"checksumSHA1": "9jnGE8j1A9mmiLQeAPIxOKxLDqA=",
 			"path": "github.com/containernetworking/cni/libcni",
-			"revision": "b87126377a207a00ce32bcf67ea059ab8b9f6ba6",
-			"revisionTime": "2017-03-17T02:20:40Z"
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "M71iHAqceG06wPm4Igejx9RiMd4=",
+			"path": "github.com/containernetworking/cni/pkg/invoke",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "F1utsFXSpgUtjxIZK8dyT5+Hi34=",
+			"path": "github.com/containernetworking/cni/pkg/ip",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "cMYIBmly2ZsAHW9eMNuoApscmU4=",
+			"path": "github.com/containernetworking/cni/pkg/ipam",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "j7+0NxTDXc6RBwJB94qSB0HXJMo=",
+			"path": "github.com/containernetworking/cni/pkg/ns",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "KbQUZQVBIgBeSVoSNoG2RqKAfbc=",
+			"path": "github.com/containernetworking/cni/pkg/skel",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "wTR0gdDem9rhKE8Yr2tJrrA/R2U=",
+			"path": "github.com/containernetworking/cni/pkg/types",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
+		},
+		{
+			"checksumSHA1": "1qdja4KM2KRpw9Rt6pyid36OQXA=",
+			"path": "github.com/containernetworking/cni/pkg/version",
+			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
+			"revisionTime": "2016-09-06T03:24:42Z"
 		},
 		{
 			"checksumSHA1": "sFhTgIss9Kw8kIf2hp7ojxedznA=",
@@ -305,6 +347,30 @@
 			"path": "github.com/onsi/gomega/types",
 			"revision": "d59fa0ac68bb5dd932ee8d24eed631cdd519efc3",
 			"revisionTime": "2016-09-11T05:10:23Z"
+		},
+		{
+			"checksumSHA1": "KG+jYQNOrKQzpx8sl+zbtAj4UtA=",
+			"path": "github.com/projectcalico/cni-plugin/utils",
+			"revision": "5c24144780b243cd19eed881959631290f3a1832",
+			"revisionTime": "2017-03-20T23:35:29Z"
+		},
+		{
+			"checksumSHA1": "ZV0cepCqRjJ1lxmsSgqCqn5iO+I=",
+			"path": "github.com/projectcalico/go-json/json",
+			"revision": "6219dc7339ba20ee4c57df0a8baac62317d19cb1",
+			"revisionTime": "2016-11-28T00:41:56Z"
+		},
+		{
+			"checksumSHA1": "0sk3Ro303zla8whOfq5PAY342Oc=",
+			"path": "github.com/projectcalico/go-yaml",
+			"revision": "955bc3e451ef0c9df8b9113bf2e341139cdafab2",
+			"revisionTime": "2016-12-01T18:36:16Z"
+		},
+		{
+			"checksumSHA1": "pZzXpqbupkEPnhWkYArztG85tuE=",
+			"path": "github.com/projectcalico/go-yaml-wrapper",
+			"revision": "598e54215bee41a19677faa4f0c32acd2a87eb56",
+			"revisionTime": "2016-11-27T22:05:27Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2016-09-06T03:24:42Z"
 		},
 		{
-			"checksumSHA1": "F1utsFXSpgUtjxIZK8dyT5+Hi34=",
+			"checksumSHA1": "5F6AxBPajtgKHuo0t70GCxVLrcQ=",
 			"path": "github.com/containernetworking/cni/pkg/ip",
-			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
-			"revisionTime": "2016-09-06T03:24:42Z"
+			"revision": "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff",
+			"revisionTime": "2017-03-22T16:47:29Z"
 		},
 		{
 			"checksumSHA1": "cMYIBmly2ZsAHW9eMNuoApscmU4=",
@@ -39,10 +39,10 @@
 			"revisionTime": "2016-09-06T03:24:42Z"
 		},
 		{
-			"checksumSHA1": "j7+0NxTDXc6RBwJB94qSB0HXJMo=",
+			"checksumSHA1": "hyXCq+WIhN6QFrgACpGG0RQd/Fg=",
 			"path": "github.com/containernetworking/cni/pkg/ns",
-			"revision": "07a8a28637e97b22eb8dfe710eeae1344f69d16e",
-			"revisionTime": "2016-09-06T03:24:42Z"
+			"revision": "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff",
+			"revisionTime": "2017-03-22T16:47:29Z"
 		},
 		{
 			"checksumSHA1": "KbQUZQVBIgBeSVoSNoG2RqKAfbc=",
@@ -57,6 +57,12 @@
 			"revisionTime": "2016-09-06T03:24:42Z"
 		},
 		{
+			"checksumSHA1": "E2g9Gfn2bq3ul02YXqLCsxraGKU=",
+			"path": "github.com/containernetworking/cni/pkg/types/current",
+			"revision": "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff",
+			"revisionTime": "2017-03-22T16:47:29Z"
+		},
+		{
 			"checksumSHA1": "8rJLO5vv9q+KlPwkS1mnNm9zxxY=",
 			"path": "github.com/containernetworking/cni/pkg/utils/hwaddr",
 			"revision": "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff",
@@ -69,10 +75,52 @@
 			"revisionTime": "2016-09-06T03:24:42Z"
 		},
 		{
+			"checksumSHA1": "Zgqp9pp3G4cSZbepa6tzhNeHZOI=",
+			"path": "github.com/coreos/etcd/client",
+			"revision": "facbb640900d2410a1e98d414b476aeea87cb0b4",
+			"revisionTime": "2017-03-22T22:45:58Z"
+		},
+		{
+			"checksumSHA1": "mKIXx1kDwmVmdIpZ3pJtRBuUKso=",
+			"path": "github.com/coreos/etcd/pkg/pathutil",
+			"revision": "facbb640900d2410a1e98d414b476aeea87cb0b4",
+			"revisionTime": "2017-03-22T22:45:58Z"
+		},
+		{
+			"checksumSHA1": "rMyIh9PsSvPs6Yd+YgKITQzQJx8=",
+			"path": "github.com/coreos/etcd/pkg/tlsutil",
+			"revision": "facbb640900d2410a1e98d414b476aeea87cb0b4",
+			"revisionTime": "2017-03-22T22:45:58Z"
+		},
+		{
+			"checksumSHA1": "F2yucoqG6enNY2XDQGbXC3o4AHk=",
+			"path": "github.com/coreos/etcd/pkg/transport",
+			"revision": "facbb640900d2410a1e98d414b476aeea87cb0b4",
+			"revisionTime": "2017-03-22T22:45:58Z"
+		},
+		{
+			"checksumSHA1": "gx1gJIMU6T0UNQ0bPZ/drQ8cpCI=",
+			"path": "github.com/coreos/etcd/pkg/types",
+			"revision": "facbb640900d2410a1e98d414b476aeea87cb0b4",
+			"revisionTime": "2017-03-22T22:45:58Z"
+		},
+		{
+			"checksumSHA1": "sp2FkEyaIGiQFOEZCTDkBZgyHOs=",
+			"path": "github.com/coreos/etcd/version",
+			"revision": "facbb640900d2410a1e98d414b476aeea87cb0b4",
+			"revisionTime": "2017-03-22T22:45:58Z"
+		},
+		{
 			"checksumSHA1": "8s6lHDs2cnGicy0zrJW4ybIYtgI=",
 			"path": "github.com/coreos/go-iptables/iptables",
 			"revision": "5463fbac3bcc6b990663941c2e12660d19f6b36d",
 			"revisionTime": "2016-09-07T22:01:51Z"
+		},
+		{
+			"checksumSHA1": "nux9tCYmTA5bOCVODF3Rqzcu60U=",
+			"path": "github.com/coreos/go-semver/semver",
+			"revision": "5e3acbb5668c4c3deb4842615c4098eb61fb6b1e",
+			"revisionTime": "2017-02-09T20:17:57Z"
 		},
 		{
 			"checksumSHA1": "p/xmG/9OavaNaNT++tI920qIriI=",
@@ -175,16 +223,29 @@
 			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
+
 			"checksumSHA1": "jb1pFNNVYzpY4Mz09WEWeTNng40=",
 			"path": "github.com/gorilla/websocket",
 			"revision": "3f3e394da2b801fbe732a935ef40724762a67a07",
 			"revisionTime": "2017-02-18T16:27:10Z"
+        },
+        {
+			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
+			"path": "github.com/hashicorp/errwrap",
+			"revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55",
+			"revisionTime": "2014-10-28T05:47:10Z"
 		},
 		{
 			"checksumSHA1": "dtkL4Y9QiX0xpeSdoH71Ov+VpW4=",
 			"path": "github.com/jeevatkm/go-model",
 			"revision": "b63a4a27f7b484e4ffac7c530a8a996b9e9c8570",
 			"revisionTime": "2016-12-31T05:27:35Z"
+		},
+		{
+			"checksumSHA1": "pyUcq4sKKVm0KzBSZIPpHsmDF6k=",
+			"path": "github.com/kelseyhightower/envconfig",
+			"revision": "8bf4bbfc795e2c7c8a5ea47b707453ed019e2ad4",
+			"revisionTime": "2017-02-06T22:33:54Z"
 		},
 		{
 			"checksumSHA1": "abKzFXAn0KDr5U+JON1ZgJ2lUtU=",
@@ -375,8 +436,8 @@
 		{
 			"checksumSHA1": "KG+jYQNOrKQzpx8sl+zbtAj4UtA=",
 			"path": "github.com/projectcalico/cni-plugin/utils",
-			"revision": "5c24144780b243cd19eed881959631290f3a1832",
-			"revisionTime": "2017-03-20T23:35:29Z"
+			"revision": "00e196fa2d9c1ab0f9b0c784066eb55ef2307ec4",
+			"revisionTime": "2017-03-22T22:52:13Z"
 		},
 		{
 			"checksumSHA1": "ZV0cepCqRjJ1lxmsSgqCqn5iO+I=",
@@ -403,14 +464,128 @@
 			"revisionTime": "2017-03-15T22:34:08Z"
 		},
 		{
+			"checksumSHA1": "XoP26AJrW4GMfOp2yGnsRTH4c4g=",
+			"path": "github.com/projectcalico/libcalico-go/lib/api/unversioned",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "gx/dXBOCQONSJrPlmggBTAC9u0I=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "1DU2wSC+kS1E1SWtN8GQzQHKdsI=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/api",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "RhahWBfPCuoYAoMxyGQpmmF42lA=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/compat",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "37sdePkJieq+YpnR5356aIIV1RI=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/etcd",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "QW2LDPdITu+OWMcN//Avnth8K9g=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/k8s",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "16O0FPhRGWNYwGpUrImW3K6B3s4=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/k8s/resources",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "8E2wzlCifvRk66KuRGhnzk/drSQ=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/k8s/thirdparty",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "ApNvFkui2VWLNqF6JhJTEUS8nPc=",
+			"path": "github.com/projectcalico/libcalico-go/lib/backend/model",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
 			"checksumSHA1": "k0uPDeqmc8skXN5pS8IqkId9srY=",
 			"path": "github.com/projectcalico/libcalico-go/lib/client",
 			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
 			"revisionTime": "2017-03-15T22:34:08Z"
 		},
 		{
+			"checksumSHA1": "YAMXVYOy3ibvjVNbeuJRtiVi0y0=",
+			"path": "github.com/projectcalico/libcalico-go/lib/errors",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "su2Ri8gIHb+4h2r5zAiL82BBWeg=",
+			"path": "github.com/projectcalico/libcalico-go/lib/hash",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "IA7hsoE98T6vwDruGqVY6f7TyrE=",
+			"path": "github.com/projectcalico/libcalico-go/lib/hwm",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "1bRqe58JKD/RT1WnYEe1AgtSfBk=",
+			"path": "github.com/projectcalico/libcalico-go/lib/ipip",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
 			"checksumSHA1": "2KWpuPSsNfF1etjr3MsGZvodkkw=",
 			"path": "github.com/projectcalico/libcalico-go/lib/net",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "RsQ9l/MLyuhj2ds7R66hYdVpqKA=",
+			"path": "github.com/projectcalico/libcalico-go/lib/numorstring",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "NKdrZ5KdUqS0lXnBL/ZfjhDrOis=",
+			"path": "github.com/projectcalico/libcalico-go/lib/scope",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "S7xCgADp7tqlmGZlhL9tt2HUd5E=",
+			"path": "github.com/projectcalico/libcalico-go/lib/selector",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "wzK1QTkNhUa9B7AbKqI4zgiqHm4=",
+			"path": "github.com/projectcalico/libcalico-go/lib/selector/parser",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "4kgZBq5EGcTzP+0LKs7oXd0urFU=",
+			"path": "github.com/projectcalico/libcalico-go/lib/selector/tokenizer",
+			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
+			"revisionTime": "2017-03-15T22:34:08Z"
+		},
+		{
+			"checksumSHA1": "4s+kIhUjZQBrVpJ9Pfu4/HjCWRU=",
+			"path": "github.com/projectcalico/libcalico-go/lib/validator",
 			"revision": "956d63e025dc7bab82798ca4f823dc4a41e07ff0",
 			"revisionTime": "2017-03-15T22:34:08Z"
 		},
@@ -439,6 +614,18 @@
 			"revisionTime": "2017-03-20T23:05:07Z"
 		},
 		{
+			"checksumSHA1": "J0FWg5W1n0qNtyXdbTENfzSaTEU=",
+			"path": "github.com/vishvananda/netlink/nl",
+			"revision": "6c782366d2d5d98d4a70eea226ec10beab397af0",
+			"revisionTime": "2017-03-20T23:05:07Z"
+		},
+		{
+			"checksumSHA1": "wiewoKrYtsdwTTpviFI7UfZYnaQ=",
+			"path": "github.com/vishvananda/netns",
+			"revision": "54f0e4339ce73702a0607f49922aaa1e749b418d",
+			"revisionTime": "2017-02-14T06:09:35Z"
+		},
+		{
 			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
 			"path": "golang.org/x/net/context",
 			"revision": "6dba816f1056709e29a1c442883cab1336d3c083",
@@ -457,10 +644,22 @@
 			"revisionTime": "2016-10-11T23:07:22Z"
 		},
 		{
+			"checksumSHA1": "39V1idWER42Lmcmg2Uy40wMzOlo=",
+			"path": "gopkg.in/go-playground/validator.v8",
+			"revision": "5f57d2222ad794d0dffb07e664ea05e2ee07d60c",
+			"revisionTime": "2016-07-18T13:41:25Z"
+		},
+		{
 			"checksumSHA1": "v0plVTBSyu5TvzfwHWNBe5/eZZo=",
 			"path": "gopkg.in/ini.v1",
 			"revision": "766e555c68dc8bda90d197ee8946c37519c19409",
 			"revisionTime": "2017-01-17T13:00:17Z"
+		},
+		{
+			"checksumSHA1": "F9xsQ9Bq8iDC7CvbKGtZ9C94dyk=",
+			"path": "gopkg.in/tchap/go-patricia.v2/patricia",
+			"revision": "666120de432aea38ab06bd5c818f04f4129882c9",
+			"revisionTime": "2016-08-11T10:25:35Z"
 		},
 		{
 			"checksumSHA1": "SPMXWeoFQa5z0pLPmqpcFzyHqQQ=",


### PR DESCRIPTION
To test this patch, please
1. Set `network_provider` to `calico` in hack/config.sh
2. Install `go get -u github.com/ugorji/go/codec`
3. Run `calico-dhcp-agent` (cluster/kubectl.sh --core create -f cluster/vagrant/calico-dhcp-agent.yaml)
 
This patch
1. Creates a tap device and assigns an IP address to it using calico-ipam 
2. Makes the tap device as an endpoint of calico network
3. Maps `interfaces` of VM spec. to `<interface>` of domain.xml as follows
```
interfaces:
  - type: cni
```

  to

```
<interface type='ethernet'>
      <mac address='96:53:62:8f:0c:06'/>
      <target dev='tap-7b3ea62d-0'/>
      <model type='virtio'/>
      <alias name='net0'/>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
</interface>
```


To do,
1. move out the calico dependent codes in a separate binary
2. remove unnecessary files from calico-dhcp-agent container