### PR TITLE
Write container logs to files instead of journalctl

### DIFF
--- a/cluster/vagrant/setup_kubernetes_common.sh
+++ b/cluster/vagrant/setup_kubernetes_common.sh
@@ -64,6 +64,9 @@ gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
 EOF
 yum install -y docker
 
+# Log to json files instead of journald
+sed -i 's/--log-driver=journald //g' /etc/sysconfig/docker
+
 # Use hard coded versions until https://github.com/kubernetes/kubeadm/issues/212 is resolved.
 # Currently older versions of kubeadm are no longer available in the rpm repos.
 # See https://github.com/kubernetes/kubeadm/issues/220 for context.


### PR DESCRIPTION
We can write logs to separate files under `/var/log/containers` instead of `journal`, and save it after under artifacts of the Jenkins job. It also will make possible to use `fluentd` from charts https://github.com/kubernetes/charts/tree/master/stable/fluent-bit
Signed-off-by: Lukianov Artyom <alukiano@redhat.com>