### PR TITLE
Dedicated ISCSI Auth functional tests (direct LUN and PVC support)

### DIFF
--- a/cluster/vm-iscsi-auth.yaml
+++ b/cluster/vm-iscsi-auth.yaml
@@ -1,0 +1,44 @@
+apiVersion: kubevirt.io/v1alpha1
+kind: VM
+metadata:
+  name: testvm
+spec:
+  domain:
+    devices:
+      graphics:
+      - type: spice
+      interfaces:
+      - type: network
+        source:
+          network: default
+      video:
+      - type: qxl
+      disks:
+      - type: network
+        snapshot: external
+        device: disk
+        auth:
+          secret:
+             type: iscsi
+             usage: iscsi-auth-demo-secret
+        driver:
+          name: qemu
+          type: raw
+          cache: none
+        source:
+          host:
+            name: iscsi-auth-demo-target.default
+            port: "3260"
+          protocol: iscsi
+          name: iqn.2017-01.io.kubevirt:sn.42/2
+        target:
+          dev: vda
+      consoles:
+      - type: pty
+    memory:
+      unit: MB
+      value: 64
+    os:
+      type:
+        os: hvm
+    type: qemu

--- a/images/iscsi-demo-target-tgtd/run-tgt.sh
+++ b/images/iscsi-demo-target-tgtd/run-tgt.sh
@@ -34,6 +34,11 @@ echo "Adding target and exposing it"
 tgtadm --lld iscsi --mode target --op new --tid=1 --targetname $WWN
 tgtadm --lld iscsi --mode target --op bind --tid=1 -I ALL
 
+if [ -n "$PASSWORD" ] && [ -n "$USERNAME" ]; then
+  tgtadm --lld iscsi --op new --mode account --user $USERNAME --password $PASSWORD
+  tgtadm --lld iscsi --op bind --mode account --tid=1 --user $USERNAME
+fi
+
 LUNID=1
 add_lun_for_file() {
   local FN=$1

--- a/manifests/iscsi-auth-demo-target.yaml.in
+++ b/manifests/iscsi-auth-demo-target.yaml.in
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iscsi-auth-demo-secret
+type: "kubernetes.io/iscsi-chap"  
+data:
+  node.session.auth.username: ZGVtb3VzZXI=
+  node.session.auth.password: ZGVtb3Bhc3N3b3Jk
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: iscsi-auth-demo-target
+spec:
+  ports:
+    - name: iscsi
+      port: 3260
+      targetPort: 3260
+  selector:
+    app: iscsi-auth-demo-target
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: iscsi-auth-demo-target-tgtd
+spec:
+  template:
+    metadata:
+      labels:
+        name: iscsi-auth-demo-target-tgtd
+        app: iscsi-auth-demo-target
+      name: iscsi-auth-demo-target-tgtd
+    spec:
+      containers:
+        - name: target
+          image: {{ docker_prefix }}/iscsi-demo-target-tgtd:{{ docker_tag }}
+          ports:
+            - containerPort: 3260
+          volumeMounts:
+          - name: host
+            mountPath: /host
+          env:
+            - name: EXPORT_HOST_PATHS
+              value:
+            - name: PASSWORD
+              value: demopassword
+            - name: USERNAME
+              value: demouser
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+      nodeSelector:
+        kubernetes.io/hostname: {{ primary_node_name }}

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -175,8 +175,6 @@ func Initialize(vm *v1.VM, virtCli kubecli.KubevirtClient) error {
 		if err != nil {
 			return err
 		}
-		pass64 := base64.StdEncoding.EncodeToString([]byte(pass))
-		user64 := base64.StdEncoding.EncodeToString([]byte(authUser))
 
 		// Store Auth as k8s secret
 		secret := kubev1.Secret{
@@ -189,8 +187,8 @@ func Initialize(vm *v1.VM, virtCli kubecli.KubevirtClient) error {
 			},
 			Type: "kubernetes.io/iscsi-chap",
 			Data: map[string][]byte{
-				"node.session.auth.password": []byte(pass64),
-				"node.session.auth.username": []byte(user64),
+				"node.session.auth.password": []byte(pass),
+				"node.session.auth.username": []byte(authUser),
 			},
 		}
 
@@ -265,7 +263,7 @@ func GenerateContainers(vm *v1.VM) ([]kubev1.Container, error) {
 						Value: port,
 					},
 					kubev1.EnvVar{
-						Name: "PASSWORD_BASE64",
+						Name: "PASSWORD",
 						ValueFrom: &kubev1.EnvVarSource{
 							SecretKeyRef: &kubev1.SecretKeySelector{
 								LocalObjectReference: kubev1.LocalObjectReference{
@@ -276,7 +274,7 @@ func GenerateContainers(vm *v1.VM) ([]kubev1.Container, error) {
 						},
 					},
 					kubev1.EnvVar{
-						Name: "USERNAME_BASE64",
+						Name: "USERNAME",
 						ValueFrom: &kubev1.EnvVarSource{
 							SecretKeyRef: &kubev1.SecretKeySelector{
 								LocalObjectReference: kubev1.LocalObjectReference{


### PR DESCRIPTION
Previously ISCSI auth was being tested implicitly by the registry disk's usage of auth. These patches explicitly test iscsi auth using both direct LUN support and PVC support outside of registry disk usage.

It's important to have ISCSI auth tests outside of registry disks because I'm working on removing the ISCSI requirement entirely from registry disks. At that point we'll have to have dedicated ISCSI tests before I can make the switch.

During the process of adding the new ISCSI auth tests, I realized the k8s secret generation was incorrect.  We were double base64 decoding the secrets which led to some odd behavior.  It just happened to work for our functional tests because of the way the registry disk secrets were generated.  That's been addressed in this patch series as well.

I also included a new vm-iscsi-auth.yaml file that demonstrates how someone can start a VM with direct LUN iscsi auth. 