### PR TITLE
Fixed typo in the docs/glossary.md

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -133,8 +133,8 @@ Method of storing and distributing VM disks with KubeVirt using the container
 registry.
 
 ## Domain
-Libvirt domain. `virt-handler` can derive a Domain XML out of a [VM Spec](##vm-spec). 
-This is the host centric view of the cluster wide [VM Spec](##vm-spec).
+Libvirt domain. `virt-handler` can derive a Domain XML out of a [VM Spec](#vm-specification-aka-vm-spec). 
+This is the host centric view of the cluster wide [VM Spec](#vm-specification-aka-vm-spec).
 
 ## Domain XML
 


### PR DESCRIPTION
Changed ##vm-spec to correct
section header.

Signed-off-by: Petr Kotas <pkotas@redhat.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/369)
<!-- Reviewable:end -->
