### PR TITLE
virt-api: run container as non-root user

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -18,11 +18,17 @@
 
 FROM centos:7
 
+# Create non-root user
+RUN useradd --create-home -s /bin/bash virt-api
+WORKDIR /home/virt-api
+USER virt-api
+
+# Configure swagger
 RUN curl -OL https://github.com/swagger-api/swagger-ui/tarball/38f74164a7062edb5dc80ef2fdddda24f3f6eb85/swagger-ui.tar.gz \
     && mkdir swagger-ui && tar xf swagger-ui.tar.gz -C swagger-ui --strip-components 1 \
-    && mkdir /third_party \
-    && mv swagger-ui/dist /third_party/swagger-ui && rm -rf swagger-ui \
-    && sed -e 's@"http://petstore.swagger.io/v2/swagger.json"@"/swaggerapi/"@' -i  /third_party/swagger-ui/index.html \
+    && mkdir third_party \
+    && mv swagger-ui/dist third_party/swagger-ui && rm -rf swagger-ui \
+    && sed -e 's@"http://petstore.swagger.io/v2/swagger.json"@"/swaggerapi/"@' -i  third_party/swagger-ui/index.html \
     && rm swagger-ui.tar.gz && rm -rf swagger-ui
 
 COPY virt-api /virt-api

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -35,5 +35,7 @@ spec:
           - containerPort: 8183
             name: "virt-api"
             protocol: "TCP"
+      securityContext:
+        runAsNonRoot: true
       nodeSelector:
         kubernetes.io/hostname: master


### PR DESCRIPTION
Create new virt-api user and run all commands under this user.
Part of the fix for #113