### PR TITLE
Adding openapi specification

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -28,6 +28,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi"
 	swagger "github.com/emicklei/go-restful-swagger12"
 	kithttp "github.com/go-kit/kit/transport/http"
+	openapispec "github.com/go-openapi/spec"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -138,13 +139,32 @@ func (app *virtAPIApp) Run() {
 	}
 	swagger.InstallSwaggerService(config)
 	openapiConf := restfulspec.Config{
-		WebServices:    restful.RegisteredWebServices(),
+		WebServices:    []*restful.WebService{ws},
 		WebServicesURL: "http://localhost:8183",
 		APIPath:        "/openapi.json",
+		PostBuildSwaggerObjectHandler: addInfoToSwaggerObject,
 	}
 	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(openapiConf))
 
 	log.Fatal(http.ListenAndServe(app.Service.Address(), nil))
+}
+
+func addInfoToSwaggerObject(swo *openapispec.Swagger) {
+	swo.Info = &openapispec.Info{
+		InfoProps: openapispec.InfoProps{
+			Title:       "KubeVirt API, ",
+			Description: "This is KubeVirt API an add-on for Kubernetes.",
+			Contact: &openapispec.ContactInfo{
+				Name:  "kubevirt-dev",
+				Email: "kubevirt-dev@googlegroups.com",
+				URL:   "https://github.com/kubevirt/kubevirt",
+			},
+			License: &openapispec.License{
+				Name: "Apache 2.0",
+				URL:  "https://www.apache.org/licenses/LICENSE-2.0",
+			},
+		},
+	}
 }
 
 func main() {

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -25,7 +25,8 @@ import (
 	"net/http"
 
 	"github.com/emicklei/go-restful"
-	"github.com/emicklei/go-restful/swagger"
+	restfulspec "github.com/emicklei/go-restful-openapi"
+	swagger "github.com/emicklei/go-restful-swagger12"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
@@ -136,6 +137,12 @@ func (app *virtAPIApp) Run() {
 		},
 	}
 	swagger.InstallSwaggerService(config)
+	openapiConf := restfulspec.Config{
+		WebServices:    restful.RegisteredWebServices(),
+		WebServicesURL: "http://localhost:8183",
+		APIPath:        "/openapi.json",
+	}
+	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(openapiConf))
 
 	log.Fatal(http.ListenAndServe(app.Service.Address(), nil))
 }

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -129,7 +129,7 @@ func (app *virtAPIApp) Run() {
 		PostBuildSwaggerObjectHandler: addInfoToSwaggerObject,
 	}
 	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(openapiConf))
-	http.Handle("/swagger-ui", http.StripPrefix("/swagger-ui", http.FileServer(http.Dir(app.SwaggerUI))))
+	http.Handle("/swagger-ui/", http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir(app.SwaggerUI))))
 
 	log.Fatal(http.ListenAndServe(app.Service.Address(), nil))
 }

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
-	swagger "github.com/emicklei/go-restful-swagger12"
 	kithttp "github.com/go-kit/kit/transport/http"
 	openapispec "github.com/go-openapi/spec"
 	"github.com/spf13/pflag"
@@ -123,28 +122,14 @@ func (app *virtAPIApp) Run() {
 	restful.Filter(filter.RequestLoggingFilter())
 	restful.Filter(restful.OPTIONSFilter())
 
-	config := swagger.Config{
-		WebServices:     restful.RegisteredWebServices(), // you control what services are visible
-		WebServicesUrl:  "http://localhost:8183",
-		ApiPath:         "/swaggerapi",
-		SwaggerPath:     "/swagger-ui/",
-		SwaggerFilePath: app.SwaggerUI,
-		Info: swagger.Info{
-			Title:       "KubeVirt API, ",
-			Description: "This is KubeVirt API an add-on for Kubernetes.",
-			Contact:     "kubevirt-dev@googlegroups.com",
-			License:     "Apache 2.0",
-			LicenseUrl:  "https://www.apache.org/licenses/LICENSE-2.0",
-		},
-	}
-	swagger.InstallSwaggerService(config)
 	openapiConf := restfulspec.Config{
-		WebServices:    []*restful.WebService{ws},
+		WebServices:    restful.RegisteredWebServices(),
 		WebServicesURL: "http://localhost:8183",
-		APIPath:        "/openapi.json",
+		APIPath:        "/swaggerapi",
 		PostBuildSwaggerObjectHandler: addInfoToSwaggerObject,
 	}
 	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(openapiConf))
