### PR TITLE
Automatically bootstrap ginkgo as a part of generate target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,16 @@ before_install:
 - sudo apt-get update -q
 
 install:
-- git reset --hard
-- go get github.com/mattn/goveralls
-- go get -u github.com/Masterminds/glide
-- go get golang.org/x/tools/cmd/goimports
-- go get -u github.com/golang/mock/gomock
-- go get -u github.com/rmohr/mock/mockgen
-- go get -u github.com/rmohr/go-swagger-utils/swagger-doc
-- sudo apt-get install libvirt-dev make
-- make sync
+ - git reset --hard # we are caching the vendor folder, make sure we see the new vendor.json file
+ - go get github.com/mattn/goveralls
+ - go get -u github.com/Masterminds/glide
+ - go get golang.org/x/tools/cmd/goimports
+ - go get -u github.com/golang/mock/gomock
+ - go get -u github.com/rmohr/mock/mockgen
+ - go get -u github.com/rmohr/go-swagger-utils/swagger-doc
+ - go get -u github.com/onsi/ginkgo/ginkgo
+ - sudo apt-get install libvirt-dev make
+ - make sync
 
 script:
 - make fmt

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ generate:
 	find pkg/ -name "*generated*.go" -exec rm {} -f \;
 	./hack/build-go.sh generate ${WHAT}
 	goimports -w -local kubevirt.io cmd/ pkg/ tests/
+	./hack/bootstrap-ginkgo.sh
 
 build: checksync fmt vet compile
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -141,6 +141,7 @@ First install the generator tools:
 go get -u github.com/golang/mock/gomock
 go get -u github.com/rmohr/mock/mockgen
 go get -u github.com/rmohr/go-swagger-utils/swagger-doc
+go get github.com/onsi/ginkgo/ginkgo
 ```
 
 Then regenerate the code:

--- a/hack/bootstrap-ginkgo.sh
+++ b/hack/bootstrap-ginkgo.sh
@@ -1,0 +1,11 @@
+DIRS=$(find pkg/*/ -type d)
+for dir in $DIRS; do
+    # Let's make sure we don't break build by bootstrapping tests in empty
+    # directories.
+    GOFILES=$(find $dir -maxdepth 1 -type f -name *_test.go | wc -l | xargs)
+    if [ "x${GOFILES}" != "x0" ]; then
+        # Since ginkgo bootstrap doesn't take path, we have to hop in the
+        # target package first.
+        (cd $dir && ginkgo bootstrap || :)
+    fi
+done

--- a/pkg/logging/logging_suite_test.go
+++ b/pkg/logging/logging_suite_test.go
@@ -1,0 +1,13 @@
+package logging_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logging Suite")
+}

--- a/pkg/mapper/mapper_suite_test.go
+++ b/pkg/mapper/mapper_suite_test.go
@@ -1,0 +1,13 @@
+package mapper_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestMapper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mapper Suite")
+}

--- a/pkg/virt-handler/virtwrap/cli/cli_suite_test.go
+++ b/pkg/virt-handler/virtwrap/cli/cli_suite_test.go
@@ -1,0 +1,13 @@
+package cli_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCli(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cli Suite")
+}

--- a/pkg/virt-manifest/virt_manifest_suite_test.go
+++ b/pkg/virt-manifest/virt_manifest_suite_test.go
@@ -1,0 +1,13 @@
+package virt_manifest_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVirtManifest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VirtManifest Suite")
+}


### PR DESCRIPTION
Ginkgo tests require each tested package to be bootstrapped to run.
This patch makes the bootstrapping available in makefile's generate
target (which is safe automatically in commit hook).

The nature of this approach causes multiple new files - these indicate
packages that were not really tested by ginkgo. On the other hand,
when adding tests for those packages, we are not required to bootstrap
them anymore.

Signed-off-by: Martin Polednik <mpolednik@redhat.com>