### PR TITLE
Generic VM console test tooling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,9 +128,21 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/google/goexpect"
+  packages = ["."]
+  revision = "28e22c82329b5a072f9c655ee35c6101bb902603"
+
+[[projects]]
+  branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/google/goterm"
+  packages = ["term"]
+  revision = "9ca8590b902f5217776d7087b120e7c97203dbc8"
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
@@ -224,7 +236,7 @@
 
 [[projects]]
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
   revision = "d172538b2cfce0c13cee31e647d0367aa8cd2486"
 
 [[projects]]
@@ -241,6 +253,12 @@
   name = "golang.org/x/text"
   packages = ["cases","encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal","internal/gen","internal/tag","internal/triegen","internal/ucd","internal/utf8internal","language","runes","secure/bidirule","secure/precis","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
   revision = "b19bf474d317b857955b12035d2c5acb57ce8b01"
+
+[[projects]]
+  name = "google.golang.org/grpc"
+  packages = ["codes"]
+  revision = ""
+  version = "v1.7.1"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -271,7 +289,7 @@
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/autoscaling/v2alpha1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/version","rest","rest/watch","testing","tools/auth","tools/cache","tools/cache/testing","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/record","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer","util/workqueue"]
+  packages = ["discovery","discovery/fake","kubernetes","kubernetes/fake","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1alpha1/fake","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta1/fake","kubernetes/typed/apps/v1beta2","kubernetes/typed/apps/v1beta2/fake","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1/fake","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authentication/v1beta1/fake","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1/fake","kubernetes/typed/authorization/v1beta1","kubernetes/typed/authorization/v1beta1/fake","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v1/fake","kubernetes/typed/autoscaling/v2alpha1","kubernetes/typed/autoscaling/v2alpha1/fake","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1/fake","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v1beta1/fake","kubernetes/typed/batch/v2alpha1","kubernetes/typed/batch/v2alpha1/fake","kubernetes/typed/certificates/v1beta1","kubernetes/typed/certificates/v1beta1/fake","kubernetes/typed/core/v1","kubernetes/typed/core/v1/fake","kubernetes/typed/extensions/v1beta1","kubernetes/typed/extensions/v1beta1/fake","kubernetes/typed/networking/v1","kubernetes/typed/networking/v1/fake","kubernetes/typed/policy/v1beta1","kubernetes/typed/policy/v1beta1/fake","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1/fake","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1alpha1/fake","kubernetes/typed/rbac/v1beta1","kubernetes/typed/rbac/v1beta1/fake","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/scheduling/v1alpha1/fake","kubernetes/typed/settings/v1alpha1","kubernetes/typed/settings/v1alpha1/fake","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1/fake","kubernetes/typed/storage/v1beta1","kubernetes/typed/storage/v1beta1/fake","pkg/version","rest","rest/watch","testing","tools/auth","tools/cache","tools/cache/testing","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/leaderelection","tools/leaderelection/resourcelock","tools/metrics","tools/record","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer","util/workqueue"]
   revision = "db8228460e2de17f5d3a9a453f61dde0ba86545a"
 
 [[projects]]
@@ -283,6 +301,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "84828a80dc032069659dc4c9cfdc4289afae07799f9e918517d47aa95292b4ef"
+  inputs-digest = "d281956d5fcf022451397f839df338984fde7242f15929910e60c5ba10ac3eaa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -94,3 +94,12 @@ ignored = ["code.google.com/p/go-charset","github.com/go-kit/kit/examples","gith
 
 [[constraint]]
   name = "k8s.io/client-go"
+
+[[constraint]]
+  name = "github.com/google/goexpect"
+
+[[constraint]]
+  name = "github.com/google/goterm"
+
+[[constraint]]
+  name = "github.com/google/grpc"

--- a/pkg/kubecli/kubecli.go
+++ b/pkg/kubecli/kubecli.go
@@ -69,3 +69,11 @@ func GetKubevirtClientFromFlags(master string, kubeconfig string) (KubevirtClien
 func GetKubevirtClient() (KubevirtClient, error) {
 	return GetKubevirtClientFromFlags(master, kubeconfig)
 }
+
+func GetKubevirtClientConfig() (*rest.Config, error) {
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -21,16 +21,12 @@ package tests_test
 
 import (
 	"flag"
-	"net/url"
-
-	"strings"
 	"time"
 
-	"github.com/gorilla/websocket"
+	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
 )
@@ -41,57 +37,28 @@ var _ = Describe("Console", func() {
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
-	var vm *v1.VirtualMachine
-	var dial func(vm string, console string) *websocket.Conn
+	virtConfig, err := kubecli.GetKubevirtClientConfig()
+	tests.PanicOnError(err)
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
-
-		vm = tests.NewRandomVMWithSerialConsole()
-
-		dial = func(vm string, console string) *websocket.Conn {
-			wsUrl, err := url.Parse(flag.Lookup("master").Value.String())
-			Expect(err).ToNot(HaveOccurred())
-			wsUrl.Scheme = "ws"
-			wsUrl.Path = "/apis/kubevirt.io/v1alpha1/namespaces/" + tests.NamespaceTestDefault + "/virtualmachines/" + vm + "/console"
-			wsUrl.RawQuery = "console=" + console
-			c, _, err := websocket.DefaultDialer.Dial(wsUrl.String(), nil)
-			Expect(err).ToNot(HaveOccurred())
-			return c
-		}
 	})
 
 	Context("New VM with a serial console given", func() {
+		It("should be returned that we are running cirros", func() {
+			vm := tests.NewRandomVMWithSerialConsole()
 
-		It("should be allowed to connect to the console", func(done Done) {
 			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
 			tests.WaitForSuccessfulVMStart(vm)
-			ws := dial(vm.ObjectMeta.GetName(), "serial0")
-			defer ws.Close()
-			close(done)
-		}, 60)
 
-		It("should be returned that we are running cirros", func(done Done) {
-			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
-			tests.WaitForSuccessfulVMStart(vm)
-			ws := dial(vm.ObjectMeta.GetName(), "serial0")
-			defer ws.Close()
-			// Check for the typical cloud init error messages
-			// TODO, use a reader instead and use ReadLine from bufio
-			next := ""
-			Eventually(func() string {
-				for {
-					if index := strings.Index(next, "\n"); index != -1 {
-						line := next[0:index]
-						next = next[index+1:]
-						return line
-					}
-					_, data, err := ws.ReadMessage()
-					Expect(err).ToNot(HaveOccurred())
-					next = next + string(data)
-				}
-			}, 60*time.Second).Should(ContainSubstring("checking http://169.254.169.254/2009-04-04/instance-id"))
-			close(done)
-		}, 90)
+			expecter, _, err := tests.NewConsoleExpecter(virtConfig, vm, "serial0", 10*time.Second)
+			defer expecter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			expecter.ExpectBatch([]expect.Batcher{
+				&expect.BExp{R: "checking http://169.254.169.254/2009-04-04/instance-id"},
+			}, 60*time.Second)
+
+		})
 	})
 })


### PR DESCRIPTION
I've stripped the work @rmohr did for his goexpect console tester in #499 and converted our existing tests to use it. 

I need this console tooling for some features I'm working on now. We shouldn't have to wait for node networking to land before taking advantage of this tooling improvement. 