### PR TITLE
Work around device mapper bug in Cent OS

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -40,4 +40,11 @@ echo "Deploying ..."
 for i in `ls manifests/*.yaml`; do
     $KUBECTL create -f $i
 done
+
+# Work around https://github.com/moby/moby/issues/33603
+# Release leaked device mapper semaphores
+for VM in `vagrant status | grep -v "^The Libvirt domain is running." | grep running | cut -d " " -f1`; do
+  vagrant ssh $VM -c "echo 'y' | sudo dmsetup udevcomplete_all"
+done
+
 echo "Done"


### PR DESCRIPTION
After every sync, explicitly release all device mapper semaphores, to
avoid new Pods which get stuck in ContainerCreating phase with the error

   devicemapper: Can't set cookie dm_task_set_cookie failed

See https://github.com/moby/moby/issues/33603 for more details.

Fixes #241 