### PR TITLE
[DO NOT MERGE] Create basic RBAC permissions for KubeVirt

### DIFF
--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -60,10 +60,6 @@ kubectl apply -f kubernetes-1.7-workaround.yml
 # Ignore retval because it might not be dedicated already
 kubectl taint nodes master node-role.kubernetes.io/master:NoSchedule- || :
 
-# TODO better scope the permissions, for now allow the default account everything
-kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
-kubectl create clusterrolebinding add-on-default-admin --clusterrole=cluster-admin --serviceaccount=default:default
-
 mkdir -p /exports/share1
 
 chmod 0755 /exports/share1

--- a/manifests/cockpit-demo.yaml.in
+++ b/manifests/cockpit-demo.yaml.in
@@ -22,6 +22,7 @@ spec:
       labels:
         name: kubevirt-cockpit-demo
     spec:
+      serviceAccountName: kubevirt
       containers:
       - name: cockpit
         image: kubevirt/cockpit-demo

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -21,6 +21,7 @@ spec:
       labels:
         app: haproxy
     spec:
+      serviceAccountName: kubevirt-admin
       containers:
       - name: haproxy
         image: {{ docker_prefix }}/haproxy:{{ docker_tag }}

--- a/manifests/permissions.yaml.in
+++ b/manifests/permissions.yaml.in
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kubevirt
+      namespace: default
+      labels:
+        name: kubevirt
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: kubevirt
+      labels:
+        name: kubevirt
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+        verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update  
+          - create  
+      - apiGroups:
+          - ''
+        resources:
+          - nodes
+          - persistentvolumeclaims  
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - kubevirt.io
+        resources:
+          - vms
+          - migrations  
+        verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - update  
+          - create  
+          - deletecollection
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kubevirt
+      labels:
+        name: kubevirt
+    roleRef:
+      kind: ClusterRole
+      name: kubevirt
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: kubevirt
+        namespace: default
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kubevirt-admin
+      namespace: default
+      labels:
+        name: kubevirt-admin
+  - apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kubevirt-admin
+      labels:
+        name: kubevirt-admin
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin
+      apiGroup: rbac.authorization.k8s.io
+    subjects:
+      - kind: ServiceAccount
+        name: kubevirt-admin
+        namespace: default

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -21,6 +21,7 @@ spec:
       labels:
         app: virt-api
     spec:
+      serviceAccountName: kubevirt
       containers:
       - name: virt-api
         image: {{ docker_prefix }}/virt-api:{{ docker_tag }}

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -21,6 +21,7 @@ spec:
       labels:
         app: virt-controller
     spec:
+      serviceAccountName: kubevirt
       containers:
       - name: virt-controller
         image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}


### PR DESCRIPTION
Make sure that KubeVirt can run on Kubernetes instances where RBAC is
enabled. Further give the haproxy admin rights right now, to allow it to
forward all calls to the apiserver.

This does not at all provide a more secure way to run KubeVirt. It's
only purpose at this stage is to allow friction-less deployments on
RBAC enabled Kubernetes clusters.

The depolyment can be properly secured, as soon as we have movedm from
our haproxy approach to the Aggregated API Server.

Fixes #299, #62 and does some initial work for #301.

Signed-off-by: Roman Mohr <rmohr@redhat.com>