### PR TITLE
Remove docker socket mount from libvirt container

### DIFF
--- a/manifests/libvirt.yaml.in
+++ b/manifests/libvirt.yaml.in
@@ -37,8 +37,6 @@ spec:
             mountPath: /var/lib/libvirt
           - name: libvirt-runtime
             mountPath: /var/run/libvirt
-          - name: docker-sock
-            mountPath: /var/run/docker.sock
           - name: virt-share-dir
             mountPath: /var/run/kubevirt
         command: ["/libvirtd.sh"]
@@ -62,9 +60,6 @@ spec:
       - name: host-sys
         hostPath:
           path: /sys
-      - name: docker-sock
-        hostPath:
-          path: /var/run/docker.sock
       - name: virt-share-dir
         hostPath:
           path: /var/run/kubevirt


### PR DESCRIPTION
The Libvirt container doesn't need access to the docker socket anymore. We now have a technology independent way of getting the cgroups and namespaces associated with a virt-launcher pod.