### PR TITLE
Convert spec command for virtctl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 go:
-  - 1.6.3
-  - 1.7.x
+  - 1.7.5
+  - 1.8.x
   - tip
 # jacob/virtualisation has updated libvirt binaries. Since
 # the statically linked libvirt-go code requires a runtime version of libvirt
@@ -44,13 +44,13 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      go: 1.6.3
+      go: 1.7.5
   - provider: script
     script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && make publish DOCKER_TAG=$TRAVIS_TAG
     skip_cleanup: true
     on:
       tags: true
-      go: 1.6.3
+      go: 1.7.5
 
 
 env:

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -4,13 +4,13 @@ source ${KUBEVIRT_PATH}hack/config.sh
 
 SYNC_CONFIG=${KUBEVIRT_PATH}cluster/vagrant/sync_config.sh
 
-if [ "x$1" == "x--init" ]
+if [ "$1" == "--init" ]
 then
     exec $SYNC_CONFIG
     exit
 fi
 
-if [ "x$1" == "xspice" ]; then
+if [ "$1" == "spice" ]; then
         viewer=${SPICE_VIEWER:-remote\-viewer}
         if [ "x$3" == "x--details" ]; then
             curl -sS http://${master_ip}:8184/apis/kubevirt.io/v1alpha1/namespaces/default/vms/$2/spice  -H"Accept:text/plain"
@@ -22,9 +22,14 @@ if [ "x$1" == "xspice" ]; then
         exit
 fi
 
-if [ "x$1" == "xconsole" ]; then
+if [ "$1" == "console" ] || [ "$1" == "convert-spec" ]; then
     cmd/virtctl/virtctl "$@" -s http://${master_ip}:8184 
     exit
+fi
+
+# Print usage from virtctl and kubectl
+if [ "$1" == "--help" ]  || [ "$1" == "-h" ] ; then
+    cmd/virtctl/virtctl "$@"
 fi
 
 if [ -e  ${KUBEVIRT_PATH}cluster/vagrant/.kubeconfig ] &&

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -21,6 +21,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler"
 	"kubevirt.io/kubevirt/pkg/virt-handler/rest"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
+	virt_api "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cache"
 )
 
@@ -110,7 +111,7 @@ func main() {
 
 	// Poplulate the VM store with known Domains on the host, to get deletes since the last run
 	for _, domain := range domainStore.List() {
-		d := domain.(*virtwrap.Domain)
+		d := domain.(*virt_api.Domain)
 		vmStore.Add(v1.NewVMReferenceFromName(d.ObjectMeta.Name))
 	}
 

--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -7,6 +7,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"kubevirt.io/kubevirt/pkg/virtctl"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
+	"kubevirt.io/kubevirt/pkg/virtctl/convert"
 	"log"
 )
 
