### PR TITLE
route OpenAPI requests to kube-apiserver

### DIFF
--- a/images/haproxy/haproxy.cfg
+++ b/images/haproxy/haproxy.cfg
@@ -8,11 +8,13 @@ frontend virt_api
   bind *:8184
   mode http
   acl is_supported_method method POST PUT GET DELETE OPTIONS PATCH
+  acl is_openapi path_beg /swagger-2.0.0.pb-v1
   acl is_swagger_api path_beg /swagger-ui
   acl is_swagger_spec path_beg /swaggerapi/apis/kubevirt.io/
   acl is_kubevirt path_beg /apis/kubevirt.io
   http-request add-header Authorization Bearer\ %[env(TOKEN)]
   timeout client 1m
+  use_backend srvs_apiserver if is_openapi
   use_backend srvs_kubevirt if is_supported_method is_kubevirt
   use_backend srvs_kubevirt if is_swagger_api
   use_backend srvs_kubevirt if is_swagger_spec


### PR DESCRIPTION
Workaround for 1.8 kube.