### PR TITLE
Make it observable if the VMRS is in paused state

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -30,11 +30,11 @@ import (
 	"fmt"
 	"reflect"
 
-	model "github.com/jeevatkm/go-model"
-	uuid "github.com/satori/go.uuid"
+	"github.com/jeevatkm/go-model"
+	"github.com/satori/go.uuid"
 
 	k8sv1 "k8s.io/api/core/v1"
-	meta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -723,10 +723,14 @@ type VMReplicaSetCondition struct {
 type VMReplicaSetConditionType string
 
 const (
-	// VMReplicaSetReplicaFailure is added in a replication controller when one of its vms
+	// VMReplicaSetReplicaFailure is added in a replica set when one of its vms
 	// fails to be created due to insufficient quota, limit ranges, pod security policy, node selectors,
 	// etc. or deleted due to kubelet being down or finalizers are failing.
 	VMReplicaSetReplicaFailure VMReplicaSetConditionType = "ReplicaFailure"
+
+	// VMReplicaSetReplicaPaused is added in a replica set when the replica set got paused by the controller.
+	// After this condition was added, it is safe to remove or add vms by hand and adjust the replica count by hand.
+	VMReplicaSetReplicaPaused VMReplicaSetConditionType = "ReplicaPaused"
 )
 
 type VMTemplateSpec struct {

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -45,7 +45,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/logging"
 )
 
-// Reasons for virtual machine events
+// Reasons for replicaset events
 const (
 	// FailedCreateVirtualMachineReason is added in an event and in a replica set condition
 	// when a virtual machine for a replica set is failed to be created.
@@ -59,6 +59,14 @@ const (
 	// SuccessfulDeleteVirtualMachineReason is added in an event when a virtual machine for a replica set
 	// is successfully deleted.
 	SuccessfulDeleteVirtualMachineReason = "SuccessfulDelete"
+	// SuccessfulPausedReplicaSetReason is added in an event when the replica set discovered that it
+	// should be paused. The event is triggered after it successfully managed to add the Paused Condition
+	// to itself.
+	SuccessfulPausedReplicaSetReason = "SuccessfulPaused"
+	// SuccessfulResumedReplicaSetReason is added in an event when the replica set discovered that it
+	// should be resumed. The event is triggered after it successfully managed to remove the Paused Condition
+	// from itself.
+	SuccessfulResumedReplicaSetReason = "SuccessfulResumed"
 )
 
 func NewVMReplicaSet(vmInformer cache.SharedIndexInformer, vmRSInformer cache.SharedIndexInformer, recorder record.EventRecorder, clientset kubecli.KubevirtClient, burstReplicas uint) *VMReplicaSet {
@@ -499,13 +507,13 @@ func limit(x int, burstReplicas uint) int {
 	return min(x, replicas)
 }
 
-func (c *VMReplicaSet) getCondition(rs *virtv1.VirtualMachineReplicaSet, cond virtv1.VMReplicaSetConditionType) *virtv1.VMReplicaSetCondition {
+func (c *VMReplicaSet) hasCondition(rs *virtv1.VirtualMachineReplicaSet, cond virtv1.VMReplicaSetConditionType) bool {
 	for _, c := range rs.Status.Conditions {
 		if c.Type == cond {
-			return &c
+			return true
 		}
 	}
-	return nil
+	return false
 }
 
 func (c *VMReplicaSet) removeCondition(rs *virtv1.VirtualMachineReplicaSet, cond virtv1.VMReplicaSetConditionType) {
@@ -529,10 +537,10 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 	statesMatch := int32(len(vms)) == rs.Status.Replicas && readyReplicas == rs.Status.ReadyReplicas
 
 	// check if we need to update because of appeared or disappeard errors
-	errorsMatch := scaleErr == nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) == nil || scaleErr != nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) != nil
+	errorsMatch := (scaleErr != nil) == c.hasCondition(rs, virtv1.VMReplicaSetReplicaFailure)
 
 	// check if we need to update because pause was modified
-	pausedMatch := rs.Spec.Paused == false && c.getCondition(rs, virtv1.VMReplicaSetReplicaPaused) == nil || rs.Spec.Paused == true && c.getCondition(rs, virtv1.VMReplicaSetReplicaPaused) != nil
+	pausedMatch := rs.Spec.Paused == c.hasCondition(rs, virtv1.VMReplicaSetReplicaPaused)
 
 	// in case the replica count matches and the scaleErr and the error condition equal, don't update
 	if statesMatch && errorsMatch && pausedMatch {
@@ -542,14 +550,27 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 	rs.Status.Replicas = int32(len(vms))
 	rs.Status.ReadyReplicas = readyReplicas
 
-	// Add/Remove Paused
+	// Add/Remove Paused condition
 	c.checkPaused(rs)
 
 	// Add/Remove Failure condition if necessary
 	c.checkFailure(rs, diff, scaleErr)
 
 	_, err := c.clientset.ReplicaSet(rs.ObjectMeta.Namespace).Update(rs)
-	return err
+
+	if err != nil {
+		return err
+	}
+	// Finally trigger resumed or paused events
+	if !pausedMatch {
+		if rs.Spec.Paused {
+			c.recorder.Eventf(rs, k8score.EventTypeNormal, SuccessfulPausedReplicaSetReason, "Paused")
+		} else {
+			c.recorder.Eventf(rs, k8score.EventTypeNormal, SuccessfulResumedReplicaSetReason, "Resumed")
+		}
+	}
+
+	return nil
 }
 
 func (c *VMReplicaSet) calcDiff(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine) int {
@@ -576,7 +597,7 @@ func (c *VMReplicaSet) getVirtualMachineBaseName(replicaset *virtv1.VirtualMachi
 
 func (c *VMReplicaSet) checkPaused(rs *virtv1.VirtualMachineReplicaSet) {
 
-	if rs.Spec.Paused == true && c.getCondition(rs, virtv1.VMReplicaSetReplicaPaused) == nil {
+	if rs.Spec.Paused == true && !c.hasCondition(rs, virtv1.VMReplicaSetReplicaPaused) {
 
 		rs.Status.Conditions = append(rs.Status.Conditions, virtv1.VMReplicaSetCondition{
 			Type:               virtv1.VMReplicaSetReplicaPaused,
@@ -585,13 +606,13 @@ func (c *VMReplicaSet) checkPaused(rs *virtv1.VirtualMachineReplicaSet) {
 			LastTransitionTime: v1.Now(),
 			Status:             k8score.ConditionTrue,
 		})
-	} else if rs.Spec.Paused == false && c.getCondition(rs, virtv1.VMReplicaSetReplicaPaused) != nil {
+	} else if rs.Spec.Paused == false && c.hasCondition(rs, virtv1.VMReplicaSetReplicaPaused) {
 		c.removeCondition(rs, virtv1.VMReplicaSetReplicaPaused)
 	}
 }
 
 func (c *VMReplicaSet) checkFailure(rs *virtv1.VirtualMachineReplicaSet, diff int, scaleErr error) {
-	if scaleErr != nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) == nil {
+	if scaleErr != nil && !c.hasCondition(rs, virtv1.VMReplicaSetReplicaFailure) {
 		var reason string
 		if diff < 0 {
 			reason = "FailedCreate"
@@ -607,7 +628,7 @@ func (c *VMReplicaSet) checkFailure(rs *virtv1.VirtualMachineReplicaSet, diff in
 			Status:             k8score.ConditionTrue,
 		})
 
-	} else if scaleErr == nil && c.getCondition(rs, virtv1.VMReplicaSetReplicaFailure) != nil {
+	} else if scaleErr == nil && c.hasCondition(rs, virtv1.VMReplicaSetReplicaFailure) {
 		c.removeCondition(rs, virtv1.VMReplicaSetReplicaFailure)
 	}
 }

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/onsi/ginkgo/extensions/table"
 
+	"strings"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/testing"
@@ -146,6 +148,7 @@ var _ = Describe("Replicaset", func() {
 			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+			expectEvent(recorder, SuccessfulResumedReplicaSetReason)
 		})
 
 		It("should not create missing VMs when it is paused and add paused condition", func() {
@@ -172,8 +175,7 @@ var _ = Describe("Replicaset", func() {
 
 			controller.Execute()
 
-			// No events expected
-			Expect(recorder.Events).To(BeEmpty())
+			expectEvent(recorder, SuccessfulPausedReplicaSetReason)
 		})
 
 		It("should create missing VMs in batches of a maximum of 10 VMs at once", func() {
@@ -189,6 +191,10 @@ var _ = Describe("Replicaset", func() {
 			}).Return(vm, nil)
 
 			controller.Execute()
+
+			for x := 0; x < 10; x++ {
+				expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+			}
 
 			// TODO test for missing 5
 		})
@@ -212,6 +218,10 @@ var _ = Describe("Replicaset", func() {
 				Times(10).Return(nil)
 
 			controller.Execute()
+
+			for x := 0; x < 10; x++ {
+				expectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
+			}
 
 			// TODO test for missing 5
 		})
@@ -372,6 +382,7 @@ var _ = Describe("Replicaset", func() {
 
 			controller.Execute()
 
+			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 			expectEvent(recorder, FailedCreateVirtualMachineReason)
 		})
 
@@ -403,7 +414,7 @@ var _ = Describe("Replicaset", func() {
 
 			controller.Execute()
 
-			expectEvent(recorder, FailedDeleteVirtualMachineReason)
+			expectEvents(recorder, SuccessfulDeleteVirtualMachineReason, FailedDeleteVirtualMachineReason)
 		})
 
 		It("should update the replica count but keep the failed state", func() {
@@ -435,6 +446,8 @@ var _ = Describe("Replicaset", func() {
 			})
 
 			controller.Execute()
+
+			expectEvents(recorder, SuccessfulCreateVirtualMachineReason, FailedCreateVirtualMachineReason)
 		})
 		It("should update the replica count and remove the failed condition", func() {
 			rs, vm := DefaultReplicaSet(3)
@@ -459,9 +472,13 @@ var _ = Describe("Replicaset", func() {
 			})
 
 			controller.Execute()
+			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
 		AfterEach(func() {
+			// Ensure that we add checks for expected events to every test
+			Expect(recorder.Events).To(BeEmpty())
 			ctrl.Finish()
 		})
 	})
@@ -507,5 +524,33 @@ func DefaultReplicaSet(replicas int32) (*v1.VirtualMachineReplicaSet, *v1.Virtua
 }
 
 func expectEvent(recorder *record.FakeRecorder, reason string) {
-	Eventually(recorder.Events).Should(Receive(ContainSubstring(reason)))
+	Expect(recorder.Events).To(Receive(ContainSubstring(reason)))
+}
+
+// expectEvents checks for given reasons in arbitrary order
+func expectEvents(recorder *record.FakeRecorder, reasons ...string) {
+	l := len(reasons)
+	for x := 0; x < l; x++ {
+		select {
+
+		case e := <-recorder.Events:
+			filtered := []string{}
+			found := false
+			for _, reason := range reasons {
+
+				if strings.Contains(e, reason) && !found {
+					found = true
+					continue
+				}
+				filtered = append(filtered, reason)
+			}
+
+			Expect(found).To(BeTrue(), "Expected to match event reason '%s' with one of %v", e, reasons)
+			reasons = filtered
+
+		default:
+			// There should be something, trigger an error
+			Expect(recorder.Events).To(Receive())
+		}
+	}
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -728,6 +728,10 @@ func newUInt(x uint) *uint {
 	return &x
 }
 
+func NewInt32(x int32) *int32 {
+	return &x
+}
+
 func newString(x string) *string {
 	return &x
 }


### PR DESCRIPTION
Once the VMRS gets paused, it adds a Paused condition to it's state, so
that it is possible to observe from outside if the controller already
stopped. Only then is it save to modify/delete VirtualMachines which the
controller controlls.

That allows cluster-autoscaler to wait until the controller stopped,
then delete unused nodes and finally enable the controller again with a
decremented replica count.

Signed-off-by: Roman Mohr <rmohr@redhat.com>