### PR TITLE
Iscsi auth using k8s secrets

### DIFF
--- a/cmd/registry-disk-v1alpha/entry-point.sh
+++ b/cmd/registry-disk-v1alpha/entry-point.sh
@@ -25,6 +25,10 @@ LUNID=1
 IMAGE_NAME=$(ls -1 /disk/ | tail -n 1)
 IMAGE_PATH=/disk/$IMAGE_NAME
 
+if [ -n "$PASSWORD_BASE64" ]; then
+	PASSWORD=$(echo $PASSWORD_BASE64 | base64 -d)
+fi
+
 # If PASSWORD is provided, enable authentication features
 authenticate=0
 if [ -n "$PASSWORD" ]; then

--- a/cmd/registry-disk-v1alpha/entry-point.sh
+++ b/cmd/registry-disk-v1alpha/entry-point.sh
@@ -28,6 +28,9 @@ IMAGE_PATH=/disk/$IMAGE_NAME
 if [ -n "$PASSWORD_BASE64" ]; then
 	PASSWORD=$(echo $PASSWORD_BASE64 | base64 -d)
 fi
+if [ -n "$USERNAME_BASE64" ]; then
+	USERNAME=$(echo $USERNAME_BASE64 | base64 -d)
+fi
 
 # If PASSWORD is provided, enable authentication features
 authenticate=0

--- a/docs/iscsi-authentication.md
+++ b/docs/iscsi-authentication.md
@@ -1,0 +1,71 @@
+This document describes how to associate a k8s secret with a VM for the purpose of iscsi initiator authentication.
+
+*NOTE: Only client authentication is supported at this time, meaning that the iscsi target with authenticate an initiator has permissions to access a device, but that a initiator can not authenticate the target.*
+
+## Workflow
+1. create a k8s secret containing the password and username fields.
+```
+cat << END > my-chap-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myK8sSecretID
+  namespace: default
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-chap-secret
+type: "kubernetes.io/iscsi-chap"  
+data:
+  node.session.auth.username: $(echo "myUsername" | base64 -w0)
+  node.session.auth.password: $(echo "mySuperSecretPassword" | base64 -w0)
+END
+```
+2. create a vm that references the **name** given to the k8s secret in the iscsi usage field
+```
+cat << END > my-vm.yaml
+kind: VM
+metadata:
+  name: testvm
+  namespace: default
+spec:
+  domain:
+    devices:
+      disks:
+      - Auth:
+          secret:
+            type: iscsi
+            usage: my-chap-secret
+        type: network
+        snapshot: external
+        device: disk
+        driver:
+          name: qemu
+          type: raw
+          cache: none
+        source:
+          host:
+            name: iscsi-demo-target.default
+            port: "3260"
+          protocol: iscsi
+          name: iqn.2017-01.io.kubevirt:sn.42/2
+        target:
+          dev: vda
+    memory:
+      unit: MB
+      value: 64
+    os:
+      type:
+        os: hvm
+    type: qemu
+END
+```
+3.  Add the secret and vm to the cluster.
+```
+kubectl create -f my-chap-secret.yaml
+kubectl create -f my-vm.yaml
+```
+
+From there, the password and username fields in the k8s secret will automatically be mapped to a libvirt secret when the VM is scheduled to a node allowing the iscsi auth to work without any further configuration. 
+

--- a/docs/iscsi-authentication.md
+++ b/docs/iscsi-authentication.md
@@ -4,6 +4,10 @@ This document describes how to associate a k8s secret with a VM for the purpose 
 
 ## Workflow
 1. create a k8s secret containing the password and username fields.
