### PR TITLE
haproxy: run container as non-root user

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -19,6 +19,11 @@
 FROM haproxy:1.6-alpine
 COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 
+RUN sed -i "s|/run|/haproxy/run|g" /docker-entrypoint.sh
 RUN cp /docker-entrypoint.sh /docker-entrypoint-orig.sh
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+RUN addgroup -S haproxy && adduser -S -D -h /haproxy -s /bin/false -G haproxy -g haproxy haproxy
+USER haproxy
+RUN mkdir /haproxy/run

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -29,5 +29,7 @@ spec:
           - containerPort: 8184
             name: "haproxy"
             protocol: "TCP"
+      securityContext:
+        runAsNonRoot: true
       nodeSelector:
         kubernetes.io/hostname: master


### PR DESCRIPTION
Create new haproxy user and run the container under this user.
Part of the fix for #113