### PR TITLE
Fix port collisions on spice port allocation

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -140,8 +140,8 @@ func main() {
 	vmController.StartInformer(stop)
 	vmController.WaitForSync(stop)
 
-	go domainController.Run(1, stop)
-	go vmController.Run(1, stop)
+	go domainController.Run(3, stop)
+	go vmController.Run(3, stop)
 
 	// TODO add a http handler which provides health check
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -93,9 +93,9 @@ func (vca *VirtControllerApp) Run() {
 	stop := make(chan struct{})
 	defer close(stop)
 	vca.informerFactory.Start(stop)
-	go vca.vmController.Run(1, stop)
+	go vca.vmController.Run(3, stop)
 	//FIXME when we have more than one worker, we need a lock on the VM
-	go vca.migrationController.Run(1, stop)
+	go vca.migrationController.Run(3, stop)
 	httpLogger := logger.With("service", "http")
 	httpLogger.Info().Log("action", "listening", "interface", vca.host, "port", vca.port)
 	if err := http.ListenAndServe(vca.host+":"+strconv.Itoa(vca.port), nil); err != nil {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -171,7 +171,7 @@ func (c *VMController) execute(key string) error {
 		graphics := vmCopy.Spec.Domain.Devices.Graphics
 		for i, _ := range graphics {
 			if strings.ToLower(graphics[i].Type) == "spice" {
-				graphics[i].Port = int32(4000) + int32(i)
+				graphics[i].Port = int32(-1)
 				graphics[i].Listen = kubev1.Listen{
 					Address: "0.0.0.0",
 					Type:    "address",

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -235,8 +235,15 @@ func (l *LibvirtConnection) checkConnectionLost() {
 		return
 	}
 
-	// TODO, find out all errors which indicate a communication error
-	if err.Code != libvirt.ERR_NO_DOMAIN {
+	switch err.Code {
+	case
+		libvirt.ERR_INTERNAL_ERROR,
+		libvirt.ERR_INVALID_CONN,
+		libvirt.ERR_AUTH_CANCELLED,
+		libvirt.ERR_NO_MEMORY,
+		libvirt.ERR_AUTH_FAILED,
+		libvirt.ERR_SYSTEM_ERROR,
+		libvirt.ERR_RPC:
 		l.alive = false
 		logging.DefaultLogger().Error().Reason(err).With("code", err.Code).Msg("Connection to libvirt lost.")
 	}

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -206,7 +206,7 @@ var _ = Describe("Vmlifecycle", func() {
 
 				handlerName := pods.Items[0].GetObjectMeta().GetName()
 				handlerNamespace := pods.Items[0].GetObjectMeta().GetNamespace()
-				seconds := int64(30)
+				seconds := int64(120)
 				logsQuery := coreCli.Pods(handlerNamespace).GetLogs(handlerName, &k8sv1.PodLogOptions{SinceSeconds: &seconds})
 
 				// Make sure we schedule the VM to master
@@ -222,7 +222,7 @@ var _ = Describe("Vmlifecycle", func() {
 					data, err := logsQuery.DoRaw()
 					Expect(err).ToNot(HaveOccurred())
 					return string(data)
-				}, 5, 0.1).Should(MatchRegexp("(name=%s)[^\n]+(kind=Domain)[^\n]+(Domain is in state Running)", vm.GetObjectMeta().GetName()))
+				}, 30, 0.5).Should(MatchRegexp("(name=%s)[^\n]+(kind=Domain)[^\n]+(Domain is in state Running)", vm.GetObjectMeta().GetName()))
 				// Check the VM Namespace
 				Expect(vm.GetObjectMeta().GetNamespace()).To(Equal(namespace))
 
@@ -236,7 +236,7 @@ var _ = Describe("Vmlifecycle", func() {
 					data, err := logsQuery.DoRaw()
 					Expect(err).ToNot(HaveOccurred())
 					return string(data)
-				}, 5, 0.1).Should(MatchRegexp("(name=%s)[^\n]+(kind=Domain)[^\n]+(Domain deleted)", vm.GetObjectMeta().GetName()))
+				}, 30, 0.5).Should(MatchRegexp("(name=%s)[^\n]+(kind=Domain)[^\n]+(Domain deleted)", vm.GetObjectMeta().GetName()))
 
 			},
 				table.Entry(tests.NamespaceTestDefault, tests.NamespaceTestDefault),


### PR DESCRIPTION
From the qemu network namespace refactoring patch, there was a hardcoded
spice port left which could lead to spice port allocation errors. Make
sure, that libvirt can freely choose a port on VM starts by setting the
port number explicitly to -1.

Also included a functional test, which ensures that two VMs with spice interfaces can be started on the same host, without port collissions.