### PR TITLE
Use correct tag for launcher image

### DIFF
--- a/cmd/virt-controller/virt-controller.go
+++ b/cmd/virt-controller/virt-controller.go
@@ -41,11 +41,12 @@ func main() {
 	host := flag.String("listen", "0.0.0.0", "Address and port where to listen on")
 	port := flag.Int("port", 8182, "Port to listen on")
 	launcherImage := flag.String("launcher-image", "virt-launcher", "Shim container for containerized VMs")
+	migratorImage := flag.String("migrator-image", "virt-handler", "Container which orchestrates a VM migration")
 
 	logger := logging.DefaultLogger()
 	flag.Parse()
 
-	templateService, err := services.NewTemplateService(*launcherImage)
+	templateService, err := services.NewTemplateService(*launcherImage, *migratorImage)
 	if err != nil {
 		golog.Fatal(err)
 	}

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -29,6 +29,8 @@ spec:
             - "/virt-controller"
             - "--launcher-image"
             - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
+            - "--migrator-image"
+            - "{{ docker_prefix }}/virt-handler:{{ docker_tag }}"
             - "--port"
             - "8182"
         ports:

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -39,6 +39,7 @@ type TemplateService interface {
 
 type templateService struct {
 	launcherImage string
+	migratorImage string
 }
 
 //Deprecated: remove the service and just use a builder or contextcless helper function
@@ -129,7 +130,7 @@ func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node,
 			Containers: []kubev1.Container{
 				{
 					Name:  "virt-migration",
-					Image: "kubevirt/virt-handler:devel",
+					Image: t.migratorImage,
 					Command: []string{
 						"/migrate", vm.Spec.Domain.Name, "--source", srcUri, "--dest", destUri, "--pod-ip", targetPod.Status.PodIP,
 					},
@@ -141,10 +142,12 @@ func (t *templateService) RenderMigrationJob(vm *v1.VM, sourceNode *kubev1.Node,
 	return &job, nil
 }
 
-func NewTemplateService(launcherImage string) (TemplateService, error) {
+func NewTemplateService(launcherImage string, migratorImage string) (TemplateService, error) {
 	precond.MustNotBeEmpty(launcherImage)
+	precond.MustNotBeEmpty(migratorImage)
 	svc := templateService{
 		launcherImage: launcherImage,
+		migratorImage: migratorImage,
 	}
 	return &svc, nil
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("Template", func() {
 
 	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
-	svc, err := NewTemplateService("kubevirt/virt-launcher")
+	svc, err := NewTemplateService("kubevirt/virt-launcher", "kubevirt/virt-handler")
 
 	Describe("Rendering", func() {
 		Context("launch template with correct parameters", func() {

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -50,7 +50,7 @@ var _ = Describe("VM", func() {
 		config := rest.Config{}
 		config.Host = server.URL()
 		clientSet, _ := kubernetes.NewForConfig(&config)
-		templateService, _ := NewTemplateService("kubevirt/virt-launcher")
+		templateService, _ := NewTemplateService("kubevirt/virt-launcher", "kubevirt/virt-handler")
 		restClient, _ = kubecli.GetRESTClientFromFlags(server.URL(), "")
 
 		vmService = NewVMService(clientSet, restClient, templateService)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Migration", func() {
 		config := rest.Config{}
 		config.Host = server.URL()
 		clientSet, _ := kubernetes.NewForConfig(&config)
-		templateService, _ := services.NewTemplateService("kubevirt/virt-launcher")
+		templateService, _ := services.NewTemplateService("kubevirt/virt-launcher", "kubevirt/virt-handler")
 		restClient, _ = kubecli.GetRESTClientFromFlags(server.URL(), "")
 
 		vmCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
@@ -105,7 +105,7 @@ var _ = Describe("Migration", func() {
 		migration.Spec.NodeSelector = map[string]string{"beta.kubernetes.io/arch": "amd64"}
 
 		// Create a target Pod for the VM
-		templateService, err := services.NewTemplateService("whatever")
+		templateService, err := services.NewTemplateService("whatever", "whatever")
 		Expect(err).ToNot(HaveOccurred())
 		pod, err = templateService.RenderLaunchManifest(vm)
 		Expect(err).ToNot(HaveOccurred())
@@ -772,7 +772,7 @@ func mockPod(i int, label string) clientv1.Pod {
 }
 
 func mockMigrationPod(vm *v1.VM) *kubev1.Pod {
-	temlateService, err := services.NewTemplateService("whatever")
+	temlateService, err := services.NewTemplateService("whatever", "whatever")
 	Expect(err).ToNot(HaveOccurred())
 	pod, err := temlateService.RenderLaunchManifest(vm)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -58,7 +58,7 @@ var _ = Describe("VM watcher", func() {
 		config := rest.Config{}
 		config.Host = server.URL()
 		clientSet, _ := kubernetes.NewForConfig(&config)
-		templateService, _ := services.NewTemplateService("kubevirt/virt-launcher")
+		templateService, _ := services.NewTemplateService("kubevirt/virt-launcher", "kubevirt/virt-handler")
 		restClient, _ = kubecli.GetRESTClientFromFlags(server.URL(), "")
 		vmService = services.NewVMService(clientSet, restClient, templateService)
 		vmCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
@@ -85,7 +85,7 @@ var _ = Describe("VM watcher", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Create a Pod for the VM
-			temlateService, err := services.NewTemplateService("whatever")
+			temlateService, err := services.NewTemplateService("whatever", "whatever")
 			Expect(err).ToNot(HaveOccurred())
 			pod, err := temlateService.RenderLaunchManifest(vm)
 			Expect(err).ToNot(HaveOccurred())
@@ -139,7 +139,7 @@ var _ = Describe("VM watcher", func() {
 			vm.ObjectMeta.SetUID(uuid.NewUUID())
 
 			// Create a target Pod for the VM
-			temlateService, err := services.NewTemplateService("whatever")
+			temlateService, err := services.NewTemplateService("whatever", "whatever")
 			Expect(err).ToNot(HaveOccurred())
 			var pod *kubev1.Pod
 			pod, err = temlateService.RenderLaunchManifest(vm)


### PR DESCRIPTION
Use the launcher image and tag, as specified on the commandline, instead
of a hardcoded launcher image.

Fixes #245 