### PR TITLE
Make vagrant rsync more robust

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,9 @@ Vagrant.configure(2) do |config|
   if $use_nfs then
     config.vm.synced_folder "./", "/vagrant", type: "nfs"
   else
-          config.vm.synced_folder "./", "/vagrant", type: "rsync", rsync__exclude: [ "cluster/vagrant/.kubectl", "cluster/vagrant/.kubeconfig", ".vagrant", "vendor", ".git"]
+          config.vm.synced_folder "./", "/vagrant", type: "rsync",
+                  rsync__exclude: [ "cluster/vagrant/.kubectl", "cluster/vagrant/.kubeconfig", ".vagrant", "vendor", ".git"],
+                  rsync__args: ["--archive", "--delete"]
   end
 
   config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
In case that there is a dangling sysmlink, it should proceed copying.

Signed-off-by: Roman Mohr <rmohr@redhat.com>