### PR TITLE
Record events when vm is migrated

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -335,6 +335,18 @@ func NewVM(name string, uid types.UID) *VirtualMachine {
 	}
 }
 
+type MigrationEvent string
+
+const (
+	StartedVirtualMachineMigration   MigrationEvent = "MigrationStarted"
+	SucceededVirtualMachineMigration MigrationEvent = "MigrationSucceeded"
+	FailedVirtualMachineMigration    MigrationEvent = "MigrationFailed"
+)
+
+func (s MigrationEvent) String() string {
+	return string(s)
+}
+
 type SyncEvent string
 
 const (

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -7,19 +7,15 @@ import (
 	"strconv"
 
 	"github.com/emicklei/go-restful"
+	"k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientrest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-
 	"k8s.io/client-go/util/workqueue"
-
-	"k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/record"
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -7,8 +7,12 @@ import (
 	"strconv"
 
 	"github.com/emicklei/go-restful"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientrest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 
 	"k8s.io/client-go/util/workqueue"
 
@@ -36,6 +40,7 @@ type VirtControllerApp struct {
 	migrationController *MigrationController
 	migrationInformer   cache.SharedIndexInformer
 	migrationQueue      workqueue.RateLimitingInterface
+	migrationRecorder   record.EventRecorder
 
 	vmCache      cache.Store
 	vmController *VMController
@@ -89,6 +94,10 @@ func Execute() {
 	app.podInformer.AddEventHandler(controller.NewResourceEventHandlerFuncsForFunc(migrationPodLabelHandler(app.migrationQueue)))
 	app.migrationCache = app.migrationInformer.GetStore()
 
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&k8coresv1.EventSinkImpl{Interface: app.clientSet.CoreV1().Events(k8sv1.NamespaceAll)})
+	app.migrationRecorder = broadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: "virt-migration-controller"})
+
 	app.rsInformer = app.informerFactory.VMReplicaSet()
 
 	app.initCommon()
@@ -118,7 +127,7 @@ func (vca *VirtControllerApp) initCommon() {
 	}
 	vca.vmService = services.NewVMService(vca.clientSet, vca.restClient, vca.templateService)
 	vca.vmController = NewVMController(vca.restClient, vca.vmService, vca.vmQueue, vca.vmCache, vca.vmInformer, vca.podInformer, nil, vca.clientSet)
-	vca.migrationController = NewMigrationController(vca.restClient, vca.vmService, vca.clientSet, vca.migrationQueue, vca.migrationInformer, vca.podInformer, vca.migrationCache)
+	vca.migrationController = NewMigrationController(vca.restClient, vca.vmService, vca.clientSet, vca.migrationQueue, vca.migrationInformer, vca.podInformer, vca.migrationCache, vca.migrationRecorder)
 }
 
 func (vca *VirtControllerApp) initReplicaSet() {

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
-	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -41,12 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
-func NewMigrationController(restClient *rest.RESTClient, migrationService services.VMService, clientset kubecli.KubevirtClient, queue workqueue.RateLimitingInterface, migrationInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer, migrationCache cache.Store) *MigrationController {
-
-	broadcaster := record.NewBroadcaster()
-	broadcaster.StartRecordingToSink(&k8coresv1.EventSinkImpl{Interface: clientset.CoreV1().Events(k8sv1.NamespaceAll)})
-	recorder := broadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: "virt-migration-controller"})
-
+func NewMigrationController(restClient *rest.RESTClient, migrationService services.VMService, clientset kubecli.KubevirtClient, queue workqueue.RateLimitingInterface, migrationInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer, migrationCache cache.Store, recorder record.EventRecorder) *MigrationController {
 	return &MigrationController{
 		restClient:        restClient,
 		vmService:         migrationService,


### PR DESCRIPTION
This patch records an event when a VM is successfully migrate.  Without this, a VM may be running on node1 while showing it's last event as having started on node2... that's super confusing. 