### PR TITLE
Introduce virt-dhcp

### DIFF
--- a/cmd/fake-dnsmasq-process/fake-dnsmasq.go
+++ b/cmd/fake-dnsmasq-process/fake-dnsmasq.go
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt,
+		syscall.SIGQUIT,
+	)
+
+	fmt.Printf("Started fake dnsmasq process\n")
+
+	timeout := time.After(60 * time.Second)
+	select {
+	case <-timeout:
+	case <-c:
+		time.Sleep(2 * time.Second)
+	}
+
+	fmt.Printf("Exit fake dnsmasq process\n")
+}

--- a/cmd/virt-dhcp/Dockerfile
+++ b/cmd/virt-dhcp/Dockerfile
@@ -1,0 +1,27 @@
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+FROM fedora:26
+
+MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+
+RUN dnf -y install dnsmasq
+
+COPY virt-dhcp /virt-dhcp
+
+ENTRYPOINT [ "/virt-dhcp" ]

--- a/cmd/virt-dhcp/virt-dhcp.go
+++ b/cmd/virt-dhcp/virt-dhcp.go
@@ -1,0 +1,37 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"kubevirt.io/kubevirt/pkg/log"
+	dhcp "kubevirt.io/kubevirt/pkg/virt-dhcp"
+	"flag"
+)
+
+const defaultDhcpSocket = "/var/run/kubevirt/virt_dhcp_sock"
+
+func main() {
+	log.InitializeLogging("virt-dhcp")
+	virtDhcpSocket := flag.String("virtdhcp-socket", defaultDhcpSocket, "Virt-DHCP socket.")
+	if *virtDhcpSocket == "" {
+		*virtDhcpSocket = defaultDhcpSocket
+	}
+	dhcp.Run(*virtDhcpSocket)
+}

--- a/cmd/virt-dhcp/virt-dhcp.go
+++ b/cmd/virt-dhcp/virt-dhcp.go
@@ -20,9 +20,10 @@
 package main
 
 import (
+	"flag"
+
 	"kubevirt.io/kubevirt/pkg/log"
 	dhcp "kubevirt.io/kubevirt/pkg/virt-dhcp"
-	"flag"
 )
 
 const defaultDhcpSocket = "/var/run/kubevirt/virt_dhcp_sock"

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,5 +1,5 @@
-binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virtctl cmd/virt-manifest cmd/fake-qemu-process"
-docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virt-manifest images/haproxy images/iscsi-demo-target-tgtd images/vm-killer images/libvirt-kubevirt images/spice-proxy cmd/virt-migrator cmd/registry-disk-v1alpha images/cirros-registry-disk-demo"
+binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virtctl cmd/virt-manifest cmd/fake-qemu-process cmd/virt-dhcp cmd/fake-dnsmasq-process"
+docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api cmd/virt-manifest images/haproxy images/iscsi-demo-target-tgtd images/vm-killer images/libvirt-kubevirt images/spice-proxy cmd/virt-migrator cmd/registry-disk-v1alpha images/cirros-registry-disk-demo cmd/virt-dhcp"
 optional_docker_images="cmd/registry-disk-v1alpha images/fedora-atomic-registry-disk-demo"
 docker_prefix=kubevirt
 docker_tag=${DOCKER_TAG:-latest}

--- a/manifests/libvirt.yaml.in
+++ b/manifests/libvirt.yaml.in
@@ -47,6 +47,18 @@ spec:
           - name: libvirt-runtime
             mountPath: /var/run/libvirt
         command: ["/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf"]
+      - name: virt-dhcp
+        image: {{ docker_prefix }}/virt-dhcp:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+          - name: libvirt-runtime
+            mountPath: /var/run/libvirt
+          - name: virt-share-dir
+            mountPath: /var/run/kubevirt
+        command: ["/virt-dhcp"]
       volumes:
       - name: libvirt-data
         hostPath:

