### PR TITLE
Remove the duplicity libvirt connection

### DIFF
--- a/pkg/virt-handler/virtwrap/cli/libvirt.go
+++ b/pkg/virt-handler/virtwrap/cli/libvirt.go
@@ -22,6 +22,7 @@ package cli
 //go:generate mockgen -source $GOFILE -imports "libvirt=github.com/libvirt/libvirt-go" -package=$GOPACKAGE -destination=generated_mock_$GOFILE
 
 import (
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -335,7 +336,7 @@ func NewConnection(uri string, user string, pass string, checkInterval time.Dura
 		return true, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot connect to libvirt daemon: %v", err)
 	}
 	logger.Info().V(1).Msg("Connected to libvirt daemon")
 

--- a/pkg/virt-handler/virtwrap/cli/libvirt_suite_test.go
+++ b/pkg/virt-handler/virtwrap/cli/libvirt_suite_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Libvirt Suite", func() {
 			_, err := NewConnection("http://", "", "", 1*time.Microsecond)
 			msg := fmt.Sprintf("%v", err)
 			Expect(err).To(HaveOccurred())
-			Expect(msg).To(Equal("timed out waiting for the condition"))
+			Expect(msg).To(Equal("cannot connect to libvirt daemon: timed out waiting for the condition"))
 		})
 	})
 })

--- a/pkg/virt-handler/virtwrap/cli/libvirt_suite_test.go
+++ b/pkg/virt-handler/virtwrap/cli/libvirt_suite_test.go
@@ -31,7 +31,7 @@ import (
 var _ = Describe("Libvirt Suite", func() {
 	Context("Upon attempt to connect to Libvirt", func() {
 		It("should time out while waiting for libvirt", func() {
-			err := waitForLibvirt("http://", "", "", 1*time.Microsecond)
+			_, err := NewConnection("http://", "", "", 1*time.Microsecond)
 			msg := fmt.Sprintf("%v", err)
 			Expect(err).To(HaveOccurred())
 			Expect(msg).To(Equal("timed out waiting for the condition"))


### PR DESCRIPTION
Code cleanup

The newConnection used to connect to the
libvirt is done twice, which is unnecesary.

It is removed and replaced with one attempt
with correct polling.

@rmohr @fabiand @davidvossel PRM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/493)
<!-- Reviewable:end -->