+	http.Handle("/swagger-ui", http.StripPrefix("/swagger-ui", http.FileServer(http.Dir(app.SwaggerUI))))
 
 	log.Fatal(http.ListenAndServe(app.Service.Address(), nil))
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 89bb7e5c0029b7970d34246cd248f5e31520a3cc462672ec6e7a1bb9c5d64ec0
-updated: 2017-10-05T15:22:32.152710297+03:00
+hash: b5dd69192737ed1e89a6ac07b50ebbf76f67f1330b84b7d3500e6f09d1c670cb
+updated: 2017-10-09T18:13:03.251486292+02:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 6fcd5b427f532a5d13738b27415e00a49e36ceef
@@ -89,7 +89,7 @@ imports:
 - name: github.com/libvirt/libvirt-go
   version: 7b2a44de9fd207c2cbc28bdbad20c8279b767553
 - name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  version: 2a92e673c9a6302dd05c3a691ae1f24aef46457d
   subpackages:
   - buffer
   - jlexer
@@ -213,7 +213,6 @@ imports:
   - certificates/v1beta1
   - core/v1
   - extensions/v1beta1
-  - imagepolicy/v1alpha1
   - networking/v1
   - policy/v1beta1
   - rbac/v1

--- a/glide.lock
+++ b/glide.lock
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - log
 - name: github.com/emicklei/go-restful-openapi
-  version: efa082cf7dfa43fc8381ca3bfb9ef9a248c5d686
+  version: 7cb0644488653a4657f941eb34631edf7d5d21e3
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/evanphx/json-patch

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 03562ad089d1614b5fa6f67af0163fe38eda2a9bd9b8794bb7460aaa7bd01d21
-updated: 2017-09-29T10:54:40.476113049-04:00
+hash: 89bb7e5c0029b7970d34246cd248f5e31520a3cc462672ec6e7a1bb9c5d64ec0
+updated: 2017-10-05T15:22:32.152710297+03:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 6fcd5b427f532a5d13738b27415e00a49e36ceef
@@ -8,10 +8,11 @@ imports:
   subpackages:
   - spew
 - name: github.com/emicklei/go-restful
-  version: 858e58f98abd32bc4d164a08e8d7ac169ae876e2
+  version: dc0f94ee75de39d6420e5446b0222490264bb90f
   subpackages:
   - log
-  - swagger
+- name: github.com/emicklei/go-restful-openapi
+  version: efa082cf7dfa43fc8381ca3bfb9ef9a248c5d686
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/evanphx/json-patch
@@ -39,12 +40,12 @@ imports:
 - name: github.com/go-stack/stack
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: github.com/gogo/protobuf
-  version: f7f1376d9d231a646d4e62fe1075623ced6db327
+  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
@@ -62,7 +63,7 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/google/gofuzz
-  version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/googleapis/gnostic
   version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
@@ -130,7 +131,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pborman/uuid
-  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -212,6 +213,7 @@ imports:
   - certificates/v1beta1
   - core/v1
   - extensions/v1beta1
+  - imagepolicy/v1alpha1
   - networking/v1
   - policy/v1beta1
   - rbac/v1
@@ -447,7 +449,7 @@ imports:
   - util/jsonpath
   - util/workqueue
 - name: k8s.io/kube-openapi
-  version: abfc5fbe1cf87ee697db107fdfd24c32fe4397a8
+  version: 80f07ef71bb4f781233c65aa8d0369e4ecafab87
   subpackages:
   - pkg/common
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: b5dd69192737ed1e89a6ac07b50ebbf76f67f1330b84b7d3500e6f09d1c670cb
-updated: 2017-10-09T18:13:03.251486292+02:00
+updated: 2017-10-16T15:49:47.265313161+02:00
 imports:
 - name: github.com/asaskevich/govalidator
