### PR TITLE
Add another libvirt hint to getting-started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,12 @@ sudo gpasswd -a ${USER} libvirt
 newgrp libvirt
 ```
 
+You might also need to change the libvirt connection string to be able to see all libvirt information:
+
+```
+export LIBVIRT_DEFAULT_URI=qemu:///system
+```
+
 ### Build dependencies
 
 Now we can finally get to the sources, before building KubeVirt we'll need

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ sudo gpasswd -a ${USER} libvirt
 newgrp libvirt
 ```
 
-You might also need to change the libvirt connection string to be able to see all libvirt information:
+On CentOS/RHEL 7 you might also need to change the libvirt connection string to be able to see all libvirt information:
 
 ```
 export LIBVIRT_DEFAULT_URI=qemu:///system


### PR DESCRIPTION
I had to tell vagrant/virsh/libvirt tools to use direct qemu
access to be able to see all information while using RHEL 7,
even though I was in the proper group.

Signed-off-by: Martin Sivak <msivak@redhat.com>