### PR TITLE
Fix event order check in unit tests

### DIFF
--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -382,8 +382,7 @@ var _ = Describe("Replicaset", func() {
 
 			controller.Execute()
 
-			expectEvent(recorder, SuccessfulCreateVirtualMachineReason)
-			expectEvent(recorder, FailedCreateVirtualMachineReason)
+			expectEvents(recorder, SuccessfulCreateVirtualMachineReason, FailedCreateVirtualMachineReason)
 		})
 
 		It("should add a fail condition if scaling down fails", func() {


### PR DESCRIPTION
Don't assume specific event order when VMs are created in parallel in
the replicaset unit tests.

See https://travis-ci.org/kubevirt/kubevirt/jobs/281439746#L934 for an example where it fails on travis.

Signed-off-by: Roman Mohr <rmohr@redhat.com>