### PR TITLE
VirtualMachineReplicaSet to scale VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ services:
 
 go:
 - 1.8.3
-- tip
+- 1.8
+- 1.9
 
 before_install:
 - sudo add-apt-repository ppa:jacob/virtualisation -y

--- a/cluster/replicaset.yaml
+++ b/cluster/replicaset.yaml
@@ -1,0 +1,50 @@
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachineReplicaSet
+metadata:
+  name: testreplicaset
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      myvm: "myvm"
+  template:
+    metadata:
+      name: test
+      labels:
+        myvm: "myvm"
+    spec:
+      domain:
+        devices:
+          graphics:
+          - type: spice
+          interfaces:
+          - type: network
+            source:
+              network: default
+          video:
+          - type: qxl
+          disks:
+          - type: network
+            snapshot: external
+            device: disk
+            driver:
+              name: qemu
+              type: raw
+              cache: none
+            source:
+              host:
+                name: iscsi-demo-target.default
+                port: "3260"
+              protocol: iscsi
+              name: iqn.2017-01.io.kubevirt:sn.42/2
+            target:
+              dev: vda
+          consoles:
+          - type: pty
+        memory:
+          unit: MB
+          value: 64
+        os:
+          type:
+            os: hvm
+        type: qemu

--- a/cluster/replicaset.yaml
+++ b/cluster/replicaset.yaml
@@ -24,21 +24,17 @@ spec:
           video:
           - type: qxl
           disks:
-          - type: network
-            snapshot: external
-            device: disk
-            driver:
-              name: qemu
-              type: raw
-              cache: none
+          - type: ContainerRegistryDisk:v1alpha
             source:
-              host:
-                name: iscsi-demo-target.default
-                port: "3260"
-              protocol: iscsi
-              name: iqn.2017-01.io.kubevirt:sn.42/2
+              name: kubevirt/cirros-registry-disk-demo:devel
             target:
               dev: vda
+          - type: file
+            target:
+              dev: vdb
+            cloudinit:
+                nocloud:
+                    userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
           consoles:
           - type: pty
         memory:

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -58,6 +58,7 @@ func (app *virtAPIApp) Run() {
 	ctx := context.Background()
 	vmGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "virtualmachines"}
 	migrationGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "migrations"}
