### PR TITLE
Add Websocket endpoint to access VM consoles

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -3,9 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
-	"time"
+	"strconv"
 
+	"github.com/emicklei/go-restful"
 	"github.com/libvirt/libvirt-go"
 	kubecorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/pkg/api"
@@ -17,6 +19,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler"
+	"kubevirt.io/kubevirt/pkg/virt-handler/rest"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cache"
 )
@@ -28,6 +31,8 @@ func main() {
 	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
 	libvirtUser := flag.String("user", "", "Libvirt user")
 	libvirtPass := flag.String("pass", "", "Libvirt password")
+	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
+	port := flag.Int("port", 8183, "Port to listen on")
 	host := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
 	flag.Parse()
 
@@ -116,10 +121,13 @@ func main() {
 	go domainController.Run(1, stop)
 	go vmController.Run(1, stop)
 
-	// Sleep forever
 	// TODO add a http handler which provides health check
-	for {
-		time.Sleep(60000 * time.Millisecond)
 
-	}
+	// Add websocket route to access consoles remotely
+	console := rest.NewConsoleResource(domainConn)
+	ws := new(restful.WebService)
+	ws.Route(ws.GET("/api/v1/console/{name}").To(console.Console))
+	restful.DefaultContainer.Add(ws)
+	server := &http.Server{Addr: *listen + ":" + strconv.Itoa(*port), Handler: restful.DefaultContainer}
+	server.ListenAndServe()
 }

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -32,7 +32,7 @@ func main() {
 	libvirtUser := flag.String("user", "", "Libvirt user")
 	libvirtPass := flag.String("pass", "", "Libvirt password")
 	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
-	port := flag.Int("port", 8183, "Port to listen on")
+	port := flag.Int("port", 8185, "Port to listen on")
 	host := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
 	flag.Parse()
 

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -9,12 +9,16 @@ spec:
       labels:
         daemon: virt-handler
     spec:
+      hostNetwork: true
       volumes:
       - name: var-run-virt
         hostPath:
           path: /var/run/libvirt
       containers:
       - name: virt-handler
+        ports:
+          - containerPort: 8185
+            hostPort: 8185
         image: {{ docker_prefix }}/virt-handler:{{ docker_tag }}
         imagePullPolicy: IfNotPresent
         command:

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -1,0 +1,139 @@
+package rest
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/gorilla/websocket"
+	"github.com/libvirt/libvirt-go"
+	"io"
+	"k8s.io/client-go/pkg/types"
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
+	"net/http"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+type Console struct {
+	connection virtwrap.Connection
+}
+
+func NewConsoleResource(connection virtwrap.Connection) *Console {
+	return &Console{connection: connection}
+}
+
+func (t *Console) Console(request *restful.Request, response *restful.Response) {
+	console := request.HeaderParameter("console")
+	vmName := request.PathParameter("name")
+	vm := v1.NewVMReferenceFromName(vmName)
+	log := logging.DefaultLogger().Object(vm)
+	domain, err := t.connection.LookupDomainByName(vmName)
+	if err != nil {
+		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
+			log.Error().Reason(err).Msg("Domain not found.")
+			response.WriteError(http.StatusNotFound, err)
+			return
+		} else {
+			response.WriteError(http.StatusInternalServerError, err)
+			log.Error().Reason(err).Msg("Failed to look up domain.")
+			return
+		}
+	}
+
+	uid, err := domain.GetUUIDString()
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+		log.Error().Reason(err).Msg("Failed to look up domain UID.")
+		return
+	}
+	vm.GetObjectMeta().SetUID(types.UID(uid))
+	log = logging.DefaultLogger().Object(vm)
+
+	log.Info().Msgf("Opening connection to console %s", console)
+
+	consoleStream, err := t.connection.NewStream(0)
+	if err != nil {
+		log.Error().Reason(err).Msg("Creating a consoleStream failed.")
+		response.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	defer consoleStream.Finish()
+	defer consoleStream.Free()
+
+	log.Info().V(3).Msg("Stream created.")
+
+	err = domain.OpenConsole(console, consoleStream.Stream, libvirt.DOMAIN_CONSOLE_FORCE)
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+		log.Error().Reason(err).Msg("Failed to open console.")
+		return
+	}
+	log.Info().V(3).Msg("Connection to console created.")
+
+	errorChan := make(chan error)
+
+	ws, err := upgrader.Upgrade(response.ResponseWriter, request.Request, nil)
+	if err != nil {
+		log.Error().Reason(err).Msg("Failed to upgrade websocket connection.")
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	defer ws.Close()
+
+	wsReadWriter := &TextReadWriter{ws}
+
+	go func() {
+		_, err := io.Copy(consoleStream, wsReadWriter)
+		errorChan <- err
+	}()
+
+	go func() {
+		_, err := io.Copy(wsReadWriter, consoleStream)
+		errorChan <- err
+	}()
+
+	err = <-errorChan
+
+	if err != nil {
+		log.Error().Reason(err).Msg("Proxying data between libvirt and the websocket failed.")
+	}
+
+	log.Info().V(3).Msg("Done.")
+	response.WriteHeader(http.StatusOK)
+}
+
+type TextReadWriter struct {
+	*websocket.Conn
+}
+
+func (s *TextReadWriter) Write(p []byte) (int, error) {
+	err := s.Conn.WriteMessage(websocket.TextMessage, p)
+	if err != nil {
+		return 0, s.err(err)
+	}
+	return len(p), nil
+}
+
+func (s *TextReadWriter) Read(p []byte) (int, error) {
+	_, r, err := s.Conn.NextReader()
+	if err != nil {
+		return 0, s.err(err)
+	}
+	n, err := r.Read(p)
+	return n, s.err(err)
+}
+
+func (s *TextReadWriter) err(err error) error {
+	if err == nil {
+		return nil
+	}
+	if e, ok := err.(*websocket.CloseError); ok {
+		if e.Code == websocket.CloseNormalClosure {
+			return io.EOF
+		}
+	}
+	return err
+}

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -26,7 +26,7 @@ func NewConsoleResource(connection virtwrap.Connection) *Console {
 }
 
 func (t *Console) Console(request *restful.Request, response *restful.Response) {
-	console := request.HeaderParameter("console")
+	console := request.QueryParameter("console")
 	vmName := request.PathParameter("name")
 	vm := v1.NewVMReferenceFromName(vmName)
 	log := logging.DefaultLogger().Object(vm)

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -60,12 +60,11 @@ func (t *Console) Console(request *restful.Request, response *restful.Response) 
 		response.WriteError(http.StatusInternalServerError, err)
 		return
 	}
-	defer consoleStream.Finish()
-	defer consoleStream.Free()
+	defer consoleStream.Close()
 
 	log.Info().V(3).Msg("Stream created.")
 
-	err = domain.OpenConsole(console, consoleStream.Stream, libvirt.DOMAIN_CONSOLE_FORCE)
+	err = domain.OpenConsole(console, consoleStream.UnderlyingStream(), libvirt.DOMAIN_CONSOLE_FORCE)
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
 		log.Error().Reason(err).Msg("Failed to open console.")

--- a/pkg/virt-handler/rest/console_test.go
+++ b/pkg/virt-handler/rest/console_test.go
@@ -32,10 +32,9 @@ var _ = Describe("Console", func() {
 
 	dial := func(vm string, console string) *websocket.Conn {
 		wsUrl.Scheme = "ws"
-		header := http.Header{}
-		header.Add("console", console)
 		wsUrl.Path = "/api/v1/console/" + vm
-		c, _, err := websocket.DefaultDialer.Dial(wsUrl.String(), header)
+		wsUrl.RawQuery = "console=" + console
+		c, _, err := websocket.DefaultDialer.Dial(wsUrl.String(), nil)
 		Expect(err).ToNot(HaveOccurred())
 		return c
 	}

--- a/pkg/virt-handler/rest/rest_suite_test.go
+++ b/pkg/virt-handler/rest/rest_suite_test.go
@@ -1,0 +1,13 @@
+package rest_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rest Suite")
+}

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -126,6 +126,17 @@ func (_mr *_MockConnectionRecorder) ListAllDomains(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllDomains", arg0)
 }
 
+func (_m *MockConnection) NewStream(flags libvirt_go.StreamFlags) (*Stream, error) {
+	ret := _m.ctrl.Call(_m, "NewStream", flags)
+	ret0, _ := ret[0].(*Stream)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockConnectionRecorder) NewStream(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewStream", arg0)
+}
+
 // Mock of VirDomain interface
 type MockVirDomain struct {
 	ctrl     *gomock.Controller
@@ -230,4 +241,14 @@ func (_m *MockVirDomain) Undefine() error {
 
 func (_mr *_MockVirDomainRecorder) Undefine() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Undefine")
+}
+
+func (_m *MockVirDomain) OpenConsole(devname string, stream *libvirt_go.Stream, flags libvirt_go.DomainConsoleFlags) error {
+	ret := _m.ctrl.Call(_m, "OpenConsole", devname, stream, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) OpenConsole(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "OpenConsole", arg0, arg1, arg2)
 }

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -126,15 +126,78 @@ func (_mr *_MockConnectionRecorder) ListAllDomains(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllDomains", arg0)
 }
 
-func (_m *MockConnection) NewStream(flags libvirt_go.StreamFlags) (*Stream, error) {
+func (_m *MockConnection) NewStream(flags libvirt_go.StreamFlags) (Stream, error) {
 	ret := _m.ctrl.Call(_m, "NewStream", flags)
-	ret0, _ := ret[0].(*Stream)
+	ret0, _ := ret[0].(Stream)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 func (_mr *_MockConnectionRecorder) NewStream(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewStream", arg0)
+}
+
+// Mock of Stream interface
+type MockStream struct {
+	ctrl     *gomock.Controller
+	recorder *_MockStreamRecorder
+}
+
+// Recorder for MockStream (not exported)
+type _MockStreamRecorder struct {
+	mock *MockStream
+}
+
+func NewMockStream(ctrl *gomock.Controller) *MockStream {
+	mock := &MockStream{ctrl: ctrl}
+	mock.recorder = &_MockStreamRecorder{mock}
+	return mock
+}
+
+func (_m *MockStream) EXPECT() *_MockStreamRecorder {
+	return _m.recorder
+}
+
+func (_m *MockStream) Read(p []byte) (int, error) {
+	ret := _m.ctrl.Call(_m, "Read", p)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockStreamRecorder) Read(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Read", arg0)
+}
+
+func (_m *MockStream) Write(p []byte) (int, error) {
+	ret := _m.ctrl.Call(_m, "Write", p)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockStreamRecorder) Write(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Write", arg0)
+}
+
+func (_m *MockStream) Close() error {
+	ret := _m.ctrl.Call(_m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockStreamRecorder) Close() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
+}
+
+func (_m *MockStream) UnderlyingStream() *libvirt_go.Stream {
+	ret := _m.ctrl.Call(_m, "UnderlyingStream")
+	ret0, _ := ret[0].(*libvirt_go.Stream)
+	return ret0
+}
+
+func (_mr *_MockStreamRecorder) UnderlyingStream() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnderlyingStream")
 }
 
 // Mock of VirDomain interface

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -103,6 +103,12 @@
 			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
+			"checksumSHA1": "jb1pFNNVYzpY4Mz09WEWeTNng40=",
+			"path": "github.com/gorilla/websocket",
+			"revision": "3f3e394da2b801fbe732a935ef40724762a67a07",
+			"revisionTime": "2017-02-18T16:27:10Z"
+		},
+		{
 			"checksumSHA1": "dtkL4Y9QiX0xpeSdoH71Ov+VpW4=",
 			"path": "github.com/jeevatkm/go-model",
 			"revision": "b63a4a27f7b484e4ffac7c530a8a996b9e9c8570",
@@ -299,6 +305,12 @@
 			"path": "github.com/satori/go.uuid",
 			"revision": "b061729afc07e77a8aa4fad0a2fd840958f1942a",
 			"revisionTime": "2016-09-27T10:08:44Z"
+		},
+		{
+			"checksumSHA1": "xiderUuvye8Kpn7yX3niiJg32bE=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "459e26527287adbc2adcc5d0d49abff9a5f315a7",
+			"revisionTime": "2017-03-17T13:29:17Z"
 		},
 		{
 			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",


### PR DESCRIPTION
virt-handler now has an '/api/v1/console/myvm' endpoint, which also takes
a 'device' header, to specify the console to connect to.