### PR TITLE
docs: Mention that go 1.8 or higher is needed

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ A quick start guide to get KubeVirt up and running inside Vagrant.
 
 ## Building
 
-### Go
+### Go (1.8 or higher)
 
 [Go](https://golang.org) needs to be setup to be able to compile the sources.
 


### PR DESCRIPTION
Otherwise you see issues like

```bash
$ make compile
./hack/build-go.sh install
../vendor/k8s.io/client-go/rest/request.go:21:2: cannot find package "context" in any of:
	$GOPATH/src/kubevirt.io/kubevirt/vendor/context (vendor tree)
	/usr/src/context (from $GOROOT)
	$GOPATH/src/context (from $GOPATH)

$ make compile
./hack/build-go.sh install 
# kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/strategicpatch
../vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go:520: undefined: sort.SliceStable
```

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>