### PR TITLE
virt-launcher refactor/unit-tests/bug-fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ vendor/*
 !vendor/vendor.json
 .idea
 *.iml
+cmd/fake-qemu-process/fake-qemu*
 cmd/virt-manifest/virt-manifest*
 cmd/virt-controller/virt-controller*
 cmd/virt-launcher/virt-launcher*

--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -21,11 +21,26 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 )
 
 func main() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt,
+		syscall.SIGQUIT,
+	)
+
 	fmt.Printf("Started fake qemu process\n")
-	time.Sleep(60 * time.Second)
+
+	timeout := time.After(60 * time.Second)
+	select {
+	case <-timeout:
+	case <-c:
+		time.Sleep(2 * time.Second)
+	}
+
 	fmt.Printf("Exit fake qemu process\n")
 }

--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Printf("Started fake qemu process\n")
+	time.Sleep(60 * time.Second)
+	fmt.Printf("Exit fake qemu process\n")
+}

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,4 +1,4 @@
-binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virtctl cmd/virt-manifest"
+binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virtctl cmd/virt-manifest cmd/fake-qemu-process"
 docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virt-manifest images/haproxy images/iscsi-demo-target-tgtd images/vm-killer images/libvirt-kubevirt images/spice-proxy cmd/virt-migrator cmd/registry-disk-v1alpha images/cirros-registry-disk-demo"
 optional_docker_images="cmd/registry-disk-v1alpha images/fedora-atomic-registry-disk-demo"
 docker_prefix=kubevirt

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -1,0 +1,194 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package virtlauncher
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type monitor struct {
+	timeout   time.Duration
+	pid       int
+	exename   string
+	start     time.Time
+	isDone    bool
+	debugMode bool
+}
+
+type ProcessMonitor interface {
+	RunForever(startTimeout time.Duration)
+}
+
+func NewProcessMonitor(execname string, debugMode bool) ProcessMonitor {
+	return &monitor{
+		exename:   execname,
+		debugMode: debugMode,
+	}
+}
+
+func (mon *monitor) refresh() {
+	if mon.isDone {
+		log.Print("Called refresh after done!")
+		return
+	}
+
+	if mon.debugMode {
+		log.Printf("Refreshing executable %s pid %d", mon.exename, mon.pid)
+	}
+
+	// is the process there?
+	if mon.pid == 0 {
+		var err error
+		mon.pid, err = pidOf(mon.exename)
+		if err == nil {
+			log.Printf("Found PID for %s: %d", mon.exename, mon.pid)
+		} else {
+			if mon.debugMode {
+				log.Printf("Missing PID for %s", mon.exename)
+			}
+			// if the proces is not there yet, is it too late?
+			elapsed := time.Since(mon.start)
+			if mon.timeout > 0 && elapsed >= mon.timeout {
+				log.Printf("%s not found after timeout", mon.exename)
+				mon.isDone = true
+			}
+		}
+		return
+	}
+
+	// is the process gone? mon.pid != 0 -> mon.pid == 0
+	// note libvirt deliver one event for this, but since we need
+	// to poll procfs anyway to detect incoming QEMUs after migrations,
+	// we choose to not use this. Bonus: we can close the connection
+	// and open it only when needed, which is a tiny part of the
+	// virt-launcher lifetime.
+	if !pidExists(mon.pid) {
+		log.Printf("Process %s is gone!", mon.exename)
+		mon.pid = 0
+		mon.isDone = true
+		return
+	}
+
+	return
+}
+
+func (mon *monitor) RunForever(startTimeout time.Duration) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	)
+
+	// random value, no real rationale
+	rate := 500 * time.Millisecond
+
+	if mon.debugMode {
+		timeoutRepr := fmt.Sprintf("%v", startTimeout)
+		if startTimeout == 0 {
+			timeoutRepr = "disabled"
+		}
+		log.Printf("Monitoring loop: rate %v start timeout %s", rate, timeoutRepr)
+	}
+
+	ticker := time.NewTicker(rate)
+
+	gotSignal := false
+	mon.isDone = false
+	mon.timeout = startTimeout
+	mon.start = time.Now()
+
+	log.Printf("Waiting forever...")
+	for !gotSignal && !mon.isDone {
+		select {
+		case <-ticker.C:
+			mon.refresh()
+		case s := <-c:
+			log.Print("Got signal: ", s)
+			gotSignal = true
+			if mon.pid != 0 {
+				// forward the signal to the VM process
+				// TODO allow a delay here to support graceful shutdown from virt-handler side
+				syscall.Kill(mon.pid, s.(syscall.Signal))
+			}
+		}
+	}
+
+	ticker.Stop()
+	log.Printf("Exiting...")
+}
+
+func readProcCmdline(pathname string) ([]string, error) {
+	content, err := ioutil.ReadFile(pathname)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.Split(string(content), "\x00"), nil
+}
+
+func pidOf(exename string) (int, error) {
+	entries, err := filepath.Glob("/proc/*/cmdline")
+	if err != nil {
+		return 0, err
+	}
+	for _, entry := range entries {
+		argv, err := readProcCmdline(entry)
+		if err != nil {
+			return 0, err
+		}
+
+		// we need to support both
+		// - /usr/bin/qemu-system-$ARCH (fedora)
+		// - /usr/libexec/qemu-kvm (*EL, CentOS)
+		match, _ := filepath.Match(fmt.Sprintf("%s*", exename), filepath.Base(argv[0]))
+
+		if match {
+			//   <empty> /    proc     /    $PID   /   cmdline
+			// items[0] sep items[1] sep items[2] sep  items[3]
+			items := strings.Split(entry, string(os.PathSeparator))
+			pid, err := strconv.Atoi(items[2])
+			if err != nil {
+				return 0, err
+			}
+
+			return pid, nil
+		}
+	}
+	return 0, fmt.Errorf("Process %s not found in /proc", exename)
+}
+
+func pidExists(pid int) bool {
+	path := fmt.Sprintf("/proc/%d/cmdline", pid)
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -113,23 +113,19 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, signalChan chan os.S
 
 	ticker := time.NewTicker(rate)
 
-	gotSignal := false
 	mon.isDone = false
 	mon.timeout = startTimeout
 	mon.start = time.Now()
 
 	log.Printf("Waiting forever...")
-	for !gotSignal && !mon.isDone {
+	for !mon.isDone {
 		select {
 		case <-ticker.C:
 			mon.refresh()
 		case s := <-signalChan:
 			log.Print("Got signal: ", s)
-			gotSignal = true
 			if mon.pid != 0 {
 				mon.forwardedSignal = s.(syscall.Signal)
-				// forward the signal to the VM process
-				// TODO allow a delay here to support graceful shutdown from virt-handler side
 				syscall.Kill(mon.pid, s.(syscall.Signal))
 			}
 		}

--- a/pkg/virt-launcher/monitor_suite_test.go
+++ b/pkg/virt-launcher/monitor_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package virtlauncher
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVirtLauncher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VirtLauncher Test Suite")
+}

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -1,0 +1,115 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package virtlauncher
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("VirtLauncher", func() {
+	var mon *monitor
+	var cmd *exec.Cmd
+
+	dir := os.Getenv("PWD")
+	dir = strings.TrimSuffix(dir, "pkg/virt-launcher")
+
+	processName := "fake-qemu-process"
+	processPath := dir + "/cmd/fake-qemu-process/" + processName
+
+	StartProcess := func() {
+		cmd = exec.Command(processPath)
+		err := cmd.Start()
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	StopProcess := func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}
+
+	VerifyProcessStarted := func() {
+		Eventually(func() bool {
+
+			mon.refresh()
+			if mon.pid != 0 {
+				return true
+			}
+			return false
+
+		}).Should(BeTrue())
+
+	}
+
+	VerifyProcessStopped := func() {
+		Eventually(func() bool {
+
+			mon.refresh()
+			if mon.pid == 0 && mon.isDone == true {
+				return true
+			}
+			return false
+
+		}).Should(BeTrue())
+
+	}
+
+	BeforeEach(func() {
+		mon = &monitor{
+			exename:   processName,
+			debugMode: true,
+		}
+	})
+
+	Describe("VirtLauncher", func() {
+		Context("process monitor", func() {
+			It("verify pid detection works", func() {
+				StartProcess()
+				VerifyProcessStarted()
+				StopProcess()
+				VerifyProcessStopped()
+			})
+
+			It("verify start timeout works", func() {
+				done := make(chan string)
+
+				go func() {
+					mon.RunForever(time.Second)
+					done <- "exit"
+				}()
+				noExitCheck := time.After(3 * time.Second)
+
+				exited := false
+				select {
+				case <-noExitCheck:
+				case <-done:
+					exited = true
+				}
+
+				Expect(exited).To(Equal(true))
+			})
+		})
+	})
+})


### PR DESCRIPTION
I want to start iterating on the VM launch flow. As a prerequisite to that, virt-launcher needs to be restructured so it is unit testable.

- refactors virt-launcher logic into a separate unit testable package
- introduces virt-launcher pkg unit test suite
- addresses race condition between Pod shutdown and VM shutdown (virt-launcher now waits on VM process to exit before allowing virt-launcher to exit)