### PR TITLE
Revert "getting-started: fix swagger port"

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -262,5 +262,5 @@ Since `kubectl` does not support TPR subresources yet, the above `cluster/kubect
 
 ## API Documentation
 
-The combined swagger documentation of Kubernetes and KubeVirt can be accessed under [/swaggerapi](http://192.168.200.2:8183/swaggerapi).
-There is also an embedded swagger-ui instance running inside the cluster. It can be accessed via [/swagger-ui](http://192.168.200.2:8183/swaggerapi).
+The combined swagger documentation of Kubernetes and KubeVirt can be accessed under [/swaggerapi](http://192.168.200.2:8184/swaggerapi).
+There is also an embedded swagger-ui instance running inside the cluster. It can be accessed via [/swagger-ui](http://192.168.200.2:8184/swaggerapi).


### PR DESCRIPTION
This reverts commit 03a5f3de36f27fda910668544c1b35d34d14dd96.
This reverts PR kubevirt/kubevirt#232

The change is invalid, because it introduces an error, and doesn't fix one.
It was my fault in meging the patch to quickly.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>