### PR TITLE
Ajust binary file detector to ignore pngs in the docs folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
  - make generate
  - make fmt
  - if git diff --name-only | grep 'generated.*.go'; then echo "Content of generated files changed. Please regenerate and commit them."; false; fi
- - if diff <(git grep -c '') <(git grep -cI '') | grep -v 'swagger-ui' | grep '^<'; then echo "Binary files are present in git repostory."; false; fi
+ - if diff <(git grep -c '') <(git grep -cI '') | egrep -v 'docs/.*\.png|swagger-ui' | grep '^<'; then echo "Binary files are present in git repostory."; false; fi
  - make check
  - make build
  - if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" ]]; then $HOME/gopath/bin/goveralls -service=travis-ci -package=./pkg/...; else make test; fi


### PR DESCRIPTION
Travis coplains about the not whitelisted pngs.