### PR TITLE
virt-handler shared informers

### DIFF
--- a/pkg/informers/virtinformers.go
+++ b/pkg/informers/virtinformers.go
@@ -37,7 +37,6 @@ import (
 
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
-	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 )
 
 type NewSharedInformerFunc func() cache.SharedIndexInformer
@@ -126,7 +125,7 @@ func (f *kubeInformerFactory) VmOnHost(host string) cache.SharedIndexInformer {
 			panic(err)
 		}
 
-		lw := kubecli.NewListWatchFromClient(f.restClient, "vms", kubeapi.NamespaceDefault, fields.Everything(), labelSelector)
+		lw := kubecli.NewListWatchFromClient(f.restClient, "vms", api.NamespaceAll, fields.Everything(), labelSelector)
 		return cache.NewSharedIndexInformer(lw, &kubev1.VM{}, f.defaultResync, cache.Indexers{})
 	})
 }

--- a/pkg/informers/virtinformers.go
+++ b/pkg/informers/virtinformers.go
@@ -20,6 +20,7 @@
 package informers
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -36,21 +37,26 @@ import (
 
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 )
 
-type newSharedInformer func() cache.SharedIndexInformer
+type NewSharedInformerFunc func() cache.SharedIndexInformer
 
 type KubeInformerFactory interface {
 	// Starts any informers that have not been started yet
 	// This function is thread safe and idempotent
 	Start(stopCh <-chan struct{})
 
+	// Watches for vm objects assigned to host
+	VmOnHost(host string) cache.SharedIndexInformer
 	// Watches for vm objects
 	VM() cache.SharedIndexInformer
 	// Watches for migration objects
 	Migration() cache.SharedIndexInformer
 	// Watches for pods related only to kubevirt
 	KubeVirtPod() cache.SharedIndexInformer
+	// Generic way of creating a shared informer
+	CustomInformer(name string, newFunc NewSharedInformerFunc) cache.SharedIndexInformer
 }
 
 type kubeInformerFactory struct {
@@ -94,7 +100,7 @@ func (f *kubeInformerFactory) Start(stopCh <-chan struct{}) {
 // internal function used to retrieve an already created informer
 // or create a new informer if one does not already exist.
 // Thread safe
-func (f *kubeInformerFactory) getInformer(key string, newFunc newSharedInformer) cache.SharedIndexInformer {
+func (f *kubeInformerFactory) getInformer(key string, newFunc NewSharedInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -106,6 +112,23 @@ func (f *kubeInformerFactory) getInformer(key string, newFunc newSharedInformer)
 	f.informers[key] = informer
 
 	return informer
+}
+
+func (f *kubeInformerFactory) CustomInformer(name string, newFunc NewSharedInformerFunc) cache.SharedIndexInformer {
+	return f.getInformer(name, newFunc)
+}
+
+func (f *kubeInformerFactory) VmOnHost(host string) cache.SharedIndexInformer {
+	name := fmt.Sprintf("vmOnHostInformer_%s", host)
+	return f.getInformer(name, func() cache.SharedIndexInformer {
+		labelSelector, err := labels.Parse(fmt.Sprintf(kubev1.NodeNameLabel+" in (%s)", host))
+		if err != nil {
+			panic(err)
+		}
+
+		lw := kubecli.NewListWatchFromClient(f.restClient, "vms", kubeapi.NamespaceDefault, fields.Everything(), labelSelector)
+		return cache.NewSharedIndexInformer(lw, &kubev1.VM{}, f.defaultResync, cache.Indexers{})
+	})
 }
 
 func (f *kubeInformerFactory) VM() cache.SharedIndexInformer {

--- a/pkg/virt-handler/domain.go
+++ b/pkg/virt-handler/domain.go
@@ -38,11 +38,13 @@ TODO: Define the exact scope of this controller.
 For now it looks like we should use domain events to detect unexpected domain changes like crashes or vms going
 into pause mode because of resource shortage or cut off connections to storage.
 */
-func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedInformer, restClient rest.RESTClient, recorder record.EventRecorder) (cache.Store, *kubecli.Controller) {
+func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedIndexInformer, restClient rest.RESTClient, recorder record.EventRecorder) (cache.Store, *kubecli.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	informer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForWorkqueue(queue))
 	dispatch := NewDomainDispatch(vmQueue, vmStore, restClient, recorder)
-	return kubecli.NewControllerFromInformer(informer.GetStore(), informer, queue, dispatch)
+	controller := kubecli.NewControllerFromInformer(informer, queue, dispatch)
+
+	return informer.GetStore(), controller
 }
 
 func NewDomainDispatch(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, restClient rest.RESTClient, recorder record.EventRecorder) kubecli.ControllerDispatch {

--- a/pkg/virt-handler/virtwrap/cache/cache.go
+++ b/pkg/virt-handler/virtwrap/cache/cache.go
@@ -70,7 +70,7 @@ var CrashedReasonTranslationMap = map[libvirt.DomainCrashedReason]api.StateChang
 }
 
 // NewListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector.
-func newListWatchFromClient(c virtwrap.Connection, events ...int) *cache.ListWatch {
+func NewListWatchFromClient(c virtwrap.Connection, events ...int) *cache.ListWatch {
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		logging.DefaultLogger().Info().V(3).Msg("Synchronizing domains")
 		doms, err := c.ListAllDomains(libvirt.CONNECT_LIST_DOMAINS_ACTIVE | libvirt.CONNECT_LIST_DOMAINS_INACTIVE)
@@ -179,7 +179,7 @@ func NewDomain(dom virtwrap.VirDomain) (*api.Domain, error) {
 }
 
 func NewSharedInformer(c virtwrap.Connection) (cache.SharedInformer, error) {
-	lw := newListWatchFromClient(c)
+	lw := NewListWatchFromClient(c)
 	informer := cache.NewSharedInformer(lw, &api.Domain{}, 0)
 	return informer, nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -39,13 +39,14 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
 )
 
-func NewVMController(lw cache.ListerWatcher, domainManager virtwrap.DomainManager, recorder record.EventRecorder, restClient rest.RESTClient, clientset *kubernetes.Clientset, host string) (cache.Store, workqueue.RateLimitingInterface, *kubecli.Controller) {
+func NewVMController(domainManager virtwrap.DomainManager, recorder record.EventRecorder, restClient rest.RESTClient, clientset *kubernetes.Clientset, host string, informer cache.SharedIndexInformer) (cache.Store, workqueue.RateLimitingInterface, *kubecli.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-
 	dispatch := NewVMHandlerDispatch(domainManager, recorder, &restClient, clientset, host)
+	informer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForWorkqueue(queue))
 
-	indexer, informer := kubecli.NewController(lw, queue, &v1.VM{}, dispatch)
-	return indexer, queue, informer
+	controller := kubecli.NewControllerFromInformer(informer, queue, dispatch)
+
+	return informer.GetStore(), queue, controller
 
 }
 func NewVMHandlerDispatch(domainManager virtwrap.DomainManager, recorder record.EventRecorder, restClient *rest.RESTClient, clientset *kubernetes.Clientset, host string) kubecli.ControllerDispatch {


### PR DESCRIPTION
migrate virt-handler to use the same informer patterns as virt-controller. 