+
+The k8s secret must be formatted in the same way kubernetes performs iscsi
+authentication for volumes. https://github.com/kubernetes/kubernetes/blob/master/examples/volumes/iscsi/chap-secret.yaml
+
 ```
 cat << END > my-chap-secret.yaml
 apiVersion: v1
@@ -33,7 +37,7 @@ spec:
   domain:
     devices:
       disks:
-      - Auth:
+      - auth:
           secret:
             type: iscsi
             usage: my-chap-secret

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -62,6 +62,17 @@ type Disk struct {
 	Serial   string      `json:"serial,omitempty"`
 	Driver   *DiskDriver `json:"driver,omitempty"`
 	ReadOnly *ReadOnly   `json:"readOnly,omitempty"`
+	Auth     *DiskAuth   `json:"auth,omitempty"`
+}
+
+type DiskAuth struct {
+	Username string      `json:"username"`
+	Secret   *DiskSecret `json:"secret,omitempty"`
+}
+
+type DiskSecret struct {
+	Type  string `json:"type"`
+	Usage string `json:"usage"`
 }
 
 type ReadOnly struct{}

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -18,6 +18,14 @@ func (Disk) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }
 
+func (DiskAuth) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
+func (DiskSecret) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
 func (ReadOnly) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -20,6 +20,8 @@
 package registrydisk
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,8 +29,12 @@ import (
 	"github.com/jeevatkm/go-model"
 
 	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/precond"
 )
 
 const registryDiskV1Alpha = "ContainerRegistryDisk:v1alpha"
@@ -36,6 +42,15 @@ const defaultIqn = "iqn.2017-01.io.kubevirt:wrapper/1"
 const defaultPort = 3261
 const defaultPortStr = "3261"
 const defaultHost = "127.0.0.1"
+
+func generateRandomString(len int) (string, error) {
+	bytes := make([]byte, len)
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(bytes), nil
+}
 
 func DisksAreReady(pod *kubev1.Pod) bool {
 	// Wait for readiness probes on image wrapper containers
@@ -49,6 +64,10 @@ func DisksAreReady(pod *kubev1.Pod) bool {
 		}
 	}
 	return true
+}
+
+func k8sSecretName(vm *v1.VM) string {
+	return fmt.Sprintf("registrydisk-iscsi-%s-%s", vm.GetObjectMeta().GetNamespace(), vm.GetObjectMeta().GetName())
 }
 
 // The virt-handler converts registry disks to their corresponding iscsi network
@@ -76,6 +95,8 @@ func MapRegistryDisks(vm *v1.VM) (*v1.VM, error) {
 			newDisk.Source.Protocol = "iscsi"
 			newDisk.Source.Host = disk.Source.Host
 
+			newDisk.Auth = disk.Auth
+
 			vmCopy.Spec.Domain.Devices.Disks[idx] = newDisk
 		}
 	}
@@ -83,18 +104,45 @@ func MapRegistryDisks(vm *v1.VM) (*v1.VM, error) {
 	return vmCopy, nil
 }
 
-// TODO Introduce logic that dynamically generates iscsi CHAP
-// Authentication credentials for a VM spec backed by registry disks.
-//
-//func ApplyAuth(vm *v1.VM) {
-//     INSERT DYNAMIC AUTH LOGIC HERE
-//}
+func CleanUp(vm *v1.VM, clientset *kubernetes.Clientset) error {
+	precond.MustNotBeNil(vm)
+	precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+	precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+
+	labelSelector, err := labels.Parse(fmt.Sprintf(v1.DomainLabel+" in (%s)", vm.GetObjectMeta().GetName()))
+	if err != nil {
+		panic(err)
+	}
+
+	listOptions := metav1.ListOptions{LabelSelector: labelSelector.String()}
+
+	if err := clientset.CoreV1().Secrets(vm.ObjectMeta.Namespace).DeleteCollection(nil, listOptions); err != nil {
+		return err
+	}
+
+	return nil
+}
 
 // The controller applies ports to registry disks when a VM spec is introduced into the cluster.
-func ApplyPorts(vm *v1.VM) {
+func Initialize(vm *v1.VM, clientset *kubernetes.Clientset) error {
+
+	var err error
+	authUser := ""
+	secretID := k8sSecretName(vm)
 	wrapperStartingPort := defaultPort
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
 	for idx, disk := range vm.Spec.Domain.Devices.Disks {
 		if disk.Type == registryDiskV1Alpha {
+
+			// Generate Dynamic Auth Credential for Registry Disks
+			if authUser == "" {
+				authUser, err = generateRandomString(32)
+				if err != nil {
+					return err
+				}
+			}
+
 			port := fmt.Sprintf("%d", wrapperStartingPort)
 			name := defaultHost
 			if disk.Source.Host != nil {
@@ -107,8 +155,50 @@ func ApplyPorts(vm *v1.VM) {
 				Name: name,
 			}
 			wrapperStartingPort++
+
+			// Reference k8s secret in Disk device
+			vm.Spec.Domain.Devices.Disks[idx].Auth = &v1.DiskAuth{
+				Username: authUser,
+				Secret: &v1.DiskSecret{
+					Type:  "iscsi",
+					Usage: secretID,
+				},
+			}
+
 		}
 	}
+
+	/* add k8s secret if authUser was generated */
+	if authUser != "" {
+		pass, err := generateRandomString(32)
+		if err != nil {
+			return err
+		}
+		pass64 := base64.StdEncoding.EncodeToString([]byte(pass))
+
+		// Store Auth as k8s secret
+		secret := kubev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretID,
+				Namespace: vm.GetObjectMeta().GetNamespace(),
+				Labels: map[string]string{
+					v1.DomainLabel: domain,
+				},
+			},
+			Type: kubev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				"password": []byte(pass64),
+			},
+		}
+
+		_, err = clientset.CoreV1().Secrets(vm.ObjectMeta.Namespace).Get(secretID, metav1.GetOptions{})
+		if err != nil {
+			if _, err := clientset.Core().Secrets(vm.GetObjectMeta().GetNamespace()).Create(&secret); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // The controller uses this function communicate the IP address of the POD
@@ -154,6 +244,9 @@ func GenerateContainers(vm *v1.VM) ([]kubev1.Container, error) {
 			if err != nil {
 				return nil, err
 			}
+
+			diskAuthUser := disk.Auth.Username
+
 			containers = append(containers, kubev1.Container{
 				Name:            diskContainerName,
 				Image:           diskContainerImage,
@@ -169,6 +262,21 @@ func GenerateContainers(vm *v1.VM) ([]kubev1.Container, error) {
 					kubev1.EnvVar{
 						Name:  "PORT",
 						Value: port,
+					},
+					kubev1.EnvVar{
+						Name: "PASSWORD_BASE64",
+						ValueFrom: &kubev1.EnvVarSource{
+							SecretKeyRef: &kubev1.SecretKeySelector{
+								LocalObjectReference: kubev1.LocalObjectReference{
+									Name: k8sSecretName(vm),
+								},
+								Key: "password",
+							},
+						},
+					},
+					kubev1.EnvVar{
+						Name:  "USERNAME",
+						Value: diskAuthUser,
 					},
 					// TODO once dynamic auth is implemented, pass creds as
 					// PASSWORD and USERNAME env vars. The registry disk base

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -179,8 +179,6 @@ func (c *VMController) execute(key string) error {
 			}
 		}
 
-		registrydisk.ApplyPorts(&vmCopy)
-
 		// Create a Pod which will be the VM destination
 		if err := c.vmService.StartVMPod(&vmCopy); err != nil {
 			logger.Error().Reason(err).Msg("Defining a target pod for the VM failed.")

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -77,6 +77,8 @@ func init() {
 	mapper.AddPtrConversion((**ChannelTarget)(nil), (**v1.ChannelTarget)(nil))
 	mapper.AddConversion(&VideoModel{}, &v1.Video{})
 	mapper.AddConversion(&Listen{}, &v1.Listen{})
+	mapper.AddPtrConversion((**DiskAuth)(nil), (**v1.DiskAuth)(nil))
+	mapper.AddPtrConversion((**DiskSecret)(nil), (**v1.DiskSecret)(nil))
 
 	model.AddConversion(&Video{}, &v1.Video{}, func(in reflect.Value) (reflect.Value, error) {
 		out := v1.Video{}
@@ -184,6 +186,17 @@ type Disk struct {
 	Serial   string      `xml:"serial,omitempty"`
 	Driver   *DiskDriver `xml:"driver,omitempty"`
 	ReadOnly *ReadOnly   `xml:"readonly,omitempty"`
+	Auth     *DiskAuth   `xml:"auth,omitempty"`
+}
+
+type DiskAuth struct {
+	Username string      `xml:"username,attr"`
+	Secret   *DiskSecret `xml:"secret,omitempty"`
+}
+
+type DiskSecret struct {
+	Type  string `xml:"type,attr"`
+	Usage string `xml:"usage,attr"`
 }
 
 type ReadOnly struct{}
@@ -442,6 +455,19 @@ type RandomGenerator struct {
 }
 
 // TODO ballooning, rng, cpu ...
+
+type SecretUsage struct {
+	Type   string `xml:"type,attr"`
+	Target string `xml:"target,omitempty"`
+}
+
+type SecretSpec struct {
+	XMLName     xml.Name    `xml:"secret"`
+	Ephemeral   string      `xml:"ephemeral,attr"`
+	Private     string      `xml:"private,attr"`
+	Description string      `xml:"description,omitempty"`
+	Usage       SecretUsage `xml:"usage,omitempty"`
+}
 
 func NewMinimalDomainSpec(vmName string) *DomainSpec {
 	precond.MustNotBeEmpty(vmName)

--- a/pkg/virt-handler/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-handler/virtwrap/cli/generated_mock_libvirt.go
@@ -94,6 +94,61 @@ func (_mr *_MockConnectionRecorder) NewStream(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewStream", arg0)
 }
 
+func (_m *MockConnection) LookupSecretByUsage(usageType libvirt_go.SecretUsageType, usageID string) (VirSecret, error) {
+	ret := _m.ctrl.Call(_m, "LookupSecretByUsage", usageType, usageID)
+	ret0, _ := ret[0].(VirSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockConnectionRecorder) LookupSecretByUsage(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LookupSecretByUsage", arg0, arg1)
+}
+
+func (_m *MockConnection) SecretDefineXML(xml string) (VirSecret, error) {
+	ret := _m.ctrl.Call(_m, "SecretDefineXML", xml)
+	ret0, _ := ret[0].(VirSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockConnectionRecorder) SecretDefineXML(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SecretDefineXML", arg0)
+}
+
+func (_m *MockConnection) ListSecrets() ([]string, error) {
+	ret := _m.ctrl.Call(_m, "ListSecrets")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockConnectionRecorder) ListSecrets() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListSecrets")
+}
+
+func (_m *MockConnection) LookupSecretByUUIDString(uuid string) (VirSecret, error) {
+	ret := _m.ctrl.Call(_m, "LookupSecretByUUIDString", uuid)
+	ret0, _ := ret[0].(VirSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockConnectionRecorder) LookupSecretByUUIDString(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LookupSecretByUUIDString", arg0)
+}
+
+func (_m *MockConnection) ListAllSecrets(flags libvirt_go.ConnectListAllSecretsFlags) ([]VirSecret, error) {
+	ret := _m.ctrl.Call(_m, "ListAllSecrets", flags)
+	ret0, _ := ret[0].([]VirSecret)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockConnectionRecorder) ListAllSecrets(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ListAllSecrets", arg0)
+}
+
 // Mock of Stream interface
 type MockStream struct {
 	ctrl     *gomock.Controller
@@ -155,6 +210,90 @@ func (_m *MockStream) UnderlyingStream() *libvirt_go.Stream {
 
 func (_mr *_MockStreamRecorder) UnderlyingStream() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnderlyingStream")
+}
+
+// Mock of VirSecret interface
+type MockVirSecret struct {
+	ctrl     *gomock.Controller
+	recorder *_MockVirSecretRecorder
+}
+
+// Recorder for MockVirSecret (not exported)
+type _MockVirSecretRecorder struct {
+	mock *MockVirSecret
+}
+
+func NewMockVirSecret(ctrl *gomock.Controller) *MockVirSecret {
+	mock := &MockVirSecret{ctrl: ctrl}
+	mock.recorder = &_MockVirSecretRecorder{mock}
+	return mock
+}
+
+func (_m *MockVirSecret) EXPECT() *_MockVirSecretRecorder {
+	return _m.recorder
+}
+
+func (_m *MockVirSecret) SetValue(value []byte, flags uint32) error {
+	ret := _m.ctrl.Call(_m, "SetValue", value, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirSecretRecorder) SetValue(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetValue", arg0, arg1)
+}
+
+func (_m *MockVirSecret) Undefine() error {
+	ret := _m.ctrl.Call(_m, "Undefine")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirSecretRecorder) Undefine() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Undefine")
+}
+
+func (_m *MockVirSecret) GetUsageID() (string, error) {
+	ret := _m.ctrl.Call(_m, "GetUsageID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirSecretRecorder) GetUsageID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUsageID")
+}
+
+func (_m *MockVirSecret) GetUUID() ([]byte, error) {
+	ret := _m.ctrl.Call(_m, "GetUUID")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirSecretRecorder) GetUUID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUUID")
+}
+
+func (_m *MockVirSecret) GetXMLDesc(flags uint32) (string, error) {
+	ret := _m.ctrl.Call(_m, "GetXMLDesc", flags)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirSecretRecorder) GetXMLDesc(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetXMLDesc", arg0)
+}
+
+func (_m *MockVirSecret) Free() error {
+	ret := _m.ctrl.Call(_m, "Free")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirSecretRecorder) Free() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Free")
 }
 
 // Mock of VirDomain interface

--- a/pkg/virt-handler/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-handler/virtwrap/cli/generated_mock_libvirt.go
@@ -264,15 +264,15 @@ func (_mr *_MockVirSecretRecorder) GetUsageID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUsageID")
 }
 
-func (_m *MockVirSecret) GetUUID() ([]byte, error) {
-	ret := _m.ctrl.Call(_m, "GetUUID")
-	ret0, _ := ret[0].([]byte)
+func (_m *MockVirSecret) GetUUIDString() (string, error) {
+	ret := _m.ctrl.Call(_m, "GetUUIDString")
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirSecretRecorder) GetUUID() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUUID")
+func (_mr *_MockVirSecretRecorder) GetUUIDString() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUUIDString")
 }
 
 func (_m *MockVirSecret) GetXMLDesc(flags uint32) (string, error) {

--- a/pkg/virt-handler/virtwrap/cli/libvirt.go
+++ b/pkg/virt-handler/virtwrap/cli/libvirt.go
@@ -300,7 +300,7 @@ type VirSecret interface {
 	SetValue(value []byte, flags uint32) error
 	Undefine() error
 	GetUsageID() (string, error)
-	GetUUID() ([]byte, error)
+	GetUUIDString() (string, error)
 	GetXMLDesc(flags uint32) (string, error)
 	Free() error
 }

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -31,6 +31,26 @@ func (_m *MockDomainManager) EXPECT() *_MockDomainManagerRecorder {
 	return _m.recorder
 }
 
+func (_m *MockDomainManager) SyncVMSecret(vm *v1.VM, usageType string, usageID string, secretValue string) error {
+	ret := _m.ctrl.Call(_m, "SyncVMSecret", vm, usageType, usageID, secretValue)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) SyncVMSecret(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncVMSecret", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockDomainManager) RemoveVMSecrets(_param0 *v1.VM) error {
+	ret := _m.ctrl.Call(_m, "RemoveVMSecrets", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) RemoveVMSecrets(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveVMSecrets", arg0)
+}
+
 func (_m *MockDomainManager) SyncVM(_param0 *v1.VM) (*api.DomainSpec, error) {
 	ret := _m.ctrl.Call(_m, "SyncVM", _param0)
 	ret0, _ := ret[0].(*api.DomainSpec)

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Manager", func() {
 			domainSpec.Name = testDomainName
 			xml, err := xml.Marshal(domainSpec)
 			Expect(err).To(BeNil())
+			mockConn.EXPECT().ListSecrets().Return(make([]string, 0, 0), nil)
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
@@ -88,6 +89,7 @@ var _ = Describe("Manager", func() {
 			Expect(model.Copy(&domainSpec, vm.Spec.Domain)).To(BeEmpty())
 			xml, err := xml.Marshal(domainSpec)
 
+			mockConn.EXPECT().ListSecrets().Return(make([]string, 0, 0), nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
@@ -104,6 +106,7 @@ var _ = Describe("Manager", func() {
 				Expect(model.Copy(&domainSpec, vm.Spec.Domain)).To(BeEmpty())
 				xml, err := xml.Marshal(domainSpec)
 
+				mockConn.EXPECT().ListSecrets().Return(make([]string, 0, 0), nil)
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().Create().Return(nil)
@@ -126,6 +129,7 @@ var _ = Describe("Manager", func() {
 			Expect(model.Copy(&domainSpec, vm.Spec.Domain)).To(BeEmpty())
 			xml, err := xml.Marshal(domainSpec)
 
+			mockConn.EXPECT().ListSecrets().Return(make([]string, 0, 0), nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, 1, nil)
 			mockDomain.EXPECT().Resume().Return(nil)
@@ -141,6 +145,7 @@ var _ = Describe("Manager", func() {
 	Context("on successful VM kill", func() {
 		table.DescribeTable("should try to undefine a VM in state",
 			func(state libvirt.DomainState) {
+				mockConn.EXPECT().ListSecrets().Return(make([]string, 0, 0), nil)
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().Undefine().Return(nil)
@@ -155,6 +160,7 @@ var _ = Describe("Manager", func() {
 		)
 		table.DescribeTable("should try to destroy and undefine a VM in state",
 			func(state libvirt.DomainState) {
+				mockConn.EXPECT().ListSecrets().Return(make([]string, 0, 0), nil)
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().Destroy().Return(nil)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -257,6 +257,16 @@ func MapPersistentVolumes(vm *v1.VM, restClient cache.Getter, namespace string) 
 					newDisk.Source.Host.Port = hostPort[1]
 				}
 
+				// This iscsi device has auth associated with it.
+				if pv.Spec.ISCSI.SecretRef != nil && pv.Spec.ISCSI.SecretRef.Name != "" {
+					newDisk.Auth = &v1.DiskAuth{
+						Secret: &v1.DiskSecret{
+							Type:  "iscsi",
+							Usage: pv.Spec.ISCSI.SecretRef.Name,
+						},
+					}
+				}
+
 				vmCopy.Spec.Domain.Devices.Disks[idx] = newDisk
 			} else {
 				logging.DefaultLogger().Object(vm).Error().Msg(fmt.Sprintf("Referenced PV %v is backed by an unsupported storage type", pv))

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -88,6 +88,7 @@ var _ = Describe("VM", func() {
 					ghttp.RespondWithJSONEncoded(http.StatusNotFound, struct{}{}),
 				),
 			)
+			domainManager.EXPECT().RemoveVMSecrets(v1.NewVMReferenceFromName("testvm")).Return(nil)
 			domainManager.EXPECT().KillVM(v1.NewVMReferenceFromName("testvm")).Do(func(vm *v1.VM) {
 				close(done)
 			})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -344,6 +344,9 @@ func cleanNamespaces() {
 
 		// Remove all Pods
 		PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("pods").Do().Error())
+
+		// Remove all VM Secrets
+		PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("secrets").Do().Error())
 	}
 }
 


### PR DESCRIPTION
This feature lets us map k8s secrets to VMs for iscsi auth. 

## Workflow
1. create a k8s secret containing the password and username fields.
```
cat << END > my-chap-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: myK8sSecretID
  namespace: default

