### PR TITLE
Add functional tests to verify cloud-init nodata is picked up by VM

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -311,7 +311,7 @@ func ApplyMetadata(vm *v1.VM) {
 			return
 		}
 		// TODO Put local-hostname in MetaData once we get pod DNS working with VMs
-		msg := fmt.Sprintf("instance-id: %s.%s\n", domain, namespace)
+		msg := fmt.Sprintf("{ \"instance-id\": \"%s.%s\" }\n", domain, namespace)
 		spec.NoCloudData.MetaDataBase64 = base64.StdEncoding.EncodeToString([]byte(msg))
 	}
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -511,10 +511,9 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VM {
 	return vm
 }
 
-func NewRandomVMWithUserData(cloudInitDataSource string) (*v1.VM, error) {
+func NewRandomVMWithUserData(cloudInitDataSource string, userData string) (*v1.VM, error) {
 	switch cloudInitDataSource {
 	case "noCloud":
-		userData := "#!/bin/sh\n\necho 'printed from cloud-init userdata'\n"
 		vm := NewRandomVMWithSerialConsole()
 		spec := &v1.CloudInitSpec{
 			NoCloudData: &v1.CloudInitDataSourceNoCloud{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -511,13 +511,11 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VM {
 	return vm
 }
 
-func NewRandomVMWithUserData(containerImage string, cloudInitDataSource string) (*v1.VM, error) {
-
+func NewRandomVMWithUserData(cloudInitDataSource string) (*v1.VM, error) {
 	switch cloudInitDataSource {
 	case "noCloud":
-		userData := "#cloud-config\npassword: atomic\nssh_pwauth: True\nchpasswd: { expire: False }\n"
-
-		vm := NewRandomVMWithEphemeralDisk(containerImage)
+		userData := "#!/bin/sh\n\necho 'printed from cloud-init userdata'\n"
+		vm := NewRandomVMWithSerialConsole()
 		spec := &v1.CloudInitSpec{
 			NoCloudData: &v1.CloudInitDataSourceNoCloud{
 				UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -22,7 +22,11 @@ package tests_test
 import (
 	"flag"
 	"fmt"
+	"net/url"
+	"strings"
+	"time"
 
+	"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -42,9 +46,16 @@ var _ = Describe("CloudInit UserData", func() {
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
 
-	BeforeEach(func() {
-		tests.BeforeTestCleanup()
-	})
+	Dial := func(vm string, console string) *websocket.Conn {
+		wsUrl, err := url.Parse(flag.Lookup("master").Value.String())
+		Expect(err).ToNot(HaveOccurred())
+		wsUrl.Scheme = "ws"
+		wsUrl.Path = "/apis/kubevirt.io/v1alpha1/namespaces/" + tests.NamespaceTestDefault + "/vms/" + vm + "/console"
+		wsUrl.RawQuery = "console=" + console
+		c, _, err := websocket.DefaultDialer.Dial(wsUrl.String(), nil)
+		Expect(err).ToNot(HaveOccurred())
+		return c
+	}
 
 	LaunchVM := func(vm *v1.VM) runtime.Object {
 		obj, err := virtClient.RestClient().Post().Resource("vms").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
@@ -56,71 +67,71 @@ var _ = Describe("CloudInit UserData", func() {
 		_, ok := obj.(*v1.VM)
 		Expect(ok).To(BeTrue(), "Object is not of type *v1.VM")
 		tests.WaitForSuccessfulVMStart(obj)
+
+		ws := Dial(vm.ObjectMeta.GetName(), "serial0")
+		defer ws.Close()
+		next := ""
+		Eventually(func() string {
+			for {
+				if index := strings.Index(next, "\n"); index != -1 {
+					line := next[0:index]
+					next = next[index+1:]
+					return line
+				}
+				_, data, err := ws.ReadMessage()
+				Expect(err).ToNot(HaveOccurred())
+				next = next + string(data)
+			}
+		}, 45*time.Second).Should(ContainSubstring("found datasource (nocloud, local)"))
 	}
 
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+	})
+
 	Context("CloudInit Data Source NoCloud", func() {
-		It("should launch multiple VMs with cloud-init data source NoCloud", func(done Done) {
-			num := 2
-			vms := make([]*v1.VM, 0, num)
-			objs := make([]runtime.Object, 0, num)
-			for i := 0; i < num; i++ {
-				vm, err := tests.NewRandomVMWithUserData("kubevirt/cirros-registry-disk-demo:devel", "noCloud")
-				Expect(err).ToNot(HaveOccurred())
-				obj := LaunchVM(vm)
-				vms = append(vms, vm)
-				objs = append(objs, obj)
-			}
-
-			for idx, vm := range vms {
-				VerifyUserDataVM(vm, objs[idx])
-			}
-
+		It("should launch vm with cloud-init data source NoCloud", func(done Done) {
+			vm, err := tests.NewRandomVMWithUserData("noCloud")
+			Expect(err).ToNot(HaveOccurred())
+			obj := LaunchVM(vm)
+			VerifyUserDataVM(vm, obj)
 			close(done)
-		}, 45)
+		}, 60)
+
 		It("should launch VMs with user-data in k8s secret", func(done Done) {
-			num := 2
-			vms := make([]*v1.VM, 0, num)
-			objs := make([]runtime.Object, 0, num)
-			for i := 0; i < num; i++ {
-				vm, err := tests.NewRandomVMWithUserData("kubevirt/cirros-registry-disk-demo:devel", "noCloud")
-				Expect(err).ToNot(HaveOccurred())
+			vm, err := tests.NewRandomVMWithUserData("noCloud")
+			Expect(err).ToNot(HaveOccurred())
 
-				for _, disk := range vm.Spec.Domain.Devices.Disks {
-					if disk.CloudInit == nil {
-						continue
-					}
-
-					secretID := fmt.Sprintf("%s-test-secret", vm.GetObjectMeta().GetName())
-					spec := disk.CloudInit
-					spec.NoCloudData.UserDataSecretRef = secretID
-					userData64 := spec.NoCloudData.UserDataBase64
-					spec.NoCloudData.UserDataBase64 = ""
-
-					// Store userdata as k8s secret
-					secret := kubev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      secretID,
-							Namespace: vm.GetObjectMeta().GetNamespace(),
-						},
-						Type: "Opaque",
-						Data: map[string][]byte{
-							"userdata": []byte(userData64),
-						},
-					}
-					_, err := virtClient.Core().Secrets(vm.GetObjectMeta().GetNamespace()).Create(&secret)
-					Expect(err).To(BeNil())
-					break
+			for _, disk := range vm.Spec.Domain.Devices.Disks {
+				if disk.CloudInit == nil {
+					continue
 				}
-				obj := LaunchVM(vm)
-				vms = append(vms, vm)
-				objs = append(objs, obj)
-			}
 
-			for idx, vm := range vms {
-				VerifyUserDataVM(vm, objs[idx])
+				secretID := fmt.Sprintf("%s-test-secret", vm.GetObjectMeta().GetName())
+				spec := disk.CloudInit
+				spec.NoCloudData.UserDataSecretRef = secretID
+				userData64 := spec.NoCloudData.UserDataBase64
+				spec.NoCloudData.UserDataBase64 = ""
+
+				// Store userdata as k8s secret
+				secret := kubev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretID,
+						Namespace: vm.GetObjectMeta().GetNamespace(),
+					},
+					Type: "Opaque",
+					Data: map[string][]byte{
+						"userdata": []byte(userData64),
+					},
+				}
+				_, err := virtClient.Core().Secrets(vm.GetObjectMeta().GetNamespace()).Create(&secret)
+				Expect(err).To(BeNil())
+				break
 			}
+			obj := LaunchVM(vm)
+			VerifyUserDataVM(vm, obj)
 
 			close(done)
-		}, 45)
+		}, 60)
 	})
 })


### PR DESCRIPTION
Tests now verify that "found datasource (nocloud, local)" is present in the console output in order to verify cloud-init is processed.