### PR TITLE
[WIP] Cloud Init support

### DIFF
--- a/cluster/vm-atomic.yaml
+++ b/cluster/vm-atomic.yaml
@@ -22,3 +22,8 @@ spec:
       type:
         os: hvm
     type: qemu
+  cloudInit:
+    dataSource: noCloud
+    noCloudData:
+      userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
+      diskTarget: vdb

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -20,6 +20,11 @@ FROM fedora:26
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
+RUN dnf install -y genisoimage && \
+	dnf clean all && \
+	groupadd --gid 1111 qemu && \
+	useradd --uid 1111 --gid 1111 qemu
+
 COPY virt-launcher /virt-launcher
 
 ENTRYPOINT [ "/virt-launcher" ]

--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -44,4 +44,9 @@ RUN rm -f /libvirtd.sh
 COPY libvirtd.sh /libvirtd.sh
 RUN chmod a+x /libvirtd.sh
 
+# Make a predictable uid and gid for qemu user
+# This allows containers to set enforce permissions on files that
+# are shared between containers on the local disk. 
+RUN groupmod -g 1111 qemu && usermod  -u 1111 qemu
+
 CMD ["/libvirtd.sh"]

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -25,6 +25,20 @@ package v1
  ATTENTION: Rerun code generators when comments on structs or fields are modified.
 */
 
