### PR TITLE
Add developers certificate of origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ of options:
  * [Libvirt][libvirt]
  * [Cockpit][cockpit]
 
+## Submitting patches
+
+When sending patches to the project, the submitter is required to certify that
+they have the legal right to submit the code. This is achieved by adding a line
+
+    Signed-off-by: Real Name <email@address.com>
+
+to the bottom of every commit message. Existance of such a line certifies
+that the submitter has complied with the Developer's Certificate of Origin 1.1,
+(as defined in the file docs/developer-certificate-of-origin).
+
+This line can be automatically added to a commit in the correct format, by
+using the '-s' option to 'git commit'.
 
 ## License
 

--- a/docs/developer-certificate-of-origin
+++ b/docs/developer-certificate-of-origin
@@ -1,0 +1,35 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Document that a Signed-off-by statement is required for all commits,
to certify compliance with the developer's certificate of origin.

Prior to merging this, it will also be necessary to enable a pull request web hook to validate this requirement on all pull requests to prevent accidental merge of code without s-o-b.