### PR TITLE
Don't let the libvirt-kubevirt docker image relabel the whole image

### DIFF
--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -21,8 +21,8 @@ FROM fedora:26
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 RUN dnf -y install libvirt-client genisoimage && \
-    groupadd --gid 1111 qemu && \
-    useradd --uid 1111 --gid 1111 qemu && \
+    groupadd --gid 107 qemu && \
+    useradd --uid 107 --gid 107 qemu && \
     dnf -y clean all
 
 COPY virt-handler /virt-handler

--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -44,9 +44,4 @@ RUN rm -f /libvirtd.sh
 COPY libvirtd.sh /libvirtd.sh
 RUN chmod a+x /libvirtd.sh
 
-# Make a predictable uid and gid for qemu user
-# This allows containers to set enforce permissions on files that
-# are shared between containers on the local disk.
-RUN groupmod -g 1111 qemu && usermod  -u 1111 qemu
-
 CMD ["/libvirtd.sh"]

--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -27,7 +27,8 @@ RUN dnf install -y \
   libcgroup-tools \
   ethtool \
   sudo \
-  docker && dnf -y clean all
+  docker && dnf -y clean all && \
+  test $(id -u qemu) = 107 # make sure that the qemu user really is 107
 
 COPY qemu-kube /usr/local/bin/qemu-system-x86_64
 RUN chmod a+x /usr/local/bin/qemu-system-x86_64


### PR DESCRIPTION
Looks like the the uid change is not used anywhere in the code. Where required 107:107 can be used instead of 1111.

Fixes #465 

Signed-off-by: Roman Mohr <rmohr@redhat.com>