### PR TITLE
Add possibility to build binaries in docker container

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,0 +1,33 @@
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+FROM fedora:26
+
+# If the container is running privileged, the permissions should be
+# kept under the current user.  If not, then we still need to create a
+# user with the same UID in the container
+ARG userid
+
+RUN dnf -y install make git golang pkg-config libvirt-devel && \
+    dnf -y clean all && \
+    useradd -o -r -u $userid -U -m builder
+
+ENV GOPATH=/builder PATH=/sbin:/bin:/builder/bin
+
+USER $userid
+WORKDIR $GOPATH/src/kubevirt.io/kubevirt/

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -34,35 +34,47 @@ else
     args=$@
 fi
 
-# forward all commands to all packages if no specific one was requested
-# TODO finetune this a little bit more
-if [ $# -eq 0 ]; then
-    if [ "${target}" = "test" ]; then
-        (cd pkg; go ${target} -v ./...)
-    elif [ "${target}" = "functest" ]; then
-        (cd tests; go test -master=http://${master_ip}:${master_port} -timeout 30m ${FUNC_TEST_ARGS})
-        exit
-    else
-        (cd pkg; go $target ./...)
-        (cd tests; go $target ./...)
+# This is the default
+KUBEVIRT_BUILD_TYPE=${KUBEVIRT_BUILD_TYPE-docker}
+
+if [[ ( $target != "install" && $target != "build" ) ||
+          $KUBEVIRT_BUILD_TYPE == "plain" ]]; then
+    if [ $# -eq 0 ]; then
+        if [ "${target}" = "test" ]; then
+            (cd pkg; go ${target} -v ./...)
+        elif [ "${target}" = "functest" ]; then
+            (cd tests; go test -master=http://${master_ip}:${master_port} -timeout 30m ${FUNC_TEST_ARGS})
+            exit
+        else
+            (cd pkg; go $target ./...)
+            (cd tests; go $target ./...)
+        fi
     fi
+
+    # handle binaries
+    for arg in $args; do
+        if [ "${target}" = "test" ]; then
+            (cd $arg; go ${target} -v ./...)
+        elif [ "${target}" = "install" ]; then
+            eval "$(go env)"
+            ARCHBIN=$(basename $arg)-$(git describe --always)-$GOHOSTOS-$GOHOSTARCH
+            ALIASLNK=$(basename $arg)
+            rm $arg/$ALIASLNK $arg/$(basename $arg)-*-$GOHOSTOS-$GOHOSTARCH || :
+            (cd $arg; GOBIN=$PWD go build -o $ARCHBIN)
+            mkdir -p bin
+            ln -sf $ARCHBIN $arg/$ALIASLNK
+            ln -sf ../$arg/$ARCHBIN bin/$ALIASLNK
+        else
+            (cd $arg; go $target ./...)
+        fi
+    done
+
+    if [[ $target == "clean" ]]; then
+        hack/docker-builder.sh clean
+    fi
+elif [[ $KUBEVIRT_BUILD_TYPE == "docker" ]]; then
+    hack/docker-builder.sh $target $args
+else
+    echo "Unknown build type, only 'plain' and 'docker' are allowed" >&2
+    exit 1
 fi
-
-# handle binaries
-for arg in $args; do
-    if [ "${target}" = "test" ]; then
-        (cd $arg; go ${target} -v ./...)
-    elif [ "${target}" = "install" ]; then
-        eval "$(go env)"
-        ARCHBIN=$(basename $arg)-$(git describe --always)-$GOHOSTOS-$GOHOSTARCH
-        ALIASLNK=$(basename $arg)
-        rm $arg/$ALIASLNK $arg/$(basename $arg)-*-$GOHOSTOS-$GOHOSTARCH || :
-        (cd $arg; GOBIN=$PWD go build -o $ARCHBIN)
-        mkdir -p bin
-        ln -sf $ARCHBIN $arg/$ALIASLNK
-        ln -sf ../$arg/$ARCHBIN bin/$ALIASLNK
-    else
-        (cd $arg; go $target ./...)
-    fi
-done
-

--- a/hack/docker-builder.sh
+++ b/hack/docker-builder.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+set -e
+
+source hack/config.sh
+
+if [ -z "$1" ]; then
+    target="build"
+else
+    target=$1
+    shift
+fi
+
+image_name="${docker_prefix}/builder:${docker_tag}"
+if [[ $target == "clean" ]]; then
+    container=$(docker ps -a --format '{{ .Image }}\t{{ .ID }}' | grep ^$image_name | cut -f2)
+    if [[ -n $container ]]; then
+	      docker rm $container
+    fi
+    if [[ -n $(docker image ls -q kubevirt/builder:latest) ]]; then
+	      docker image rm $image_name
+    fi
+elif [[ $target == "install" ]]; then
+    echo "Creating a container for the build"
+    docker build --build-arg userid=$UID -t $image_name hack/
+    echo "Running build in a docker container"
+    docker run -v $(go env GOPATH):/builder -e KUBEVIRT_BUILD_TYPE=plain $image_name hack/build-go.sh $target $@
+else
+    echo "Running $0 with invalid target: $target" 1>&2
+fi


### PR DESCRIPTION
Add possibility to build binaries in docker container

This is just a proposal that fixes #436 by creating a docker container
for various builds.  This is just a proposal, please feel free to
suggest changes, any suggestions would be very welcome.  It is not
enabled by default, but you can try it out by specifying the make
command explicitly.

This is also added to the `.travis.yml` just so we see if it fails or
not, but of course it makes the subsequent `make build` almost
useless.  The idea is that building in such docker image would be
default (as it should not add any more time once the image was built
once).

It still doesn't fix the deploy for me, but I have to investigate a bit more
and that's time-consuming due to all the docker builds.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>