### PR TITLE
VM Grace Period and Shutdown Flow Rework

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3197,6 +3197,11 @@
      "nodeSelector": {
       "description": "If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.",
       "type": "object"
+     },
+     "terminationGracePeriodSeconds": {
+      "description": "Grace period observed after signalling a VM to stop after which the VM is force terminated.",
+      "type": "integer",
+      "format": "int64"
      }
     }
    },

--- a/cluster/vm-atomic.yaml
+++ b/cluster/vm-atomic.yaml
@@ -3,6 +3,7 @@ metadata:
 apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachine
 spec:
+  terminationGracePeriodSeconds: 0
   domain:
     devices:
       disks:

--- a/cluster/vm-ephemeral.yaml
+++ b/cluster/vm-ephemeral.yaml
@@ -3,6 +3,7 @@ metadata:
 apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachine
 spec:
+  terminationGracePeriodSeconds: 0
   domain:
     devices:
       graphics:

--- a/cluster/vm-iscsi-auth.yaml
+++ b/cluster/vm-iscsi-auth.yaml
@@ -3,6 +3,7 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
+  terminationGracePeriodSeconds: 0
   domain:
     devices:
       graphics:

--- a/cluster/vm-nocloud.yaml
+++ b/cluster/vm-nocloud.yaml
@@ -3,8 +3,13 @@ metadata:
 apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachine
 spec:
+  terminationGracePeriodSeconds: 5
   domain:
     devices:
+      graphics:
+      - type: spice
+      consoles:
+      - type: pty
       disks:
       - type: RegistryDisk:v1alpha
         source:

--- a/cluster/vm.yaml
+++ b/cluster/vm.yaml
@@ -3,6 +3,7 @@ kind: VirtualMachine
 metadata:
   name: testvm
 spec:
+  terminationGracePeriodSeconds: 0
   domain:
     devices:
       graphics:

--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -30,7 +30,7 @@ import (
 func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,
-		syscall.SIGQUIT,
+		syscall.SIGTERM,
 	)
 
 	fmt.Printf("Started fake qemu process\n")
