### PR TITLE
[WIP] Allow building boxes of kubevirt vagrant VMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ cluster/vagrant/.kubectl
 cluster/.console.vv
 build-tools/desc/desc
 tags
+box/Vagrantfile
+box/*.box
+create_box.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
   if $use_nfs then
     config.vm.synced_folder "./", "/vagrant", type: "nfs"
   else
-          config.vm.synced_folder "./", "/vagrant", type: "rsync", rsync__exclude: [ "cluster/vagrant/.kubectl", "cluster/vagrant/.kubeconfig", ".vagrant" ]
+          config.vm.synced_folder "./", "/vagrant", type: "rsync", rsync__exclude: [ "cluster/vagrant/.kubectl", "cluster/vagrant/.kubeconfig", ".vagrant", "box" ]
   end
 
   config.vm.provision "shell", inline: <<-SHELL

--- a/box/boxes.sh
+++ b/box/boxes.sh
@@ -1,0 +1,4 @@
+curl -O https://raw.githubusercontent.com/vagrant-libvirt/vagrant-libvirt/master/tools/create_box.sh
+touch Vagrantfile
+sudo bash create_box.sh /var/lib/libvirt/images/kubevirt_master.img kubevirt_master.box
+sudo bash create_box.sh /var/lib/libvirt/images/kubevirt_node0.img kubevirt_node0.box


### PR DESCRIPTION
Add script which builds boxes out of preprovisioned master and node vms.

Building them works: Only problem is, when you want to use the boxes, kubernetes does not come up properly becaues it wants to connect to etcd via an invalid ip (proably the IP of eth0 during the provisioning).