### PR TITLE
[WIP] Add sockets as secondary controller resource

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 0bbc356631e6f43e5b2022c18bfd42e07f8f6be526593d873a3309a5a31763f4
-updated: 2017-09-17T09:22:45.36183886+03:00
+hash: 03562ad089d1614b5fa6f67af0163fe38eda2a9bd9b8794bb7460aaa7bd01d21
+updated: 2017-09-27T17:35:26.302300007+02:00
 imports:
 - name: github.com/asaskevich/govalidator
-  version: 73945b6115bfbbcc57d89b7316e28109364124e1
+  version: eb06e9c4d8e04c43e16e5241db85df221ec5c17f
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
@@ -16,6 +16,8 @@ imports:
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/evanphx/json-patch
   version: ba18e35c5c1b36ef6334cad706eb681153d2d379
+- name: github.com/fsnotify/fsnotify
+  version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-kit/kit
@@ -31,24 +33,24 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/go-stack/stack
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 2adc21fd136931e0388e278825291678e1d98309
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
   - lru
 - name: github.com/golang/mock
-  version: c7d0ee73a597d1349404607d9f692cacd09cdc06
+  version: 2b473a1a899b0c9967501477ec03c71c32550cbe
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
@@ -60,7 +62,7 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+  version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
 - name: github.com/googleapis/gnostic
   version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
@@ -68,7 +70,7 @@ imports:
   - compiler
   - extensions
 - name: github.com/gorilla/websocket
-  version: 6f34763140ed8887aed6a044912009832b4733d7
+  version: 4201258b820c74ac8e6922fc9e6b52f71fe46f8d
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
@@ -84,7 +86,7 @@ imports:
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/libvirt/libvirt-go
-  version: 0822ea6d658d7a0deeaa2ce63ed3efd6306bee03
+  version: 7b2a44de9fd207c2cbc28bdbad20c8279b767553
 - name: github.com/mailru/easyjson
   version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
@@ -128,7 +130,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -210,7 +212,6 @@ imports:
   - certificates/v1beta1
   - core/v1
   - extensions/v1beta1
-  - imagepolicy/v1alpha1
   - networking/v1
   - policy/v1beta1
   - rbac/v1
@@ -428,6 +429,7 @@ imports:
   - third_party/forked/golang/template
   - tools/auth
   - tools/cache
+  - tools/cache/testing
   - tools/clientcmd
   - tools/clientcmd/api
   - tools/clientcmd/api/latest
@@ -445,7 +447,7 @@ imports:
   - util/jsonpath
   - util/workqueue
 - name: k8s.io/kube-openapi
-  version: 80f07ef71bb4f781233c65aa8d0369e4ecafab87
+  version: abfc5fbe1cf87ee697db107fdfd24c32fe4397a8
   subpackages:
   - pkg/common
 testImports:
@@ -462,7 +464,7 @@ testImports:
   subpackages:
   - assert
 - name: golang.org/x/sync
-  version: f52d1811a62927559de87708c8913c1650ce4f26
+  version: 8e0aa688b654ef28caa72506fa5ec8dba9fc7690
   subpackages:
   - errgroup
 - name: gopkg.in/check.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -184,6 +184,8 @@ import:
   - util/integer
   - util/jsonpath
   - util/workqueue
+- package: github.com/fsnotify/fsnotify
+  version: ^1.4.2
 testImport:
 - package: github.com/elazarl/goproxy
   version: 07b16b6e30fcac0ad8c0435548e743bcf2ca7e92

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -49,7 +49,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
 	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
 	uid := precond.MustNotBeEmpty(string(vm.GetObjectMeta().GetUID()))
-	socketDir := t.socketBaseDir + "/" + namespace + "/" + domain
 
 	initialDelaySeconds := 2
 	timeoutSeconds := 5
@@ -72,7 +71,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		VolumeMounts: []kubev1.VolumeMount{
 			{
 				Name:      "sockets",
-				MountPath: socketDir,
+				MountPath: t.socketBaseDir,
 			},
 		},
 		ReadinessProbe: &kubev1.Probe{
@@ -117,7 +116,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 					Name: "sockets",
 					VolumeSource: kubev1.VolumeSource{
 						HostPath: &kubev1.HostPathVolumeSource{
-							Path: socketDir,
+							Path: t.socketBaseDir,
 						},
 					},
 				},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -88,8 +88,8 @@ var _ = Describe("Template", func() {
 					"--namespace", "default",
 					"--socket-dir", "/var/run/libvirt",
 					"--readiness-file", "/tmp/healthy"}))
