### PR TITLE
advertise proper API base to k8s

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -82,7 +82,7 @@ func init() {
 		&announced.GroupMetaFactoryArgs{
 			GroupName:              GroupName,
 			VersionPreferenceOrder: []string{GroupVersion.Version},
-			ImportPrefix:           "kubevirt.io/kubevirt/pgk/api/v1",
+			ImportPrefix:           "kubevirt.io/kubevirt/pkg/api/v1",
 		},
 		announced.VersionToSchemeFunc{
 			GroupVersion.Version: SchemeBuilder.AddToScheme,


### PR DESCRIPTION
Typo actually advertised kubevirt.io/pgk/api instead of
kubevirt.io/pkg/api.

Signed-off-by: Martin Polednik <mpolednik@redhat.com>