### PR TITLE
Stabilize storage and event handling tests

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 	virt_api "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cache"
+	"time"
 )
 
 func main() {
@@ -55,8 +56,7 @@ func main() {
 			}
 		}
 	}()
-	// TODO we need to handle disconnects
-	domainConn, err := virtwrap.NewConnection(*libvirtUri, *libvirtUser, *libvirtPass)
+	domainConn, err := virtwrap.NewConnection(*libvirtUri, *libvirtUser, *libvirtPass, 10*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("failed to connect to libvirtd: %s", err))
 	}

--- a/pkg/virt-handler/virtwrap/cache/cache_test.go
+++ b/pkg/virt-handler/virtwrap/cache/cache_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Cache", func() {
 	Context("on syncing with libvirt", func() {
 		table.DescribeTable("should receive a VM through the initial listing of domains",
 			func(state libvirt.DomainState, kubevirtState api.LifeCycle) {
-				mockConn.EXPECT().DomainEventLifecycleRegister(nil, gomock.Any()).Return(0, nil)
+				mockConn.EXPECT().DomainEventLifecycleRegister(gomock.Any()).Return(nil)
 				mockDomain.EXPECT().GetState().Return(state, -1, nil)
 				mockDomain.EXPECT().GetName().Return("test", nil)
 				mockDomain.EXPECT().GetUUIDString().Return("1235", nil)
@@ -73,7 +73,7 @@ var _ = Describe("Cache", func() {
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(x), nil)
 
 				watcher := &DomainWatcher{make(chan watch.Event, 1)}
-				callback(mockDomain, &libvirt.DomainEventLifecycle{Event: event}, watcher)
+				callback(mockDomain, &libvirt.DomainEventLifecycle{Event: event}, watcher.C)
 
 				e := <-watcher.C
 
@@ -96,7 +96,7 @@ var _ = Describe("Cache", func() {
 				mockDomain.EXPECT().GetUUIDString().Return("1235", nil)
 
 				watcher := &DomainWatcher{make(chan watch.Event, 1)}
-				callback(mockDomain, &libvirt.DomainEventLifecycle{Event: libvirt.DOMAIN_EVENT_UNDEFINED}, watcher)
+				callback(mockDomain, &libvirt.DomainEventLifecycle{Event: libvirt.DOMAIN_EVENT_UNDEFINED}, watcher.C)
 
 				e := <-watcher.C
 

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -104,15 +104,14 @@ func (_mr *_MockConnectionRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
 }
 
-func (_m *MockConnection) DomainEventLifecycleRegister(dom *libvirt_go.Domain, callback libvirt_go.DomainEventLifecycleCallback) (int, error) {
-	ret := _m.ctrl.Call(_m, "DomainEventLifecycleRegister", dom, callback)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+func (_m *MockConnection) DomainEventLifecycleRegister(callback libvirt_go.DomainEventLifecycleCallback) error {
+	ret := _m.ctrl.Call(_m, "DomainEventLifecycleRegister", callback)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockConnectionRecorder) DomainEventLifecycleRegister(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DomainEventLifecycleRegister", arg0, arg1)
+func (_mr *_MockConnectionRecorder) DomainEventLifecycleRegister(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DomainEventLifecycleRegister", arg0)
 }
 
 func (_m *MockConnection) ListAllDomains(flags libvirt_go.ConnectListAllDomainsFlags) ([]VirDomain, error) {


### PR DESCRIPTION
* Add a general libvirt reconnect strategy, fixes #194 
* Make sure that  storage tests don't start before previous connections were dropped