### PR TITLE
Fix vagrant deployment

### DIFF
--- a/cluster/vagrant/setup_kubernetes_common.sh
+++ b/cluster/vagrant/setup_kubernetes_common.sh
@@ -55,6 +55,13 @@ yum install -y docker kubelet kubeadm kubectl kubernetes-cni
 # To get the qemu user and libvirt
 yum install -y qemu-common qemu-kvm qemu-system-x86 libcgroup-tools libvirt || :
 
+# Latest docker on CentOS uses systemd for cgroup management
+cat << EOT >>/etc/systemd/system/kubelet.service.d/09-kubeadm.conf
+[Service]
+Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
+EOT
+systemctl daemon-reload
+
 systemctl enable docker && systemctl start docker
 systemctl enable kubelet && systemctl start kubelet
 

--- a/cluster/vagrant/setup_kubernetes_common.sh
+++ b/cluster/vagrant/setup_kubernetes_common.sh
@@ -50,7 +50,7 @@ repo_gpgcheck=1
 gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOF
-yum install -y docker kubelet kubeadm kubectl kubernetes-cni
+yum install -y docker kubelet-1.5.4 kubeadm kubectl kubernetes-cni
 
 # To get the qemu user and libvirt
 yum install -y qemu-common qemu-kvm qemu-system-x86 libcgroup-tools libvirt || :

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -35,7 +35,11 @@ fi
 
 # Allow scheduling pods on master
 # Ignore retval because it might not be dedicated already
-kubectl -s 127.0.0.1:8080 taint nodes --all dedicated- || :
+# kubectl -s 127.0.0.1:8080 taint nodes --all dedicated- || :
+
+# Investigate why taint is failing now
+kubectl -s 127.0.0.1:8080 patch node master --type='json' -p='[{"op": "remove", "path": "/metadata/annotations/scheduler.alpha.kubernetes.io~1taints"}]'
+
 
 mkdir -p /exports/share1
 


### PR DESCRIPTION
Two issues at the moment:

 * Aparrently latest CentOS docker releases use systemd for cgroup
management. The kubelet needs to use that too, otherwise kubernetes does
not come up.
 * With latest kubelet, bootstrapping  the cluster is broken https://github.com/kubernetes/kubeadm/issues/212

~The first one is fixed below, still looking for a good workaround for the second one.~

fixes #43.