### PR TITLE
build: Include version, os and arch in binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,9 @@ deploy:
   skip_cleanup: true
   api_key:
     secure: dy3AlSki7p9sRjItOiWoPv4s28+hZ9wMcuvtZv0bWHbEZ7y/EvzXcwWmn+/Tjjk4Np59LImUjJw1E5Yv2Q16ViuNwKbX7TA7fu+wAcTz4DF4wFLIrJBcCRetiud4175aJ1ylOvmtHOuWHfo6Wx5HRxRT0fLcMFdSoagpe4Dh7BJYfI4Sgu/jghMMJ4wcDsMLZqi6RRM6jywFXQXMmBY87E57/ZLlXZ5Nud5RoWXJxfFfc/vTn/frCBu7r+JW8ayGeGVPEkEMtWX1huWnIvVjNu1twuZnL3zWmLNmpFXfk3j/gLbdIwLn3jgtariNz/Rvigqaj18F0Fa/QNL6VcruqgXd6ryWxmGm9sD6MYC3kk0HoqwSI7WBf88tlfz27FR+cHFZtjTBXnZHBtM5skuzUpT4kUKhLkwcfgA5PmoW/7NcmnN0eKvOQuQYq/8pREwdmYAvYsGPWJZjNYHBCv9KRT1lDRN5jRLMi5wn7NWFMR1p+mbdHyd7i43zM8gnumqvGF/chZ9PEH38hnm835RZAwnzdJ3EQ4YFAaOE2AaUBe9Yw1FP6f22MOC8+N9CY+a1AlGQBmovPjaf+x4f+Jx6y9jjxahJpoXxEKgeFvfSVUoKbkMPMOHxMAb0UL9Rqq3BhlLnPQIjcwdCZU/+wTcV/sFHdcnIqdl9/wb/L+mMjOs=
+  file_glob: true
   file:
-  - cmd/virtctl/virtctl
+  - cmd/virtctl/virtctl*
   on:
     tags: true
     repo: kubevirt/kubevirt

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -53,9 +53,12 @@ for arg in $args; do
     if [ "${target}" = "test" ]; then
         (cd $arg; go ${target} -v ./...)
     elif [ "${target}" = "install" ]; then
-        (cd $arg; GOBIN=$PWD go ${target} .)
+        eval "$(go env)"
+        ARCHBIN=$(basename $arg)-$(git describe --always)-$GOHOSTOS-$GOHOSTARCH
+        (cd $arg; GOBIN=$PWD go build -o $ARCHBIN)
         mkdir -p bin
-        ln -sf ../$arg/$(basename $arg) bin/$(basename $arg)
+        ln -sf $ARCHBIN $arg/$(basename $arg)
+        ln -sf ../$arg/$ARCHBIN bin/$(basename $arg)
     else
         (cd $arg; go $target ./...)
     fi


### PR DESCRIPTION
Previously the binaries were just named according to their name.
To allow users to see what arch and OS they target, this patch is adding
version, OS, and arch to the filename of the cmds.

Before: virtctl
After:  virtctl-v0.0.1-alpha.6-linux-amd64

This filename is used inthe cmd/*/* directories only, the names in bin/*
are left untouched to keep a friendly usability.

The change is mainly intended to keep the version, OS, and arch
informations in case that the binaries get published (like during
releases).

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>