### PR TITLE
makefile: fix clean target when vendor doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ clean:
 	rm ./bin -rf
 
 distclean: clean
-	find vendor/ -maxdepth 1 -mindepth 1 -not -name vendor.json -exec rm {} -rf \;
+	test -d vendor && find vendor/ -maxdepth 1 -mindepth 1 -not -name vendor.json -exec rm {} -rf \;
 	rm -f manifest/*.yaml
 	rm -f .glide.*.hash
 	glide cc


### PR DESCRIPTION
When you clone repo from scratch you don't have vendor directory
there. Then it makes 'make clean' execution fail.