### PR TITLE
Stop using a different network namespace

### DIFF
--- a/cluster/verify-qemu-kube
+++ b/cluster/verify-qemu-kube
@@ -62,7 +62,7 @@ done
 # Check namespaces
 echo ""
 echo "Checking for required namespaces:"
-NAMESPACES='pid net'
+NAMESPACES='pid'
 for NS in $NAMESPACES; do
   NS_PRETTY=`echo $NS | tr '[:lower:]' '[:upper:]'`
   VM_PID_NS=$(ls -iL /proc/$VM_PID/ns/$NS | cut -f 1 -d " ")

--- a/cmd/virt-migrator/migrate
+++ b/cmd/virt-migrator/migrate
@@ -6,8 +6,8 @@ do
 key="$1"
 
 case $key in
-    -p|--pod-ip)
-    POD_IP="$2"
+    -n|--node-ip)
+    NODE_IP="$2"
     shift
     ;;
     -s|--source)
@@ -29,16 +29,16 @@ esac
 shift
 done
 
-if [ -z $POD_IP ] || [ -z $DEST ] || [ -z $SOURCE ] || [ -z $VM ]  || [ -z $NAMESPACE ]; then
-echo "Usage: migrate DOMAIN --source SOURCE --dest DESTINATION --pod-ip POD_IP --namespace NAMESPACE"
+if [ -z $NODE_IP ] || [ -z $DEST ] || [ -z $SOURCE ] || [ -z $VM ] || [ -z $NAMESPACE ]; then
+echo "Usage: migrate DOMAIN --source SOURCE --dest DESTINATION --node-ip NODE_IP --namespace NAMESPACE"
 exit 1
 fi 
 DOMAIN=${NAMESPACE}_${VM}
 
 # Tell libvirt where qemu will listen for spice connections on the new host
 virsh -c $SOURCE dumpxml $DOMAIN > $DOMAIN.xml
-xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/@listen" -v $POD_IP $DOMAIN.xml
-xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/listen/@address" -v $POD_IP $DOMAIN.xml
+xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/@listen" -v $NODE_IP $DOMAIN.xml
+xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/listen/@address" -v $NODE_IP $DOMAIN.xml
 
 # Migrate
-virsh -c $SOURCE migrate --xml $DOMAIN.xml $DOMAIN $DEST tcp://$POD_IP
+virsh -c $SOURCE migrate --xml $DOMAIN.xml $DOMAIN $DEST tcp://$NODE_IP

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -100,7 +100,6 @@ set -e
 exec sudo -C 10000 unshare --mount bash -s << END
 
   function _term() {
-    rm -rf /etc/resolv.conf.\$\$
     pkill -P \$! --signal SIG\$1
   }
 
@@ -111,12 +110,8 @@ exec sudo -C 10000 unshare --mount bash -s << END
   trap "_term TERM" EXIT
   trap "_term TERM" ERR
 
-  # Make sure qemu can resolve kubernetes DNS entries
-  nsenter -m -t $CONTAINER_PID cat /etc/resolv.conf > /etc/resolv.conf.\$\$
-  mount --bind /etc/resolv.conf.\$\$ /etc/resolv.conf
-
   cgclassify -g ${CGROUPS}:$CGROUP_PATH --sticky \$\$
-  nsenter -t $CONTAINER_PID -n -p $CMD &
+  nsenter -t $CONTAINER_PID -p $CMD &
 
   wait
 END

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -9,7 +9,6 @@ spec:
       labels:
         daemon: virt-handler
     spec:
-      hostNetwork: true
       containers:
       - name: virt-handler
         ports:

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -125,6 +125,13 @@ type VMStatus struct {
 	MigrationNodeName string        `json:"migrationNodeName,omitempty"`
 	Conditions        []VMCondition `json:"conditions,omitempty"`
 	Phase             VMPhase       `json:"phase"`
+	Graphics          []VMGraphics  `json:"graphics"`
+}
+
+type VMGraphics struct {
+	Type string `json:"type"`
+	Host string `json:"host"`
+	Port int32  `json:"port"`
 }
 
 // Required to satisfy Object interface

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -25,6 +25,10 @@ func (VMStatus) SwaggerDoc() map[string]string {
 	}
 }
 
