### PR TITLE
Convert commands over to use pflag library for POSIX style opts

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful/swagger"
 	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -47,7 +48,8 @@ func main() {
 	swaggerui := flag.String("swagger-ui", "third_party/swagger-ui", "swagger-ui location")
 	host := flag.String("listen", "0.0.0.0", "Address and port where to listen on")
 	port := flag.Int("port", 8183, "Port to listen on")
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
 
 	ctx := context.Background()
 	vmGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "vms"}

--- a/cmd/virt-controller/virt-controller.go
+++ b/cmd/virt-controller/virt-controller.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 
 	"github.com/emicklei/go-restful"
+	"github.com/spf13/pflag"
 	clientrest "k8s.io/client-go/rest"
 
 	kubeinformers "kubevirt.io/kubevirt/pkg/informers"
@@ -45,7 +46,8 @@ func main() {
 	migratorImage := flag.String("migrator-image", "virt-handler", "Container which orchestrates a VM migration")
 
 	logger := logging.DefaultLogger()
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
 
 	templateService, err := services.NewTemplateService(*launcherImage, *migratorImage)
 	if err != nil {

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/emicklei/go-restful"
 	"github.com/libvirt/libvirt-go"
+	"github.com/spf13/pflag"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,14 +49,14 @@ import (
 )
 
 func main() {
-
 	logging.InitializeLogging("virt-handler")
 	libvirt.EventRegisterDefaultImpl()
 	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
 	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
 	port := flag.Int("port", 8185, "Port to listen on")
 	host := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
 
 	if *host == "" {
 		defaultHostName, err := os.Hostname()

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -33,6 +33,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/pflag"
+
 	"kubevirt.io/kubevirt/pkg/logging"
 )
 
@@ -144,7 +146,8 @@ func main() {
 	logging.InitializeLogging("virt-launcher")
 	qemuTimeout := flag.Duration("qemu-timeout", startTimeout, "Amount of time to wait for qemu")
 	debugMode := flag.Bool("debug", false, "Enable debug messages")
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
 
 	mon := Monitor{
 		exename:   "qemu",

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/emicklei/go-restful"
+	"github.com/spf13/pflag"
 
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
@@ -38,7 +39,8 @@ func main() {
 	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
 	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
 	port := flag.Int("port", 8186, "Port to listen on")
-	flag.Parse()
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
 
 	log := logging.DefaultLogger()
 	log.Info().Msg("Starting virt-manifest server")


### PR DESCRIPTION
The standard Go flag library treats long & short options as
identical (eg --foo & -foo are the same). This prevents the
creation of short aliases for flags. The replacement pflag
library supports full POSIX opts syntax where long and
short options are distinct.  The virtctl command already
uses this library. Convert the remaining commands over to
use it too, so we can later add short options for common
args.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>