### PR TITLE
Always run goformat after regenerating code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: build manifests
 
 generate:
 	./hack/build-go.sh generate ${WHAT}
+	goimports -w -local kubevirt.io cmd/ pkg/ tests/
 
 build: sync fmt vet compile
 


### PR DESCRIPTION
The code generated for the mock files has all the imports
in one block, while goformat will insert spacing between
groups of imports. Thus if you don't run goformat after
re-generating mocks, you'll see bogus whitespace changes.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>