### PR TITLE
Set domain fixed values like name and UUID in the virt-handler

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -25,13 +25,7 @@ package v1
  ATTENTION: Rerun code generators when comments on structs or fields are modified.
 */
 
-import (
-	"kubevirt.io/kubevirt/pkg/precond"
-)
-
 type DomainSpec struct {
-	Name    string   `json:"name"`
-	UUID    string   `json:"uuid,omitempty"`
 	Memory  Memory   `json:"memory"`
 	Type    string   `json:"type"`
 	OS      OS       `json:"os"`
@@ -320,9 +314,8 @@ type RandomGenerator struct {
 
 // TODO ballooning, rng, cpu ...
 
-func NewMinimalDomainSpec(vmName string) *DomainSpec {
-	precond.MustNotBeEmpty(vmName)
-	domain := DomainSpec{OS: OS{Type: OSType{OS: "hvm"}}, Type: "qemu", Name: vmName}
+func NewMinimalDomainSpec() *DomainSpec {
+	domain := DomainSpec{OS: OS{Type: OSType{OS: "hvm"}}, Type: "qemu"}
 	domain.Memory = Memory{Unit: "KiB", Value: 8192}
 	domain.Devices = Devices{}
 	domain.Devices.Interfaces = []Interface{

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 var exampleJSON = `{
-  "name": "testvm",
   "memory": {
     "value": 8192,
     "unit": "KiB"
@@ -74,7 +73,7 @@ var exampleJSON = `{
 
 var _ = Describe("Schema", func() {
 	//The example domain should stay in sync to the json above
-	var exampleVM = NewMinimalDomainSpec("testvm")
+	var exampleVM = NewMinimalDomainSpec()
 	exampleVM.Devices.Disks = []Disk{
 		{
 			Type:   "network",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -282,7 +282,7 @@ func NewMinimalVM(vmName string) *VM {
 func NewMinimalVMWithNS(namespace string, vmName string) *VM {
 	precond.CheckNotEmpty(vmName)
 	vm := NewVMReferenceFromNameWithNS(namespace, vmName)
-	vm.Spec = VMSpec{Domain: NewMinimalDomainSpec(vmName)}
+	vm.Spec = VMSpec{Domain: NewMinimalDomainSpec()}
 	vm.TypeMeta = metav1.TypeMeta{
 		APIVersion: GroupVersion.String(),
 		Kind:       "VM",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -167,11 +167,9 @@ func (c *VMController) execute(key string) error {
 		// TODO move defaulting to virt-api
 		// TODO move constants to virt-handler and remove from the spec
 		if vmCopy.Spec.Domain == nil {
-			spec := kubev1.NewMinimalDomainSpec(vmCopy.GetObjectMeta().GetName())
+			spec := kubev1.NewMinimalDomainSpec()
 			vmCopy.Spec.Domain = spec
 		}
-		vmCopy.Spec.Domain.UUID = string(vmCopy.GetObjectMeta().GetUID())
-		vmCopy.Spec.Domain.Name = vmCopy.GetObjectMeta().GetName()
 
 		// TODO when we move this to virt-api, we have to block that they are set on POST or changed on PUT
 		graphics := vmCopy.Spec.Domain.Devices.Graphics

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Schema", func() {
 
 	})
 	Context("With v1.DomainSpec", func() {
-		var v1DomainSpec = v1.NewMinimalDomainSpec("testvm")
+		var v1DomainSpec = v1.NewMinimalDomainSpec()
 		v1DomainSpec.Devices.Disks = []v1.Disk{
 			{Type: "network",
 				Device: "disk",

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -338,6 +338,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) (*api.DomainSpec, error) {
 
 	domName := VMNamespaceKeyFunc(vm)
 	wantedSpec.Name = domName
+	wantedSpec.UUID = string(vm.GetObjectMeta().GetUID())
 	dom, err := l.virConn.LookupDomainByName(domName)
 	if err != nil {
 		// We need the domain but it does not exist, so create it

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -180,6 +180,6 @@ var _ = Describe("Manager", func() {
 func newVM(namespace string, name string) *v1.VM {
 	return &v1.VM{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec:       v1.VMSpec{Domain: v1.NewMinimalDomainSpec(name)},
+		Spec:       v1.VMSpec{Domain: v1.NewMinimalDomainSpec()},
 	}
 }

--- a/pkg/virt-manifest/defaults.go
+++ b/pkg/virt-manifest/defaults.go
@@ -20,8 +20,6 @@
 package virt_manifest
 
 import (
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 
@@ -30,7 +28,6 @@ func AddMinimalVMSpec(vm *v1.VM) {
 	if vm.Spec.Domain == nil {
 		vm.Spec.Domain = new(v1.DomainSpec)
 	}
-	vm.Spec.Domain.Name = vm.ObjectMeta.Name + "-" + rand.String(5)
 
 	AddMinimalDomainSpec(vm.Spec.Domain)
 }

--- a/pkg/virt-manifest/defaults_test.go
+++ b/pkg/virt-manifest/defaults_test.go
@@ -78,8 +78,7 @@ var _ = Describe("Defaults", func() {
 		It("should assign a random name to domain spec", func() {
 			vm.Spec.Domain = nil
 			AddMinimalVMSpec(vm)
-			Expect(vm.Spec.Domain.Name).ToNot(BeNil())
-			Expect(vm.ObjectMeta.Name).ToNot(Equal(vm.Spec.Domain.Name))
+			Expect(vm.GetObjectMeta().GetName()).ToNot(BeNil())
 		})
 
 		It("should create missing domain", func() {

--- a/pkg/virt-manifest/mapper.go
+++ b/pkg/virt-manifest/mapper.go
@@ -85,6 +85,8 @@ func MapVM(con virtwrap.Connection, vm *v1.VM) (*v1.VM, error) {
 		return nil, errors.NewAggregate(mappingErrs)
 	}
 
+	wantedSpec.Name = vmCopy.GetObjectMeta().GetName()
+	wantedSpec.UUID = string(vmCopy.GetObjectMeta().GetUID())
 	xmlStr, err := xml.Marshal(&wantedSpec)
 	if err != nil {
 		log.Object(vm).Error().Reason(err).Msg("Generating the domain XML failed.")

--- a/pkg/virt-manifest/rest/manifest.go
+++ b/pkg/virt-manifest/rest/manifest.go
@@ -95,7 +95,6 @@ func (m manifest) mapManifest(_ context.Context, request interface{}) (interface
 	virt_manifest.AddMinimalVMSpec(vm)
 
 	mappedVm, err := virt_manifest.MapVM(m.connection, vm)
-	mappedVm.Spec.Domain.Name = mappedVm.ObjectMeta.Name
 	if err != nil {
 		return nil, middleware.NewInternalServerError(err)
 	} else {


### PR DESCRIPTION
Remove UUID and name attributes from the domain spec 
Resolve #124 