-  version: 6fcd5b427f532a5d13738b27415e00a49e36ceef
+  version: ca5f9e638c83bac66bfac70ded5bded1503135a7
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - log
 - name: github.com/emicklei/go-restful-openapi
-  version: 7cb0644488653a4657f941eb34631edf7d5d21e3
+  version: 0d037b269a5b53b582789e25dee0d0a0614119e5
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/evanphx/json-patch
@@ -30,13 +30,13 @@ imports:
 - name: github.com/go-logfmt/logfmt
   version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
 - name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+  version: 36d33bfe519efae5632669801b180bf1a245da3b
 - name: github.com/go-openapi/spec
   version: 48c2a7185575f9103a5a3863eff950bb776899d2
 - name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/go-stack/stack
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: github.com/gogo/protobuf
@@ -45,13 +45,13 @@ imports:
   - proto
   - sortkeys
 - name: github.com/golang/glog
-  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/groupcache
   version: 02826c3e79038b59d737d3b1c0a1d937f71a4433
   subpackages:
   - lru
 - name: github.com/golang/mock
-  version: 2b473a1a899b0c9967501477ec03c71c32550cbe
+  version: 6e20fef50e74e443696bc32b693cf286b612d45b
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
@@ -63,7 +63,7 @@ imports:
   - ptypes/duration
   - ptypes/timestamp
 - name: github.com/google/gofuzz
-  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+  version: 24818f796faf91cd76ec7bddd72458fbced7a6c1
 - name: github.com/googleapis/gnostic
   version: 0c5108395e2debce0d731cf0287ddf7242066aba
   subpackages:
@@ -71,7 +71,7 @@ imports:
   - compiler
   - extensions
 - name: github.com/gorilla/websocket
-  version: 4201258b820c74ac8e6922fc9e6b52f71fe46f8d
+  version: 71fa72d4842364bc5f74185f4161e0099ea3624a
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
@@ -131,7 +131,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/pborman/uuid
-  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -139,7 +139,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/spf13/pflag
-  version: 7aff26db30c1be810f9de5038ec5ef96ac41fd7c
+  version: a9789e855c7696159b7db0db7f440b449edf2b31
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
@@ -192,7 +192,7 @@ imports:
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/ini.v1
-  version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
+  version: 5b3e00af70a9484542169a976dcab8d03e601a17
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
@@ -448,7 +448,7 @@ imports:
   - util/jsonpath
   - util/workqueue
 - name: k8s.io/kube-openapi
-  version: 80f07ef71bb4f781233c65aa8d0369e4ecafab87
+  version: abfc5fbe1cf87ee697db107fdfd24c32fe4397a8
   subpackages:
   - pkg/common
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,10 +13,9 @@ import:
   subpackages:
   - log
 - package: github.com/emicklei/go-restful
-  version: 858e58f98abd32bc4d164a08e8d7ac169ae876e2
+  version: dc0f94ee75de39d6420e5446b0222490264bb90f
   subpackages:
   - log
-  - swagger
 - package: github.com/evanphx/json-patch
   version: ba18e35c5c1b36ef6334cad706eb681153d2d379
 - package: k8s.io/client-go
@@ -186,6 +185,9 @@ import:
   - util/workqueue
 - package: github.com/fsnotify/fsnotify
   version: ^1.4.2
+- package: github.com/emicklei/go-restful-openapi
+- package: github.com/go-openapi/spec
+- package: github.com/emicklei/go-restful-swagger12
 testImport:
 - package: github.com/elazarl/goproxy
   version: 07b16b6e30fcac0ad8c0435548e743bcf2ca7e92

--- a/glide.yaml
+++ b/glide.yaml
@@ -185,6 +185,8 @@ import:
   - util/workqueue
 - package: github.com/fsnotify/fsnotify
   version: ^1.4.2
+- package: github.com/mailru/easyjson
+  version: 2a92e673c9a6302dd05c3a691ae1f24aef46457d
 - package: github.com/emicklei/go-restful-openapi
 - package: github.com/go-openapi/spec
 - package: github.com/emicklei/go-restful-swagger12

