### PR TITLE
VM controller refactoring

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -182,14 +182,15 @@ type VMPhase string
 
 // These are the valid statuses of pods.
 const (
-	//When a VM Object is first initialized and no phase has been set.
+	//When a VM Object is first initialized and no phase, or Pending is present.
 	VmPhaseUnset VMPhase = ""
+	Pending      VMPhase = "Pending"
 	// VMPending means the VM has been accepted by the system.
 	// Either a target pod does not yet exist or a target Pod exists but is not yet scheduled and in running state.
 	Scheduling VMPhase = "Scheduling"
 	// A target pod was scheduled and the system saw that Pod in runnig state.
 	// Here is where the responsibility of virt-controller ends and virt-handler takes over.
-	Pending VMPhase = "Pending"
+	Scheduled VMPhase = "Scheduled"
 	// VMRunning means the pod has been bound to a node and the VM is started.
 	Running VMPhase = "Running"
 	// VMMigrating means the VM is currently migrated by a controller.

--- a/pkg/virt-controller/services/vm.go
+++ b/pkg/virt-controller/services/vm.go
@@ -12,7 +12,6 @@ import (
 
 	corev1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
-	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 
@@ -48,16 +47,6 @@ func (v *vmService) StartVMPod(vm *corev1.VM) error {
 	precond.MustNotBeNil(vm)
 	precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
 	precond.MustNotBeEmpty(string(vm.GetObjectMeta().GetUID()))
-
-	podList, err := v.GetRunningVMPods(vm)
-	if err != nil {
-		return err
-	}
-
-	// Pod for VM already exists
-	if len(podList.Items) > 0 {
-		return middleware.NewResourceExistsError("VM", vm.GetObjectMeta().GetName())
-	}
 
 	pod, err := v.TemplateService.RenderLaunchManifest(vm)
 	if err != nil {

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -85,17 +85,13 @@ var _ = Describe("VM", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, pod),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/api/v1/namespaces/default/pods"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, pod),
 				),
 			)
 			err := vmService.StartVMPod(vm)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(server.ReceivedRequests())).To(Equal(2))
+			Expect(len(server.ReceivedRequests())).To(Equal(1))
 		})
 	})
 

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Migration", func() {
 		It("Should mark Migration failed if VM not running ", func() {
 			// Register the expected REST call
 			server.AppendHandlers(
-				handleGetTestVM(buildExpectedVM(v1.Pending)),
+				handleGetTestVM(buildExpectedVM(v1.Scheduled)),
 				handlePutMigration(migration, v1.MigrationFailed),
 			)
 			migrationCache.Add(migration)
@@ -266,7 +266,7 @@ var _ = Describe("Migration", func() {
 		It("Should Requeue if VM not running and updateMigratio0n Failure", func() {
 			// Register the expected REST call
 			server.AppendHandlers(
-				handleGetTestVM(buildExpectedVM(v1.Pending)),
+				handleGetTestVM(buildExpectedVM(v1.Scheduled)),
 				handlePutMigrationAuthError(),
 			)
 			migrationCache.Add(migration)

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -25,8 +25,6 @@ import (
 
 var _ = Describe("VM watcher", func() {
 	var server *ghttp.Server
-	var podCache cache.Store
-	var podDispatch kubecli.ControllerDispatch
 	var vmService services.VMService
 	var restClient *rest.RESTClient
 
@@ -61,9 +59,6 @@ var _ = Describe("VM watcher", func() {
 			queue:      vmQueue,
 			store:      vmCache,
 		}
-
-		podCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
-		podDispatch = NewPodControllerDispatch(vmCache, restClient, vmService, clientSet)
 	})
 
 	Context("Creating a VM ", func() {
@@ -132,9 +127,6 @@ var _ = Describe("VM watcher", func() {
 			vm.Status.Phase = v1.Scheduling
 			vm.ObjectMeta.SetUID(uuid.NewUUID())
 
-			// Add the VM to the cache
-			vmCache.Add(vm)
-
 			// Create a target Pod for the VM
 			temlateService, err := services.NewTemplateService("whatever")
 			Expect(err).ToNot(HaveOccurred())
@@ -142,18 +134,26 @@ var _ = Describe("VM watcher", func() {
 			pod, err = temlateService.RenderLaunchManifest(vm)
 			Expect(err).ToNot(HaveOccurred())
 			pod.Spec.NodeName = "mynode"
+			pod.Status.Phase = kubev1.PodRunning
+			pods := clientv1.PodList{
+				Items: []kubev1.Pod{*pod},
+			}
 
 			// Create the expected VM after the update
 			obj, err := conversion.NewCloner().DeepCopy(vm)
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedVM := obj.(*v1.VM)
-			expectedVM.Status.Phase = v1.Pending
+			expectedVM.Status.Phase = v1.Scheduled
 			expectedVM.Status.NodeName = pod.Spec.NodeName
 			expectedVM.ObjectMeta.Labels = map[string]string{v1.NodeNameLabel: pod.Spec.NodeName}
 
 			// Register the expected REST call
 			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, pods),
+				),
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("PUT", "/apis/kubevirt.io/v1alpha1/namespaces/default/vms/testvm"),
 					ghttp.VerifyJSONRepresenting(expectedVM),
@@ -162,14 +162,12 @@ var _ = Describe("VM watcher", func() {
 			)
 
 			// Tell the controller that there is a new running Pod
+			key, _ := cache.MetaNamespaceKeyFunc(vm)
+			vmCache.Add(vm)
+			vmQueue.Add(key)
+			vmController.Execute()
 
-			queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-			key, _ := cache.MetaNamespaceKeyFunc(pod)
-			podCache.Add(pod)
-			queue.Add(key)
-			podDispatch.Execute(podCache, queue, key)
-
-			Expect(len(server.ReceivedRequests())).To(Equal(1))
+			Expect(len(server.ReceivedRequests())).To(Equal(2))
 			close(done)
 		}, 10)
 	})


### PR DESCRIPTION
Another part of refactoring our controller code, so that it matches the Kubernetes suggestions.
This one refactors the VM controller, to only use one Controller loop for  the whole logic. The primary resource is the VM, the only secondary resource, the Pods, updates the main controller loop via an informer.

Do not merge before #213 .