### PR TITLE
trival crd cleanup changes. 

### DIFF
--- a/cluster/vm-atomic.yaml
+++ b/cluster/vm-atomic.yaml
@@ -22,7 +22,3 @@ spec:
       type:
         os: hvm
     type: qemu
-  cloudInit:
-    type: configDisk
-    userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
-    configDiskTarget: vdb

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,6 +1,6 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virtctl cmd/virt-manifest"
 docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virt-manifest images/haproxy images/iscsi-demo-target-tgtd images/vm-killer images/libvirt-kubevirt images/spice-proxy cmd/virt-migrator cmd/registry-disk-v1alpha images/cirros-registry-disk-demo"
-optional_docker_images="images/fedora-atomic-registry-disk-demo"
+optional_docker_images="cmd/registry-disk-v1alpha images/fedora-atomic-registry-disk-demo"
 docker_prefix=kubevirt
 docker_tag=${DOCKER_TAG:-latest}
 manifest_templates="`ls manifests/*.in`"


### PR DESCRIPTION
- make sure crd base container is available when syncing optional
- remove references to cloud-init support in vm-atomic.yaml file. cloud-init support isn't merged. That reference in vm-atomic got leaked in because of some testing i was doing. 