### PR TITLE
images: Run as non-root

### DIFF
--- a/images/haproxy/Dockerfile
+++ b/images/haproxy/Dockerfile
@@ -28,7 +28,9 @@ RUN cp /docker-entrypoint.sh /docker-entrypoint-orig.sh
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 RUN addgroup -S haproxy && adduser -S -D -h /haproxy -s /bin/false -G haproxy -g haproxy haproxy
-#USER haproxy
+
 RUN mkdir /haproxy/run  && \
     chgrp -R 0 /haproxy/run && \
     chmod -R g=u /haproxy/run
+
+USER 1001

--- a/images/spice-proxy/Dockerfile
+++ b/images/spice-proxy/Dockerfile
@@ -21,4 +21,6 @@ RUN mkdir /home/proxy/run  && \
     chgrp -R 0 /home/proxy/run && \
     chmod -R g=u /home/proxy/run
 
+USER 1001
+
 CMD squid -NCd1 -f /home/proxy/squid.conf


### PR DESCRIPTION
The pod was already enforcing the container to run as non-root, but the
container itself was still run as the root user (with uid 0). Now the
containers are explicitly run with a different user id, which meets the
pod's security constrtaints.

Fixes #389

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>