--- a/pkg/rest/endpoints/encoders.go
+++ b/pkg/rest/endpoints/encoders.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ghodss/yaml"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"golang.org/x/net/context"
-	"gopkg.in/ini.v1"
+	ini "gopkg.in/ini.v1"
 
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/rest"

--- a/pkg/rest/endpoints/get_test.go
+++ b/pkg/rest/endpoints/get_test.go
@@ -22,6 +22,7 @@ package endpoints
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	ini "gopkg.in/ini.v1"
 
 	"net/http"
 
@@ -34,7 +35,6 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"
 	"golang.org/x/net/context"
-	"gopkg.in/ini.v1"
 
 	"kubevirt.io/kubevirt/pkg/rest"
 )

--- a/pkg/virt-api/rest/kubeproxy.go
+++ b/pkg/virt-api/rest/kubeproxy.go
@@ -147,7 +147,7 @@ func GenericResourceProxy(ws *restful.WebService, ctx context.Context, gvr schem
 	))
 
 	// TODO, implement watch. For now it is here to provide swagger doc only
-	ws.Route(addWatchGetListParams(
+	ws.Route(addWatchNamespacedGetListParams(
 		ws.GET("/watch"+ResourceBasePath(gvr)).
 			Operation("watchNamespaced"+objKind).
 			Produces(mime.MIME_JSON).
@@ -187,9 +187,13 @@ func ResourceProxyAutodiscovery(ctx context.Context, gvr schema.GroupVersionReso
 }
 
 func addWatchGetListParams(builder *restful.RouteBuilder, ws *restful.WebService) *restful.RouteBuilder {
-	return builder.Param(NamespaceParam(ws)).Param(fieldSelectorParam(ws)).Param(labelSelectorParam(ws)).
+	return builder.Param(fieldSelectorParam(ws)).Param(labelSelectorParam(ws)).
 		Param(ws.QueryParameter("resourceVersion", "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.")).
 		Param(ws.QueryParameter("timeoutSeconds", "TimeoutSeconds for the list/watch call.").DataType("integer"))
+}
+
+func addWatchNamespacedGetListParams(builder *restful.RouteBuilder, ws *restful.WebService) *restful.RouteBuilder {
+	return addWatchGetListParams(builder.Param(NamespaceParam(ws)), ws)
 }
 
 func addGetAllNamespacesListParams(builder *restful.RouteBuilder, ws *restful.WebService) *restful.RouteBuilder {
@@ -199,7 +203,7 @@ func addGetAllNamespacesListParams(builder *restful.RouteBuilder, ws *restful.We
 }
 
 func addDeleteListParams(builder *restful.RouteBuilder, ws *restful.WebService) *restful.RouteBuilder {
-	return builder.Param(NameParam(ws)).Param(fieldSelectorParam(ws)).Param(labelSelectorParam(ws))
+	return builder.Param(fieldSelectorParam(ws)).Param(labelSelectorParam(ws))
 }
 
 func addGetParams(builder *restful.RouteBuilder, ws *restful.WebService) *restful.RouteBuilder {

--- a/pkg/virt-api/rest/kubeproxy_test.go
+++ b/pkg/virt-api/rest/kubeproxy_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Kubeproxy", func() {
 		})
 		It("Get with invalid VM name should fail with 400", func() {
 			result := restClient.Get().Resource(vmResource).Namespace(k8sv1.NamespaceDefault).Name("UPerLetterIsInvalid").Do()
-			Expect(result).To(HaveStatusCode(http.StatusNotFound))
+			Expect(result).To(HaveStatusCode(http.StatusBadRequest))
 		})
 		table.DescribeTable("PUT should succeed", func(contentType string, accept string) {
 			apiserverMock.AppendHandlers(

--- a/tests/spice_test.go
+++ b/tests/spice_test.go
@@ -33,7 +33,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/ini.v1"
+	ini "gopkg.in/ini.v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"


### PR DESCRIPTION
In order to provide openapi specification v2.0 . It is part of #485 to provide online API documentation.

The openapi.json is available under http://192.168.200.2:8183/openapi.json .