+func (VMGraphics) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
 func (VMCondition) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -21,8 +21,6 @@ package services
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
@@ -55,18 +53,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VM) (*kubev1.Pod, error) {
 		ImagePullPolicy: kubev1.PullIfNotPresent,
 		Command:         []string{"/virt-launcher", "-qemu-timeout", "60s"},
 	}
-
-	// Set up spice ports
-	ports := []kubev1.ContainerPort{}
-	for i, g := range vm.Spec.Domain.Devices.Graphics {
-		if strings.ToLower(g.Type) == "spice" {
-			ports = append(ports, kubev1.ContainerPort{
-				ContainerPort: g.Port,
-				Name:          "spice" + strconv.Itoa(i),
-			})
-		}
-	}
-	container.Ports = ports
 
 	// TODO use constants for labels
 	pod := kubev1.Pod{
@@ -135,7 +121,7 @@ func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node,
 						"/migrate", vm.ObjectMeta.Name,
 						"--source", srcUri,
 						"--dest", destUri,
-						"--pod-ip", targetPod.Status.PodIP,
+						"--node-ip", dstAddr,
 						"--namespace", vm.ObjectMeta.Namespace,
 					},
 				},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Template", func() {
 						refCommand := []string{
 							"/migrate", "testvm", "--source", "qemu+tcp://127.0.0.2/system",
 							"--dest", "qemu+tcp://127.0.0.3/system",
-							"--pod-ip", "127.0.0.1", "--namespace", "default"}
+							"--node-ip", "127.0.0.3", "--namespace", "default"}
 						Expect(job.Spec.Containers[0].Command).To(Equal(refCommand))
 					})
 				})

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -8,6 +8,7 @@ import (
 	libvirt_go "github.com/libvirt/libvirt-go"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+	api "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
 // Mock of DomainManager interface
@@ -31,10 +32,11 @@ func (_m *MockDomainManager) EXPECT() *_MockDomainManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDomainManager) SyncVM(_param0 *v1.VM) error {
+func (_m *MockDomainManager) SyncVM(_param0 *v1.VM) (*api.DomainSpec, error) {
 	ret := _m.ctrl.Call(_m, "SyncVM", _param0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*api.DomainSpec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockDomainManagerRecorder) SyncVM(arg0 interface{}) *gomock.Call {

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -347,7 +347,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) (*api.DomainSpec, error) {
 				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Generating the domain XML failed.")
 				return nil, err
 			}
-			logging.DefaultLogger().Object(vm).Info().V(3).Msg("Domain XML generated.")
+			logging.DefaultLogger().Object(vm).Info().V(3).Msgf("Domain XML generated %s.", xmlStr)
 			dom, err = l.virConn.DomainDefineXML(string(xmlStr))
 			if err != nil {
 				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Defining the VM failed.")

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -45,7 +45,7 @@ import (
 )
 
 type DomainManager interface {
-	SyncVM(*v1.VM) error
+	SyncVM(*v1.VM) (*api.DomainSpec, error)
 	KillVM(*v1.VM) error
 }
 
@@ -328,12 +328,12 @@ func VMNamespaceKeyFunc(vm *v1.VM) string {
 	return domName
 }
 
-func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
+func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) (*api.DomainSpec, error) {
 	var wantedSpec api.DomainSpec
 	mappingErrs := model.Copy(&wantedSpec, vm.Spec.Domain)
 
 	if len(mappingErrs) > 0 {
-		return errors.NewAggregate(mappingErrs)
+		return nil, errors.NewAggregate(mappingErrs)
 	}
 
 	domName := VMNamespaceKeyFunc(vm)
@@ -345,26 +345,26 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
 			xmlStr, err := xml.Marshal(&wantedSpec)
 			if err != nil {
 				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Generating the domain XML failed.")
-				return err
+				return nil, err
 			}
 			logging.DefaultLogger().Object(vm).Info().V(3).Msg("Domain XML generated.")
 			dom, err = l.virConn.DomainDefineXML(string(xmlStr))
 			if err != nil {
 				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Defining the VM failed.")
-				return err
+				return nil, err
 			}
 			logging.DefaultLogger().Object(vm).Info().Msg("Domain defined.")
 			l.recorder.Event(vm, kubev1.EventTypeNormal, v1.Created.String(), "VM defined")
 		} else {
 			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the domain failed.")
-			return err
+			return nil, err
 		}
 	}
 	defer dom.Free()
 	domState, _, err := dom.GetState()
 	if err != nil {
 		logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the domain state failed.")
-		return err
+		return nil, err
 	}
 	// TODO Suspend, Pause, ..., for now we only support reaching the running state
 	// TODO for migration and error detection we also need the state change reason
@@ -374,7 +374,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
 		err := dom.Create()
 		if err != nil {
 			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Starting the VM failed.")
-			return err
+			return nil, err
 		}
 		logging.DefaultLogger().Object(vm).Info().Msg("Domain started.")
 		l.recorder.Event(vm, kubev1.EventTypeNormal, v1.Started.String(), "VM started.")
@@ -383,7 +383,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
 		err := dom.Resume()
 		if err != nil {
 			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Resuming the VM failed.")
-			return err
+			return nil, err
 		}
 		logging.DefaultLogger().Object(vm).Info().Msg("Domain resumed.")
 		l.recorder.Event(vm, kubev1.EventTypeNormal, v1.Resumed.String(), "VM resumed")
@@ -392,8 +392,20 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) error {
 		// TODO: blocked state
 	}
 
