### PR TITLE
Log VMRS events on VMRS and not on the VM

### DIFF
--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -247,11 +247,11 @@ func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.V
 				if err != nil {
 					// We can't observe a delete if it was not accepted by the server
 					c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(deleteCandidate))
-					c.recorder.Eventf(deleteCandidate, k8score.EventTypeWarning, FailedDeleteVirtualMachineReason, "Error deleting: %v", err)
+					c.recorder.Eventf(rs, k8score.EventTypeWarning, FailedDeleteVirtualMachineReason, "Error deleting virtual machine %s: %v", deleteCandidate.ObjectMeta.Name, err)
 					errChan <- err
 					return
 				}
-				c.recorder.Eventf(deleteCandidate, k8score.EventTypeNormal, SuccessfulDeleteVirtualMachineReason, "Deleted virtual machine: %v", deleteCandidate.ObjectMeta.UID)
+				c.recorder.Eventf(rs, k8score.EventTypeNormal, SuccessfulDeleteVirtualMachineReason, "Deleted virtual machine: %v", deleteCandidate.ObjectMeta.UID)
 			}(i)
 		}
 
@@ -272,11 +272,11 @@ func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.V
 				vm, err := c.clientset.VM(rs.ObjectMeta.Namespace).Create(vm)
 				if err != nil {
 					c.expectations.CreationObserved(rsKey)
-					c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedCreateVirtualMachineReason, "Error deleting: %v", err)
+					c.recorder.Eventf(rs, k8score.EventTypeWarning, FailedCreateVirtualMachineReason, "Error creating virtual machine: %v", err)
 					errChan <- err
 					return
 				}
-				c.recorder.Eventf(vm, k8score.EventTypeNormal, SuccessfulCreateVirtualMachineReason, "Created virtual machine: %v", vm.ObjectMeta.Name)
+				c.recorder.Eventf(rs, k8score.EventTypeNormal, SuccessfulCreateVirtualMachineReason, "Created virtual machine: %v", vm.ObjectMeta.Name)
 			}()
 		}
 	}


### PR DESCRIPTION
VMRS related events, like creation or deletion of VMs through the
controller need to be logged on the VMRS. virt-handler will log the
actual lifecycle event for the VM on the node side independently.

Signed-off-by: Roman Mohr <rmohr@redhat.com>