### PR TITLE
Remove inject framework

### DIFF
--- a/cmd/virt-controller/virt-controller.go
+++ b/cmd/virt-controller/virt-controller.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 
 	"github.com/emicklei/go-restful"
-	"github.com/facebookgo/inject"
 	clientrest "k8s.io/client-go/rest"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
@@ -46,9 +45,6 @@ func main() {
 	logger := logging.DefaultLogger()
 	flag.Parse()
 
-	var g inject.Graph
-
-	vmService := services.NewVMService()
 	templateService, err := services.NewTemplateService(*launcherImage)
 	if err != nil {
 		golog.Fatal(err)
@@ -66,17 +62,8 @@ func main() {
 		golog.Fatal(err)
 	}
 
-	g.Provide(
-		&inject.Object{Value: restClient},
-		&inject.Object{Value: clientSet},
-		&inject.Object{Value: templateService},
-		&inject.Object{Value: vmService},
-	)
+	vmService := services.NewVMService(clientSet, restClient, templateService)
 
-	err = g.Populate()
-	if err != nil {
-		golog.Fatal(err)
-	}
 	restful.Add(rest.WebService)
 
 	// Bootstrapping. From here on the initialization order is important

--- a/pkg/virt-controller/services/vm.go
+++ b/pkg/virt-controller/services/vm.go
@@ -56,9 +56,9 @@ type VMService interface {
 }
 
 type vmService struct {
-	KubeCli         *kubernetes.Clientset `inject:""`
-	RestClient      *rest.RESTClient      `inject:""`
-	TemplateService TemplateService       `inject:""`
+	KubeCli         *kubernetes.Clientset
+	RestClient      *rest.RESTClient
+	TemplateService TemplateService
 }
 
 func (v *vmService) StartVMPod(vm *corev1.VM) error {
@@ -138,8 +138,14 @@ func (v *vmService) FetchMigration(migrationName string) (*corev1.Migration, boo
 	return migration, true, nil
 }
 
-func NewVMService() VMService {
-	svc := vmService{}
+func NewVMService(KubeCli *kubernetes.Clientset,
+	RestClient *rest.RESTClient,
+	TemplateService TemplateService) VMService {
+	svc := vmService{
+		KubeCli:         KubeCli,
+		RestClient:      RestClient,
+		TemplateService: TemplateService,
+	}
 	return &svc
 }
 

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"net/http"
 
-	"github.com/facebookgo/inject"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
@@ -45,10 +44,8 @@ var _ = Describe("VM", func() {
 	var restClient *rest.RESTClient
 
 	BeforeEach(func() {
-		var g inject.Graph
 
 		flag.Parse()
-		vmService = NewVMService()
 		server = ghttp.NewServer()
 		config := rest.Config{}
 		config.Host = server.URL()
@@ -56,13 +53,7 @@ var _ = Describe("VM", func() {
 		templateService, _ := NewTemplateService("kubevirt/virt-launcher")
 		restClient, _ = kubecli.GetRESTClientFromFlags(server.URL(), "")
 
-		g.Provide(
-			&inject.Object{Value: restClient},
-			&inject.Object{Value: clientSet},
-			&inject.Object{Value: vmService},
-			&inject.Object{Value: templateService},
-		)
-		g.Populate()
+		vmService = NewVMService(clientSet, restClient, templateService)
 
 	})
 	Context("calling Setup Migration ", func() {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/facebookgo/inject"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
@@ -71,8 +70,7 @@ var _ = Describe("Migration", func() {
 	destinationNodeName := "mynode"
 	sourceNodeName := "sourcenode"
 	BeforeEach(func() {
-		var g inject.Graph
-		vmService = services.NewVMService()
+
 		server = ghttp.NewServer()
 		config := rest.Config{}
 		config.Host = server.URL()
@@ -81,13 +79,9 @@ var _ = Describe("Migration", func() {
 		restClient, _ = kubecli.GetRESTClientFromFlags(server.URL(), "")
 
 		vmCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
-		g.Provide(
-			&inject.Object{Value: restClient},
-			&inject.Object{Value: clientSet},
-			&inject.Object{Value: vmService},
-			&inject.Object{Value: templateService},
-		)
-		g.Populate()
+
+		vmService = services.NewVMService(clientSet, restClient, templateService)
+
 		migrationCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 		migrationQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -22,7 +22,6 @@ package watch
 import (
 	"net/http"
 
-	"github.com/facebookgo/inject"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
@@ -54,21 +53,14 @@ var _ = Describe("VM watcher", func() {
 	var vmController *VMController
 
 	BeforeEach(func() {
-		var g inject.Graph
-		vmService = services.NewVMService()
+
 		server = ghttp.NewServer()
 		config := rest.Config{}
 		config.Host = server.URL()
 		clientSet, _ := kubernetes.NewForConfig(&config)
 		templateService, _ := services.NewTemplateService("kubevirt/virt-launcher")
 		restClient, _ = kubecli.GetRESTClientFromFlags(server.URL(), "")
-		g.Provide(
-			&inject.Object{Value: restClient},
-			&inject.Object{Value: clientSet},
-			&inject.Object{Value: vmService},
-			&inject.Object{Value: templateService},
-		)
-		g.Populate()
+		vmService = services.NewVMService(clientSet, restClient, templateService)
 		vmCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 		vmQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,12 +33,6 @@
 			"revisionTime": "2017-01-23T15:48:00Z"
 		},
 		{
-			"checksumSHA1": "GqkBIw2lUA6lv/jgh9WIyR0YdWY=",
-			"path": "github.com/facebookgo/inject",
-			"revision": "643b7206b487b04fbea325cf6e8d06a66f8db772",
-			"revisionTime": "2016-04-24T21:37:20Z"
-		},
-		{
 			"checksumSHA1": "i7FZ2nvv/aE37h5KD2b5hW+fHUo=",
 			"path": "github.com/facebookgo/structtag",
 			"revision": "217e25fb96916cc60332e399c9aa63f5c422ceed",


### PR DESCRIPTION
We were barely using it.

The framework requires fully creating objects before wiring
up dependencies, which is a violation of OO concepts. An
object should be complelely valid after the constructor returns.