### PR TITLE
document v1.VM and api.DomainSpec

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -100,11 +100,14 @@ func init() {
 	})
 }
 
+// VM is *the* VM Definition. It represents a virtual machine in the runtime environment of kubernetes.
 type VM struct {
 	metav1.TypeMeta `json:",inline"`
 	ObjectMeta      metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec            VMSpec            `json:"spec,omitempty" valid:"required"`
-	Status          VMStatus          `json:"status"`
+	// VM Spec contains the VM specification.
+	Spec VMSpec `json:"spec,omitempty" valid:"required"`
+	// Status is the high level overview of how the VM is doing. It contains information available to controllers and users.
+	Status VMStatus `json:"status"`
 }
 
 // VMList is a list of VMs
@@ -114,8 +117,10 @@ type VMList struct {
 	Items           []VM            `json:"items"`
 }
 
-// VMSpec is a description of a VM
+// VMSpec is a description of a VM. Not to be confused with api.DomainSpec in virt-handler.
+// It is expected that v1.DomainSpec will be merged into this structure.
 type VMSpec struct {
+	// Domain is the actual libvirt domain.
 	Domain *DomainSpec `json:"domain,omitempty"`
 	// If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
@@ -124,11 +129,16 @@ type VMSpec struct {
 // VMStatus represents information about the status of a VM. Status may trail the actual
 // state of a system.
 type VMStatus struct {
-	NodeName          string        `json:"nodeName,omitempty"`
-	MigrationNodeName string        `json:"migrationNodeName,omitempty"`
-	Conditions        []VMCondition `json:"conditions,omitempty"`
-	Phase             VMPhase       `json:"phase"`
-	Graphics          []VMGraphics  `json:"graphics"`
+	// NodeName is the name where the VM is currently running.
+	NodeName string `json:"nodeName,omitempty"`
+	// MigrationNodeName is the node where the VM is live migrating to.
+	MigrationNodeName string `json:"migrationNodeName,omitempty"`
+	// Conditions are specific points in VM's pod runtime.
+	Conditions []VMCondition `json:"conditions,omitempty"`
+	// Phase is the status of the VM in kubernetes world. It is not the VM status, but partially correlates to it.
+	Phase VMPhase `json:"phase"`
+	// Graphics represent the details of available graphical consoles.
+	Graphics []VMGraphics `json:"graphics"`
 }
 
 type VMGraphics struct {

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -3,7 +3,11 @@
 package v1
 
 func (VM) SwaggerDoc() map[string]string {
-	return map[string]string{}
+	return map[string]string{
+		"":       "VM is *the* VM Definition. It represents a virtual machine in the runtime environment of kubernetes.",
+		"spec":   "VM Spec contains the VM specification.",
+		"status": "Status is the high level overview of how the VM is doing. It contains information available to controllers and users.",
+	}
 }
 
 func (VMList) SwaggerDoc() map[string]string {
@@ -14,14 +18,20 @@ func (VMList) SwaggerDoc() map[string]string {
 
 func (VMSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":             "VMSpec is a description of a VM",
+		"":             "VMSpec is a description of a VM. Not to be confused with api.DomainSpec in virt-handler.\nIt is expected that v1.DomainSpec will be merged into this structure.",
+		"domain":       "Domain is the actual libvirt domain.",
 		"nodeSelector": "If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.",
 	}
 }
 
 func (VMStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "VMStatus represents information about the status of a VM. Status may trail the actual\nstate of a system.",
+		"":                  "VMStatus represents information about the status of a VM. Status may trail the actual\nstate of a system.",
+		"nodeName":          "NodeName is the name where the VM is currently running.",
+		"migrationNodeName": "MigrationNodeName is the node where the VM is live migrating to.",
+		"conditions":        "Conditions are specific points in VM's pod runtime.",
+		"phase":             "Phase is the status of the VM in kubernetes world. It is not the VM status, but partially correlates to it.",
+		"graphics":          "Graphics represent the details of available graphical consoles.",
 	}
 }
 

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -141,6 +141,9 @@ type DomainList struct {
 	Items    []Domain
 }
 
+// DomainSpec represents the actual conversion to libvirt XML. The fields must be
+// tagged, and they must correspond to the libvirt domain as described in
+// https://libvirt.org/formatdomain.html.
 type DomainSpec struct {
 	XMLName xml.Name `xml:"domain"`
 	Name    string   `xml:"name"`


### PR DESCRIPTION
Both v1 and api contain structures that are essential to kubevirt. It
is easy to confuse them as right now, v1.VM contains a structure
identical to api.DomainSpec. To help with the confusion, we add a
godoc compatible to the structures, making it easy to distinguish
which structure we are dealing with.

Related to #212, although it doesn't fully document the libvirt interface.

Signed-off-by: Martin Polednik <mpolednik@redhat.com>