### PR TITLE
Note on VAGRANT_NUM_NODES variable

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,9 @@ This would create a master and two nodes:
     VAGRANT_NUM_NODES=2 vagrant up
 ```
 
-However, just running `master` is enough for most development tasks.
+If you decide to use separate nodes, pass `VAGRANT_NUM_NODES` variable to all
+vagrant interacting commands. However, just running `master` is enough for most
+development tasks.
 
 You could also run some build steps individually:
 


### PR DESCRIPTION
If multiple nodes were created (VAGRANT_NUM_NODES=2 vagrant up) and
VAGRANT_NUM_NODES is not passed to `make vagrant-deploy` then docker
fails to download images and pods ends up in state `ImagePullBackOff`.