### PR TITLE
Use Fedora base for iscsi-demo-target-tgtd image

### DIFF
--- a/images/iscsi-demo-target-tgtd/Dockerfile
+++ b/images/iscsi-demo-target-tgtd/Dockerfile
@@ -16,17 +16,13 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM debian:sid
-# Enable once https://bugzilla.redhat.com/show_bug.cgi?id=1471920 is fixed
-#FROM fedora:26
+FROM fedora:26
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
-RUN apt-get update && apt-get install -y \
-  tgt bash curl bzip2 qemu-utils
-#RUN dnf -y install scsi-target-utils bzip2 qemu-img \
-#    && dnf -y clean all
+RUN dnf -y update && dnf -y install scsi-target-utils bzip2 qemu-img \
+    && dnf -y clean all
 
 RUN mkdir -p /volume
 


### PR DESCRIPTION
Bug # 1471920 which previously prevented the use of tgtd in a docker
container on Fedora has been resolved. Revert back to using Fedora base by re-enabling the comment out pieces and removing the Debian references. Added `dnf update -y` to package installation RUN statement for functional equivalency with the apt usage that was being used.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1471920