### PR TITLE
Use Github mirror of Cirros Cloud image.

### DIFF
--- a/images/cirros-registry-disk-demo/Dockerfile
+++ b/images/cirros-registry-disk-demo/Dockerfile
@@ -21,4 +21,4 @@ FROM kubevirt/registry-disk-v1alpha
 MAINTAINER "David Vossel" \<dvossel@redhat.com\>
 
 # Add cirros
-RUN curl http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img > /disk/cirros.img
+RUN curl https://github.com/sshnaidm/cirros-mirror/raw/master/cirros-0.3.5-x86_64-disk.img > /disk/cirros.img


### PR DESCRIPTION
Use Github mirror for Cirros Cloud image until https://bugs.launchpad.net/cirros/+bug/1713358 is resolved.

Signed-off-by: Stu Gott <sgott@redhat.com>