### PR TITLE
Add support for node affinity to VM.Spec

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -180,6 +180,14 @@ type VMSpec struct {
 	Domain *DomainSpec `json:"domain,omitempty"`
 	// If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// If affinity is specifies, obey all the affinity rules
+	Affinity *Affinity `json:"affinity,omitempty"`
+}
+
+// Affinity groups all the affinity rules related to a VM
+type Affinity struct {
+	// Host affinity support
+	NodeAffinity *k8sv1.NodeAffinity `json:"nodeAffinity,omitempty"`
 }
 
 // VMStatus represents information about the status of a VM. Status may trail the actual

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -21,6 +21,14 @@ func (VMSpec) SwaggerDoc() map[string]string {
 		"":             "VMSpec is a description of a VM. Not to be confused with api.DomainSpec in virt-handler.\nIt is expected that v1.DomainSpec will be merged into this structure.",
 		"domain":       "Domain is the actual libvirt domain.",
 		"nodeSelector": "If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.",
+		"affinity":     "If affinity is specifies, obey all the affinity rules",
+	}
+}
+
+func (Affinity) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"":             "Affinity groups all the affinity rules related to a VM",
+		"nodeAffinity": "Host affinity support",
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -125,6 +125,14 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		},
 	}
 
+	if vm.Spec.Affinity != nil {
+		pod.Spec.Affinity = &kubev1.Affinity{}
+
+		if vm.Spec.Affinity.NodeAffinity != nil {
+			pod.Spec.Affinity.NodeAffinity = vm.Spec.Affinity.NodeAffinity
+		}
+	}
+
 	return &pod, nil
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -91,6 +91,34 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/libvirt/default/testvm"))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/libvirt/default/testvm"))
 			})
+
+			It("should add node affinity to pod", func() {
+				nodeAffinity := kubev1.NodeAffinity{}
+				vm := v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{Name: "testvm", Namespace: "default", UID: "1234"},
+					Spec: v1.VMSpec{
+						Affinity: &v1.Affinity{NodeAffinity: &nodeAffinity},
+						Domain:   &v1.DomainSpec{},
+					},
+				}
+				pod, err := svc.RenderLaunchManifest(&vm)
+
+				Expect(err).To(BeNil())
+				Expect(pod.Spec.Affinity).To(BeEquivalentTo(&kubev1.Affinity{NodeAffinity: &nodeAffinity}))
+			})
+
+			It("should not add empty node affinity to pod", func() {
+				vm := v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{Name: "testvm", Namespace: "default", UID: "1234"},
+					Spec: v1.VMSpec{
+						Domain: &v1.DomainSpec{},
+					},
+				}
+				pod, err := svc.RenderLaunchManifest(&vm)
+
+				Expect(err).To(BeNil())
+				Expect(pod.Spec.Affinity).To(BeNil())
+			})
 		})
 		Context("migration", func() {
 			var (

--- a/pkg/virt-controller/services/vm.go
+++ b/pkg/virt-controller/services/vm.go
@@ -169,7 +169,9 @@ func (v *vmService) CreateMigrationTargetPod(migration *corev1.Migration, vm *co
 
 	pod.ObjectMeta.Labels[corev1.MigrationLabel] = migrationLabel
 	pod.ObjectMeta.Labels[corev1.MigrationUIDLabel] = string(migration.GetObjectMeta().GetUID())
-	pod.Spec.Affinity = corev1.AntiAffinityFromVMNode(vm)
+
+	pod.Spec.Affinity = corev1.UpdateAntiAffinityFromVMNode(pod, vm)
+
 	if err == nil {
 		_, err = v.KubeCli.CoreV1().Pods(migration.GetObjectMeta().GetNamespace()).Create(pod)
 	}

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -72,7 +72,7 @@ var _ = Describe("VM", func() {
 
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/api/v1/namespaces/default/pods"),
-					VerifyAffinity(v1.AntiAffinityFromVMNode(vm)),
+					VerifyAffinity(v1.UpdateAntiAffinityFromVMNode(&pod, vm)),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, pod),
 				),
 			)

--- a/tests/vm_migration_test.go
+++ b/tests/vm_migration_test.go
@@ -89,6 +89,52 @@ var _ = Describe("VmMigration", func() {
 			close(done)
 		}, 30)
 
+		It("Should respect and preserve pre-set node affinity on the VM", func(done Done) {
+			// Prepare dummy affinity rule
+			sourceVM.Spec.Affinity = &v1.Affinity{
+				NodeAffinity: &k8sv1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+						NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+							{
+								MatchExpressions: []k8sv1.NodeSelectorRequirement{
+									{
+										Key:      "invalidtag",
+										Values:   []string{"nothing"},
+										Operator: k8sv1.NodeSelectorOpNotIn,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			vm, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(sourceVM).Do().Get()
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMStart(vm)
+
+			migration := tests.NewRandomMigrationForVm(sourceVM)
+			err = virtClient.RestClient().Post().Resource("migrations").Namespace(tests.NamespaceTestDefault).Body(migration).Do().Error()
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() v1.MigrationPhase {
+				obj, err := virtClient.RestClient().Get().Resource("migrations").Namespace(tests.NamespaceTestDefault).Name(migration.ObjectMeta.Name).Do().Get()
+				Expect(err).ToNot(HaveOccurred())
+				var m *v1.Migration = obj.(*v1.Migration)
+				return m.Status.Phase
+			}, TIMEOUT, POLLING_INTERVAL).Should(Equal(v1.MigrationSucceeded))
+
+			// Check Pod and VM affinity
+			labelSelector, err := labels.Parse(v1.DomainLabel + "=" + sourceVM.ObjectMeta.Name + "," + v1.MigrationLabel + "=" + migration.ObjectMeta.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			pods, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(metav1.ListOptions{LabelSelector: labelSelector.String()})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods.Items[0].Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]).To(BeEquivalentTo(sourceVM.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]))
+
+			close(done)
+		}, 30)
+
 		Context("New Migration given", func() {
 			table.DescribeTable("Should migrate the VM", func(namespace string, migrateCount int) {
 

--- a/tests/vm_migration_test.go
+++ b/tests/vm_migration_test.go
@@ -122,7 +122,7 @@ var _ = Describe("VmMigration", func() {
 				Expect(err).ToNot(HaveOccurred())
 				var m *v1.Migration = obj.(*v1.Migration)
 				return m.Status.Phase
-			}, TIMEOUT, POLLING_INTERVAL).Should(Equal(v1.MigrationSucceeded))
+			}, 3*TIMEOUT, POLLING_INTERVAL).Should(Equal(v1.MigrationSucceeded))
 
 			// Check Pod and VM affinity
 			labelSelector, err := labels.Parse(v1.DomainLabel + "=" + sourceVM.ObjectMeta.Name + "," + v1.MigrationLabel + "=" + migration.ObjectMeta.Name)
@@ -133,7 +133,7 @@ var _ = Describe("VmMigration", func() {
 			Expect(pods.Items[0].Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]).To(BeEquivalentTo(sourceVM.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]))
 
 			close(done)
-		}, 30)
+		}, 90)
 
 		Context("New Migration given", func() {
 			table.DescribeTable("Should migrate the VM", func(namespace string, migrateCount int) {


### PR DESCRIPTION
This adds a new field to Vm.Spec.NodeAffinity that is directly
translated to pod's Pod.Spec.Affinity.NodeAffinity.

Fixes: #438

Signed-off-by: Martin Sivak <msivak@redhat.com>