### PR TITLE
Fix security flaw in username/password handling for libvirt connections

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -33,8 +33,6 @@ func main() {
 	logging.InitializeLogging("virt-handler")
 	libvirt.EventRegisterDefaultImpl()
 	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
-	libvirtUser := flag.String("user", "", "Libvirt user")
-	libvirtPass := flag.String("pass", "", "Libvirt password")
 	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
 	port := flag.Int("port", 8185, "Port to listen on")
 	host := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
@@ -58,7 +56,7 @@ func main() {
 			}
 		}
 	}()
-	domainConn, err := virtwrap.NewConnection(*libvirtUri, *libvirtUser, *libvirtPass, 10*time.Second)
+	domainConn, err := virtwrap.NewConnection(*libvirtUri, "", "", 10*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("failed to connect to libvirtd: %v", err))
 	}

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -17,8 +17,6 @@ import (
 func main() {
 	logging.InitializeLogging("virt-manifest")
 	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
-	libvirtUser := flag.String("user", "", "Libvirt user")
-	libvirtPasswd := flag.String("pass", "", "Libvirt password")
 	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
 	port := flag.Int("port", 8186, "Port to listen on")
 	flag.Parse()
@@ -28,7 +26,7 @@ func main() {
 
 	log.Info().Msg("Connecting to libvirt")
 
-	domainConn, err := virtwrap.NewConnection(*libvirtUri, *libvirtUser, *libvirtPasswd, 60*time.Second)
+	domainConn, err := virtwrap.NewConnection(*libvirtUri, "", "", 60*time.Second)
 	if err != nil {
 		log.Error().Reason(err).Msg("cannot connect to libvirt")
 		panic(fmt.Sprintf("failed to connect to libvirt: %v", err))

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -275,7 +275,7 @@ func NewConnection(uri string, user string, pass string, checkInterval time.Dura
 }
 
 // TODO: needs a functional test.
-func authWithPassword(uri string, user string, pass string) (*libvirt.Connect, error) {
+func newConnection(uri string, user string, pass string) (*libvirt.Connect, error) {
 	callback := func(creds []*libvirt.ConnectCredential) {
 		for _, cred := range creds {
 			if cred.Type == libvirt.CRED_AUTHNAME {
@@ -295,17 +295,6 @@ func authWithPassword(uri string, user string, pass string) (*libvirt.Connect, e
 	}
 	virConn, err := libvirt.NewConnectWithAuth(uri, auth, 0)
 
-	return virConn, err
-}
-
-func newConnection(uri string, user string, pass string) (*libvirt.Connect, error) {
-	var virConn *libvirt.Connect
-	var err error
-	if user == "" {
-		virConn, err = libvirt.NewConnect(uri)
-	} else {
-		virConn, err = authWithPassword(uri, user, pass)
-	}
 	return virConn, err
 }
 


### PR DESCRIPTION
Providing a password via a command line argument is a security flaw since that is exposed all users / services on a host. This removes the ability to provide passwords on the cli in several commands. This is not even needed by the libvirt images built for kubevirt, but for custom setups it is now possible to do this out of band via the libvirt client auth config.