### PR TITLE
Move manifests from TPRs to CRDs

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -29,6 +29,9 @@ cluster/kubectl.sh --core delete pods -l=daemon=virt-handler --force --grace-per
 cluster/kubectl.sh --core delete -f manifests/libvirt.yaml --cascade=false --grace-period 0 2>/dev/null || :
 cluster/kubectl.sh --core delete pods -l=daemon=libvirt --force --grace-period 0 2>/dev/null || :
 
+# Make sure TPRs are deleted, we use CRDs now
+cluster/kubectl.sh --core delete thirdpartyresources --all  || :
+
 # Delete everything else
 for i in `ls manifests/*.yaml`; do
     $KUBECTL delete -f $i --grace-period 0 2>/dev/null || :

--- a/manifests/migration-resource.yaml.in
+++ b/manifests/migration-resource.yaml.in
@@ -1,7 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: migration.kubevirt.io
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-description: "VM migration management"
-versions:
-  - name: v1alpha1
+  name: migrations.kubevirt.io
+spec:
+  scope: Namespaced
+  group: kubevirt.io
+  version: v1alpha1
+  names:
+    kind: Migration
+    plural: migrations
+    singular: migration

--- a/manifests/vm-resource.yaml.in
+++ b/manifests/vm-resource.yaml.in
@@ -1,7 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: v-m.kubevirt.io
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-description: "VM management"
-versions:
-  - name: v1alpha1
+  name: vms.kubevirt.io
+spec:
+  scope: Namespaced
+  group: kubevirt.io
+  version: v1alpha1
+  names:
+    kind: VM
+    plural: vms
+    singular: vm


### PR DESCRIPTION
@aglitke that should fix your problem with the latest kubernetes code from github master. TPRs don't exist there anymore. 

Since the switch from TPRs to CRDs is very easy, I would suggest that we do it, although we get our own apiserver within the next one or two weeks. @fabiand @stu-gott thoughts?

Signed-off-by: Roman Mohr <rmohr@redhat.com>