+// http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html
+type CloudInitDataSourceNoCloud struct {
+	UserDataBase64 string `json:"userDataBase64"`
+	MetaDataBase64 string `json:"metaDataBase64"`
+	DiskTarget     string `json:"diskTarget"`
+}
+
+type CloudInitSpec struct {
+	DataSource string `json:"dataSource"`
+
+	// DataSource specific data structures
+	NoCloudData *CloudInitDataSourceNoCloud `json:"noCloudData"`
+}
+
 type DomainSpec struct {
 	Memory  Memory   `json:"memory"`
 	Type    string   `json:"type"`

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -2,6 +2,18 @@
 
 package v1
 
+func (CloudInitDataSourceNoCloud) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"": "http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+	}
+}
+
+func (CloudInitSpec) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"noCloudData": "DataSource specific data structures",
+	}
+}
+
 func (DomainSpec) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -122,6 +122,8 @@ type VMList struct {
 type VMSpec struct {
 	// Domain is the actual libvirt domain.
 	Domain *DomainSpec `json:"domain,omitempty"`
+	// The cloud-init data associated with this VM.
+	CloudInit *CloudInitSpec `json:"cloudInit,omitempty"`
 	// If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -20,6 +20,7 @@ func (VMSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":             "VMSpec is a description of a VM. Not to be confused with api.DomainSpec in virt-handler.\nIt is expected that v1.DomainSpec will be merged into this structure.",
 		"domain":       "Domain is the actual libvirt domain.",
+		"cloudInit":    "The cloud-init data associated with this VM.",
 		"nodeSelector": "If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.",
 	}
 }

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -1,0 +1,241 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package cloudinit
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+
+	kubev1 "k8s.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/precond"
+)
+
+const noCloudBasePath = "/var/run/libvirt/kubevirt"
+const noCloudFile = "noCloud.iso"
+
+// Supported DataSources
+const (
+	dataSourceNoCloud = "noCloud"
+)
+
+// This is called right before a VM is defined with libvirt.
+// If the cloud-init type requires altering the domain, this
+// is the place to do that.
+func InjectDomainData(vm *v1.VM) (*v1.VM, error) {
+	if vm.Spec.CloudInit == nil {
+		return vm, nil
+	}
+
+	err := ValidateArgs(vm)
+	if err != nil {
+		return vm, err
+	}
+
+	switch vm.Spec.CloudInit.DataSource {
+	case dataSourceNoCloud:
+		filePath := fmt.Sprintf("%s/%s", getDiskPath(vm), noCloudFile)
+
+		newDisk := v1.Disk{}
+		newDisk.Type = "file"
+		newDisk.Device = "disk"
+		newDisk.Driver = &v1.DiskDriver{
+			Type: "raw",
+			Name: "qemu",
+		}
+		newDisk.Source.File = filePath
+		newDisk.Target = v1.DiskTarget{
+			Device: vm.Spec.CloudInit.NoCloudData.DiskTarget,
+			Bus:    "virtio",
+		}
+
+		vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, newDisk)
+	default:
+		return vm, errors.New(fmt.Sprintf("Unknown CloudInit type %s", vm.Spec.CloudInit.DataSource))
+	}
+
+	return vm, nil
+}
+
+// TODO must make directory something that is passed in.
+func getDiskPath(vm *v1.VM) string {
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	return fmt.Sprintf("%s/%s/%s", noCloudBasePath, namespace, domain)
+}
+
+func ValidateArgs(vm *v1.VM) error {
+	if vm.Spec.CloudInit == nil {
+		return nil
+	}
+
+	switch vm.Spec.CloudInit.DataSource {
+	case dataSourceNoCloud:
+		if vm.Spec.CloudInit.NoCloudData == nil {
+			return errors.New(fmt.Sprintf("DataSource %s does not have the required data initialized", vm.Spec.CloudInit.DataSource))
+		}
+		if vm.Spec.CloudInit.NoCloudData.UserDataBase64 == "" {
+			return errors.New(fmt.Sprintf("userDataBase64 is required for cloudInit type %s", vm.Spec.CloudInit.DataSource))
+		}
+		if vm.Spec.CloudInit.NoCloudData.MetaDataBase64 == "" {
+			return errors.New(fmt.Sprintf("metaDataBase64 is required for cloudInit type %s", vm.Spec.CloudInit.DataSource))
+		}
+		if vm.Spec.CloudInit.NoCloudData.DiskTarget == "" {
+			return errors.New(fmt.Sprintf("noCloudTarget is required for cloudInit type %s", vm.Spec.CloudInit.DataSource))
+		}
+	default:
+		return errors.New(fmt.Sprintf("Unknown CloudInit dataSource %s", vm.Spec.CloudInit.DataSource))
+	}
+
+	return nil
+}
+
+func ApplyMetadata(vm *v1.VM) {
+	if vm.Spec.CloudInit == nil {
+		return
+	}
+
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	// TODO Put local-hostname in MetaData once we get pod DNS working with VMs
+	msg := fmt.Sprintf("instance-id: %s-%s\n", namespace, domain)
+	vm.Spec.CloudInit.NoCloudData.MetaDataBase64 = base64.StdEncoding.EncodeToString([]byte(msg))
+}
+
+// This function removes any local data associated with cloud-init
+// Not all cloud-init types require local data.
+func RemoveLocalData(directory string) {
+	dataSource := os.Getenv("CLOUD_INIT_DS")
+	if dataSource == "" {
+		return
+	}
+
+	switch dataSource {
+	case dataSourceNoCloud:
+		metaFile := fmt.Sprintf("%s/%s", directory, "meta-data")
+		userFile := fmt.Sprintf("%s/%s", directory, "user-data")
+		iso := fmt.Sprintf("%s/%s", directory, os.Getenv("NO_CLOUD_FILE"))
+
+		os.Remove(metaFile)
+		os.Remove(userFile)
+		os.Remove(iso)
+		log.Printf("Removed nocloud local data files")
+	}
+}
+
+func GenerateLocalData(directory string) error {
+	dataSource := os.Getenv("CLOUD_INIT_DS")
+	if dataSource == "" {
+		return nil
+	}
+
+	switch dataSource {
+	case dataSourceNoCloud:
+		metaFile := fmt.Sprintf("%s/%s", directory, "meta-data")
+		userFile := fmt.Sprintf("%s/%s", directory, "user-data")
+		iso := fmt.Sprintf("%s/%s", directory, os.Getenv("NO_CLOUD_FILE"))
+		userData64 := os.Getenv("USER_DATA_BASE64")
+		metaData64 := os.Getenv("META_DATA_BASE64")
+
+		userDataBytes, err := base64.StdEncoding.DecodeString(userData64)
+		if err != nil {
+			return err
+		}
+		metaDataBytes, err := base64.StdEncoding.DecodeString(metaData64)
+		if err != nil {
+			return err
+		}
+
+		err = ioutil.WriteFile(userFile, userDataBytes, 0644)
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(metaFile, metaDataBytes, 0644)
+		if err != nil {
+			return err
+		}
+
+		//genisoimage -output $ISO -volid cidata -joliet -rock $USER_DATA $META_DATA
+		cmd := exec.Command("genisoimage",
+			"-output",
+			iso,
+			"-volid",
+			"cidata",
+			"-joliet",
+			"-rock",
+			userFile,
+			metaFile)
+
+		err = cmd.Run()
+		if err != nil {
+			return err
+		}
+		os.Chown(iso, 1111, 1111)
+		log.Printf("Generated nocloud local data files")
+	}
+	return nil
+}
+
+func GenerateEnvVars(vm *v1.VM) ([]kubev1.EnvVar, error) {
+	var containerVars []kubev1.EnvVar
+
+	if vm.Spec.CloudInit == nil {
+		return containerVars, nil
+	}
+
+	err := ValidateArgs(vm)
+	if err != nil {
+		return containerVars, err
+	}
+
+	switch vm.Spec.CloudInit.DataSource {
+	case dataSourceNoCloud:
+		containerVars = append(containerVars, kubev1.EnvVar{
+			Name:  "CLOUD_INIT_DS",
+			Value: dataSourceNoCloud,
+		})
+		containerVars = append(containerVars, kubev1.EnvVar{
+			Name:  "NO_CLOUD_PATH",
+			Value: getDiskPath(vm),
+		})
+
+		containerVars = append(containerVars, kubev1.EnvVar{
+			Name:  "NO_CLOUD_FILE",
+			Value: noCloudFile,
+		})
+		containerVars = append(containerVars, kubev1.EnvVar{
+			Name:  "USER_DATA_BASE64",
+			Value: vm.Spec.CloudInit.NoCloudData.UserDataBase64,
+		})
+		containerVars = append(containerVars, kubev1.EnvVar{
+			Name:  "META_DATA_BASE64",
+			Value: vm.Spec.CloudInit.NoCloudData.MetaDataBase64,
+		})
+	}
+	return containerVars, nil
+}

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -22,7 +22,6 @@ package registrydisk
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/jeevatkm/go-model"
 
