### PR TITLE
Integrate kubernetes security into console client code

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -15,6 +15,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -59,37 +60,50 @@ func (c *Console) Run(flags *flag.FlagSet) int {
 		return 1
 	}
 
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt)
-
-	u, err := url.Parse(config.Host)
+	// Create a round tripper with all necessary kubernetes security details
+	wrappedRoundTripper, err := roundTripperFromConfig(config)
 	if err != nil {
-		log.Fatal("dial:", err)
+		log.Println(err)
+		return 1
 	}
-	u.Scheme = "ws"
-	u.Path = fmt.Sprintf("/apis/kubevirt.io/v1alpha1/namespaces/%s/vms/%s/console", namespace, vm)
-	if device != "" {
-		u.RawQuery = "console=" + device
-	}
-	log.Printf("connecting to %s", u.String())
 
-	ws, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	// Create the basic console request
+	req, err := requestFromConfig(config, vm, namespace, device)
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
+
+	// Do the call and process the websocket connection with the callback
+	_, err = wrappedRoundTripper.RoundTrip(req)
+
+	if err != nil {
+		log.Println(err)
+		return 1
+	}
+	return 0
+}
+
+func WebsocketCallback(ws *websocket.Conn, resp *http.Response, err error) error {
+
 	if err != nil {
 		if resp != nil && resp.StatusCode != http.StatusOK {
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(resp.Body)
-			log.Fatalf("Can't connect to console (%d): %s\n", resp.StatusCode, buf.String())
+			return fmt.Errorf("Can't connect to console (%d): %s\n", resp.StatusCode, buf.String())
 		}
-		log.Fatalf("Can't connect to console: %s\n", err.Error())
+		return fmt.Errorf("Can't connect to console: %s\n", err.Error())
 	}
-	defer ws.Close()
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
 
 	writeStop := make(chan struct{})
 	readStop := make(chan struct{})
 
 	state, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
-		log.Fatal("Make raw terminal failed:", err)
+		return fmt.Errorf("Make raw terminal failed: %s", err)
 	}
 	defer terminal.Restore(int(os.Stdin.Fd()), state)
 	fmt.Fprint(os.Stderr, "Escape sequence is ^]")
@@ -136,11 +150,78 @@ func (c *Console) Run(flags *flag.FlagSet) int {
 
 	err = ws.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
 	if err != nil {
-		log.Fatalf("Error on close announcement: %s", err.Error())
+		return fmt.Errorf("Error on close announcement: %s", err.Error())
 	}
 	select {
 	case <-readStop:
 	case <-time.After(time.Second):
 	}
-	return 0
+	return nil
+}
+
+func requestFromConfig(config *rest.Config, vm string, namespace string, device string) (*http.Request, error) {
+
+	u, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	default:
+		return nil, fmt.Errorf("Unsupported Protocol %s", u.Scheme)
+	}
+
+	u.Path = fmt.Sprintf("/apis/kubevirt.io/v1alpha1/namespaces/%s/vms/%s/console", namespace, vm)
+	if device != "" {
+		u.RawQuery = "console=" + device
+	}
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+	}
+
+	return req, nil
+}
+
+func roundTripperFromConfig(config *rest.Config) (http.RoundTripper, error) {
+
+	// Configure TLS
+	tlsConfig, err := rest.TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure the websocket dialer
+	dialer := &websocket.Dialer{
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsConfig,
+	}
+
+	// Create a roundtripper which will pass in the final underlying websocket connection to a callback
+	rt := &WebsocketRoundTripper{
+		Do:     WebsocketCallback,
+		Dialer: dialer,
+	}
+
+	// Make sure we inherit all relevant security headers
+	return rest.HTTPWrappersForConfig(config, rt)
+}
+
+type RoundTripCallback func(conn *websocket.Conn, resp *http.Response, err error) error
+
+type WebsocketRoundTripper struct {
+	Dialer *websocket.Dialer
+	Do     RoundTripCallback
+}
+
+func (d *WebsocketRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	conn, resp, err := d.Dialer.Dial(r.URL.String(), r.Header)
+	if err == nil {
+		defer conn.Close()
+	}
+	return resp, d.Do(conn, resp, err)
 }


### PR DESCRIPTION
In order to leverege kubernetes security mechanisms, we need to wrap our
websocket connections with the kubernetes http round trippers.