### PR TITLE
Move VMs to HostPid Namespace

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -56,6 +56,8 @@ import (
 	watchdog "kubevirt.io/kubevirt/pkg/watchdog"
 )
 
+const defaultWatchdogTimeout = 30 * time.Second
+
 type virtHandlerApp struct {
 	Service                 *service.Service
 	HostOverride            string
@@ -218,8 +220,6 @@ func (app *virtHandlerApp) Run() {
 }
 
 func main() {
-	defaultExpires := 30 * time.Second
-
 	logging.InitializeLogging("virt-handler")
 	libvirt.EventRegisterDefaultImpl()
 	libvirtUri := flag.String("libvirt-uri", "qemu:///system", "Libvirt connection string.")
@@ -228,7 +228,7 @@ func main() {
 	hostOverride := flag.String("hostname-override", "", "Kubernetes Pod to monitor for changes")
 	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	ephemeralDiskDir := flag.String("ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk", "Base directory for ephemeral disk data")
-	watchdogTimeoutDuration := flag.Duration("watchdog-timeout", defaultExpires, "Watchdog file timeout.")
+	watchdogTimeoutDuration := flag.Duration("watchdog-timeout", defaultWatchdogTimeout, "Watchdog file timeout.")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -120,6 +120,7 @@ func (app *virtHandlerApp) Run() {
 	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn,
 		recorder,
 		isolation.NewSocketBasedIsolationDetector(app.VirtShareDir),
+		app.VirtShareDir,
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -124,7 +124,6 @@ func (app *virtHandlerApp) Run() {
 	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn,
 		recorder,
 		isolation.NewSocketBasedIsolationDetector(app.VirtShareDir),
-		app.VirtShareDir,
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -72,7 +72,6 @@ func main() {
 
 	logging.InitializeLogging("virt-launcher")
 	qemuTimeout := flag.Duration("qemu-timeout", startTimeout, "Amount of time to wait for qemu")
-	debugMode := flag.Bool("debug", false, "Enable debug messages")
 	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	name := flag.String("name", "", "Name of the VM")
 	namespace := flag.String("namespace", "", "Namespace of the VM")
@@ -115,7 +114,7 @@ func main() {
 		}
 	}()
 
-	mon := virtlauncher.NewProcessMonitor("qemu", *debugMode)
+	mon := virtlauncher.NewProcessMonitor("qemu")
 
 	markReady(*readinessFile)
 	mon.RunForever(*qemuTimeout)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -34,6 +34,9 @@ import (
 	watchdog "kubevirt.io/kubevirt/pkg/watchdog"
 )
 
+const defaultStartTimeout = 3 * time.Minute
+const defaultWatchdogInterval = 10 * time.Second
+
 func markReady(readinessFile string) {
 	f, err := os.OpenFile(readinessFile, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
@@ -67,15 +70,12 @@ func createSocket(virtShareDir string, namespace string, name string) net.Listen
 }
 
 func main() {
-	startTimeout := 0 * time.Second
-	defaultInterval := 10 * time.Second
-
 	logging.InitializeLogging("virt-launcher")
-	qemuTimeout := flag.Duration("qemu-timeout", startTimeout, "Amount of time to wait for qemu")
+	qemuTimeout := flag.Duration("qemu-timeout", defaultStartTimeout, "Amount of time to wait for qemu")
 	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	name := flag.String("name", "", "Name of the VM")
 	namespace := flag.String("namespace", "", "Namespace of the VM")
-	watchdogInterval := flag.Duration("watchdog-update-interval", defaultInterval, "Interval at which watchdog file should be updated")
+	watchdogInterval := flag.Duration("watchdog-update-interval", defaultWatchdogInterval, "Interval at which watchdog file should be updated")
 	readinessFile := flag.String("readiness-file", "/tmp/health", "Pod looks for tihs file to determine when virt-launcher is initialized")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"flag"
-	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -41,7 +40,7 @@ func markReady(readinessFile string) {
 		panic(err)
 	}
 	f.Close()
-	log.Printf("Marked as ready\n")
+	logging.DefaultLogger().Info().Msgf("Marked as ready")
 }
 
 func createSocket(virtShareDir string, namespace string, name string) net.Listener {
@@ -49,16 +48,19 @@ func createSocket(virtShareDir string, namespace string, name string) net.Listen
 
 	err := os.MkdirAll(filepath.Dir(sockFile), 0755)
 	if err != nil {
-		log.Fatal("Could not create directory for socket.", err)
+		logging.DefaultLogger().Reason(err).Error().Msgf("Could not create directory for socket.")
+		panic(err)
 	}
 
 	if err := os.RemoveAll(sockFile); err != nil {
-		log.Fatal("Could not clean up old socket for cgroup detection", err)
+		logging.DefaultLogger().Reason(err).Error().Msgf("Could not clean up old socket for cgroup detection")
+		panic(err)
 	}
 	socket, err := net.Listen("unix", sockFile)
 
 	if err != nil {
-		log.Fatal("Could not create socket for cgroup detection.", err)
+		logging.DefaultLogger().Reason(err).Error().Msgf("Could not create socket for cgroup detection.")
+		panic(err)
 	}
 
 	return socket
@@ -93,7 +95,7 @@ func main() {
 		panic(err)
 	}
 
-	log.Printf("Watchdog file created at %s\n", watchdogFile)
+	logging.DefaultLogger().Info().Msgf("Watchdog file created at %s", watchdogFile)
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -79,7 +79,13 @@ func main() {
 	socket := createSocket(*virtShareDir, *namespace, *name)
 	defer socket.Close()
 
-	mon := virtlauncher.NewProcessMonitor("qemu", *debugMode)
+	err := virtlauncher.InitializeSharedDirectories(*virtShareDir)
+	if err != nil {
+		panic(err)
+	}
+
+	pidFile := virtlauncher.QemuPidfileFromNamespaceName(*virtShareDir, *namespace, *name)
+	mon := virtlauncher.NewProcessMonitor(pidFile, *debugMode)
 
 	markReady(*readinessFile)
 	mon.RunForever(*qemuTimeout)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -42,12 +43,18 @@ func markReady(readinessFile string) {
 	log.Printf("Marked as ready")
 }
 
-func createSocket(socketDir string, namespace string, name string) net.Listener {
-	socketPath := isolation.SocketFromNamespaceName(socketDir, namespace, name)
-	if err := os.RemoveAll(socketPath); err != nil {
+func createSocket(virtShareDir string, namespace string, name string) net.Listener {
+	sockFile := isolation.SocketFromNamespaceName(virtShareDir, namespace, name)
+
+	err := os.MkdirAll(filepath.Dir(sockFile), 0755)
+	if err != nil {
+		log.Fatal("Could not create directory for socket.", err)
+	}
+
+	if err := os.RemoveAll(sockFile); err != nil {
 		log.Fatal("Could not clean up old socket for cgroup detection", err)
 	}
-	socket, err := net.Listen("unix", isolation.SocketFromNamespaceName(socketDir, namespace, name))
+	socket, err := net.Listen("unix", sockFile)
 
 	if err != nil {
 		log.Fatal("Could not create socket for cgroup detection.", err)
@@ -62,14 +69,14 @@ func main() {
 	logging.InitializeLogging("virt-launcher")
 	qemuTimeout := flag.Duration("qemu-timeout", startTimeout, "Amount of time to wait for qemu")
 	debugMode := flag.Bool("debug", false, "Enable debug messages")
-	socketDir := flag.String("socket-dir", "/var/run/kubevirt", "Directory where to place a socket for cgroup detection")
+	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	name := flag.String("name", "", "Name of the VM")
 	namespace := flag.String("namespace", "", "Namespace of the VM")
 	readinessFile := flag.String("readiness-file", "/tmp/health", "Pod looks for tihs file to determine when virt-launcher is initialized")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	socket := createSocket(*socketDir, *namespace, *name)
+	socket := createSocket(*virtShareDir, *namespace, *name)
 	defer socket.Close()
 
 	mon := virtlauncher.NewProcessMonitor("qemu", *debugMode)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -113,8 +113,7 @@ func main() {
 		}
 	}()
 
-	pidFile := virtlauncher.QemuPidfileFromNamespaceName(*virtShareDir, *namespace, *name)
-	mon := virtlauncher.NewProcessMonitor(pidFile, *debugMode)
+	mon := virtlauncher.NewProcessMonitor("qemu", *debugMode)
 
 	markReady(*readinessFile)
 	mon.RunForever(*qemuTimeout)

--- a/cmd/virt-migrator/migrate
+++ b/cmd/virt-migrator/migrate
@@ -30,10 +30,6 @@ case $key in
     CONTROLLER="$2"
     shift
     ;;
-    --pidns)
-    PIDNS="$2"
-    shift
-    ;;
     *)
     VM=$1
     ;;
@@ -41,8 +37,8 @@ esac
 shift
 done
 
-if [ -z $NODE_IP ] || [ -z $DEST ] || [ -z $SOURCE ] || [ -z $VM ] || [ -z $NAMESPACE ] || [ -z $CONTROLLER ] || [ -z $SLICE ] || [ -z $PIDNS ]; then
-echo "Usage: migrate DOMAIN --source SOURCE --dest DESTINATION --node-ip NODE_IP --namespace NAMESPACE --controller CONTROLLER --slice SLICE --pidns PIDNS"
+if [ -z $NODE_IP ] || [ -z $DEST ] || [ -z $SOURCE ] || [ -z $VM ] || [ -z $NAMESPACE ] || [ -z $CONTROLLER ] || [ -z $SLICE ]; then
+echo "Usage: migrate DOMAIN --source SOURCE --dest DESTINATION --node-ip NODE_IP --namespace NAMESPACE --controller CONTROLLER --slice SLICE"
 exit 1
 fi 
 DOMAIN=${NAMESPACE}_${VM}
@@ -57,9 +53,6 @@ xmlstarlet ed --inplace -u  "/domain/devices/graphics[@type='spice']/listen/@add
 # cgroups
 xmlstarlet ed --inplace -u  "/domain/qemu:commandline/qemu:env[@name='SLICE']/@value" -v $SLICE $DOMAIN.xml
 xmlstarlet ed --inplace -u  "/domain/qemu:commandline/qemu:env[@name='CONTROLLERS']/@value" -v $CONTROLLER $DOMAIN.xml
-
-#namespaces
-xmlstarlet ed --inplace -u  "/domain/qemu:commandline/qemu:env[@name='PIDNS']/@value" -v $PIDNS $DOMAIN.xml
 
 # Migrate
 virsh -c $SOURCE migrate --xml $DOMAIN.xml $DOMAIN $DEST tcp://$NODE_IP

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -54,6 +54,7 @@ set -e
 exec sudo -C 10000 bash -s << END
 
   function _term() {
+    rm -f $PIDFILE
     pkill -P \$! --signal SIG\$1
   }
 
@@ -70,4 +71,8 @@ exec sudo -C 10000 bash -s << END
   echo "\$pid" > $PIDFILE
   echo "LAUNCHED PID \$pid" >> $LOG
   wait
+  res=\$?
+
+  rm -f $PIDFILE
+  exit \$res
 END

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -40,7 +40,6 @@ CMD="$QEMU $ARGS"
 
 log "cgroup path: $SLICE" >> $LOG
 log "cgroups: $CONTROLLERS" >> $LOG
-log "PID namespace: $PIDNS" >> $LOG
 
 log "$CMD" >> $LOG
 

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -46,33 +46,14 @@ log "PIDFILE: $PIDFILE" >> $LOG
 log "$CMD" >> $LOG
 
 set -e
+sudo cgclassify -g ${CONTROLLERS}:$SLICE --sticky $$
 
-# Start qemu in the pid namespace of the container to receive signals on
-# container kills Don't close file descriptors smaller than 10000 to allow
-# passing tap device fds Start the qemu process in the cgroups of the docker
-# container to adhere to the resource limitations of the container.
-exec sudo -C 10000 bash -s << END
-
-  function _term() {
-    rm -f $PIDFILE
-    kill -SIG\$1 \$pid
-  }
-
-  trap "_term TERM" TERM
-  trap "_term INT" INT
-  trap "_term HUP" HUP
-  trap "_term QUIT" QUIT
-  trap "_term TERM" EXIT
-  trap "_term TERM" ERR
-
-  cgclassify -g ${CONTROLLERS}:$SLICE --sticky \$\$
-  $CMD &
-  pid=\$!
-  echo "\$pid" > $PIDFILE
-  echo "LAUNCHED PID \$pid" >> $LOG
-  wait
-  res=\$?
-
-  rm -f $PIDFILE
-  exit \$res
+pid=$$
+sudo bash -s << END
+  echo "$pid" > $PIDFILE
 END
+
+echo "Launching qemu process with pid $pid" >> $LOG
+
+exec $CMD
+

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -41,6 +41,7 @@ CMD="$QEMU $ARGS"
 log "cgroup path: $SLICE" >> $LOG
 log "cgroups: $CONTROLLERS" >> $LOG
 log "PID namespace: $PIDNS" >> $LOG
+log "PIDFILE: $PIDFILE" >> $LOG
 
 log "$CMD" >> $LOG
 
@@ -64,7 +65,9 @@ exec sudo -C 10000 bash -s << END
   trap "_term TERM" ERR
 
   cgclassify -g ${CONTROLLERS}:$SLICE --sticky \$\$
-  nsenter --pid=$PIDNS $CMD &
-
+  $CMD &
+  pid=\$!
+  echo "\$pid" > $PIDFILE
+  echo "LAUNCHED PID \$pid" >> $LOG
   wait
 END

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -55,7 +55,7 @@ exec sudo -C 10000 bash -s << END
 
   function _term() {
     rm -f $PIDFILE
-    pkill -P \$! --signal SIG\$1
+    kill -SIG\$1 \$pid
   }
 
   trap "_term TERM" TERM

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -41,7 +41,6 @@ CMD="$QEMU $ARGS"
 log "cgroup path: $SLICE" >> $LOG
 log "cgroups: $CONTROLLERS" >> $LOG
 log "PID namespace: $PIDNS" >> $LOG
-log "PIDFILE: $PIDFILE" >> $LOG
 
 log "$CMD" >> $LOG
 
@@ -49,10 +48,6 @@ set -e
 sudo cgclassify -g ${CONTROLLERS}:$SLICE --sticky $$
 
 pid=$$
-sudo bash -s << END
-  echo "$pid" > $PIDFILE
-END
-
 echo "Launching qemu process with pid $pid" >> $LOG
 
 exec $CMD

--- a/manifests/libvirt.yaml.in
+++ b/manifests/libvirt.yaml.in
@@ -39,6 +39,8 @@ spec:
             mountPath: /var/run/libvirt
           - name: docker-sock
             mountPath: /var/run/docker.sock
+          - name: virt-share-dir
+            mountPath: /var/run/kubevirt
         command: ["/libvirtd.sh"]
       - name: virtlogd
         image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
@@ -63,3 +65,6 @@ spec:
       - name: docker-sock
         hostPath:
           path: /var/run/docker.sock
+      - name: virt-share-dir
+        hostPath:
+          path: /var/run/kubevirt

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -31,7 +31,7 @@ spec:
         volumeMounts:
         - name: libvirt-runtime
           mountPath: /var/run/libvirt
-        - name: sockets
+        - name: virt-share-dir
           mountPath: /var/run/kubevirt
         env:
           - name: NODE_NAME
@@ -42,6 +42,6 @@ spec:
       - name: libvirt-runtime
         hostPath:
           path: /var/run/libvirt
-      - name: sockets
+      - name: virt-share-dir
         hostPath:
           path: /var/run/kubevirt

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -117,6 +117,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 			},
 		},
 		Spec: kubev1.PodSpec{
+			HostPID:       true,
 			RestartPolicy: kubev1.RestartPolicyNever,
 			Containers:    containers,
 			NodeSelector:  vm.Spec.NodeSelector,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -41,7 +41,7 @@ type TemplateService interface {
 type templateService struct {
 	launcherImage string
 	migratorImage string
-	socketBaseDir string
+	virtShareDir  string
 }
 
 func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.Pod, error) {
@@ -49,7 +49,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
 	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
 	uid := precond.MustNotBeEmpty(string(vm.GetObjectMeta().GetUID()))
-	socketDir := t.socketBaseDir + "/" + namespace + "/" + domain
 
 	initialDelaySeconds := 2
 	timeoutSeconds := 5
@@ -66,13 +65,13 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 			"--qemu-timeout", "5m",
 			"--name", domain,
 			"--namespace", namespace,
-			"--socket-dir", t.socketBaseDir,
+			"--kubevirt-share-dir", t.virtShareDir,
 			"--readiness-file", "/tmp/healthy",
 		},
 		VolumeMounts: []kubev1.VolumeMount{
 			{
-				Name:      "sockets",
-				MountPath: socketDir,
+				Name:      "virt-share-dir",
+				MountPath: t.virtShareDir,
 			},
 		},
 		ReadinessProbe: &kubev1.Probe{
@@ -98,10 +97,10 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	}
 
 	volumes = append(volumes, kubev1.Volume{
-		Name: "sockets",
+		Name: "virt-share-dir",
 		VolumeSource: kubev1.VolumeSource{
 			HostPath: &kubev1.HostPathVolumeSource{
-				Path: socketDir,
+				Path: t.virtShareDir,
 			},
 		},
 	})
@@ -197,13 +196,13 @@ func (t *templateService) RenderMigrationJob(vm *v1.VirtualMachine, sourceNode *
 	return &job, nil
 }
 
-func NewTemplateService(launcherImage string, migratorImage string, socketDir string) (TemplateService, error) {
+func NewTemplateService(launcherImage string, migratorImage string, virtShareDir string) (TemplateService, error) {
 	precond.MustNotBeEmpty(launcherImage)
 	precond.MustNotBeEmpty(migratorImage)
 	svc := templateService{
 		launcherImage: launcherImage,
 		migratorImage: migratorImage,
-		socketBaseDir: socketDir,
+		virtShareDir:  virtShareDir,
 	}
 	return &svc, nil
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -187,7 +187,6 @@ func (t *templateService) RenderMigrationJob(vm *v1.VirtualMachine, sourceNode *
 						"--namespace", vm.ObjectMeta.Namespace,
 						"--slice", targetHostInfo.Slice,
 						"--controller", strings.Join(targetHostInfo.Controller, ","),
-						"--pidns", targetHostInfo.PidNS,
 					},
 				},
 			},

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Template", func() {
 
 	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
-	svc, err := NewTemplateService("kubevirt/virt-launcher", "kubevirt/virt-handler", "/var/run/libvirt")
+	svc, err := NewTemplateService("kubevirt/virt-launcher", "kubevirt/virt-handler", "/var/run/kubevirt")
 
 	Describe("Rendering", func() {
 		Context("launch template with correct parameters", func() {
@@ -57,7 +57,7 @@ var _ = Describe("Template", func() {
 					"--qemu-timeout", "5m",
 					"--name", "testvm",
 					"--namespace", "testns",
-					"--socket-dir", "/var/run/libvirt",
+					"--kubevirt-share-dir", "/var/run/kubevirt",
 					"--readiness-file", "/tmp/healthy"}))
 			})
 		})
@@ -86,10 +86,10 @@ var _ = Describe("Template", func() {
 					"--qemu-timeout", "5m",
 					"--name", "testvm",
 					"--namespace", "default",
-					"--socket-dir", "/var/run/libvirt",
+					"--kubevirt-share-dir", "/var/run/kubevirt",
 					"--readiness-file", "/tmp/healthy"}))
-				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/libvirt/default/testvm"))
-				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/libvirt/default/testvm"))
+				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/kubevirt"))
+				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/kubevirt"))
 			})
 
 			It("should add node affinity to pod", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Template", func() {
 							"/migrate", "testvm", "--source", "qemu+tcp://127.0.0.2/system",
 							"--dest", "qemu+tcp://127.0.0.3/system",
 							"--node-ip", "127.0.0.3", "--namespace", "default",
-							"--slice", "slice", "--controller", "cpu,memory", "--pidns", "pidns",
+							"--slice", "slice", "--controller", "cpu,memory",
 						}
 						Expect(job.Spec.Containers[0].Command).To(Equal(refCommand))
 					})

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -55,7 +55,7 @@ type VirtControllerApp struct {
 	port             int
 	launcherImage    string
 	migratorImage    string
-	socketDir        string
+	virtShareDir     string
 	ephemeralDiskDir string
 	readyChan        chan bool
 }
@@ -182,7 +182,7 @@ func (vca *VirtControllerApp) initCommon() {
 	if err != nil {
 		golog.Fatal(err)
 	}
-	vca.templateService, err = services.NewTemplateService(vca.launcherImage, vca.migratorImage, vca.socketDir)
+	vca.templateService, err = services.NewTemplateService(vca.launcherImage, vca.migratorImage, vca.virtShareDir)
 	if err != nil {
 		golog.Fatal(err)
 	}
@@ -217,7 +217,7 @@ func (vca *VirtControllerApp) DefineFlags() {
 	flag.IntVar(&vca.port, "port", 8182, "Port to listen on")
 	flag.StringVar(&vca.launcherImage, "launcher-image", "virt-launcher", "Shim container for containerized VMs")
 	flag.StringVar(&vca.migratorImage, "migrator-image", "virt-handler", "Container which orchestrates a VM migration")
-	flag.StringVar(&vca.socketDir, "socket-dir", "/var/run/kubevirt", "Directory where to look for sockets for cgroup detection")
+	flag.StringVar(&vca.virtShareDir, "kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk", "Base direcetory for ephemeral disk data")
 	leaderelectionconfig.BindFlags(&vca.LeaderElection)
 	flag.Parse()

--- a/pkg/virt-handler/virtwrap/isolation/isolation.go
+++ b/pkg/virt-handler/virtwrap/isolation/isolation.go
@@ -67,7 +67,8 @@ func NewSocketBasedIsolationDetector(virtShareDir string) PodIsolationDetector {
 }
 
 func SocketFromNamespaceName(baseDir string, namespace string, name string) string {
-	return filepath.Clean(baseDir) + "/sockets/" + namespace + "_" + name + "_sock"
+	sockFile := namespace + "_" + name + "_sock"
+	return filepath.Join(baseDir, "sockets", sockFile)
 }
 
 // This function is only used by unit test suite

--- a/pkg/virt-handler/virtwrap/isolation/isolation_test.go
+++ b/pkg/virt-handler/virtwrap/isolation/isolation_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Isolation", func() {
 		BeforeEach(func() {
 			var err error
 			tmpDir, err = ioutil.TempDir("", "kubevirt")
-			os.MkdirAll(tmpDir+"/default/testvm", os.ModePerm)
+			os.MkdirAll(tmpDir+"/sockets", os.ModePerm)
 			socket, err = net.Listen("unix", SocketFromNamespaceName(
 				tmpDir,
 				vm.ObjectMeta.Namespace,

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -194,7 +194,6 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine) (*api.DomainSpec, e
 		QEMUEnv: []api.Env{
 			{Name: "SLICE", Value: res.Slice()},
 			{Name: "CONTROLLERS", Value: strings.Join(res.Controller(), ",")},
-			{Name: "PIDNS", Value: res.PidNS()},
 		},
 	}
 

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -40,11 +40,13 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cache"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cli"
 	domainerrors "kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/errors"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/isolation"
+	virtlauncher "kubevirt.io/kubevirt/pkg/virt-launcher"
 )
 
 type DomainManager interface {
@@ -59,6 +61,7 @@ type LibvirtDomainManager struct {
 	recorder             record.EventRecorder
 	secretCache          map[string][]string
 	podIsolationDetector isolation.PodIsolationDetector
+	virtShareDir         string
 }
 
 func (l *LibvirtDomainManager) initiateSecretCache() error {
@@ -100,12 +103,13 @@ func (l *LibvirtDomainManager) initiateSecretCache() error {
 	return nil
 }
 
-func NewLibvirtDomainManager(connection cli.Connection, recorder record.EventRecorder, isolationDetector isolation.PodIsolationDetector) (DomainManager, error) {
+func NewLibvirtDomainManager(connection cli.Connection, recorder record.EventRecorder, isolationDetector isolation.PodIsolationDetector, virtShareDir string) (DomainManager, error) {
 	manager := LibvirtDomainManager{
 		virConn:              connection,
 		recorder:             recorder,
 		secretCache:          make(map[string][]string),
 		podIsolationDetector: isolationDetector,
+		virtShareDir:         virtShareDir,
 	}
 
 	err := manager.initiateSecretCache()
@@ -189,12 +193,16 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine) (*api.DomainSpec, e
 		return nil, err
 	}
 
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	name := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
 	logging.DefaultLogger().Object(vm).Info().With("slice", res.Slice()).V(3).Msg("Detected cgroup slice.")
 	wantedSpec.QEMUCmd = &api.Commandline{
 		QEMUEnv: []api.Env{
 			{Name: "SLICE", Value: res.Slice()},
 			{Name: "CONTROLLERS", Value: strings.Join(res.Controller(), ",")},
 			{Name: "PIDNS", Value: res.PidNS()},
+			{Name: "PIDFILE", Value: virtlauncher.QemuPidfileFromNamespaceName(l.virtShareDir, namespace, name)},
 		},
 	}
 

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -71,7 +71,6 @@ var _ = Describe("Manager", func() {
 			QEMUEnv: []api.Env{
 				{Name: "SLICE", Value: "dfd"},
 				{Name: "CONTROLLERS", Value: "a,b"},
-				{Name: "PIDNS", Value: "/proc/1234/ns/pid"},
 			},
 		}
 		isolationResult := isolation.NewIsolationResult(1234, "dfd", []string{"a", "b"})

--- a/pkg/virt-handler/virtwrap/manager_test.go
+++ b/pkg/virt-handler/virtwrap/manager_test.go
@@ -34,7 +34,6 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
-	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/isolation"
@@ -49,8 +48,6 @@ var _ = Describe("Manager", func() {
 	testVmName := "testvm"
 	testNamespace := "testnamespace"
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
-
-	virtShareDir := "/var/run/kubevirt"
 
 	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
 
@@ -68,10 +65,6 @@ var _ = Describe("Manager", func() {
 		var domainSpec api.DomainSpec
 		Expect(model.Copy(&domainSpec, vm.Spec.Domain)).To(BeEmpty())
 
-		namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
-		domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
-		pidFile := virtShareDir + "/qemu-pids/" + namespace + "_" + domain
-
 		domainSpec.Name = testDomainName
 		domainSpec.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
 		domainSpec.QEMUCmd = &api.Commandline{
@@ -79,7 +72,6 @@ var _ = Describe("Manager", func() {
 				{Name: "SLICE", Value: "dfd"},
 				{Name: "CONTROLLERS", Value: "a,b"},
 				{Name: "PIDNS", Value: "/proc/1234/ns/pid"},
-				{Name: "PIDFILE", Value: pidFile},
 			},
 		}
 		isolationResult := isolation.NewIsolationResult(1234, "dfd", []string{"a", "b"})
@@ -101,7 +93,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-			manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector, virtShareDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector)
 			newspec, err := manager.SyncVM(vm)
 			Expect(newspec).ToNot(BeNil())
 			Expect(err).To(BeNil())
@@ -118,7 +110,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-			manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector, virtShareDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector)
 			newspec, err := manager.SyncVM(vm)
 			Expect(newspec).ToNot(BeNil())
 			Expect(err).To(BeNil())
@@ -136,7 +128,7 @@ var _ = Describe("Manager", func() {
 				mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 				mockDomain.EXPECT().Create().Return(nil)
 				mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-				manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector, virtShareDir)
+				manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector)
 				newspec, err := manager.SyncVM(vm)
 				Expect(newspec).ToNot(BeNil())
 				Expect(err).To(BeNil())
@@ -158,7 +150,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, 1, nil)
 			mockDomain.EXPECT().Resume().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-			manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector, virtShareDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector)
 			newspec, err := manager.SyncVM(vm)
 			Expect(newspec).ToNot(BeNil())
 			Expect(err).To(BeNil())
@@ -173,7 +165,7 @@ var _ = Describe("Manager", func() {
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().Undefine().Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector, virtShareDir)
+				manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector)
 				err := manager.KillVM(newVM(testNamespace, testVmName))
 				Expect(err).To(BeNil())
 			},
@@ -189,7 +181,7 @@ var _ = Describe("Manager", func() {
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().Destroy().Return(nil)
 				mockDomain.EXPECT().Undefine().Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector, virtShareDir)
+				manager, _ := NewLibvirtDomainManager(mockConn, recorder, mockDetector)
 				err := manager.KillVM(newVM(testNamespace, testVmName))
 				Expect(err).To(BeNil())
 				Expect(<-recorder.Events).To(ContainSubstring(v1.Stopped.String()))

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -20,7 +20,9 @@
 package virthandler
 
 import (
+	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -59,9 +61,14 @@ var _ = Describe("VM", func() {
 
 	var recorder record.EventRecorder
 
+	var shareDir string
+
 	logging.DefaultLogger().SetIOWriter(GinkgoWriter)
 
 	BeforeEach(func() {
+		shareDir, err := ioutil.TempDir("", "kubevirt-share")
+		Expect(err).ToNot(HaveOccurred())
+
 		server = ghttp.NewServer()
 		host := ""
 
@@ -79,7 +86,7 @@ var _ = Describe("VM", func() {
 		configDiskClient := configdisk.NewConfigDiskClient(virtClient)
 
 		recorder = record.NewFakeRecorder(100)
-		dispatch = NewVMHandlerDispatch(domainManager, recorder, restClient, virtClient, host, configDiskClient)
+		dispatch = NewVMHandlerDispatch(domainManager, recorder, restClient, virtClient, host, configDiskClient, shareDir, 1)
 
 	})
 
@@ -136,6 +143,7 @@ var _ = Describe("VM", func() {
 	AfterEach(func() {
 		server.Close()
 		ctrl.Finish()
+		os.RemoveAll(shareDir)
 	})
 })
 

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -50,7 +50,16 @@ type ProcessMonitor interface {
 }
 
 func InitializeSharedDirectories(baseDir string) error {
-	return os.MkdirAll(baseDir+"/qemu-pids", 0755)
+	err := os.MkdirAll(baseDir+"/qemu-pids", 0755)
+	if err != nil {
+		return err
+	}
+
+	return os.MkdirAll(baseDir+"/watchdog-files", 0755)
+}
+
+func WatchdogFileFromNamespaceName(baseDir string, namespace string, name string) string {
+	return filepath.Clean(baseDir) + "/watchdog-files/" + namespace + "_" + name
 }
 
 func QemuPidfileFromNamespaceName(baseDir string, namespace string, name string) string {

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -148,7 +148,7 @@ func (mon *monitor) refresh() {
 
 func (mon *monitor) monitorLoop(startTimeout time.Duration, signalChan chan os.Signal) {
 	// random value, no real rationale
-	rate := 500 * time.Millisecond
+	rate := 1 * time.Second
 
 	if mon.debugMode {
 		timeoutRepr := fmt.Sprintf("%v", startTimeout)

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -43,7 +43,6 @@ type monitor struct {
 	start           time.Time
 	isDone          bool
 	forwardedSignal os.Signal
-	debugMode       bool
 }
 
 type ProcessMonitor interface {
@@ -54,10 +53,9 @@ func InitializeSharedDirectories(baseDir string) error {
 	return os.MkdirAll(watchdog.WatchdogFileDirectory(baseDir), 0755)
 }
 
-func NewProcessMonitor(commandPrefix string, debugMode bool) ProcessMonitor {
+func NewProcessMonitor(commandPrefix string) ProcessMonitor {
 	return &monitor{
 		commandPrefix: commandPrefix,
-		debugMode:     debugMode,
 	}
 }
 

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	watchdog "kubevirt.io/kubevirt/pkg/watchdog"
 )
 
 type monitor struct {
@@ -55,11 +56,7 @@ func InitializeSharedDirectories(baseDir string) error {
 		return err
 	}
 
-	return os.MkdirAll(baseDir+"/watchdog-files", 0755)
-}
-
-func WatchdogFileFromNamespaceName(baseDir string, namespace string, name string) string {
-	return filepath.Clean(baseDir) + "/watchdog-files/" + namespace + "_" + name
+	return os.MkdirAll(watchdog.WatchdogFileDirectory(baseDir), 0755)
 }
 
 func QemuPidfileFromNamespaceName(baseDir string, namespace string, name string) string {

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -86,7 +86,6 @@ var _ = Describe("VirtLauncher", func() {
 	BeforeEach(func() {
 		mon = &monitor{
 			commandPrefix: "fake-qemu",
-			debugMode:     true,
 		}
 	})
 

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -20,8 +20,6 @@
 package virtlauncher
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -38,11 +36,6 @@ var _ = Describe("VirtLauncher", func() {
 
 	dir := os.Getenv("PWD")
 	dir = strings.TrimSuffix(dir, "pkg/virt-launcher")
-	tmpDir, err := ioutil.TempDir("", "virt-launcher-unit-test")
-	if err != nil {
-		panic(err)
-	}
-	pidFile := tmpDir + "/pid-file"
 
 	processName := "fake-qemu-process"
 	processPath := dir + "/cmd/fake-qemu-process/" + processName
@@ -54,10 +47,6 @@ var _ = Describe("VirtLauncher", func() {
 
 		currentPid := cmd.Process.Pid
 		Expect(currentPid).ToNot(Equal(0))
-
-		pidStr := fmt.Sprintf("%d", currentPid)
-		err = ioutil.WriteFile(pidFile, []byte(pidStr), 0644)
-		Expect(err).ToNot(HaveOccurred())
 	}
 
 	StopProcess := func() {
@@ -95,10 +84,9 @@ var _ = Describe("VirtLauncher", func() {
 	}
 
 	BeforeEach(func() {
-		os.Remove(pidFile)
 		mon = &monitor{
-			pidFile:   pidFile,
-			debugMode: true,
+			commandPrefix: "fake-qemu",
+			debugMode:     true,
 		}
 	})
 

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -1,0 +1,253 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package watchdog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/logging"
+	"kubevirt.io/kubevirt/pkg/precond"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
+)
+
+func NewWatchdogListWatchFromClient(virtShareDir string, watchdogTimeout int) cache.ListerWatcher {
+
+	d := &WatchdogListWatcher{
+		fileDir:                  WatchdogFileDirectory(virtShareDir),
+		backgroundWatcherStarted: false,
+		watchdogTimeout:          watchdogTimeout,
+	}
+	return d
+}
+
+func WatchdogFileDirectory(baseDir string) string {
+	return filepath.Clean(baseDir) + "/watchdog-files"
+}
+
+func WatchdogFileFromNamespaceName(baseDir string, namespace string, name string) string {
+	return filepath.Clean(baseDir) + "/watchdog-files/" + namespace + "_" + name
+}
+
+func WatchdogFileRemove(baseDir string, vm *v1.VirtualMachine) error {
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	file := WatchdogFileFromNamespaceName(baseDir, namespace, domain)
+
+	return diskutils.RemoveFile(file)
+}
+
+func WatchdogFileUpdate(watchdogFile string) error {
+	f, err := os.Create(watchdogFile)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	return nil
+}
+
+func WatchdogFileExists(baseDir string, vm *v1.VirtualMachine) (bool, error) {
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	filePath := WatchdogFileFromNamespaceName(baseDir, namespace, domain)
+	exists, err := diskutils.FileExists(filePath)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
+func WatchdogFileIsExpired(timeoutSeconds int, baseDir string, vm *v1.VirtualMachine) (bool, error) {
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	filePath := WatchdogFileFromNamespaceName(baseDir, namespace, domain)
+
+	exists, err := diskutils.FileExists(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	if exists == false {
+		return true, nil
+	}
+
+	stat, err := os.Stat(filePath)
+	if err != nil {
+		return false, err
+	}
+
+	now := time.Now().UTC().Unix()
+
+	return isExpired(now, timeoutSeconds, stat), nil
+}
+
+func isExpired(now int64, timeoutSeconds int, stat os.FileInfo) bool {
+	mod := stat.ModTime().UTC().Unix()
+	diff := now - mod
+
+	if diff > int64(timeoutSeconds) {
+		return true
+	}
+	return false
+}
+
+func detectExpiredFiles(timeoutSeconds int, fileDir string) ([]string, error) {
+	var expiredFiles []string
+	files, err := ioutil.ReadDir(fileDir)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC().Unix()
+	for _, file := range files {
+		if isExpired(now, timeoutSeconds, file) == true {
+			expiredFiles = append(expiredFiles, file.Name())
+		}
+	}
+	return expiredFiles, nil
+}
+
+type WatchdogListWatcher struct {
+	lock                     sync.Mutex
+	wg                       sync.WaitGroup
+	fileDir                  string
+	stopChan                 chan struct{}
+	eventChan                chan watch.Event
+	watchDogTicker           <-chan time.Time
+	backgroundWatcherStarted bool
+	watchdogTimeout          int
+}
+
+func splitFileNamespaceName(fullPath string) (namespace string, domain string, err error) {
+	fileName := filepath.Base(fullPath)
+	namespaceName := strings.Split(fileName, "_")
+	if len(namespaceName) != 2 {
+		return "", "", fmt.Errorf("Invalid file path: %s", fullPath)
+	}
+
+	namespace = namespaceName[0]
+	domain = namespaceName[1]
+	return namespace, domain, nil
+}
+
+func (d *WatchdogListWatcher) startBackground() error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.backgroundWatcherStarted == true {
+		return nil
+	}
+
+	d.stopChan = make(chan struct{}, 1)
+	d.eventChan = make(chan watch.Event, 100)
+
+	tickRate := 1
+
+	if d.watchdogTimeout > 1 {
+		tickRate = d.watchdogTimeout / 2
+	}
+	d.watchDogTicker = time.NewTicker(time.Duration(tickRate) * time.Second).C
+
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		for {
+			select {
+			case <-d.stopChan:
+				return
+			case <-d.watchDogTicker:
+				expiredKeys, err := detectExpiredFiles(d.watchdogTimeout, d.fileDir)
+				if err != nil {
+					logging.DefaultLogger().Error().Reason(err).Msg("Invalid content detected during watchdog tick, ignoring and continuing.")
+					continue
+				}
+
+				for _, key := range expiredKeys {
+					namespace, name, err := splitFileNamespaceName(key)
+					if err != nil {
+						logging.DefaultLogger().Error().Reason(err).Msgf("Invalid key (%s) detected during watchdog tick, ignoring and continuing.", key)
+						continue
+					}
+					d.eventChan <- watch.Event{Type: watch.Modified, Object: api.NewMinimalDomainWithNS(namespace, name)}
+				}
+			}
+		}
+	}()
+
+	d.backgroundWatcherStarted = true
+	return nil
+}
+
+func (d *WatchdogListWatcher) List(options k8sv1.ListOptions) (runtime.Object, error) {
+	err := d.startBackground()
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := detectExpiredFiles(d.watchdogTimeout, d.fileDir)
+	domainList := &api.DomainList{
+		Items: []api.Domain{},
+	}
+	for _, file := range files {
+		namespace, name, err := splitFileNamespaceName(file)
+		if err != nil {
+			logging.DefaultLogger().Error().Reason(err).Msg("Invalid content detected, ignoring and continuing.")
+			continue
+		}
+		domainList.Items = append(domainList.Items, *api.NewMinimalDomainWithNS(namespace, name))
+
+	}
+	return domainList, nil
+}
+
+func (d *WatchdogListWatcher) Watch(options k8sv1.ListOptions) (watch.Interface, error) {
+	return d, nil
+}
+
+func (d *WatchdogListWatcher) Stop() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.backgroundWatcherStarted == false {
+		return
+	}
+	close(d.stopChan)
+	d.wg.Wait()
+	d.backgroundWatcherStarted = false
+}
+
+func (d *WatchdogListWatcher) ResultChan() <-chan watch.Event {
+	return d.eventChan
+}

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -51,11 +51,12 @@ func NewWatchdogListWatchFromClient(virtShareDir string, watchdogTimeout int) ca
 }
 
 func WatchdogFileDirectory(baseDir string) string {
-	return filepath.Clean(baseDir) + "/watchdog-files"
+	return filepath.Join(baseDir, "watchdog-files")
 }
 
 func WatchdogFileFromNamespaceName(baseDir string, namespace string, name string) string {
-	return filepath.Clean(baseDir) + "/watchdog-files/" + namespace + "_" + name
+	watchdogFile := namespace + "_" + name
+	return filepath.Join(baseDir, "watchdog-files", watchdogFile)
 }
 
 func WatchdogFileRemove(baseDir string, vm *v1.VirtualMachine) error {
@@ -84,6 +85,8 @@ func WatchdogFileExists(baseDir string, vm *v1.VirtualMachine) (bool, error) {
 	filePath := WatchdogFileFromNamespaceName(baseDir, namespace, domain)
 	exists, err := diskutils.FileExists(filePath)
 	if err != nil {
+		logging.DefaultLogger().Error().Reason(err).Msgf("Error encountered while attempting to verify if watchdog file at path %s exists.", filePath)
+
 		return false, err
 	}
 	return exists, nil

--- a/pkg/watchdog/watchdog_suite_test.go
+++ b/pkg/watchdog/watchdog_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package watchdog
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestWatchdog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Watchdog Test Suite")
+}

--- a/pkg/watchdog/watchdog_test.go
+++ b/pkg/watchdog/watchdog_test.go
@@ -1,0 +1,203 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package watchdog
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/precond"
+	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
+)
+
+var _ = Describe("Watchdog", func() {
+
+	Context("When watching files in a directory", func() {
+
+		var tmpVirtShareDir string
+		var tmpWatchdogDir string
+		var informer cache.SharedIndexInformer
+		var stopInformer chan struct{}
+		var queue workqueue.RateLimitingInterface
+
+		startedInformer := false
+
+		TestForKeyEvent := func(expectedKey string, shouldExist bool) bool {
+			// wait for key to either enter or exit the store.
+			Eventually(func() bool {
+				_, exists, _ := informer.GetStore().GetByKey(expectedKey)
+
+				if shouldExist == exists {
+					return true
+				}
+				return false
+			}).Should(BeTrue())
+
+			// ensure queue item for key exists
+			len := queue.Len()
+			for i := len; i > 0; i-- {
+				key, _ := queue.Get()
+				defer queue.Done(key)
+				if key == expectedKey {
+					return true
+				}
+			}
+			return false
+		}
+
+		startWatchdogInformer := func() {
+			var err error
+			stopInformer = make(chan struct{})
+			startedInformer = true
+			tmpVirtShareDir, err = ioutil.TempDir("", "kubevirt")
+			Expect(err).ToNot(HaveOccurred())
+
+			tmpWatchdogDir = WatchdogFileDirectory(tmpVirtShareDir)
+			err = os.Mkdir(tmpWatchdogDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+			informer = cache.NewSharedIndexInformer(
+				NewWatchdogListWatchFromClient(tmpVirtShareDir, 2),
+				&api.Domain{},
+				0,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+			informer.AddEventHandler(controller.NewResourceEventHandlerFuncsForWorkqueue(queue))
+			go informer.Run(stopInformer)
+			Expect(cache.WaitForCacheSync(stopInformer, informer.HasSynced)).To(BeTrue())
+		}
+
+		It("should detect expired watchdog files", func() {
+			startWatchdogInformer()
+
+			keyExpired := "default/expiredvm"
+			fileName := tmpWatchdogDir + "/default_expiredvm"
+			Expect(os.Create(fileName)).ToNot(BeNil())
+
+			files, err := detectExpiredFiles(1, tmpWatchdogDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(files)).To(Equal(0))
+
+			time.Sleep(time.Second * 3)
+
+			Expect(TestForKeyEvent(keyExpired, true)).To(Equal(true))
+
+			files, err = detectExpiredFiles(1, tmpWatchdogDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(files)).To(Equal(1))
+
+			Expect(os.Create(fileName)).ToNot(BeNil())
+			files, err = detectExpiredFiles(1, tmpWatchdogDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(files)).To(Equal(0))
+		})
+
+		It("should successfully remove watchdog file", func() {
+
+			vm := v1.NewMinimalVM("tvm")
+			namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+			domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+			startWatchdogInformer()
+
+			keyExpired := fmt.Sprintf("%s/%s", namespace, domain)
+			fileName := WatchdogFileFromNamespaceName(tmpVirtShareDir, namespace, domain)
+			Expect(os.Create(fileName)).ToNot(BeNil())
+
+			files, err := detectExpiredFiles(1, tmpWatchdogDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(files)).To(Equal(0))
+
+			expired, err := WatchdogFileIsExpired(1, tmpVirtShareDir, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(expired).To(Equal(false))
+
+			time.Sleep(time.Second * 3)
+
+			Expect(TestForKeyEvent(keyExpired, true)).To(Equal(true))
+
+			files, err = detectExpiredFiles(1, tmpWatchdogDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(files)).To(Equal(1))
+
+			expired, err = WatchdogFileIsExpired(1, tmpVirtShareDir, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(expired).To(Equal(true))
+
+			exists, err := WatchdogFileExists(tmpVirtShareDir, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(Equal(true))
+
+			err = WatchdogFileRemove(tmpVirtShareDir, vm)
+			Expect(err).ToNot(HaveOccurred())
+
+			files, err = detectExpiredFiles(1, tmpWatchdogDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(files)).To(Equal(0))
+
+			exists, err = WatchdogFileExists(tmpVirtShareDir, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(Equal(false))
+		})
+
+		It("should not expire updated files", func() {
+			startWatchdogInformer()
+
+			fileName := tmpVirtShareDir + "/default_expiredvm"
+			Expect(os.Create(fileName)).ToNot(BeNil())
+
+			for i := 0; i < 4; i++ {
+				WatchdogFileUpdate(fileName)
+				time.Sleep(time.Second * 1)
+				files, err := detectExpiredFiles(2, tmpWatchdogDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(files)).To(Equal(0))
+				Expect(queue.Len()).To(Equal(0))
+			}
+		})
+
+		It("should provide file in watchdog subdirectory", func() {
+			dir := WatchdogFileDirectory(tmpVirtShareDir)
+			Expect(dir).To(Equal(tmpVirtShareDir + "/watchdog-files"))
+
+			dir = WatchdogFileFromNamespaceName(tmpVirtShareDir, "tnamespace", "tvm")
+			Expect(dir).To(Equal(tmpVirtShareDir + "/watchdog-files/tnamespace_tvm"))
+		})
+
+		AfterEach(func() {
+			if startedInformer {
+				close(stopInformer)
+			}
+			os.RemoveAll(tmpVirtShareDir)
+			startedInformer = false
+		})
+
+	})
+})

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -83,13 +83,13 @@ var _ = Describe("RegistryDisk", func() {
 			for i := 0; i < num; i++ {
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
 				Expect(err).To(BeNil())
-				tests.WaitForSuccessfulVMStartWithTimeout(obj, 30)
+				tests.WaitForSuccessfulVMStartWithTimeout(obj, 60)
 				_, err = virtClient.RestClient().Delete().Resource("virtualmachines").Namespace(vm.GetObjectMeta().GetNamespace()).Name(vm.GetObjectMeta().GetName()).Do().Get()
 				Expect(err).To(BeNil())
 				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)
 			}
 			close(done)
-		}, 90)
+		}, 180)
 
 		It("should launch multiple VMs using ephemeral registry disks", func(done Done) {
 			num := 5
@@ -107,6 +107,6 @@ var _ = Describe("RegistryDisk", func() {
 			}
 
 			close(done)
-		}, 60) // Timeout is long because this test involves multiple parallel VM launches.
+		}, 120) // Timeout is long because this test involves multiple parallel VM launches.
 	})
 })

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -184,6 +184,34 @@ var _ = Describe("Vmlifecycle", func() {
 				close(done)
 			}, 50)
 		})
+
+		Context("New VM when virt-launcher crashes", func() {
+			It("should stop and be in Failed phase", func(done Done) {
+				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
+				Expect(err).To(BeNil())
+
+				nodeName := tests.WaitForSuccessfulVMStart(obj)
+				_, ok := obj.(*v1.VirtualMachine)
+				Expect(ok).To(BeTrue(), "Object is not of type *v1.VM")
+				Expect(err).ToNot(HaveOccurred())
+
+				time.Sleep(10 * time.Second)
+				err = pkillAllLaunchers(virtClient, nodeName, dockerTag)
+				Expect(err).To(BeNil())
+
+				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.WarningEvent, v1.Stopped)
+
+				Expect(func() v1.VMPhase {
+					vm := &v1.VirtualMachine{}
+					err := virtClient.RestClient().Get().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Name(obj.(*v1.VirtualMachine).ObjectMeta.Name).Do().Into(vm)
+					Expect(err).ToNot(HaveOccurred())
+					return vm.Status.Phase
+				}()).To(Equal(v1.Failed))
+
+				close(done)
+			}, 50)
+		})
+
 		Context("in a non-default namespace", func() {
 			table.DescribeTable("Should log libvirt start and stop lifecycle events of the domain", func(namespace string) {
 
@@ -237,7 +265,7 @@ var _ = Describe("Vmlifecycle", func() {
 	})
 })
 
-func renderPkillAllVmsJob(dockerTag string) *k8sv1.Pod {
+func renderPkillAllJob(dockerTag string, processName string) *k8sv1.Pod {
 	job := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "vm-killer",
@@ -254,7 +282,7 @@ func renderPkillAllVmsJob(dockerTag string) *k8sv1.Pod {
 					Command: []string{
 						"pkill",
 						"-9",
-						"qemu",
+						processName,
 					},
 					SecurityContext: &k8sv1.SecurityContext{
 						Privileged: newBool(true),
@@ -272,8 +300,16 @@ func renderPkillAllVmsJob(dockerTag string) *k8sv1.Pod {
 	return &job
 }
 
+func pkillAllLaunchers(virtCli kubecli.KubevirtClient, node, dockerTag string) error {
+	job := renderPkillAllJob(dockerTag, "virt-launcher")
+	job.Spec.NodeName = node
+	_, err := virtCli.CoreV1().Pods(tests.NamespaceTestDefault).Create(job)
+
+	return err
+}
+
 func pkillAllVms(virtCli kubecli.KubevirtClient, node, dockerTag string) error {
-	job := renderPkillAllVmsJob(dockerTag)
+	job := renderPkillAllJob(dockerTag, "qemu")
 	job.Spec.NodeName = node
 	_, err := virtCli.CoreV1().Pods(tests.NamespaceTestDefault).Create(job)
 


### PR DESCRIPTION
**Short explanation:** VM processes are now in host pid namespace. Virt-launcher detects VM pid through a pid file. POD to VM process coupling is guaranteed and enforced through a watchdog informer

**Host Pid Namespace Changes**
- qemu wrapper launches process in host pid namespace. Records pid to a pid file on a shared host mount
- Virt-Launcher detects VM process through pid file on shared host mount, verifies pid is in virt-launcher's cgroup slice before monitoring

**VM Process Cleanup Guarantees**
- virt-launcher creates watchdog file and periodically updates the modification time of that file by touching it. 
- virt-handler requires watchdog file from virt-launcher before allowing vm to be started.
- virt-handler uses watchdog informer to learn about expired virt-launcher's
- virt-handler destroys VMs with expired watchdog files. 

**Misc**
- pidfiles, watchdog files, and virt-launcher sockets have been moved to one flat shared host mount directory. 