### PR TITLE
makefile: provides easy command to load manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ publish: docker
 manifests: $(wildcard manifests/*.in)
 	./hack/build-manifests.sh
 
+load-manifests: manifests
+	for i in manifests/*.yaml ; \
+	do \
+	    ./cluster/kubectl.sh create -f $$i ; \
+	done
+
 check: check-bash vet
 	test -z "`./hack/build-go.sh fmt`"
 

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -45,5 +45,5 @@ if [ -e  ${KUBEVIRT_PATH}cluster/vagrant/.kubeconfig ] &&
 elif [ -e ${KUBEVIRT_PATH}cluster/vagrant/.kubectl ];then
     ${KUBEVIRT_PATH}cluster/vagrant/.kubectl -s http://${master_ip}:8184 "$@"
 else
-    echo "Did you already run '$SYNC_CONFIG' to deploy kubevirt?"
+    kubectl "$@"
 fi


### PR DESCRIPTION
Updates Makefile to provide command to load the k8s manifests. In
order to take into account deployment without vagrant, this commit
also updates cluster/kubectl.sh to fallback on a local kubectl client
installed.

Signed-off-by: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@redhat.com>