### PR TITLE
Add more structure to the running services

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -54,17 +54,7 @@ func newVirtAPIApp(host *string, port *int, swaggerUI *string) *virtAPIApp {
 	}
 }
 
-func main() {
-
-	logging.InitializeLogging("virt-api")
-	swaggerui := flag.String("swagger-ui", "third_party/swagger-ui", "swagger-ui location")
-	host := flag.String("listen", "0.0.0.0", "Address and port where to listen on")
-	port := flag.Int("port", 8183, "Port to listen on")
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.Parse()
-
-	app := newVirtAPIApp(host, port, swaggerui)
-
+func (app *virtAPIApp) Run() {
 	ctx := context.Background()
 	vmGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "vms"}
 	migrationGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "migrations"}
@@ -133,4 +123,16 @@ func main() {
 	swagger.InstallSwaggerService(config)
 
 	log.Fatal(http.ListenAndServe(app.Service.Address(), nil))
+}
+
+func main() {
+	logging.InitializeLogging("virt-api")
+	swaggerui := flag.String("swagger-ui", "third_party/swagger-ui", "swagger-ui location")
+	host := flag.String("listen", "0.0.0.0", "Address and port where to listen on")
+	port := flag.Int("port", 8183, "Port to listen on")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	app := newVirtAPIApp(host, port, swaggerui)
+	app.Run()
 }

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -78,20 +78,7 @@ func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri
 	}
 }
 
-func main() {
-	logging.InitializeLogging("virt-handler")
-	libvirt.EventRegisterDefaultImpl()
-	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
-	host := flag.String("listen", "0.0.0.0", "Address where to listen on")
-	port := flag.Int("port", 8185, "Port to listen on")
-	hostOverride := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
-	socketDir := flag.String("socket-dir", "/var/run/kubevirt", "Directory where to look for sockets for cgroup detection")
-	cloudInitDir := flag.String("cloud-init-dir", "/var/run/libvirt/cloud-init-dir", "Base directory for ephemeral cloud init data")
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.Parse()
-
-	app := newVirtHandlerApp(host, port, hostOverride, libvirtUri, socketDir, cloudInitDir)
-
+func (app *virtHandlerApp) Run() {
 	log := logging.DefaultLogger()
 	log.Info().V(1).Log("hostname", app.HostOverride)
 
@@ -191,4 +178,20 @@ func main() {
 	restful.DefaultContainer.Add(ws)
 	server := &http.Server{Addr: app.Service.Address(), Handler: restful.DefaultContainer}
 	server.ListenAndServe()
+}
+
+func main() {
+	logging.InitializeLogging("virt-handler")
+	libvirt.EventRegisterDefaultImpl()
+	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
+	host := flag.String("listen", "0.0.0.0", "Address where to listen on")
+	port := flag.Int("port", 8185, "Port to listen on")
+	hostOverride := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
+	socketDir := flag.String("socket-dir", "/var/run/kubevirt", "Directory where to look for sockets for cgroup detection")
+	cloudInitDir := flag.String("cloud-init-dir", "/var/run/libvirt/cloud-init-dir", "Base directory for ephemeral cloud init data")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	app := newVirtHandlerApp(host, port, hostOverride, libvirtUri, socketDir, cloudInitDir)
+	app.Run()
 }

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -46,16 +46,7 @@ func newVirtManifestApp(host *string, port *int, libvirtUri *string) *virtManife
 	}
 }
 
-func main() {
-	logging.InitializeLogging("virt-manifest")
-	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
-	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
-	port := flag.Int("port", 8186, "Port to listen on")
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.Parse()
-
-	app := newVirtManifestApp(listen, port, libvirtUri)
-
+func (app *virtManifestApp) Run() {
 	log := logging.DefaultLogger()
 	log.Info().Msg("Starting virt-manifest server")
 
@@ -82,4 +73,16 @@ func main() {
 	if err := server.ListenAndServe(); err != nil {
 		log.Error().Reason(err).Msg("Unable to start web server.")
 	}
+}
+
+func main() {
+	logging.InitializeLogging("virt-manifest")
+	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
+	listen := flag.String("listen", "0.0.0.0", "Address where to listen on")
+	port := flag.Int("port", 8186, "Port to listen on")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	app := newVirtManifestApp(listen, port, libvirtUri)
+	app.Run()
 }

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -23,16 +23,28 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/emicklei/go-restful"
 	"github.com/spf13/pflag"
 
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-manifest/rest"
 )
+
+type virtManifestApp struct {
+	Service    *service.Service
+	LibvirtUri string
+}
+
+func newVirtManifestApp(host *string, port *int, libvirtUri *string) *virtManifestApp {
+	return &virtManifestApp{
+		Service:    service.NewService("virt-manifest", host, port),
+		LibvirtUri: *libvirtUri,
+	}
+}
 
 func main() {
 	logging.InitializeLogging("virt-manifest")
@@ -42,12 +54,14 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
+	app := newVirtManifestApp(listen, port, libvirtUri)
+
 	log := logging.DefaultLogger()
 	log.Info().Msg("Starting virt-manifest server")
 
 	log.Info().Msg("Connecting to libvirt")
 
-	domainConn, err := cli.NewConnection(*libvirtUri, "", "", 60*time.Second)
+	domainConn, err := cli.NewConnection(app.LibvirtUri, "", "", 60*time.Second)
 	if err != nil {
 		log.Error().Reason(err).Msg("cannot connect to libvirt")
 		panic(fmt.Sprintf("failed to connect to libvirt: %v", err))
@@ -62,7 +76,7 @@ func main() {
 	}
 
 	restful.DefaultContainer.Add(ws)
-	server := &http.Server{Addr: *listen + ":" + strconv.Itoa(*port), Handler: restful.DefaultContainer}
+	server := &http.Server{Addr: app.Service.Address(), Handler: restful.DefaultContainer}
 	log.Info().Msg("Listening for client connections")
 
 	if err := server.ListenAndServe(); err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -26,18 +26,18 @@ import (
 
 type Service struct {
 	Name string
-	host string
-	port string
+	Host string
+	Port string
 }
 
 func NewService(name string, host *string, port *int) *Service {
 	return &Service{
 		Name: name,
-		host: *host,
-		port: strconv.Itoa(*port),
+		Host: *host,
+		Port: strconv.Itoa(*port),
 	}
 }
 
 func (service *Service) Address() string {
-	return fmt.Sprintf("%s:%s", service.host, service.port)
+	return fmt.Sprintf("%s:%s", service.Host, service.Port)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package service
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type Service struct {
+	Name string
+	host string
+	port string
+}
+
+func NewService(name string, host *string, port *int) *Service {
+	return &Service{
+		Name: name,
+		host: *host,
+		port: strconv.Itoa(*port),
+	}
+}
+
+func (service *Service) Address() string {
+	return fmt.Sprintf("%s:%s", service.host, service.port)
+}


### PR DESCRIPTION
Most of the current services (not virt-controller) are not really structured and leave all the initialization and running code in main(). We can try to start adding some structure to them by initializing service structs and moving some of the internals to these. Later on, this gives us the ability to properly decompose service code, similarly to what virt-controller does.