### PR TITLE
Preserve RegistryDisk and CloudInit on VM object

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -126,7 +126,7 @@ func GetDomainBasePath(domain string, namespace string) string {
 // This is called right before a VM is defined with libvirt.
 // If the cloud-init type requires altering the domain, this
 // is the place to do that.
-func MapCloudInitDisks(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
+func PopulateCloudInitDisks(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
 	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
 	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
 
@@ -149,16 +149,12 @@ func MapCloudInitDisks(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
 
 		for idx, disk := range vmCopy.Spec.Domain.Devices.Disks {
 			if disk.Type == "file" && disk.CloudInit != nil {
-				newDisk := v1.Disk{}
-				newDisk.Type = "file"
-				newDisk.Device = "disk"
-				newDisk.Driver = &v1.DiskDriver{
+				vmCopy.Spec.Domain.Devices.Disks[idx].Device = "disk"
+				vmCopy.Spec.Domain.Devices.Disks[idx].Driver = &v1.DiskDriver{
 					Type: "raw",
 					Name: "qemu",
 				}
-				newDisk.Source.File = filePath
-				newDisk.Target = disk.Target
-				vmCopy.Spec.Domain.Devices.Disks[idx] = newDisk
+				vmCopy.Spec.Domain.Devices.Disks[idx].Source.File = filePath
 			}
 		}
 		return vmCopy, nil

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -126,7 +126,7 @@ var _ = Describe("CloudInit", func() {
 			It("Verify no cloudinit data is a domain xml no-op", func() {
 				vm := v1.NewMinimalVM("fake-vm-nocloud")
 
-				vm, err := MapCloudInitDisks(vm)
+				vm, err := PopulateCloudInitDisks(vm)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(vm.Spec.Domain.Devices.Disks)).To(Equal(0))
 			})
@@ -151,7 +151,7 @@ var _ = Describe("CloudInit", func() {
 				newDisk.CloudInit = spec
 
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, newDisk)
-				vm, err := MapCloudInitDisks(vm)
+				vm, err := PopulateCloudInitDisks(vm)
 				Expect(err).ToNot(HaveOccurred())
 				disk := vm.Spec.Domain.Devices.Disks[0]
 

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -63,7 +63,7 @@ var _ = Describe("RegistryDisk", func() {
 		filePath := volumeMountDir + "/disk0/disk-image." + diskExtension
 		_, err := os.Create(filePath)
 
-		vm, err = MapRegistryDisks(vm)
+		vm, err = PopulateRegistryDisks(vm)
 		Expect(err).ToNot(HaveOccurred())
 
 		// verify file gets renamed by virt-handler to prevent container from
@@ -77,7 +77,7 @@ var _ = Describe("RegistryDisk", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(exists).To(Equal(true))
 
-		Expect(vm.Spec.Domain.Devices.Disks[0].Type).To(Equal("file"))
+		Expect(vm.Spec.Domain.Devices.Disks[0].Type).To(Equal(RegistryDiskV1Alpha))
 		Expect(vm.Spec.Domain.Devices.Disks[0].Target.Device).To(Equal("vda"))
 		Expect(vm.Spec.Domain.Devices.Disks[0].Driver).ToNot(Equal(nil))
 		Expect(vm.Spec.Domain.Devices.Disks[0].Driver.Type).To(Equal(diskExtension))
@@ -126,7 +126,7 @@ var _ = Describe("RegistryDisk", func() {
 					},
 				})
 
-				vm, err := MapRegistryDisks(vm)
+				vm, err := PopulateRegistryDisks(vm)
 				Expect(err).To(HaveOccurred())
 			})
 			It("by verifying container generation", func() {

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -40,6 +40,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/logging"
+	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cache"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/cli"
@@ -172,6 +173,28 @@ func (l *LibvirtDomainManager) SyncVMSecret(vm *v1.VirtualMachine, usageType str
 	return nil
 }
 
+func mapRegistryDisks(domain *api.DomainSpec) {
+	for diskCount, disk := range domain.Devices.Disks {
+		if disk.Type != registrydisk.RegistryDiskV1Alpha {
+			continue
+		}
+		newDisk := api.Disk{
+			Type:   "file",
+			Device: "disk",
+		}
+		newDisk.Source.File = disk.Source.File
+		newDisk.Target.Bus = disk.Target.Bus
+		newDisk.Target.Device = disk.Target.Device
+
+		newDisk.Driver = &api.DiskDriver{
+			Type: disk.Driver.Type,
+			Name: "qemu",
+		}
+
+		domain.Devices.Disks[diskCount] = newDisk
+	}
+}
+
 func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine) (*api.DomainSpec, error) {
 	var wantedSpec api.DomainSpec
 	wantedSpec.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
@@ -201,6 +224,8 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine) (*api.DomainSpec, e
 	domName := cache.VMNamespaceKeyFunc(vm)
 	wantedSpec.Name = domName
 	wantedSpec.UUID = string(vm.GetObjectMeta().GetUID())
+	mapRegistryDisks(&wantedSpec)
+
 	dom, err := l.virConn.LookupDomainByName(domName)
 	newDomain := false
 	if err != nil {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -426,7 +426,7 @@ func (d *VMHandlerDispatch) processVmUpdate(vm *v1.VirtualMachine, shouldDeleteV
 	}
 
 	// Map whatever devices are being used for config-init
-	vm, err = cloudinit.MapCloudInitDisks(vm)
+	vm, err = cloudinit.PopulateCloudInitDisks(vm)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -415,7 +415,7 @@ func (d *VMHandlerDispatch) processVmUpdate(vm *v1.VirtualMachine, shouldDeleteV
 	}
 
 	// Map Container Registry Disks to block devices Libvirt can consume
-	vm, err = registrydisk.MapRegistryDisks(vm)
+	vm, err = registrydisk.PopulateRegistryDisks(vm)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Previously we were mutating the VM object when mapping ephemeral disks to the underlying libvirt file disk type. This would result in CloudInit and RegistryDisk entries being changed to file based disks on the actual VM cluster object. 

This patch preserves CloudInit and RegistryDisk disk types on the cluster object, and does the mapping to the file based disk on the domain spec during creation. 