### PR TITLE
Translate VM memory requirements to Pod resource requests

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -26,17 +26,24 @@ package v1
 */
 
 type DomainSpec struct {
-	Memory  Memory   `json:"memory"`
-	Type    string   `json:"type"`
-	OS      OS       `json:"os"`
-	SysInfo *SysInfo `json:"sysInfo,omitempty"`
-	Devices Devices  `json:"devices"`
-	Clock   *Clock   `json:"clock,omitempty"`
+	Memory     Memory      `json:"memory"`
+	MaxMemory  MaxMemory   `json:"maxMemory,omitempty"`
+	Type       string      `json:"type"`
+	OS         OS          `json:"os"`
+	SysInfo    *SysInfo    `json:"sysInfo,omitempty"`
+	Devices    Devices     `json:"devices"`
+	Clock      *Clock      `json:"clock,omitempty"`
 }
 
 type Memory struct {
 	Value uint   `json:"value"`
 	Unit  string `json:"unit"`
+}
+
+type MaxMemory struct {
+	Value uint   `json:"value"`
+	Unit  string `json:"unit"`
+	Slots uint   `json:"slots"`
 }
 
 type Devices struct {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -80,6 +80,36 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher", "--qemu-timeout", "60s"}))
 			})
 		})
+		Context("with memory", func() {
+			It("should add memory constraints to template", func() {
+
+				vm := v1.VM{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testvm",
+						UID:  "1234",
+					},
+					Spec: v1.VMSpec{
+						Domain: &v1.DomainSpec{
+							Memory: v1.Memory{
+								Value: 8,
+								Unit: "MB",
+							},
+							MaxMemory: v1.MaxMemory{
+								Value: 64,
+								Unit: "MB",
+								Slots: 16,
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vm)
+
+				Expect(err).To(BeNil())
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("73551k"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("32768k"))
+			})
+		})
 		Context("migration", func() {
 			var (
 				srcIp      = kubev1.NodeAddress{}

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -39,6 +39,7 @@ type StateChangeReason string
 func init() {
 	// TODO the whole mapping registration can be done be an automatic process with reflection
 	mapper.AddConversion(&Memory{}, &v1.Memory{})
+	mapper.AddConversion(&MaxMemory{}, &v1.MaxMemory{})
 	mapper.AddConversion(&OS{}, &v1.OS{})
 	mapper.AddConversion(&Devices{}, &v1.Devices{})
 	mapper.AddPtrConversion((**Clock)(nil), (**v1.Clock)(nil))
@@ -147,20 +148,27 @@ type DomainList struct {
 // tagged, and they must correspond to the libvirt domain as described in
 // https://libvirt.org/formatdomain.html.
 type DomainSpec struct {
-	XMLName xml.Name `xml:"domain"`
-	Name    string   `xml:"name"`
-	UUID    string   `xml:"uuid,omitempty"`
-	Memory  Memory   `xml:"memory"`
-	Type    string   `xml:"type,attr"`
-	OS      OS       `xml:"os"`
-	SysInfo *SysInfo `xml:"sysinfo,omitempty"`
-	Devices Devices  `xml:"devices"`
-	Clock   *Clock   `xml:"clock,omitempty"`
+	XMLName    xml.Name  `xml:"domain"`
+	Name       string    `xml:"name"`
+	UUID       string    `xml:"uuid,omitempty"`
+	Memory     Memory    `xml:"memory"`
+	MaxMemory  MaxMemory `xml:"maxMemory,omitempty"`
+	Type       string    `xml:"type,attr"`
+	OS         OS        `xml:"os"`
+	SysInfo    *SysInfo  `xml:"sysinfo,omitempty"`
+	Devices    Devices   `xml:"devices"`
+	Clock      *Clock    `xml:"clock,omitempty"`
 }
 
 type Memory struct {
 	Value uint   `xml:",chardata"`
 	Unit  string `xml:"unit,attr"`
+}
+
+type MaxMemory struct {
+	Value uint   `xml:",chardata"`
+	Unit  string `xml:"unit,attr"`
+	Slots uint   `xml:"slots,attr"`
 }
 
 type Devices struct {


### PR DESCRIPTION
This is still work in progress as I am too new to the kubevirt sources and need some directions first!

The resources section of Pod is filled in with memory data
based on the VM memory and QEMU overhead.

This patch also changes the v1.Memory API to make sure all
the necessary information can be represented there.

Signed-off-by: Martin Sivak <msivak@redhat.com>