### PR TITLE
manifests: Remove nodeSelector attribute

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -34,7 +34,6 @@ rm -f "manifests/*.yaml"
 for arg in $args; do
     sed -e "s/{{ master_ip }}/$master_ip/g" \
         -e "s/{{ primary_nic }}/$primary_nic/g" \
-        -e "s/{{ primary_node_name }}/$primary_node_name/g" \
         -e "s/{{ docker_tag }}/$docker_tag/g" \
         -e "s/{{ docker_prefix }}/$docker_prefix/g" \
         $arg > ${arg%%.in}

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -44,5 +44,3 @@ spec:
           periodSeconds: 20
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/iscsi-auth-demo-target.yaml.in
+++ b/manifests/iscsi-auth-demo-target.yaml.in
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: iscsi-auth-demo-secret
-type: "kubernetes.io/iscsi-chap"  
+type: "kubernetes.io/iscsi-chap"
 data:
   node.session.auth.username: ZGVtb3VzZXI=
   node.session.auth.password: ZGVtb3Bhc3N3b3Jk
@@ -50,5 +50,3 @@ spec:
         - name: host
           hostPath:
             path: /
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/iscsi-demo-target.yaml.in
+++ b/manifests/iscsi-demo-target.yaml.in
@@ -133,5 +133,3 @@ spec:
         - name: host
           hostPath:
             path: /
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/squid.yaml.in
+++ b/manifests/squid.yaml.in
@@ -31,5 +31,3 @@ spec:
               protocol: "TCP"
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -38,5 +38,3 @@ spec:
             protocol: "TCP"
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -54,5 +54,3 @@ spec:
           timeoutSeconds: 10
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -64,5 +64,3 @@ spec:
       volumes:
       - name: libvirt-runtime
         emptyDir: {}
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}


### PR DESCRIPTION
In order to make the manifests more general, stop injecting
'nodeSelector' attribute.

Signed-off-by: gbenhaim <galbh2@gmail.com>

part of https://github.com/kubevirt/kubevirt/issues/265