### PR TITLE
Fix registry disk cirros demo and add new functional tests

### DIFF
--- a/cluster/vm-ephemeral.yaml
+++ b/cluster/vm-ephemeral.yaml
@@ -5,6 +5,8 @@ kind: VirtualMachine
 spec:
   domain:
     devices:
+      graphics:
+      - type: spice
       disks:
       - type: ContainerRegistryDisk:v1alpha
         source:
@@ -15,6 +17,10 @@ spec:
       - source:
           network: default
         type: network
+      video:
+      - type: qxl
+      consoles:
+      - type: pty
     memory:
       unit: MB
       value: 64

--- a/images/cirros-registry-disk-demo/Dockerfile
+++ b/images/cirros-registry-disk-demo/Dockerfile
@@ -21,4 +21,4 @@ FROM kubevirt/registry-disk-v1alpha
 MAINTAINER "David Vossel" \<dvossel@redhat.com\>
 
 # Add cirros
-RUN curl https://github.com/sshnaidm/cirros-mirror/raw/master/cirros-0.3.5-x86_64-disk.img > /disk/cirros.img
+RUN curl http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img > /disk/cirros.img

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -101,6 +101,17 @@ var _ = Describe("CloudInit UserData", func() {
 			close(done)
 		}, 60)
 
+		It("should launch ephemeral vm with cloud-init data source NoCloud", func(done Done) {
+			magicStr := "printed from cloud-init userdata"
+			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)
+
+			vm, err := tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", "noCloud", userData)
+			Expect(err).ToNot(HaveOccurred())
+			obj := LaunchVM(vm)
+			VerifyUserDataVM(vm, obj, magicStr)
+			close(done)
+		}, 60)
+
 		It("should launch VMs with user-data in k8s secret", func(done Done) {
 			magicStr := "printed from cloud-init userdata"
 			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -82,7 +82,7 @@ var _ = Describe("CloudInit UserData", func() {
 				Expect(err).ToNot(HaveOccurred())
 				next = next + string(data)
 			}
-		}, 45*time.Second).Should(ContainSubstring(magicStr))
+		}, 60*time.Second).Should(ContainSubstring(magicStr))
 	}
 
 	BeforeEach(func() {
@@ -99,7 +99,7 @@ var _ = Describe("CloudInit UserData", func() {
 			obj := LaunchVM(vm)
 			VerifyUserDataVM(vm, obj, magicStr)
 			close(done)
-		}, 60)
+		}, 90)
 
 		It("should launch ephemeral vm with cloud-init data source NoCloud", func(done Done) {
 			magicStr := "printed from cloud-init userdata"
@@ -110,7 +110,7 @@ var _ = Describe("CloudInit UserData", func() {
 			obj := LaunchVM(vm)
 			VerifyUserDataVM(vm, obj, magicStr)
 			close(done)
-		}, 60)
+		}, 90)
 
 		It("should launch VMs with user-data in k8s secret", func(done Done) {
 			magicStr := "printed from cloud-init userdata"
@@ -148,6 +148,6 @@ var _ = Describe("CloudInit UserData", func() {
 			VerifyUserDataVM(vm, obj, magicStr)
 
 			close(done)
-		}, 60)
+		}, 90)
 	})
 })


### PR DESCRIPTION
Fixes #444 It turns out the registry disk feature was not broken. Instead, the registry disk image used to demo the feature was.

This patch fixes the container image so it properly downloads the cirros image, and it adds new regression tests that verify ephemeral registry disk initialize properly. 