### PR TITLE
Wait for virt-launcher readiness check before assigning vm to node

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -141,6 +141,15 @@ func (mon *Monitor) RunForever(startTimeout time.Duration) {
 	log.Printf("Exiting...")
 }
 
+func markReady(readinessFile string) {
+	f, err := os.OpenFile(readinessFile, os.O_RDONLY|os.O_CREATE, 0666)
+	if err != nil {
+		panic(err)
+	}
+	f.Close()
+	log.Printf("Marked as ready")
+}
+
 func main() {
 	startTimeout := 0 * time.Second
 
@@ -150,6 +159,7 @@ func main() {
 	socketDir := flag.String("socket-dir", "/var/run/kubevirt", "Directory where to place a socket for cgroup detection")
 	name := flag.String("name", "", "Name of the VM")
 	namespace := flag.String("namespace", "", "Namespace of the VM")
+	readinessFile := flag.String("readiness-file", "/tmp/health", "Pod looks for tihs file to determine when virt-launcher is initialized")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
@@ -165,6 +175,7 @@ func main() {
 		debugMode: *debugMode,
 	}
 
+	markReady(*readinessFile)
 	mon.RunForever(*qemuTimeout)
 }
 

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/jeevatkm/go-model"
 
@@ -50,20 +49,6 @@ func generateRandomString(len int) (string, error) {
 		return "", err
 	}
 	return base64.URLEncoding.EncodeToString(bytes), nil
-}
-
-func DisksAreReady(pod *kubev1.Pod) bool {
-	// Wait for readiness probes on image wrapper containers
-	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if strings.Contains(containerStatus.Name, "disk") == false {
-			// only check readiness of disk containers
-			continue
-		}
-		if containerStatus.Ready == false {
-			return false
-		}
-	}
-	return true
 }
 
 func k8sSecretName(vm *v1.VM) string {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -57,7 +57,8 @@ var _ = Describe("Template", func() {
 					"--qemu-timeout", "60s",
 					"--name", "testvm",
 					"--namespace", "testns",
-					"--socket-dir", "/var/run/libvirt"}))
+					"--socket-dir", "/var/run/libvirt",
+					"--readiness-file", "/tmp/healthy"}))
 			})
 		})
 		Context("with node selectors", func() {
@@ -85,7 +86,8 @@ var _ = Describe("Template", func() {
 					"--qemu-timeout", "60s",
 					"--name", "testvm",
 					"--namespace", "default",
-					"--socket-dir", "/var/run/libvirt"}))
+					"--socket-dir", "/var/run/libvirt",
+					"--readiness-file", "/tmp/healthy"}))
 				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/libvirt/default/testvm"))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/libvirt/default/testvm"))
 			})

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -229,9 +229,8 @@ func (c *VMController) execute(key string) error {
 			return nil
 		}
 
-		// Ensure registry disks are online before placing VM
-		if registrydisk.DisksAreReady(&pods.Items[0]) == false {
-			logger.Info().V(2).Msg("Waiting on image wrapper disks to become ready.")
+		if verifyReadiness(&pods.Items[0]) == false {
+			logger.Info().V(2).Msg("Waiting on all virt-launcher containers to be marked ready")
 			return nil
 		}
 
@@ -254,6 +253,16 @@ func (c *VMController) execute(key string) error {
 		logger.Info().Msgf("VM successfully scheduled to %s.", vmCopy.Status.NodeName)
 	}
 	return nil
+}
+
+func verifyReadiness(pod *k8sv1.Pod) bool {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Ready == false {
+			return false
+		}
+	}
+
+	return true
 }
 
 func vmLabelHandler(vmQueue workqueue.RateLimitingInterface) func(obj interface{}) {


### PR DESCRIPTION
There's a race condition in the new cgroup detection logic between starting the virt-launcher pod and assigning the VM.  VMs launch successfully with the new logic, but there's some unnecessary errors and rate limiting occurring that could impact performance and debugging in the future. 

Right now, virt-controller can assign the VM to a node before the virt-launcher's socket has been created.  This causes the VM to fail to sync with libvirt and get rate limited. Eventually, the VM will launch once the socket appears, but we'll see a bunch of ERRORs in the virt-handler logs related to **"Could not detect virt-launcher cgroups."** in the mean time.

To narrow the timing gap, I've added a readiness check to the virt-launcher container.  Now virt-launcher writes a file 'tmp/healthy' once it is completely initialized. The container is marked as 'ready' in the POD object once the kubelet detects this file has been created.  Virt-controller now waits for the 'ready' status before assigning the VM to the node. 

All of this means that the VM won't get assigned to a node until virt-launcher is marked as ready... which means the socket has been successfully created **before** virt-handler will ever see the VM. 