### PR TITLE
Don't dereference nil libvirt connections

### DIFF
--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -139,9 +139,11 @@ type LibvirtDomainManager struct {
 
 func NewConnection(uri string, user string, pass string) (Connection, error) {
 	virConn, err := newConnection(uri, user, pass)
+	if err != nil {
+		return nil, err
+	}
 	lvConn := &LibvirtConnection{Connect: *virConn, user: user, pass: pass, uri: uri, alive: true}
-	return lvConn, err
-
+	return lvConn, nil
 }
 
 // TODO: needs a functional test.


### PR DESCRIPTION
In case of error, we were first trying to dereference the libvirt
connection, before we returned the error.