@@ -36,20 +35,6 @@ const defaultIqn = "iqn.2017-01.io.kubevirt:wrapper/1"
 const defaultPort = 3261
 const defaultPortStr = "3261"
 const defaultHost = "127.0.0.1"
-
-func DisksAreReady(pod *kubev1.Pod) bool {
-	// Wait for readiness probes on image wrapper containers
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if strings.Contains(containerStatus.Name, "disk") == false {
-			// only check readiness of disk containers
-			continue
-		}
-		if containerStatus.Ready == false {
-			return false
-		}
-	}
-	return true
-}
 
 // The virt-handler converts registry disks to their corresponding iscsi network
 // disks when the VM spec is being defined as a domain with libvirt.

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/precond"
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
@@ -43,23 +44,69 @@ type templateService struct {
 
 //Deprecated: remove the service and just use a builder or contextcless helper function
 func (t *templateService) RenderLaunchManifest(vm *v1.VM) (*kubev1.Pod, error) {
+	var containers []kubev1.Container
+
 	precond.MustNotBeNil(vm)
 	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
 	uid := precond.MustNotBeEmpty(string(vm.GetObjectMeta().GetUID()))
+
+	domainTmpDir := fmt.Sprintf("%s/%s/%s", "/var/run/libvirt/kubevirt", namespace, domain)
+	initialDelaySeconds := 5
+	timeoutSeconds := 5
+	periodSeconds := 10
+	successThreshold := 2
+	failureThreshold := 5
+
+	envVars, err := cloudinit.GenerateEnvVars(vm)
+	if err != nil {
+		return nil, err
+	}
 
 	// VM target container
 	container := kubev1.Container{
 		Name:            "compute",
 		Image:           t.launcherImage,
 		ImagePullPolicy: kubev1.PullIfNotPresent,
-		Command:         []string{"/virt-launcher", "--qemu-timeout", "60s"},
+		Command: []string{"/virt-launcher",
+			"--qemu-timeout",
+			"60s",
+			"--domain-tmp-dir",
+			domainTmpDir,
+			"--readiness-file",
+			"/tmp/healthy",
+		},
+		Env: envVars,
+		VolumeMounts: []kubev1.VolumeMount{
+			{
+				Name:      "domain-tmp-dir",
+				MountPath: domainTmpDir,
+			},
+		},
+		ReadinessProbe: &kubev1.Probe{
+			Handler: kubev1.Handler{
+				Exec: &kubev1.ExecAction{
+					Command: []string{
+						"cat",
+						"/tmp/healthy",
+					},
+				},
+			},
+			InitialDelaySeconds: int32(initialDelaySeconds),
+			PeriodSeconds:       int32(periodSeconds),
+			TimeoutSeconds:      int32(timeoutSeconds),
+			SuccessThreshold:    int32(successThreshold),
+			FailureThreshold:    int32(failureThreshold),
+		},
 	}
 
-	containers, err := registrydisk.GenerateContainers(vm)
+	diskContainers, err := registrydisk.GenerateContainers(vm)
 	if err != nil {
 		return nil, err
 	}
+
 	containers = append(containers, container)
+	containers = append(containers, diskContainers...)
 
 	// TODO use constants for labels
 	pod := kubev1.Pod{
@@ -75,6 +122,16 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VM) (*kubev1.Pod, error) {
 			RestartPolicy: kubev1.RestartPolicyNever,
 			Containers:    containers,
 			NodeSelector:  vm.Spec.NodeSelector,
+			Volumes: []kubev1.Volume{
+				{
+					Name: "domain-tmp-dir",
+					VolumeSource: kubev1.VolumeSource{
+						HostPath: &kubev1.HostPathVolumeSource{
+							Path: domainTmpDir,
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -173,6 +173,7 @@ func (l *LibvirtDomainManager) KillVM(vm *v1.VM) error {
 		logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Undefining the domain state failed.")
 		return err
 	}
+
 	logging.DefaultLogger().Object(vm).Info().Msg("Domain undefined.")
 	l.recorder.Event(vm, kubev1.EventTypeNormal, v1.Deleted.String(), "VM undefined")
 	return nil

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
@@ -302,6 +303,12 @@ func (d *VMHandlerDispatch) processVmUpdate(vm *v1.VM, shouldDeleteVm bool) erro
 
 	// Map Container Registry Disks to block devices Libvirt can consume
 	vm, err = registrydisk.MapRegistryDisks(vm)
+	if err != nil {
+		return err
+	}
+
+	// Map whatever devices are being used for config-init
+	vm, err = cloudinit.InjectDomainData(vm)
 	if err != nil {
 		return err
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -20,6 +20,8 @@
 package tests
 
 import (
+	"encoding/base64"
+	goerrors "errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -415,6 +417,26 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VM {
 		},
 	}}
 	return vm
+}
+
+func NewRandomVMWithUserData(containerImage string, cloudInitDataSource string) (*v1.VM, error) {
+
+	switch cloudInitDataSource {
+	case "noCloud":
+		userData := "#cloud-config\npassword: atomic\nssh_pwauth: True\nchpasswd: { expire: False }\n"
+
+		vm := NewRandomVMWithEphemeralDisk(containerImage)
+		vm.Spec.CloudInit = &v1.CloudInitSpec{
+			DataSource: "noCloud",
+			NoCloudData: &v1.CloudInitDataSourceNoCloud{
+				DiskTarget:     "vdb",
+				UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
+			},
+		}
+		return vm, nil
+	}
+
+	return nil, goerrors.New("Unknown cloud-init data source")
 }
 
 func NewRandomVMWithDirectLun(lun int) *v1.VM {

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"flag"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("CloudInit UserData", func() {
+
+	flag.Parse()
+
+	coreClient, err := kubecli.Get()
+	tests.PanicOnError(err)
+
+	restClient, err := kubecli.GetRESTClient()
+	tests.PanicOnError(err)
+
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+	})
+
+	LaunchVM := func(vm *v1.VM) runtime.Object {
+		obj, err := restClient.Post().Resource("vms").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
+		Expect(err).To(BeNil())
+		return obj
+	}
+
+	VerifyUserDataVM := func(vm *v1.VM, obj runtime.Object) {
+		_, ok := obj.(*v1.VM)
+		Expect(ok).To(BeTrue(), "Object is not of type *v1.VM")
+		tests.WaitForSuccessfulVMStart(obj)
+
+		// Verify Registry Disks are Online
+		pods, err := coreClient.CoreV1().Pods(tests.NamespaceTestDefault).List(services.UnfinishedVMPodSelector(vm))
+		Expect(err).To(BeNil())
+		// TODO verify nocloud datasource somehow here.
+		//disksFound := 0
+		//for _, pod := range pods.Items {
+		//	if pod.ObjectMeta.DeletionTimestamp != nil {
+		//		continue
+		//	}
+		//	for _, containerStatus := range pod.Status.ContainerStatuses {
+		//		if strings.Contains(containerStatus.Name, "cloud-init-no-cloud") == false {
+		//			// only check readiness of cloud-init-no-cloud containers
+		//			continue
+		//		}
+		//		if containerStatus.Ready == true {
+		//			disksFound++
+		//		}
+		//	}
+		//	break
+		//}
+		//Expect(disksFound).To(Equal(1))
+	}
+
+	Context("CloudInit Data Source NoCloud", func() {
+		It("should launch multiple VMs with cloud-init data source NoCloud", func(done Done) {
+			num := 2
+			vms := make([]*v1.VM, 0, num)
+			objs := make([]runtime.Object, 0, num)
+			for i := 0; i < num; i++ {
+				vm, err := tests.NewRandomVMWithUserData("kubevirt/cirros-registry-disk-demo:devel", "noCloud")
+				Expect(err).ToNot(HaveOccurred())
+				obj := LaunchVM(vm)
+				vms = append(vms, vm)
+				objs = append(objs, obj)
+			}
+
+			for idx, vm := range vms {
+				VerifyUserDataVM(vm, objs[idx])
+			}
+
+			close(done)
+		}, 45)
+	})
+})


### PR DESCRIPTION
### Overview
Cloud-Init is a project that standardizes methods for injecting data into cloud VMs on launch.  Data typically includes **metadata** and **userdata**

**Metadata** is dynamically generated by the cloud provider and contains information about the unique instance.

**Userdata** is VM configuration data supplied by the user that executes when the VM instance starts.

It is common for cloud IaaS users to associate userdata with a VM instance in order to execute a short script that software provisions on startup.

### Data Sources
The Cloud Init project supports multiple ways of supplying metadata and userdata to a VM. These methods are called **data sources**.

http://cloudinit.readthedocs.io/en/latest/topics/datasources.html

### Implementation Details

Our support of cloud-init is driven by the goal of being able to provision fedora atomic VM instances using the 'NoCloud' data source. http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html

The **NoCloud** data source involves generating an iso with userdata and metadata in it, and attaching that iso the the VM instance. 

To associated userdata with a VM instance using the NoCloud data source, all users have to do is base64 encode userdata information into the VM definition. 

Example
```
metadata:
  name: atomic-ephemeral
apiVersion: kubevirt.io/v1alpha1
kind: VM
spec:
  domain:
    devices:
      disks:
      - type: ContainerRegistryDisk:v1alpha
        source:
          name: kubevirt/fedora-atomic-registry-disk-demo:devel
        target:
          dev: vda
      interfaces:
      - source:
          network: default
        type: network
    memory:
      unit: MB
      value: 1024
    os:
      type:
        os: hvm
    type: qemu
  cloudInit:
    dataSource: noCloud
    noCloudData:
      userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
      diskTarget: vdb
```

Internally KubeVirt creates a container in the virt-launcher pod that is responsible for generating the resulting NoCloud data source's .iso file.

Virt-controller waits for the iso file to be available (using readiness checks) before it allows the VM to be placed on the corresponding pod's node.

When virt-handler sees a VM with the 'NoCloud' data source, it attaches the iso file as a disk device to the domain before starting the VM.

### Future DataSources
The VM definition structures and cloud-init package have been architected in a way that should allow for additional data sources to be added in the future. 

Example: User facing details related to another data source.
```
  cloudInit:
    dataSource: SomeOtherSource
    SomeOtherProviderData:
      userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
      Whatever1: somethingelse
      Whatever2: otherstuff
```

The cloud-init package would then get a new data source called 'SomeOtherSource'. Everything related to the 'NoCloud' source is isolated by switch statements already. The 'SomeOtherSource' implementation details would just need to be added in whatever way makes sense for that data source. 