### PR TITLE
gitignore: Ignore generated Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build-tools/desc/desc
 hack/config-local.sh
 tags
 .glide.*
+.GeneratedDockerfile


### PR DESCRIPTION
When build of the docker image fails the .GeneratedDockerfile is left
on the filesystem.  In order to allow inspection let's not delete the
file on failure, but rather tell git to ignore it instead.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>