@@ -16,8 +17,9 @@ func main() {
 	log.SetOutput(os.Stderr)
 
 	registry := map[string]virtctl.App{
-		"console": &console.Console{},
-		"options": &virtctl.Options{},
+		"console":      &console.Console{},
+		"options":      &virtctl.Options{},
+		"convert-spec": convert.NewConvertCommand(),
 	}
 
 	for cmd, app := range registry {
@@ -53,10 +55,11 @@ func Parse(flags *flag.FlagSet) (*flag.FlagSet, error) {
 
 func Usage() {
 	fmt.Fprintln(os.Stderr,
-		`virtctl controll VM related operations on your kubernetes cluster.
+		`virtctl controls VM related operations on your kubernetes cluster.
 
 Basic Commands:
   console        Connect to a serial console on a VM
+  convert-spec   Convert between Libvirt and KubeVirt specifications
 
 Use "virtctl <command> --help" for more information about a given command.
 Use "virtctl options" for a list of global command-line options (applies to all commands).

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -7,12 +7,10 @@ package v1
 */
 
 import (
-	"encoding/xml"
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 
 type DomainSpec struct {
-	XMLName xml.Name `json:"-"`
 	Name    string   `json:"name"`
 	UUID    string   `json:"uuid,omitempty"`
 	Memory  Memory   `json:"memory"`

--- a/pkg/virt-handler/domain_test.go
+++ b/pkg/virt-handler/domain_test.go
@@ -13,7 +13,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	. "kubevirt.io/kubevirt/pkg/virt-handler"
-	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
 var _ = Describe("Domain", func() {
@@ -39,7 +39,7 @@ var _ = Describe("Domain", func() {
 
 	Context("A new domain appears on the host", func() {
 		It("should inform vm controller if no correspnding VM is in the cache", func() {
-			dom := virtwrap.NewMinimalDomain("testvm")
+			dom := api.NewMinimalDomain("testvm")
 
 			vm := v1.NewMinimalVM("testvm")
 			vm.Status.Phase = ""
@@ -58,7 +58,7 @@ var _ = Describe("Domain", func() {
 			vm.GetObjectMeta().SetUID(types.UID("uuid1"))
 			vmStore.Add(vm)
 
-			domain := virtwrap.NewMinimalDomain("testvm")
+			domain := api.NewMinimalDomain("testvm")
 			domain.GetObjectMeta().SetUID(types.UID("uuid2"))
 			domainStore.Add(domain)
 			key, _ := cache.MetaNamespaceKeyFunc(domain)
@@ -68,7 +68,7 @@ var _ = Describe("Domain", func() {
 		})
 		It("should not inform vm controller if a correspnding VM is in the cache", func() {
 			vmStore.Add(v1.NewMinimalVM("testvm"))
-			domain := virtwrap.NewMinimalDomain("testvm")
+			domain := api.NewMinimalDomain("testvm")
 			domainStore.Add(domain)
 			key, _ := cache.MetaNamespaceKeyFunc(domain)
 			domainQueue.Add(key)
@@ -86,7 +86,7 @@ var _ = Describe("Domain", func() {
 
 		It("should not requeue if domain reference is not in the cache", func() {
 			vmStore.Add(v1.NewMinimalVM("testvm"))
-			domain := virtwrap.NewMinimalDomain("testvm")
+			domain := api.NewMinimalDomain("testvm")
 			key, _ := cache.MetaNamespaceKeyFunc(domain)
 			domainQueue.Add(key)
 			kubecli.Dequeue(domainStore, domainQueue, dispatch)

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -1,9 +1,8 @@
-package virtwrap
+package api
 
 import (
 	"encoding/xml"
 	"github.com/jeevatkm/go-model"
-	"github.com/libvirt/libvirt-go"
 	"k8s.io/client-go/pkg/api/meta"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
@@ -102,33 +101,6 @@ const (
 	ReasonFailed       StateChangeReason = "Failed"
 	ReasonFromSnapshot StateChangeReason = "FromSnapshot"
 )
-
-var LifeCycleTranslationMap = map[libvirt.DomainState]LifeCycle{
-	libvirt.DOMAIN_NOSTATE:     NoState,
-	libvirt.DOMAIN_RUNNING:     Running,
-	libvirt.DOMAIN_BLOCKED:     Blocked,
-	libvirt.DOMAIN_PAUSED:      Paused,
-	libvirt.DOMAIN_SHUTDOWN:    Shutdown,
-	libvirt.DOMAIN_SHUTOFF:     Shutoff,
-	libvirt.DOMAIN_CRASHED:     Crashed,
-	libvirt.DOMAIN_PMSUSPENDED: PMSuspended,
-}
-
-var ShutdownReasonTranslationMap = map[libvirt.DomainShutdownReason]StateChangeReason{
-	libvirt.DOMAIN_SHUTDOWN_UNKNOWN: ReasonUnknown,
-	libvirt.DOMAIN_SHUTDOWN_USER:    ReasonUser,
-}
-
-var ShutoffReasonTranslationMap = map[libvirt.DomainShutoffReason]StateChangeReason{
-	libvirt.DOMAIN_SHUTOFF_UNKNOWN:       ReasonUnknown,
-	libvirt.DOMAIN_SHUTOFF_SHUTDOWN:      ReasonShutdown,
-	libvirt.DOMAIN_SHUTOFF_DESTROYED:     ReasonDestroyed,
-	libvirt.DOMAIN_SHUTOFF_CRASHED:       ReasonCrashed,
-	libvirt.DOMAIN_SHUTOFF_MIGRATED:      ReasonMigrated,
-	libvirt.DOMAIN_SHUTOFF_SAVED:         ReasonSaved,
-	libvirt.DOMAIN_SHUTOFF_FAILED:        ReasonFailed,
-	libvirt.DOMAIN_SHUTOFF_FROM_SNAPSHOT: ReasonFromSnapshot,
-}
 
 type Domain struct {
 	metav1.TypeMeta
@@ -479,16 +451,9 @@ func NewDomainReferenceFromName(name string) *Domain {
 	}
 }
 
-func (d *Domain) SetState(status libvirt.DomainState, reason int) {
-	d.Status.Status = LifeCycleTranslationMap[status]
-
-	switch status {
-	case libvirt.DOMAIN_SHUTDOWN:
-		d.Status.Reason = ShutdownReasonTranslationMap[libvirt.DomainShutdownReason(reason)]
-	case libvirt.DOMAIN_SHUTOFF:
-		d.Status.Reason = ShutoffReasonTranslationMap[libvirt.DomainShutoffReason(reason)]
-	default:
-	}
+func (d *Domain) SetState(state LifeCycle, reason StateChangeReason) {
+	d.Status.Status = state
+	d.Status.Reason = reason
 }
 
 // Required to satisfy Object interface

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -1,4 +1,4 @@
-package virtwrap
+package api
 
 import (
 	"encoding/xml"

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
 type DomainManager interface {
@@ -187,7 +188,7 @@ func NewLibvirtDomainManager(connection Connection, recorder record.EventRecorde
 }
 
 func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
-	var wantedSpec DomainSpec
+	var wantedSpec api.DomainSpec
 	mappingErrs := model.Copy(&wantedSpec, vm.Spec.Domain)
 	if len(mappingErrs) > 0 {
 		// TODO: proper aggregation

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
 var _ = Describe("Manager", func() {
@@ -35,7 +36,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName("testvm").Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 
 			// we have to make sure that we use correct DomainSpec (from virtwrap)
-			var domainSpec DomainSpec
+			var domainSpec api.DomainSpec
 			Expect(model.Copy(&domainSpec, vm.Spec.Domain)).To(BeEmpty())
 
 			xml, err := xml.Marshal(domainSpec)

--- a/pkg/virtctl/convert/convert.go
+++ b/pkg/virtctl/convert/convert.go
@@ -1,0 +1,126 @@
+package convert
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"fmt"
+	flag "github.com/spf13/pflag"
+)
+
+func NewConvertCommand() *Convert {
+	return &Convert{stdin: os.Stdin, stdout: os.Stdout}
+}
+
+const (
+	RunSucceeded int = 0
+	RunFailed    int = 1
+)
+
+type Convert struct {
+	stdin  io.ReadCloser
+	stdout io.Writer
+}
+
+func (c *Convert) FlagSet() *flag.FlagSet {
+	cf := flag.NewFlagSet("convert", flag.ExitOnError)
+	cf.StringP("filename", "f", "", "Filename, directory, or URL to files identifying the resource to get from a server.")
+	cf.StringP("output", "o", "json", "Output format. One of: json|yaml|xml.")
+	cf.String("output-version", "kubevirt.io/v1alpha1", "Output the formatted object with the given group version")
+	return cf
+}
+
+func (c *Convert) Usage() string {
+	usage := "Convert between KubeVirt and Libvirt VM representations:\n\n"
+	usage += "Examples:\n"
+	usage += "# Convert Domain xml to yaml via stdin\n"
+	usage += "virsh dumpxml testvm | virtctl convert-spec -f - -o yaml\n\n"
+	usage += "# Convert yaml into json from a http resource\n"
+	usage += "virtctl convert-spec -f http://127.0.0.1:4012/vm.yaml -o json\n\n"
+	usage += "# Convert VM specification from a yaml file into a Libvirt Domain XML\n"
+	usage += "virtctl convert-spec -f vm.yaml -o xml > dom.xml\n\n"
+	usage += "Options:\n"
+	usage += c.FlagSet().FlagUsages()
+	return usage
+}
+
+func (c *Convert) Run(flags *flag.FlagSet) int {
+	sourceName, _ := flags.GetString("filename")
+
+	outputFlag, _ := flags.GetString("output")
+	outputFormat := Type(outputFlag)
+
+	if sourceName == "" {
+		log.Println("No source specified")
+		return RunFailed
+	}
+
+	rawSource, err := c.open(sourceName)
+	if err != nil {
+		log.Println("Failed to open source", err)
+		return RunFailed
+	}
+	defer rawSource.Close()
+
+	source, inputFormat := GuessStreamType(rawSource, 2048)
+
+	var encoder Encoder
+	var decoder Decoder
+
+	if outputFormat == UNSPECIFIED {
+		outputFormat = JSON
+	}
+
+	switch inputFormat {
+	case XML:
+		decoder = fromXML
+	case JSON, YAML:
+		decoder = fromYAMLOrJSON
+	default:
+		log.Printf("Unsupported input format '%s'\n", inputFormat)
+		return RunFailed
+	}
+
+	switch outputFormat {
+	case XML:
+		encoder = toXML
+	case JSON:
+		encoder = toJSON
+	case YAML:
+		encoder = toYAML
+	default:
+		log.Printf("Unsupported output format '%s'\n", outputFormat)
+		return RunFailed
+	}
+
+	vm, err := decoder(source)
+	if err != nil {
+		log.Println("Failed to decode struct", err)
+		return RunFailed
+	}
+	err = encoder(vm, c.stdout)
+	if err != nil {
+		log.Println("Failed to encode struct", err)
+		return RunFailed
+	}
+	fmt.Fprint(c.stdout, "\n")
+	return RunSucceeded
+}
+
+func (c *Convert) open(sourceName string) (io.ReadCloser, error) {
+	if sourceName == "-" {
+		return c.stdin, nil
+	} else if strings.HasPrefix(sourceName, "http") {
+		resp, err := http.Get(sourceName)
+		if err != nil {
+			return nil, err
+		}
+		return resp.Body, nil
+
+	} else {
+		return os.Open(sourceName)
+	}
+}

--- a/pkg/virtctl/convert/convert_suite_test.go
+++ b/pkg/virtctl/convert/convert_suite_test.go
@@ -1,0 +1,13 @@
+package convert_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestConvert(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Convert Suite")
+}

--- a/pkg/virtctl/convert/convert_test.go
+++ b/pkg/virtctl/convert/convert_test.go
@@ -1,0 +1,101 @@
+package convert
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/spf13/pflag"
+	"kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+var _ = Describe("Convert", func() {
+
+	vm := v1.NewMinimalVM("testvm")
+	var buffer *bytes.Buffer
+	var cmd *Convert
+	var flags *pflag.FlagSet
+
+	BeforeEach(func() {
+		buffer = bytes.NewBuffer(nil)
+		cmd = &Convert{ioutil.NopCloser(buffer), buffer}
+		flags = cmd.FlagSet()
+	})
+
+	Context("Document conversions", func() {
+
+		table.DescribeTable("converter invocation given, it", func(s *v1.VM, toStream Encoder, arguments string, fromStream Decoder, t *v1.VM) {
+			flags.Parse(strings.Split(arguments, " "))
+
+			Expect(toStream(s, buffer)).To(Succeed())
+			cmd.Run(flags)
+			Expect(fromStream(buffer)).To(Equal(t))
+		},
+			table.Entry("should take YAML and convert it explicit to JSON", vm, toYAML, "-f - -o json", fromJSON, vm),
+			table.Entry("should take YAML and convert it implicit to JSON", vm, toYAML, "-f - ", fromJSON, vm),
+			table.Entry("should take YAML and output YAML", vm, toJSON, "-f - -o yaml", fromYAML, vm),
+			table.Entry("should take YAML and output XML", vm, toYAML, "-f - -o xml", fromXML, vm),
+			table.Entry("should take XML and output YAML", vm, toXML, "-f - -o yaml", fromYAML, vm),
+		)
+
+	})
+
+	Context("Document sources", func() {
+		It("should read the source from stdin", func() {
+			Expect(toJSON(vm, buffer)).To(Succeed())
+			flags.Parse(strings.Split("-f -", " "))
+			Expect(fromJSON(buffer)).To(Equal(vm))
+
+		})
+		It("should read the source from a file", func() {
+			// Create temporary file
+			tmpfile, err := ioutil.TempFile("", "conversiontest")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.Remove(tmpfile.Name())
+
+			// Write content
+			Expect(toJSON(vm, tmpfile)).To(Succeed())
+			tmpfile.Close()
+
+			// Reopen for reading the content
+			tmpfile, err = os.Open(tmpfile.Name())
+			flags.Parse(strings.Split("-f "+tmpfile.Name(), " "))
+			cmd.Run(flags)
+			Expect(fromJSON(buffer)).To(Equal(vm))
+		})
+		It("should read the source from a http resource", func() {
+			server := ghttp.NewServer()
+			defer server.Close()
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/spec/vm"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
+				),
+			)
+			flags.Parse(strings.Split("-f "+server.URL()+"/spec/vm", " "))
+			cmd.Run(flags)
+			Expect(server.ReceivedRequests()).To(HaveLen(1))
+			Expect(fromJSON(buffer)).To(Equal(vm))
+		})
+
+	})
+})
+
+func fromYAML(reader io.Reader) (*v1.VM, error) {
+	r, t := GuessStreamType(reader, 2048)
+	Expect(t).To(Equal(YAML))
+	return fromYAMLOrJSON(r)
+}
+
+func fromJSON(reader io.Reader) (*v1.VM, error) {
+	r, t := GuessStreamType(reader, 2048)
+	Expect(t).To(Equal(JSON))
+	return fromYAMLOrJSON(r)
+}

--- a/pkg/virtctl/convert/converter.go
+++ b/pkg/virtctl/convert/converter.go
@@ -1,0 +1,74 @@
+package convert
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	ghodss_yaml "github.com/ghodss/yaml"
+	"github.com/jeevatkm/go-model"
+	"io"
+	"k8s.io/client-go/pkg/util/yaml"
+	virt "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
+)
+
+type Type string
+
+const (
+	UNSPECIFIED Type = ""
+	XML         Type = "xml"
+	YAML        Type = "yaml"
+	JSON        Type = "json"
+)
+
+func fromXML(reader io.Reader) (vm *virt.VM, err error) {
+	domainSpec := api.DomainSpec{}
+	err = xml.NewDecoder(reader).Decode(&domainSpec)
+	if err != nil {
+		return
+	}
+	vm = virt.NewMinimalVM(domainSpec.Name)
+	if e := model.Copy(vm.Spec.Domain, &domainSpec); len(e) > 0 {
+		err = e[0]
+		return
+	}
+	return
+}
+
+func fromYAMLOrJSON(reader io.Reader) (vm *virt.VM, err error) {
+	vm = new(virt.VM)
+	err = yaml.NewYAMLOrJSONDecoder(reader, 100).Decode(vm)
+	return
+}
+
+func toXML(vm *virt.VM, writer io.Writer) error {
+	domainSpec := new(api.DomainSpec)
+	if e := model.Copy(domainSpec, vm.Spec.Domain); len(e) > 0 {
+		return e[0]
+	}
+	domainSpec.Name = vm.GetObjectMeta().GetName()
+	encoder := xml.NewEncoder(writer)
+	encoder.Indent("", "  ")
+	return encoder.Encode(domainSpec)
+}
+
+func toYAML(vm *virt.VM, writer io.Writer) error {
+	b, err := json.Marshal(vm)
+	if err != nil {
+		return err
+	}
+	b, err = ghodss_yaml.JSONToYAML(b)
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(b)
+	return err
+}
+
+func toJSON(vm *virt.VM, writer io.Writer) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(vm)
+}
+
+type Encoder func(*virt.VM, io.Writer) error
+type Decoder func(io.Reader) (*virt.VM, error)

--- a/pkg/virtctl/convert/converter_test.go
+++ b/pkg/virtctl/convert/converter_test.go
@@ -1,0 +1,24 @@
+package convert
+
+import (
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+var _ = Describe("Converter", func() {
+
+	vm := v1.NewMinimalVM("testvm")
+
+	table.DescribeTable("", func(s *v1.VM, toStream Encoder, fromStream Decoder, t *v1.VM) {
+		b := bytes.NewBuffer(nil)
+		Expect(toStream(s, b)).To(Succeed())
+		Expect(fromStream(b)).To(Equal(t))
+	},
+		table.Entry("Should convert to YAML and back to struct", vm, toYAML, fromYAMLOrJSON, vm),
+		table.Entry("Should convert to JSON and back to struct", vm, toJSON, fromYAMLOrJSON, vm),
+		table.Entry("Should convert to XML and back to struct", vm, toXML, fromXML, vm),
+	)
+})

--- a/pkg/virtctl/convert/guess.go
+++ b/pkg/virtctl/convert/guess.go
@@ -1,0 +1,35 @@
+package convert
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"unicode"
+
+	"k8s.io/client-go/pkg/util/yaml"
+)
+
+// Guess if the provided reader represents a XML or JSON stream.
+// If neither is true, YAML is assumed.
+func GuessStreamType(source io.Reader, size int) (io.Reader, Type) {
+	if r, _, isXML := guessXMLStream(source, size); isXML {
+		return r, XML
+	} else if r, _, isJSON := yaml.GuessJSONStream(r, size); isJSON {
+		return r, JSON
+	} else {
+		return r, YAML
+	}
+}
+
+func guessXMLStream(r io.Reader, size int) (io.Reader, []byte, bool) {
+	buffer := bufio.NewReaderSize(r, size)
+	b, _ := buffer.Peek(size)
+	return buffer, b, hasXMLPrefix(b)
+}
+
+var xmlPrefix = []byte("<")
+
+func hasXMLPrefix(buf []byte) bool {
+	trim := bytes.TrimLeftFunc(buf, unicode.IsSpace)
+	return bytes.HasPrefix(trim, xmlPrefix)
+}

--- a/pkg/virtctl/convert/guess_test.go
+++ b/pkg/virtctl/convert/guess_test.go
@@ -1,0 +1,24 @@
+package convert_test
+
+import (
+	. "kubevirt.io/kubevirt/pkg/virtctl/convert"
+
+	"bytes"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+)
+
+var _ = Describe("Guess", func() {
+	table.DescribeTable("Should detect stream type", func(data string, detected Type) {
+		b := []byte(data)
+		reader, t := GuessStreamType(bytes.NewReader(b), 2048)
+		Expect(t).To(Equal(detected))
+		Expect(ioutil.ReadAll(reader)).To(Equal(b))
+	},
+		table.Entry("Should detect a XML stream", "    <xml></xml>", XML),
+		table.Entry("Should detect a JSON stream", `    {"a": "b"}`, JSON),
+		table.Entry("Should fall back to YAML if it is not a JSON or XML stream", `    a: "b"`, YAML),
+	)
+})


### PR DESCRIPTION
~Three things missing:~

 * ~The libvirt struct still depends on libvirt-go stuff~
 * ~Tests~
 * ~Documentation~


Example usage:

```bash
Convert between Kubevirt and Libvirt VM representations:

Examples:
# Convert Domain xml to yaml via stdin
virsh dumpxml testvm | virtctl convert-spec -f - -o yaml

# Convert yaml into json from a http resource
virtctl convert-spec -f http://127.0.0.1:4012/vm.yaml -o json

# Convert VM specification from a yaml file into a Libvirt Domain XML
virtctl convert-spec -f vm.yaml -o xml > dom.xml

Options:
  -f, --filename string         Filename, directory, or URL to files identifying the resource to get from a server.
  -o, --output string           Output format. One of: json|yaml|xml. (default "json")
      --output-version string   Output the formatted object with the given group version (default "kubevirt.io/v1alpha1")
```

The input format is automatically detected.