### PR TITLE
Fix VM status update and registry disk handover

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -115,11 +115,10 @@ type VirtualMachine struct {
 }
 
 func (in *VirtualMachine) DeepCopyInto(out *VirtualMachine) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*VirtualMachine)
 	return
 }
 
@@ -148,11 +147,10 @@ type VirtualMachineList struct {
 }
 
 func (in *VirtualMachineList) DeepCopyInto(out *VirtualMachineList) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*VirtualMachineList)
 	return
 }
 
@@ -409,11 +407,10 @@ type Spice struct {
 }
 
 func (in *Spice) DeepCopyInto(out *Spice) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*Spice)
 	return
 }
 
@@ -495,11 +492,10 @@ type Migration struct {
 }
 
 func (in *Migration) DeepCopyInto(out *Migration) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*Migration)
 	return
 }
 
@@ -598,11 +594,10 @@ type MigrationList struct {
 }
 
 func (in *MigrationList) DeepCopyInto(out *MigrationList) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*MigrationList)
 	return
 }
 
@@ -819,11 +814,10 @@ func (vl *VirtualMachineReplicaSetList) GetListMeta() meta.List {
 }
 
 func (in *VirtualMachineReplicaSet) DeepCopyInto(out *VirtualMachineReplicaSet) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*VirtualMachineReplicaSet)
 	return
 }
 
@@ -845,11 +839,10 @@ func (in *VirtualMachineReplicaSet) DeepCopyObject() runtime.Object {
 }
 
 func (in *VirtualMachineReplicaSetList) DeepCopyInto(out *VirtualMachineReplicaSetList) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*VirtualMachineReplicaSetList)
 	return
 }
 

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -135,11 +135,6 @@ func MapCloudInitDisks(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
 		return vm, nil
 	}
 
