### PR TITLE
Add make target for running just the compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ all: build manifests
 generate:
 	./hack/build-go.sh generate ${WHAT}
 
-build: sync fmt vet
+build: sync fmt vet compile
+
+compile:
 	./hack/build-go.sh install ${WHAT}
 
 vet:


### PR DESCRIPTION
Running 'make build' to test compile code changes triggers dependent
rules that do a govendor sync and source code 'vet'. These steps are
significantly slower than the actual code compile, even if there is
nothing todo or report. This adds a 'compile' target so that it is
easier to skip those steps and fast compile testing.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>