### PR TITLE
Better virt-control processing of deleted pods (fixes registry-disk func test)

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -90,15 +90,11 @@ func (c *VMController) Execute() bool {
 		return false
 	}
 	defer c.queue.Done(key)
-	isPending, err := c.execute(key.(string))
+	err := c.execute(key.(string))
 
 	if err != nil {
 		log.Log.Reason(err).Infof("reenqueuing VM %v", key)
 		c.queue.AddRateLimited(key)
-	} else if isPending {
-		log.Log.V(4).Infof("reenqueuing pending VM %v", key)
-		c.queue.AddAfter(key, 1*time.Second)
-		c.queue.Forget(key)
 	} else {
 		log.Log.V(4).Infof("processed VM %v", key)
 		c.queue.Forget(key)
@@ -106,13 +102,13 @@ func (c *VMController) Execute() bool {
 	return true
 }
 
-func (c *VMController) execute(key string) (bool, error) {
+func (c *VMController) execute(key string) error {
 
 	// Fetch the latest Vm state from cache
 	obj, exists, err := c.store.GetByKey(key)
 
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	// Retrieve the VM
@@ -120,7 +116,7 @@ func (c *VMController) execute(key string) (bool, error) {
 	if !exists {
 		namespace, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
-			return false, err
+			return err
 		}
 		vm = kubev1.NewVMReferenceFromNameWithNS(namespace, name)
 	} else {
@@ -133,10 +129,10 @@ func (c *VMController) execute(key string) (bool, error) {
 		err := c.vmService.DeleteVMPod(vm)
 		if err != nil {
 			logger.Reason(err).Error("Deleting VM target Pod failed.")
-			return false, err
+			return err
 		}
 		logger.Info("Deleting VM target Pod succeeded.")
-		return false, nil
+		return nil
 	}
 
 	switch vm.Status.Phase {
@@ -152,7 +148,7 @@ func (c *VMController) execute(key string) (bool, error) {
 		pods, err := c.vmService.GetRunningVMPods(&vmCopy)
 		if err != nil {
 			logger.Reason(err).Error("Fetching VM pods failed.")
-			return false, err
+			return err
 		}
 
 		// If there are already pods, delete them before continuing ...
@@ -160,9 +156,12 @@ func (c *VMController) execute(key string) (bool, error) {
 			logger.Error("VM Pods do already exist, will clean up before continuing.")
 			if err := c.vmService.DeleteVMPod(&vmCopy); err != nil {
 				logger.Reason(err).Error("Deleting VM pods failed.")
-				return false, err
+				return err
 			}
-			return true, nil
+
+			log.Log.V(4).Infof("reenqueuing VM key %s because still waiting on previous pod to terminate", key)
+			c.queue.AddAfter(key, 3*time.Second)
+			return nil
 		}
 
 		// Defaulting and setting constants
@@ -189,7 +188,7 @@ func (c *VMController) execute(key string) (bool, error) {
 		// Create a Pod which will be the VM destination
 		if err := c.vmService.StartVMPod(&vmCopy); err != nil {
 			logger.Reason(err).Error("Defining a target pod for the VM failed.")
-			return false, err
+			return err
 		}
 
 		// Mark the VM as "initialized". After the created Pod above is scheduled by
@@ -197,7 +196,7 @@ func (c *VMController) execute(key string) (bool, error) {
 		vmCopy.Status.Phase = kubev1.Scheduling
 		if err := c.restClient.Put().Resource("virtualmachines").Body(&vmCopy).Name(vmCopy.ObjectMeta.Name).Namespace(vmCopy.ObjectMeta.Namespace).Do().Error(); err != nil {
 			logger.Reason(err).Error("Updating the VM state to 'Scheduling' failed.")
-			return false, err
+			return err
 		}
 		logger.Info("Handing over the VM to the scheduler succeeded.")
 	case kubev1.Scheduling:
@@ -211,7 +210,7 @@ func (c *VMController) execute(key string) (bool, error) {
 		pods, err := c.vmService.GetRunningVMPods(&vmCopy)
 		if err != nil {
 			logger.Reason(err).Error("Fetching VM pods failed.")
-			return false, err
+			return err
 		}
 
 		//TODO, we can improve the pod checks here, for now they are as good as before the refactoring
@@ -219,23 +218,36 @@ func (c *VMController) execute(key string) (bool, error) {
 		// If not, something is wrong and the VM, stay stuck in the Scheduling phase
 		if len(pods.Items) == 0 {
 			logger.V(3).Info("No VM target pod in running state found.")
-			return false, nil
+			return nil
 		}
 
-		// Whatever is going on here, I don't know what to do, don't reprocess this
 		if len(pods.Items) > 1 {
 			logger.V(3).Error("More than one VM target pods found.")
-			return false, nil
+
+			wasDeleted := false
+			for _, pod := range pods.Items {
+				if pod.GetObjectMeta().GetDeletionTimestamp() != nil {
+					wasDeleted = true
+					break
+				}
+			}
+
+			if wasDeleted {
+				log.Log.V(4).Infof("reenqueuing VM key %s because still waiting on pod deletion cleanup", key)
+				c.queue.AddAfter(key, 3*time.Second)
+			}
+
+			return nil
 		}
 
 		// Pod is not yet running
 		if pods.Items[0].Status.Phase != k8sv1.PodRunning {
-			return false, nil
+			return nil
 		}
 
 		if verifyReadiness(&pods.Items[0]) == false {
 			logger.V(2).Info("Waiting on all virt-launcher containers to be marked ready")
-			return false, nil
+			return nil
 		}
 
 		// VM got scheduled
@@ -249,18 +261,18 @@ func (c *VMController) execute(key string) (bool, error) {
 		vmCopy.Status.NodeName = pods.Items[0].Spec.NodeName
 		if _, err := c.vmService.PutVm(&vmCopy); err != nil {
 			logger.Reason(err).Error("Updating the VM state to 'Scheduled' failed.")
-			return false, err
+			return err
 		}
 		logger.Infof("VM successfully scheduled to %s.", vmCopy.Status.NodeName)
 	case kubev1.Failed, kubev1.Succeeded:
 		err := c.vmService.DeleteVMPod(vm)
 		if err != nil {
 			logger.Reason(err).Error("Deleting VM target Pod failed.")
-			return false, err
+			return err
 		}
 		logger.Info("Deleted VM target Pod for VM in finalized state.")
 	}
-	return false, nil
+	return nil
 }
 
 func verifyReadiness(pod *k8sv1.Pod) bool {

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -79,7 +79,7 @@ var _ = Describe("RegistryDisk", func() {
 	Context("Ephemeral RegistryDisk", func() {
 		It("should be able to start and stop the same VM multiple times.", func(done Done) {
 			vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
-			num := 3
+			num := 2
 			for i := 0; i < num; i++ {
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
 				Expect(err).To(BeNil())
@@ -89,7 +89,7 @@ var _ = Describe("RegistryDisk", func() {
 				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)
 			}
 			close(done)
-		}, 200)
+		}, 140)
 
 		It("should launch multiple VMs using ephemeral registry disks", func(done Done) {
 			num := 5

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -83,13 +83,13 @@ var _ = Describe("RegistryDisk", func() {
 			for i := 0; i < num; i++ {
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
 				Expect(err).To(BeNil())
-				tests.WaitForSuccessfulVMStartWithTimeout(obj, 60)
+				tests.WaitForSuccessfulVMStartWithTimeout(obj, 120)
 				_, err = virtClient.RestClient().Delete().Resource("virtualmachines").Namespace(vm.GetObjectMeta().GetNamespace()).Name(vm.GetObjectMeta().GetName()).Do().Get()
 				Expect(err).To(BeNil())
 				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)
 			}
 			close(done)
-		}, 180)
+		}, 200)
 
 		It("should launch multiple VMs using ephemeral registry disks", func(done Done) {
 			num := 5


### PR DESCRIPTION
virt-controller needs to process deleted pods.  This lets us remove the "pending" reenqueue logic from virt-controller.

This also solves the transient failure I've been seeing with the registry disk functional tests. There's an inconsistency in k8s that causes a deleted pod to flap between succeeded and pending phases (99% sure this is a k8s bug). However, since we weren't processing changes to deleted pods, virt-controller would stop processing VMs that hit the 'if' statement with the "More than one VM target pods found." log message in it.