### PR TITLE
virt-launcher lifecycle cleanup

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -63,7 +63,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		Image:           t.launcherImage,
 		ImagePullPolicy: kubev1.PullIfNotPresent,
 		Command: []string{"/virt-launcher",
-			"--qemu-timeout", "60s",
+			"--qemu-timeout", "5m",
 			"--name", domain,
 			"--namespace", namespace,
 			"--socket-dir", t.socketBaseDir,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvm-----"))
 				Expect(pod.Spec.NodeSelector).To(BeEmpty())
 				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher",
-					"--qemu-timeout", "60s",
+					"--qemu-timeout", "5m",
 					"--name", "testvm",
 					"--namespace", "testns",
 					"--socket-dir", "/var/run/libvirt",
@@ -83,7 +83,7 @@ var _ = Describe("Template", func() {
 					"kubernetes.io/hostname": "master",
 				}))
 				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/virt-launcher",
-					"--qemu-timeout", "60s",
+					"--qemu-timeout", "5m",
 					"--name", "testvm",
 					"--namespace", "default",
 					"--socket-dir", "/var/run/libvirt",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -245,6 +245,13 @@ func (c *VMController) execute(key string) error {
 			return err
 		}
 		logger.Info().Msgf("VM successfully scheduled to %s.", vmCopy.Status.NodeName)
+	case kubev1.Failed, kubev1.Succeeded:
+		err := c.vmService.DeleteVMPod(vm)
+		if err != nil {
+			logger.Error().Reason(err).Msg("Deleting VM target Pod failed.")
+			return err
+		}
+		logger.Info().Msg("Deleted VM target Pod for VM in finalized state.")
 	}
 	return nil
 }


### PR DESCRIPTION

## Virt-Launcher Lifecycle Management
In general for Kubevirt, I think we need to strive to make whatever component creates a resource be in charge of that resource's lifecycle.

For virt-launcher, the component that creates that resource is virt-controller. For a VM in virt-controller, the flow is...

- start virt-launcher pod for the VM
- assign the VM to the node the virt-launcher pod started on
- watch for VM to be finalized
- **ensure virt-launcher pod terminates for a finalized VM.**

That last step of **"ensuring virt-launcher pod terminates"** is what this patch addresses. Previously we depended on the virt-launcher's timeout to clean up orphaned virt-launches. While I think the timeout has a role in our design, I believe the normal mode of operation is that virt-controller should ensure cleanup of the virt-launcher pods it creates.

## Virt-Launcher Timeout
Virt-launcher has a timeout duration it will wait trying to detect the VM process before exiting. This timeout should be seen as a failsafe mechanism that gives us a guarantee that a virt-launcher pod will not remain active indefinitely without a corresponding VM process. 

However, I don't think that it is wise for the virt-launcher timeout to be associated with the normal mode of operation. This timeout needs to be very generous and only exist as a safety mechanism.  The 60 second timeout we previously had is not enough time to guarantee the VM has launched. There are too many variables involved.

For example, during virt-controller failover, the time between when virt-launcher starts and when the VM get's it's node assignment could exceed 60 seconds. This would cause the VM to fail to start after virt-controller recovers because the virt-launcher pod for the corresponding VM expired.

The virt-launcher timeout being hit means something outside of the normal mode of operation has occurred. To account for this change in perspective, the timeout has been increased to 5 minutes.


