### PR TITLE
Ephemeral Registry Disk Rewrite

### DIFF
--- a/cluster/vm-atomic.yaml
+++ b/cluster/vm-atomic.yaml
@@ -6,7 +6,7 @@ spec:
   domain:
     devices:
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         source:
           name: kubevirt/fedora-atomic-registry-disk-demo:devel
         target:

--- a/cluster/vm-ephemeral.yaml
+++ b/cluster/vm-ephemeral.yaml
@@ -8,7 +8,7 @@ spec:
       graphics:
       - type: spice
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         source:
           name: kubevirt/cirros-registry-disk-demo:devel
         target:

--- a/cluster/vm-nocloud.yaml
+++ b/cluster/vm-nocloud.yaml
@@ -6,7 +6,7 @@ spec:
   domain:
     devices:
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         source:
           name: kubevirt/cirros-registry-disk-demo:devel
         target:

--- a/cmd/registry-disk-v1alpha/Dockerfile
+++ b/cmd/registry-disk-v1alpha/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER "David Vossel" \<dvossel@redhat.com\>
 ENV container docker
 
 RUN apt-get update && apt-get install -y \
-	tgt bash curl bzip2 qemu-utils && \
+	bash curl bzip2 qemu-utils && \
 	mkdir -p /disk && \
 	rm -rf /var/lib/apt/lists/*
 

--- a/cmd/registry-disk-v1alpha/README.md
+++ b/cmd/registry-disk-v1alpha/README.md
@@ -4,9 +4,9 @@ The KubeVirt Registry Disk Base Container allows users to store VM disks in
 a container registry and attach those disk to VMs automatically using the
 KubeVirt runtime.
 
-This Base Container is compatible with disk type ContainerRegistryDisk:v1alpha
+This Base Container is compatible with disk type RegistryDisk:v1alpha
 
-# ContainerRegistryDisk:v1alpha
+# RegistryDisk:v1alpha
 ## Storing Disks in Container Registry
 
 VM disks can be stored in either qcow2 format or raw format by copying the vm
@@ -28,7 +28,7 @@ docker push vmdisks/fedora25:latest
 ## Assigning Ephemeral Disks to VMs
 
 Assign an ephemeral disk backed by an image in the container registry by
-adding a ContainerRegistryDisk:v1alpha disk to the VM definition and supplying
+adding a RegistryDisk:v1alpha disk to the VM definition and supplying
 the container image as the disk's source name.
 
 Example: Create a KubeVirt VM definition with container backed ephemeral disk.
@@ -43,7 +43,7 @@ spec:
   domain:
     devices:
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         source:
           name: vmdisks/fedora25:devel
         target:

--- a/cmd/registry-disk-v1alpha/entry-point.sh
+++ b/cmd/registry-disk-v1alpha/entry-point.sh
@@ -19,67 +19,40 @@
 
 # https://fedoraproject.org/wiki/Scsi-target-utils_Quickstart_Guide
 
-PORT=${PORT:-3260}
-WWN=${WWN:-iqn.2017-01.io.kubevirt:wrapper}
-LUNID=1
-IMAGE_NAME=$(ls -1 /disk/ | tail -n 1)
-IMAGE_PATH=/disk/$IMAGE_NAME
-
-if [ -n "$PASSWORD_BASE64" ]; then
-	PASSWORD=$(echo $PASSWORD_BASE64 | base64 -d)
-fi
-if [ -n "$USERNAME_BASE64" ]; then
-	USERNAME=$(echo $USERNAME_BASE64 | base64 -d)
-fi
-
-# If PASSWORD is provided, enable authentication features
-authenticate=0
-if [ -n "$PASSWORD" ]; then
-	authenticate=1
-fi
-
-if [ -z "$IMAGE_NAME" ] || ! [ -f "$IMAGE_PATH" ]; then
-	echo "vm image not found in /disk directory"
+if [ -z "$COPY_PATH" ]; then
+	echo "COPY_PATH variable not set"
 	exit 1
 fi
 
-echo $IMAGE_NAME | grep -q "\.raw$"
+IMAGE_NAME=$(ls -1 /disk/ | tail -n 1)
+if [ -z "$IMAGE_NAME" ]; then
+	echo "no images found in /disk directory"
+	exit 1
+fi
+
+IMAGE_PATH=/disk/$IMAGE_NAME
+IMAGE_EXTENSION=$(echo $IMAGE_NAME | sed  -n -e 's/^.*\.\(.*\)$/\1/p')
+
+echo $IMAGE_NAME | grep -q -e "raw" -e "qcow2"
 if [ $? -ne 0 ]; then
-	/usr/bin/qemu-img convert $IMAGE_PATH /disk/image.raw
+	IMAGE_EXTENSION="raw"
+	/usr/bin/qemu-img convert $IMAGE_PATH ${COPY_PATH}.${IMAGE_EXTENSION}
 	if [ $? -ne 0 ]; then
 		echo "Failed to convert image $IMAGE_PATH to .raw file"
 		exit 1
 	fi
-	IMAGE_PATH=/disk/image.raw
+else 
+	cp $IMAGE_PATH ${COPY_PATH}.${IMAGE_EXTENSION}
+	if [ $? -ne 0 ]; then
+		echo "Failed to copy $IMAGE_PATH to $COPY_PATH.${IMAGE_EXTENSION}"
+		exit 1
+	fi
 fi
+echo "copied $IMAGE_PATH to $COPY_PATH.${IMAGE_EXTENSION}"
 
-# USING 'set -e' error detection for everything below this point.
-set -e
+trap "rm -f ${COPY_PATH}.${IMAGE_EXTENSION}" TERM INT HUP QUIT EXIT ERR
 
-echo "Starting tgtd at port $PORT"
-tgtd -f --iscsi portal="0.0.0.0:${PORT}" &
-sleep 5
-
-echo "Adding target and exposing it"
-tgtadm --lld iscsi --mode target --op new --tid=1 --targetname $WWN
-tgtadm --lld iscsi --mode target --op bind --tid=1 -I ALL
-
-if [ $authenticate -eq 1 ]; then
-	echo "Adding authentication for user $USERNAME"
-	tgtadm --lld iscsi --op new --mode account --user $USERNAME --password $PASSWORD
-	tgtadm --lld iscsi --op bind --mode account --tid=1 --user $USERNAME
-fi
-
-echo "Adding volume file as LUN"
-tgtadm --lld iscsi --mode logicalunit --op new --tid=1 --lun=$LUNID -b $IMAGE_PATH
-tgtadm --lld iscsi --mode logicalunit --op update --tid=1 --lun=$LUNID --params thin_provisioning=1
-
-echo "Start monitoring"
 touch /tmp/healthy
-touch previous_state
-while true ; do
-	tgtadm --lld iscsi --mode target --op show > current_state
-	diff -q previous_state current_state || ( date ; cat current_state ; )
-	mv -f current_state previous_state
+while [ -f "${COPY_PATH}.${IMAGE_EXTENSION}" ]; do
 	sleep 5
 done

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -43,6 +43,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
+	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/virt-handler"
 	"kubevirt.io/kubevirt/pkg/virt-handler/rest"
@@ -54,14 +55,14 @@ import (
 )
 
 type virtHandlerApp struct {
-	Service      *service.Service
-	HostOverride string
-	LibvirtUri   string
-	SocketDir    string
-	CloudInitDir string
+	Service          *service.Service
+	HostOverride     string
+	LibvirtUri       string
+	SocketDir        string
+	EphemeralDiskDir string
 }
 
-func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri *string, socketDir *string, cloudInitDir *string) *virtHandlerApp {
+func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri *string, socketDir *string, ephemeralDiskDir *string) *virtHandlerApp {
 	if *hostOverride == "" {
 		defaultHostName, err := os.Hostname()
 		if err != nil {
@@ -71,11 +72,11 @@ func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri
 	}
 
 	return &virtHandlerApp{
-		Service:      service.NewService("virt-handler", host, port),
-		HostOverride: *hostOverride,
-		LibvirtUri:   *libvirtUri,
-		SocketDir:    *socketDir,
-		CloudInitDir: *cloudInitDir,
+		Service:          service.NewService("virt-handler", host, port),
+		HostOverride:     *hostOverride,
+		LibvirtUri:       *libvirtUri,
+		SocketDir:        *socketDir,
+		EphemeralDiskDir: *ephemeralDiskDir,
 	}
 }
 
@@ -83,7 +84,11 @@ func (app *virtHandlerApp) Run() {
 	log := logging.DefaultLogger()
 	log.Info().V(1).Log("hostname", app.HostOverride)
 
-	err := cloudinit.SetLocalDirectory(app.CloudInitDir)
+	err := cloudinit.SetLocalDirectory(app.EphemeralDiskDir + "/cloud-init-data")
+	if err != nil {
+		panic(err)
+	}
+	err = registrydisk.SetLocalDirectory(app.EphemeralDiskDir + "/registry-disk-data")
 	if err != nil {
 		panic(err)
 	}
@@ -189,10 +194,10 @@ func main() {
 	port := flag.Int("port", 8185, "Port to listen on")
 	hostOverride := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
 	socketDir := flag.String("socket-dir", "/var/run/kubevirt", "Directory where to look for sockets for cgroup detection")
-	cloudInitDir := flag.String("cloud-init-dir", "/var/run/libvirt/cloud-init-dir", "Base directory for ephemeral cloud init data")
+	ephemeralDiskDir := flag.String("ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk", "Base directory for ephemeral disk data")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	app := newVirtHandlerApp(host, port, hostOverride, libvirtUri, socketDir, cloudInitDir)
+	app := newVirtHandlerApp(host, port, hostOverride, libvirtUri, socketDir, ephemeralDiskDir)
 	app.Run()
 }

--- a/docs/cloud-init.md
+++ b/docs/cloud-init.md
@@ -42,7 +42,7 @@ spec:
   domain:
     devices:
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         source:
           name: kubevirt/cirros-registry-disk-demo:devel
         target:
@@ -100,7 +100,7 @@ spec:
   domain:
     devices:
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         source:
           name: kubevirt/cirros-registry-disk-demo:devel
         target:

--- a/docs/container-register-disks.md
+++ b/docs/container-register-disks.md
@@ -41,49 +41,14 @@ Users want to attach a non-bootable disk to a VM preloaded with data. This data
 could consist of anything. It could be configuration data, rpms, or anything
 else a user might want to distribute with their VMs.
 
-## Future Use Cases
-For the sake of simplicity, this proposal is focusing on the details involved
-with use cases where Immutable VMs are launched using ephemeral storage that is
-not persistent between VM restarts.
-
-Container Registry backed disks can be extended work with stateful block
-storage. This persistent block storage functionality will be built upon the
-foundation laid by this initial proposal.
-
-High level notes related to how container registry disks integrate with
-persistent block storage is provided at the end of this document.
-
 ## Implementation 
-
-### Concepts
-
-When a container starts, the container's image is pulled from a remote
-container registry. Each container image consists of multiple layers and only
-the layers that are not already present locally are retrieved from the remote
-registry. 
-
-When a container is being initialized, a union mount filesystem is used to
-combine all the container image's layers together to form the container's
-directory tree. When processes in a container modify contents on the filesystem,
-the processes are not modifying the layers provided by the container image, they
-are modifying a layer of the union filesystem that is tracking the delta between
-the active container and the underlying layers provided by the container image.
-
-The delta between the container image and an active container is ephemeral and
-is automatically freed when container is destroyed. Depending on the union
-mount filesystem implementation used, the delta may be tracked at the block
-level or the file level. When tracked at the file level, the first time a file
-is written to causes the entire file to be copied into the delta layer.
-
-These are the concepts we're building upon to provide an ephemeral disk to a VM
-backed backed by a container image.
 
 ### High Level Design
 
 **Standardised KubeVirt VM disk Wrapper**
 
 KubeVirt provides a standardized base wrapper container image that serves up a
-user provided VM disk as a network disk consumable by Libvirt. This base
+user provided VM disk as a local file consumable by Libvirt. This base
 container image does not have a VM disk inside of it, it merely contains
 everything necessary for serving up a VM disk in a way Libvirt can consume.
 
@@ -103,8 +68,6 @@ END
 docker build -t vmdisks/fedora25:latest .
 docker push vmdisks/fedora25:latest
 ```
-*NOTE: there's more info on how qcow2 is served as a block device later*
-
 Users start a VM using a "container registry backed VM disk" by referencing the
 image name they pushed to the registry. Any number of VMs can be started
 anywhere in the cluster referencing the same image.
@@ -129,119 +92,16 @@ When virt-controller sees a VM object with a disk type of
 **ContainerRegistryDisk:v1alpha**, virt-controller places the image wrapper container
 in the virt-launcher pod along with the container that monitors the VM process.
 
-When the virt-launcher pod starts, the wrapper container serves up the user's VM
-image as an network block device Libvirt can consume. The logic that serves up
-the vm image as a block device is what we provide in the standardized KubeVirt
-base wrapper container.
+When the virt-launcher pod starts, the wrapper container copies the user's VM
+image as file on a shared host directory.
 
 When virt-handler sees a VM is placed on the local node with the
 **ContainerRegistryDisk:v1alpha** disk type defined, virt-handler injects the
-necessary configuration into the domain xml file required to connect to the
-block device served up by the wrapper container.
+necessary configuration into the domain xml required to add the disk backed by
+a local file.
 
 The **v1** part of the ContainerRegistryDisk disk type represents the standard
 used during the virt-handler disk conversion process. As we gain more
 experience with this feature, we may want to adopt a new standard for how VM
 images are wrapped by a container while maintaining backwards compatibility. 
 
-**Bringing it all together**
-* KubeVirt provides a base container that serves up VM disks as a network
-  block device libvirt can consume
-* Users push their VM disks into the container registry using the base image
-* Users reference VM disks backed by the container registry with the
-  **ContainerRegistryDisk:v1alpha** disk type.
-* The virt-launcher pod has an instance of the wrapper container which serves
-  up the VM disk as an ephemeral block device.
-* virt-handler sees the ContainerRegistryDisk:v1alpha disk type and automatically
-  injects disk configuration into the domain xml that gives the VM access to the
-  block device served up by the wrapper container.
-* Anything the VM writes to disk is destroyed when when the VM is torn down as a
-  result of the virt-launcher pod (which has the wrapper container) being
-  destroyed.
-
-### v1 Base Container Design
-
-**iscsi Base Container**
-
-The **v1** base container will serve up a VM disk as a block device using
-iscsi. Conceptually, this base container will do the equivalent of what the
-images/iscsi-demo-target-tgtd does today. The big difference here is no actual
-VM disk will be present in the base container, only the dependencies and
-entry point script required to serve up a user provided image.
-
-**Recommended qcow2 Usage**
-
-Although we don't have to enforce this, It is recommended that users upload
-their images in qcow2 format.
-
-This is important for two reasons.
-1. VMs with large disks can be stored in the container registry while only
-   consuming the minimal amount of network storage.
-2. The most common union mount filesystems do not act on block storage, but
-   instead copy up on file writes. To avoid the copy up performance penalty,
-   the wrapper container will have its own unique copy of the VM disk. Using
-   qcow2 will reduce the local disk space required. The container image will
-   only need the qcow2 file, while the actual running wrapper container will
-   expand that image to raw format.
-
-Example of the logic the wrapper container will use to expand a qcow2 image to
-a raw image that can be served as a block device. The qcow2 image could be 1gb
-which could expand to a 100gb ephemeral raw file.
-```
-qemu-img convert image.qcow2 image.raw
-```
-
-**Authentication**
-
-The KubeVirt runtime will handle automatically generating credentials required
-for iscsi CHAP authentication. The credentials will be passed to the image
-wrapper container via environment variables.  Virt-handler will coordinate
-injecting these credentials into libvirt allowing the VM access to the container
-backed disk.
-
-# The Future: Persistent Disks, Live Migrations and Flying Cars.
-This proposal is meant to provide a starting point for introducing the concept
-of storing and accessing VM disks in a container registry. To reduce complexity
-the scope has been reduced to ephemeral disks for the initial work.
-
-However, this concept can be extended to provide persistent disks and support
-live migrations by using PersistentVolumeClaims in conjunction with the VM Image
-wrapper container.
-
-**Persistent Disks**
-
-Persistent disks can be supported by backing the VM disk wrapper container with
-a generic PrsistentVolumeClaim.  When the VM disk wrapper container starts up
-to provide a VM disk to a new VM for the very first time, the image in the
-container is written over to a PersistentVolumeClaim
-
-Example: Expand a 1g qcow2 image in a wrapper container into a 100gb .raw image
-on a persistent volume
-```
-qemu-img convert image.qcow2 /path/to/persistent/volume/mount/image.raw
-```
-
-From then on, where ever the VM is launched the wrapper container serves up the
-persistent volume claim as the block device. 
-
-**Live Migrations**
-
-To take this a step further and support live migrations, we can decouple the
-wrapper container from the virt-launcher pod and place the wrapper container
-anywhere in the cluster. This will let multiple VMs reference the wrapper
-container's block device during a migration at the same time and not tie the
-life-cycle of the wrapper container to a specific VM.
-
-# Why are we doing this again?
-
-This proposal is a missing piece in merging VMs and containers into the same
-user workflow. We are already working out the details required to connect both
-pods and VMs into the same overlay network. With this proposal we'll be able to
-converge pods and VMs into the same image repository.
-
-Soon both the storage and network story will be the same for pods and VMs.
-
-This proposal also aligns our usage of PersistentVolumeClaims with how they are
-intended to be used. PersistentVolumeClaims are meant to be claimed by a pod.
-By assigning PVC to a wrapper container's POD, we are using a supported
-kubernetes use case.

--- a/docs/container-register-disks.md
+++ b/docs/container-register-disks.md
@@ -79,7 +79,7 @@ spec:
   domain:
     devices:
       disks:
-      - type: ContainerRegistryDisk:v1alpha
+      - type: RegistryDisk:v1alpha
         - source:
           name: vmdisks/fedora25:latest
         - target:
@@ -89,18 +89,18 @@ spec:
 **KubeVirt Runtime Implementation**
 
 When virt-controller sees a VM object with a disk type of
-**ContainerRegistryDisk:v1alpha**, virt-controller places the image wrapper container
+**RegistryDisk:v1alpha**, virt-controller places the image wrapper container
 in the virt-launcher pod along with the container that monitors the VM process.
 
 When the virt-launcher pod starts, the wrapper container copies the user's VM
 image as file on a shared host directory.
 
 When virt-handler sees a VM is placed on the local node with the
-**ContainerRegistryDisk:v1alpha** disk type defined, virt-handler injects the
+**RegistryDisk:v1alpha** disk type defined, virt-handler injects the
 necessary configuration into the domain xml required to add the disk backed by
 a local file.
 
-The **v1** part of the ContainerRegistryDisk disk type represents the standard
+The **v1** part of the RegistryDisk disk type represents the standard
 used during the virt-handler disk conversion process. As we gain more
 experience with this feature, we may want to adopt a new standard for how VM
 images are wrapped by a container while maintaining backwards compatibility. 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -127,7 +127,7 @@ Likely, like a PodPreset. It will allow to inject specific resources into a VM.
 VMP is a good candidate for injecting disks and devices into VMs during VM spec
 completion.
 
-## ContainerRegistryDisk (WIP)
+## RegistryDisk (WIP)
 
 Method of storing and distributing VM disks with KubeVirt using the container
 registry.

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -24,8 +24,6 @@ spec:
           - "3"
           - "--libvirt-uri"
           - "qemu:///system"
-          - "--cloud-init-dir"
-          - "/var/run/libvirt/cloud-init-dir"
           - "--hostname-override"
           - "$(NODE_NAME)"
         securityContext:

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -36,7 +36,7 @@ func RemoveFile(path string) error {
 	if err != nil && os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("failed to remove cloud-init temporary data file %s", path))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("failed to remove cloud-init temporary data file %s", path))
 		return err
 	}
 	return nil
@@ -53,11 +53,10 @@ func FileExists(path string) (bool, error) {
 	return exists, err
 }
 func Md5CheckSum(filePath string) ([]byte, error) {
-	var result []byte
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	defer file.Close()
 
@@ -65,29 +64,29 @@ func Md5CheckSum(filePath string) ([]byte, error) {
 	_, err = io.Copy(hash, file)
 
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 
-	result = hash.Sum(result)
+	result := hash.Sum(nil)
 	return result, nil
 }
 
 func SetFileOwnership(username string, file string) error {
 	usrObj, err := user.Lookup(username)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unable to look up username %s", username))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("unable to look up username %s", username))
 		return err
 	}
 
 	uid, err := strconv.Atoi(usrObj.Uid)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unable to find uid for username %s", username))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("unable to find uid for username %s", username))
 		return err
 	}
 
 	gid, err := strconv.Atoi(usrObj.Gid)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unable to find gid for username %s", username))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("unable to find gid for username %s", username))
 		return err
 	}
 
@@ -97,7 +96,7 @@ func SetFileOwnership(username string, file string) error {
 func FilesAreEqual(path1 string, path2 string) (bool, error) {
 	exists, err := FileExists(path1)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unexpected error encountered while attempting to determine if %s exists", path1))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("unexpected error encountered while attempting to determine if %s exists", path1))
 		return false, err
 	} else if exists == false {
 		return false, nil
@@ -105,7 +104,7 @@ func FilesAreEqual(path1 string, path2 string) (bool, error) {
 
 	exists, err = FileExists(path2)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unexpected error encountered while attempting to determine if %s exists", path2))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("unexpected error encountered while attempting to determine if %s exists", path2))
 		return false, err
 	} else if exists == false {
 		return false, nil
@@ -113,12 +112,12 @@ func FilesAreEqual(path1 string, path2 string) (bool, error) {
 
 	sum1, err := Md5CheckSum(path1)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("calculating md5 checksum failed for %s", path1))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("calculating md5 checksum failed for %s", path1))
 		return false, err
 	}
 	sum2, err := Md5CheckSum(path2)
 	if err != nil {
-		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("calculating md5 checksum failed for %s", path2))
+		logging.DefaultLogger().Error().Reason(err).Msg(fmt.Sprintf("calculating md5 checksum failed for %s", path2))
 		return false, err
 	}
 

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -1,0 +1,126 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package ephemeraldiskutils
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"strconv"
+
+	"kubevirt.io/kubevirt/pkg/logging"
+)
+
+func RemoveFile(path string) error {
+	err := os.Remove(path)
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("failed to remove cloud-init temporary data file %s", path))
+		return err
+	}
+	return nil
+}
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	exists := false
+
+	if err == nil {
+		exists = true
+	} else if os.IsNotExist(err) {
+		err = nil
+	}
+	return exists, err
+}
+func Md5CheckSum(filePath string) ([]byte, error) {
+	var result []byte
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return result, err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	_, err = io.Copy(hash, file)
+
+	if err != nil {
+		return result, err
+	}
+
+	result = hash.Sum(result)
+	return result, nil
+}
+
+func SetFileOwnership(username string, file string) error {
+	usrObj, err := user.Lookup(username)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unable to look up username %s", username))
+		return err
+	}
+
+	uid, err := strconv.Atoi(usrObj.Uid)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unable to find uid for username %s", username))
+		return err
+	}
+
+	gid, err := strconv.Atoi(usrObj.Gid)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unable to find gid for username %s", username))
+		return err
+	}
+
+	return os.Chown(file, uid, gid)
+}
+
+func FilesAreEqual(path1 string, path2 string) (bool, error) {
+	exists, err := FileExists(path1)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unexpected error encountered while attempting to determine if %s exists", path1))
+		return false, err
+	} else if exists == false {
+		return false, nil
+	}
+
+	exists, err = FileExists(path2)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("unexpected error encountered while attempting to determine if %s exists", path2))
+		return false, err
+	} else if exists == false {
+		return false, nil
+	}
+
+	sum1, err := Md5CheckSum(path1)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("calculating md5 checksum failed for %s", path1))
+		return false, err
+	}
+	sum2, err := Md5CheckSum(path2)
+	if err != nil {
+		logging.DefaultLogger().V(2).Error().Reason(err).Msg(fmt.Sprintf("calculating md5 checksum failed for %s", path2))
+		return false, err
+	}
+
+	return bytes.Equal(sum1, sum2), nil
+}

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -20,19 +20,16 @@
 package registrydisk
 
 import (
-	"crypto/rand"
-	"encoding/base64"
+	"errors"
 	"fmt"
-	"strconv"
+	"os"
 
 	"github.com/jeevatkm/go-model"
 
 	kubev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
-	"kubevirt.io/kubevirt/pkg/kubecli"
+	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 
@@ -40,19 +37,65 @@ const registryDiskV1Alpha = "ContainerRegistryDisk:v1alpha"
 const defaultIqn = "iqn.2017-01.io.kubevirt:wrapper/1"
 const defaultPort = 3261
 const defaultPortStr = "3261"
+const filePrefix = "disk-image"
 const defaultHost = "127.0.0.1"
 
-func generateRandomString(len int) (string, error) {
-	bytes := make([]byte, len)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return "", err
-	}
-	return base64.URLEncoding.EncodeToString(bytes), nil
+var registryDiskOwner = "qemu"
+
+var mountBaseDir = "/var/run/libvirt/kubevirt-disk-dir"
+
+func generateVMBaseDir(vm *v1.VirtualMachine) string {
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	return fmt.Sprintf("%s/%s/%s", mountBaseDir, namespace, domain)
+}
+func generateVolumeMountDir(vm *v1.VirtualMachine, diskCount int) string {
+	baseDir := generateVMBaseDir(vm)
+	return fmt.Sprintf("%s/disk%d", baseDir, diskCount)
 }
 
 func k8sSecretName(vm *v1.VirtualMachine) string {
 	return fmt.Sprintf("registrydisk-iscsi-%s-%s", vm.GetObjectMeta().GetNamespace(), vm.GetObjectMeta().GetName())
+}
+
+func SetLocalDirectory(dir string) error {
+	mountBaseDir = dir
+	return nil
+}
+
+// The unit test suite uses this function
+func SetLocalDataOwner(user string) {
+	registryDiskOwner = user
+}
+
+func getFilePath(basePath string) (string, string, error) {
+	rawPath := basePath + "/" + filePrefix + ".raw"
+	qcow2Path := basePath + "/" + filePrefix + ".qcow2"
+
+	exists, err := diskutils.FileExists(rawPath)
+	if err != nil {
+		return "", "", err
+	} else if exists {
+		return rawPath, "raw", nil
+	}
+
+	exists, err = diskutils.FileExists(qcow2Path)
+	if err != nil {
+		return "", "", err
+	} else if exists {
+		return qcow2Path, "qcow2", nil
+	}
+
+	return "", "", errors.New(fmt.Sprintf("no supported file disk found in directory %s", basePath))
+}
+
+func CleanupEphemeralDisks(vm *v1.VirtualMachine) error {
+	volumeMountDir := generateVMBaseDir(vm)
+	err := os.RemoveAll(volumeMountDir)
+	if err != nil && os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 // The virt-handler converts registry disks to their corresponding iscsi network
@@ -62,215 +105,92 @@ func MapRegistryDisks(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
 	vmCopy := &v1.VirtualMachine{}
 	model.Copy(vmCopy, vm)
 
-	for idx, disk := range vmCopy.Spec.Domain.Devices.Disks {
+	for diskCount, disk := range vmCopy.Spec.Domain.Devices.Disks {
 		if disk.Type == registryDiskV1Alpha {
-			newDisk := v1.Disk{}
+			volumeMountDir := generateVolumeMountDir(vm, diskCount)
 
-			newDisk.Type = "network"
-			newDisk.Device = "disk"
-			newDisk.Target = disk.Target
-
-			newDisk.Driver = &v1.DiskDriver{
-				Type:  "raw",
-				Name:  "qemu",
-				Cache: "none",
+			diskPath, diskType, err := getFilePath(volumeMountDir)
+			if err != nil {
+				return vm, err
 			}
 
-			newDisk.Source.Name = defaultIqn
-			newDisk.Source.Protocol = "iscsi"
-			newDisk.Source.Host = disk.Source.Host
+			// Rename file to release management of it from container process.
+			oldDiskPath := diskPath
+			diskPath = oldDiskPath + ".virt"
+			err = os.Rename(oldDiskPath, diskPath)
+			if err != nil {
+				return vm, err
+			}
 
-			newDisk.Auth = disk.Auth
+			err = diskutils.SetFileOwnership(registryDiskOwner, diskPath)
+			if err != nil {
+				return vm, err
+			}
 
-			vmCopy.Spec.Domain.Devices.Disks[idx] = newDisk
+			newDisk := v1.Disk{}
+			newDisk.Type = "file"
+			newDisk.Device = "disk"
+			newDisk.Driver = &v1.DiskDriver{
+				Type: diskType,
+				Name: "qemu",
+			}
+			newDisk.Source.File = diskPath
+			newDisk.Target = disk.Target
+			vmCopy.Spec.Domain.Devices.Disks[diskCount] = newDisk
 		}
 	}
 
 	return vmCopy, nil
 }
 
-func CleanUp(vm *v1.VirtualMachine, virtCli kubecli.KubevirtClient) error {
-	precond.MustNotBeNil(vm)
-	precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
-	precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
-
-	labelSelector, err := labels.Parse(fmt.Sprintf(v1.DomainLabel+" in (%s)", vm.GetObjectMeta().GetName()))
-	if err != nil {
-		panic(err)
-	}
-
-	listOptions := metav1.ListOptions{LabelSelector: labelSelector.String()}
-
-	if err := virtCli.CoreV1().Secrets(vm.ObjectMeta.Namespace).DeleteCollection(nil, listOptions); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// The controller applies ports to registry disks when a VM spec is introduced into the cluster.
-func Initialize(vm *v1.VirtualMachine, virtCli kubecli.KubevirtClient) error {
-
-	var err error
-	authUser := ""
-	secretID := k8sSecretName(vm)
-	wrapperStartingPort := defaultPort
-	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
-
-	for idx, disk := range vm.Spec.Domain.Devices.Disks {
-		if disk.Type == registryDiskV1Alpha {
-
-			// Generate Dynamic Auth Credential for Registry Disks the first
-			// time one is encountered. This random user will be used to authenticate
-			// all ephemeral disks associated with this VM.
-			if authUser == "" {
-				authUser, err = generateRandomString(32)
-				if err != nil {
-					return err
-				}
-			}
-
-			port := fmt.Sprintf("%d", wrapperStartingPort)
-			name := defaultHost
-			if disk.Source.Host != nil {
-				name = disk.Source.Host.Name
-			}
-			// We fill in the port here for the iscsi target
-			// to coordinate avoiding port collisions in the virt-launcher pod.
-			vm.Spec.Domain.Devices.Disks[idx].Source.Host = &v1.DiskSourceHost{
-				Port: port,
-				Name: name,
-			}
-			wrapperStartingPort++
-
-			// Reference k8s secret in Disk device
-			vm.Spec.Domain.Devices.Disks[idx].Auth = &v1.DiskAuth{
-				Secret: &v1.DiskSecret{
-					Type:  "iscsi",
-					Usage: secretID,
-				},
-			}
-
-		}
-	}
-
-	/* add k8s secret if authUser was generated */
-	if authUser != "" {
-		pass, err := generateRandomString(32)
-		if err != nil {
-			return err
-		}
-
-		// Store Auth as k8s secret
-		secret := kubev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretID,
-				Namespace: vm.GetObjectMeta().GetNamespace(),
-				Labels: map[string]string{
-					v1.DomainLabel: domain,
-				},
-			},
-			Type: "kubernetes.io/iscsi-chap",
-			Data: map[string][]byte{
-				"node.session.auth.password": []byte(pass),
-				"node.session.auth.username": []byte(authUser),
-			},
-		}
-
-		_, err = virtCli.CoreV1().Secrets(vm.ObjectMeta.Namespace).Get(secretID, metav1.GetOptions{})
-		if err != nil {
-			if _, err := virtCli.Core().Secrets(vm.GetObjectMeta().GetNamespace()).Create(&secret); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// The controller uses this function communicate the IP address of the POD
-// with the containers hosting the registry disks.
-func ApplyHost(vm *v1.VirtualMachine, pod *kubev1.Pod) {
-	ip := pod.Status.PodIP
-	for idx, disk := range vm.Spec.Domain.Devices.Disks {
-		if disk.Type == registryDiskV1Alpha {
-			port := defaultPortStr
-			name := ip
-			if disk.Source.Host != nil {
-				port = disk.Source.Host.Port
-			}
-			vm.Spec.Domain.Devices.Disks[idx].Source.Host = &v1.DiskSourceHost{
-				Port: port,
-				Name: name,
-			}
-		}
-	}
-}
-
 // The controller uses this function to generate the container
 // specs for hosting the container registry disks.
-func GenerateContainers(vm *v1.VirtualMachine) ([]kubev1.Container, error) {
+func GenerateContainers(vm *v1.VirtualMachine) ([]kubev1.Container, []kubev1.Volume, error) {
 	var containers []kubev1.Container
+	var volumes []kubev1.Volume
 
-	initialDelaySeconds := 5
+	initialDelaySeconds := 2
 	timeoutSeconds := 5
-	periodSeconds := 10
+	periodSeconds := 5
 	successThreshold := 2
 	failureThreshold := 5
 
 	// Make VM Image Wrapper Containers
-	diskCount := 0
-	for _, disk := range vm.Spec.Domain.Devices.Disks {
+	for diskCount, disk := range vm.Spec.Domain.Devices.Disks {
 		if disk.Type == registryDiskV1Alpha {
+
+			volumeMountDir := generateVolumeMountDir(vm, diskCount)
+			volumeName := fmt.Sprintf("disk%d-volume", diskCount)
 			diskContainerName := fmt.Sprintf("disk%d", diskCount)
 			// container image is disk.Source.Name
 			diskContainerImage := disk.Source.Name
-			// disk.Source.Host.Port has the port field expanded before templating.
-			port := disk.Source.Host.Port
-			portInt, err := strconv.Atoi(port)
-			if err != nil {
-				return nil, err
-			}
 
+			volumes = append(volumes, kubev1.Volume{
+				Name: volumeName,
+				VolumeSource: kubev1.VolumeSource{
+					HostPath: &kubev1.HostPathVolumeSource{
+						Path: volumeMountDir,
+					},
+				},
+			})
 			containers = append(containers, kubev1.Container{
 				Name:            diskContainerName,
 				Image:           diskContainerImage,
 				ImagePullPolicy: kubev1.PullIfNotPresent,
-				Command:         []string{"/entry-point.sh", port},
-				Ports: []kubev1.ContainerPort{
-					kubev1.ContainerPort{
-						ContainerPort: int32(portInt),
-						Protocol:      kubev1.ProtocolTCP,
-					},
-				},
+				Command:         []string{"/entry-point.sh"},
 				Env: []kubev1.EnvVar{
 					kubev1.EnvVar{
-						Name:  "PORT",
-						Value: port,
-					},
-					kubev1.EnvVar{
-						Name: "PASSWORD",
-						ValueFrom: &kubev1.EnvVarSource{
-							SecretKeyRef: &kubev1.SecretKeySelector{
-								LocalObjectReference: kubev1.LocalObjectReference{
-									Name: k8sSecretName(vm),
-								},
-								Key: "node.session.auth.password",
-							},
-						},
-					},
-					kubev1.EnvVar{
-						Name: "USERNAME",
-						ValueFrom: &kubev1.EnvVarSource{
-							SecretKeyRef: &kubev1.SecretKeySelector{
-								LocalObjectReference: kubev1.LocalObjectReference{
-									Name: k8sSecretName(vm),
-								},
-								Key: "node.session.auth.username",
-							},
-						},
+						Name:  "COPY_PATH",
+						Value: volumeMountDir + "/" + filePrefix,
 					},
 				},
-				// The readiness probes ensure the ISCSI targets are available
+				VolumeMounts: []kubev1.VolumeMount{
+					{
+						Name:      volumeName,
+						MountPath: volumeMountDir,
+					},
+				},
+				// The readiness probes ensure the disk coversion and copy finished
 				// before the container is marked as "Ready: True"
 				ReadinessProbe: &kubev1.Probe{
 					Handler: kubev1.Handler{
@@ -290,5 +210,5 @@ func GenerateContainers(vm *v1.VirtualMachine) ([]kubev1.Container, error) {
 			})
 		}
 	}
-	return containers, nil
+	return containers, volumes, nil
 }

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -34,11 +34,7 @@ import (
 )
 
 const registryDiskV1Alpha = "RegistryDisk:v1alpha"
-const defaultIqn = "iqn.2017-01.io.kubevirt:wrapper/1"
-const defaultPort = 3261
-const defaultPortStr = "3261"
 const filePrefix = "disk-image"
-const defaultHost = "127.0.0.1"
 
 var registryDiskOwner = "qemu"
 
@@ -52,10 +48,6 @@ func generateVMBaseDir(vm *v1.VirtualMachine) string {
 func generateVolumeMountDir(vm *v1.VirtualMachine, diskCount int) string {
 	baseDir := generateVMBaseDir(vm)
 	return fmt.Sprintf("%s/disk%d", baseDir, diskCount)
-}
-
-func k8sSecretName(vm *v1.VirtualMachine) string {
-	return fmt.Sprintf("registrydisk-iscsi-%s-%s", vm.GetObjectMeta().GetNamespace(), vm.GetObjectMeta().GetName())
 }
 
 func SetLocalDirectory(dir string) error {

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -33,7 +33,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 
-const registryDiskV1Alpha = "ContainerRegistryDisk:v1alpha"
+const registryDiskV1Alpha = "RegistryDisk:v1alpha"
 const defaultIqn = "iqn.2017-01.io.kubevirt:wrapper/1"
 const defaultPort = 3261
 const defaultPortStr = "3261"

--- a/pkg/registry-disk/registry-disk_suite_test.go
+++ b/pkg/registry-disk/registry-disk_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package registrydisk
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestRegistryDisk(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RegistryDisk Suite")
+}

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -25,6 +25,7 @@ import (
 	"os/user"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
@@ -101,6 +102,13 @@ var _ = Describe("RegistryDisk", func() {
 
 	Describe("registry-disk", func() {
 		Context("verify helper functions", func() {
+			table.DescribeTable("by verifying mapping of ",
+				func(diskType string) {
+					VerifyDiskType(diskType)
+				},
+				table.Entry("qcow2 disk", "qcow2"),
+				table.Entry("raw disk", "raw"),
+			)
 			It("by verifying error when no disk is present", func() {
 
 				vm := v1.NewMinimalVM("fake-vm")
@@ -118,15 +126,6 @@ var _ = Describe("RegistryDisk", func() {
 				vm, err := MapRegistryDisks(vm)
 				Expect(err).To(HaveOccurred())
 			})
-
-			It("by verifying mapping of qcow2 disk", func() {
-				VerifyDiskType("qcow2")
-			})
-
-			It("by verifying mapping of raw disk", func() {
-				VerifyDiskType("raw")
-			})
-
 			It("by verifying container generation", func() {
 				vm := v1.NewMinimalVM("fake-vm")
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
@@ -158,7 +157,6 @@ var _ = Describe("RegistryDisk", func() {
 			})
 
 			It("by verifying data cleanup", func() {
-
 				vm := v1.NewMinimalVM("fake-vm")
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
 					Type:   "RegistryDisk:v1alpha",

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -41,7 +41,7 @@ var _ = Describe("RegistryDisk", func() {
 	VerifyDiskType := func(diskExtension string) {
 		vm := v1.NewMinimalVM("fake-vm")
 		vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-			Type:   "ContainerRegistryDisk:v1alpha",
+			Type:   "RegistryDisk:v1alpha",
 			Device: "disk",
 			Source: v1.DiskSource{
 				Name: "someimage:v1.2.3.4",
@@ -105,7 +105,7 @@ var _ = Describe("RegistryDisk", func() {
 
 				vm := v1.NewMinimalVM("fake-vm")
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-					Type:   "ContainerRegistryDisk:v1alpha",
+					Type:   "RegistryDisk:v1alpha",
 					Device: "disk",
 					Source: v1.DiskSource{
 						Name: "someimage:v1.2.3.4",
@@ -130,7 +130,7 @@ var _ = Describe("RegistryDisk", func() {
 			It("by verifying container generation", func() {
 				vm := v1.NewMinimalVM("fake-vm")
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-					Type:   "ContainerRegistryDisk:v1alpha",
+					Type:   "RegistryDisk:v1alpha",
 					Device: "disk",
 					Source: v1.DiskSource{
 						Name: "someimage:v1.2.3.4",
@@ -140,7 +140,7 @@ var _ = Describe("RegistryDisk", func() {
 					},
 				})
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-					Type:   "ContainerRegistryDisk:v1alpha",
+					Type:   "RegistryDisk:v1alpha",
 					Device: "disk",
 					Source: v1.DiskSource{
 						Name: "someimage:v1.2.3.4",
@@ -161,7 +161,7 @@ var _ = Describe("RegistryDisk", func() {
 
 				vm := v1.NewMinimalVM("fake-vm")
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-					Type:   "ContainerRegistryDisk:v1alpha",
+					Type:   "RegistryDisk:v1alpha",
 					Device: "disk",
 					Source: v1.DiskSource{
 						Name: "someimage:v1.2.3.4",

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package registrydisk
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+)
+
+var _ = Describe("RegistryDisk", func() {
+	tmpDir, _ := ioutil.TempDir("", "registrydisktest")
+	owner, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+
+	VerifyDiskType := func(diskExtension string) {
+		vm := v1.NewMinimalVM("fake-vm")
+		vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+			Type:   "ContainerRegistryDisk:v1alpha",
+			Device: "disk",
+			Source: v1.DiskSource{
+				Name: "someimage:v1.2.3.4",
+			},
+			Target: v1.DiskTarget{
+				Device: "vda",
+			},
+		})
+
+		// create a fake disk file
+		volumeMountDir := generateVMBaseDir(vm)
+		err = os.MkdirAll(volumeMountDir+"/disk0", 0750)
+		Expect(err).ToNot(HaveOccurred())
+
+		filePath := volumeMountDir + "/disk0/disk-image." + diskExtension
+		_, err := os.Create(filePath)
+
+		vm, err = MapRegistryDisks(vm)
+		Expect(err).ToNot(HaveOccurred())
+
+		// verify file gets renamed by virt-handler to prevent container from
+		// removing it before VM is exited
+		exists, err := diskutils.FileExists(filePath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(Equal(false))
+
+		// verify file rename takes place
+		exists, err = diskutils.FileExists(filePath + ".virt")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(Equal(true))
+
+		Expect(vm.Spec.Domain.Devices.Disks[0].Type).To(Equal("file"))
+		Expect(vm.Spec.Domain.Devices.Disks[0].Target.Device).To(Equal("vda"))
+		Expect(vm.Spec.Domain.Devices.Disks[0].Driver).ToNot(Equal(nil))
+		Expect(vm.Spec.Domain.Devices.Disks[0].Driver.Type).To(Equal(diskExtension))
+		Expect(vm.Spec.Domain.Devices.Disks[0].Source).ToNot(Equal(nil))
+		Expect(vm.Spec.Domain.Devices.Disks[0].Source.File).To(Equal(filePath + ".virt"))
+
+		err = CleanupEphemeralDisks(vm)
+		exists, err = diskutils.FileExists(volumeMountDir)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(exists).To(Equal(false))
+	}
+
+	BeforeSuite(func() {
+		err := SetLocalDirectory(tmpDir)
+		if err != nil {
+			panic(err)
+		}
+		SetLocalDataOwner(owner.Username)
+	})
+
+	AfterSuite(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	Describe("registry-disk", func() {
+		Context("verify helper functions", func() {
+			It("by verifying error when no disk is present", func() {
+
+				vm := v1.NewMinimalVM("fake-vm")
+				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+					Type:   "ContainerRegistryDisk:v1alpha",
+					Device: "disk",
+					Source: v1.DiskSource{
+						Name: "someimage:v1.2.3.4",
+					},
+					Target: v1.DiskTarget{
+						Device: "vda",
+					},
+				})
+
+				vm, err := MapRegistryDisks(vm)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("by verifying mapping of qcow2 disk", func() {
+				VerifyDiskType("qcow2")
+			})
+
+			It("by verifying mapping of raw disk", func() {
+				VerifyDiskType("raw")
+			})
+
+			It("by verifying container generation", func() {
+				vm := v1.NewMinimalVM("fake-vm")
+				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+					Type:   "ContainerRegistryDisk:v1alpha",
+					Device: "disk",
+					Source: v1.DiskSource{
+						Name: "someimage:v1.2.3.4",
+					},
+					Target: v1.DiskTarget{
+						Device: "vda",
+					},
+				})
+				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+					Type:   "ContainerRegistryDisk:v1alpha",
+					Device: "disk",
+					Source: v1.DiskSource{
+						Name: "someimage:v1.2.3.4",
+					},
+					Target: v1.DiskTarget{
+						Device: "vdb",
+					},
+				})
+
+				containers, volumes, err := GenerateContainers(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(containers)).To(Equal(2))
+				Expect(len(volumes)).To(Equal(2))
+			})
+
+			It("by verifying data cleanup", func() {
+
+				vm := v1.NewMinimalVM("fake-vm")
+				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+					Type:   "ContainerRegistryDisk:v1alpha",
+					Device: "disk",
+					Source: v1.DiskSource{
+						Name: "someimage:v1.2.3.4",
+					},
+					Target: v1.DiskTarget{
+						Device: "vda",
+					},
+				})
+
+				volumeMountDir := generateVMBaseDir(vm)
+				err = os.MkdirAll(volumeMountDir, 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.MkdirAll(volumeMountDir+"/disk0", 0755)
+				Expect(err).ToNot(HaveOccurred())
+				err = os.MkdirAll(volumeMountDir+"/disk1", 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				exists, err := diskutils.FileExists(volumeMountDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(exists).To(Equal(true))
+
+				err = CleanupEphemeralDisks(vm)
+				exists, err = diskutils.FileExists(volumeMountDir)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(exists).To(Equal(false))
+
+			})
+		})
+	})
+})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -92,10 +92,19 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		},
 	}
 
-	containers, err := registrydisk.GenerateContainers(vm)
+	containers, volumes, err := registrydisk.GenerateContainers(vm)
 	if err != nil {
 		return nil, err
 	}
+
+	volumes = append(volumes, kubev1.Volume{
+		Name: "sockets",
+		VolumeSource: kubev1.VolumeSource{
+			HostPath: &kubev1.HostPathVolumeSource{
+				Path: socketDir,
+			},
+		},
+	})
 	containers = append(containers, container)
 
 	// TODO use constants for labels
@@ -112,16 +121,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 			RestartPolicy: kubev1.RestartPolicyNever,
 			Containers:    containers,
 			NodeSelector:  vm.Spec.NodeSelector,
-			Volumes: []kubev1.Volume{
-				{
-					Name: "sockets",
-					VolumeSource: kubev1.VolumeSource{
-						HostPath: &kubev1.HostPathVolumeSource{
-							Path: socketDir,
-						},
-					},
-				},
-			},
+			Volumes:       volumes,
 		},
 	}
 

--- a/pkg/virt-controller/services/vm.go
+++ b/pkg/virt-controller/services/vm.go
@@ -33,7 +33,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
 	"kubevirt.io/kubevirt/pkg/precond"
-	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
 //go:generate mockgen -source $GOFILE -package=$GOPACKAGE -destination=generated_mock_$GOFILE
@@ -69,13 +68,6 @@ func (v *vmService) StartVMPod(vm *corev1.VirtualMachine) error {
 	precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
 	precond.MustNotBeEmpty(string(vm.GetObjectMeta().GetUID()))
 
-	err := registrydisk.Initialize(vm, v.KubeCli)
-	if err != nil {
-		logger := logging.DefaultLogger().Object(vm)
-		logger.Error().Reason(err).Msg("Initializing container registry disks failed.")
-		return err
-	}
-
 	pod, err := v.TemplateService.RenderLaunchManifest(vm)
 	if err != nil {
 		return err
@@ -106,8 +98,6 @@ func (v *vmService) DeleteVMPod(vm *corev1.VirtualMachine) error {
 	if err := v.KubeCli.CoreV1().Pods(vm.ObjectMeta.Namespace).DeleteCollection(nil, UnfinishedVMPodSelector(vm)); err != nil {
 		return err
 	}
-
-	registrydisk.CleanUp(vm, v.KubeCli)
 
 	return nil
 }

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
+	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/virt-controller/rest"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
@@ -46,11 +47,12 @@ type VirtControllerApp struct {
 	rsController *VMReplicaSet
 	rsInformer   cache.SharedIndexInformer
 
-	host          string
-	port          int
-	launcherImage string
-	migratorImage string
-	socketDir     string
+	host             string
+	port             int
+	launcherImage    string
+	migratorImage    string
+	socketDir        string
+	ephemeralDiskDir string
 }
 
 func Execute() {
@@ -117,6 +119,11 @@ func (vca *VirtControllerApp) Run() {
 
 func (vca *VirtControllerApp) initCommon() {
 	var err error
+
+	err = registrydisk.SetLocalDirectory(vca.ephemeralDiskDir + "/registry-disk-data")
+	if err != nil {
+		golog.Fatal(err)
+	}
 	vca.templateService, err = services.NewTemplateService(vca.launcherImage, vca.migratorImage, vca.socketDir)
 	if err != nil {
 		golog.Fatal(err)
@@ -141,5 +148,6 @@ func (vca *VirtControllerApp) DefineFlags() {
 	flag.StringVar(&vca.launcherImage, "launcher-image", "virt-launcher", "Shim container for containerized VMs")
 	flag.StringVar(&vca.migratorImage, "migrator-image", "virt-handler", "Container which orchestrates a VM migration")
 	flag.StringVar(&vca.socketDir, "socket-dir", "/var/run/kubevirt", "Directory where to look for sockets for cgroup detection")
+	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk", "Base direcetory for ephemeral disk data")
 	flag.Parse()
 }

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -35,7 +35,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
-	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
@@ -234,9 +233,6 @@ func (c *VMController) execute(key string) error {
 
 		// VM got scheduled
 		vmCopy.Status.Phase = kubev1.Scheduled
-
-		// Fill in host info for container registry disks
-		registrydisk.ApplyHost(&vmCopy, &pods.Items[0])
 
 		// FIXME we store this in the metadata since field selectors are currently not working for TPRs
 		if vmCopy.GetObjectMeta().GetLabels() == nil {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -134,14 +134,7 @@ var _ = Describe("VM watcher", func() {
 				Target: v1.DiskTarget{
 					Device: "vda",
 				},
-				Auth: &v1.DiskAuth{
-					Username: "fake",
-				},
 			})
-			vm.Spec.Domain.Devices.Disks[0].Source.Host = &v1.DiskSourceHost{
-				Port: "4444",
-				Name: "127.0.0.1",
-			}
 
 			// Create a Pod for the VM
 			templateService, err := services.NewTemplateService("whatever", "whatever", "whatever")
@@ -171,8 +164,6 @@ var _ = Describe("VM watcher", func() {
 			podListPostCreate := clientv1.PodList{}
 			podListPostCreate.Items = []clientv1.Pod{*pod}
 
-			secret := clientv1.Secret{}
-
 			// Register the expected REST call
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -180,14 +171,9 @@ var _ = Describe("VM watcher", func() {
 					ghttp.RespondWithJSONEncoded(http.StatusOK, podListInitial),
 				),
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/secrets/registrydisk-iscsi-default-testvm"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, secret),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/api/v1/namespaces/default/pods"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, pod),
 				),
-
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("PUT", "/apis/kubevirt.io/v1alpha1/namespaces/default/virtualmachines/testvm"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, vm),
@@ -200,7 +186,7 @@ var _ = Describe("VM watcher", func() {
 			app.vmQueue.Add(key)
 			app.vmController.Execute()
 
-			Expect(len(server.ReceivedRequests())).To(Equal(4))
+			Expect(len(server.ReceivedRequests())).To(Equal(3))
 			close(done)
 		}, 10)
 	})

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -126,7 +126,7 @@ var _ = Describe("VM watcher", func() {
 			vm.Status.Phase = ""
 			vm.ObjectMeta.SetUID(uuid.NewUUID())
 			vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-				Type:   "ContainerRegistryDisk:v1alpha",
+				Type:   "RegistryDisk:v1alpha",
 				Device: "disk",
 				Source: v1.DiskSource{
 					Name: "someimage:v1.2.3.4",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -391,6 +391,12 @@ func (d *VMHandlerDispatch) processVmUpdate(vm *v1.VirtualMachine, shouldDeleteV
 		if err != nil {
 			return false, err
 		}
+
+		err = registrydisk.CleanupEphemeralDisks(vm)
+		if err != nil {
+			return false, err
+		}
+
 		return false, d.configDisk.Undefine(vm)
 	} else if isWorthSyncing(vm) == false {
 		// nothing to do here.

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -77,6 +77,20 @@ var _ = Describe("RegistryDisk", func() {
 	}
 
 	Context("Ephemeral RegistryDisk", func() {
+		It("should be able to start and stop the same VM multiple times.", func(done Done) {
+			vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
+			num := 3
+			for i := 0; i < num; i++ {
+				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
+				Expect(err).To(BeNil())
+				tests.WaitForSuccessfulVMStartWithTimeout(obj, 30)
+				_, err = virtClient.RestClient().Delete().Resource("virtualmachines").Namespace(vm.GetObjectMeta().GetNamespace()).Name(vm.GetObjectMeta().GetName()).Do().Get()
+				Expect(err).To(BeNil())
+				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)
+			}
+			close(done)
+		}, 90)
+
 		It("should launch multiple VMs using ephemeral registry disks", func(done Done) {
 			num := 5
 			vms := make([]*v1.VirtualMachine, 0, num)

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -69,9 +69,7 @@ var _ = Describe("RegistryDisk", func() {
 					// only check readiness of disk containers
 					continue
 				}
-				if containerStatus.Ready == true {
-					disksFound++
-				}
+				disksFound++
 			}
 			break
 		}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -681,7 +681,7 @@ func NewRandomVMWithSpice() *v1.VirtualMachine {
 }
 
 // Block until the specified VM started and return the target node name.
-func WaitForSuccessfulVMStart(vm runtime.Object) (nodeName string) {
+func WaitForSuccessfulVMStartWithTimeout(vm runtime.Object, seconds int) (nodeName string) {
 	_, ok := vm.(*v1.VirtualMachine)
 	Expect(ok).To(BeTrue(), "Object is not of type *v1.VM")
 	virtClient, err := kubecli.GetKubevirtClient()
@@ -699,8 +699,12 @@ func WaitForSuccessfulVMStart(vm runtime.Object) (nodeName string) {
 		fetchedVM := obj.(*v1.VirtualMachine)
 		nodeName = fetchedVM.Status.NodeName
 		return fetchedVM.Status.Phase
-	}).Should(Equal(v1.Running))
+	}, time.Duration(seconds)*time.Second).Should(Equal(v1.Running))
 	return
+}
+
+func WaitForSuccessfulVMStart(vm runtime.Object) string {
+	return WaitForSuccessfulVMStartWithTimeout(vm, 5)
 }
 
 func GetReadyNodes() []k8sv1.Node {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -502,7 +502,7 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 	vm.Spec.Domain.Memory.Unit = "MB"
 	vm.Spec.Domain.Memory.Value = 64
 	vm.Spec.Domain.Devices.Disks = []v1.Disk{{
-		Type:   "ContainerRegistryDisk:v1alpha",
+		Type:   "RegistryDisk:v1alpha",
 		Device: "disk",
 		Source: v1.DiskSource{
 			Name: containerImage,


### PR DESCRIPTION
- Renames feature from ContainerRegistryDisk to RegistryDisk
- Removes ISCSI from feature and uses direct file access now, resolving #373 
- Adds unit testing for registry-disk package
- Adds direct qcow2 support without converting to raw format
- Updates documentation

These changes greatly simplify the features implementation and improve overall test coverage as well. 