### PR TITLE
Use /bin/bash instead of /usr/bin/bash

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 #
 # This file is part of the KubeVirt project
 #

--- a/images/libvirt-kubevirt/libvirtd-limited.sh
+++ b/images/libvirt-kubevirt/libvirtd-limited.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 #
 # This file is part of the KubeVirt project
 #

--- a/images/libvirt-kubevirt/libvirtd.sh
+++ b/images/libvirt-kubevirt/libvirtd.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 #
 # This file is part of the KubeVirt project
 #


### PR DESCRIPTION
For distros not having the /usr merge these could fail as bash is
considered essential command binary.  For all others both will work.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>