### PR TITLE
vagrant: Work around controller race bug until Kubernetes 1.7.1 is released

### DIFF
--- a/cluster/vagrant/kubernetes-1.7-workaround.yml
+++ b/cluster/vagrant/kubernetes-1.7-workaround.yml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:controller:bootstrap-signer
+  namespace: kube-public
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - cluster-info
+  resources:
+  - configmaps
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:controller:bootstrap-signer
+  namespace: kube-public
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system:controller:bootstrap-signer
+subjects:
+- kind: ServiceAccount
+  name: bootstrap-signer
+  namespace: kube-system

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -53,6 +53,9 @@ else
   kubectl create -f kube-$NETWORK_PROVIDER.yaml
 fi
 
+# Work around https://github.com/kubernetes/kubeadm/issues/335 until Kubernetes 1.7.1 is released
+kubectl apply -f kubernetes-1.7-workaround.yml
+
 # Allow scheduling pods on master
 # Ignore retval because it might not be dedicated already
 kubectl taint nodes master node-role.kubernetes.io/master:NoSchedule- || :


### PR DESCRIPTION
When nodes try to join a master, they can fail because cluster-info is
not updated with the expected tokens. To work around that, add the
required Role and RoleBinging to let the token signer do its work in
time. See https://github.com/kubernetes/kubeadm/issues/335 for details
about the workaround. Fixes #286 