### PR TITLE
Disable log event parsing vmlifecycle tests for JENKINs

### DIFF
--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -187,6 +187,10 @@ var _ = Describe("Vmlifecycle", func() {
 		Context("in a non-default namespace", func() {
 			table.DescribeTable("Should log libvirt start and stop lifecycle events of the domain", func(namespace string) {
 
+				_, exists := os.LookupEnv("JENKINS_HOME")
+				if exists {
+					Skip("Skip log query tests for JENKINs ci test environment")
+				}
 				vm = tests.NewRandomVMWithNS(namespace)
 				virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).ForNode(primaryNodeName).Pod()
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The vmlifecycle test that parses the virt-handler's pod logs fails fairly consistently in JENKINs ci, but passes consistently for all of us locally.

We've spent quite a bit of time investigating this and still don't have a grasp on why this is occurring. The virt-handler pod's logs don't get updated when streaming them via k8s... but this only happens for our JENKINs test runs.   

I've created issue #422 to track the log flushing problem.

This is currently impacting our ability to rely on the CI environment's results. In this PR I suggest we disable the single test case leading to all the false negatives when the functional tests are being run by jenkins.