### PR TITLE
fix travis docker push

### DIFF
--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -38,7 +38,14 @@ fi
 
 for arg in $args; do
     if [ "${target}" = "build" ]; then
-        (cd $arg; docker $target -t ${docker_prefix}/$(basename $arg):${docker_tag} .)
+        # TODO the version of docker we're using in our vagrant dev environment
+        # does not support using ARGS in FROM field.
+        # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+        # Because of this we have to manipulate the Dockerfile for kubevirt containers
+        # that depend on other kubevirt containers.
+        cat $arg/Dockerfile | sed s/registry-disk-v1alpha/registry-disk-v1alpha\:$docker_tag/g > $arg/.GeneratedDockerfile
+        (cd $arg; docker $target -t ${docker_prefix}/$(basename $arg):${docker_tag} -f .GeneratedDockerfile .)
+        rm $arg/.GeneratedDockerfile
     elif [ "${target}" = "push" ]; then
         (cd $arg; docker $target ${docker_prefix}/$(basename $arg):${docker_tag})
     fi

--- a/images/cirros-registry-disk-demo/Dockerfile
+++ b/images/cirros-registry-disk-demo/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM kubevirt/registry-disk-v1alpha:devel
+FROM kubevirt/registry-disk-v1alpha
 
 MAINTAINER "David Vossel" \<dvossel@redhat.com\>
 

--- a/images/fedora-atomic-registry-disk-demo/Dockerfile
+++ b/images/fedora-atomic-registry-disk-demo/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM kubevirt/registry-disk-v1alpha:devel
+FROM kubevirt/registry-disk-v1alpha
 
 MAINTAINER "David Vossel" \<dvossel@redhat.com\>
 


### PR DESCRIPTION
Travis can't build the latest tags because the container registry disks were explicitly looking for a 'devel' kubevirt base container.

The proper fix for this is to use https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact

in docker file
```
ARG KUBEVIRT_VERSION=latest
FROM kubevirt/registry-disk-v1alpha:${KUBEVIRT_VERSION}
```
```
docker build ... --build-arg KUBEVIRT_VERSION=devel ...
```

However, we can't use that method because our vagrant setup is based on an older version of docker. This functionality just made it into docker recently. Because of this, our only option (that I've found) is file manipulation. 
