### PR TITLE
Kubevirt shared informer factory

### DIFF
--- a/cmd/virt-controller/virt-controller.go
+++ b/cmd/virt-controller/virt-controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/emicklei/go-restful"
 	clientrest "k8s.io/client-go/rest"
 
+	kubeinformers "kubevirt.io/kubevirt/pkg/informers"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-controller/rest"
@@ -77,11 +78,17 @@ func main() {
 		golog.Fatal(err)
 	}
 
-	vmController := watch.NewVMController(vmService, nil, restClient, clientSet)
+	informerFactory := kubeinformers.NewKubeInformerFactory(restClient, clientSet)
+	vmInformer := informerFactory.VM()
+	migrationInformer := informerFactory.Migration()
+	podInformer := informerFactory.KubeVirtPod()
+	informerFactory.Start(stop)
+
+	vmController := watch.NewVMController(vmService, nil, restClient, clientSet, vmInformer, podInformer)
 	go vmController.Run(1, stop)
 
 	//FIXME when we have more than one worker, we need a lock on the VM
-	migrationController := watch.NewMigrationController(vmService, restClient, clientSet)
+	migrationController := watch.NewMigrationController(vmService, restClient, clientSet, migrationInformer, podInformer)
 	go migrationController.Run(1, stop)
 
 	httpLogger := logger.With("service", "http")

