### PR TITLE
Finish rename of quickcheck to vm-isolation-check

### DIFF
--- a/cluster/vm-isolation-check.sh
+++ b/cluster/vm-isolation-check.sh
@@ -19,7 +19,7 @@
 
 source hack/config.sh
 usage () {
-echo "Usage: ./cluster/quickcheck.sh [-vm  <VM>]"
+echo "Usage: ./cluster/vm-isolation-check.sh [-vm <VM>]"
 }
 
 VM_NAME=testvm

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,5 @@ therefore required. For best results, use this path:
  * `cluster/sync_config.sh`: This script will contact the master node and
    collect its config and kubectl. It is called by sync.sh so does not generally
    need to be run separately.
- * `cluster/quickcheck.sh`: This script will run a series of tests to ensure
+ * `cluster/vm-isolation-check.sh`: This script will run a series of tests to ensure
    the system is set up correctly.
-
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -211,7 +211,7 @@ tap networking device attached.
 Basic verification is possible by running
 
 ```bash
-    bash cluster/quickcheck.sh
+    bash cluster/vm-isolation-check.sh
 ```
 
 #### Example


### PR DESCRIPTION
Since commit 69c40db04b6b5dbf7be64ebe5e7445f4c0eb8ed8 the script is
called vm-isolation-check.sh (which corresponds more to what it is
actually doing).  However some places in the docs and the script got
stuck with the former name.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>