+	xmlstr, err := dom.GetXMLDesc(0)
+	if err != nil {
+		return nil, err
+	}
+
+	var newSpec api.DomainSpec
+	err = xml.Unmarshal([]byte(xmlstr), &newSpec)
+	if err != nil {
+		logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Parsing domain XML failed.")
+		return nil, err
+	}
+
 	// TODO: check if VM Spec and Domain Spec are equal or if we have to sync
-	return nil
+	return &newSpec, nil
 }
 
 func (l *LibvirtDomainManager) KillVM(vm *v1.VM) error {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jeevatkm/go-model"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	kubeapi "k8s.io/client-go/pkg/api"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
@@ -37,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
 func NewVMController(lw cache.ListerWatcher, domainManager virtwrap.DomainManager, recorder record.EventRecorder, restClient rest.RESTClient, clientset *kubernetes.Clientset, host string) (cache.Store, workqueue.RateLimitingInterface, *kubecli.Controller) {
@@ -64,6 +66,61 @@ type VMHandlerDispatch struct {
 	restClient    rest.RESTClient
 	clientset     *kubernetes.Clientset
 	host          string
+}
+
+func (d *VMHandlerDispatch) getVMNodeAddress(vm *v1.VM) (string, error) {
+	node, err := d.clientset.CoreV1().Nodes().Get(vm.Status.NodeName, metav1.GetOptions{})
+	if err != nil {
+		logging.DefaultLogger().Error().Reason(err).Msgf("fetching source node %s failed", vm.Status.NodeName)
+		return "", err
+	}
+
+	addrStr := ""
+	for _, addr := range node.Status.Addresses {
+		if (addr.Type == kubev1.NodeInternalIP) && (addrStr == "") {
+			addrStr = addr.Address
+			break
+		}
+	}
+	if addrStr == "" {
+		err := fmt.Errorf("VM node is unreachable")
+		logging.DefaultLogger().Error().Msg("VM node is unreachable")
+		return "", err
+	}
+
+	return addrStr, nil
+}
+
+func (d *VMHandlerDispatch) updateVMStatus(vm *v1.VM, cfg *api.DomainSpec) error {
+	obj, err := kubeapi.Scheme.Copy(vm)
+	if err != nil {
+		return err
+	}
+	vm = obj.(*v1.VM)
+	vm.Status.Phase = v1.Running
+
+	vm.Status.Graphics = []v1.VMGraphics{}
+
+	podIP, err := d.getVMNodeAddress(vm)
+	if err != nil {
+		return err
+	}
+
+	for _, src := range cfg.Devices.Graphics {
+		if (src.Type != "spice" && src.Type != "vnc") || src.Port == -1 {
+			continue
+		}
+		dst := v1.VMGraphics{
+			Type: src.Type,
+			Host: podIP,
+			Port: src.Port,
+		}
+		vm.Status.Graphics = append(vm.Status.Graphics, dst)
+	}
+
+	return d.restClient.Put().Resource("vms").Body(vm).
+		Name(vm.ObjectMeta.Name).Namespace(vm.ObjectMeta.Namespace).Do().Error()
+
 }
 
 func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimitingInterface, key interface{}) {
@@ -219,27 +276,12 @@ func (d *VMHandlerDispatch) processVmUpdate(vm *v1.VM, shouldDeleteVm bool) erro
 
 	// TODO check if found VM has the same UID like the domain,
 	// if not, delete the Domain first
-	err = d.domainManager.SyncVM(vm)
+	newCfg, err := d.domainManager.SyncVM(vm)
 	if err != nil {
 		return err
 	}
 
-	// Update VM status to running
-	if vm.Status.Phase != v1.Running {
-		obj, err := kubeapi.Scheme.Copy(vm)
-		if err != nil {
-			return err
-		}
-		vm = obj.(*v1.VM)
-		vm.Status.Phase = v1.Running
-		err = d.restClient.Put().Resource("vms").Body(vm).
-			Name(vm.ObjectMeta.Name).Namespace(vm.ObjectMeta.Namespace).Do().Error()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return d.updateVMStatus(vm, newCfg)
 }
 
 func (d *VMHandlerDispatch) isMigrationDestination(namespace string, vmName string) (bool, error) {

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -27,23 +27,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/pkg/api"
 	kubev1 "k8s.io/client-go/pkg/api/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
-	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/tests"
 )
-
-func LibvirtdPodSelector() metav1.ListOptions {
-	labelSelector, err := labels.Parse("daemon=libvirt")
-	if err != nil {
-		panic(err)
-	}
-	return metav1.ListOptions{LabelSelector: labelSelector.String()}
-}
 
 var _ = Describe("Storage", func() {
 
@@ -97,36 +86,15 @@ var _ = Describe("Storage", func() {
 		Expect(err).To(BeNil())
 		tests.WaitForSuccessfulVMStart(obj)
 
-		// Let's get the IP of the pod of the VM
-		pods, err := coreClient.CoreV1().Pods(tests.NamespaceTestDefault).List(services.UnfinishedVMPodSelector(vm))
-		//FIXME Sometimes pods hang in terminating state, select the pod which does not have a deletion timestamp
-		hostIP := ""
-		for _, pod := range pods.Items {
-			if pod.ObjectMeta.DeletionTimestamp == nil {
-				hostIP = pod.Status.HostIP
-				break
-			}
-		}
-		Expect(hostIP).ToNot(BeEmpty())
-
-		// Let's get the IP of the pod of libvirtd
-		pods, err = coreClient.CoreV1().Pods(api.NamespaceDefault).List(LibvirtdPodSelector())
-		podIP := ""
-		for _, pod := range pods.Items {
-			if pod.Status.HostIP == hostIP {
-				podIP = pod.Status.PodIP
-				break
-			}
-		}
-		Expect(podIP).ToNot(BeEmpty())
-
 		// Periodically check if we now have a connection on the target
-		// We don't check against the full pod IP, since depending on the kubernetes proxy mode, we either see the
-		// full PodIP or just the proxy IP which connects through different ports
+		// We don't check against the actual IP, since depending on the kubernetes proxy mode, and the network provider
+		// we will see different IPs here. The BeforeEach function makes sure that no other connections exist.
 		Eventually(func() string { return getTargetLogs(70) },
 			11*time.Second,
 			500*time.Millisecond).
-			Should(ContainSubstring(fmt.Sprintf("IP Address: %s", podIP[0:8])))
+			Should(
+				MatchRegexp(fmt.Sprintf("IP Address: [0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+")),
+			)
 	}
 
 	Context("Given a fresh iSCSI target", func() {


### PR DESCRIPTION
As a first step towards refactoring the VM startup process so that a QEMU wrapper script is no longer used, this stop using the network namespace of the POD. The SPICE listen address is now associated with the libvirtd POD ip addresses. The SPICE console API is updated to reflect this too, so that still works.

Eventually it might be possible to have some kind of connection forwarder running in the VM POD that connects to the QEMU server in the libvirtd namespace, thus allowing users to connect to SPICE using a virtual service IP assigned to the POD. This is an exercise for future work though.