@@ -39,7 +39,7 @@ func main() {
 	select {
 	case <-timeout:
 	case <-c:
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 
 	fmt.Printf("Exit fake qemu process\n")

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -163,6 +163,8 @@ func (app *virtHandlerApp) Run() {
 		cache.Indexers{},
 	)
 
+	virtlauncher.InitializeSharedDirectories(app.VirtShareDir)
+
 	watchdogInformer := cache.NewSharedIndexInformer(
 		watchdog.NewWatchdogListWatchFromClient(
 			app.VirtShareDir,

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -114,7 +114,14 @@ func main() {
 		}
 	}()
 
-	mon := virtlauncher.NewProcessMonitor("qemu")
+	gracefulShutdownTriggerFile := virtlauncher.GracefulShutdownTriggerFromNamespaceName(*virtShareDir, *namespace, *name)
+	err = virtlauncher.GracefulShutdownTriggerClear(gracefulShutdownTriggerFile)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Error detected clearning graceful shutdown trigger file %s.", gracefulShutdownTriggerFile)
+		panic(err)
+	}
+
+	mon := virtlauncher.NewProcessMonitor("qemu", gracefulShutdownTriggerFile)
 
 	markReady(*readinessFile)
 	mon.RunForever(*qemuTimeout)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -77,6 +77,7 @@ func main() {
 	namespace := flag.String("namespace", "", "Namespace of the VM")
 	watchdogInterval := flag.Duration("watchdog-update-interval", defaultWatchdogInterval, "Interval at which watchdog file should be updated")
 	readinessFile := flag.String("readiness-file", "/tmp/health", "Pod looks for tihs file to determine when virt-launcher is initialized")
+	gracePeriodSeconds := flag.Int("grace-period-seconds", 30, "Grace period to observe before sending SIGTERM to vm process.")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
@@ -121,7 +122,7 @@ func main() {
 		panic(err)
 	}
 
-	mon := virtlauncher.NewProcessMonitor("qemu", gracefulShutdownTriggerFile)
+	mon := virtlauncher.NewProcessMonitor("qemu", gracefulShutdownTriggerFile, *gracePeriodSeconds)
 
 	markReady(*readinessFile)
 	mon.RunForever(*qemuTimeout)

--- a/docs/graceful-shutdown.md
+++ b/docs/graceful-shutdown.md
@@ -1,0 +1,112 @@
+# Virtual Machine Graceful Shutdown
+
+## Overview
+
+Virtual machine graceful shutdown is the process of signaling a virtual
+machine to begin shutting down before forcing the virtual machine off. This
+process gives the virtual machine a chance to react to a shutdown request
+before the KubeVirt runtime does the equivalent of pulling the power plug on
+the virtual machine.
+
+The period between when a virtual machine is signaled to shutdown, and the
+point in time that KubeVirt will force the virtual machine off if it is still
+active is called a **Grace Period**. The grace period is a configurable value
+represented in the Virtual Machine's specification by the
+**terminationGracePeriodSeconds** option.
+
+## Usage Examples
+
+### Default: No terminationGracePeriodSeconds specified
+
+By default, if the grace period option is not set a small default grace period
+will be observed before killing the virtual machine. At the moment this default
+is 30 seconds, which is consistent with value used for containers by
+Kubernetes.
+
+### Immediate Force Shutdown: terminationGracePeriodSeconds = 0
+
+A 0 value for the grace period option means that the virtual machine should not
+have a grace period observed during shutdown. If a user specifies 0 for this
+value, the virtual machine will be immediately force killed on shutdown.
+
+### Grace Period Values > 0
+
+Any value > 0 specified for terminationGracePeriodSeconds represents the number
+of seconds the KubeVirt runtime will wait between signaling a virtual machine
+to shutdown and killing the virtual machine if it is still active.
+
+## Design and Implementation
+
+At the moment, the only way to shutdown a virtual machine is to remove the
+cluster object from kubernetes. Once the virtual machine object has been
+removed, we no longer have access to the terminationGracePeriodSeconds value
+stored on the Virtual Machine's spec. 
+
+In order to guarantee the value stored in the virtual machine's
+terinationGracePeriodSeconds is observed after the cluster object is deleted,
+that value is cached locally by virt-handler during the start flow. When a
+deleted virtual machine cluster object is detected, the cached grace period
+value is observed as virt-handler is shutting the virtual machine down.
+
+### Virt-Controller Involvement
+
+The only change to virt-controller is that it now configurs a custom
+grace period for virt-launcher pods that matches the grace period set on
+the corresponding virtual machine object. The virt-launcher grace period
+is slightly padded in order to ensure under normal operation that
+virt-handler will have a chance to force a virtual machine off before the
+virt-launcher pod terminates.  If the virt-launcher pod terminates first,
+the virtual machine will be forced off as a result of the kubernetes
+runtime killing all processes in the virt-launcher cgroup.
+
+### Virt-Handler Involvement
+
+Virt-handler is now responsible for both signaling the virtual machine to
+shutdown and ensuring the virtual machine is forced off after the grace
+period is observed.
+
+Signaling the beginning of the grace period can come from two sources.
+
+1. The virt-handler virtual machine object informer can notify virt-handler
+the cluster object has been removed for currently active virtual machine.
+
+2. A virtual machine's corresponding virt-launcher pod can signal shutdown
+by writing to a graceful shutdown trigger file in a shared directory between
+virt-launcher and virt-handler.
+
+Once the grace period begins for a virtual machine, virt-handler maintains
+the state associated with the grace period in a local cache file. This
+allows the grace period to be observed even if the virt-handler process
+recovers during this period.
+
+### Virt-Launcher Involvement
+
+Virt-launcher intercepts signals (such as SIGTERM) sent to it by the kubernetes
+runtime and notifies virt-handler to begin the gracefull shutdown process by
+writting to the graceful shutdown trigger file. 
+
+After writting to the graceful shutdown trigger file, virt-launcher continues to
+watch the pid until either the pid exits (as a result of virt-handler shutting
+it down) or the kubernetes runtime kills the virt-launcher process with SIGKILL.
+
+A force kill of virt-launcher will result in the corresponding virtual machine
+exiting.
+
+### Shutdown Notification Race (Virt-Launcher VS. VM Object Informer)
+
+When a Virtual Machine object is removed from the cluster, that sets off a race
+between two sources used to notify virt-handler it should shutdown the virtual
+machine.
+
+1. The virtual machine cluster informer.
+
+2. virt-launcher graceful shutdown trigger.
+
+It doesn't matter which one of these comes first. Once it begins, graceful
+shutdown process idempotent.
+
+It is worth noting that this race condition one of the reasons why
+virt-launcher needs to signal virt-handler to perform graceful shutdown instead
+of virt-launcher acting directly on the process. By centralizing the shutdown
+flow to virt-handler, we can guarantee a single grace period is observed
+accurately.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -49,6 +49,8 @@ import (
 // GroupName is the group name use in this package
 const GroupName = "kubevirt.io"
 
+const DefaultGracePeriodSeconds = 60
+
 // GroupVersion is group version used to register these objects
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
@@ -180,6 +182,8 @@ type VMSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// If affinity is specifies, obey all the affinity rules
 	Affinity *Affinity `json:"affinity,omitempty"`
+	// Grace period observed after signalling a VM to stop after which the VM is force terminated.
+	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 }
 
 // Affinity groups all the affinity rules related to a VM

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -357,12 +357,13 @@ func (s MigrationEvent) String() string {
 type SyncEvent string
 
 const (
-	Created    SyncEvent = "Created"
-	Deleted    SyncEvent = "Deleted"
-	Started    SyncEvent = "Started"
-	Stopped    SyncEvent = "Stopped"
-	SyncFailed SyncEvent = "SyncFailed"
-	Resumed    SyncEvent = "Resumed"
+	Created      SyncEvent = "Created"
+	Deleted      SyncEvent = "Deleted"
+	Started      SyncEvent = "Started"
+	ShuttingDown SyncEvent = "ShuttingDown"
+	Stopped      SyncEvent = "Stopped"
+	SyncFailed   SyncEvent = "SyncFailed"
+	Resumed      SyncEvent = "Resumed"
 )
 
 func (s SyncEvent) String() string {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -49,7 +49,7 @@ import (
 // GroupName is the group name use in this package
 const GroupName = "kubevirt.io"
 
-const DefaultGracePeriodSeconds = 60
+const DefaultGracePeriodSeconds int64 = 30
 
 // GroupVersion is group version used to register these objects
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -18,10 +18,11 @@ func (VirtualMachineList) SwaggerDoc() map[string]string {
 
 func (VMSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":             "VMSpec is a description of a VM. Not to be confused with api.DomainSpec in virt-handler.\nIt is expected that v1.DomainSpec will be merged into this structure.",
-		"domain":       "Domain is the actual libvirt domain.",
-		"nodeSelector": "If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.",
-		"affinity":     "If affinity is specifies, obey all the affinity rules",
+		"":                              "VMSpec is a description of a VM. Not to be confused with api.DomainSpec in virt-handler.\nIt is expected that v1.DomainSpec will be merged into this structure.",
+		"domain":                        "Domain is the actual libvirt domain.",
+		"nodeSelector":                  "If labels are specified, only nodes marked with all of these labels are considered when scheduling the VM.",
+		"affinity":                      "If affinity is specifies, obey all the affinity rules",
+		"terminationGracePeriodSeconds": "Grace period observed after signalling a VM to stop after which the VM is force terminated.",
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -56,9 +56,16 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	successThreshold := 1
 	failureThreshold := 5
 
-	// TODO we will want to make this configurable on the
-	// vm spec at some point.
-	gracePeriodSeconds := int64(60)
+	gracePeriodSeconds := v1.DefaultGracePeriodSeconds
+	if vm.Spec.TerminationGracePeriodSeconds != nil {
+		gracePeriodSeconds = *vm.Spec.TerminationGracePeriodSeconds
+	}
+
+	// Pad the virt-launcher grace period.
+	// Ideally we want virt-handler to handle tearing down
+	// the vm without virt-launcher's termination forcing
+	// the vm down.
+	gracePeriodSeconds = gracePeriodSeconds + int64(15)
 
 	// VM target container
 	container := kubev1.Container{

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -56,6 +56,10 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	successThreshold := 1
 	failureThreshold := 5
 
+	// TODO we will want to make this configurable on the
+	// vm spec at some point.
+	gracePeriodSeconds := int64(60)
+
 	// VM target container
 	container := kubev1.Container{
 		Name:            "compute",
@@ -117,11 +121,12 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 			},
 		},
 		Spec: kubev1.PodSpec{
-			HostPID:       true,
-			RestartPolicy: kubev1.RestartPolicyNever,
-			Containers:    containers,
-			NodeSelector:  vm.Spec.NodeSelector,
-			Volumes:       volumes,
+			HostPID: true,
+			TerminationGracePeriodSeconds: &gracePeriodSeconds,
+			RestartPolicy:                 kubev1.RestartPolicyNever,
+			Containers:                    containers,
+			NodeSelector:                  vm.Spec.NodeSelector,
+			Volumes:                       volumes,
 		},
 	}
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -21,6 +21,7 @@ package services
 
 import (
 	"fmt"
+	"strconv"
 
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +67,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	// the vm without virt-launcher's termination forcing
 	// the vm down.
 	gracePeriodSeconds = gracePeriodSeconds + int64(15)
+	gracePeriodKillAfter := gracePeriodSeconds + int64(15)
 
 	// VM target container
 	container := kubev1.Container{
@@ -78,6 +80,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 			"--namespace", namespace,
 			"--kubevirt-share-dir", t.virtShareDir,
 			"--readiness-file", "/tmp/healthy",
+			"--grace-period-seconds", strconv.Itoa(int(gracePeriodSeconds)),
 		},
 		VolumeMounts: []kubev1.VolumeMount{
 			{
@@ -129,7 +132,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		},
 		Spec: kubev1.PodSpec{
 			HostPID: true,
-			TerminationGracePeriodSeconds: &gracePeriodSeconds,
+			TerminationGracePeriodSeconds: &gracePeriodKillAfter,
 			RestartPolicy:                 kubev1.RestartPolicyNever,
 			Containers:                    containers,
 			NodeSelector:                  vm.Spec.NodeSelector,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -58,7 +58,9 @@ var _ = Describe("Template", func() {
 					"--name", "testvm",
 					"--namespace", "testns",
 					"--kubevirt-share-dir", "/var/run/kubevirt",
-					"--readiness-file", "/tmp/healthy"}))
+					"--readiness-file", "/tmp/healthy",
+					"--grace-period-seconds", "45"}))
+				Expect(*pod.Spec.TerminationGracePeriodSeconds).To(Equal(int64(60)))
 			})
 		})
 		Context("with node selectors", func() {
@@ -87,9 +89,11 @@ var _ = Describe("Template", func() {
 					"--name", "testvm",
 					"--namespace", "default",
 					"--kubevirt-share-dir", "/var/run/kubevirt",
-					"--readiness-file", "/tmp/healthy"}))
+					"--readiness-file", "/tmp/healthy",
+					"--grace-period-seconds", "45"}))
 				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/var/run/kubevirt"))
 				Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).To(Equal("/var/run/kubevirt"))
