### PR TITLE
Fix some migration bugs

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -268,6 +268,10 @@ func (md *MigrationDispatch) execute(store cache.Store, key string) error {
 			vm.Status.NodeName = targetPod.Spec.NodeName
 			vm.Status.MigrationNodeName = ""
 			vm.Status.Phase = kubev1.Running
+			if vm.ObjectMeta.Labels == nil {
+				vm.ObjectMeta.Labels = map[string]string{}
+			}
+			vm.ObjectMeta.Labels[kubev1.NodeNameLabel] = vm.Status.NodeName
 			if _, err = md.vmService.PutVm(vm); err != nil {
 				logger.Error().Reason(err).Msg("updating the VM failed.")
 				return err

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Migration", func() {
 		expectedVM.Status.Phase = phase
 		expectedVM.Status.MigrationNodeName = pod.Spec.NodeName
 		expectedVM.Spec.NodeSelector = map[string]string{"beta.kubernetes.io/arch": "amd64"}
+		expectedVM.ObjectMeta.Labels = map[string]string{}
 
 		return expectedVM
 	}
@@ -504,6 +505,7 @@ var _ = Describe("Migration", func() {
 			expectedVM2 := buildExpectedVM(v1.Running)
 			expectedVM2.Status.MigrationNodeName = ""
 			expectedVM2.Status.NodeName = destinationNodeName
+			expectedVM2.ObjectMeta.Labels = map[string]string{v1.NodeNameLabel: destinationNodeName}
 
 			migrationPod := *mockMigrationPod(expectedVM2)
 			migrationPod.Status.Phase = clientv1.PodSucceeded

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -193,8 +193,8 @@ func NewRandomVMWithPVC(claimName string) *v1.VM {
 	return vm
 }
 
-func NewMigrationForVm(vm *v1.VM) *v1.Migration {
-	return v1.NewMinimalMigration(vm.ObjectMeta.Name+"migrate", vm.ObjectMeta.Name)
+func NewRandomMigrationForVm(vm *v1.VM) *v1.Migration {
+	return v1.NewMinimalMigration(vm.ObjectMeta.Name+"migrate"+rand.String(5), vm.ObjectMeta.Name)
 }
 
 func NewRandomVMWithSerialConsole() *v1.VM {


### PR DESCRIPTION
* A label was not set after successful migration, which left the VM visible after the migration to the old virt-handler