### PR TITLE
Replace hard-coded spice proxy in virt-api with ConfigMap lookup.

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/pkg/healthz"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/logging"
@@ -86,9 +87,11 @@ func (app *virtAPIApp) Run() {
 		log.Fatal(err)
 	}
 
+	kconfig := config.NewKubevirtConfig(virtCli.CoreV1().RESTClient())
+
 	//  TODO, allow Encoder and Decoders per type and combine the endpoint logic
 	spice := endpoints.MakeGoRestfulWrapper(endpoints.NewHandlerBuilder().Get().
-		Endpoint(rest.NewSpiceEndpoint(virtCli.RestClient(), vmGVR)).Encoder(
+		Endpoint(rest.NewSpiceEndpoint(virtCli.RestClient(), kconfig, vmGVR)).Encoder(
 		endpoints.NewMimeTypeAwareEncoder(endpoints.NewEncodeINIResponse(http.StatusOK),
 			map[string]kithttp.EncodeResponseFunc{
 				mime.MIME_INI:  endpoints.NewEncodeINIResponse(http.StatusOK),

--- a/manifests/configmap.yaml.in
+++ b/manifests/configmap.yaml.in
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: default
+data:
+  spice-proxy.ip: "{{ master_ip }}"
+  spice-proxy.port: "3128"

--- a/manifests/configmap.yaml.in
+++ b/manifests/configmap.yaml.in
@@ -4,5 +4,4 @@ metadata:
   name: kubevirt-config
   namespace: default
 data:
-  spice-proxy.ip: "{{ master_ip }}"
-  spice-proxy.port: "3128"
+  spice-proxy: "{{ master_ip }}:3218"

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -30,8 +30,6 @@ spec:
             - "/virt-api"
             - "--port"
             - "8183"
-            - "--spice-proxy"
-            - "{{ master_ip }}:3128"
         ports:
           - containerPort: 8183
             name: "virt-api"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 John Levon <levon@movementarian.org>
+ *
+ */
+
+// Package config tracks changes in the kubevirt-config ConfigMap,
+// providing access to any of the current key values via Get()
+package config
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+type KubevirtConfig struct {
+	informer cache.SharedInformer
+	stop     chan struct{}
+}
+
+func NewKubevirtConfig(cli rest.Interface) *KubevirtConfig {
+	var config KubevirtConfig
+
+	watcher := cache.NewListWatchFromClient(cli, "configmaps", v1.NamespaceDefault,
+		fields.ParseSelectorOrDie("metadata.name=kubevirt-config"))
+
+	config.informer = cache.NewSharedInformer(watcher, &v1.ConfigMap{}, 0)
+
+	go config.informer.Run(config.stop)
+
+	return &config
+}
+
+func (c *KubevirtConfig) Get(key string) (value string, ok bool) {
+	storeval, ok, _ := c.informer.GetStore().GetByKey("default/kubevirt-config")
+	if !ok {
+		return
+	}
+
+	value, ok = storeval.(*v1.ConfigMap).Data[key]
+	return
+}

--- a/pkg/virt-api/rest/spice.go
+++ b/pkg/virt-api/rest/spice.go
@@ -69,9 +69,8 @@ func spiceFromVM(vm *v1.VirtualMachine, config *config.KubevirtConfig) (*v1.Spic
 				Port: d.Port,
 			}
 
-			if proxyIP, ok := config.Get("spice-proxy.ip"); ok {
-				proxyPort, _ := config.Get("spice-proxy.port")
-				spice.Info.Proxy = fmt.Sprintf("http://%s:%s", proxyIP, proxyPort)
+			if proxy, ok := config.Get("spice-proxy"); ok {
+				spice.Info.Proxy = fmt.Sprintf("http://%s", proxy)
 			}
 
 			return spice, nil


### PR DESCRIPTION
This fixes #457 virt-api depends on spice proxy ip in manifest

Instead of hard-coding the spice proxy as an argument to virt-api, we introduce a ConfigMap for general kubevirt configuration, and watch for changes to it. This allows the proxy details to be specified later, updated, removed, etc. without having to re-deploy virt-api.

As I mentioned to @fabiand, while this has been unit tested as well as run through make functest, there isn't yet any automated testing that covers ConfigMap changes.