+				Expect(*pod.Spec.TerminationGracePeriodSeconds).To(Equal(int64(60)))
 			})
 
 			It("should add node affinity to pod", func() {

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -22,6 +22,7 @@ package api
 import (
 	"encoding/xml"
 	"reflect"
+	"time"
 
 	"github.com/jeevatkm/go-model"
 	kubev1 "k8s.io/api/core/v1"
@@ -231,8 +232,8 @@ type Metadata struct {
 }
 
 type GracePeriodMetadata struct {
-	Seconds       int64 `xml:"period"`
-	StartTimeUnix int64 `xml:"start"`
+	DeletionGracePeriodSeconds int64      `xml:"deletionGracePeriodSeconds"`
+	DeletionTimestamp          *time.Time `xml:"deletionTimestamp,omitempty"`
 }
 
 type Commandline struct {

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -215,6 +215,16 @@ type DomainSpec struct {
 	Clock    *Clock       `xml:"clock,omitempty"`
 	Resource *Resource    `xml:"resource,omitempty"`
 	QEMUCmd  *Commandline `xml:"qemu:commandline,omitempty"`
+	Metadata Metadata     `xml:"metadata,omitempty"`
+}
+
+type Metadata struct {
+	GracePeriod GracePeriodMetadata `xml:"http://kubevirt.io graceperiod,omitempty"`
+}
+
+type GracePeriodMetadata struct {
+	Seconds       int64 `xml:"period"`
+	StartTimeUnix int64 `xml:"start"`
 }
 
 type Commandline struct {

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -163,6 +163,14 @@ func (in *Domain) DeepCopyObject() runtime.Object {
 	}
 }
 
+func (in *Metadata) DeepCopyInto(out *Metadata) {
+	err := model.Copy(out, in)
+	if err != nil {
+		panic(err)
+	}
+	return
+}
+
 type DomainStatus struct {
 	Status LifeCycle
 	Reason StateChangeReason

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -60,6 +60,12 @@ var exampleXML = `<domain type="qemu">
     </console>
     <watchdog model="i6300esb" action="poweroff"></watchdog>
   </devices>
+  <metadata>
+    <graceperiod xmlns="http://kubevirt.io">
+      <period>0</period>
+      <start>0</start>
+    </graceperiod>
+  </metadata>
 </domain>`
 
 var _ = Describe("Schema", func() {

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -62,8 +62,7 @@ var exampleXML = `<domain type="qemu">
   </devices>
   <metadata>
     <graceperiod xmlns="http://kubevirt.io">
-      <period>0</period>
-      <start>0</start>
+      <deletionGracePeriodSeconds>0</deletionGracePeriodSeconds>
     </graceperiod>
   </metadata>
 </domain>`

--- a/pkg/virt-handler/virtwrap/cache/cache_test.go
+++ b/pkg/virt-handler/virtwrap/cache/cache_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Cache", func() {
 				x, err := xml.Marshal(api.NewMinimalDomainSpec("test"))
 				Expect(err).To(BeNil())
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(x), nil)
+				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_INACTIVE)).Return(string(x), nil)
 				mockConn.EXPECT().ListAllDomains(gomock.Eq(libvirt.CONNECT_LIST_DOMAINS_ACTIVE|libvirt.CONNECT_LIST_DOMAINS_INACTIVE)).Return([]cli.VirDomain{mockDomain}, nil)
 
 				informer, err := NewSharedInformer(mockConn)
@@ -92,6 +93,7 @@ var _ = Describe("Cache", func() {
 				x, err := xml.Marshal(api.NewMinimalDomainSpec("test"))
 				Expect(err).To(BeNil())
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(x), nil)
+				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_INACTIVE)).Return(string(x), nil)
 
 				watcher := &DomainWatcher{make(chan watch.Event, 1)}
 				callback(mockDomain, &libvirt.DomainEventLifecycle{Event: event}, watcher.C)

--- a/pkg/virt-handler/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-handler/virtwrap/cli/generated_mock_libvirt.go
@@ -359,6 +359,16 @@ func (_mr *_MockVirDomainRecorder) Destroy() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Destroy")
 }
 
+func (_m *MockVirDomain) Shutdown() error {
+	ret := _m.ctrl.Call(_m, "Shutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) Shutdown() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
+}
+
 func (_m *MockVirDomain) GetName() (string, error) {
 	ret := _m.ctrl.Call(_m, "GetName")
 	ret0, _ := ret[0].(string)

--- a/pkg/virt-handler/virtwrap/cli/libvirt.go
+++ b/pkg/virt-handler/virtwrap/cli/libvirt.go
@@ -313,6 +313,7 @@ type VirDomain interface {
 	Create() error
 	Resume() error
 	Destroy() error
+	Shutdown() error
 	GetName() (string, error)
 	GetUUIDString() (string, error)
 	GetXMLDesc(flags libvirt.DomainXMLFlags) (string, error)

--- a/pkg/virt-handler/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-handler/virtwrap/generated_mock_manager.go
@@ -71,3 +71,13 @@ func (_m *MockDomainManager) KillVM(_param0 *v1.VirtualMachine) error {
 func (_mr *_MockDomainManagerRecorder) KillVM(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "KillVM", arg0)
 }
+
+func (_m *MockDomainManager) SignalShutdownVM(_param0 *v1.VirtualMachine) error {
+	ret := _m.ctrl.Call(_m, "SignalShutdownVM", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) SignalShutdownVM(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignalShutdownVM", arg0)
+}

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -310,19 +310,7 @@ func (l *LibvirtDomainManager) RemoveVMSecrets(vm *v1.VirtualMachine) error {
 }
 
 func (l *LibvirtDomainManager) getDomainSpec(dom cli.VirDomain) (*api.DomainSpec, error) {
-
-	xmlStr, err := dom.GetXMLDesc(0)
-	if err != nil {
-		return nil, err
-	}
-
-	var spec api.DomainSpec
-	err = xml.Unmarshal([]byte(xmlStr), &spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return &spec, nil
+	return cache.GetDomainSpec(dom)
 }
 
 func (l *LibvirtDomainManager) SignalShutdownVM(vm *v1.VirtualMachine) error {

--- a/pkg/virt-handler/virtwrap/manager.go
+++ b/pkg/virt-handler/virtwrap/manager.go
@@ -330,7 +330,7 @@ func (l *LibvirtDomainManager) SignalShutdownVM(vm *v1.VirtualMachine) error {
 			log.Log.Object(vm).Reason(err).Error("Signalling graceful shutdown failed.")
 			return err
 		}
-		log.Log.Object(vm).Info("Signaled graceful shutdown")
+		log.Log.Object(vm).Infof("Signaled graceful shutdown for %s", vm.GetObjectMeta().GetName())
 		l.recorder.Event(vm, kubev1.EventTypeNormal, v1.ShuttingDown.String(), "Signaled Graceful Shutdown")
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -748,7 +748,7 @@ func (d *VirtualMachineController) processVmDeletion(vm *v1.VirtualMachine) erro
 		return nil
 	}
 
-	log.Log.Object(vm).Info("grace period expired, killing deleted VM.")
+	log.Log.Object(vm).Infof("grace period expired, killing deleted VM %s", vm.GetObjectMeta().GetName())
 
 	// Since the VM was not in the cache, we delete it
 	err = d.domainManager.KillVM(vm)
@@ -807,7 +807,7 @@ func (d *VirtualMachineController) processGracefulShutdown(vm *v1.VirtualMachine
 	}
 
 	if expired {
-		log.Log.Object(vm).Info("grace period expired, killing VM.")
+		log.Log.Object(vm).Infof("grace period expired, killing VM %s", vm.GetObjectMeta().GetName())
 		return d.processVmDeletion(vm)
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -233,7 +233,7 @@ func (d *VirtualMachineController) hasGracePeriodExpired(vm *v1.VirtualMachine) 
 	now := time.Now().UTC().Unix()
 	diff := now - info.GracePeriodStartTimeUnix
 
-	if diff > info.GracePeriodSeconds {
+	if diff >= info.GracePeriodSeconds {
 		return true, 0, nil
 	}
 
@@ -950,9 +950,9 @@ func (d *VirtualMachineController) setVmPhaseForStatusReason(domain *api.Domain,
 func (d *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.Domain, vm *v1.VirtualMachine) v1.VMPhase {
 
 	if domain == nil {
-		if !vm.IsRunning() {
+		if !vm.IsRunning() && !vm.IsFinal() {
 			return v1.Scheduled
-		} else {
+		} else if !vm.IsFinal() {
 			// That is unexpected. We should not be able to delete a VM before we stop it.
 			// However, if someone directly interacts with libvirt it is possible
 			return v1.Failed

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -129,8 +129,11 @@ func (d *VirtualMachineController) hasGracePeriodExpired(dom *api.Domain) (bool,
 		return true, 0, nil
 	}
 
-	startTime := dom.Spec.Metadata.GracePeriod.StartTimeUnix
-	gracePeriod := dom.Spec.Metadata.GracePeriod.Seconds
+	startTime := int64(0)
+	if dom.Spec.Metadata.GracePeriod.DeletionTimestamp != nil {
+		startTime = dom.Spec.Metadata.GracePeriod.DeletionTimestamp.UTC().Unix()
+	}
+	gracePeriod := dom.Spec.Metadata.GracePeriod.DeletionGracePeriodSeconds
 
 	if gracePeriod == 0 {
 		return true, 0, nil

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -438,10 +438,10 @@ func (d *VirtualMachineController) execute(key string) error {
 		syncErr = d.processVmShutdown(vm, domain)
 	} else if shouldCleanUp {
 		log.Log.Object(vm).V(3).Info("Processing local ephemeral data cleanup for shutdown domain.")
-		syncErr = d.processVmCleanup(vm, domain)
+		syncErr = d.processVmCleanup(vm)
 	} else if shouldUpdate {
 		log.Log.Object(vm).V(3).Info("Processing vm update")
-		syncErr = d.processVmUpdate(vm, domain)
+		syncErr = d.processVmUpdate(vm)
 	} else {
 		log.Log.Object(vm).V(3).Info("No update processing required")
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -138,7 +138,7 @@ var _ = Describe("VM", func() {
 
 	initGracePeriodHelper := func(gracePeriod int64, vm *v1.VirtualMachine, dom *api.Domain) {
 		vm.Spec.TerminationGracePeriodSeconds = &gracePeriod
-		dom.Spec.Metadata.GracePeriod.Seconds = gracePeriod
+		dom.Spec.Metadata.GracePeriod.DeletionGracePeriodSeconds = gracePeriod
 	}
 
 	Context("VM controller gets informed about a Domain change through the Domain controller", func() {
@@ -212,7 +212,8 @@ var _ = Describe("VM", func() {
 			domain.Status.Status = api.Running
 
 			initGracePeriodHelper(1, vm, domain)
-			domain.Spec.Metadata.GracePeriod.StartTimeUnix = time.Now().UTC().Unix() - 3
+			now := time.Unix(time.Now().UTC().Unix()-3, 0)
+			domain.Spec.Metadata.GracePeriod.DeletionTimestamp = &now
 
 			mockWatchdog.CreateFile(vm)
 			mockGracefulShutdown.TriggerShutdown(vm)

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -30,32 +30,97 @@ import (
 	"syscall"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/api/v1"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/virt-handler/virtwrap/isolation"
 	watchdog "kubevirt.io/kubevirt/pkg/watchdog"
 )
 
 type monitor struct {
-	timeout         time.Duration
-	pid             int
-	commandPrefix   string
-	start           time.Time
-	isDone          bool
-	forwardedSignal os.Signal
+	timeout                     time.Duration
+	pid                         int
+	commandPrefix               string
+	start                       time.Time
+	isDone                      bool
+	gracefulShutdownTriggerFile string
 }
 
 type ProcessMonitor interface {
 	RunForever(startTimeout time.Duration)
 }
 
-func InitializeSharedDirectories(baseDir string) error {
-	return os.MkdirAll(watchdog.WatchdogFileDirectory(baseDir), 0755)
+func GracefulShutdownTriggerDir(baseDir string) string {
+	return filepath.Join(baseDir, "graceful-shutdown-trigger")
 }
 
-func NewProcessMonitor(commandPrefix string) ProcessMonitor {
+func GracefulShutdownTriggerFromNamespaceName(baseDir string, namespace string, name string) string {
+	triggerFile := namespace + "_" + name
+	return filepath.Join(baseDir, "graceful-shutdown-trigger", triggerFile)
+}
+
+func VmGracefulShutdownTriggerClear(baseDir string, vm *v1.VirtualMachine) error {
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	triggerFile := GracefulShutdownTriggerFromNamespaceName(baseDir, namespace, domain)
+
+	return diskutils.RemoveFile(triggerFile)
+}
+
+func GracefulShutdownTriggerClear(triggerFile string) error {
+	return diskutils.RemoveFile(triggerFile)
+}
+
+func VmHasGracefulShutdownTrigger(baseDir string, vm *v1.VirtualMachine) (bool, error) {
+	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
+	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
+
+	return hasGracefulShutdownTrigger(baseDir, namespace, domain)
+}
+
+func hasGracefulShutdownTrigger(baseDir string, namespace string, name string) (bool, error) {
+	triggerFile := GracefulShutdownTriggerFromNamespaceName(baseDir, namespace, name)
+
+	return diskutils.FileExists(triggerFile)
+}
+
+func GracefulShutdownTriggerInitiate(triggerFile string) error {
+	exists, err := diskutils.FileExists(triggerFile)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	f, err := os.Create(triggerFile)
+	if err != nil {
+		return err
+	}
+	f.Close()
+
+	return nil
+}
+
+func InitializeSharedDirectories(baseDir string) error {
+	err := os.MkdirAll(watchdog.WatchdogFileDirectory(baseDir), 0755)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(GracefulShutdownTriggerDir(baseDir), 0755)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewProcessMonitor(commandPrefix string, gracefulShutdownTriggerFile string) ProcessMonitor {
 	return &monitor{
-		commandPrefix: commandPrefix,
+		commandPrefix:               commandPrefix,
+		gracefulShutdownTriggerFile: gracefulShutdownTriggerFile,
 	}
 }
 
@@ -155,8 +220,10 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, signalChan chan os.S
 		case s := <-signalChan:
 			log.Log.Infof("Received signal %d.", s)
 			if mon.pid != 0 {
-				mon.forwardedSignal = s.(syscall.Signal)
-				syscall.Kill(mon.pid, s.(syscall.Signal))
+				err := GracefulShutdownTriggerInitiate(mon.gracefulShutdownTriggerFile)
+				if err != nil {
+					log.Log.Reason(err).Errorf("Error detected attempting to initalize graceful shutdown using trigger file %s.", mon.gracefulShutdownTriggerFile)
+				}
 			}
 		}
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -56,6 +56,8 @@ const (
 	WarningEvent EventType = "Warning"
 )
 
+const defaultTestGracePeriod int64 = 1
+
 const (
 	// tests.NamespaceTestDefault is the default namespace, to test non-infrastructure related KubeVirt objects.
 	NamespaceTestDefault string = "kubevirt-test-default"
@@ -502,7 +504,11 @@ func NewRandomVM() *v1.VirtualMachine {
 }
 
 func NewRandomVMWithNS(namespace string) *v1.VirtualMachine {
-	return v1.NewMinimalVMWithNS(namespace, "testvm"+rand.String(5))
+	vm := v1.NewMinimalVMWithNS(namespace, "testvm"+rand.String(5))
+
+	t := defaultTestGracePeriod
+	vm.Spec.TerminationGracePeriodSeconds = &t
+	return vm
 }
 
 func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -56,7 +56,7 @@ const (
 	WarningEvent EventType = "Warning"
 )
 
-const defaultTestGracePeriod int64 = 1
+const defaultTestGracePeriod int64 = 0
 
 const (
 	// tests.NamespaceTestDefault is the default namespace, to test non-infrastructure related KubeVirt objects.


### PR DESCRIPTION
I think we can perform VM graceful shutdown without the aggregated API server. We can do this by leveraging the virt-launcher pod's grace period during termination.

Here's the flow.
- create VM object with custom graceful shutdown duration
- virt-controller creates virt-launcher POD and use graceful shutdown duration is the grace period timeout.
... VM is running ....
- delete VM object
- virt-controller signals virt-launcher to terminate
- virt-launcher gets a termination signal which causes it to tell virt-handler to begin the graceful shutdown process.
- virt-handler begins gracefully tearing down the deleted VM.
- Virt-launcher either exits because the VM process exits, or terminates because the POD's grace period expired. If the former occurs, the VM was successfully gracefully terminated before the grace period expires. If the grace period expires, then the VM is force terminated as a result of the POD terminating. 

**Development**
- [x] centralize shutdown flow to virt-handler (virt-launcher now signals virt-handler to perform shutdown instead of acting on the VM process directly)
- [x] Have virt-handler attempt to gracefully shutdown deleted VMs rather than immediately force deleting them.
- [x] Make the graceful shutdown duration period configurable on the VM spec.
- [x] Unit/Functional Tests
- [x] Design doc docs/graceful-shutdown.md
- [x] Merge status update changes in #530