### PR TITLE
Give k8s more time to delete namespaces

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -423,8 +423,10 @@ func removeNamespaces() {
 	}
 
 	// Wait until the namespaces are terminated
+	fmt.Println("")
 	for _, namespace := range testNamespaces {
-		Eventually(func() bool { return errors.IsNotFound(virtCli.CoreV1().Namespaces().Delete(namespace, nil)) }, 60*time.Second, 1*time.Second).
+		fmt.Printf("Waiting for namespace %s to be removed, this can take a while ...\n", namespace)
+		Eventually(func() bool { return errors.IsNotFound(virtCli.CoreV1().Namespaces().Delete(namespace, nil)) }, 180*time.Second, 1*time.Second).
 			Should(BeTrue())
 	}
 }


### PR DESCRIPTION
Wait up to three minutes for k8s to delete our test namespaces after the
whole test suite ran.

Signed-off-by: Roman Mohr <rmohr@redhat.com>