--- a/pkg/virt-dhcp/client.go
+++ b/pkg/virt-dhcp/client.go
@@ -1,0 +1,46 @@
+package virtdhcp
+
+import (
+	"fmt"
+	"net/rpc"
+
+	"kubevirt.io/kubevirt/pkg/log"
+)
+
+type VirtDHCPClient struct {
+	client *rpc.Client
+}
+
+func GetClient() (*VirtDHCPClient, error) {
+	conn, err := rpc.Dial("unix", DhcpSocket)
+	if err != nil {
+		log.Log.Reason(err).Errorf("client failed to connect to virt-dhcp socket: %s", DhcpSocket)
+		return nil, err
+	}
+
+	return &VirtDHCPClient{client: conn}, nil
+}
+
+func (dhcp *VirtDHCPClient) AddIP(mac string, ip string, lease int) error {
+	addArgs := &AddArgs{ip, mac, lease}
+	addReply := &DhcpReply{}
+
+	dhcp.client.Call("DHCP.AddIP", addArgs, addReply)
+	if addReply.Success != true {
+		msg := fmt.Sprintf("failed to add interface to dhcp, ip: %s, mac: %s - %s", ip, mac, addReply.Message)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+func (dhcp *VirtDHCPClient) RemoveIP(mac string, ip string) error {
+	removeArgs := &RemoveArgs{ip, mac}
+	removeReply := &DhcpReply{}
+
+	dhcp.client.Call("DHCP.RemoveIP", removeArgs, removeReply)
+	if removeReply.Success != true {
+		msg := fmt.Sprintf("failed to remove interface from dhcp, ip: %s, mac: %s - %s", ip, mac, removeReply.Message)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}

--- a/pkg/virt-dhcp/client.go
+++ b/pkg/virt-dhcp/client.go
@@ -44,3 +44,14 @@ func (dhcp *VirtDHCPClient) RemoveIP(mac string, ip string) error {
 	}
 	return nil
 }
+
+func (dhcp *VirtDHCPClient) SetIPs(hosts *[]AddArgs, reply *DhcpReply) error {
+	addReply := &DhcpReply{}
+
+	dhcp.client.Call("DHCP.SetIPs", hosts, addReply)
+	if addReply.Success != true {
+		msg := fmt.Sprintf("failed to set known hosts to dhcp: %s", addReply.Message)
+		return fmt.Errorf(msg)
+	}
+	return nil
+}

--- a/pkg/virt-dhcp/dnsmasq.go
+++ b/pkg/virt-dhcp/dnsmasq.go
@@ -1,0 +1,307 @@
+package virtdhcp
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"text/template"
+
+	"kubevirt.io/kubevirt/pkg/log"
+)
+
+const (
+	DNSmasqExec   = "/usr/sbin/dnsmasq"
+	DHCPLeaseFile = "/tmp/dhcp.leases"
+	DHCPPidFile   = "/tmp/dhcp.pid"
+	DHCPHostsFile = "/tmp/dhcp.hosts"
+)
+
+type hostsDetails struct {
+	Mac   string
+	Lease int
+}
+
+type DNSmasqInstance struct {
+	hosts    map[string]hostsDetails
+	ipRange  [][]byte
+	confpath string
+	args     []string
+	cmd      *exec.Cmd
+	monitor  Monitor
+}
+
+func NewDNSmasq() *DNSmasqInstance {
+	dnsMasq := new(DNSmasqInstance)
+	dnsMasq.hosts = make(map[string]hostsDetails)
+	dnsMasq.ipRange = make([][]byte, 2)
+	dnsMasq.args = []string{"-k", "-d", "--strict-order", "--bind-dynamic", "--no-resolv", "--dhcp-no-override", "--dhcp-authoritative",
+		"--except-interface=lo", "--dhcp-hostsfile=" + DHCPHostsFile, "--dhcp-leasefile=" + DHCPLeaseFile,
+		"--pid-file=" + DHCPPidFile}
+	dnsMasq.monitor = NewMonitor()
+	OS = &OSHandler{}
+	return dnsMasq
+}
+
+// implement `Interface` in sort package.
+type sortByteArrays [][]byte
+
+func (b sortByteArrays) Len() int {
+	return len(b)
+}
+
+func (b sortByteArrays) Less(i, j int) bool {
+	// bytes package already implements Comparable for []byte.
+	switch bytes.Compare(b[i], b[j]) {
+	case -1:
+		return true
+	case 0, 1:
+		return false
+	default:
+		return false
+	}
+}
+
+func (b sortByteArrays) Swap(i, j int) {
+	b[j], b[i] = b[i], b[j]
+}
+
+type OSOps interface {
+	IsFileExist(path string) (bool, error)
+	getPidFromFile(file string) (int, error)
+	checkProcessExist(pid int) (bool, *os.Process)
+	killProcessIfExist(pid int) error
+	RecreateHostsFile() (*os.File, error)
+	executeCommand(string, []string) *exec.Cmd
+	readFromFile(file string) ([]byte, error)
+	IsDNSMasqPidRunning(pid int) bool
+}
+
+type OSHandler struct {
+	dnsmasq *DNSmasqInstance
+}
+
+var OS OSOps
+
+func (o *OSHandler) IsFileExist(path string) (bool, error) {
+	_, err := os.Stat(path)
+	exists := false
+
+	if err == nil {
+		exists = true
+	} else if os.IsNotExist(err) {
+		err = nil
+	}
+	return exists, err
+}
+
+func (o *OSHandler) getPidFromFile(file string) (int, error) {
+	content, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to open dnsmasq pid file: %s", file)
+		return -1, err
+	}
+	lines := strings.Split(string(content), "\n")
+	pid, _ := strconv.Atoi(lines[0])
+	log.Log.Debugf("found dnsmasq pid: %s", pid)
+	return pid, nil
+}
+
+func (o *OSHandler) killProcessIfExist(pid int) error {
+	procExist, proc := OS.checkProcessExist(pid)
+	if procExist {
+		log.Log.Debugf("killing process %d", proc.Pid)
+		killErr := proc.Kill()
+		if killErr != nil {
+			log.Log.Warningf("failed to kill process %d", proc.Pid)
+		}
+	}
+	return nil
+}
+
+func (o *OSHandler) checkProcessExist(pid int) (bool, *os.Process) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		log.Log.Warningf("failed to find process %d", pid)
+		return false, nil
+	}
+	procErr := proc.Signal(syscall.Signal(0))
+	return procErr == nil, proc
+}
+
+func (o *OSHandler) RecreateHostsFile() (*os.File, error) {
+	// Remove the config file
+	ferr := os.RemoveAll(DHCPHostsFile)
+	if ferr != nil {
+		log.Log.Reason(ferr).Warningf("failed to remove dhcp hosts file: %s", DHCPHostsFile)
+	}
+
+	f, err := os.Create(DHCPHostsFile)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to create dnsmasq hosts file in %s", DHCPHostsFile)
+		return nil, err
+	}
+	return f, nil
+}
+
+func (o *OSHandler) IsDNSMasqPidRunning(pid int) bool {
+	path := fmt.Sprintf("/proc/%d/cmdline", pid)
+	fileExist, err := OS.IsFileExist(path)
+	if err != nil {
+		panic(err)
+	}
+
+	if fileExist {
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(string(content), "dnsmasq")
+	}
+	return false
+}
+
+func (o *OSHandler) executeCommand(path string, startArgs []string) *exec.Cmd {
+	return exec.Command(path, startArgs...)
+}
+
+func (dnsmasq *DNSmasqInstance) formatDhcpRange() string {
+	return fmt.Sprintf("--dhcp-range=%s,%s", net.IP(dnsmasq.ipRange[0]).String(), net.IP(dnsmasq.ipRange[1]).String())
+}
+
+func (dnsmasq *DNSmasqInstance) Start() error {
+	log.Log.Info("starting Dnsmasq")
+	dhcpRange := dnsmasq.formatDhcpRange()
+	startArgs := append(dnsmasq.args, dhcpRange)
+	dnsmasq.monitor.Start(DNSmasqExec, startArgs)
+	return nil
+}
+
+func (dnsmasq *DNSmasqInstance) stop() error {
+	log.Log.Info("Stopping Dnsmasq")
+	if dnsmasq.monitor.IsRunning() {
+		dnsmasq.monitor.Stop()
+	} else {
+		fileExist, err := OS.IsFileExist(DHCPPidFile)
+		if err != nil {
+			return err
+		}
+		if fileExist {
+			pid, err1 := OS.getPidFromFile(DHCPPidFile)
+			if err1 == nil {
+				OS.killProcessIfExist(pid)
+			}
+		}
+	}
+	return nil
+}
+
+func (dnsmasq *DNSmasqInstance) Restart() error {
+	log.Log.Debug("restarting Dnsmasq")
+
+	err := dnsmasq.stop()
+	if err != nil {
+		log.Log.Reason(err).Error("failed to stop Dnsmasq")
+		return err
+	}
+
+	dnsmasq.updateRange()
+	err = dnsmasq.handleDHCPHostsFile()
+	if err != nil {
+		return nil
+	}
+	if len(dnsmasq.hosts) != 0 {
+		return dnsmasq.Start()
+	}
+
+	return nil
+}
+
+func (dnsmasq *DNSmasqInstance) AddHost(mac string, ipaddr string, lease int) error {
+	dnsmasq.hosts[ipaddr] = hostsDetails{Mac: mac, Lease: lease}
+	log.Log.Debugf("added host %s, ip %s, to hosts", mac, ipaddr)
+	return dnsmasq.Restart()
+}
+
+func (dnsmasq *DNSmasqInstance) RemoveHost(ipaddr string) error {
+	delete(dnsmasq.hosts, ipaddr)
+	return dnsmasq.Restart()
+}
+
+func (dnsmasq *DNSmasqInstance) writeDHCPHostsFile(file *os.File, dhcpHosts []string) error {
+	if len(dhcpHosts) != 0 {
+		t := template.Must(template.New("dhcpshosts").Parse(`{{range $k:=.}}{{printf "%s\n" $k }}{{end}}
+`))
+
+		err := t.Execute(file, dhcpHosts)
+		if err != nil {
+			log.Log.Reason(err).Error("failed to write dhcp hosts file")
+			return err
+		}
+	}
+	return nil
+}
+
+func (dnsmasq *DNSmasqInstance) handleDHCPHostsFile() error {
+	f, err := OS.RecreateHostsFile()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	dhcpHosts := make([]string, 0, len(dnsmasq.hosts))
+	for key, val := range dnsmasq.hosts {
+		dhcpHosts = append(dhcpHosts, fmt.Sprintf("%s,%s,%d", val.Mac, key, val.Lease))
+	}
+	err = dnsmasq.writeDHCPHostsFile(f, dhcpHosts)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (dnsmasq *DNSmasqInstance) updateRange() {
+	sorted := sortByteArrays(getMapValues(dnsmasq.hosts))
+	sort.Sort(sorted)
+	if len(sorted) > 0 {
+		dnsmasq.ipRange[0] = sorted[0]
+		dnsmasq.ipRange[1] = sorted[len(sorted)-1]
+		log.Log.Debugf("updated range %s - %s", net.IP(dnsmasq.ipRange[0]).String(), net.IP(dnsmasq.ipRange[1]).String())
+	}
+}
+
+func (dnsmasq *DNSmasqInstance) loadHostsFile() error {
+	fileExist, err := OS.IsFileExist(DHCPPidFile)
+	if err != nil {
+		return err
+	}
+	if !fileExist {
+		return nil
+	}
+	content, err := OS.readFromFile(DHCPHostsFile)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		data := strings.Split(line, ",")
+		lease, _ := strconv.Atoi(data[2])
+		dnsmasq.hosts[data[1]] = hostsDetails{Mac: data[0], Lease: lease}
+	}
+	dnsmasq.Restart()
+	return nil
+}
+
+func getMapValues(dict map[string]hostsDetails) [][]byte {
+	vals := make([][]byte, 0, len(dict))
+	for key, _ := range dict {
+		vals = append(vals, net.ParseIP(key))
+	}
+	return vals
+}

