### PR TITLE
With the switch to pflag double-dashes are required.

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -51,7 +51,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VM) (*kubev1.Pod, error) {
 		Name:            "compute",
 		Image:           t.launcherImage,
 		ImagePullPolicy: kubev1.PullIfNotPresent,
-		Command:         []string{"/virt-launcher", "-qemu-timeout", "60s"},
+		Command:         []string{"/virt-launcher", "--qemu-timeout", "60s"},
 	}
 
 	// TODO use constants for labels

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Template", func() {
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvm-----"))
 				Expect(pod.Spec.NodeSelector).To(BeEmpty())
-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher", "-qemu-timeout", "60s"}))
+				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher", "--qemu-timeout", "60s"}))
 			})
 		})
 		Context("with node selectors", func() {
@@ -77,7 +77,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
 					"kubernetes.io/hostname": "master",
 				}))
-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher", "-qemu-timeout", "60s"}))
+				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher", "--qemu-timeout", "60s"}))
 			})
 		})
 		Context("migration", func() {


### PR DESCRIPTION
virt-launcher was started with "-qemu-timeout", but with the switch from
flag to pflag it needs to be "--qemu-timeout". pflag would interpret
"-qemu-timeout" as short option "-q" with a value of "emu-timeout".

Fixes regression from #332 

Signed-off-by: Roman Mohr <rmohr@redhat.com>