### PR TITLE
Drop node selectors and use ingress [skip ci]

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -124,7 +124,14 @@ while [ "$(kubectl get pods -o'custom-columns=status:status.containerStatuses[*]
     sleep 10
 done
 
-kubectl get pods
+# Wait until all pods are running
+while [ -n "$(kubectl get pods --no-headers --all-namespaces | grep -v Running)" ]; do
+    echo "Waiting for pods in all namespaces to enter the Running state ..."
+    kubectl get pods --no-headers --all-namespaces | >&2 grep -v Running || true
+    sleep 5
+done
+
+kubectl get pods --all-namespaces
 kubectl version
 
 # Disable proxy configuration since it causes test issues

--- a/cluster/vagrant/ingress.yaml.in
+++ b/cluster/vagrant/ingress.yaml.in
@@ -1,0 +1,42 @@
+#
+# This is two staged:
+# 1. Tell nginx where which ports should be redirected to
+# 2. Open the relevant ports using a service
+
+# This configmap needs to know all ports which ngninx should redirect
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tcp-services
+  namespace: kube-system
+data:
+  3128: "default/spice-proxy:3128"
+  8182: "default/virt-controller-service:8182"
+  8183: "default/virt-api-service:8183"
+  8184: "default/haproxy-service:8184"
+  8186: "default/virt-manifest-service:8186"
+---
+# This service needs to open all ports which should be publicly accessible
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: kube-system
+spec:
+  externalIPs:
+  - {{ master_ip }}
+  ports:
+  - name: spice-proxy
+    port: 3128
+    targetPort: 3128
+    protocol: TCP
+  - name: haproxy
+    port: 8184
+    targetPort: 8184
+    protocol: TCP
+  - name: virt-manifest
+    port: 8186
+    targetPort: 8186
+    protocol: TCP
+  selector:
+    app: ingress-nginx

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -88,6 +88,7 @@ metadata:
   namespace: kube-system
 data:
   8184: "default/haproxy-service:8184"
+  3128: "default/spice-proxy:3128"
 EOY
 }
 

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -62,13 +62,7 @@ fi
     https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/tcp-services-configmap.yaml \
     https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/udp-services-configmap.yaml \
     https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/rbac.yaml \
-      | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
-      | kubectl apply -f -
-
-  # Pin the controller to the master
-  ( curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/with-rbac.yaml && \
-    echo -e "      nodeSelector:\n        kubernetes.io/hostname: master" \
-  ) \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/with-rbac.yaml \
       | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
       | kubectl apply -f -
 

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -75,7 +75,7 @@ fi
   pushd /vagrant
   source hack/config.sh
   popd
-  sed "s/{{ master_ip }}/${master_ip}/g" /vagrant/cluster/vagrant/ingress.yaml.in \
+  sed "s/{{ master_ip }}/${master_ip}/g" /vagrant/manifests/ingress.yaml.in \
       | kubectl apply -f -
 }
 

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -91,6 +91,7 @@ data:
   8182: "default/virt-controller-service:8182"
   8183: "default/virt-api-service:8183"
   8184: "default/haproxy-service:8184"
+  8186: "default/virt-manifest-service:8186"
 EOY
 }
 

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -52,30 +52,21 @@ fi
 
 # Create an ingress-nginx setup
 # See: https://github.com/kubernetes/ingress-nginx/tree/master/deploy
