### PR TITLE
Virtual Machine watchdog device support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1617,6 +1617,9 @@
       "items": {
        "$ref": "#/definitions/v1.Video"
       }
+     },
+     "watchdog": {
+      "$ref": "#/definitions/v1.Watchdog"
      }
     }
    },
@@ -2862,6 +2865,23 @@
      },
      "metadata": {
       "$ref": "#/definitions/v1.ListMeta"
+     }
+    }
+   },
+   "v1.Watchdog": {
+    "description": "Hardware watchdog device",
+    "required": [
+     "model",
+     "action"
+    ],
+    "properties": {
+     "action": {
+      "description": "The action to take. poweroff, reset, shutdown, pause, dump.",
+      "type": "string"
+     },
+     "model": {
+      "description": "Defines what watchdog model to use, typically 'i6300esb'",
+      "type": "string"
      }
     }
    }

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -67,6 +67,7 @@ type Devices struct {
 	Disks      []Disk      `json:"disks,omitempty"`
 	Serials    []Serial    `json:"serials,omitempty"`
 	Consoles   []Console   `json:"consoles,omitempty"`
+	Watchdog   *Watchdog   `json:"watchdog,omitempty"`
 }
 
 // BEGIN Disk -----------------------------
@@ -340,6 +341,11 @@ type Ballooning struct {
 }
 
 type RandomGenerator struct {
+}
+
+type Watchdog struct {
+	Model  string `json:"model"`
+	Action string `json:"action"`
 }
 
 // TODO ballooning, rng, cpu ...

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -343,8 +343,11 @@ type Ballooning struct {
 type RandomGenerator struct {
 }
 
+// Hardware watchdog device
 type Watchdog struct {
-	Model  string `json:"model"`
+	// Defines what watchdog model to use, typically 'i6300esb'
+	Model string `json:"model"`
+	// The action to take. poweroff, reset, shutdown, pause, dump.
 	Action string `json:"action"`
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -203,5 +203,9 @@ func (RandomGenerator) SwaggerDoc() map[string]string {
 }
 
 func (Watchdog) SwaggerDoc() map[string]string {
-	return map[string]string{}
+	return map[string]string{
+		"":       "Hardware watchdog device",
+		"model":  "Defines what watchdog model to use, typically 'i6300esb'",
+		"action": "The action to take. poweroff, reset, shutdown, pause, dump.",
+	}
 }

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -201,3 +201,7 @@ func (Ballooning) SwaggerDoc() map[string]string {
 func (RandomGenerator) SwaggerDoc() map[string]string {
 	return map[string]string{}
 }
+
+func (Watchdog) SwaggerDoc() map[string]string {
+	return map[string]string{}
+}

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -81,6 +81,7 @@ func init() {
 	mapper.AddConversion(&Listen{}, &v1.Listen{})
 	mapper.AddPtrConversion((**DiskAuth)(nil), (**v1.DiskAuth)(nil))
 	mapper.AddPtrConversion((**DiskSecret)(nil), (**v1.DiskSecret)(nil))
+	mapper.AddPtrConversion((**Watchdog)(nil), (**v1.Watchdog)(nil))
 
 	model.AddConversion(&Video{}, &v1.Video{}, func(in reflect.Value) (reflect.Value, error) {
 		out := v1.Video{}
@@ -244,6 +245,7 @@ type Devices struct {
 	Disks      []Disk      `xml:"disk"`
 	Serials    []Serial    `xml:"serial"`
 	Consoles   []Console   `xml:"console"`
+	Watchdog   *Watchdog   `xml:"watchdog,omitempty"`
 }
 
 // BEGIN Disk -----------------------------
@@ -523,6 +525,11 @@ type Ballooning struct {
 }
 
 type RandomGenerator struct {
+}
+
+type Watchdog struct {
+	Model  string `xml:"model,attr"`
+	Action string `xml:"action,attr"`
 }
 
 // TODO ballooning, rng, cpu ...

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -58,6 +58,7 @@ var exampleXML = `<domain type="qemu">
     <console type="pty">
       <target type="serial" port="123"></target>
     </console>
+    <watchdog model="i6300esb" action="poweroff"></watchdog>
   </devices>
 </domain>`
 
@@ -84,6 +85,10 @@ var _ = Describe("Schema", func() {
 	}
 	exampleDomain.Devices.Consoles = []Console{
 		{Type: "pty", Target: &ConsoleTarget{Type: newString("serial"), Port: newUInt(123)}},
+	}
+	exampleDomain.Devices.Watchdog = &Watchdog{
+		Model:  "i6300esb",
+		Action: "poweroff",
 	}
 
 	Context("With schema", func() {
@@ -112,7 +117,6 @@ var _ = Describe("Schema", func() {
 		It("Marshal into xml", func() {
 			buf, err := xml.MarshalIndent(*exampleDomain, "", "  ")
 			Expect(err).To(BeNil())
-
 			Expect(string(buf)).To(Equal(exampleXML))
 		})
 
@@ -139,6 +143,10 @@ var _ = Describe("Schema", func() {
 		}
 		v1DomainSpec.Devices.Consoles = []v1.Console{
 			{Type: "pty", Target: &v1.ConsoleTarget{Type: newString("serial"), Port: newUInt(123)}},
+		}
+		v1DomainSpec.Devices.Watchdog = &v1.Watchdog{
+			Model:  "i6300esb",
+			Action: "poweroff",
 		}
 
 		It("converts to libvirt.DomainSpec", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -646,6 +646,32 @@ func NewRandomMigrationForVm(vm *v1.VirtualMachine) *v1.Migration {
 	return v1.NewMinimalMigrationWithNS(ns, vm.ObjectMeta.Name+"migrate"+rand.String(5), vm.ObjectMeta.Name)
 }
 
+func NewRandomVMWithWatchdog() *v1.VirtualMachine {
+	vm := NewRandomVMWithDirectLun(2, false)
+	vm.Spec.Domain.Devices.Serials = []v1.Serial{
+		{
+			Type: "pty",
+			Target: &v1.SerialTarget{
+				Port: newUInt(0),
+			},
+		},
+	}
+	vm.Spec.Domain.Devices.Consoles = []v1.Console{
+		{
+			Type: "pty",
+			Target: &v1.ConsoleTarget{
+				Type: newString("serial"),
+				Port: newUInt(0),
+			},
+		},
+	}
+	vm.Spec.Domain.Devices.Watchdog = &v1.Watchdog{
+		Model:  "i6300esb",
+		Action: "poweroff",
+	}
+
+	return vm
+}
 func NewRandomVMWithSerialConsole() *v1.VirtualMachine {
 	vm := NewRandomVMWithPVC("disk-cirros")
 	vm.Spec.Domain.Devices.Serials = []v1.Serial{

--- a/tests/vm_monitoring_test.go
+++ b/tests/vm_monitoring_test.go
@@ -62,17 +62,18 @@ var _ = Describe("Health Monitoring", func() {
 			defer expecter.Close()
 			Expect(err).ToNot(HaveOccurred())
 
-			expecter.ExpectBatch([]expect.Batcher{
+			_, err = expecter.ExpectBatch([]expect.Batcher{
 				&expect.BExp{R: "Welcome to Alpine"},
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "login"},
 				&expect.BSnd{S: "root\n"},
 				&expect.BExp{R: "#"},
-				&expect.BSnd{S: "watchdog -t 5000ms -T 10000ms /dev/watchdog && sleep 10 && killall -9 watchdog\n"},
+				&expect.BSnd{S: "watchdog -t 2000ms -T 4000ms /dev/watchdog && sleep 5 && killall -9 watchdog\n"},
 				&expect.BExp{R: "#"},
 				&expect.BSnd{S: "echo $?\n"},
 				&expect.BExp{R: "0"},
-			}, 60*time.Second)
+			}, 150*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 
 			namespace := vm.ObjectMeta.Namespace
 			name := vm.ObjectMeta.Name
@@ -82,9 +83,9 @@ var _ = Describe("Health Monitoring", func() {
 				err := virtClient.RestClient().Get().Resource("virtualmachines").Namespace(namespace).Name(name).Do().Into(vm)
 				Expect(err).ToNot(HaveOccurred())
 				return vm.Status.Phase
-			}, 60*time.Second).Should(Equal(v1.Failed))
+			}, 40*time.Second).Should(Equal(v1.Failed))
 
 			close(done)
-		}, 130)
+		}, 200)
 	})
 })

--- a/tests/vm_monitoring_test.go
+++ b/tests/vm_monitoring_test.go
@@ -1,0 +1,90 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"flag"
+	"time"
+
+	"github.com/google/goexpect"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("Health Monitoring", func() {
+
+	flag.Parse()
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	tests.PanicOnError(err)
+	virtConfig, err := kubecli.GetKubevirtClientConfig()
+	tests.PanicOnError(err)
+
+	launchVM := func(vm *v1.VirtualMachine) {
+		obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
+		Expect(err).To(BeNil())
+
+		tests.WaitForSuccessfulVMStart(obj)
+	}
+
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+	})
+
+	Context("Watchdog device", func() {
+		It("should cause VM to shutdown when watchdog expires", func(done Done) {
+			vm := tests.NewRandomVMWithWatchdog()
+			Expect(err).ToNot(HaveOccurred())
+			launchVM(vm)
+
+			expecter, _, err := tests.NewConsoleExpecter(virtConfig, vm, "serial0", 10*time.Second)
+			defer expecter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			expecter.ExpectBatch([]expect.Batcher{
+				&expect.BExp{R: "Welcome to Alpine"},
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: "login"},
+				&expect.BSnd{S: "root\n"},
+				&expect.BExp{R: "#"},
+				&expect.BSnd{S: "watchdog -t 5000ms -T 10000ms /dev/watchdog && sleep 10 && killall -9 watchdog\n"},
+				&expect.BExp{R: "#"},
+				&expect.BSnd{S: "echo $?\n"},
+				&expect.BExp{R: "0"},
+			}, 60*time.Second)
+
+			namespace := vm.ObjectMeta.Namespace
+			name := vm.ObjectMeta.Name
+
+			Eventually(func() v1.VMPhase {
+				vm := &v1.VirtualMachine{}
+				err := virtClient.RestClient().Get().Resource("virtualmachines").Namespace(namespace).Name(name).Do().Into(vm)
+				Expect(err).ToNot(HaveOccurred())
+				return vm.Status.Phase
+			}, 60*time.Second).Should(Equal(v1.Failed))
+
+			close(done)
+		}, 130)
+	})
+})


### PR DESCRIPTION
This PR implements the equivalent of  https://wiki.openstack.org/wiki/LibvirtWatchdog for KubeVirt.

Example spec with "watchdog" device
```
apiVersion: kubevirt.io/v1alpha1
kind: VirtualMachine
metadata:
  name: alpine
spec:
  domain:
    devices:
      graphics:
      - type: spice
      interfaces:
      - type: network
        source:
          network: default
      video:
      - type: qxl
      disks:
      - type: network
        snapshot: external
        device: disk
        driver:
          name: qemu
          type: raw
          cache: none
        source:
          host:
            name: iscsi-demo-target.default
            port: "3260"
          protocol: iscsi
          name: iqn.2017-01.io.kubevirt:sn.42/2
        target:
          dev: vda
      consoles:
      - type: pty
      watchdog:
        model: i6300esb
        action: poweroff
    memory:
      unit: MB
      value: 64
    os:
      type:
        os: hvm
    type: qemu

```

