### PR TITLE
Add pause function to replication controller

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -693,6 +693,10 @@ type VMReplicaSetSpec struct {
 
 	// Template describes the pods that will be created.
 	Template *VMTemplateSpec `json:"template" valid:"required"`
+
+	// Indicates that the replica set is paused.
+	// +optional
+	Paused bool `json:"paused,omitempty" protobuf:"varint,7,opt,name=paused"`
 }
 
 type VMReplicaSetStatus struct {

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -108,6 +108,7 @@ func (VMReplicaSetSpec) SwaggerDoc() map[string]string {
 		"replicas": "Number of desired pods. This is a pointer to distinguish between explicit\nzero and not specified. Defaults to 1.\n+optional",
 		"selector": "Label selector for pods. Existing ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.\n+optional",
 		"template": "Template describes the pods that will be created.",
+		"paused":   "Indicates that the replica set is paused.\n+optional",
 	}
 }
 

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -186,7 +186,7 @@ func (c *VMReplicaSet) execute(key string) error {
 
 	// Scale up or down, if all expected creates and deletes were report by the listener
 	var scaleErr error
-	if needsSync {
+	if needsSync && !rs.Spec.Paused {
 		scaleErr = c.scale(rs, vms)
 	}
 


### PR DESCRIPTION
In order to allow removing specific nodes on scale-down, allow pausing
the controller.

Signed-off-by: Roman Mohr <rmohr@redhat.com>