-false && {
-  curl_combine() { for $URL in $@; do curl -L $URL ; echo --- ; done }
-  
-  curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/default-backend.yaml \
-      | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
-      | kubectl apply -f -
-  
-  curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/configmap.yaml \
-      | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
-      | kubectl apply -f -
-  
-  curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/tcp-services-configmap.yaml \
-      | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
-      | kubectl apply -f -
-  
-  curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/udp-services-configmap.yaml \
+{
+  curl_yaml_combine() { for URL in $@; do curl -L $URL ; echo --- ; done }
+
+  # Do the basic deployment
+  curl_yaml_combine \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/default-backend.yaml \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/configmap.yaml \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/tcp-services-configmap.yaml \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/udp-services-configmap.yaml \
+    https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/rbac.yaml \
       | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
       | kubectl apply -f -
 
-  curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/rbac.yaml \
-      | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
-      | kubectl apply -f -
-
-  ( curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/with-rbac.yaml && \
+  # Pin the controller to the master
+  ( curl -L https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/with-rbac.yaml && \
     echo -e "      nodeSelector:\n        kubernetes.io/hostname: master" \
   ) \
       | sed "s#namespace: ingress-nginx#namespace: kube-system#" \

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -87,8 +87,9 @@ metadata:
   name: tcp-services
   namespace: kube-system
 data:
-  8184: "default/haproxy-service:8184"
   3128: "default/spice-proxy:3128"
+  8182: "default/virt-controller-service:8182"
+  8184: "default/haproxy-service:8184"
 EOY
 }
 

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -89,6 +89,7 @@ metadata:
 data:
   3128: "default/spice-proxy:3128"
   8182: "default/virt-controller-service:8182"
+  8183: "default/virt-api-service:8183"
   8184: "default/haproxy-service:8184"
 EOY
 }

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -81,46 +81,11 @@ false && {
       | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
       | kubectl apply -f -
 
-  curl https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/baremetal/service-nodeport.yaml \
-      | sed "s#namespace: ingress-nginx#namespace: kube-system#" \
-      | kubectl apply -f -
-
   pushd /vagrant
   source hack/config.sh
   popd
-  kubectl apply -f - <<EOY
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: tcp-services
-  namespace: kube-system
-data:
-  3128: "default/spice-proxy:3128"
-  8182: "default/virt-controller-service:8182"
-  8183: "default/virt-api-service:8183"
-  8184: "default/haproxy-service:8184"
-  8186: "default/virt-manifest-service:8186"
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ingress-nginx
-  namespace: kube-system
-spec:
-  externalIPs:
-  - ${master_ip}
-  ports:
-  - name: spice-proxy
-    port: 3128
-    targetPort: 3128
-    protocol: TCP
-  - name: haproxy
-    port: 8184
-    targetPort: 8184
-    protocol: TCP
-  selector:
-    app: ingress-nginx
-EOY
+  sed "s/{{ master_ip }}/${master_ip}/g" /vagrant/cluster/vagrant/ingress.yaml.in \
+      | kubectl apply -f -
 }
 
 # Allow scheduling pods on master

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -1,4 +1,11 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: haproxy-tcp-ingress
+data:
+  8184: "default/haproxy-service:8184"
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: haproxy-service
@@ -6,8 +13,6 @@ spec:
   ports:
     - port: 8184
       targetPort: haproxy
-  externalIPs :
-    - "{{ master_ip }}"
   selector:
     app: haproxy
 ---
@@ -44,5 +49,3 @@ spec:
           periodSeconds: 20
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/ingress.yaml.in
+++ b/manifests/ingress.yaml.in
@@ -4,6 +4,7 @@
 # 2. Open the relevant ports using a service
 
 # This configmap needs to know all ports which ngninx should redirect
+# In plain words: These are the nginx stream configurations
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,6 +18,7 @@ data:
   8186: "default/virt-manifest-service:8186"
 ---
 # This service needs to open all ports which should be publicly accessible
+# In plain words: This tells k8s to forward these ports to nginx
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/iscsi-auth-demo-target.yaml.in
+++ b/manifests/iscsi-auth-demo-target.yaml.in
@@ -50,5 +50,3 @@ spec:
         - name: host
           hostPath:
             path: /
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/iscsi-demo-target.yaml.in
+++ b/manifests/iscsi-demo-target.yaml.in
@@ -133,5 +133,3 @@ spec:
         - name: host
           hostPath:
             path: /
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/squid.yaml.in
+++ b/manifests/squid.yaml.in
@@ -6,8 +6,6 @@ spec:
   ports:
     - port: 3128
       targetPort: spice-proxy
-  externalIPs:
-    - "{{ master_ip }}"
   selector:
     app: spice-proxy
 ---
@@ -31,5 +29,3 @@ spec:
               protocol: "TCP"
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -38,5 +38,3 @@ spec:
             protocol: "TCP"
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -6,8 +6,6 @@ spec:
   ports:
     - port: 8183
       targetPort: virt-api
-  externalIPs :
-    - "{{ master_ip }}"
   selector:
     app: virt-api
 ---

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -6,8 +6,6 @@ spec:
   ports:
     - port: 8182
       targetPort: virt-controller
-  externalIPs:
-    - "{{ master_ip }}"
   selector:
     app: virt-controller
 ---
@@ -54,5 +52,3 @@ spec:
           timeoutSeconds: 10
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -64,5 +64,3 @@ spec:
       volumes:
       - name: libvirt-runtime
         emptyDir: {}
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -6,8 +6,6 @@ spec:
   ports:
     - port: 8186
       targetPort: virt-manifest
-  externalIPs:
-    - "{{ master_ip }}"
   selector:
     app: virt-manifest
 ---

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -85,7 +85,7 @@ var _ = Describe("RegistryDisk", func() {
 			for i := 0; i < num; i++ {
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
 				Expect(err).To(BeNil())
-				tests.WaitForSuccessfulVMStartWithTimeout(obj, 120)
+				tests.WaitForSuccessfulVMStartWithTimeout(obj, 180)
 				_, err = virtClient.RestClient().Delete().Resource("virtualmachines").Namespace(vm.GetObjectMeta().GetNamespace()).Name(vm.GetObjectMeta().GetName()).Do().Get()
 				Expect(err).To(BeNil())
 				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -105,7 +105,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 				rs, err := virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return int(rs.Status.ReadyReplicas)
-			}, 60*time.Second, 1*time.Second).Should(Equal(2))
+			}, 120*time.Second, 1*time.Second).Should(Equal(2))
 		})
 
 		It("should not scale when paused and scale when resume", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -720,7 +720,7 @@ func WaitForSuccessfulVMStartWithTimeout(vm runtime.Object, seconds int) (nodeNa
 }
 
 func WaitForSuccessfulVMStart(vm runtime.Object) string {
-	return WaitForSuccessfulVMStartWithTimeout(vm, 5)
+	return WaitForSuccessfulVMStartWithTimeout(vm, 30)
 }
 
 func GetReadyNodes() []k8sv1.Node {

--- a/tests/vm_migration_test.go
+++ b/tests/vm_migration_test.go
@@ -45,7 +45,7 @@ var _ = Describe("VmMigration", func() {
 
 	var sourceVM *v1.VirtualMachine
 
-	var TIMEOUT float64 = 10.0
+	var TIMEOUT float64 = 60.0
 	var POLLING_INTERVAL float64 = 0.1
 
 	BeforeEach(func() {


### PR DESCRIPTION
This patch set does two things:

1. Drop a lot of `nodeSelectors`
2. Drop `externalIPs` from services and move inbound access to ingress

Dropping the *nodeSelectors` is done in order to be independent of hostnames.
Dropping the `externalIPs` from services is done to make the services independent of the external setup (i.e. the external IP). Instead all external access is now driven by an ngninx ingress controller.

These changes are mainly driven by the requirement to use the manifests in other cluster setups, or in other words, to make the manifests more generic.