### PR TITLE
Make sure that we fail on unsupported Disk types

### DIFF
--- a/pkg/virt-handler/domain_test.go
+++ b/pkg/virt-handler/domain_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virthandler_test
+package virthandler
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -32,7 +32,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
-	. "kubevirt.io/kubevirt/pkg/virt-handler"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 

--- a/pkg/virt-handler/virt_handler_suite_test.go
+++ b/pkg/virt-handler/virt_handler_suite_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package virthandler_test
+package virthandler
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
Fix an issue where we only log that we don't support a Disk type, but
don't return an error, and pass the disk unconverted to Libvirt.