### PR TITLE
 Clean up orphaned registry disks after virt-handler recovery

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -170,6 +170,11 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
+	err = registrydisk.CleanupOrphanedEphemeralDisks(vmStore)
+	if err != nil {
+		panic(err)
+	}
+
 	go domainController.Run(3, stop)
 	go vmController.Run(3, stop)
 

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -26,8 +26,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 	"time"
 
 	model "github.com/jeevatkm/go-model"
@@ -357,33 +355,5 @@ func GenerateLocalData(domain string, namespace string, spec *v1.CloudInitSpec) 
 
 // Lists all vms cloud-init has local data for
 func ListVmWithLocalData() ([]*v1.VirtualMachine, error) {
-	var keys []*v1.VirtualMachine
-
-	err := filepath.Walk(cloudInitLocalDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() == false {
-			return nil
-		}
-
-		relativePath := strings.TrimPrefix(path, cloudInitLocalDir+"/")
-		if relativePath == "" {
-			return nil
-		}
-		dirs := strings.Split(relativePath, "/")
-		if len(dirs) != 2 {
-			return nil
-		}
-
-		namespace := dirs[0]
-		domain := dirs[1]
-		if namespace == "" || domain == "" {
-			return nil
-		}
-		keys = append(keys, v1.NewVMReferenceFromNameWithNS(dirs[0], dirs[1]))
-		return nil
-	})
-
-	return keys, err
+	return diskutils.ListVmWithEphemeralDisk(cloudInitLocalDir)
 }

--- a/pkg/config-disk/config-disk_test.go
+++ b/pkg/config-disk/config-disk_test.go
@@ -108,6 +108,12 @@ var _ = Describe("ConfigDiskServer", func() {
 				err := vmStore.Add(v1.NewVMReferenceFromNameWithNS("fakens1", "fakedomain1"))
 				Expect(err).ToNot(HaveOccurred())
 
+				// verifies VM data in finalized state are removed
+				vm := v1.NewVMReferenceFromNameWithNS("fakens1", "fakedomain2")
+				vm.Status.Phase = v1.Succeeded
+				err = vmStore.Add(vm)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = client.UndefineUnseen(vmStore)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -131,7 +131,15 @@ func FilesAreEqual(path1 string, path2 string) (bool, error) {
 func ListVmWithEphemeralDisk(localPath string) ([]*v1.VirtualMachine, error) {
 	var keys []*v1.VirtualMachine
 
-	err := filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
+	exists, err := FileExists(localPath)
+	if err != nil {
+		return nil, err
+	}
+	if exists == false {
+		return nil, nil
+	}
+
+	err = filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -89,12 +89,22 @@ func CleanupOrphanedEphemeralDisks(indexer cache.Store) error {
 	}
 
 	for _, vm := range vms {
+		cleanup := false
 		key, err := cache.MetaNamespaceKeyFunc(vm)
 		if err != nil {
 			return err
 		}
-		_, exists, _ := indexer.GetByKey(key)
+		obj, exists, _ := indexer.GetByKey(key)
 		if exists == false {
+			cleanup = true
+		} else {
+			vm := obj.(*v1.VirtualMachine)
+			if vm.IsFinal() {
+				cleanup = true
+			}
+		}
+
+		if cleanup {
 			err := CleanupEphemeralDisks(vm)
 			if err != nil {
 				return err

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jeevatkm/go-model"
 
 	kubev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -79,6 +80,28 @@ func getFilePath(basePath string) (string, string, error) {
 	}
 
 	return "", "", errors.New(fmt.Sprintf("no supported file disk found in directory %s", basePath))
+}
+
+func CleanupOrphanedEphemeralDisks(indexer cache.Store) error {
+	vms, err := diskutils.ListVmWithEphemeralDisk(mountBaseDir)
+	if err != nil {
+		return err
+	}
+
+	for _, vm := range vms {
+		key, err := cache.MetaNamespaceKeyFunc(vm)
+		if err != nil {
+			return err
+		}
+		_, exists, _ := indexer.GetByKey(key)
+		if exists == false {
+			err := CleanupEphemeralDisks(vm)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func CleanupEphemeralDisks(vm *v1.VirtualMachine) error {

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -202,6 +202,13 @@ var _ = Describe("RegistryDisk", func() {
 					}
 					Expect(exists).To(Equal(false))
 				}
+
+				// verify cleaning up a non-existent directory does not fail
+				err = SetLocalDirectory(tmpDir + "/made/this/path/up")
+				Expect(err).ToNot(HaveOccurred())
+				err = CleanupOrphanedEphemeralDisks(vmStore)
+				Expect(err).ToNot(HaveOccurred())
+
 			})
 
 			It("by verifying data cleanup", func() {

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -183,6 +183,12 @@ var _ = Describe("RegistryDisk", func() {
 				err := vmStore.Add(v1.NewVMReferenceFromNameWithNS("fakens1", "fakedomain1"))
 				Expect(err).ToNot(HaveOccurred())
 
+				// verifies VM data in finalized state are removed
+				vm := v1.NewVMReferenceFromNameWithNS("fakens1", "fakedomain2")
+				vm.Status.Phase = v1.Succeeded
+				err = vmStore.Add(vm)
+				Expect(err).ToNot(HaveOccurred())
+
 				err = CleanupOrphanedEphemeralDisks(vmStore)
 				Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Without this change, it is theoretically possible for a registry disk to be permanently orphaned on the local disk in the even that virt-handler crashes while in the process of destroying a VM. 