### PR TITLE
Increate functional test timeout to 30 minutes

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -40,7 +40,7 @@ if [ $# -eq 0 ]; then
     if [ "${target}" = "test" ]; then
         (cd pkg; go ${target} -v ./...)
     elif [ "${target}" = "functest" ]; then
-        (cd tests; go test -master=http://${master_ip}:${master_port} ${FUNC_TEST_ARGS})
+        (cd tests; go test -master=http://${master_ip}:${master_port} -timeout 30m ${FUNC_TEST_ARGS})
         exit
     else
         (cd pkg; go $target ./...)


### PR DESCRIPTION
On slower systems and more and more often on CI, the test suit runs more
than 10 minutes and therefore increase the allowed execution time to 30
minutes.

Signed-off-by: Roman Mohr <rmohr@redhat.com>