--- a/pkg/informers/virtinformers.go
+++ b/pkg/informers/virtinformers.go
@@ -1,0 +1,137 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package informers
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"k8s.io/client-go/kubernetes"
+	k8sv1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
+
+	kubeapi "k8s.io/client-go/pkg/api"
+
+	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/logging"
+)
+
+type newSharedInformer func() cache.SharedIndexInformer
+
+type KubeInformerFactory interface {
+	// Starts any informers that have not been started yet
+	// This function is thread safe and idempotent
+	Start(stopCh <-chan struct{})
+
+	// Watches for vm objects
+	VM() cache.SharedIndexInformer
+	// Watches for migration objects
+	Migration() cache.SharedIndexInformer
+	// Watches for pods related only to kubevirt
+	KubeVirtPod() cache.SharedIndexInformer
+}
+
+type kubeInformerFactory struct {
+	restClient    *rest.RESTClient
+	clientSet     *kubernetes.Clientset
+	lock          sync.Mutex
+	defaultResync time.Duration
+
+	informers        map[string]cache.SharedIndexInformer
+	startedInformers map[string]bool
+}
+
+func NewKubeInformerFactory(restClient *rest.RESTClient, clientSet *kubernetes.Clientset) KubeInformerFactory {
+	return &kubeInformerFactory{
+		restClient:       restClient,
+		clientSet:        clientSet,
+		defaultResync:    0,
+		informers:        make(map[string]cache.SharedIndexInformer),
+		startedInformers: make(map[string]bool),
+	}
+}
+
+// Start can be called from multiple controllers in different go routines safely.
+// Only informers that have not started are triggered by this function.
+// Multiple calls to this function are idempotent.
+func (f *kubeInformerFactory) Start(stopCh <-chan struct{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	for name, informer := range f.informers {
+		if f.startedInformers[name] {
+			// skip informers that have already started.
+			continue
+		}
+		logging.DefaultLogger().Info().Msgf("STARTING informer %s", name)
+		go informer.Run(stopCh)
+		f.startedInformers[name] = true
+	}
+}
+
+// internal function used to retrieve an already created informer
+// or create a new informer if one does not already exist.
+// Thread safe
+func (f *kubeInformerFactory) getInformer(key string, newFunc newSharedInformer) cache.SharedIndexInformer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	informer, exists := f.informers[key]
+	if exists {
+		return informer
+	}
+	informer = newFunc()
+	f.informers[key] = informer
+
+	return informer
+}
+
+func (f *kubeInformerFactory) VM() cache.SharedIndexInformer {
+	return f.getInformer("vmInformer", func() cache.SharedIndexInformer {
+		lw := cache.NewListWatchFromClient(f.restClient, "vms", kubeapi.NamespaceDefault, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &kubev1.VM{}, f.defaultResync, cache.Indexers{})
+	})
+}
+
+func (f *kubeInformerFactory) Migration() cache.SharedIndexInformer {
+	return f.getInformer("migrationInformer", func() cache.SharedIndexInformer {
+		lw := cache.NewListWatchFromClient(f.restClient, "migrations", kubeapi.NamespaceDefault, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &kubev1.Migration{}, f.defaultResync, cache.Indexers{})
+	})
+}
+
+func (f *kubeInformerFactory) KubeVirtPod() cache.SharedIndexInformer {
+	return f.getInformer("kubeVirtPodInformer", func() cache.SharedIndexInformer {
+		// Watch all pods with the kubevirt app label
+		labelSelector, err := labels.Parse(kubev1.AppLabel)
+		if err != nil {
+			panic(err)
+		}
+
+		lw := kubecli.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "pods", kubeapi.NamespaceDefault, fields.Everything(), labelSelector)
+		return cache.NewSharedIndexInformer(lw, &k8sv1.Pod{}, f.defaultResync, cache.Indexers{})
+	})
+}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -41,27 +39,32 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
-func NewMigrationController(migrationService services.VMService, restClient *rest.RESTClient, clientset *kubernetes.Clientset) *MigrationController {
-	lw := cache.NewListWatchFromClient(restClient, "migrations", k8sv1.NamespaceDefault, fields.Everything())
+func NewMigrationController(migrationService services.VMService, restClient *rest.RESTClient, clientset *kubernetes.Clientset, migrationInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer) *MigrationController {
+
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	store, informer := cache.NewIndexerInformer(lw, &kubev1.Migration{}, 0, kubecli.NewResourceEventHandlerFuncsForWorkqueue(queue), cache.Indexers{})
+	migrationInformer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForWorkqueue(queue))
+	podInformer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForFunc(migrationJobLabelHandler(queue)))
+	podInformer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForFunc(migrationPodLabelHandler(queue)))
+
 	return &MigrationController{
-		restClient: restClient,
-		vmService:  migrationService,
-		clientset:  clientset,
-		queue:      queue,
-		store:      store,
-		informer:   informer,
+		restClient:        restClient,
+		vmService:         migrationService,
+		clientset:         clientset,
+		queue:             queue,
+		store:             migrationInformer.GetStore(),
+		migrationInformer: migrationInformer,
+		podInformer:       podInformer,
 	}
 }
 
 type MigrationController struct {
-	restClient *rest.RESTClient
-	vmService  services.VMService
-	clientset  *kubernetes.Clientset
-	queue      workqueue.RateLimitingInterface
-	store      cache.Store
-	informer   cache.Controller
+	restClient        *rest.RESTClient
+	vmService         services.VMService
+	clientset         *kubernetes.Clientset
+	queue             workqueue.RateLimitingInterface
+	store             cache.Store
+	migrationInformer cache.SharedIndexInformer
+	podInformer       cache.SharedIndexInformer
 }
 
 func (c *MigrationController) Run(threadiness int, stopCh chan struct{}) {
@@ -69,13 +72,7 @@ func (c *MigrationController) Run(threadiness int, stopCh chan struct{}) {
 	defer c.queue.ShutDown()
 	logging.DefaultLogger().Info().Msg("Starting controller.")
 
-	// Start all informers and wait for the cache sync
-	_, jobInformer := NewMigrationJobInformer(c.clientset, c.queue)
-	go jobInformer.Run(stopCh)
-	_, podInformer := NewMigrationPodInformer(c.clientset, c.queue)
-	go podInformer.Run(stopCh)
-	go c.informer.Run(stopCh)
-	cache.WaitForCacheSync(stopCh, c.informer.HasSynced, jobInformer.HasSynced, podInformer.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.migrationInformer.HasSynced, c.podInformer.HasSynced)
 
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {
@@ -355,51 +352,44 @@ func mergeConstraints(migration *kubev1.Migration, vm *kubev1.VM) error {
 	return nil
 }
 
-func migrationVMPodSelector() kubeapi.ListOptions {
-	fieldSelectionQuery := fmt.Sprintf("status.phase=%s", string(kubeapi.PodRunning))
-	fieldSelector := fields.ParseSelectorOrDie(fieldSelectionQuery)
-	labelSelectorQuery := fmt.Sprintf("%s, %s in (virt-launcher)", string(kubev1.MigrationLabel), kubev1.AppLabel)
-	labelSelector, err := labels.Parse(labelSelectorQuery)
-
-	if err != nil {
-		panic(err)
-	}
-	return kubeapi.ListOptions{FieldSelector: fieldSelector, LabelSelector: labelSelector}
-}
-
-func migrationJobSelector() kubeapi.ListOptions {
-	fieldSelector := fields.ParseSelectorOrDie(
-		"status.phase!=" + string(k8sv1.PodPending) +
-			",status.phase!=" + string(k8sv1.PodRunning) +
-			",status.phase!=" + string(k8sv1.PodUnknown))
-	labelSelector, err := labels.Parse(kubev1.AppLabel + "=migration," + kubev1.DomainLabel + "," + kubev1.MigrationLabel)
-	if err != nil {
-		panic(err)
-	}
-	return kubeapi.ListOptions{FieldSelector: fieldSelector, LabelSelector: labelSelector}
-}
-
-// Informer, which checks for Jobs, orchestrating the migrations done by libvirt
-func NewMigrationJobInformer(clientSet *kubernetes.Clientset, migrationQueue workqueue.RateLimitingInterface) (cache.Store, cache.Controller) {
-	selector := migrationJobSelector()
-	lw := kubecli.NewListWatchFromClient(clientSet.CoreV1().RESTClient(), "pods", kubeapi.NamespaceDefault, selector.FieldSelector, selector.LabelSelector)
-	return cache.NewIndexerInformer(lw, &k8sv1.Pod{}, 0,
-		kubecli.NewResourceEventHandlerFuncsForFunc(migrationLabelHandler(migrationQueue)),
-		cache.Indexers{})
-}
-
-// Informer, which checks for potential migration target Pods
-func NewMigrationPodInformer(clientSet *kubernetes.Clientset, migrationQueue workqueue.RateLimitingInterface) (cache.Store, cache.Controller) {
-	selector := migrationVMPodSelector()
-	lw := kubecli.NewListWatchFromClient(clientSet.CoreV1().RESTClient(), "pods", kubeapi.NamespaceDefault, selector.FieldSelector, selector.LabelSelector)
-	return cache.NewIndexerInformer(lw, &k8sv1.Pod{}, 0,
-		kubecli.NewResourceEventHandlerFuncsForFunc(migrationLabelHandler(migrationQueue)),
-		cache.Indexers{})
-}
-
-func migrationLabelHandler(migrationQueue workqueue.RateLimitingInterface) func(obj interface{}) {
+func migrationJobLabelHandler(migrationQueue workqueue.RateLimitingInterface) func(obj interface{}) {
 	return func(obj interface{}) {
-		migrationLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.MigrationLabel]
+		phase := obj.(*k8sv1.Pod).Status.Phase
+		appLabel, hasAppLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.AppLabel]
+		migrationLabel, hasMigrationLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.MigrationLabel]
+		_, hasDomainLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.DomainLabel]
+
+		if phase == k8sv1.PodRunning ||
+			phase == k8sv1.PodUnknown ||
+			phase == k8sv1.PodPending {
+
+			return
+		} else if hasDomainLabel == false || hasMigrationLabel == false || hasAppLabel == false {
+			// missing required labels
+			return
+		} else if appLabel != "migration" {
+			return
+		}
+
+		migrationQueue.Add(k8sv1.NamespaceDefault + "/" + migrationLabel)
+	}
+}
+
+func migrationPodLabelHandler(migrationQueue workqueue.RateLimitingInterface) func(obj interface{}) {
+	return func(obj interface{}) {
+		phase := obj.(*k8sv1.Pod).Status.Phase
+		appLabel, hasAppLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.AppLabel]
+		migrationLabel, hasMigrationLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.MigrationLabel]
+
+		if phase != k8sv1.PodRunning {
+			return
+		} else if hasMigrationLabel == false || hasAppLabel == false {
+			// missing required labels
+			return
+		} else if appLabel != "virt-launcher" {
+			return
+		}
+
 		migrationQueue.Add(k8sv1.NamespaceDefault + "/" + migrationLabel)
 	}
 }

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -87,12 +87,13 @@ var _ = Describe("Migration", func() {
 		migrationQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 		migrationController = &MigrationController{
-			restClient: restClient,
-			vmService:  vmService,
-			clientset:  clientSet,
-			queue:      migrationQueue,
-			store:      migrationCache,
-			informer:   nil,
+			restClient:        restClient,
+			vmService:         vmService,
+			clientset:         clientSet,
+			queue:             migrationQueue,
+			store:             migrationCache,
+			migrationInformer: nil,
+			podInformer:       nil,
 		}
 		// Create a VM which is being scheduled
 


### PR DESCRIPTION
The kubevirt shared informer factory allows multiple controllers to reuse the same informers.

For example, multiple calls to 'informerFactory.VM()' will return the same shared informer for watching VM objects.  The exact same shared informer can be retrieved and started safely across multiple goroutines.

At the moment, only virt-controller takes advantage of this factory. If we're satisfied with this direction, we can convert virt-handler to use the informer factory in a follow up patch.

The main functional advantage of using shared informers is that it allows sharing a single informer across multiple goroutines. Virt-controller however doesn't actually overlap usage of informers across multiple controllers right now. Because of this, the primary benefit we receive from this patch right now is an investment in a development pattern that should make managing informers easier moving forward.