+	vmrsGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "virtualmachinereplicasets"}
 
 	ws, err := rest.GroupVersionProxyBase(ctx, v1.GroupVersion)
 	if err != nil {
@@ -70,6 +71,11 @@ func (app *virtAPIApp) Run() {
 	}
 
 	ws, err = rest.GenericResourceProxy(ws, ctx, migrationGVR, &v1.Migration{}, v1.MigrationGroupVersionKind.Kind, &v1.MigrationList{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ws, err = rest.GenericResourceProxy(ws, ctx, vmrsGVR, &v1.VirtualMachineReplicaSet{}, v1.VMReplicaSetGroupVersionKind.Kind, &v1.VirtualMachineReplicaSetList{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	configdisk "kubevirt.io/kubevirt/pkg/config-disk"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/service"
@@ -127,7 +128,7 @@ func (app *virtHandlerApp) Run() {
 	configDiskClient := configdisk.NewConfigDiskClient(virtCli)
 
 	// Wire VM controller
-	vmListWatcher := kubecli.NewListWatchFromClient(virtCli.RestClient(), "virtualmachines", k8sv1.NamespaceAll, fields.Everything(), l)
+	vmListWatcher := controller.NewListWatchFromClient(virtCli.RestClient(), "virtualmachines", k8sv1.NamespaceAll, fields.Everything(), l)
 	vmStore, vmQueue, vmController := virthandler.NewVMController(vmListWatcher, domainManager, recorder, *virtCli.RestClient(), virtCli, app.HostOverride, configDiskClient)
 
 	// Wire Domain controller

--- a/docs/replica-sets.md
+++ b/docs/replica-sets.md
@@ -1,0 +1,117 @@
+# VirtualMachineReplicaSet
+
+## Overview
+
+In order to allow scaling up or down similar VMs, add a way to specify
+`VirtualMachine` templates and the amount of replicas required, to let the
+runtime create these `VirtualMachine`s.
+
+## Use-cases
+
+### Ephemeral VMs
+
+Scaling ephemeral VMs which only have read-only mounts, or work with a backing
+store, to keep temporary data, which can be deleted after the VM gets
+undefined.
+
+## Implementation
+
+A new object `VirtualMachineReplicaSet`, backed with a controller will be
+implemented:
+
+```yaml
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachineReplicaSet
+metadata:
+  name: replicasetn9z3w
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      mylabel: mylabel
+  template:
+    metadata:
+      name: test
+      labels:
+        mylabel: mylabel
+    spec:
+      domain:
+        devices:
+      [...]  
+```
+
+`spec.template` is similar to a `VirtualMachineSpec`. `spec.replicas` specifies
+how many instances should be created out of `spec.temlate`. `spec.selector`
+contains selectors, which need to match `spec.template.metadata.labels`.
+
+The status looks like this:
+
+```yaml
+status:
+  conditions: null
+  replicas: 3
+```
+
+It shows the number of `VirtualMachine`s which are in a non-final state nad
+which match `spec.selector`. In case of a scaling error, a `ReplicaFailure`
+condition is added to the status.
+
+In case of a delete failure:
+
+```yaml
+status:
+  conditions:
+  - type: "ReplicaFailure"
+    status: True
+    reason: "FailureDelete"
+    message: "no permission to delete VMs"
+    lastTransmissionTime: "..."
+  replicas: 4
+```
+
+In case of a create failure:
+
+```yaml
+status:
+  conditions:
+  - type: "ReplicaFailure"
+    status: True
+    reason: "FailureCreate"
+    message: "no permission to create VMs"
+    lastTransmissionTime: "..."
+  replicas: 2
+```
+
+### Guarantees
+
+Once Graceful Deletes are implemented, the VirtualMachineReplicaSet guarantees
+that it will never create more than the requested numbers of VMs in a non-final
+state.
+
+As a consequence, in case of node failures, or in case of connection loss to
+virt-handlers which run VMs which are part of that set, no new VMs will be
+spawned until the VMs in unknown state are explicitly removed, or the node
+reconnects. This behaviour allows plugging in fencing controllers in a well
+defined way.
+
+It might make sense to weaken these guarantees in the future, and instead add a
+`StatefulSet` equivalent to KubeVirt in the future.
+
+### Milestones
+
+ * Basic functionality
+ * Support graceful delete [1]
+ * Support controller references [2]
+ * Support label changes
+ * Support adopting orphaned Pods [2]
+ * Define a well known scale-down order
+
+The basic functionality includes scaling up, down and reporting errors if
+scaling does not work. In this stage it is the full responsibility of the user
+to attach labels to the VMs in a way, so that selectors of multiple
+VirtualMachineReplicaSets don't overlap.
+
+### References
+
+1. https://kubernetes.io/docs/tasks/run-application/force-delete-stateful-set-pod/#delete-pods
+2. https://github.com/kubernetes/community/blob/58b1c30d95719749068497ba35dfe4c64b21aa72/contributors/design-proposals/api-machinery/controller-ref.md

--- a/docs/replica-sets.md
+++ b/docs/replica-sets.md
@@ -98,6 +98,47 @@ unknown VirtualMachine states and graceful deletes, it might decide to already
 create new replicas in advance, to make sure that the amount of ready replicas
 stays close to the expected replica count.
 
+### Chosen Implementation
+
+The implementation of the VirtualMachineReplicaSet is a reimplementation of the
+ReplicaSet for Pods in Kubernetes. It does not wrap around a Kubernetes
+ReplicaSet. 
+
+
+There two *hard* reasons why one was chose over the other:
+
+ 1. Allow possible VirtualMachine related optimizations by implementing a
+    custom deletion order. When scaling down, it can make sense to take
+    migrating VirtualMachines into account. A possible deletion order would be:
+    not ready VMs, migrating VMs, ready VMs. This would be impossible to
+    represent by wrapping around the ReplicaSet.
+ 2. Make Live Migrations an orthogonal feature for every VirtualMachine
+    controller. If a controller does not have to care about the
+    VirtualMachine/Pod relationship, it does not have to care in any special
+    way about migrations. By wrapping around existing controllers, we will
+    always have to hide migration target Pods from the controller, until the
+    VirtualMachine was migrated, and then have to make it somehow visible
+    again. This solution leads to tricky synchronization problems which may not
+    even be completely solvable.
+
+There are several *soft* reasons why one was chosen over the other:
+
+ 1. Provide a clear VirtualMachine abstraction via our VirtualMachine
+    object. This allows domain specific modelling of controllers.
+ 2. Hide the whole relationship between VirtualMachines and Pods behind on
+    controller, so that others don't have to care about it.
+ 3. The actual business-logic of scaling the VirtualMachines is very easy to
+    understand and simple to implement. We get almost all the necessary
+    infrastructure code from k8s libraries. The infrastructure code has a
+    similar similar complexity (entity listeners, creating/deleting resources,
+    ... ) for both implementations.  For different types of controllers this
+    argument may not apply (e.g.  DaemonSet equivalent for VirtualMachines).
+ 4. Because of the simplicity of the business-logic, the equal complexity
+    regarding to the controller infrastructure and the fact that there exists a
+    ReplicaSet reference implementation from which we can learn/copy, it seems
+    beneficial to really express our domain and avoid design errors, by
+    implementing another complex flow around the existing ReplicaSet.
+
 ### Milestones
 
  * Basic functionality

--- a/docs/replica-sets.md
+++ b/docs/replica-sets.md
@@ -23,7 +23,7 @@ implemented:
 apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachineReplicaSet
 metadata:
-  name: replicasetn9z3w
+  name: myreplicaset
 spec:
   replicas: 3
   selector:

--- a/docs/replica-sets.md
+++ b/docs/replica-sets.md
@@ -40,7 +40,7 @@ spec:
       [...]  
 ```
 
-`spec.template` is similar to a `VirtualMachineSpec`. `spec.replicas` specifies
+`spec.template` is equal to a `VirtualMachineSpec`. `spec.replicas` specifies
 how many instances should be created out of `spec.temlate`. `spec.selector`
 contains selectors, which need to match `spec.template.metadata.labels`.
 

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -30,6 +30,18 @@ spec:
           - containerPort: 8184
             name: "haproxy"
             protocol: "TCP"
+        livenessProbe:
+          httpGet:
+            path: /apis/kubevirt.io/v1alpha1/healthz
+            port: 8184
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /apis/kubevirt.io/v1alpha1/healthz
+            port: 8184
+          initialDelaySeconds: 10
+          periodSeconds: 20
       securityContext:
         runAsNonRoot: true
       nodeSelector:

--- a/manifests/rbac.authorization.k8s.io.yaml.in
+++ b/manifests/rbac.authorization.k8s.io.yaml.in
@@ -30,6 +30,7 @@ rules:
     resources:
       - virtualmachines
       - migrations  
+      - virtualmachinereplicasets  
     verbs:
       - get
       - list

--- a/manifests/replicase-resource.yaml.in
+++ b/manifests/replicase-resource.yaml.in
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: virtualmachinereplicasets.kubevirt.io
+spec:
+  scope: Namespaced
+  group: kubevirt.io
+  version: v1alpha1
+  names:
+    kind: VirtualMachineReplicaSet
+    plural: virtualmachinereplicasets
+    singular: virtualmachinereplicaset
+    shortNames:
+    - vmrc
+    - vmrcs

--- a/manifests/replicase-resource.yaml.in
+++ b/manifests/replicase-resource.yaml.in
@@ -11,5 +11,5 @@ spec:
     plural: virtualmachinereplicasets
     singular: virtualmachinereplicaset
     shortNames:
-    - vmrc
-    - vmrcs
+    - vmrs
+    - vmrss

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -213,6 +213,11 @@ func (v *VirtualMachine) GetObjectMeta() metav1.Object {
 	return &v.ObjectMeta
 }
 
+func (v *VirtualMachine) IsReady() bool {
+	// TODO once we support a ready condition, use it instead
+	return v.IsRunning()
+}
+
 func (v *VirtualMachine) IsRunning() bool {
 	return v.Status.Phase == Running || v.Status.Phase == Migrating
 }
@@ -682,6 +687,10 @@ type VMReplicaSetStatus struct {
 	// Total number of non-terminated pods targeted by this deployment (their labels match the selector).
 	// +optional
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,2,opt,name=replicas"`
+
+	// The number of ready replicas for this replica set.
+	// +optional
+	ReadyReplicas int32 `json:"readyReplicas,omitempty" protobuf:"varint,4,opt,name=readyReplicas"`
 
 	Conditions []VMReplicaSetCondition `json:"conditions"`
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -217,7 +217,7 @@ func (v *VirtualMachine) IsRunning() bool {
 	return v.Status.Phase == Running || v.Status.Phase == Migrating
 }
 
-func (v *VM) IsFinal() bool {
+func (v *VirtualMachine) IsFinal() bool {
 	return v.Status.Phase == Failed || v.Status.Phase == Succeeded
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -672,10 +672,10 @@ type VMReplicaSetSpec struct {
 	// Label selector for pods. Existing ReplicaSets whose pods are
 	// selected by this will be the ones affected by this deployment.
 	// +optional
-	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+	Selector *metav1.LabelSelector `json:"selector,omitempty" valid:"required"`
 
 	// Template describes the pods that will be created.
-	Template *VMTemplateSpec `json:"template"`
+	Template *VMTemplateSpec `json:"template" valid:"required"`
 }
 
 type VMReplicaSetStatus struct {
@@ -742,4 +742,14 @@ func (vl *VirtualMachineReplicaSetList) UnmarshalJSON(data []byte) error {
 	tmp2 := VirtualMachineReplicaSetList(tmp)
 	*vl = tmp2
 	return nil
+}
+
+// Required to satisfy Object interface
+func (vl *VirtualMachineReplicaSetList) GetObjectKind() schema.ObjectKind {
+	return &vl.TypeMeta
+}
+
+// Required to satisfy ListMetaAccessor interface
+func (vl *VirtualMachineReplicaSetList) GetListMeta() metav1.List {
+	return &vl.ListMeta
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -750,6 +750,58 @@ func (vl *VirtualMachineReplicaSetList) GetObjectKind() schema.ObjectKind {
 }
 
 // Required to satisfy ListMetaAccessor interface
-func (vl *VirtualMachineReplicaSetList) GetListMeta() metav1.List {
+func (vl *VirtualMachineReplicaSetList) GetListMeta() meta.List {
 	return &vl.ListMeta
+}
+
+func (in *VirtualMachineReplicaSet) DeepCopyInto(out *VirtualMachineReplicaSet) {
+	v, err := model.Clone(in)
+	if err != nil {
+		panic(err)
+	}
+	out = v.(*VirtualMachineReplicaSet)
+	return
+}
+
+func (in *VirtualMachineReplicaSet) DeepCopy() *VirtualMachineReplicaSet {
+	if in == nil {
+		return nil
+	}
+	out := new(VirtualMachineReplicaSet)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *VirtualMachineReplicaSet) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	} else {
+		return nil
+	}
+}
+
+func (in *VirtualMachineReplicaSetList) DeepCopyInto(out *VirtualMachineReplicaSetList) {
+	v, err := model.Clone(in)
+	if err != nil {
+		panic(err)
+	}
+	out = v.(*VirtualMachineReplicaSetList)
+	return
+}
+
+func (in *VirtualMachineReplicaSetList) DeepCopy() *VirtualMachineReplicaSetList {
+	if in == nil {
+		return nil
+	}
+	out := new(VirtualMachineReplicaSetList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+func (in *VirtualMachineReplicaSetList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	} else {
+		return nil
+	}
 }

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -88,3 +88,41 @@ func (MigrationHostInfo) SwaggerDoc() map[string]string {
 		"": "Host specific data, used by the migration controller to fetch host specific migration information from the target host",
 	}
 }
+
+func (VirtualMachineReplicaSet) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"":       "VM is *the* VM Definition. It represents a virtual machine in the runtime environment of kubernetes.",
+		"spec":   "VM Spec contains the VM specification.",
+		"status": "Status is the high level overview of how the VM is doing. It contains information available to controllers and users.",
+	}
+}
+
+func (VirtualMachineReplicaSetList) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"": "VMList is a list of VMs",
+	}
+}
+
+func (VMReplicaSetSpec) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"replicas": "Number of desired pods. This is a pointer to distinguish between explicit\nzero and not specified. Defaults to 1.\n+optional",
+		"selector": "Label selector for pods. Existing ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.\n+optional",
+		"template": "Template describes the pods that will be created.",
+	}
+}
+
+func (VMReplicaSetStatus) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"replicas": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).\n+optional",
+	}
+}
+
+func (VMReplicaSetCondition) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}
+
+func (VMTemplateSpec) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"spec": "VM Spec contains the VM specification.",
+	}
+}

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -113,7 +113,8 @@ func (VMReplicaSetSpec) SwaggerDoc() map[string]string {
 
 func (VMReplicaSetStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"replicas": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).\n+optional",
+		"replicas":      "Total number of non-terminated pods targeted by this deployment (their labels match the selector).\n+optional",
+		"readyReplicas": "The number of ready replicas for this replica set.\n+optional",
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,7 +17,7 @@
  *
  */
 
-package kubecli
+package controller
 
 import (
 	"runtime/debug"

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,0 +1,13 @@
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller Suite")
+}

--- a/pkg/controller/expectations.go
+++ b/pkg/controller/expectations.go
@@ -19,7 +19,7 @@ Taken from https://github.com/kubernetes/kubernetes/blob/1889a6ef52eb18b08e24843
 As soon as expectations become available in client-go or apimachinery, delete this and switch.
 */
 
-package kubecli
+package controller
 
 import (
 	"fmt"

--- a/pkg/controller/expectations_test.go
+++ b/pkg/controller/expectations_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* TODO:
+Taken from https://github.com/kubernetes/kubernetes/blob/1889a6ef52eb18b08e24843577c5b9d3b9a65daa/pkg/controller/controller_utils_test.go
+As soon as expectations become available in client-go or apimachinery, delete this.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/cache"
+)
+
+// PodKey returns a key unique to the given pod within a cluster.
+// It's used so we consistently use the same key scheme in this module.
+// It does exactly what cache.MetaNamespaceKeyFunc would have done
+// except there's not possibility for error since we know the exact type.
+func PodKey(pod *v1.Pod) string {
+	return fmt.Sprintf("%v/%v", pod.Namespace, pod.Name)
+}
+
+// ValidSecurityContextWithContainerDefaults creates a valid security context provider based on
+// empty container defaults.  Used for testing.
+func ValidSecurityContextWithContainerDefaults() *v1.SecurityContext {
+	priv := false
+	return &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{},
+		Privileged:   &priv,
+	}
+}
+
+// NewFakeControllerExpectationsLookup creates a fake store for PodExpectations.
+func NewFakeControllerExpectationsLookup(ttl time.Duration) (*ControllerExpectations, *clock.FakeClock) {
+	fakeTime := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	fakeClock := clock.NewFakeClock(fakeTime)
+	ttlPolicy := &cache.TTLPolicy{Ttl: ttl, Clock: fakeClock}
+	ttlStore := cache.NewFakeExpirationStore(
+		ExpKeyFunc, nil, ttlPolicy, fakeClock)
+	return &ControllerExpectations{ttlStore}, fakeClock
+}
+
+func newReplicationController(replicas int) *v1.ReplicationController {
+
+	rc := &v1.ReplicationController{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			UID:             uuid.NewUUID(),
+			Name:            "foobar",
+			Namespace:       metav1.NamespaceDefault,
+			ResourceVersion: "18",
+		},
+		Spec: v1.ReplicationControllerSpec{
+			Replicas: func() *int32 { i := int32(replicas); return &i }(),
+			Selector: map[string]string{"foo": "bar"},
+			Template: &v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": "foo",
+						"type": "production",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "foo/bar",
+							TerminationMessagePath: v1.TerminationMessagePathDefault,
+							ImagePullPolicy:        v1.PullIfNotPresent,
+							SecurityContext:        ValidSecurityContextWithContainerDefaults(),
+						},
+					},
+					RestartPolicy: v1.RestartPolicyAlways,
+					DNSPolicy:     v1.DNSDefault,
+					NodeSelector: map[string]string{
+						"baz": "blah",
+					},
+				},
+			},
+		},
+	}
+	return rc
+}
+
+// create count pods with the given phase for the given rc (same selectors and namespace), and add them to the store.
+func newPodList(store cache.Store, count int, status v1.PodPhase, rc *v1.ReplicationController) *v1.PodList {
+	pods := []v1.Pod{}
+	for i := 0; i < count; i++ {
+		newPod := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod%d", i),
+				Labels:    rc.Spec.Selector,
+				Namespace: rc.Namespace,
+			},
+			Status: v1.PodStatus{Phase: status},
+		}
+		if store != nil {
+			store.Add(&newPod)
+		}
+		pods = append(pods, newPod)
+	}
+	return &v1.PodList{
+		Items: pods,
+	}
+}
+
+func TestControllerExpectations(t *testing.T) {
+	ttl := 30 * time.Second
+	e, fakeClock := NewFakeControllerExpectationsLookup(ttl)
+	// In practice we can't really have add and delete expectations since we only either create or
+	// delete replicas in one rc pass, and the rc goes to sleep soon after until the expectations are
+	// either fulfilled or timeout.
+	adds, dels := 10, 30
+	rc := newReplicationController(1)
+
+	// RC fires off adds and deletes at apiserver, then sets expectations
+	rcKey, err := KeyFunc(rc)
+	if err != nil {
+		t.Errorf("Couldn't get key for object %#v: %v", rc, err)
+	}
+	e.SetExpectations(rcKey, adds, dels)
+	var wg sync.WaitGroup
+	for i := 0; i < adds+1; i++ {
+		wg.Add(1)
+		go func() {
+			// In prod this can happen either because of a failed create by the rc
+			// or after having observed a create via informer
+			e.CreationObserved(rcKey)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// There are still delete expectations
+	if e.SatisfiedExpectations(rcKey) {
+		t.Errorf("Rc will sync before expectations are met")
+	}
+	for i := 0; i < dels+1; i++ {
+		wg.Add(1)
+		go func() {
+			e.DeletionObserved(rcKey)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// Expectations have been surpassed
+	if podExp, exists, err := e.GetExpectations(rcKey); err == nil && exists {
+		add, del := podExp.GetExpectations()
+		if add != -1 || del != -1 {
+			t.Errorf("Unexpected pod expectations %#v", podExp)
+		}
+	} else {
+		t.Errorf("Could not get expectations for rc, exists %v and err %v", exists, err)
+	}
+	if !e.SatisfiedExpectations(rcKey) {
+		t.Errorf("Expectations are met but the rc will not sync")
+	}
+
+	// Next round of rc sync, old expectations are cleared
+	e.SetExpectations(rcKey, 1, 2)
+	if podExp, exists, err := e.GetExpectations(rcKey); err == nil && exists {
+		add, del := podExp.GetExpectations()
+		if add != 1 || del != 2 {
+			t.Errorf("Unexpected pod expectations %#v", podExp)
+		}
+	} else {
+		t.Errorf("Could not get expectations for rc, exists %v and err %v", exists, err)
+	}
+
+	// Expectations have expired because of ttl
+	fakeClock.Step(ttl + 1)
+	if !e.SatisfiedExpectations(rcKey) {
+		t.Errorf("Expectations should have expired but didn't")
+	}
+}
+
+func TestUIDExpectations(t *testing.T) {
+	uidExp := NewUIDTrackingControllerExpectations(NewControllerExpectations())
+	rcList := []*v1.ReplicationController{
+		newReplicationController(2),
+		newReplicationController(1),
+		newReplicationController(0),
+		newReplicationController(5),
+	}
+	rcToPods := map[string][]string{}
+	rcKeys := []string{}
+	for i := range rcList {
+		rc := rcList[i]
+		rcName := fmt.Sprintf("rc-%v", i)
+		rc.Name = rcName
+		rc.Spec.Selector[rcName] = rcName
+		podList := newPodList(nil, 5, v1.PodRunning, rc)
+		rcKey, err := KeyFunc(rc)
+		if err != nil {
+			t.Fatalf("Couldn't get key for object %#v: %v", rc, err)
+		}
+		rcKeys = append(rcKeys, rcKey)
+		rcPodNames := []string{}
+		for i := range podList.Items {
+			p := &podList.Items[i]
+			p.Name = fmt.Sprintf("%v-%v", p.Name, rc.Name)
+			rcPodNames = append(rcPodNames, PodKey(p))
+		}
+		rcToPods[rcKey] = rcPodNames
+		uidExp.ExpectDeletions(rcKey, rcPodNames)
+	}
+	for i := range rcKeys {
+		j := rand.Intn(i + 1)
+		rcKeys[i], rcKeys[j] = rcKeys[j], rcKeys[i]
+	}
+	for _, rcKey := range rcKeys {
+		if uidExp.SatisfiedExpectations(rcKey) {
+			t.Errorf("Controller %v satisfied expectations before deletion", rcKey)
+		}
+		for _, p := range rcToPods[rcKey] {
+			uidExp.DeletionObserved(rcKey, p)
+		}
+		if !uidExp.SatisfiedExpectations(rcKey) {
+			t.Errorf("Controller %v didn't satisfy expectations after deletion", rcKey)
+		}
+		uidExp.DeleteExpectations(rcKey)
+		if uidExp.GetUIDs(rcKey) != nil {
+			t.Errorf("Failed to delete uid expectations for %v", rcKey)
+		}
+	}
+}

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -17,7 +17,7 @@
  *
  */
 
-package informers
+package controller
 
 import (
 	"sync"
@@ -138,7 +138,7 @@ func (f *kubeInformerFactory) KubeVirtPod() cache.SharedIndexInformer {
 			panic(err)
 		}
 
-		lw := kubecli.NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "pods", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
+		lw := NewListWatchFromClient(f.clientSet.CoreV1().RESTClient(), "pods", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
 		return cache.NewSharedIndexInformer(lw, &k8sv1.Pod{}, f.defaultResync, cache.Indexers{})
 	})
 }

--- a/pkg/informers/virtinformers.go
+++ b/pkg/informers/virtinformers.go
@@ -83,6 +83,7 @@ func (f *kubeInformerFactory) Start(stopCh <-chan struct{}) {
 	for name, informer := range f.informers {
 		if f.startedInformers[name] {
 			// skip informers that have already started.
+			logging.DefaultLogger().Info().Msgf("SKIPPING informer %s", name)
 			continue
 		}
 		logging.DefaultLogger().Info().Msgf("STARTING informer %s", name)
@@ -123,7 +124,7 @@ func (f *kubeInformerFactory) Migration() cache.SharedIndexInformer {
 }
 
 func (f *kubeInformerFactory) VMReplicaSet() cache.SharedIndexInformer {
-	return f.getInformer("VirtualMachineReplicaSet", func() cache.SharedIndexInformer {
+	return f.getInformer("vmrsInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.restClient, "virtualmachinereplicasets", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineReplicaSet{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})

--- a/pkg/informers/virtinformers.go
+++ b/pkg/informers/virtinformers.go
@@ -47,6 +47,8 @@ type KubeInformerFactory interface {
 	VM() cache.SharedIndexInformer
 	// Watches for migration objects
 	Migration() cache.SharedIndexInformer
+
+	VMReplicaSet() cache.SharedIndexInformer
 	// Watches for pods related only to kubevirt
 	KubeVirtPod() cache.SharedIndexInformer
 }
@@ -109,7 +111,7 @@ func (f *kubeInformerFactory) getInformer(key string, newFunc newSharedInformer)
 func (f *kubeInformerFactory) VM() cache.SharedIndexInformer {
 	return f.getInformer("vmInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.restClient, "virtualmachines", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachine{}, f.defaultResync, cache.Indexers{})
+		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachine{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 
@@ -117,6 +119,13 @@ func (f *kubeInformerFactory) Migration() cache.SharedIndexInformer {
 	return f.getInformer("migrationInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.restClient, "migrations", k8sv1.NamespaceAll, fields.Everything())
 		return cache.NewSharedIndexInformer(lw, &kubev1.Migration{}, f.defaultResync, cache.Indexers{})
+	})
+}
+
+func (f *kubeInformerFactory) VMReplicaSet() cache.SharedIndexInformer {
+	return f.getInformer("VirtualMachineReplicaSet", func() cache.SharedIndexInformer {
+		lw := cache.NewListWatchFromClient(f.restClient, "virtualmachinereplicasets", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineReplicaSet{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/kubecli/controller.go
+++ b/pkg/kubecli/controller.go
@@ -78,19 +78,19 @@ func HandlePanic() {
 func NewResourceEventHandlerFuncsForWorkqueue(queue workqueue.RateLimitingInterface) cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			key, err := KeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
 		UpdateFunc: func(old interface{}, new interface{}) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(new)
+			key, err := KeyFunc(new)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+			key, err := KeyFunc(obj)
 			if err == nil {
 				queue.Add(key)
 			}

--- a/pkg/kubecli/controller.go
+++ b/pkg/kubecli/controller.go
@@ -32,6 +32,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"fmt"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
 )
 
@@ -179,4 +182,16 @@ func (c *Controller) runWorker() {
 // new items will be accepted. It is possible to wait via #WaitUntilDone() until the last item was processed.
 func (c *Controller) ShutDownQueue() {
 	c.queue.ShutDown()
+}
+
+func VirtualMachineKey(vm *v1.VirtualMachine) string {
+	return fmt.Sprintf("%v/%v", vm.ObjectMeta.Namespace, vm.ObjectMeta.Name)
+}
+
+func VirtualMachineKeys(vms []v1.VirtualMachine) []string {
+	keys := []string{}
+	for _, vm := range vms {
+		keys = append(keys, VirtualMachineKey(&vm))
+	}
+	return keys
 }

--- a/pkg/kubecli/controller.go
+++ b/pkg/kubecli/controller.go
@@ -38,6 +38,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/logging"
 )
 
+const (
+	// BurstReplicas is the maximum amount of requests in a row for CRUD operations on resources by controllers,
+	// to avoid unintentional DoS
+	BurstReplicas uint = 250
+)
+
 // NewListWatchFromClient creates a new ListWatch from the specified client, resource, namespace and field selector.
 func NewListWatchFromClient(c cache.Getter, resource string, namespace string, fieldSelector fields.Selector, labelSelector labels.Selector) *cache.ListWatch {
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/kubecli/expectations.go
+++ b/pkg/kubecli/expectations.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* TODO:
+Taken from https://github.com/kubernetes/kubernetes/blob/1889a6ef52eb18b08e24843577c5b9d3b9a65daa/pkg/controller/controller_utils.go
+As soon as expectations become available in client-go or apimachinery, delete this and switch.
+*/
+
+package kubecli
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	// If a watch drops a delete event for a pod, it'll take this long
+	// before a dormant controller waiting for those packets is woken up anyway. It is
+	// specifically targeted at the case where some problem prevents an update
+	// of expectations, without it the controller could stay asleep forever. This should
+	// be set based on the expected latency of watch events.
+	//
+	// Currently a controller can service (create *and* observe the watch events for said
+	// creation) about 10 pods a second, so it takes about 1 min to service
+	// 500 pods. Just creation is limited to 20qps, and watching happens with ~10-30s
+	// latency/pod at the scale of 3000 pods over 100 nodes.
+	ExpectationsTimeout = 5 * time.Minute
+)
+
+var UpdateTaintBackoff = wait.Backoff{
+	Steps:    5,
+	Duration: 100 * time.Millisecond,
+	Jitter:   1.0,
+}
+
+var (
+	KeyFunc = cache.DeletionHandlingMetaNamespaceKeyFunc
+)
+
+type ResyncPeriodFunc func() time.Duration
+
+// Returns 0 for resyncPeriod in case resyncing is not needed.
+func NoResyncPeriodFunc() time.Duration {
+	return 0
+}
+
+// StaticResyncPeriodFunc returns the resync period specified
+func StaticResyncPeriodFunc(resyncPeriod time.Duration) ResyncPeriodFunc {
+	return func() time.Duration {
+		return resyncPeriod
+	}
+}
+
+// Expectations are a way for controllers to tell the controller manager what they expect. eg:
+//	ControllerExpectations: {
+//		controller1: expects  2 adds in 2 minutes
+//		controller2: expects  2 dels in 2 minutes
+//		controller3: expects -1 adds in 2 minutes => controller3's expectations have already been met
+//	}
+//
+// Implementation:
+//	ControlleeExpectation = pair of atomic counters to track controllee's creation/deletion
+//	ControllerExpectationsStore = TTLStore + a ControlleeExpectation per controller
+//
+// * Once set expectations can only be lowered
+// * A controller isn't synced till its expectations are either fulfilled, or expire
+// * Controllers that don't set expectations will get woken up for every matching controllee
+
+// ExpKeyFunc to parse out the key from a ControlleeExpectation
+var ExpKeyFunc = func(obj interface{}) (string, error) {
+	if e, ok := obj.(*ControlleeExpectations); ok {
+		return e.key, nil
+	}
+	return "", fmt.Errorf("Could not find key for obj %#v", obj)
+}
+
+// ControllerExpectationsInterface is an interface that allows users to set and wait on expectations.
+// Only abstracted out for testing.
+// Warning: if using KeyFunc it is not safe to use a single ControllerExpectationsInterface with different
+// types of controllers, because the keys might conflict across types.
+type ControllerExpectationsInterface interface {
+	GetExpectations(controllerKey string) (*ControlleeExpectations, bool, error)
+	SatisfiedExpectations(controllerKey string) bool
+	DeleteExpectations(controllerKey string)
+	SetExpectations(controllerKey string, add, del int) error
+	ExpectCreations(controllerKey string, adds int) error
+	ExpectDeletions(controllerKey string, dels int) error
+	CreationObserved(controllerKey string)
+	DeletionObserved(controllerKey string)
+	RaiseExpectations(controllerKey string, add, del int)
+	LowerExpectations(controllerKey string, add, del int)
+}
+
+// ControllerExpectations is a cache mapping controllers to what they expect to see before being woken up for a sync.
+type ControllerExpectations struct {
+	cache.Store
+}
+
+// GetExpectations returns the ControlleeExpectations of the given controller.
+func (r *ControllerExpectations) GetExpectations(controllerKey string) (*ControlleeExpectations, bool, error) {
+	if exp, exists, err := r.GetByKey(controllerKey); err == nil && exists {
+		return exp.(*ControlleeExpectations), true, nil
+	} else {
+		return nil, false, err
+	}
+}
+
+// DeleteExpectations deletes the expectations of the given controller from the TTLStore.
+func (r *ControllerExpectations) DeleteExpectations(controllerKey string) {
+	if exp, exists, err := r.GetByKey(controllerKey); err == nil && exists {
+		if err := r.Delete(exp); err != nil {
+			glog.V(2).Infof("Error deleting expectations for controller %v: %v", controllerKey, err)
+		}
+	}
+}
+
+// SatisfiedExpectations returns true if the required adds/dels for the given controller have been observed.
+// Add/del counts are established by the controller at sync time, and updated as controllees are observed by the controller
+// manager.
+func (r *ControllerExpectations) SatisfiedExpectations(controllerKey string) bool {
+	if exp, exists, err := r.GetExpectations(controllerKey); exists {
+		if exp.Fulfilled() {
+			glog.V(4).Infof("Controller expectations fulfilled %#v", exp)
+			return true
+		} else if exp.isExpired() {
+			glog.V(4).Infof("Controller expectations expired %#v", exp)
+			return true
+		} else {
+			glog.V(4).Infof("Controller still waiting on expectations %#v", exp)
+			return false
+		}
+	} else if err != nil {
+		glog.V(2).Infof("Error encountered while checking expectations %#v, forcing sync", err)
+	} else {
+		// When a new controller is created, it doesn't have expectations.
+		// When it doesn't see expected watch events for > TTL, the expectations expire.
+		//	- In this case it wakes up, creates/deletes controllees, and sets expectations again.
+		// When it has satisfied expectations and no controllees need to be created/destroyed > TTL, the expectations expire.
+		//	- In this case it continues without setting expectations till it needs to create/delete controllees.
+		glog.V(4).Infof("Controller %v either never recorded expectations, or the ttl expired.", controllerKey)
+	}
+	// Trigger a sync if we either encountered and error (which shouldn't happen since we're
+	// getting from local store) or this controller hasn't established expectations.
+	return true
+}
+
+// TODO: Extend ExpirationCache to support explicit expiration.
+// TODO: Make this possible to disable in tests.
+// TODO: Support injection of clock.
+func (exp *ControlleeExpectations) isExpired() bool {
+	return clock.RealClock{}.Since(exp.timestamp) > ExpectationsTimeout
+}
+
+// SetExpectations registers new expectations for the given controller. Forgets existing expectations.
+func (r *ControllerExpectations) SetExpectations(controllerKey string, add, del int) error {
+	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
+	glog.V(4).Infof("Setting expectations %#v", exp)
+	return r.Add(exp)
+}
+
+func (r *ControllerExpectations) ExpectCreations(controllerKey string, adds int) error {
+	return r.SetExpectations(controllerKey, adds, 0)
+}
+
+func (r *ControllerExpectations) ExpectDeletions(controllerKey string, dels int) error {
+	return r.SetExpectations(controllerKey, 0, dels)
+}
+
+// Decrements the expectation counts of the given controller.
+func (r *ControllerExpectations) LowerExpectations(controllerKey string, add, del int) {
+	if exp, exists, err := r.GetExpectations(controllerKey); err == nil && exists {
+		exp.Add(int64(-add), int64(-del))
+		// The expectations might've been modified since the update on the previous line.
+		glog.V(4).Infof("Lowered expectations %#v", exp)
+	}
+}
+
+// Increments the expectation counts of the given controller.
+func (r *ControllerExpectations) RaiseExpectations(controllerKey string, add, del int) {
+	if exp, exists, err := r.GetExpectations(controllerKey); err == nil && exists {
+		exp.Add(int64(add), int64(del))
+		// The expectations might've been modified since the update on the previous line.
+		glog.V(4).Infof("Raised expectations %#v", exp)
+	}
+}
+
+// CreationObserved atomically decrements the `add` expectation count of the given controller.
+func (r *ControllerExpectations) CreationObserved(controllerKey string) {
+	r.LowerExpectations(controllerKey, 1, 0)
+}
+
+// DeletionObserved atomically decrements the `del` expectation count of the given controller.
+func (r *ControllerExpectations) DeletionObserved(controllerKey string) {
+	r.LowerExpectations(controllerKey, 0, 1)
+}
+
+// Expectations are either fulfilled, or expire naturally.
+type Expectations interface {
+	Fulfilled() bool
+}
+
+// ControlleeExpectations track controllee creates/deletes.
+type ControlleeExpectations struct {
+	// Important: Since these two int64 fields are using sync/atomic, they have to be at the top of the struct due to a bug on 32-bit platforms
+	// See: https://golang.org/pkg/sync/atomic/ for more information
+	add       int64
+	del       int64
+	key       string
+	timestamp time.Time
+}
+
+// Add increments the add and del counters.
+func (e *ControlleeExpectations) Add(add, del int64) {
+	atomic.AddInt64(&e.add, add)
+	atomic.AddInt64(&e.del, del)
+}
+
+// Fulfilled returns true if this expectation has been fulfilled.
+func (e *ControlleeExpectations) Fulfilled() bool {
+	// TODO: think about why this line being atomic doesn't matter
+	return atomic.LoadInt64(&e.add) <= 0 && atomic.LoadInt64(&e.del) <= 0
+}
+
+// GetExpectations returns the add and del expectations of the controllee.
+func (e *ControlleeExpectations) GetExpectations() (int64, int64) {
+	return atomic.LoadInt64(&e.add), atomic.LoadInt64(&e.del)
+}
+
+// NewControllerExpectations returns a store for ControllerExpectations.
+func NewControllerExpectations() *ControllerExpectations {
+	return &ControllerExpectations{cache.NewStore(ExpKeyFunc)}
+}
+
+// UIDSetKeyFunc to parse out the key from a UIDSet.
+var UIDSetKeyFunc = func(obj interface{}) (string, error) {
+	if u, ok := obj.(*UIDSet); ok {
+		return u.key, nil
+	}
+	return "", fmt.Errorf("Could not find key for obj %#v", obj)
+}
+
+// UIDSet holds a key and a set of UIDs. Used by the
+// UIDTrackingControllerExpectations to remember which UID it has seen/still
+// waiting for.
+type UIDSet struct {
+	sets.String
+	key string
+}
+
+// UIDTrackingControllerExpectations tracks the UID of the pods it deletes.
+// This cache is needed over plain old expectations to safely handle graceful
+// deletion. The desired behavior is to treat an update that sets the
+// DeletionTimestamp on an object as a delete. To do so consistently, one needs
+// to remember the expected deletes so they aren't double counted.
+// TODO: Track creates as well (#22599)
+type UIDTrackingControllerExpectations struct {
+	ControllerExpectationsInterface
+	// TODO: There is a much nicer way to do this that involves a single store,
+	// a lock per entry, and a ControlleeExpectationsInterface type.
+	uidStoreLock sync.Mutex
+	// Store used for the UIDs associated with any expectation tracked via the
+	// ControllerExpectationsInterface.
+	uidStore cache.Store
+}
+
+// GetUIDs is a convenience method to avoid exposing the set of expected uids.
+// The returned set is not thread safe, all modifications must be made holding
+// the uidStoreLock.
+func (u *UIDTrackingControllerExpectations) GetUIDs(controllerKey string) sets.String {
+	if uid, exists, err := u.uidStore.GetByKey(controllerKey); err == nil && exists {
+		return uid.(*UIDSet).String
+	}
+	return nil
+}
+
+// ExpectDeletions records expectations for the given deleteKeys, against the given controller.
+func (u *UIDTrackingControllerExpectations) ExpectDeletions(rcKey string, deletedKeys []string) error {
+	u.uidStoreLock.Lock()
+	defer u.uidStoreLock.Unlock()
+
+	if existing := u.GetUIDs(rcKey); existing != nil && existing.Len() != 0 {
+		glog.Errorf("Clobbering existing delete keys: %+v", existing)
+	}
+	expectedUIDs := sets.NewString()
+	for _, k := range deletedKeys {
+		expectedUIDs.Insert(k)
+	}
+	glog.V(4).Infof("Controller %v waiting on deletions for: %+v", rcKey, deletedKeys)
+	if err := u.uidStore.Add(&UIDSet{expectedUIDs, rcKey}); err != nil {
+		return err
+	}
+	return u.ControllerExpectationsInterface.ExpectDeletions(rcKey, expectedUIDs.Len())
+}
+
+// DeletionObserved records the given deleteKey as a deletion, for the given rc.
+func (u *UIDTrackingControllerExpectations) DeletionObserved(rcKey, deleteKey string) {
+	u.uidStoreLock.Lock()
+	defer u.uidStoreLock.Unlock()
+
+	uids := u.GetUIDs(rcKey)
+	if uids != nil && uids.Has(deleteKey) {
+		glog.V(4).Infof("Controller %v received delete for pod %v", rcKey, deleteKey)
+		u.ControllerExpectationsInterface.DeletionObserved(rcKey)
+		uids.Delete(deleteKey)
+	}
+}
+
+// DeleteExpectations deletes the UID set and invokes DeleteExpectations on the
+// underlying ControllerExpectationsInterface.
+func (u *UIDTrackingControllerExpectations) DeleteExpectations(rcKey string) {
+	u.uidStoreLock.Lock()
+	defer u.uidStoreLock.Unlock()
+
+	u.ControllerExpectationsInterface.DeleteExpectations(rcKey)
+	if uidExp, exists, err := u.uidStore.GetByKey(rcKey); err == nil && exists {
+		if err := u.uidStore.Delete(uidExp); err != nil {
+			glog.V(2).Infof("Error deleting uid expectations for controller %v: %v", rcKey, err)
+		}
+	}
+}
+
+// NewUIDTrackingControllerExpectations returns a wrapper around
+// ControllerExpectations that is aware of deleteKeys.
+func NewUIDTrackingControllerExpectations(ce ControllerExpectationsInterface) *UIDTrackingControllerExpectations {
+	return &UIDTrackingControllerExpectations{ControllerExpectationsInterface: ce, uidStore: cache.NewStore(UIDSetKeyFunc)}
+}

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -593,9 +593,9 @@ func (_m *MockReplicaSetInterface) EXPECT() *_MockReplicaSetInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockReplicaSetInterface) Get(name string, options v1.GetOptions) (*v17.VirtualMachineReplicaSet, error) {
+func (_m *MockReplicaSetInterface) Get(name string, options v1.GetOptions) (*v18.VirtualMachineReplicaSet, error) {
 	ret := _m.ctrl.Call(_m, "Get", name, options)
-	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSet)
+	ret0, _ := ret[0].(*v18.VirtualMachineReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -604,9 +604,9 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
 }
 
-func (_m *MockReplicaSetInterface) List(opts v1.ListOptions) (*v17.VirtualMachineReplicaSetList, error) {
+func (_m *MockReplicaSetInterface) List(opts v1.ListOptions) (*v18.VirtualMachineReplicaSetList, error) {
 	ret := _m.ctrl.Call(_m, "List", opts)
-	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSetList)
+	ret0, _ := ret[0].(*v18.VirtualMachineReplicaSetList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -615,9 +615,9 @@ func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
 }
 
-func (_m *MockReplicaSetInterface) Create(_param0 *v17.VirtualMachineReplicaSet) (*v17.VirtualMachineReplicaSet, error) {
+func (_m *MockReplicaSetInterface) Create(_param0 *v18.VirtualMachineReplicaSet) (*v18.VirtualMachineReplicaSet, error) {
 	ret := _m.ctrl.Call(_m, "Create", _param0)
-	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSet)
+	ret0, _ := ret[0].(*v18.VirtualMachineReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -626,9 +626,9 @@ func (_mr *_MockReplicaSetInterfaceRecorder) Create(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
 }
 
-func (_m *MockReplicaSetInterface) Update(_param0 *v17.VirtualMachineReplicaSet) (*v17.VirtualMachineReplicaSet, error) {
+func (_m *MockReplicaSetInterface) Update(_param0 *v18.VirtualMachineReplicaSet) (*v18.VirtualMachineReplicaSet, error) {
 	ret := _m.ctrl.Call(_m, "Update", _param0)
-	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSet)
+	ret0, _ := ret[0].(*v18.VirtualMachineReplicaSet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -77,6 +77,16 @@ func (_mr *_MockKubevirtClientRecorder) Migration(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Migration", arg0)
 }
 
+func (_m *MockKubevirtClient) ReplicaSet(namespace string) ReplicaSetInterface {
+	ret := _m.ctrl.Call(_m, "ReplicaSet", namespace)
+	ret0, _ := ret[0].(ReplicaSetInterface)
+	return ret0
+}
+
+func (_mr *_MockKubevirtClientRecorder) ReplicaSet(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReplicaSet", arg0)
+}
+
 func (_m *MockKubevirtClient) RestClient() *rest.RESTClient {
 	ret := _m.ctrl.Call(_m, "RestClient")
 	ret0, _ := ret[0].(*rest.RESTClient)
@@ -559,6 +569,81 @@ func (_m *MockVMInterface) Delete(name string, options *v1.DeleteOptions) error 
 }
 
 func (_mr *_MockVMInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+}
+
+// Mock of ReplicaSetInterface interface
+type MockReplicaSetInterface struct {
+	ctrl     *gomock.Controller
+	recorder *_MockReplicaSetInterfaceRecorder
+}
+
+// Recorder for MockReplicaSetInterface (not exported)
+type _MockReplicaSetInterfaceRecorder struct {
+	mock *MockReplicaSetInterface
+}
+
+func NewMockReplicaSetInterface(ctrl *gomock.Controller) *MockReplicaSetInterface {
+	mock := &MockReplicaSetInterface{ctrl: ctrl}
+	mock.recorder = &_MockReplicaSetInterfaceRecorder{mock}
+	return mock
+}
+
+func (_m *MockReplicaSetInterface) EXPECT() *_MockReplicaSetInterfaceRecorder {
+	return _m.recorder
+}
+
+func (_m *MockReplicaSetInterface) Get(name string, options v1.GetOptions) (*v17.VirtualMachineReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Get", name, options)
+	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+}
+
+func (_m *MockReplicaSetInterface) List(opts v1.ListOptions) (*v17.VirtualMachineReplicaSetList, error) {
+	ret := _m.ctrl.Call(_m, "List", opts)
+	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSetList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) List(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "List", arg0)
+}
+
+func (_m *MockReplicaSetInterface) Create(_param0 *v17.VirtualMachineReplicaSet) (*v17.VirtualMachineReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Create", _param0)
+	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Create(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Create", arg0)
+}
+
+func (_m *MockReplicaSetInterface) Update(_param0 *v17.VirtualMachineReplicaSet) (*v17.VirtualMachineReplicaSet, error) {
+	ret := _m.ctrl.Call(_m, "Update", _param0)
+	ret0, _ := ret[0].(*v17.VirtualMachineReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Update(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0)
+}
+
+func (_m *MockReplicaSetInterface) Delete(name string, options *v1.DeleteOptions) error {
+	ret := _m.ctrl.Call(_m, "Delete", name, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockReplicaSetInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
 }
 

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -36,6 +36,7 @@ import (
 type KubevirtClient interface {
 	VM(namespace string) VMInterface
 	Migration(namespace string) MigrationInterface
+	ReplicaSet(namespace string) ReplicaSetInterface
 	RestClient() *rest.RESTClient
 	kubernetes.Interface
 }
@@ -54,6 +55,14 @@ type VMInterface interface {
 	List(opts k8smetav1.ListOptions) (*v1.VirtualMachineList, error)
 	Create(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Update(*v1.VirtualMachine) (*v1.VirtualMachine, error)
+	Delete(name string, options *k8smetav1.DeleteOptions) error
+}
+
+type ReplicaSetInterface interface {
+	Get(name string, options k8smetav1.GetOptions) (*v1.VirtualMachineReplicaSet, error)
+	List(opts k8smetav1.ListOptions) (*v1.VirtualMachineReplicaSetList, error)
+	Create(*v1.VirtualMachineReplicaSet) (*v1.VirtualMachineReplicaSet, error)
+	Update(*v1.VirtualMachineReplicaSet) (*v1.VirtualMachineReplicaSet, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
 }
 

--- a/pkg/kubecli/migration.go
+++ b/pkg/kubecli/migration.go
@@ -80,6 +80,7 @@ func (v *migrations) Create(migration *v1.Migration) (result *v1.Migration, err 
 func (v *migrations) Update(migration *v1.Migration) (result *v1.Migration, err error) {
 	result = &v1.Migration{}
 	err = v.restClient.Put().
+		Name(migration.ObjectMeta.Name).
 		Namespace(v.namespace).
 		Resource(v.resource).
 		Body(migration).

--- a/pkg/kubecli/migration_test.go
+++ b/pkg/kubecli/migration_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Kubevirt Migration Client", func() {
 	It("should update a Migration", func() {
 		migration := v1.NewMinimalMigration("testmigration", "testmigration")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", basePath),
+			ghttp.VerifyRequest("PUT", migrationPath),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, migration),
 		))
 		updatedMigration, err := client.Migration(k8sv1.NamespaceDefault).Update(migration)

--- a/pkg/kubecli/replicaset.go
+++ b/pkg/kubecli/replicaset.go
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package kubecli
+
+import (
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+func (k *kubevirt) ReplicaSet(namespace string) ReplicaSetInterface {
+	return &rc{k.restClient, namespace, "virtualmachinereplicasets"}
+}
+
+type rc struct {
+	restClient *rest.RESTClient
+	namespace  string
+	resource   string
+}
+
+func (v *rc) Get(name string, options k8smetav1.GetOptions) (migration *v1.VirtualMachineReplicaSet, err error) {
+	migration = &v1.VirtualMachineReplicaSet{}
+	err = v.restClient.Get().
+		Resource(v.resource).
+		Namespace(v.namespace).
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(migration)
+	migration.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
+	return
+}
+
+func (v *rc) List(options k8smetav1.ListOptions) (migrationList *v1.VirtualMachineReplicaSetList, err error) {
+	migrationList = &v1.VirtualMachineReplicaSetList{}
+	err = v.restClient.Get().
+		Resource(v.resource).
+		Namespace(v.namespace).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(migrationList)
+	for _, migration := range migrationList.Items {
+		migration.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
+	}
+
+	return
+}
+
+func (v *rc) Create(migration *v1.VirtualMachineReplicaSet) (result *v1.VirtualMachineReplicaSet, err error) {
+	result = &v1.VirtualMachineReplicaSet{}
+	err = v.restClient.Post().
+		Namespace(v.namespace).
+		Resource(v.resource).
+		Body(migration).
+		Do().
+		Into(result)
+	result.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
+	return
+}
+
+func (v *rc) Update(migration *v1.VirtualMachineReplicaSet) (result *v1.VirtualMachineReplicaSet, err error) {
+	result = &v1.VirtualMachineReplicaSet{}
+	err = v.restClient.Put().
+		Namespace(v.namespace).
+		Resource(v.resource).
+		Body(migration).
+		Do().
+		Into(result)
+	result.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
+	return
+}
+
+func (v *rc) Delete(name string, options *k8smetav1.DeleteOptions) error {
+	return v.restClient.Delete().
+		Namespace(v.namespace).
+		Resource(v.resource).
+		Name(name).
+		Body(options).
+		Do().
+		Error()
+}

--- a/pkg/kubecli/replicaset.go
+++ b/pkg/kubecli/replicaset.go
@@ -37,52 +37,53 @@ type rc struct {
 	resource   string
 }
 
-func (v *rc) Get(name string, options k8smetav1.GetOptions) (migration *v1.VirtualMachineReplicaSet, err error) {
-	migration = &v1.VirtualMachineReplicaSet{}
+func (v *rc) Get(name string, options k8smetav1.GetOptions) (replicaset *v1.VirtualMachineReplicaSet, err error) {
+	replicaset = &v1.VirtualMachineReplicaSet{}
 	err = v.restClient.Get().
 		Resource(v.resource).
 		Namespace(v.namespace).
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do().
-		Into(migration)
-	migration.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
+		Into(replicaset)
+	replicaset.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
 	return
 }
 
-func (v *rc) List(options k8smetav1.ListOptions) (migrationList *v1.VirtualMachineReplicaSetList, err error) {
-	migrationList = &v1.VirtualMachineReplicaSetList{}
+func (v *rc) List(options k8smetav1.ListOptions) (replicasetList *v1.VirtualMachineReplicaSetList, err error) {
+	replicasetList = &v1.VirtualMachineReplicaSetList{}
 	err = v.restClient.Get().
 		Resource(v.resource).
 		Namespace(v.namespace).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do().
-		Into(migrationList)
-	for _, migration := range migrationList.Items {
-		migration.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
+		Into(replicasetList)
+	for _, replicaset := range replicasetList.Items {
+		replicaset.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
 	}
 
 	return
 }
 
-func (v *rc) Create(migration *v1.VirtualMachineReplicaSet) (result *v1.VirtualMachineReplicaSet, err error) {
+func (v *rc) Create(replicaset *v1.VirtualMachineReplicaSet) (result *v1.VirtualMachineReplicaSet, err error) {
 	result = &v1.VirtualMachineReplicaSet{}
 	err = v.restClient.Post().
 		Namespace(v.namespace).
 		Resource(v.resource).
-		Body(migration).
+		Body(replicaset).
 		Do().
 		Into(result)
 	result.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)
 	return
 }
 
-func (v *rc) Update(migration *v1.VirtualMachineReplicaSet) (result *v1.VirtualMachineReplicaSet, err error) {
+func (v *rc) Update(replicaset *v1.VirtualMachineReplicaSet) (result *v1.VirtualMachineReplicaSet, err error) {
 	result = &v1.VirtualMachineReplicaSet{}
 	err = v.restClient.Put().
+		Name(replicaset.ObjectMeta.Name).
 		Namespace(v.namespace).
 		Resource(v.resource).
-		Body(migration).
+		Body(replicaset).
 		Do().
 		Into(result)
 	result.SetGroupVersionKind(v1.VMReplicaSetGroupVersionKind)

--- a/pkg/kubecli/replicaset_test.go
+++ b/pkg/kubecli/replicaset_test.go
@@ -1,0 +1,139 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package kubecli
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	k8sv1 "k8s.io/api/core/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+var _ = Describe("Kubevirt VirtualMachineReplicaSet Client", func() {
+
+	var server *ghttp.Server
+	var client KubevirtClient
+	basePath := "/apis/kubevirt.io/v1alpha1/namespaces/default/virtualmachinereplicasets"
+	rsPath := basePath + "/testrs"
+
+	BeforeEach(func() {
+		var err error
+		server = ghttp.NewServer()
+		client, err = GetKubevirtClientFromFlags(server.URL(), "")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should fetch a VirtualMachineReplicaSet", func() {
+		rs := NewMinimalVMReplicaSet("testrs")
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", rsPath),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
+		))
+		fetchedVMReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetchedVMReplicaSet).To(Equal(rs))
+	})
+
+	It("should detect non existent VMReplicaSets", func() {
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", rsPath),
+			ghttp.RespondWithJSONEncoded(http.StatusNotFound, errors.NewNotFound(schema.GroupResource{}, "testrs")),
+		))
+		_, err := client.ReplicaSet(k8sv1.NamespaceDefault).Get("testrs", k8smetav1.GetOptions{})
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).To(HaveOccurred())
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should fetch a VirtualMachineReplicaSet list", func() {
+		rs := NewMinimalVMReplicaSet("testrs")
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", basePath),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, NewVMReplicaSetList(*rs)),
+		))
+		fetchedVMReplicaSetList, err := client.ReplicaSet(k8sv1.NamespaceDefault).List(k8smetav1.ListOptions{})
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetchedVMReplicaSetList.Items).To(HaveLen(1))
+		Expect(fetchedVMReplicaSetList.Items[0]).To(Equal(*rs))
+	})
+
+	It("should create a VirtualMachineReplicaSet", func() {
+		rs := NewMinimalVMReplicaSet("testrs")
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("POST", basePath),
+			ghttp.RespondWithJSONEncoded(http.StatusCreated, rs),
+		))
+		createdVMReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Create(rs)
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createdVMReplicaSet).To(Equal(rs))
+	})
+
+	It("should update a VirtualMachineReplicaSet", func() {
+		rs := NewMinimalVMReplicaSet("testrs")
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("PUT", basePath),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
+		))
+		updatedVMReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Update(rs)
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updatedVMReplicaSet).To(Equal(rs))
+	})
+
+	It("should delete a VirtualMachineReplicaSet", func() {
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("DELETE", rsPath),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
+		))
+		err := client.ReplicaSet(k8sv1.NamespaceDefault).Delete("testrs", &k8smetav1.DeleteOptions{})
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+})
+
+func NewVMReplicaSetList(rss ...v1.VirtualMachineReplicaSet) *v1.VirtualMachineReplicaSetList {
+	return &v1.VirtualMachineReplicaSetList{TypeMeta: k8smetav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "VirtualMachineReplicaSetList"}, Items: rss}
+}
+
+func NewMinimalVMReplicaSet(name string) *v1.VirtualMachineReplicaSet {
+	return &v1.VirtualMachineReplicaSet{TypeMeta: k8smetav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "VirtualMachineReplicaSet"}, ObjectMeta: k8smetav1.ObjectMeta{Name: name}}
+}

--- a/pkg/kubecli/replicaset_test.go
+++ b/pkg/kubecli/replicaset_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Kubevirt VirtualMachineReplicaSet Client", func() {
 	It("should update a VirtualMachineReplicaSet", func() {
 		rs := NewMinimalVMReplicaSet("testrs")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", basePath),
+			ghttp.VerifyRequest("PUT", rsPath),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, rs),
 		))
 		updatedVMReplicaSet, err := client.ReplicaSet(k8sv1.NamespaceDefault).Update(rs)

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -80,6 +80,7 @@ func (v *vms) Create(vm *v1.VirtualMachine) (result *v1.VirtualMachine, err erro
 func (v *vms) Update(vm *v1.VirtualMachine) (result *v1.VirtualMachine, err error) {
 	result = &v1.VirtualMachine{}
 	err = v.restClient.Put().
+		Name(vm.ObjectMeta.Name).
 		Namespace(v.namespace).
 		Resource(v.resource).
 		Body(vm).

--- a/pkg/kubecli/vm_test.go
+++ b/pkg/kubecli/vm_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Kubevirt VM Client", func() {
 	It("should update a VM", func() {
 		vm := v1.NewMinimalVM("testvm")
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("PUT", basePath),
+			ghttp.VerifyRequest("PUT", vmPath),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
 		))
 		updatedVM, err := client.VM(k8sv1.NamespaceDefault).Update(vm)

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -127,7 +127,7 @@ func (vca *VirtControllerApp) initReplicaSet() {
 	// TODO what is scheme used for in Recorder?
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "virtualmachinereplicaset-controller"})
 
-	vca.rsController = NewVMReplicaSet(vca.vmInformer, vca.rsInformer, recorder, vca.clientSet)
+	vca.rsController = NewVMReplicaSet(vca.vmInformer, vca.rsInformer, recorder, vca.clientSet, kubecli.BurstReplicas)
 }
 
 func (vca *VirtControllerApp) DefineFlags() {

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
@@ -62,7 +63,7 @@ type MigrationController struct {
 }
 
 func (c *MigrationController) Run(threadiness int, stopCh chan struct{}) {
-	defer kubecli.HandlePanic()
+	defer controller.HandlePanic()
 	defer c.queue.ShutDown()
 	logging.DefaultLogger().Info().Msg("Starting controller.")
 

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -90,10 +90,10 @@ func (c *VMReplicaSet) Execute() bool {
 	}
 	defer c.queue.Done(key)
 	if err := c.execute(key.(string)); err != nil {
-		logging.DefaultLogger().Info().Reason(err).Msgf("reenqueuing VirtualmachinePool %v", key)
+		logging.DefaultLogger().Info().Reason(err).Msgf("reenqueuing VirtualMachineReplicaSet %v", key)
 		c.queue.AddRateLimited(key)
 	} else {
-		logging.DefaultLogger().Info().V(4).Msgf("processed VirtualMachinePool %v", key)
+		logging.DefaultLogger().Info().V(4).Msgf("processed VirtualMachineReplicaSet %v", key)
 		c.queue.Forget(key)
 	}
 	return true
@@ -145,10 +145,10 @@ func (c *VMReplicaSet) execute(key string) error {
 	if vmCount < wantedReplicas {
 		// create VM
 		vm := kubev1.NewVMReferenceFromNameWithNS(rs.ObjectMeta.Namespace, "")
-		vm.ObjectMeta.GenerateName = rs.ObjectMeta.Namespace + "-"
+		vm.ObjectMeta.GenerateName = rs.ObjectMeta.Name + "-"
 		vm.Spec = rs.Spec.Template.Spec
 		// TODO check if vm labels exist, and when make sure that they match. For now just override them
-		vm.ObjectMeta.Labels = rs.Spec.Selector.MatchLabels
+		vm.ObjectMeta.Labels = rs.Spec.Template.ObjectMeta.Labels
 		_, err := c.clientset.VM(rs.ObjectMeta.Namespace).Create(vm)
 		if err != nil {
 			return err

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -1,0 +1,266 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package watch
+
+import (
+	"time"
+
+	"github.com/jeevatkm/go-model"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/logging"
+)
+
+func NewVMReplicaSet(vmInformer cache.SharedIndexInformer, vmRSInformer cache.SharedIndexInformer, recorder record.EventRecorder, clientset kubecli.KubevirtClient) *VMReplicaSet {
+
+	c := &VMReplicaSet{
+		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		vmInformer:   vmInformer,
+		vmRSInformer: vmRSInformer,
+		recorder:     recorder,
+		clientset:    clientset,
+	}
+
+	vmRSInformer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForWorkqueue(c.queue))
+
+	c.vmInformer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForFunc(c.vmChangeFunc))
+
+	return c
+}
+
+type VMReplicaSet struct {
+	clientset    kubecli.KubevirtClient
+	queue        workqueue.RateLimitingInterface
+	vmInformer   cache.SharedIndexInformer
+	vmRSInformer cache.SharedIndexInformer
+	recorder     record.EventRecorder
+}
+
+func (c *VMReplicaSet) Run(threadiness int, stopCh chan struct{}) {
+	defer kubecli.HandlePanic()
+	defer c.queue.ShutDown()
+	logging.DefaultLogger().Info().Msg("Starting controller.")
+
+	// Wait for cache sync before we start the pod controller
+	cache.WaitForCacheSync(stopCh, c.vmInformer.HasSynced, c.vmRSInformer.HasSynced)
+
+	// Start the actual work
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	logging.DefaultLogger().Info().Msg("Stopping controller.")
+}
+
+func (c *VMReplicaSet) runWorker() {
+	for c.Execute() {
+	}
+}
+
+func (c *VMReplicaSet) Execute() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+	if err := c.execute(key.(string)); err != nil {
+		logging.DefaultLogger().Info().Reason(err).Msgf("reenqueuing VirtualmachinePool %v", key)
+		c.queue.AddRateLimited(key)
+	} else {
+		logging.DefaultLogger().Info().V(4).Msgf("processed VirtualMachinePool %v", key)
+		c.queue.Forget(key)
+	}
+	return true
+}
+
+func (c *VMReplicaSet) execute(key string) error {
+
+	obj, exists, err := c.vmRSInformer.GetStore().GetByKey(key)
+	if err != nil {
+		return nil
+	}
+	if !exists {
+		// nothing we need to do. It should always be possible to re-create this type of controller
+		return nil
+	}
+	rs := obj.(*kubev1.VirtualMachineReplicaSet)
+
+	//TODO default rs if necessary, the aggregated apiserver will do that in the future
+	if rs.Spec.Template == nil || rs.Spec.Selector == nil || rs.Spec.Selector.Size() == 0 {
+		logging.DefaultLogger().Object(rs).Error().Msg("Invalid controller spec, will not retry processing it.")
+		return nil
+	}
+
+	//TODO should be added when creating the controller
+	// This is a default value
+	wantedReplicas := int32(1)
+	if rs.Spec.Replicas != nil {
+		wantedReplicas = *rs.Spec.Replicas
+	}
+	selector, err := v1.LabelSelectorAsSelector(rs.Spec.Selector)
+	if err != nil {
+		return nil
+	}
+
+	// get all potentially interesting VMs from the cache
+	vms, err := c.listPodsFromNamespace(rs.ObjectMeta.Namespace)
+
+	if err != nil {
+		return err
+	}
+
+	// make sure we only consider active VMs
+	vms = c.filterActiveVMs(vms)
+
+	// make sure the selector of the controller matches and the VMs match
+	vms = c.filterMatchingVMs(selector, vms)
+
+	vmCount := int32(len(vms))
+	if vmCount < wantedReplicas {
+		// create VM
+		vm := kubev1.NewVMReferenceFromNameWithNS(rs.ObjectMeta.Namespace, "")
+		vm.ObjectMeta.GenerateName = rs.ObjectMeta.Namespace + "-"
+		vm.Spec = rs.Spec.Template.Spec
+		// TODO check if vm labels exist, and when make sure that they match. For now just override them
+		vm.ObjectMeta.Labels = rs.Spec.Selector.MatchLabels
+		_, err := c.clientset.VM(rs.ObjectMeta.Namespace).Create(vm)
+		if err != nil {
+			return err
+		}
+		vmCount += 1
+	} else if vmCount > wantedReplicas {
+		// delete VM
+		// TODO graceful delete only
+		deleteCandidate := vms[0]
+		if err != nil {
+			return err
+		}
+		c.clientset.VM(rs.ObjectMeta.Namespace).Delete(deleteCandidate.ObjectMeta.Name, &v1.DeleteOptions{})
+		vmCount -= 1
+	}
+	if rs.Status.Replicas != vmCount {
+		obj, err = model.Clone(rs)
+		if err != nil {
+			return err
+		}
+		rsCopy := obj.(*kubev1.VirtualMachineReplicaSet)
+		rsCopy.Status.Replicas = vmCount
+		_, err := c.clientset.ReplicaSet(rs.ObjectMeta.Namespace).Update(rsCopy)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// filterActiveVMs takes a list of VMs and returns all VMs which are not in a final state
+// Note that vms which have a deletion timestamp set, are still treated as active.
+// This is a difference to Pod ReplicaSets
+func (c *VMReplicaSet) filterActiveVMs(vms []kubev1.VM) []kubev1.VM {
+	filtered := []kubev1.VM{}
+	for _, vm := range vms {
+		if !vm.IsFinal() {
+			filtered = append(filtered, vm)
+		}
+	}
+	return filtered
+}
+
+// filterMatchingVMs takes a selector and a list of VMs. If the VM labels match the selector it is added to the filtered collection.
+// Returns the list of all VMs which match the selector
+func (c *VMReplicaSet) filterMatchingVMs(selector labels.Selector, vms []kubev1.VM) []kubev1.VM {
+	//TODO take owner reference into account
+	filtered := []kubev1.VM{}
+	for _, vm := range vms {
+		if selector.Matches(labels.Set(vm.ObjectMeta.Labels)) {
+			filtered = append(filtered, vm)
+		}
+	}
+	return filtered
+}
+
+// listPodsFromNamespace takes a namespace and returns all VMs from the VM cache which run in this namespace
+func (c *VMReplicaSet) listPodsFromNamespace(namespace string) ([]kubev1.VM, error) {
+	objs, err := c.vmInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return nil, err
+	}
+	vms := []kubev1.VM{}
+	for _, obj := range objs {
+		vms = append(vms, *obj.(*kubev1.VM))
+	}
+	return vms, nil
+}
+
+// listControllerFromNamespace takes a namespace and returns all VMReplicaSets from the ReplicaSet cache which run in this namespace
+func (c *VMReplicaSet) listControllerFromNamespace(namespace string) ([]kubev1.VirtualMachineReplicaSet, error) {
+	objs, err := c.vmRSInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return nil, err
+	}
+	replicaSets := []kubev1.VirtualMachineReplicaSet{}
+	for _, obj := range objs {
+		rs := obj.(*kubev1.VirtualMachineReplicaSet)
+		replicaSets = append(replicaSets, *rs)
+	}
+	return replicaSets, nil
+}
+
+// vmChangeFunc checks if the supplied VM matches a replica set controller in it's namespace
+// and wakes the first controller it encounters.
+func (c *VMReplicaSet) vmChangeFunc(obj interface{}) {
+	vm := obj.(*kubev1.VM)
+	controllers, err := c.listControllerFromNamespace(vm.ObjectMeta.Namespace)
+	if err != nil {
+		//TODO error handling
+		return
+	}
+
+	// TODO check owner reference, if we have an existing controller which owns this one
+
+	for _, rs := range controllers {
+		selector, err := v1.LabelSelectorAsSelector(rs.Spec.Selector)
+		if err != nil {
+			// selector is invalid, continue with next controller
+			continue
+		}
+
+		if selector.Matches(labels.Set(vm.ObjectMeta.Labels)) {
+			// The first matching rs will be informed
+			key, err := cache.MetaNamespaceKeyFunc(&rs)
+			if err != nil {
+				return
+			}
+			c.queue.Add(key)
+			return
+		}
+
+	}
+}

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -40,9 +40,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
-	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/logging"
 )
 
 // Reasons for virtual machine events

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -368,7 +368,7 @@ func (c *VMReplicaSet) addVirtualMachine(obj interface{}) {
 		return
 	}
 
-	// If an unexpected error occured, log it and ignore
+	// If an unexpected error occurred, log it and ignore
 	if err != nil {
 		log.Error().Object(vm).Reason(err).Msg("Searching for matching replicasets failed.")
 		return
@@ -432,7 +432,7 @@ func (c *VMReplicaSet) updateVirtualMachine(old, curr interface{}) {
 		return
 	}
 
-	// If an unexpected error occured, log it and ignore
+	// If an unexpected error occurred, log it and ignore
 	if err != nil {
 		log.Error().Object(vm).Reason(err).Msg("Searching for matching replicasets failed.")
 		return
@@ -470,17 +470,17 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 	diff := c.calcDiff(rs, vms)
 
 	// check if we have reached the equilibrium
-	// in case the replica count matches and the scaleErr and the error conditaion equal, don't update
+	// in case the replica count matches and the scaleErr and the error condition equal, don't update
 	if diff == 0 && scaleErr == nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) == nil ||
 		diff == 0 && scaleErr != nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) != nil {
 		return nil
 	}
 
 	if scaleErr != nil {
-		// If an error occured, only update to filtered pod count
+		// If an error occurred, only update to filtered pod count
 		rs.Status.Replicas = int32(len(vms))
 	} else {
-		// If no error occured we have reached our required scale number
+		// If no error occurred we have reached our required scale number
 		rs.Status.Replicas = int32(len(vms) - diff)
 	}
 

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -482,7 +482,7 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 	readyReplicas := int32(len(c.filterReadyVMs(vms)))
 
 	// check if we have reached the equilibrium
-	statesMatch := diff == 0 && readyReplicas == rs.Status.ReadyReplicas
+	statesMatch := int32(len(vms)) == rs.Status.Replicas && readyReplicas == rs.Status.ReadyReplicas
 
 	// check if we need to update because of appeared or disappeard errors
 	errorsMatch := scaleErr == nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) == nil || scaleErr != nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) != nil
@@ -492,13 +492,7 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 		return nil
 	}
 
-	if scaleErr != nil {
-		// If an error occurred, only update to filtered pod count
-		rs.Status.Replicas = int32(len(vms))
-	} else {
-		// If no error occurred we have reached our required scale number
-		rs.Status.Replicas = int32(len(vms) - diff)
-	}
+	rs.Status.Replicas = int32(len(vms))
 	rs.Status.ReadyReplicas = readyReplicas
 
 	if scaleErr != nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) == nil {

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -163,6 +163,11 @@ func (c *VMReplicaSet) execute(key string) error {
 		return nil
 	}
 
+	if !selector.Matches(labels.Set(rs.Spec.Template.ObjectMeta.Labels)) {
+		log.Error().Reason(err).Msg("Selector does not match template labels, will not re-enqueue.")
+		return nil
+	}
+
 	needsSync := c.expectations.SatisfiedExpectations(key)
 
 	// get all potentially interesting VMs from the cache

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -151,7 +151,7 @@ func (c *VMReplicaSet) execute(key string) error {
 	return c.updateStatus(rsCopy, vms, scaleErr)
 }
 
-func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VM) error {
+func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine) error {
 
 	diff := c.calcDiff(rs, vms)
 
@@ -213,8 +213,8 @@ func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.V
 // filterActiveVMs takes a list of VMs and returns all VMs which are not in a final state
 // Note that vms which have a deletion timestamp set, are still treated as active.
 // This is a difference to Pod ReplicaSets
-func (c *VMReplicaSet) filterActiveVMs(vms []virtv1.VM) []virtv1.VM {
-	filtered := []virtv1.VM{}
+func (c *VMReplicaSet) filterActiveVMs(vms []virtv1.VirtualMachine) []virtv1.VirtualMachine {
+	filtered := []virtv1.VirtualMachine{}
 	for _, vm := range vms {
 		if !vm.IsFinal() {
 			filtered = append(filtered, vm)
@@ -225,9 +225,9 @@ func (c *VMReplicaSet) filterActiveVMs(vms []virtv1.VM) []virtv1.VM {
 
 // filterMatchingVMs takes a selector and a list of VMs. If the VM labels match the selector it is added to the filtered collection.
 // Returns the list of all VMs which match the selector
-func (c *VMReplicaSet) filterMatchingVMs(selector labels.Selector, vms []virtv1.VM) []virtv1.VM {
+func (c *VMReplicaSet) filterMatchingVMs(selector labels.Selector, vms []virtv1.VirtualMachine) []virtv1.VirtualMachine {
 	//TODO take owner reference into account
-	filtered := []virtv1.VM{}
+	filtered := []virtv1.VirtualMachine{}
 	for _, vm := range vms {
 		if selector.Matches(labels.Set(vm.ObjectMeta.Labels)) {
 			filtered = append(filtered, vm)
@@ -237,14 +237,14 @@ func (c *VMReplicaSet) filterMatchingVMs(selector labels.Selector, vms []virtv1.
 }
 
 // listVMsFromNamespace takes a namespace and returns all VMs from the VM cache which run in this namespace
-func (c *VMReplicaSet) listVMsFromNamespace(namespace string) ([]virtv1.VM, error) {
+func (c *VMReplicaSet) listVMsFromNamespace(namespace string) ([]virtv1.VirtualMachine, error) {
 	objs, err := c.vmInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}
-	vms := []virtv1.VM{}
+	vms := []virtv1.VirtualMachine{}
 	for _, obj := range objs {
-		vms = append(vms, *obj.(*virtv1.VM))
+		vms = append(vms, *obj.(*virtv1.VirtualMachine))
 	}
 	return vms, nil
 }
@@ -266,7 +266,7 @@ func (c *VMReplicaSet) listControllerFromNamespace(namespace string) ([]virtv1.V
 // vmChangeFunc checks if the supplied VM matches a replica set controller in it's namespace
 // and wakes the first controller which matches the VM labels.
 func (c *VMReplicaSet) vmChangeFunc(obj interface{}) {
-	vm := obj.(*virtv1.VM)
+	vm := obj.(*virtv1.VirtualMachine)
 	controllers, err := c.listControllerFromNamespace(vm.ObjectMeta.Namespace)
 	if err != nil {
 		//TODO error handling
@@ -311,7 +311,7 @@ func (c *VMReplicaSet) getCondition(rs *virtv1.VirtualMachineReplicaSet, cond vi
 	return nil
 }
 
-func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VM, scaleErr error) error {
+func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine, scaleErr error) error {
 
 	diff := c.calcDiff(rs, vms)
 
@@ -349,7 +349,7 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 	return err
 }
 
-func (c *VMReplicaSet) calcDiff(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VM) int {
+func (c *VMReplicaSet) calcDiff(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine) int {
 	// TODO default this on the aggregated api server
 	wantedReplicas := int32(1)
 	if rs.Spec.Replicas != nil {

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -469,6 +469,13 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 
 	diff := c.calcDiff(rs, vms)
 
+	// check if we have reached the equilibrium
+	// in case the replica count matches and the scaleErr and the error conditaion equal, don't update
+	if diff == 0 && scaleErr == nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) == nil ||
+		diff == 0 && scaleErr != nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) != nil {
+		return nil
+	}
+
 	if scaleErr != nil {
 		// If an error occured, only update to filtered pod count
 		rs.Status.Replicas = int32(len(vms))

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -68,7 +68,9 @@ var _ = Describe("Replicaset", func() {
 			sync(stop)
 
 			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface).AnyTimes()
-			vmInterface.EXPECT().Create(gomock.Any()).Times(3)
+			vmInterface.EXPECT().Create(gomock.Any()).Times(3).Do(func(arg interface{}) {
+				Expect(arg.(*v1.VM).ObjectMeta.GenerateName).To(Equal("testvm"))
+			})
 			virtClient.EXPECT().ReplicaSet(vm.ObjectMeta.Namespace).Return(rsInterface)
 			rsInterface.EXPECT().Update(expectedRS)
 

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -130,17 +130,12 @@ var _ = Describe("Replicaset", func() {
 
 			rsInterface.EXPECT().Update(gomock.Any()).AnyTimes()
 
-			invocations := 0
-			// Count up on every invocation, so that we can measure how often this was called on one invocation
+			// Check if only 10 are created
 			vmInterface.EXPECT().Create(gomock.Any()).Times(10).Do(func(arg interface{}) {
 				Expect(arg.(*v1.VirtualMachine).ObjectMeta.GenerateName).To(Equal("testvm"))
-			}).Return(vm, nil).Do(func(obj interface{}) {
-				invocations++
-			})
+			}).Return(vm, nil)
 
-			// Check if only 10 are created
 			controller.Execute()
-			Expect(invocations).To(Equal(10))
 
 			// TODO test for missing 5
 		})
@@ -159,16 +154,11 @@ var _ = Describe("Replicaset", func() {
 
 			rsInterface.EXPECT().Update(gomock.Any()).AnyTimes()
 
-			invocations := 0
-			// Count up on every invocation, so that we can measure how often this was called on one invocation
-			vmInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).
-				Times(10).Return(nil).Do(func(vm interface{}, _ interface{}) {
-				invocations++
-			})
-
 			// Check if only 10 are deleted
+			vmInterface.EXPECT().Delete(gomock.Any(), gomock.Any()).
+				Times(10).Return(nil)
+
 			controller.Execute()
-			Expect(invocations).To(Equal(10))
 
 			// TODO test for missing 5
 		})

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -51,20 +51,20 @@ var _ = Describe("Replicaset", func() {
 
 	Context("One valid ReplicaSet controller given", func() {
 
-		It("should create a VM and increase the replica count", func() {
+		It("should create missing VMs and increase the replica count", func() {
 			vm := v1.NewMinimalVM("testvm")
 			vm.ObjectMeta.Labels = map[string]string{"test": "test"}
 			rs := ReplicaSetFromVM("rs", vm, 3)
 
 			expectedRS := clone(rs)
-			expectedRS.Status.Replicas = 1
+			expectedRS.Status.Replicas = 3
 
 			rsSource.Add(rs)
 
 			sync(stop)
 
-			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface)
-			vmInterface.EXPECT().Create(gomock.Any())
+			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface).AnyTimes()
+			vmInterface.EXPECT().Create(gomock.Any()).Times(3)
 			virtClient.EXPECT().ReplicaSet(vm.ObjectMeta.Namespace).Return(rsInterface)
 			rsInterface.EXPECT().Update(expectedRS)
 

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -1,0 +1,156 @@
+package watch_test
+
+import (
+	. "kubevirt.io/kubevirt/pkg/virt-controller/watch"
+
+	"github.com/golang/mock/gomock"
+	"github.com/jeevatkm/go-model"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/cache/testing"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+)
+
+var _ = Describe("Replicaset", func() {
+
+	var ctrl *gomock.Controller
+	var virtClient *kubecli.MockKubevirtClient
+	var vmInterface *kubecli.MockVMInterface
+	var rsInterface *kubecli.MockReplicaSetInterface
+	var vmSource *framework.FakeControllerSource
+	var rsSource *framework.FakeControllerSource
+	var vmInformer cache.SharedIndexInformer
+	var rsInformer cache.SharedIndexInformer
+	var stop chan struct{}
+	var controller *VMReplicaSet
+
+	sync := func(stop chan struct{}) {
+		go vmInformer.Run(stop)
+		go rsInformer.Run(stop)
+		Expect(cache.WaitForCacheSync(stop, vmInformer.HasSynced, rsInformer.HasSynced)).To(BeTrue())
+	}
+
+	BeforeEach(func() {
+		stop = make(chan struct{})
+		ctrl = gomock.NewController(GinkgoT())
+		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+		vmInterface = kubecli.NewMockVMInterface(ctrl)
+		rsInterface = kubecli.NewMockReplicaSetInterface(ctrl)
+
+		vmSource = framework.NewFakeControllerSource()
+		rsSource = framework.NewFakeControllerSource()
+		vmInformer = cache.NewSharedIndexInformer(vmSource, &v1.VM{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		rsInformer = cache.NewSharedIndexInformer(rsSource, &v1.VirtualMachineReplicaSet{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+		controller = NewVMReplicaSet(vmInformer, rsInformer, nil, virtClient)
+	})
+
+	Context("One valid ReplicaSet controller given", func() {
+
+		It("should create a VM and increase the replica count", func() {
+			vm := v1.NewMinimalVM("testvm")
+			vm.ObjectMeta.Labels = map[string]string{"test": "test"}
+			rs := ReplicaSetFromVM("rs", vm, 3)
+
+			expectedRS := clone(rs)
+			expectedRS.Status.Replicas = 1
+
+			rsSource.Add(rs)
+
+			sync(stop)
+
+			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface)
+			vmInterface.EXPECT().Create(gomock.Any())
+			virtClient.EXPECT().ReplicaSet(vm.ObjectMeta.Namespace).Return(rsInterface)
+			rsInterface.EXPECT().Update(expectedRS)
+
+			controller.Execute()
+		})
+
+		It("should delete a VM and decrease the replica count", func() {
+			vm := v1.NewMinimalVM("testvm")
+			vm.ObjectMeta.Labels = map[string]string{"test": "test"}
+			rs := ReplicaSetFromVM("rs", vm, 0)
+			rs.Status.Replicas = 1
+
+			expectedRS := clone(rs)
+			expectedRS.Status.Replicas = 0
+
+			vmSource.Add(vm)
+			rsSource.Add(rs)
+
+			sync(stop)
+
+			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface)
+			vmInterface.EXPECT().Delete(vm.ObjectMeta.Name, gomock.Any())
+			virtClient.EXPECT().ReplicaSet(vm.ObjectMeta.Namespace).Return(rsInterface)
+			rsInterface.EXPECT().Update(expectedRS)
+
+			controller.Execute()
+		})
+
+		It("should detect that it has nothing to do", func() {
+			vm := v1.NewMinimalVM("testvm")
+			vm.ObjectMeta.Labels = map[string]string{"test": "test"}
+			rs := ReplicaSetFromVM("rs", vm, 1)
+			rs.Status.Replicas = 1
+
+			vmSource.Add(vm)
+			rsSource.Add(rs)
+
+			sync(stop)
+
+			controller.Execute()
+		})
+
+		It("should be woken by a stopped VM and create a new one", func() {
+			vm := v1.NewMinimalVM("testvm")
+			vm.ObjectMeta.Labels = map[string]string{"test": "test"}
+			rs := ReplicaSetFromVM("rs", vm, 1)
+			rs.Status.Replicas = 1
+
+			vmSource.Add(vm)
+			rsSource.Add(rs)
+
+			sync(stop)
+
+			// First make sure that we don't have to do anything
+			controller.Execute()
+
+			// Move one VM to a final state
+			vm.Status.Phase = v1.Succeeded
+			vmSource.Modify(vm)
+
+			// Expect the recrate of the VM
+			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface)
+			vmInterface.EXPECT().Create(gomock.Any())
+
+			// Run the controller again
+			controller.Execute()
+		})
+	})
+})
+
+func clone(rs *v1.VirtualMachineReplicaSet) *v1.VirtualMachineReplicaSet {
+	c, err := model.Clone(rs)
+	Expect(err).ToNot(HaveOccurred())
+	return c.(*v1.VirtualMachineReplicaSet)
+}
+
+func ReplicaSetFromVM(name string, vm *v1.VM, replicas int32) *v1.VirtualMachineReplicaSet {
+	rs := &v1.VirtualMachineReplicaSet{
+		ObjectMeta: v12.ObjectMeta{Name: name, Namespace: vm.ObjectMeta.Namespace, ResourceVersion: "1"},
+		Spec: v1.VMReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &v12.LabelSelector{
+				MatchLabels: vm.ObjectMeta.Labels,
+			},
+			Template: &v1.VMTemplateSpec{Spec: vm.Spec},
+		},
+	}
+	return rs
+}

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -15,6 +15,8 @@ import (
 
 	v13 "k8s.io/api/core/v1"
 
+	"k8s.io/client-go/tools/record"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 )
@@ -31,6 +33,7 @@ var _ = Describe("Replicaset", func() {
 	var rsInformer cache.SharedIndexInformer
 	var stop chan struct{}
 	var controller *VMReplicaSet
+	var recorder *record.FakeRecorder
 
 	sync := func(stop chan struct{}) {
 		go vmInformer.Run(stop)
@@ -49,8 +52,9 @@ var _ = Describe("Replicaset", func() {
 		rsSource = framework.NewFakeControllerSource()
 		vmInformer = cache.NewSharedIndexInformer(vmSource, &v1.VirtualMachine{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		rsInformer = cache.NewSharedIndexInformer(rsSource, &v1.VirtualMachineReplicaSet{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		recorder = record.NewFakeRecorder(100)
 
-		controller = NewVMReplicaSet(vmInformer, rsInformer, nil, virtClient)
+		controller = NewVMReplicaSet(vmInformer, rsInformer, recorder, virtClient)
 	})
 
 	Context("One valid ReplicaSet controller given", func() {

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Replicaset", func() {
 
 		vmSource = framework.NewFakeControllerSource()
 		rsSource = framework.NewFakeControllerSource()
-		vmInformer = cache.NewSharedIndexInformer(vmSource, &v1.VM{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		vmInformer = cache.NewSharedIndexInformer(vmSource, &v1.VirtualMachine{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		rsInformer = cache.NewSharedIndexInformer(rsSource, &v1.VirtualMachineReplicaSet{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 		controller = NewVMReplicaSet(vmInformer, rsInformer, nil, virtClient)
@@ -69,7 +69,7 @@ var _ = Describe("Replicaset", func() {
 
 			virtClient.EXPECT().VM(vm.ObjectMeta.Namespace).Return(vmInterface).AnyTimes()
 			vmInterface.EXPECT().Create(gomock.Any()).Times(3).Do(func(arg interface{}) {
-				Expect(arg.(*v1.VM).ObjectMeta.GenerateName).To(Equal("testvm"))
+				Expect(arg.(*v1.VirtualMachine).ObjectMeta.GenerateName).To(Equal("testvm"))
 			})
 			virtClient.EXPECT().ReplicaSet(vm.ObjectMeta.Namespace).Return(rsInterface)
 			rsInterface.EXPECT().Update(expectedRS)
@@ -278,7 +278,7 @@ func clone(rs *v1.VirtualMachineReplicaSet) *v1.VirtualMachineReplicaSet {
 	return c.(*v1.VirtualMachineReplicaSet)
 }
 
-func ReplicaSetFromVM(name string, vm *v1.VM, replicas int32) *v1.VirtualMachineReplicaSet {
+func ReplicaSetFromVM(name string, vm *v1.VirtualMachine, replicas int32) *v1.VirtualMachineReplicaSet {
 	rs := &v1.VirtualMachineReplicaSet{
 		ObjectMeta: v12.ObjectMeta{Name: name, Namespace: vm.ObjectMeta.Namespace, ResourceVersion: "1"},
 		Spec: v1.VMReplicaSetSpec{

--- a/pkg/virt-controller/watch/testing/mock_queue.go
+++ b/pkg/virt-controller/watch/testing/mock_queue.go
@@ -1,0 +1,54 @@
+package testing
+
+import (
+	"sync"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+/*
+MockWorkQueue is a helper workqueue which can be wrapped around
+any RateLimitingInterface implementing queue. This allows synchronous
+testing of the controller. The typical pattern is:
+
+    mockQueue.ExpectAdd(3)
+    vmSource.Add(vm)
+    vmSource.Add(vm1)
+    vmSource.Add(vm2)
+    mockQueue.Wait()
+
+This ensures that informer callbacks which are listening on vmSource
+enqueued three times an object. Since enqueing is typically the last
+action in listener callbacks, we can assume that the wanted scenario for
+a controller is set up, and an execution will process this scenario.
+*/
+type MockWorkQueue struct {
+	workqueue.RateLimitingInterface
+	addWG *sync.WaitGroup
+}
+
+func (q *MockWorkQueue) Add(obj interface{}) {
+	q.RateLimitingInterface.Add(obj)
+	if q.addWG != nil {
+		q.addWG.Done()
+	}
+}
+
+// ExpectAdds allows setting the amount of expected enqueues.
+func (q *MockWorkQueue) ExpectAdds(diff int) {
+	q.addWG = &sync.WaitGroup{}
+	q.addWG.Add(diff)
+}
+
+// Wait waits until the expected amount of ExpectedAdds has happened.
+// It will not block if there were no expectations set.
+func (q *MockWorkQueue) Wait() {
+	if q.addWG != nil {
+		q.addWG.Wait()
+		q.addWG = nil
+	}
+}
+
+func NewMockWorkQueue(queue workqueue.RateLimitingInterface) *MockWorkQueue {
+	return &MockWorkQueue{queue, nil}
+}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
@@ -63,7 +64,7 @@ type VMController struct {
 }
 
 func (c *VMController) Run(threadiness int, stopCh chan struct{}) {
-	defer kubecli.HandlePanic()
+	defer controller.HandlePanic()
 	defer c.queue.ShutDown()
 	logging.DefaultLogger().Info().Msg("Starting controller.")
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -271,7 +271,7 @@ func vmLabelHandler(vmQueue workqueue.RateLimitingInterface) func(obj interface{
 		_, hasMigrationLabel := obj.(*k8sv1.Pod).ObjectMeta.Labels[kubev1.MigrationLabel]
 
 		if phase != k8sv1.PodRunning {
-			// Filter out non running pods from queue
+			// Filter out non running pods from Queue
 			return
 		} else if hasMigrationLabel {
 			// Filter out migration target pods

--- a/pkg/virt-handler/domain.go
+++ b/pkg/virt-handler/domain.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
-	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
@@ -38,14 +38,14 @@ TODO: Define the exact scope of this controller.
 For now it looks like we should use domain events to detect unexpected domain changes like crashes or vms going
 into pause mode because of resource shortage or cut off connections to storage.
 */
-func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedInformer, restClient rest.RESTClient, recorder record.EventRecorder) (cache.Store, *kubecli.Controller) {
+func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedInformer, restClient rest.RESTClient, recorder record.EventRecorder) (cache.Store, *controller.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
-	informer.AddEventHandler(kubecli.NewResourceEventHandlerFuncsForWorkqueue(queue))
+	informer.AddEventHandler(controller.NewResourceEventHandlerFuncsForWorkqueue(queue))
 	dispatch := NewDomainDispatch(vmQueue, vmStore, restClient, recorder)
-	return kubecli.NewControllerFromInformer(informer.GetStore(), informer, queue, dispatch)
+	return controller.NewControllerFromInformer(informer.GetStore(), informer, queue, dispatch)
 }
 
-func NewDomainDispatch(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, restClient rest.RESTClient, recorder record.EventRecorder) kubecli.ControllerDispatch {
+func NewDomainDispatch(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, restClient rest.RESTClient, recorder record.EventRecorder) controller.ControllerDispatch {
 	return &DomainDispatch{
 		vmQueue:    vmQueue,
 		vmStore:    vmStore,

--- a/pkg/virt-handler/domain_test.go
+++ b/pkg/virt-handler/domain_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
-	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
@@ -41,7 +41,7 @@ var _ = Describe("Domain", func() {
 	var vmQueue workqueue.RateLimitingInterface
 	var domainStore cache.Store
 	var domainQueue workqueue.RateLimitingInterface
-	var dispatch kubecli.ControllerDispatch
+	var dispatch controller.ControllerDispatch
 	var restClient rest.RESTClient
 
 	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
@@ -68,7 +68,7 @@ var _ = Describe("Domain", func() {
 			key, _ := cache.MetaNamespaceKeyFunc(dom)
 			domainStore.Add(dom)
 			domainQueue.Add(key)
-			kubecli.Dequeue(domainStore, domainQueue, dispatch)
+			controller.Dequeue(domainStore, domainQueue, dispatch)
 
 			Expect(vmQueue.Len()).To(Equal(1))
 		})
@@ -82,7 +82,7 @@ var _ = Describe("Domain", func() {
 			domainStore.Add(domain)
 			key, _ := cache.MetaNamespaceKeyFunc(domain)
 			domainQueue.Add(key)
-			kubecli.Dequeue(domainStore, domainQueue, dispatch)
+			controller.Dequeue(domainStore, domainQueue, dispatch)
 			Expect(vmQueue.Len()).To(Equal(1))
 		})
 		It("should not inform vm controller if a correspnding VM is in the cache", func() {
@@ -98,7 +98,7 @@ var _ = Describe("Domain", func() {
 		It("should error out if the key is unparsable", func() {
 			key := "a/b/c/d"
 			domainQueue.Add(key)
-			kubecli.Dequeue(domainStore, domainQueue, dispatch)
+			controller.Dequeue(domainStore, domainQueue, dispatch)
 			Expect(domainQueue.NumRequeues(key)).To(Equal(1))
 			Expect(vmQueue.Len()).To(Equal(0))
 		})
@@ -108,7 +108,7 @@ var _ = Describe("Domain", func() {
 			domain := api.NewMinimalDomain("testvm")
 			key, _ := cache.MetaNamespaceKeyFunc(domain)
 			domainQueue.Add(key)
-			kubecli.Dequeue(domainStore, domainQueue, dispatch)
+			controller.Dequeue(domainStore, domainQueue, dispatch)
 			Expect(domainQueue.NumRequeues(key)).To(Equal(0))
 		})
 

--- a/pkg/virt-handler/virtwrap/isolation/isolation_test.go
+++ b/pkg/virt-handler/virtwrap/isolation/isolation_test.go
@@ -10,9 +10,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/logging"
 )
 
 var _ = Describe("Isolation", func() {
+
+	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
 
 	Context("With an existing socket", func() {
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	configdisk "kubevirt.io/kubevirt/pkg/config-disk"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
@@ -52,12 +53,12 @@ func NewVMController(lw cache.ListerWatcher,
 	restClient rest.RESTClient,
 	clientset kubecli.KubevirtClient,
 	host string,
-	configDiskClient configdisk.ConfigDiskClient) (cache.Store, workqueue.RateLimitingInterface, *kubecli.Controller) {
+	configDiskClient configdisk.ConfigDiskClient) (cache.Store, workqueue.RateLimitingInterface, *controller.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
 	dispatch := NewVMHandlerDispatch(domainManager, recorder, &restClient, clientset, host, configDiskClient)
 
-	indexer, informer := kubecli.NewController(lw, queue, &v1.VirtualMachine{}, dispatch)
+	indexer, informer := controller.NewController(lw, queue, &v1.VirtualMachine{}, dispatch)
 	return indexer, queue, informer
 
 }
@@ -66,7 +67,7 @@ func NewVMHandlerDispatch(domainManager virtwrap.DomainManager,
 	restClient *rest.RESTClient,
 	clientset kubecli.KubevirtClient,
 	host string,
-	configDiskClient configdisk.ConfigDiskClient) kubecli.ControllerDispatch {
+	configDiskClient configdisk.ConfigDiskClient) controller.ControllerDispatch {
 	return &VMHandlerDispatch{
 		domainManager: domainManager,
 		recorder:      recorder,

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -42,6 +42,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	configdisk "kubevirt.io/kubevirt/pkg/config-disk"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap"
@@ -54,7 +55,7 @@ var _ = Describe("VM", func() {
 	var domainManager *virtwrap.MockDomainManager
 
 	var ctrl *gomock.Controller
-	var dispatch kubecli.ControllerDispatch
+	var dispatch controller.ControllerDispatch
 
 	var recorder record.EventRecorder
 
@@ -113,7 +114,7 @@ var _ = Describe("VM", func() {
 		It("should re-enqueue if the Key is unparseable", func() {
 			Expect(vmQueue.Len()).Should(Equal(0))
 			vmQueue.Add("a/b/c/d/e")
-			kubecli.Dequeue(vmStore, vmQueue, dispatch)
+			controller.Dequeue(vmStore, vmQueue, dispatch)
 			Expect(vmQueue.NumRequeues("a/b/c/d/e")).To(Equal(1))
 		})
 
@@ -123,7 +124,7 @@ var _ = Describe("VM", func() {
 			vmStore.Add(vm)
 
 			vmQueue.Add("default/testvm")
-			kubecli.Dequeue(vmStore, vmQueue, dispatch)
+			controller.Dequeue(vmStore, vmQueue, dispatch)
 			// expect no mock interactions
 			Expect(vmQueue.NumRequeues("default/testvm")).To(Equal(0))
 		},

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -51,7 +51,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 
 		table.DescribeTable("should scale", func(startScale int, stopScale int) {
 
-			template := tests.NewRandomVM()
+			template := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
 			newRS := tests.NewRandomReplicaSetFromVM(template, int32(0))
 			newRS, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Create(newRS)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"flag"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("VirtualMachineReplicaSet", func() {
+
+	flag.Parse()
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	tests.PanicOnError(err)
+
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+	})
+
+	Context("A valid VirtualMachineReplicaSet given", func() {
+
+		It("should scale up to three replicas", func() {
+
+			template := tests.NewRandomVM()
+			rs := tests.NewRandomReplicaSetFromVM(template, 3)
+			rs, err := virtClient.ReplicaSet(tests.NamespaceTestDefault).Create(rs)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() int32 {
+				res, err := virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return res.Status.Replicas
+			}, 10, 1).Should(Equal(3))
+
+			vms, err := virtClient.VM(tests.NamespaceTestDefault).List(v12.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(3))
+		})
+	})
+
+})

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -31,8 +31,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
-	"time"
-
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
@@ -73,7 +71,6 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 					break
 				}
 
-				//resourceVersion := rs.ObjectMeta.ResourceVersion
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() int32 {
@@ -85,14 +82,6 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 				vms, err := virtClient.VM(tests.NamespaceTestDefault).List(v12.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vms.Items).To(HaveLen(int(scale)))
-
-				/*
-					for _, vm := range vms.Items {
-						tests.NewObjectEventWatcher(&vm).SinceResourceVersion(resourceVersion).Timeout(20 * time.Second).WaitFor(tests.NormalEvent, watch.SuccessfulCreateVirtualMachineReason)
-						tests.NewObjectEventWatcher(&vm).SinceResourceVersion(resourceVersion).Timeout(20 * time.Second).WaitFor(tests.NormalEvent, watch.SuccessfulDeleteVirtualMachineReason)
-					}
-				*/
-				time.Sleep(20)
 			}
 
 			doScale(newRS.ObjectMeta.Name, int32(startScale))
@@ -100,7 +89,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 			doScale(newRS.ObjectMeta.Name, int32(0))
 
 		},
-			table.FEntry("to three, to two and then to zero replicas", 3, 2),
+			table.Entry("to three, to two and then to zero replicas", 3, 2),
 			table.Entry("to four, to six and then to zero replicas", 5, 6),
 		)
 	})

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -31,6 +31,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	"time"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
@@ -49,41 +51,44 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 
 	Context("A valid VirtualMachineReplicaSet given", func() {
 
-		table.DescribeTable("should scale", func(startScale int, stopScale int) {
+		doScale := func(name string, scale int32) {
 
+			// Status updates can conflict with our desire to change the spec
+			var rs *v1.VirtualMachineReplicaSet
+			for {
+				rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				rs.Spec.Replicas = &scale
+				rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Update(rs)
+				if errors.IsConflict(err) {
+					continue
+				}
+				break
+			}
+
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() int32 {
+				rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return rs.Status.Replicas
+			}, 10, 1).Should(Equal(int32(scale)))
+
+			vms, err := virtClient.VM(tests.NamespaceTestDefault).List(v12.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vms.Items).To(HaveLen(int(scale)))
+		}
+
+		newReplicaSet := func() *v1.VirtualMachineReplicaSet {
 			template := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
 			newRS := tests.NewRandomReplicaSetFromVM(template, int32(0))
 			newRS, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Create(newRS)
 			Expect(err).ToNot(HaveOccurred())
+			return newRS
+		}
 
-			doScale := func(name string, scale int32) {
-
-				// Status updates can conflict with our desire to change the spec
-				var rs *v1.VirtualMachineReplicaSet
-				for {
-					rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(name, v12.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					rs.Spec.Replicas = &scale
-					rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Update(rs)
-					if errors.IsConflict(err) {
-						continue
-					}
-					break
-				}
-
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(func() int32 {
-					rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(name, v12.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return rs.Status.Replicas
-				}, 10, 1).Should(Equal(int32(scale)))
-
-				vms, err := virtClient.VM(tests.NamespaceTestDefault).List(v12.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vms.Items).To(HaveLen(int(scale)))
-			}
-
+		table.DescribeTable("should scale", func(startScale int, stopScale int) {
+			newRS := newReplicaSet()
 			doScale(newRS.ObjectMeta.Name, int32(startScale))
 			doScale(newRS.ObjectMeta.Name, int32(stopScale))
 			doScale(newRS.ObjectMeta.Name, int32(0))
@@ -92,5 +97,15 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 			table.Entry("to three, to two and then to zero replicas", 3, 2),
 			table.Entry("to four, to six and then to zero replicas", 5, 6),
 		)
+
+		It("should update readyReplicas once VMs are up", func() {
+			newRS := newReplicaSet()
+			doScale(newRS.ObjectMeta.Name, 2)
+			Eventually(func() int {
+				rs, err := virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return int(rs.Status.ReadyReplicas)
+			}, 60*time.Second, 1*time.Second).Should(Equal(2))
+		})
 	})
 })

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -55,7 +55,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 				res, err := virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(rs.ObjectMeta.Name, v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return res.Status.Replicas
-			}, 10, 1).Should(Equal(3))
+			}, 10, 1).Should(Equal(int32(3)))
 
 			vms, err := virtClient.VM(tests.NamespaceTestDefault).List(v12.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -31,6 +31,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	"time"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
@@ -70,6 +72,8 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 					}
 					break
 				}
+
+				//resourceVersion := rs.ObjectMeta.ResourceVersion
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() int32 {
@@ -81,6 +85,14 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 				vms, err := virtClient.VM(tests.NamespaceTestDefault).List(v12.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vms.Items).To(HaveLen(int(scale)))
+
+				/*
+					for _, vm := range vms.Items {
+						tests.NewObjectEventWatcher(&vm).SinceResourceVersion(resourceVersion).Timeout(20 * time.Second).WaitFor(tests.NormalEvent, watch.SuccessfulCreateVirtualMachineReason)
+						tests.NewObjectEventWatcher(&vm).SinceResourceVersion(resourceVersion).Timeout(20 * time.Second).WaitFor(tests.NormalEvent, watch.SuccessfulDeleteVirtualMachineReason)
+					}
+				*/
+				time.Sleep(20)
 			}
 
 			doScale(newRS.ObjectMeta.Name, int32(startScale))
@@ -88,7 +100,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 			doScale(newRS.ObjectMeta.Name, int32(0))
 
 		},
-			table.Entry("to three, to two and then to zero replicas", 3, 2),
+			table.FEntry("to three, to two and then to zero replicas", 3, 2),
 			table.Entry("to four, to six and then to zero replicas", 5, 6),
 		)
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -393,6 +393,9 @@ func cleanNamespaces() {
 			continue
 		}
 
+		// Remove all VirtualMachineReplicaSets
+		PanicOnError(virtCli.RestClient().Delete().Namespace(namespace).Resource("virtualmachinereplicasets").Do().Error())
+
 		// Remove all Migrations
 		PanicOnError(virtCli.RestClient().Delete().Namespace(namespace).Resource("migrations").Do().Error())
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -732,13 +732,19 @@ func newString(x string) *string {
 func NewRandomReplicaSetFromVM(vm *v1.VM, replicas int32) *v1.VirtualMachineReplicaSet {
 	name := "replicaset" + rand.String(5)
 	rs := &v1.VirtualMachineReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(5), ResourceVersion: "1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(5)},
 		Spec: v1.VMReplicaSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"name": name},
 			},
-			Template: &v1.VMTemplateSpec{Spec: vm.Spec},
+			Template: &v1.VMTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"name": name},
+					Name:   vm.ObjectMeta.Name,
+				},
+				Spec: vm.Spec,
+			},
 		},
 	}
 	return rs

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -728,3 +728,18 @@ func newUInt(x uint) *uint {
 func newString(x string) *string {
 	return &x
 }
+
+func NewRandomReplicaSetFromVM(vm *v1.VM, replicas int32) *v1.VirtualMachineReplicaSet {
+	name := "replicaset" + rand.String(5)
+	rs := &v1.VirtualMachineReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(5), ResourceVersion: "1"},
+		Spec: v1.VMReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"name": name},
+			},
+			Template: &v1.VMTemplateSpec{Spec: vm.Spec},
+		},
+	}
+	return rs
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -732,7 +732,7 @@ func newString(x string) *string {
 	return &x
 }
 
-func NewRandomReplicaSetFromVM(vm *v1.VM, replicas int32) *v1.VirtualMachineReplicaSet {
+func NewRandomReplicaSetFromVM(vm *v1.VirtualMachine, replicas int32) *v1.VirtualMachineReplicaSet {
 	name := "replicaset" + rand.String(5)
 	rs := &v1.VirtualMachineReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(5)},


### PR DESCRIPTION
Initial simple implementation of a VirtualMachineReplicaSet.

Usage:

```yaml
apiVersion: kubevirt.io/v1alpha1
kind: VirtualMachineReplicaSet
metadata:
  name: myrs
spec:
  replicas: 3
  selector:
    matchLabels:
      myselector: myselector
  template:
    metadata:
      name: test
      labels:
        myselector: myselector
    spec:
      domain:
        devices:
          consoles:
          - type: pty
        memory:
          unit: MB
          value: 64
        os:
          type:
            os: hvm
        type: qemu
```

TODO:

- [x] proposal
- [x] logging
- [x] events
- [ ] graceful delete
 