apiVersion: v1
kind: Secret
metadata:
  name: my-chap-secret
type: "kubernetes.io/iscsi-chap"  
data:
  node.session.auth.username: $(echo "myUsername" | base64 -w0)
  node.session.auth.password: $(echo "mySuperSecretPassword" | base64 -w0)
END
```
2. create a vm that references the **name** given to the k8s secret in the iscsi usage field
```
cat << END > my-vm.yaml
kind: VM
metadata:
  name: testvm
  namespace: default
spec:
  domain:
    devices:
      disks:
      - Auth:
          secret:
            type: iscsi
            usage: my-chap-secret
        type: network
        snapshot: external
        device: disk
        driver:
          name: qemu
          type: raw
          cache: none
        source:
          host:
            name: iscsi-demo-target.default
            port: "3260"
          protocol: iscsi
          name: iqn.2017-01.io.kubevirt:sn.42/2
        target:
          dev: vda
    memory:
      unit: MB
      value: 64
    os:
      type:
        os: hvm
    type: qemu
END
```
3.  Add the secret and vm to the cluster.
```
kubectl create -f my-chap-secret.yaml
kubectl create -f my-vm.yaml
```

From there, the **password** field in the k8s secret will automatically be mapped to a libvirt secret when the VM is scheduled to a node allowing the iscsi auth to work without any further configuration. 

## Container Registry Disk Iscsi Auth

The second part of this PR involves auto generating k8s user/secret combos for container registry disks associated with a VM. This ensures CRD disks can only be accessed by their corresponding VM process.

In the future it would also be wise for us to introduce a network policy that further locks down CRD disks to the local node. 