### PR TITLE
Enhance the chance that libvirt is started after installation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,9 +34,9 @@ demo environment:
 
 ```bash
     sudo dnf install vagrant vagrant-libvirt
+    sudo systemctl restart virtlogd # Work around rpm packaging bug
+    sudo systemctl restart libvirtd
 ```
-
-That's it for now with vagrant, it will be used further down.
 
 On some systems Vagrant will always ask you for your sudo password when you try
 to do something with a VM. To avoid retyping your password all the time you can


### PR DESCRIPTION
On some fedora versions virtlogd is not declared as a libvirtd
dependency and therefore not started directly after the installation.