### PR TITLE
Improve readiness checks and give namespaces more time to be deleted

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -80,8 +80,6 @@ done
 echo "Nodes are ready:"
 kubectl get nodes
 
-echo "Work around bug https://github.com/kubernetes/kubernetes/issues/31123: Force a recreate of the discovery pods"
-kubectl delete pods -n kube-system -l k8s-app=kube-discovery
 sleep 10
 while [ -n "$(kubectl get pods -n kube-system --no-headers | grep -v Running)" ]; do
     echo "Waiting for kubernetes pods to become ready ..."

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -101,14 +101,22 @@ kubectl delete pods --all
 # Deploy kubevirt
 cluster/sync.sh
 
-# Wait until kubevirt is ready
+# Wait until kubevirt pods are running
 while [ -n "$(kubectl get pods --no-headers | grep -v Running)" ]; do
-    echo "Waiting for kubevirt pods to become ready ..."
+    echo "Waiting for kubevirt pods to enter the Running state ..."
     kubectl get pods --no-headers | >&2 grep -v Running
     sleep 10
 done
+
+# Make sure all containers are ready
+while [ -n "$(kubectl get pods -o'custom-columns=status:status.containerStatuses[*].ready' --no-headers | grep false)" ]; do
+    echo "Waiting for KubeVirt containers to become ready ..."
+    kubectl get pods -ocustom-columns='name:metadata.name,ready:status.containerStatuses[*].ready' | grep false
+    sleep 10
+done
+
 kubectl get pods
-cluster/kubectl.sh version
+kubectl version
 
 # Run functional tests
 FUNC_TEST_ARGS="--ginkgo.noColor" make functest

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -42,6 +42,12 @@ spec:
             port: 8186
           initialDelaySeconds: 10
           periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /api/v1/status
+            port: 8186
+          initialDelaySeconds: 10
+          periodSeconds: 3
       - name: manifest-libvirtd
         image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
         imagePullPolicy: IfNotPresent

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -363,7 +363,7 @@ func removeNamespaces() {
 
 	// Wait until the namespaces are terminated
 	for _, namespace := range testNamespaces {
-		Eventually(func() bool { return errors.IsNotFound(coreClient.Namespaces().Delete(namespace, nil)) }, 30*time.Second, 1*time.Second).
+		Eventually(func() bool { return errors.IsNotFound(coreClient.Namespaces().Delete(namespace, nil)) }, 60*time.Second, 1*time.Second).
 			Should(BeTrue())
 	}
 }


### PR DESCRIPTION
 * Make sure that all containers are in ready state, before running tests agains them
 * Give the namespaces more time to be deleted

Both sometimes made CI fail.