### PR TITLE
Clear glide cache before updating glide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,12 @@ distclean: clean
 	find vendor/ -maxdepth 1 -mindepth 1 -not -name vendor.json -exec rm {} -rf \;
 	rm -f manifest/*.yaml
 	rm -f .glide.*.hash
+	glide cc
 
 checksync:
 	test -f .glide.yaml.hash || ${HASH} glide.yaml > .glide.yaml.hash
 	if [ "`${HASH} glide.yaml`" != "`cat .glide.yaml.hash`" ]; then \
+		glide cc; \
 		glide update --strip-vendor; \
 		${HASH} glide.yaml > .glide.yaml.hash; \
 		${HASH} glide.lock > .glide.lock.hash; \


### PR DESCRIPTION
Glide uses cached dependencies during update. This can lead to consistency problems e.g. when switching between branches. I propose that we automatically clear the cache right before running `glide update`.

In particular this fixes the glide problems noted in: https://github.com/kubevirt/kubevirt/pull/437