### PR TITLE
Remove references to VDSM config in the qemu-kube wrapper

### DIFF
--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -4,12 +4,6 @@ alias log='echo "[$(date)] "'
 
 ARGS="$@"
 # static config
-if [ -r "/etc/vdsm/qemu_kube.conf" ]; then
-    source "/etc/vdsm/qemu_kube.conf"
-fi
-# runtime config
-# TODO: let Makefile fill this
-# source "/var/run/vdsm/qemu_kube.conf"
 
 if [ -z "$QEMU" ]; then
     QEMU="/usr/bin/qemu-system-x86_64"


### PR DESCRIPTION
There is no reason for the qemu-kube wrapper script to be
loading VDSM config files.

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>