### PR TITLE
User Kubernetes 1.6.6 in the Vagrant deployment

### DIFF
--- a/cluster/vagrant/setup_kubernetes_common.sh
+++ b/cluster/vagrant/setup_kubernetes_common.sh
@@ -68,9 +68,9 @@ yum install -y docker
 # Currently older versions of kubeadm are no longer available in the rpm repos.
 # See https://github.com/kubernetes/kubeadm/issues/220 for context.
 yum install -y \
-      kubeadm \
-      kubelet \
-      kubectl \
+      kubeadm-1.6.6 \
+      kubelet-1.6.6 \
+      kubectl-1.6.6 \
       kubernetes-cni
 
 # Latest docker on CentOS uses systemd for cgroup management

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -25,7 +25,7 @@ yum install -y cockpit cockpit-kubernetes
 systemctl enable cockpit.socket && systemctl start cockpit.socket
 
 # Create the master
-kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --apiserver-advertise-address=$ADVERTISED_MASTER_IP
+kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --apiserver-advertise-address=$ADVERTISED_MASTER_IP --kubernetes-version=stable-1.6
 
 # Tell kubectl which config to use
 export KUBECONFIG=/etc/kubernetes/admin.conf


### PR DESCRIPTION
Make sure, we don't use Kubernetes 1.7, until [1] is fixed or we know a
workaround for it.

[1] https://github.com/kubernetes/kubeadm/issues/335