### PR TITLE
Avoid setting emulator script explicitly

### DIFF
--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -29,8 +29,9 @@ RUN yum install -y \
   sudo \
   docker && yum -y clean all
 
-COPY qemu-kube /usr/local/bin/qemu-x86_64
-RUN chmod a+x /usr/local/bin/qemu-x86_64
+COPY qemu-kube /usr/local/bin/qemu-system-x86_64
+RUN chmod a+x /usr/local/bin/qemu-system-x86_64
+ENV PATH /usr/local/bin:/bin:/sbin
 
 COPY kubevirt-sudo /etc/sudoers.d/kubevirt
 RUN chmod 0640 /etc/sudoers.d/kubevirt

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -46,7 +46,7 @@ type Memory struct {
 }
 
 type Devices struct {
-	Emulator   string      `json:"emulator"`
+	Emulator   string      `json:"emulator,omitempty"`
 	Interfaces []Interface `json:"interfaces,omitempty"`
 	Channels   []Channel   `json:"channels,omitempty"`
 	Video      []Video     `json:"video,omitempty"`
@@ -324,7 +324,7 @@ func NewMinimalDomainSpec(vmName string) *DomainSpec {
 	precond.MustNotBeEmpty(vmName)
 	domain := DomainSpec{OS: OS{Type: OSType{OS: "hvm"}}, Type: "qemu", Name: vmName}
 	domain.Memory = Memory{Unit: "KiB", Value: 8192}
-	domain.Devices = Devices{Emulator: "/usr/local/bin/qemu-x86_64"}
+	domain.Devices = Devices{}
 	domain.Devices.Interfaces = []Interface{
 		{Type: "network", Source: InterfaceSource{Network: "default"}},
 	}

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -40,7 +40,6 @@ var exampleJSON = `{
     "bootOrder": null
   },
   "devices": {
-    "emulator": "/usr/local/bin/qemu-x86_64",
     "interfaces": [
       {
         "type": "network",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -172,7 +172,6 @@ func (c *VMController) execute(key string) error {
 			vmCopy.Spec.Domain = spec
 		}
 		vmCopy.Spec.Domain.UUID = string(vmCopy.GetObjectMeta().GetUID())
-		vmCopy.Spec.Domain.Devices.Emulator = "/usr/local/bin/qemu-x86_64"
 		vmCopy.Spec.Domain.Name = vmCopy.GetObjectMeta().GetName()
 
 		// TODO when we move this to virt-api, we have to block that they are set on POST or changed on PUT

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -159,7 +159,7 @@ type Memory struct {
 }
 
 type Devices struct {
-	Emulator   string      `xml:"emulator"`
+	Emulator   string      `xml:"emulator,omitempty"`
 	Interfaces []Interface `xml:"interface"`
 	Channels   []Channel   `xml:"channel"`
 	Video      []Video     `xml:"video"`
@@ -444,7 +444,7 @@ func NewMinimalDomainSpec(vmName string) *DomainSpec {
 	precond.MustNotBeEmpty(vmName)
 	domain := DomainSpec{OS: OS{Type: OSType{OS: "hvm"}}, Type: "qemu", Name: vmName}
 	domain.Memory = Memory{Unit: "KiB", Value: 8192}
-	domain.Devices = Devices{Emulator: "/usr/local/bin/qemu-x86_64"}
+	domain.Devices = Devices{}
 	domain.Devices.Interfaces = []Interface{
 		{Type: "network", Source: InterfaceSource{Network: "default"}},
 	}

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -36,7 +36,6 @@ var exampleXML = `<domain type="qemu">
     <type>hvm</type>
   </os>
   <devices>
-    <emulator>/usr/local/bin/qemu-x86_64</emulator>
     <interface type="network">
       <source network="default"></source>
     </interface>


### PR DESCRIPTION
Libvirt automatically detects emulator binaries in $PATH.
There is no need to set the emulator field to point to
the wrapper script, if we give it the normal name and
put its install location first in $PATH.  This avoids
naming confusion because 'qemu-x86_64' is a valid QEMU
binary used for userspace emulator, which is a very
different thing than system emulators.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>