-	err := ValidateArgs(spec)
-	if err != nil {
-		return vm, err
-	}
-
 	dataSource := getDataSource(spec)
 	switch dataSource {
 	case dataSourceNoCloud:

--- a/pkg/config-disk/config-disk.go
+++ b/pkg/config-disk/config-disk.go
@@ -72,6 +72,7 @@ func (c *configDiskClient) Define(vm *v1.VirtualMachine) (bool, error) {
 
 	jobKey := createKey(vm)
 
+	// FIXME support re-creating the disks if the VM is down and the data changed
 	v, ok := c.jobs[jobKey]
 	if ok == false {
 		v = make(chan string, 1)

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -34,8 +34,6 @@ import (
 
 	k8score "k8s.io/api/core/v1"
 
-	"github.com/jeevatkm/go-model"
-
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -202,15 +200,7 @@ func (c *VMReplicaSet) execute(key string) error {
 		logger.Reason(err).Error("Scaling the replicaset failed.")
 	}
 
-	clone, err := model.Clone(rs)
-
-	if err != nil {
-		logger.Reason(err).Error("Cloning the replicaset failed.")
-		return nil
-	}
-	rsCopy := clone.(*virtv1.VirtualMachineReplicaSet)
-
-	err = c.updateStatus(rsCopy, vms, scaleErr)
+	err = c.updateStatus(rs.DeepCopy(), vms, scaleErr)
 	if err != nil {
 		logger.Reason(err).Error("Updating the replicaset status failed.")
 	}

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -2,7 +2,6 @@ package watch
 
 import (
 	"github.com/golang/mock/gomock"
-	"github.com/jeevatkm/go-model"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -131,7 +130,7 @@ var _ = Describe("Replicaset", func() {
 				},
 			}
 
-			expectedRS := clone(rs)
+			expectedRS := rs.DeepCopy()
 			expectedRS.Status.Replicas = 0
 			expectedRS.Status.ReadyReplicas = 0
 			expectedRS.Status.Conditions = nil
@@ -157,7 +156,7 @@ var _ = Describe("Replicaset", func() {
 
 			// This will trigger a status update, since there are no replicas present
 			rs.Status.Replicas = 1
-			expectedRS := clone(rs)
+			expectedRS := rs.DeepCopy()
 			expectedRS.Status.Replicas = 0
 			expectedRS.Status.ReadyReplicas = 0
 
@@ -251,7 +250,7 @@ var _ = Describe("Replicaset", func() {
 
 			rs.Status.Replicas = 0
 
-			expectedRS := clone(rs)
+			expectedRS := rs.DeepCopy()
 			expectedRS.Status.Replicas = 1
 
 			addReplicaSet(rs)
@@ -279,7 +278,7 @@ var _ = Describe("Replicaset", func() {
 			rs, vm := DefaultReplicaSet(1)
 			rs.Status.Replicas = 1
 
-			rsCopy := clone(rs)
+			rsCopy := rs.DeepCopy()
 			rsCopy.Status.Replicas = 0
 
 			addReplicaSet(rs)
@@ -308,7 +307,7 @@ var _ = Describe("Replicaset", func() {
 			rs.Status.Replicas = 1
 			rs.Status.ReadyReplicas = 0
 
-			expectedRS := clone(rs)
+			expectedRS := rs.DeepCopy()
 			expectedRS.Status.Replicas = 1
 			expectedRS.Status.ReadyReplicas = 1
 
@@ -332,7 +331,7 @@ var _ = Describe("Replicaset", func() {
 			rs, vm := DefaultReplicaSet(1)
 			rs.Status.Replicas = 1
 
-			rsCopy := clone(rs)
+			rsCopy := rs.DeepCopy()
 			// The count stays at zero, since we just experienced the delete when we create the new VM
 			rsCopy.Status.Replicas = 0
 
@@ -387,7 +386,7 @@ var _ = Describe("Replicaset", func() {
 
 		It("should add a fail condition if scaling down fails", func() {
 			rs, vm := DefaultReplicaSet(0)
-			vm1 := cloneVM(vm)
+			vm1 := vm.DeepCopy()
 			vm1.ObjectMeta.Name = "test1"
 
 			addReplicaSet(rs)
@@ -482,18 +481,6 @@ var _ = Describe("Replicaset", func() {
 		})
 	})
 })
-
-func clone(rs *v1.VirtualMachineReplicaSet) *v1.VirtualMachineReplicaSet {
-	c, err := model.Clone(rs)
-	Expect(err).ToNot(HaveOccurred())
-	return c.(*v1.VirtualMachineReplicaSet)
-}
-
-func cloneVM(rs *v1.VirtualMachine) *v1.VirtualMachine {
-	c, err := model.Clone(rs)
-	Expect(err).ToNot(HaveOccurred())
-	return c.(*v1.VirtualMachine)
-}
 
 func ReplicaSetFromVM(name string, vm *v1.VirtualMachine, replicas int32) *v1.VirtualMachineReplicaSet {
 	rs := &v1.VirtualMachineReplicaSet{

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -135,11 +135,10 @@ type Domain struct {
 }
 
 func (in *Domain) DeepCopyInto(out *Domain) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*Domain)
 	return
 }
 
@@ -172,11 +171,10 @@ type DomainList struct {
 }
 
 func (in *DomainList) DeepCopyInto(out *DomainList) {
-	v, err := model.Clone(in)
+	err := model.Copy(out, in)
 	if err != nil {
 		panic(err)
 	}
-	out = v.(*DomainList)
 	return
 }
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -23,6 +23,7 @@ import (
 	goerror "errors"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -126,45 +126,70 @@ func (d *VMHandlerDispatch) getVMNodeAddress(vm *v1.VirtualMachine) (string, err
 	return addrStr, nil
 }
 
-func (d *VMHandlerDispatch) updateVMStatus(cachedVM *v1.VirtualMachine, mappedVM *v1.VirtualMachine, newDomainSpec *api.DomainSpec) error {
+func (d *VMHandlerDispatch) updateVMStatus(vm *v1.VirtualMachine, isPending bool, newDomainSpec *api.DomainSpec, syncError error) error {
 
-	obj, err := scheme.Scheme.Copy(cachedVM)
-	if err != nil {
-		return err
-	}
-	cachedVM = obj.(*v1.VirtualMachine)
+	var err error
+	oldPhase := vm.Status.Phase
 
-	// XXX When we start supporting hotplug, this needs to be altered.
-	// Check if the VM is already marked as running. If yes, don't update the VM.
-	// Otherwise we end up in endless controller requeues.
-	if cachedVM.Status.Phase == v1.Running {
+	// TODO, update a VM condition, right now, do nothing
+	if syncError != nil {
 		return nil
 	}
 
-	cachedVM.Status.Phase = v1.Running
+	// Don't update the VM if it is already in a final state
+	if vm.IsFinal() {
+		return nil
+	}
 
-	cachedVM.Status.Graphics = []v1.VMGraphics{}
+	// While the VM is migrating, don't do anything, the Migration Controller is in charge
+	if vm.Status.MigrationNodeName != "" {
+		return nil
+	}
 
-	podIP, err := d.getVMNodeAddress(cachedVM)
+	// Failed/Succeeded is currently handled somewhere else, do nothing if the spec is not there
+	if newDomainSpec == nil {
+		return nil
+	}
+
+	// TODO update to Failed if VM e.g. crashes
+	// TODO update based on api.Domain succeeded/failed here, instead of the extra controller
+	if isPending {
+		// FIXME Make Scheduled a condition and allow using Pening here
+		vm.Status.Phase = v1.Scheduled
+	} else {
+		vm.Status.Phase = v1.Running
+	}
+
+	vm.Status.Graphics = []v1.VMGraphics{}
+
+	// Update devices if device status changed
+	// TODO needs caching, better position or init fetch
+	nodeIP, err := d.getVMNodeAddress(vm)
 	if err != nil {
 		return err
 	}
 
+	oldGraphics := vm.Status.Graphics
+	vm.Status.Graphics = []v1.VMGraphics{}
 	for _, src := range newDomainSpec.Devices.Graphics {
 		if (src.Type != "spice" && src.Type != "vnc") || src.Port == -1 {
 			continue
 		}
 		dst := v1.VMGraphics{
 			Type: src.Type,
-			Host: podIP,
+			Host: nodeIP,
 			Port: src.Port,
 		}
-		cachedVM.Status.Graphics = append(cachedVM.Status.Graphics, dst)
+		vm.Status.Graphics = append(vm.Status.Graphics, dst)
 	}
 
-	return d.restClient.Put().Resource("virtualmachines").Body(cachedVM).
-		Name(cachedVM.ObjectMeta.Name).Namespace(cachedVM.ObjectMeta.Namespace).Do().Error()
+	phaseChanged := oldPhase != vm.Status.Phase
+	deviceChanged := reflect.DeepEqual(vm.Status.Graphics, oldGraphics)
 
+	if deviceChanged || phaseChanged {
+		_, err = d.clientset.VM(vm.ObjectMeta.Namespace).Update(vm)
+	}
+	return err
 }
 
 func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimitingInterface, key interface{}) {
@@ -229,11 +254,23 @@ func (d *VMHandlerDispatch) Execute(store cache.Store, queue workqueue.RateLimit
 	log.Log.Object(vm).V(3).Info("Processing VM update.")
 
 	// Process the VM
-	isPending, err := d.processVmUpdate(vm, shouldDeleteVm)
-	if err != nil {
-		// Something went wrong, reenqueue the item with a delay
-		log.Log.Object(vm).Reason(err).Error("Synchronizing the VM failed.")
-		d.recorder.Event(vm, k8sv1.EventTypeWarning, v1.SyncFailed.String(), err.Error())
+	newConfig, isPending, syncErr := d.processVmUpdate(vm.DeepCopy(), shouldDeleteVm)
+	if syncErr != nil {
+		d.recorder.Event(vm, k8sv1.EventTypeWarning, v1.SyncFailed.String(), syncErr.Error())
+		log.Log.Object(vm).Reason(syncErr).Error("Synchronizing the VM failed.")
+	}
+
+	// Update the VM status, if the VM exists
+	if exists {
+		err = d.updateVMStatus(vm.DeepCopy(), isPending, newConfig, syncErr)
+		if err != nil {
+			log.Log.Object(vm).Reason(err).Error("Updating the VM status failed.")
+			queue.AddRateLimited(key)
+			return
+		}
+	}
+
+	if syncErr != nil {
 		queue.AddRateLimited(key)
 		return
 	} else if isPending {
@@ -409,97 +446,87 @@ func (d *VMHandlerDispatch) injectDiskAuth(vm *v1.VirtualMachine) (*v1.VirtualMa
 	return vm, nil
 }
 
-func (d *VMHandlerDispatch) processVmUpdate(cachedVM *v1.VirtualMachine, shouldDeleteVm bool) (bool, error) {
+func (d *VMHandlerDispatch) processVmUpdate(vm *v1.VirtualMachine, shouldDeleteVM bool) (*api.DomainSpec, bool, error) {
 
-	obj, err := scheme.Scheme.Copy(cachedVM)
-	if err != nil {
-		return false, err
-	}
-	mappedVM := obj.(*v1.VirtualMachine)
-
-	if shouldDeleteVm {
+	if shouldDeleteVM || vm.ObjectMeta.DeletionTimestamp != nil {
 		// Since the VM was not in the cache, we delete it
-		err := d.domainManager.KillVM(mappedVM)
+		err := d.domainManager.KillVM(vm)
 		if err != nil {
-			return false, err
+			return nil, false, err
 		}
 
 		// remove any defined libvirt secrets associated with this vm
-		err = d.domainManager.RemoveVMSecrets(mappedVM)
+		err = d.domainManager.RemoveVMSecrets(vm)
 		if err != nil {
-			return false, err
+			return nil, false, err
 		}
 
-		err = registrydisk.CleanupEphemeralDisks(mappedVM)
+		err = registrydisk.CleanupEphemeralDisks(vm)
 		if err != nil {
-			return false, err
+			return nil, false, err
 		}
 
-		err = watchdog.WatchdogFileRemove(d.virtShareDir, mappedVM)
+		err = watchdog.WatchdogFileRemove(d.virtShareDir, vm)
 		if err != nil {
-			return false, err
+			return nil, false, err
 		}
 
-		return false, d.configDisk.Undefine(mappedVM)
-	} else if isWorthSyncing(mappedVM) == false {
+		return nil, false, d.configDisk.Undefine(vm)
+	} else if isWorthSyncing(vm) == false {
 		// nothing to do here.
-		return false, nil
+		return nil, false, nil
 	}
 
-	hasWatchdog, err := watchdog.WatchdogFileExists(d.virtShareDir, mappedVM)
+	hasWatchdog, err := watchdog.WatchdogFileExists(d.virtShareDir, vm)
 	if err != nil {
-		log.Log.Object(mappedVM).Reason(err).V(3).Error("Error accessing virt-launcher watchdog file.")
-		return false, err
+		log.Log.Object(vm).Reason(err).V(3).Error("Error accessing virt-launcher watchdog file.")
+		return nil, false, err
 	}
 	if hasWatchdog == false {
-		log.Log.Object(mappedVM).Reason(err).V(3).Error("Could not detect virt-launcher watchdog file.")
-		return false, goerror.New(fmt.Sprintf("No watchdog file found for vm"))
+		log.Log.Object(vm).Reason(err).V(3).Error("Could not detect virt-launcher watchdog file.")
+		return nil, false, goerror.New(fmt.Sprintf("No watchdog file found for vm"))
 	}
 
-	isPending, err := d.configDisk.Define(mappedVM)
+	isPending, err := d.configDisk.Define(vm)
 	if err != nil || isPending == true {
-		return isPending, err
+		return nil, isPending, err
 	}
 
 	// Synchronize the VM state
-	mappedVM, err = MapPersistentVolumes(mappedVM, d.clientset.CoreV1().RESTClient(), mappedVM.ObjectMeta.Namespace)
+	vm, err = MapPersistentVolumes(vm, d.clientset.CoreV1().RESTClient(), vm.ObjectMeta.Namespace)
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
 	// Map Container Registry Disks to block devices Libvirt can consume
-	mappedVM, err = registrydisk.MapRegistryDisks(mappedVM)
+	vm, err = registrydisk.MapRegistryDisks(vm)
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
-	mappedVM, err = d.injectDiskAuth(mappedVM)
+	vm, err = d.injectDiskAuth(vm)
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
 	// Map whatever devices are being used for config-init
-	mappedVM, err = cloudinit.MapCloudInitDisks(mappedVM)
+	vm, err = cloudinit.MapCloudInitDisks(vm)
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
 	// TODO MigrationNodeName should be a pointer
-	if mappedVM.Status.MigrationNodeName != "" {
+	if vm.Status.MigrationNodeName != "" {
 		// Only sync if the VM is not marked as migrating.
 		// Everything except shutting down the VM is not
 		// permitted when it is migrating.
-		return false, nil
+		return nil, false, nil
 	}
 
 	// TODO check if found VM has the same UID like the domain,
 	// if not, delete the Domain first
-	newCfg, err := d.domainManager.SyncVM(mappedVM)
-	if err != nil {
-		return false, err
-	}
-
-	return false, d.updateVMStatus(cachedVM, mappedVM, newCfg)
+	newCfg, err := d.domainManager.SyncVM(vm)
+	return newCfg, false, err
 }
 
 func (d *VMHandlerDispatch) isMigrationDestination(namespace string, vmName string) (bool, error) {
@@ -525,5 +552,5 @@ func (d *VMHandlerDispatch) isMigrationDestination(namespace string, vmName stri
 }
 
 func isWorthSyncing(vm *v1.VirtualMachine) bool {
-	return vm.Status.Phase != v1.Succeeded && vm.Status.Phase != v1.Failed
+	return !vm.IsFinal()
 }

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -148,5 +148,15 @@ var _ = Describe("Storage", func() {
 			RunVMAndExpectLaunch(vm, true)
 			close(done)
 		}, 30)
+
+		It("should not modify the VM spec on status update", func() {
+			vm := tests.NewRandomVMWithPVC("disk-auth-alpine")
+			vm, err := virtClient.VM(tests.NamespaceTestDefault).Create(vm)
+			Expect(err).To(BeNil())
+			tests.WaitForSuccessfulVMStartWithTimeout(vm, 60)
+			startedVM, err := virtClient.VM(tests.NamespaceTestDefault).Get(vm.ObjectMeta.Name, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			Expect(startedVM.Spec).To(Equal(vm.Spec))
+		})
 	})
 })


### PR DESCRIPTION
* Make sure that we only update the VM status in virt-handler, and not the spec too
* If VM start with a registry disk failed, make sure that it will still recognize the handed over disk