### PR TITLE
consistent libvirt error handling in virt-handler

### DIFF
--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -54,7 +54,7 @@ func (t *Console) Console(request *restful.Request, response *restful.Response) 
 	log := logging.DefaultLogger().Object(vm)
 	domain, err := t.connection.LookupDomainByName(virtwrap.VMNamespaceKeyFunc(vm))
 	if err != nil {
-		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
+		if virtwrap.IsNotFound(err) {
 			log.Error().Reason(err).Msg("Domain not found.")
 			response.WriteError(http.StatusNotFound, err)
 			return

--- a/pkg/virt-handler/virtwrap/errors.go
+++ b/pkg/virt-handler/virtwrap/errors.go
@@ -1,5 +1,5 @@
 /*
- * This file is part of the kubevirt project
+ * This file is part of the KubeVirt project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +20,24 @@
 package virtwrap
 
 import (
-	"reflect"
-
 	"github.com/libvirt/libvirt-go"
 )
 
-func checkError(err interface{}, expectedError libvirt.ErrorNumber) bool {
-	return err.(libvirt.Error).Code == expectedError
+func checkError(err error, expectedError libvirt.ErrorNumber) bool {
+	libvirtError, ok := err.(libvirt.Error)
+	if ok {
+		return libvirtError.Code == expectedError
+	}
+
+	return false
 }
 
 // IsNotFound detects libvirt's ERR_NO_DOMAIN. It accepts both error and libvirt.Error (as returned by GetLastError function).
-func IsNotFound(err interface{}) bool {
+func IsNotFound(err error) bool {
 	return checkError(err, libvirt.ERR_NO_DOMAIN)
 }
 
 // IsOk detects libvirt's ERR_OK. It accepts both error and libvirt.Error (as returned by GetLastError function).
-func IsOk(err interface{}) bool {
+func IsOk(err error) bool {
 	return checkError(err, libvirt.ERR_OK)
 }

--- a/pkg/virt-handler/virtwrap/errors.go
+++ b/pkg/virt-handler/virtwrap/errors.go
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package virtwrap
+
+import (
+	"reflect"
+
+	"github.com/libvirt/libvirt-go"
+)
+
+func checkError(err interface{}, expectedError libvirt.ErrorNumber) bool {
+	return err.(libvirt.Error).Code == expectedError
+}
+
+// IsNotFound detects libvirt's ERR_NO_DOMAIN. It accepts both error and libvirt.Error (as returned by GetLastError function).
+func IsNotFound(err interface{}) bool {
+	return checkError(err, libvirt.ERR_NO_DOMAIN)
+}
+
+// IsOk detects libvirt's ERR_OK. It accepts both error and libvirt.Error (as returned by GetLastError function).
+func IsOk(err interface{}) bool {
+	return checkError(err, libvirt.ERR_OK)
+}

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -231,7 +231,7 @@ func (l *LibvirtConnection) checkConnectionLost() {
 	defer l.reconnectLock.Unlock()
 
 	err := libvirt.GetLastError()
-	if err.Code == libvirt.ERR_OK {
+	if IsOk(err) {
 		return
 	}
 
@@ -342,7 +342,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VM) (*api.DomainSpec, error) {
 	dom, err := l.virConn.LookupDomainByName(domName)
 	if err != nil {
 		// We need the domain but it does not exist, so create it
-		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
+		if IsNotFound(err) {
 			xmlStr, err := xml.Marshal(&wantedSpec)
 			if err != nil {
 				logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Generating the domain XML failed.")
@@ -414,7 +414,7 @@ func (l *LibvirtDomainManager) KillVM(vm *v1.VM) error {
 	dom, err := l.virConn.LookupDomainByName(domName)
 	if err != nil {
 		// If the VM does not exist, we are done
-		if err.(libvirt.Error).Code == libvirt.ERR_NO_DOMAIN {
+		if IsNotFound(err) {
 			return nil
 		} else {
 			logging.DefaultLogger().Object(vm).Error().Reason(err).Msg("Getting the domain failed.")


### PR DESCRIPTION
This PR adds a new module to virtwrap package that is reponsible for handling libvirt errors. We do that to unify the way errors are handled within virt-handler. Without these patches, the errors must be explicitly casted to libvirt.Error and compared to libvirt.ErrorNumber, unless the return is already typed (that's the case for libvirt.GetLastError).

The abstraction brought by the new module adds currently two checked ErrorNumber: ERR_OK and ERR_NO_DOMAIN. Any new error should be added to the module with descriptive name so the rest of the code can use it.

The idea is based on error abstractions in k8s apimachinery.