### PR TITLE
Convert libvirt-kubevirt image to use dnf instead of yum

### DIFF
--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -22,12 +22,12 @@ MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
 # util-linux listed here explicity as nsenter must be present in this image
-RUN yum install -y \
+RUN dnf install -y \
   util-linux \
   libcgroup-tools \
   ethtool \
   sudo \
-  docker && yum -y clean all
+  docker && dnf -y clean all
 
 COPY qemu-kube /usr/local/bin/qemu-system-x86_64
 RUN chmod a+x /usr/local/bin/qemu-system-x86_64


### PR DESCRIPTION
We are inheriting from kubevirt/libvirt image which uses
Fedora, and thus we should be using dnf not yum.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>