### PR TITLE
Move all cloud-init logic in virt-controller into virt-handler

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -283,7 +283,7 @@ func ApplyMetadata(vm *v1.VM) {
 			return
 		}
 		// TODO Put local-hostname in MetaData once we get pod DNS working with VMs
-		msg := fmt.Sprintf("instance-id: %s-%s\n", domain, namespace)
+		msg := fmt.Sprintf("instance-id: %s.%s\n", domain, namespace)
 		spec.NoCloudData.MetaDataBase64 = base64.StdEncoding.EncodeToString([]byte(msg))
 	}
 }

--- a/pkg/config-disk/config-disk.go
+++ b/pkg/config-disk/config-disk.go
@@ -74,6 +74,7 @@ func (c *configDiskClient) Define(vm *v1.VM) (bool, error) {
 		v = make(chan string, 1)
 
 		go func() {
+			cloudinit.ApplyMetadata(vm)
 			err := cloudinit.GenerateLocalData(domain, namespace, cloudInitSpec)
 			if err == nil {
 				v <- "success"

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
-	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
@@ -179,8 +178,6 @@ func (c *VMController) execute(key string) error {
 
 			}
 		}
-
-		cloudinit.ApplyMetadata(&vmCopy)
 
 		// Create a Pod which will be the VM destination
 		if err := c.vmService.StartVMPod(&vmCopy); err != nil {


### PR DESCRIPTION
virt-controller doesn't need to be involved with cloud-init right now. We can consolidate all the logic into virt-handler. 

Previously the metadata was being generated for the cloud-init object before scheduling the VM to a node. There's really no good reason for the metadata to be generated in the virt-controller component. 