### PR TITLE
Make sure old VMs are deleted if UIDs don't match

### DIFF
--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -32,15 +32,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jeevatkm/go-model"
 	"github.com/libvirt/libvirt-go"
-	"k8s.io/apimachinery/pkg/util/errors"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/record"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/mapper"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
@@ -322,35 +323,69 @@ func NewLibvirtDomainManager(connection Connection, recorder record.EventRecorde
 	return &manager, nil
 }
 
-func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
-	var wantedSpec api.DomainSpec
-	mappingErrs := model.Copy(&wantedSpec, vm.Spec.Domain)
-	if len(mappingErrs) > 0 {
-		return errors.NewAggregate(mappingErrs)
+// Check if a Domain with the VM name and UID exists. If a Domain with the VM name but with a different
+// UID exists, delete it. If everything matches, return the loaded Domain.
+func (l *LibvirtDomainManager) getActualOrDeleteOutdatedDomain(vm *v1.VM) (VirDomain, bool, error) {
+	// In case it does not exist, check if another VM with that name exists already
+	dom, err := l.virConn.LookupDomainByName(vm.ObjectMeta.GetName())
+	exists := err == nil
+	connectionErr := err != nil && err.(libvirt.Error).Code != libvirt.ERR_NO_DOMAIN
+	if connectionErr {
+		logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the domain failed.")
+		return nil, false, err
 	}
-	dom, err := l.virConn.LookupDomainByName(vm.GetObjectMeta().GetName())
-	if err != nil {
-		// We need the domain but it does not exist, so create it
-		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
-			xmlStr, err := xml.Marshal(&wantedSpec)
-			if err != nil {
-				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Generating the domain XML failed.")
-				return err
+	if exists {
+		uid, err := dom.GetUUIDString()
+		if err != nil {
+			dom.Free()
+			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the UID of the domain failed.")
+			return nil, false, err
+		}
+		// Check if the UIDs match and delete the old VM if they don't
+		if string(vm.GetObjectMeta().GetUID()) != uid {
+			vm := v1.NewVMReferenceFromName(vm.ObjectMeta.Name)
+			vm.GetObjectMeta().SetUID(types.UID(uid))
+			if err = l.killDomain(vm, dom); err != nil {
+				dom.Free()
+				return nil, false, err
 			}
-			logging.DefaultLogger().Object(vm).Info().V(3).Msg("Domain XML generated.")
-			dom, err = l.virConn.DomainDefineXML(string(xmlStr))
-			if err != nil {
-				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Defining the VM failed.")
-				return err
-			}
-			logging.DefaultLogger().Object(vm).Info().Msg("Domain defined.")
-			l.recorder.Event(vm, kubev1.EventTypeNormal, v1.Created.String(), "VM defined")
-		} else {
-			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the domain failed.")
-			return err
+			dom.Free()
+			return nil, false, nil
 		}
 	}
+
+	return dom, exists, nil
+}
+
+func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
+	var wantedSpec api.DomainSpec
+	if err := mapper.Copy(&wantedSpec, vm.Spec.Domain); err != nil {
+		return err
+	}
+
+	// Get the VM if it exists and make sure that VMs with the same name but different UIDs
+	dom, exists, err := l.getActualOrDeleteOutdatedDomain(vm)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		xmlStr, err := xml.Marshal(&wantedSpec)
+		if err != nil {
+			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Generating the domain XML failed.")
+			return err
+		}
+		logging.DefaultLogger().Object(vm).Info().V(3).Msg("Domain XML generated.")
+		dom, err = l.virConn.DomainDefineXML(string(xmlStr))
+		if err != nil {
+			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Defining the VM failed.")
+			return err
+		}
+		logging.DefaultLogger().Object(vm).Info().Msg("Domain defined.")
+		l.recorder.Event(vm, kubev1.EventTypeNormal, v1.Created.String(), "VM defined")
+	}
 	defer dom.Free()
+
 	domState, _, err := dom.GetState()
 	if err != nil {
 		logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the domain state failed.")
@@ -398,6 +433,10 @@ func (l *LibvirtDomainManager) KillVM(vm *v1.VM) error {
 		}
 	}
 	defer dom.Free()
+	return l.killDomain(vm, dom)
+}
+
+func (l *LibvirtDomainManager) killDomain(vm *v1.VM, dom VirDomain) error {
 	// TODO: Graceful shutdown
 	domState, _, err := dom.GetState()
 	if err != nil {
@@ -408,7 +447,7 @@ func (l *LibvirtDomainManager) KillVM(vm *v1.VM) error {
 	if domState == libvirt.DOMAIN_RUNNING || domState == libvirt.DOMAIN_PAUSED {
 		err = dom.Destroy()
 		if err != nil {
-			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Destroying the domain state failed.")
+			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Destroying the domain failed.")
 			return err
 		}
 		logging.DefaultLogger().Object(vm).Info().Msg("Domain stopped.")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -351,7 +351,7 @@ func WaitForSuccessfulVMStart(vm runtime.Object) (nodeName string) {
 		fetchedVM := obj.(*v1.VM)
 		nodeName = fetchedVM.Status.NodeName
 		return fetchedVM.Status.Phase
-	}).Should(Equal(v1.Running))
+	}, 60*time.Second).Should(Equal(v1.Running), "timed out waiting for VM to start")
 	return
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -342,6 +342,7 @@ func WaitForSuccessfulVMStart(vm runtime.Object) (nodeName string) {
 
 	// Fetch the VM, to make sure we have a resourceVersion as a starting point for the watch
 	obj, err := restClient.Get().Resource("vms").Namespace(api.NamespaceDefault).Name(vm.(*v1.VM).ObjectMeta.Name).Do().Get()
+	Expect(err).ToNot(HaveOccurred())
 	NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().FailOnWarnings().WaitFor(NormalEvent, v1.Started)
 
 	// FIXME the event order is wrong. First the document should be updated

--- a/tests/virt_handler_test.go
+++ b/tests/virt_handler_test.go
@@ -1,0 +1,296 @@
+package tests_test
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/jeevatkm/go-model"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	kubev1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("Virt-Handler", func() {
+	Context("Replace VM", func() {
+		flag.Parse()
+
+		var coreClient *kubernetes.Clientset
+
+		var vm *v1.VM
+
+		var virtHandler *v1beta1.DaemonSet
+		var namespace string
+
+		BeforeEach(func() {
+			tests.MustCleanup()
+			var err error
+			namespace = api.NamespaceDefault
+
+			coreClient, err = kubecli.Get()
+			Expect(err).ToNot(HaveOccurred())
+
+			vm = tests.NewRandomVM()
+
+			virtHandler, err = getVirtHandler(coreClient, namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(virtHandler).ToNot(BeNil())
+		})
+
+		AfterEach(func() {
+			ensureVirtHandlerIsRunning(coreClient, namespace, virtHandler)
+		})
+
+		It("should replace VM if virt-handler restarts", func() {
+			// Start the VM and wait for the confirmation of the start
+			restClient, err := kubecli.GetRESTClient()
+			Expect(err).ToNot(HaveOccurred())
+
+			var vmCopy = v1.VM{}
+			errs := model.Copy(&vmCopy, vm)
+			if errs != nil {
+				Expect(errors.NewAggregate(errs)).ToNot(HaveOccurred())
+			}
+
+			obj, err := restClient.Post().Resource("vms").Namespace(namespace).Body(vm).Do().Get()
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMStart(obj)
+
+			uuid := obj.(*v1.VM).ObjectMeta.UID
+
+			Expect(deleteVirtHandler(coreClient, namespace)).To(Succeed())
+
+			// Delete VM
+			// Create a new VM
+			err = reCreateVM(&vmCopy)
+			Expect(err).To(BeNil())
+
+			vmRestarted := make(chan bool, 1)
+
+			// Wait for the event log to show the VM was re-created
+			go func() {
+				defer GinkgoRecover()
+				waitForSuccessfulVMRestart(coreClient, vm)
+				vmRestarted <- true
+			}()
+
+			// Re-instantiate virt-handler daemonset
+			err = createDaemonSet(coreClient, namespace, virtHandler)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for virt-handler pod to re-start
+			Eventually(func() bool {
+				running, err := isVirtHandlerPodRunning(coreClient, namespace, vm.Status.NodeName)
+				Expect(err).ToNot(HaveOccurred())
+				return running
+			}, 120*time.Second).Should(Equal(true), "virt-handler is still not running after 120 seconds")
+
+			// Ensure the event log shows that a VM restart took place
+			<- vmRestarted
+
+			// Verify that the VM's UID has changed
+			obj, err = restClient.Get().Resource("vms").Namespace(namespace).Name(vm.ObjectMeta.Name).Do().Get()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(obj.(*v1.VM).ObjectMeta.UID).ShouldNot(Equal(uuid))
+		}, 120)
+	})
+})
+
+func getVirtHandler(coreClient *kubernetes.Clientset, namespace string) (*v1beta1.DaemonSet, error) {
+	betaRestClient := coreClient.ExtensionsV1beta1Client.RESTClient()
+	obj, err := betaRestClient.Get().Resource("daemonsets").Namespace(namespace).Name("virt-handler").Param("export", "true").Do().Get()
+	if err != nil {
+		return nil, err
+	}
+	ds := obj.(*v1beta1.DaemonSet)
+	return ds, nil
+}
+
+func getVirtHandlerPodLabelSelector() (labels.Selector, error) {
+	return labels.Parse("daemon in (virt-handler)")
+}
+
+func deleteVirtHandlerPods(coreClient *kubernetes.Clientset, namespace string) error {
+	labelSelector, err := getVirtHandlerPodLabelSelector()
+	if err != nil {
+		return err
+	}
+	err = coreClient.Core().Pods(api.NamespaceDefault).
+		DeleteCollection(nil, meta_v1.ListOptions{LabelSelector: labelSelector.String()})
+	if err != nil {
+		return err
+	}
+
+	// Wait for virt-handler to really terminate
+	Eventually(func() bool {
+		running, err := isVirtHandlerRunning(coreClient, namespace, "")
+		Expect(err).ToNot(HaveOccurred())
+		return running
+	}, 60*time.Second).Should(Equal(false), "Timed out waiting for virt-handler to stop")
+
+	return nil
+}
+
+func deleteVirtHandler(coreClient *kubernetes.Clientset, namespace string) error {
+	betaRestClient := coreClient.ExtensionsV1beta1Client.RESTClient()
+
+	err := betaRestClient.Delete().Resource("daemonsets").Namespace(namespace).Name("virt-handler").Do().Error()
+	if err != nil {
+		return err
+	}
+
+	// Work around: https://github.com/kubernetes/kubernetes/issues/33517
+	deleteVirtHandlerPods(coreClient, namespace)
+
+	return nil
+}
+
+func reCreateVM(vm *v1.VM) error {
+	restClient, err := kubecli.GetRESTClient()
+	if err != nil {
+		return err
+	}
+	namespace := vm.ObjectMeta.Namespace
+	name := vm.ObjectMeta.Name
+
+	Expect(string(vm.ObjectMeta.UID)).To(Equal(""))
+	Expect(vm.ObjectMeta.ResourceVersion).To(Equal(""))
+
+	err = restClient.Delete().Resource("vms").Namespace(namespace).Name(name).Do().Error()
+	if err != nil {
+		return err
+	}
+
+	err = restClient.Post().Resource("vms").Namespace(namespace).Body(vm).Do().Error()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func isVirtHandlerPodRunning(coreClient *kubernetes.Clientset, namespace string, nodeName string) (bool, error) {
+	restClient := coreClient.CoreV1().RESTClient()
+	labelSelector, err := getVirtHandlerPodLabelSelector()
+	if err != nil {
+		return false, err
+	}
+
+	obj, err := restClient.Get().Resource("pods").Namespace(namespace).LabelsSelectorParam(labelSelector).Do().Get()
+	Expect(err).ToNot(HaveOccurred())
+
+	podList := obj.(*kubev1.PodList)
+	for _, pod := range podList.Items {
+		if nodeName != "" {
+			if (pod.Spec.NodeName == nodeName) && (pod.Status.Phase == kubev1.PodRunning) {
+				return true, nil
+			}
+		} else {
+			// If nodeName isn't specified, return true if any virt-handler pod is running
+			// useful when checking to see if virt-handler is down
+			if pod.Status.Phase == kubev1.PodRunning {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func isVirtHandlerRunning(coreClient *kubernetes.Clientset, namespace string, nodeName string) (bool, error) {
+	betaRestClient := coreClient.ExtensionsV1beta1Client.RESTClient()
+
+	running, err := isVirtHandlerPodRunning(coreClient, namespace, nodeName)
+	if err != nil {
+		return false, err
+	}
+	if running {
+		// Double check that virt-handler daemonset is not present
+		obj, err := betaRestClient.Get().Resource("daemonsets").Namespace(namespace).Name("virt-handler").Do().Get()
+		if (err == nil) || (obj != nil) {
+			return false, fmt.Errorf("Unexpected result: virt-handler daemonset still exists")
+		}
+	}
+	return running, nil
+}
+
+func createDaemonSet(coreClient *kubernetes.Clientset, namespace string, ds *v1beta1.DaemonSet) error {
+	betaRestClient := coreClient.ExtensionsV1beta1Client.RESTClient()
+	err := betaRestClient.Post().Resource("daemonsets").Namespace(namespace).Body(ds).Do().Error()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//This function is run during AfterEach.
+func ensureVirtHandlerIsRunning(coreClient *kubernetes.Clientset, namespace string, ds *v1beta1.DaemonSet) {
+	betaRestClient := coreClient.ExtensionsV1beta1Client.RESTClient()
+
+	// check if DaemonSet exists
+	// if not, start it.
+	name := ds.ObjectMeta.Name
+	err := betaRestClient.Get().Resource("daemonsets").Namespace(namespace).Name(name).Do().Error()
+	if err != nil {
+		if !(strings.Contains(err.Error(), "could not find") || (strings.Contains(err.Error(), "not found"))) {
+			panic(fmt.Sprintf("Unable to verify status of virt-handler daemonset. Test suite cannot continue: %v", err))
+		}
+		// It's possible to delete a daemonset and not the pods due to:
+		// https://github.com/kubernetes/kubernetes/issues/33517
+		running, err := isVirtHandlerPodRunning(coreClient, namespace, "")
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				panic(fmt.Sprintf("Unable to verify status of virt-handler pods. Test suite cannot continue: %v", err))
+			}
+		}
+		if running == true {
+			deleteVirtHandlerPods(coreClient, namespace)
+		}
+		tests.PanicOnError(betaRestClient.Post().Resource("daemonsets").Namespace(namespace).Body(ds).Do().Error())
+	}
+}
+
+func waitForSuccessfulVMRestart(coreClient *kubernetes.Clientset, vm runtime.Object) (nodeName string) {
+	_, ok := vm.(*v1.VM)
+	vmName := vm.(*v1.VM).ObjectMeta.Name
+	Expect(ok).To(BeTrue(), "Object is not of type *v1.VM")
+	restClient, err := kubecli.GetRESTClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	w := tests.NewObjectEventWatcher(vm).SinceNow().FailOnWarnings()
+	func() {
+		stopped := false
+		started := false
+		// watch for both started and deleted events. don't return until both are seen.
+		w.Watch(func(event *kubev1.Event) bool {
+			if event.Type == string(tests.NormalEvent) && event.Reason == reflect.ValueOf(v1.Started).String() {
+				started = true
+			}
+			if event.Type == string(tests.NormalEvent) && event.Reason == reflect.ValueOf(v1.Deleted).String() {
+				stopped = true
+			}
+			return started && stopped
+		})
+	}()
+
+	Eventually(func() v1.VMPhase {
+		obj, err := restClient.Get().Resource("vms").Namespace(api.NamespaceDefault).Name(vmName).Do().Get()
+		Expect(err).ToNot(HaveOccurred())
+		fetchedVM := obj.(*v1.VM)
+		nodeName = fetchedVM.Status.NodeName
+		return fetchedVM.Status.Phase
+	}, 60*time.Second).Should(Equal(v1.Running), "timed out waiting for VM to re-start")
+	return
+}


### PR DESCRIPTION
WIP because: Not yet sure how to write a functional test which covers that.

If virt-handler is under load, it can miss a delete and instead see a
replaced VM with the same name. Check for the UIDs to detect such
mismatches and delete the old VM before starting the new one.

Fixes #193 