### PR TITLE
Fix infinite vm deletion reenqueue

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -141,7 +141,7 @@ func (c *VMController) execute(key string) error {
 			return err
 		}
 		logger.Info().Msg("Deleting VM target Pod succeeded.")
-		return fmt.Errorf("Found outdated VM target pods.")
+		return nil
 	}
 
 	switch vm.Status.Phase {


### PR DESCRIPTION
A few weeks ago this patch https://github.com/kubevirt/kubevirt/commit/0ca016f7276815f753ab6824fc5f72dbd85031b2 changed the logic so that an error was being returned when the VM pod was successfully deleted. I'm pretty sure this wasn't intended because it results in the key getting reenqueued in the job queue forever.

I happened to find this while I was debugging some of my shared informer work.  Functionally everything works with the infinite reenqueue (which is why functional tests pass), but it will cause issues under load as the queue continues to grow. 



