### PR TITLE
virt-controller: run container as non-root user

### DIFF
--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -18,6 +18,10 @@
 
 FROM centos:7
 
+# Create non-root user
+RUN useradd --create-home -s /bin/bash virt-controller
+WORKDIR /home/virt-controller
+USER virt-controller
 COPY virt-controller /virt-controller
 
 ENTRYPOINT [ "/virt-controller" ]

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -37,5 +37,7 @@ spec:
           - containerPort: 8182
             name: "virt-controller"
             protocol: "TCP"
+      securityContext:
+        runAsNonRoot: true
       nodeSelector:
         kubernetes.io/hostname: master


### PR DESCRIPTION
Create new virt-controller user and run the container under this user.
Part of the fix for #113