### PR TITLE
Remove dependancy on j2cli python package

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,10 +56,6 @@ to install a few build requirements:
     # We are interfacing with libvirt
     sudo dnf install libvirt-devel
 
-    sudo dnf install python-pip
-    sudo pip install j2cli
-
-
     cd $GOPATH
     # Use goimports for package import ordering
     go get golang.org/x/tools/cmd/goimports

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -15,5 +15,8 @@ rm -f "manifests/*.yaml"
 
 # Render kubernetes manifests
 for arg in $args; do
-    env | j2 --format=env $arg > ${arg%%.in}
+    sed -e "s/{{ master_ip }}/$master_ip/g" \
+        -e "s/{{ docker_tag }}/$docker_tag/g" \
+        -e "s/{{ docker_prefix }}/$docker_prefix/g" \
+        $arg > ${arg%%.in}
 done


### PR DESCRIPTION
Requiring installation of the python jinja CLI tool with pip
is overkill for subsituting a couple of plain strings into
a text file.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>