### PR TITLE
Get rid of userspace proxying

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure(2) do |config|
       master.vm.provision "shell", inline: <<-SHELL
         #!/bin/bash
         set -xe
-        export ADVERTISED_MASTER_IP=#{$master_ip}
+        export MASTER_IP=#{$master_ip}
         export WITH_LOCAL_NFS=true
         export NETWORK_PROVIDER=#{$network_provider}
         cd /vagrant/cluster/vagrant
@@ -91,7 +91,7 @@ Vagrant.configure(2) do |config|
         node.vm.provision "shell", inline: <<-SHELL
           #!/bin/bash
           set -xe
-          export ADVERTISED_MASTER_IP=#{$master_ip}
+          export MASTER_IP=#{$master_ip}
           cd /vagrant/cluster/vagrant
           bash setup_kubernetes_node.sh
           set +x

--- a/cluster/vagrant/setup_kubernetes_common.sh
+++ b/cluster/vagrant/setup_kubernetes_common.sh
@@ -28,7 +28,7 @@ yum -y remove NetworkManager firewalld
 
 # Install epel
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install jq
+yum -y install jq sshpass
 
 yum -y install bind-utils net-tools
 

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -25,7 +25,7 @@ yum install -y cockpit cockpit-kubernetes
 systemctl enable cockpit.socket && systemctl start cockpit.socket
 
 # Create the master
-kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456 --apiserver-advertise-address=$ADVERTISED_MASTER_IP
+kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456
 
 # Tell kubectl which config to use
 export KUBECONFIG=/etc/kubernetes/admin.conf
@@ -40,12 +40,6 @@ while [ $? -ne 0 ]; do
 done
 
 set -e
-
-# Work around https://github.com/kubernetes/kubernetes/issues/34101
-# Weave otherwise the network provider does not work
-kubectl -n kube-system get ds -l 'k8s-app=kube-proxy' -o json \
-        | jq '.items[0].spec.template.spec.containers[0].command |= .+ ["--proxy-mode=userspace"]' \
-        |   kubectl apply -f - && kubectl -n kube-system delete pods -l 'k8s-app=kube-proxy'
 
 if [ "$NETWORK_PROVIDER" == "weave" ]; then 
   kubectl apply -f https://github.com/weaveworks/weave/releases/download/v1.9.4/weave-daemonset-k8s-1.6.yaml

--- a/cluster/vagrant/setup_kubernetes_node.sh
+++ b/cluster/vagrant/setup_kubernetes_node.sh
@@ -19,6 +19,7 @@
 
 bash ./setup_kubernetes_common.sh
 
+ADVERTISED_MASTER_IP=`sshpass -p vagrant ssh -oStrictHostKeyChecking=no vagrant@$MASTER_IP hostname -I | cut -d " " -f1`
 set +e
 
 echo 'Trying to register myself...'


### PR DESCRIPTION
Determine the master IP via ssh over eth1. This allows nodes to find out
the IP of eth0 of the master.

Background is, that DNS probes from nodes to resolve the master IP, in some libvirt/vagrant combinations point to wrong IPs. Therefore, use the well known IP of eth1, to connect  to the master, and get the IP of eth0 from the master directly. This allows kubeadm on the node, to use the right IP to connect to the master. If we don't do that, we have to mess around with Kubernetes and the netork providers, to use eth1, which is error prone, and some people are still seeing deployment issues.