### PR TITLE
getting-started: fix swagger port

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -262,5 +262,5 @@ Since `kubectl` does not support TPR subresources yet, the above `cluster/kubect
 
 ## API Documentation
 
-The combined swagger documentation of Kubernetes and KubeVirt can be accessed under [/swaggerapi](http://192.168.200.2:8184/swaggerapi).
-There is also an embedded swagger-ui instance running inside the cluster. It can be accessed via [/swagger-ui](http://192.168.200.2:8184/swaggerapi).
+The combined swagger documentation of Kubernetes and KubeVirt can be accessed under [/swaggerapi](http://192.168.200.2:8183/swaggerapi).
+There is also an embedded swagger-ui instance running inside the cluster. It can be accessed via [/swagger-ui](http://192.168.200.2:8183/swaggerapi).


### PR DESCRIPTION
Swagger is actually started at port 8183 (as seen in
cmd/virt-api/virt-api.go), not 8184 as the documentation mentions.

Trivial change.