--- a/pkg/virt-dhcp/dnsmasq_test.go
+++ b/pkg/virt-dhcp/dnsmasq_test.go
@@ -1,0 +1,130 @@
+package virtdhcp
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var testdnsmasq *DNSmasqInstance
+var cmdArgs []string
+var cmdArgsPrefix string
+
+type MockMonitor struct {
+	MonitorRuntime
+}
+
+func (mon MockMonitor) Start(cmd string, args []string) {
+	cmdArgs = args
+}
+
+func FakeMonitor() Monitor {
+	mon := MockMonitor{}
+	mon.isRunning = false
+	mon.stopChan = make(chan bool)
+	mon.pid = 0
+	return &mon
+}
+
+type MockOSHandler struct {
+	OSHandler
+}
+
+func (o *MockOSHandler) writeDHCPHostsFile(file *os.File, dhcpHosts []string) error {
+	errRet := fmt.Errorf("failed to match dhcphosts")
+	if len(testdnsmasq.hosts) != len(dhcpHosts) {
+		return errRet
+	}
+	for _, host := range dhcpHosts {
+		data := strings.Split(host, ",")
+		if val, ok := testdnsmasq.hosts[data[1]]; ok {
+			lease, _ := strconv.Atoi(data[2])
+			if val.Mac != data[0] || val.Lease != lease {
+				return errRet
+			}
+		}
+	}
+	return nil
+}
+
+func (o *MockOSHandler) killProcessIfExist(pid int) error {
+	return nil
+}
+
+var _ = Describe("DHCP", func() {
+
+	BeforeEach(func() {
+		testdnsmasq = NewDNSmasq()
+		OS = &MockOSHandler{}
+		testdnsmasq.monitor = FakeMonitor()
+	})
+
+	Context("handle requests to add/remove a hosts", func() {
+		It("should restart dnsmasq with new configuration", func() {
+			err := testdnsmasq.AddHost("12:d4:4f:99:7d:3f", "10.32.0.15", 86400)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(testdnsmasq.hosts)).To(Equal(1))
+			key, val := testdnsmasq.hosts["10.32.0.15"]
+			Expect(val).To(Equal(true))
+			Expect(key.Lease).To(Equal(86400))
+			Expect(key.Mac).To(Equal("12:d4:4f:99:7d:3f"))
+		})
+		It("should start dnsmasq with 2 hosts", func() {
+			err := testdnsmasq.AddHost("12:d4:4f:99:7d:3f", "10.32.0.15", 86400)
+			Expect(err).NotTo(HaveOccurred())
+			err = testdnsmasq.AddHost("af:21:ac:bd:c3:ba", "10.32.0.12", 86400)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(testdnsmasq.hosts)).To(Equal(2))
+			key, val := testdnsmasq.hosts["10.32.0.15"]
+			Expect(val).To(Equal(true))
+			Expect(key.Lease).To(Equal(86400))
+			Expect(key.Mac).To(Equal("12:d4:4f:99:7d:3f"))
+			key, val = testdnsmasq.hosts["10.32.0.12"]
+			Expect(val).To(Equal(true))
+			Expect(key.Lease).To(Equal(86400))
+			Expect(key.Mac).To(Equal("af:21:ac:bd:c3:ba"))
+			testArgs := cmdArgsPrefix + " --dhcp-range=10.32.0.12,10.32.0.15"
+			expectedArgs := strings.Join(cmdArgs, " ")
+			Expect(expectedArgs).To(Equal(testArgs))
+		})
+		It("should start dnsmasq with 1 host after remove", func() {
+			err := testdnsmasq.AddHost("12:d4:4f:99:7d:3f", "10.32.0.15", 86400)
+			Expect(err).NotTo(HaveOccurred())
+			err = testdnsmasq.AddHost("af:21:ac:bd:c3:ba", "10.32.0.12", 86400)
+			Expect(err).NotTo(HaveOccurred())
+			err = testdnsmasq.RemoveHost("10.32.0.15")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(testdnsmasq.hosts)).To(Equal(1))
+			key, val := testdnsmasq.hosts["10.32.0.15"]
+			Expect(val).To(Equal(false))
+			key, val = testdnsmasq.hosts["10.32.0.12"]
+			Expect(val).To(Equal(true))
+			Expect(key.Lease).To(Equal(86400))
+			Expect(key.Mac).To(Equal("af:21:ac:bd:c3:ba"))
+			testArgs := cmdArgsPrefix + " --dhcp-range=10.32.0.12,10.32.0.12"
+			expectedArgs := strings.Join(cmdArgs, " ")
+			Expect(expectedArgs).To(Equal(testArgs))
+		})
+		It("should not start dnsmasq with all hosts removed", func() {
+			err := testdnsmasq.AddHost("12:d4:4f:99:7d:3f", "10.32.0.15", 86400)
+			Expect(err).NotTo(HaveOccurred())
+			err = testdnsmasq.AddHost("af:21:ac:bd:c3:ba", "10.32.0.12", 86400)
+			Expect(err).NotTo(HaveOccurred())
+			err = testdnsmasq.RemoveHost("10.32.0.15")
+			Expect(err).NotTo(HaveOccurred())
+
+			cmdArgs = []string{}
+			err = testdnsmasq.RemoveHost("10.32.0.12")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(testdnsmasq.hosts)).To(Equal(0))
+			Expect(cmdArgs).To(Equal([]string{}))
+		})
+	})
+})

