### PR TITLE
Move "test" directory to "pkg/testutils"

### DIFF
--- a/pkg/testutils/matchers.go
+++ b/pkg/testutils/matchers.go
@@ -17,17 +17,19 @@
  *
  */
 
-package rest
+package testutils
 
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+
 	"github.com/ghodss/yaml"
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
+
 	rest2 "kubevirt.io/kubevirt/pkg/rest"
-	"reflect"
 )
 
 func RepresentMimeType(expected interface{}) types.GomegaMatcher {

--- a/pkg/virt-api/rest/kubeproxy_test.go
+++ b/pkg/virt-api/rest/kubeproxy_test.go
@@ -46,8 +46,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	rest2 "kubevirt.io/kubevirt/pkg/rest"
+	. "kubevirt.io/kubevirt/pkg/testutils"
 	. "kubevirt.io/kubevirt/pkg/virt-api/rest"
-	. "kubevirt.io/kubevirt/test"
 )
 
 const vmResource = "vms"


### PR DESCRIPTION
Having top level directories called "test" and "tests" is
rather confusing. For even more confusion the go files in
the "test" directory declare they are in a go package called
"rest". Rename the "test" directory to "pkg/testutils" and
the go package to "testutils".

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>