### PR TITLE
manifests: Set a storageClass for iSCSI Demo PVCs

### DIFF
--- a/manifests/iscsi-demo-target.yaml.in
+++ b/manifests/iscsi-demo-target.yaml.in
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: disk-custom
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
@@ -18,6 +19,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: disk-alpine
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
@@ -33,6 +35,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: disk-cirros
 spec:
+  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
We need to set an empty storageClass on our PVCs to prevent that a
default provisioner is set eventually (like in minikube), which does then
lead to new PVs created by the clusters default provisioner.

See the following link for more details:
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims

Fixes #425 

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>