-				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/libvirt/default/testvm"))
-				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/libvirt/default/testvm"))
+				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/libvirt"))
+				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/libvirt"))
 			})
 		})
 		Context("migration", func() {

--- a/pkg/virt-handler/domain.go
+++ b/pkg/virt-handler/domain.go
@@ -37,6 +37,7 @@ import (
 TODO: Define the exact scope of this controller.
 For now it looks like we should use domain events to detect unexpected domain changes like crashes or vms going
 into pause mode because of resource shortage or cut off connections to storage.
+TODO: Use domain events as additional, secondary source in the VM controller
 */
 func NewDomainController(vmQueue workqueue.RateLimitingInterface, vmStore cache.Store, informer cache.SharedInformer, restClient rest.RESTClient, recorder record.EventRecorder) (cache.Store, *controller.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())

--- a/pkg/virt-handler/virtwrap/cache/inotify.go
+++ b/pkg/virt-handler/virtwrap/cache/inotify.go
@@ -1,0 +1,116 @@
+package cache
+
+import (
+	"io/ioutil"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/isolation"
+)
+
+// NewSocketListWatchFromClient creates a ListWatcher which watches for virt-launcher socket creations, recreations and deletions.
+// It is a very special ListWatcher, since it can't be used to stay completely in sync with the file system content.
+// Instead of that, it provides at-least-once delivery of events, where the order on an initial sync is not guaranteed.
+// While for many tasks this is not good enough, it is a sufficient pattern to use the socket creation as a secondary resource for the VM controller in virt-handler
+// TODO: In case Watch is never called, we could leak inotify go-routines, since it is not guaranteed that Stop() would ever be called
+// Since the ListWatcher is only created once at start-up that is not an issue right now
+func NewSocketListWatchFromClient(socketDir string) cache.ListerWatcher {
+	d := &DirectoryListWatcher{socketDir: socketDir}
+	return d
+}
+
+type DirectoryListWatcher struct {
+	socketDir string
+	watcher   *fsnotify.Watcher
+}
+
+func (d *DirectoryListWatcher) List(options v1.ListOptions) (runtime.Object, error) {
+	// Stop the running watcher if necessary
+	// This ensures we clean up previous watchers, when we encountered an error or when we resync
+	d.Stop()
+	var err error
+	d.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	// This starts the watch already.
+	// Starting watching before the actual sync, has the advantage, that we don't mich notifications about file changes.
+	// It also means that we can't reliably follow file system changes, because we are informed at least once about changes.
+	err = d.watcher.Add(d.socketDir)
+	if err != nil {
+		return nil, err
+	}
+	files, err := ioutil.ReadDir(d.socketDir)
+	if err != nil {
+		d.Stop()
+		return nil, err
+	}
+
+	domainList := &api.DomainList{
+		Items: []api.Domain{},
+	}
+	for _, file := range files {
+		namespace, name, err := isolation.SplitSocketNamespaceNameFunc(file.Name())
+		if err != nil {
+			logging.DefaultLogger().Error().Reason(err).Msg("Invalid content detected, ignoring and continuing.")
+			continue
+		}
+		domainList.Items = append(domainList.Items, *api.NewMinimalDomainWithNS(namespace, name))
+
+	}
+	return domainList, nil
+}
+func (d *DirectoryListWatcher) Watch(options v1.ListOptions) (watch.Interface, error) {
+
+	return d, nil
+}
+
+func (d *DirectoryListWatcher) Stop() {
+	if d.watcher != nil {
+		d.watcher.Close()
+	}
+}
+
+func (d *DirectoryListWatcher) ResultChan() <-chan watch.Event {
+	c := make(chan watch.Event)
+	go func() {
+		defer close(c)
+		for {
+			var e watch.EventType
+			var fse fsnotify.Event
+			select {
+			case event, more := <-d.watcher.Events:
+				if !more {
+					return
+				}
+				fse = event
+				switch event.Op {
+				case fsnotify.Create:
+					e = watch.Added
+				case fsnotify.Remove:
+					e = watch.Deleted
+				}
+
+			case err, more := <-d.watcher.Errors:
+				if !more {
+					return
+				}
+				c <- watch.Event{Type: watch.Error, Object: &v1.Status{Status: v1.StatusFailure, Message: err.Error()}}
+				return
+			}
+			namespace, name, err := isolation.SplitSocketNamespaceNameFunc(fse.Name)
+			if err != nil {
+				logging.DefaultLogger().Error().Reason(err).Msg("Invalid content detected, ignoring and continuing.")
+				continue
+			}
+			c <- watch.Event{Type: e, Object: api.NewMinimalDomainWithNS(namespace, name)}
+		}
+	}()
+	return c
+}

--- a/pkg/virt-handler/virtwrap/cache/inotify_test.go
+++ b/pkg/virt-handler/virtwrap/cache/inotify_test.go
@@ -1,0 +1,99 @@
+package cache
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
+)
+
+var _ = Describe("Inotify", func() {
+
+	Context("When watching virt-launcher files in a directory", func() {
+
+		var tmpDir string
+		var informer cache.SharedIndexInformer
+		var stopInformer chan struct{}
+
+		BeforeEach(func() {
+			var err error
+			stopInformer = make(chan struct{})
+			tmpDir, err = ioutil.TempDir("", "kubevirt")
+			Expect(err).ToNot(HaveOccurred())
+
+			// create two files
+			Expect(os.Create(tmpDir + "/" + "default_testvm.sock")).ToNot(BeNil())
+			Expect(os.Create(tmpDir + "/" + "default1_testvm1.sock")).ToNot(BeNil())
+
+			informer = cache.NewSharedIndexInformer(
+				NewSocketListWatchFromClient(tmpDir),
+				&api.Domain{},
+				0,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+			go informer.Run(stopInformer)
+			Expect(cache.WaitForCacheSync(stopInformer, informer.HasSynced)).To(BeTrue())
+
+		})
+
+		It("should update the cache with all files in the directory", func() {
+			Expect(informer.GetStore().ListKeys()).To(HaveLen(2))
+			_, exists, _ := informer.GetStore().GetByKey("default/testvm")
+			Expect(exists).To(BeTrue())
+			_, exists, _ = informer.GetStore().GetByKey("default1/testvm1")
+			Expect(exists).To(BeTrue())
+		})
+
+		It("should detect a file creation", func() {
+			Expect(os.Create(tmpDir + "/" + "default2_testvm2.sock")).ToNot(BeNil())
+			Eventually(func() bool {
+				_, exists, _ := informer.GetStore().GetByKey("default2/testvm2")
+				return exists
+			}).Should(BeTrue())
+		})
+
+		It("should detect a file deletion", func() {
+			Expect(os.Remove(tmpDir + "/" + "default1_testvm1.sock")).To(Succeed())
+			Eventually(func() bool {
+				_, exists, _ := informer.GetStore().GetByKey("default1/testvm1")
+				return exists
+			}).Should(BeFalse())
+		})
+		Context("and something goes wrong", func() {
+			It("should notify and abort when listing files", func() {
+				lw := NewSocketListWatchFromClient(tmpDir)
+				// Deleting the watch directory should have some impact
+				Expect(os.RemoveAll(tmpDir)).To(Succeed())
+				_, err := lw.List(v1.ListOptions{})
+				Expect(err).To(HaveOccurred())
+			})
+			It("should ignore invalid file content", func() {
+				lw := NewSocketListWatchFromClient(tmpDir)
+				_, err := lw.List(v1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				i, err := lw.Watch(v1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				defer i.Stop()
+
+				// Adding files in wrong formats should have an impact
+				// TODO should we just ignore them?
+				Expect(os.Create(tmpDir + "/" + "test.sock")).ToNot(BeNil())
+
+				// No event should be received
+				Consistently(i.ResultChan()).ShouldNot(Receive())
+			})
+		})
+
+		AfterEach(func() {
+			close(stopInformer)
+			os.RemoveAll(tmpDir)
+		})
+
+	})
+})

--- a/pkg/virt-handler/virtwrap/isolation/isolation.go
+++ b/pkg/virt-handler/virtwrap/isolation/isolation.go
@@ -62,7 +62,16 @@ func NewSocketBasedIsolationDetector(socketDir string) PodIsolationDetector {
 }
 
 func SocketFromNamespaceName(baseDir string, namespace string, name string) string {
-	return filepath.Clean(baseDir) + "/" + namespace + "/" + name + "/sock"
+	return filepath.Clean(baseDir) + "/" + namespace + "_" + name + ".sock"
+}
+
+func SplitSocketNamespaceNameFunc(fullPath string) (namespace string, name string, err error) {
+	socket := strings.TrimSuffix(filepath.Base(fullPath), ".sock")
+	namespaceName := strings.Split(socket, "_")
+	if len(namespaceName) != 2 {
+		return "", "", fmt.Errorf("Invalid socket path: %s", fullPath)
+	}
+	return namespaceName[0], namespaceName[1], nil
 }
 
 func (s *socketBasedIsolationDetector) Whitelist(controller []string) PodIsolationDetector {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -47,14 +47,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 )
 
-func NewVMController(lw cache.ListerWatcher,
-	domainManager virtwrap.DomainManager,
-	recorder record.EventRecorder,
-	restClient rest.RESTClient,
-	clientset kubecli.KubevirtClient,
-	host string,
+func NewVMController(lw cache.ListerWatcher, socketIntofrmer cache.SharedIndexInformer, domainManager virtwrap.DomainManager, recorder record.EventRecorder, restClient rest.RESTClient, clientset kubecli.KubevirtClient, host string,
 	configDiskClient configdisk.ConfigDiskClient) (cache.Store, workqueue.RateLimitingInterface, *controller.Controller) {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	// Tie the socket based informer into the VM controller
+	socketIntofrmer.AddEventHandler(controller.NewResourceEventHandlerFuncsForWorkqueue(queue))
 
 	dispatch := NewVMHandlerDispatch(domainManager, recorder, &restClient, clientset, host, configDiskClient)
 


### PR DESCRIPTION
The controller inside virt-handler, now considers virt-launcher sockets,
when starting a VM. Inotify is used to watch the socket directory.

POC I have for a few weeks already which could solve #421. It flattens the socket directory and there were some security conserns mentioned by @davidvossel.

Signed-off-by: Roman Mohr <rmohr@redhat.com>