### PR TITLE
Make it easier to define VMs

### DIFF
--- a/cluster/vm.json
+++ b/cluster/vm.json
@@ -51,18 +51,6 @@
         ],
         "consoles": [
           {
-            "target": {
-              "port": 0,
-              "type": "serial"
-            },
-            "type": "pty"
-          }
-        ],
-        "serials": [
-          {
-            "target": {
-              "port": 0
-            },
             "type": "pty"
           }
         ]

--- a/cluster/vm.json
+++ b/cluster/vm.json
@@ -41,9 +41,7 @@
         ],
         "video": [
           {
-            "model": {
-              "type": "qxl"
-            }
+            "type": "qxl"
           }
         ],
         "graphics": [

--- a/cluster/vm.yaml
+++ b/cluster/vm.yaml
@@ -12,8 +12,7 @@ spec:
         source:
           network: default
       video:
-      - model:
-          type: qxl
+      - type: qxl
       disks:
       - type: network
         snapshot: external

--- a/cluster/vm.yaml
+++ b/cluster/vm.yaml
@@ -29,15 +29,8 @@ spec:
           name: iqn.2017-01.io.kubevirt:sn.42/2
         target:
           dev: vda
-      serials:
-      - type: pty
-        target:
-          port: 0
       consoles:
       - type: pty
-        target:
-          type: serial
-          port: 0
     memory:
       unit: MB
       value: 64

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -261,10 +261,6 @@ type ChannelSource struct {
 */
 
 type Video struct {
-	Model VideoModel `json:"model"`
-}
-
-type VideoModel struct {
 	Type   string `json:"type"`
 	Heads  *uint  `json:"heads,omitempty"`
 	Ram    *uint  `json:"ram,omitempty"`

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -86,12 +86,12 @@ type DiskSourceHost struct {
 // BEGIN Serial -----------------------------
 
 type Serial struct {
-	Type   string       `json:"type"`
-	Target SerialTarget `json:"target"`
+	Type   string        `json:"type"`
+	Target *SerialTarget `json:"target,omitempty"`
 }
 
 type SerialTarget struct {
-	Port uint `json:"port"`
+	Port *uint `json:"port,omitempty"`
 }
 
 // END Serial -----------------------------
@@ -99,13 +99,13 @@ type SerialTarget struct {
 // BEGIN Console -----------------------------
 
 type Console struct {
-	Type   string        `json:"type"`
-	Target ConsoleTarget `json:"target"`
+	Type   string         `json:"type"`
+	Target *ConsoleTarget `json:"target,omitempty"`
 }
 
 type ConsoleTarget struct {
-	Type string `json:"type"`
-	Port *uint  `json:"port,omitempty"`
+	Type *string `json:"type,omitempty"`
+	Port *uint   `json:"port,omitempty"`
 }
 
 // END Serial -----------------------------

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -158,10 +158,6 @@ func (Video) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }
 
-func (VideoModel) SwaggerDoc() map[string]string {
-	return map[string]string{}
-}
-
 func (Graphics) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }

--- a/pkg/virt-handler/virtwrap/schema.go
+++ b/pkg/virt-handler/virtwrap/schema.go
@@ -36,9 +36,9 @@ func init() {
 	mapper.AddPtrConversion((**ReadOnly)(nil), (**v1.ReadOnly)(nil))
 	mapper.AddPtrConversion((**Address)(nil), (**v1.Address)(nil))
 	mapper.AddConversion(&Serial{}, &v1.Serial{})
-	mapper.AddConversion(&SerialTarget{}, &v1.SerialTarget{})
+	mapper.AddPtrConversion((**SerialTarget)(nil), (**v1.SerialTarget)(nil))
 	mapper.AddConversion(&Console{}, &v1.Console{})
-	mapper.AddConversion(&ConsoleTarget{}, &v1.ConsoleTarget{})
+	mapper.AddPtrConversion((**ConsoleTarget)(nil), (**v1.ConsoleTarget)(nil))
 	mapper.AddConversion(&InterfaceSource{}, &v1.InterfaceSource{})
 	mapper.AddPtrConversion((**InterfaceTarget)(nil), (**v1.InterfaceTarget)(nil))
 	mapper.AddPtrConversion((**Model)(nil), (**v1.Model)(nil))
@@ -223,12 +223,12 @@ type DiskSourceHost struct {
 // BEGIN Serial -----------------------------
 
 type Serial struct {
-	Type   string       `xml:"type,attr"`
-	Target SerialTarget `xml:"target"`
+	Type   string        `xml:"type,attr"`
+	Target *SerialTarget `xml:"target,omitempty"`
 }
 
 type SerialTarget struct {
-	Port uint `xml:"port,attr"`
+	Port *uint `xml:"port,attr,omitempty"`
 }
 
 // END Serial -----------------------------
@@ -236,13 +236,13 @@ type SerialTarget struct {
 // BEGIN Console -----------------------------
 
 type Console struct {
-	Type   string        `xml:"type,attr"`
-	Target ConsoleTarget `xml:"target"`
+	Type   string         `xml:"type,attr"`
+	Target *ConsoleTarget `xml:"target,omitempty"`
 }
 
 type ConsoleTarget struct {
-	Type string `xml:"type,attr"`
-	Port *uint  `xml:"port,attr,omitempty"`
+	Type *string `xml:"type,attr,omitempty"`
+	Port *uint   `xml:"port,attr,omitempty"`
 }
 
 // END Serial -----------------------------

--- a/pkg/virt-handler/virtwrap/schema.go
+++ b/pkg/virt-handler/virtwrap/schema.go
@@ -2,6 +2,7 @@ package virtwrap
 
 import (
 	"encoding/xml"
+	"github.com/jeevatkm/go-model"
 	"github.com/libvirt/libvirt-go"
 	"k8s.io/client-go/pkg/api/meta"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
@@ -10,6 +11,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/mapper"
 	"kubevirt.io/kubevirt/pkg/precond"
+	"reflect"
 )
 
 type LifeCycle string
@@ -24,7 +26,6 @@ func init() {
 	mapper.AddPtrConversion((**SysInfo)(nil), (**v1.SysInfo)(nil))
 	mapper.AddConversion(&Channel{}, &v1.Channel{})
 	mapper.AddConversion(&Interface{}, &v1.Interface{})
-	mapper.AddConversion(&Video{}, &v1.Video{})
 	mapper.AddConversion(&Graphics{}, &v1.Graphics{})
 	mapper.AddPtrConversion((**Ballooning)(nil), (**v1.Ballooning)(nil))
 	mapper.AddConversion(&Disk{}, &v1.Disk{})
@@ -55,8 +56,25 @@ func init() {
 	mapper.AddConversion(&Entry{}, &v1.Entry{})
 	mapper.AddConversion(&ChannelSource{}, &v1.ChannelSource{})
 	mapper.AddPtrConversion((**ChannelTarget)(nil), (**v1.ChannelTarget)(nil))
-	mapper.AddConversion(&VideoModel{}, &v1.VideoModel{})
+	mapper.AddConversion(&VideoModel{}, &v1.Video{})
 	mapper.AddConversion(&Listen{}, &v1.Listen{})
+
+	model.AddConversion(&Video{}, &v1.Video{}, func(in reflect.Value) (reflect.Value, error) {
+		out := v1.Video{}
+		errs := model.Copy(&out, in.Interface().(Video).Model)
+		if len(errs) > 0 {
+			return reflect.ValueOf(out), errs[0]
+		}
+		return reflect.ValueOf(out), nil
+	})
+	model.AddConversion(&v1.Video{}, &Video{}, func(in reflect.Value) (reflect.Value, error) {
+		out := Video{}
+		errs := model.Copy(&out.Model, in.Interface())
+		if len(errs) > 0 {
+			return reflect.ValueOf(out), errs[0]
+		}
+		return reflect.ValueOf(out), nil
+	})
 }
 
 const (

--- a/pkg/virt-handler/virtwrap/schema_test.go
+++ b/pkg/virt-handler/virtwrap/schema_test.go
@@ -32,6 +32,12 @@ var exampleXML = `<domain type="qemu">
       <target dev="vda"></target>
       <driver name="qemu" type="raw"></driver>
     </disk>
+    <serial type="pty">
+      <target port="123"></target>
+    </serial>
+    <console type="pty">
+      <target type="serial" port="123"></target>
+    </console>
   </devices>
 </domain>`
 
@@ -52,6 +58,12 @@ var _ = Describe("Schema", func() {
 	exampleDomain.Devices.Video = []Video{
 		{Model: VideoModel{Type: "vga"}},
 		{Model: VideoModel{Type: "qxl"}},
+	}
+	exampleDomain.Devices.Serials = []Serial{
+		{Type: "pty", Target: &SerialTarget{Port: newUInt(123)}},
+	}
+	exampleDomain.Devices.Consoles = []Console{
+		{Type: "pty", Target: &ConsoleTarget{Type: newString("serial"), Port: newUInt(123)}},
 	}
 
 	Context("With schema", func() {
@@ -102,6 +114,12 @@ var _ = Describe("Schema", func() {
 			{Type: "vga"},
 			{Type: "qxl"},
 		}
+		v1DomainSpec.Devices.Serials = []v1.Serial{
+			{Type: "pty", Target: &v1.SerialTarget{Port: newUInt(123)}},
+		}
+		v1DomainSpec.Devices.Consoles = []v1.Console{
+			{Type: "pty", Target: &v1.ConsoleTarget{Type: newString("serial"), Port: newUInt(123)}},
+		}
 
 		It("converts to libvirt.DomainSpec", func() {
 			virtDomainSpec := DomainSpec{}
@@ -117,3 +135,11 @@ var _ = Describe("Schema", func() {
 		})
 	})
 })
+
+func newUInt(v uint) *uint {
+	return &v
+}
+
+func newString(v string) *string {
+	return &v
+}

--- a/pkg/virt-handler/virtwrap/schema_test.go
+++ b/pkg/virt-handler/virtwrap/schema_test.go
@@ -19,6 +19,12 @@ var exampleXML = `<domain type="qemu">
     <interface type="network">
       <source network="default"></source>
     </interface>
+    <video>
+      <model type="vga"></model>
+    </video>
+    <video>
+      <model type="qxl"></model>
+    </video>
     <disk device="disk" type="network">
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
@@ -42,6 +48,10 @@ var _ = Describe("Schema", func() {
 				Host: &DiskSourceHost{Name: "example.com", Port: "3260"}},
 			Target: DiskTarget{Device: "vda"},
 		},
+	}
+	exampleDomain.Devices.Video = []Video{
+		{Model: VideoModel{Type: "vga"}},
+		{Model: VideoModel{Type: "qxl"}},
 	}
 
 	Context("With schema", func() {
@@ -88,11 +98,21 @@ var _ = Describe("Schema", func() {
 				Target: v1.DiskTarget{Device: "vda"},
 			},
 		}
+		v1DomainSpec.Devices.Video = []v1.Video{
+			{Type: "vga"},
+			{Type: "qxl"},
+		}
 
 		It("converts to libvirt.DomainSpec", func() {
 			virtDomainSpec := DomainSpec{}
 			errs := model.Copy(&virtDomainSpec, v1DomainSpec)
 			Expect(virtDomainSpec).To(Equal(*exampleDomain))
+			Expect(errs).To(BeEmpty())
+		})
+		It("converts to v1.DomainSpec", func() {
+			convertedDomainSpec := v1.DomainSpec{}
+			errs := model.Copy(&convertedDomainSpec, exampleDomain)
+			Expect(convertedDomainSpec).To(Equal(*v1DomainSpec))
 			Expect(errs).To(BeEmpty())
 		})
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -201,13 +201,11 @@ func NewRandomVMWithSpice() *v1.VM {
 	vm := NewRandomVM()
 	vm.Spec.Domain.Devices.Video = []v1.Video{
 		{
-			Model: v1.VideoModel{
-				Type:   "qxl",
-				Heads:  newUInt(1),
-				Ram:    newUInt(65563),
-				VGAMem: newUInt(16384),
-				VRam:   newUInt(8192),
-			},
+			Type:   "qxl",
+			Heads:  newUInt(1),
+			Ram:    newUInt(65563),
+			VGAMem: newUInt(16384),
+			VRam:   newUInt(8192),
 		},
 	}
 	vm.Spec.Domain.Devices.Graphics = []v1.Graphics{


### PR DESCRIPTION
* Move VideoModel up to Video on cluster level, since Video itself does not have any fields
* Make it possible to rely on libvirt defaults, to allow smaller VM definitions