### PR TITLE
Don't look for virtctl command if none is given

### DIFF
--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -26,25 +26,27 @@ func main() {
 		"convert-spec": convert.NewConvertCommand(),
 	}
 
-	for cmd, app := range registry {
-		f := app.FlagSet()
-		f.Bool("help", false, "Print usage.")
-		f.MarkHidden("help")
-		f.Usage = func() {
-			fmt.Fprint(os.Stderr, app.Usage())
-		}
+	if len(os.Args) > 1 {
+		for cmd, app := range registry {
+			f := app.FlagSet()
+			f.Bool("help", false, "Print usage.")
+			f.MarkHidden("help")
+			f.Usage = func() {
+				fmt.Fprint(os.Stderr, app.Usage())
+			}
 
-		if os.Args[1] != cmd {
-			continue
-		}
-		flags, err := Parse(f)
+			if os.Args[1] != cmd {
+				continue
+			}
+			flags, err := Parse(f)
 
-		h, _ := flags.GetBool("help")
-		if h || err != nil {
-			f.Usage()
-			return
+			h, _ := flags.GetBool("help")
+			if h || err != nil {
+				f.Usage()
+				return
+			}
+			os.Exit(app.Run(flags))
 		}
-		os.Exit(app.Run(flags))
 	}
 
 	Usage()


### PR DESCRIPTION
Running 'virtctl' with no command results in a panic:

panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x112e0c0, 0xc42000c100)
	/usr/lib/golang/src/runtime/panic.go:500 +0x1a1
main.main()
	/home/berrange/src/kubevirt/src/kubevirt.io/kubevirt/cmd/virtctl/virtctl.go:38 +0x5d7

Because it is trying to access os.Args[1] when os.Args
only has a single element.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>