--- a/pkg/virt-dhcp/monitor.go
+++ b/pkg/virt-dhcp/monitor.go
@@ -19,18 +19,18 @@ type MonitorRuntime struct {
 }
 
 type MonitorCmd struct {
-	Stop    chan bool
+	Stop           chan bool
 	processStopped chan bool
-	ProcCmd *exec.Cmd
-	cmdArgs []string
-	cmdPath string
-	retries int
+	ProcCmd        *exec.Cmd
+	cmdArgs        []string
+	cmdPath        string
+	retries        int
 }
 
 func NewMonitor() Monitor {
 	mon := MonitorRuntime{
-		stopChan:  make(chan bool),
-		pid:       0,
+		stopChan: make(chan bool),
+		pid:      0,
 	}
 	return &mon
 }
@@ -50,7 +50,7 @@ func (runtime *MonitorRuntime) IsRunning() bool {
 }
 
 func (mon *MonitorCmd) restart(pid *int) {
-	defer func () {mon.processStopped <- true}()
+	defer func() { mon.processStopped <- true }()
 	mon.ProcCmd = exec.Command(mon.cmdPath, mon.cmdArgs...)
 	err := mon.ProcCmd.Start()
 	mon.retries += 1

--- a/pkg/virt-dhcp/monitor.go
+++ b/pkg/virt-dhcp/monitor.go
@@ -1,0 +1,93 @@
+package virtdhcp
+
+import (
+	"os/exec"
+
+	"kubevirt.io/kubevirt/pkg/log"
+)
+
+type Monitor interface {
+	Start(cmd string, args []string)
+	Stop()
+	IsRunning() bool
+}
+
+type MonitorRuntime struct {
+	isRunning bool
+	stopChan  chan bool
+	pid       int
+}
+
+type MonitorCmd struct {
+	Stop    chan bool
+	processStopped chan bool
+	ProcCmd *exec.Cmd
+	cmdArgs []string
+	cmdPath string
+	retries int
+}
+
+func NewMonitor() Monitor {
+	mon := MonitorRuntime{
+		stopChan:  make(chan bool),
+		pid:       0,
+	}
+	return &mon
+}
+
+func (runtime *MonitorRuntime) Start(cmd string, args []string) {
+	go RunMonitor(cmd, args, runtime.stopChan, &runtime.pid)
+	runtime.isRunning = true
+}
+
+func (runtime *MonitorRuntime) Stop() {
+	runtime.stopChan <- true
+	runtime.isRunning = false
+}
+
+func (runtime *MonitorRuntime) IsRunning() bool {
+	return runtime.isRunning
+}
+
+func (mon *MonitorCmd) restart(pid *int) {
+	defer func () {mon.processStopped <- true}()
+	mon.ProcCmd = exec.Command(mon.cmdPath, mon.cmdArgs...)
+	err := mon.ProcCmd.Start()
+	mon.retries += 1
+	if err != nil {
+		log.Log.Reason(err).Error("failed to start dnsmasq")
+		return
+	}
+
+	*pid = mon.ProcCmd.Process.Pid
+	mon.ProcCmd.Wait()
+}
+
+func RunMonitor(cmd string, args []string, stopChan chan bool, pid *int) error {
+
+	mon := &MonitorCmd{}
+	mon.processStopped = make(chan bool)
+	mon.Stop = stopChan
+	mon.cmdPath = cmd
+	mon.cmdArgs = args
+	mon.retries = 0
+	done := false
+	go mon.restart(pid)
+
+	for !done {
+		select {
+		case <-mon.processStopped:
+			if !done {
+				go mon.restart(pid)
+			}
+		case <-mon.Stop:
+			mon.ProcCmd.Process.Kill()
+			done = true
+
+		}
+		if mon.retries >= 3 {
+			panic("failed to start dnsmasq after 3 attempts")
+		}
+	}
+	return nil
+}

--- a/pkg/virt-dhcp/monitor_test.go
+++ b/pkg/virt-dhcp/monitor_test.go
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package virtdhcp
+
+import (
+	"os"
+	"strings"
+
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"fmt"
+	"io/ioutil"
+)
+
+func IsDNSMasqPidRunning(pid int) bool {
+	path := fmt.Sprintf("/proc/%d/cmdline", pid)
+	fileExist, err := OS.IsFileExist(path)
+	if err != nil {
+		panic(err)
+	}
+
+	if fileExist {
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(string(content), "dnsmasq")
+	}
+	return false
+}
+
+var _ = Describe("Virt-DHCP Monitor test", func() {
+	var pid int
+	var prevPid int
+	var monStop = make(chan bool)
+
+	OS = &OSHandler{}
+	dir := os.Getenv("PWD")
+	dir = strings.TrimSuffix(dir, "pkg/virt-dhcp")
+	processName := "fake-dnsmasq-process"
+	processPath := dir + "/cmd/fake-dnsmasq-process/" + processName
+	processArgs := []string{"-k", "-d", "--strict-order", "--bind-dynamic"}
+
+	StartProcess := func() {
+		go RunMonitor(processPath, processArgs, monStop, &pid)
+		time.Sleep(1 * time.Second)
+	}
+
+	StopProcess := func() {
+		monStop <- true
+	}
+
+	KillProcess := func() {
+		prevPid = pid
+		OS.killProcessIfExist(pid)
+		time.Sleep(1 * time.Second)
+	}
+
+	VerifyProcessRestarted := func() {
+		Eventually(func() bool {
+			if pid != prevPid {
+				return IsDNSMasqPidRunning(pid)
+			}
+			return false
+		}).Should(BeTrue())
+	}
+
+	VerifyProcessStarted := func() {
+		Eventually(func() bool {
+			if pid != 0 {
+				return IsDNSMasqPidRunning(pid)
+			}
+			return false
+		}).Should(BeTrue())
+	}
+
+	VerifyProcessStopped := func() {
+		Eventually(func() bool {
+			ret := !IsDNSMasqPidRunning(pid)
+			return ret
+		}).Should(BeTrue())
+	}
+
+	BeforeEach(func() {
+		OS = &OSHandler{}
+		pid = 0
+		prevPid = 0
+	})
+
+	Describe("Monitor test", func() {
+		Context("process monitor", func() {
+			It("verify pid detection works", func() {
+				StartProcess()
+				VerifyProcessStarted()
+				StopProcess()
+				VerifyProcessStopped()
+			})
+
+			It("should restart dnsmasq if killed", func() {
+				StartProcess()
+				VerifyProcessStarted()
+				KillProcess()
+				VerifyProcessRestarted()
+				StopProcess()
+				VerifyProcessStopped()
+			})
+		})
+	})
+})

--- a/pkg/virt-dhcp/monitor_test.go
+++ b/pkg/virt-dhcp/monitor_test.go
@@ -25,10 +25,11 @@ import (
 
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"fmt"
 	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func IsDNSMasqPidRunning(pid int) bool {

--- a/pkg/virt-dhcp/virt-dhcp.go
+++ b/pkg/virt-dhcp/virt-dhcp.go
@@ -1,0 +1,96 @@
+package virtdhcp
+
+import (
+	"net"
+	"net/rpc"
+	"os"
+	"sync"
+
+	"kubevirt.io/kubevirt/pkg/log"
+)
+
+var DhcpSocket string
+
+type DHCP struct {
+	name    string
+	dnsmasq *DNSmasqInstance
+	mutex   *sync.Mutex
+}
+
+type RemoveArgs struct {
+	IP  string
+	Mac string
+}
+
+type DhcpReply struct {
+	Message string
+	Success bool
+}
+
+type AddArgs struct {
+	IP    string
+	Mac   string
+	Lease int
+}
+
+func (s *DHCP) AddIP(args *AddArgs, reply *DhcpReply) error {
+	reply.Success = true
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	err := s.dnsmasq.AddHost(args.Mac, args.IP, args.Lease)
+
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to add ip: %s and mac: %s to dhcp", args.IP, args.Mac)
+		reply.Success = false
+		reply.Message = err.Error()
+	}
+	return nil
+}
+
+func (s *DHCP) RemoveIP(args *RemoveArgs, reply *DhcpReply) error {
+	reply.Success = true
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	err := s.dnsmasq.RemoveHost(args.IP)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to remove ip: %s and mac: %s from dhcp", args.IP, args.Mac)
+		reply.Success = false
+		reply.Message = err.Error()
+	}
+	return nil
+}
+
+func createSocket(socketPath string) (net.Listener, error) {
+
+	os.RemoveAll(socketPath)
+	socket, err := net.Listen("unix", socketPath)
+
+	if err != nil {
+		log.Log.Reason(err).Error("failed to create a socket for dhcp service")
+		return nil, err
+	}
+	return socket, nil
+}
+
+func Run(socket string) error {
+	DhcpSocket = socket
+	var mutex = &sync.Mutex{}
+
+	rpcServer := rpc.NewServer()
+	server := &DHCP{name: "virt-dhcp",
+		dnsmasq: NewDNSmasq(),
+		mutex:   mutex}
+	rpcServer.Register(server)
+	sock, err := createSocket(DhcpSocket)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		sock.Close()
+		os.Remove(DhcpSocket)
+	}()
+	rpcServer.Accept(sock)
+
+	return nil
+}

--- a/pkg/virt-dhcp/virt_dhcp_suite_test.go
+++ b/pkg/virt-dhcp/virt_dhcp_suite_test.go
@@ -1,0 +1,13 @@
+package virtdhcp
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVirtDHCP(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VirtDHCP Suite")
+}


### PR DESCRIPTION
virt-dhcp is a client-server service intended to dynamically update the dnsmasq
configuration to provide addresses for VMs in KubeVirt
virt-dhcp runs in a separate container in the libvirt pod. This patch also
provides a client library to be consumed kubevirt components.