### PR TITLE
Support for storing cloud-init userdata in k8s secret

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -124,7 +124,7 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	configDiskClient := configdisk.NewConfigDiskClient()
+	configDiskClient := configdisk.NewConfigDiskClient(virtCli)
 
 	// Wire VM controller
 	vmListWatcher := kubecli.NewListWatchFromClient(virtCli.RestClient(), "vms", k8sv1.NamespaceAll, fields.Everything(), l)

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -27,6 +27,8 @@ package v1
 
 // http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html
 type CloudInitDataSourceNoCloud struct {
+	// Reference to a k8s secret that contains NoCloud userdata
+	UserDataSecretRef string `json:"userDataSecretRef"`
 	// The NoCloud cloud-init userdata as a base64 encoded string
 	UserDataBase64 string `json:"userDataBase64"`
 	// The NoCloud cloud-init metadata as a base64 encoded string

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -4,9 +4,10 @@ package v1
 
 func (CloudInitDataSourceNoCloud) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":               "http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
-		"userDataBase64": "The NoCloud cloud-init userdata as a base64 encoded string",
-		"metaDataBase64": "The NoCloud cloud-init metadata as a base64 encoded string",
+		"":                  "http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+		"userDataSecretRef": "Reference to a k8s secret that contains NoCloud userdata",
+		"userDataBase64":    "The NoCloud cloud-init userdata as a base64 encoded string",
+		"metaDataBase64":    "The NoCloud cloud-init metadata as a base64 encoded string",
 	}
 }
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -76,7 +76,7 @@ var _ = Describe("VM", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		domainManager = virtwrap.NewMockDomainManager(ctrl)
 
-		configDiskClient := configdisk.NewConfigDiskClient()
+		configDiskClient := configdisk.NewConfigDiskClient(virtClient)
 
 		recorder = record.NewFakeRecorder(100)
 		dispatch = NewVMHandlerDispatch(domainManager, recorder, restClient, virtClient, host, configDiskClient)


### PR DESCRIPTION
Example: Create a k8s secret with UserData. Reference the secret in the NoCloud disk definition.

First create the secret.
```
apiVersion: v1
kind: Secret
metadata:
  name: my-vm-secret
type: Opaque
data:
  userdata: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
```

Then reference the secret in the userDataSecretRef field.
```
metadata:
  name: testvm-nocloud
apiVersion: kubevirt.io/v1alpha1
kind: VM
spec:
  domain:
    devices:
      disks:
      - type: ContainerRegistryDisk:v1alpha
        source:
          name: kubevirt/cirros-registry-disk-demo:devel
        target:
          dev: vda
      - type: file
        target:
          dev: vdb
        cloudinit:
            nocloud:
                userDataSecretRef: my-vm-userdata 
      interfaces:
      - source:
          network: default
        type: network
    memory:
      unit: MB
      value: 64
    os:
      type:
        os: hvm
    type: qemu
```

Multiple VMs can reference the same k8s secret object containing userdata.