### PR TITLE
Integrate openapi-spec generation with generate target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cmd/virt-launcher/virt-launcher*
 cmd/virt-handler/virt-handler*
 cmd/virt-api/virt-api*
 cmd/virtctl/virtctl*
+tools/openapispec/openapispec
 manifests/*.yaml
 **/bin
 bin/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ script:
 - make fmt
 - if git diff --name-only | grep 'generated.*.go'; then echo "Content of generated
   files changed. Please regenerate and commit them."; false; fi
+- if git diff --name-only | grep 'swagger.json' ; then echo "Content of generated
+  files changed. Please regenerate and commit them." ; false ; fi
 - if diff <(git grep -c '') <(git grep -cI '') | egrep -v 'docs/.*\.png|swagger-ui'
   | grep '^<'; then echo "Binary files are present in git repostory."; false; fi
 - make check
@@ -42,9 +44,6 @@ script:
 - if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" ]]; then $HOME/gopath/bin/goveralls
   -service=travis-ci -package=./pkg/... -ignore=$(find -name generated_mock*.go -printf
   "%P\n" | paste -d, -s) ; else make test; fi
-- make generate-openapi-spec
-- if git diff --name-only | grep 'swagger.json' ; then echo "The OpenAPI Specification
-  was changed. Please run `make generate-openapi-spec` and commit it." ; false ; fi
 
 cache:
   directories:

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -77,7 +77,7 @@ func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri
 	}
 
 	return &virtHandlerApp{
-		Service:                 service.NewService("virt-handler", host, port),
+		Service:                 service.NewService("virt-handler", *host, *port),
 		HostOverride:            *hostOverride,
 		LibvirtUri:              *libvirtUri,
 		VirtShareDir:            *virtShareDir,

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -41,7 +41,7 @@ type virtManifestApp struct {
 
 func newVirtManifestApp(host *string, port *int, libvirtUri *string) *virtManifestApp {
 	return &virtManifestApp{
-		Service:    service.NewService("virt-manifest", host, port),
+		Service:    service.NewService("virt-manifest", *host, *port),
 		LibvirtUri: *libvirtUri,
 	}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -30,11 +30,11 @@ type Service struct {
 	Port string
 }
 
-func NewService(name string, host *string, port *int) *Service {
+func NewService(name string, host string, port int) *Service {
 	return &Service{
 		Name: name,
-		Host: *host,
-		Port: strconv.Itoa(*port),
+		Host: host,
+		Port: strconv.Itoa(port),
 	}
 }
 

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1,0 +1,138 @@
+package virt_api
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful-openapi"
+	kithttp "github.com/go-kit/kit/transport/http"
+	openapispec "github.com/go-openapi/spec"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/healthz"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	mime "kubevirt.io/kubevirt/pkg/rest"
+	"kubevirt.io/kubevirt/pkg/rest/endpoints"
+	"kubevirt.io/kubevirt/pkg/rest/filter"
+	"kubevirt.io/kubevirt/pkg/service"
+	"kubevirt.io/kubevirt/pkg/virt-api/rest"
+)
+
+type virtAPIApp struct {
+	Service   *service.Service
+	SwaggerUI string
+}
+
+func NewVirtAPIApp(host string, port int, swaggerUI string) *virtAPIApp {
+	return &virtAPIApp{
+		Service:   service.NewService("virt-api", host, port),
+		SwaggerUI: swaggerUI,
+	}
+}
+
+func (app *virtAPIApp) Compose() {
+	ctx := context.Background()
+	vmGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "virtualmachines"}
+	migrationGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "migrations"}
+	vmrsGVR := schema.GroupVersionResource{Group: v1.GroupVersion.Group, Version: v1.GroupVersion.Version, Resource: "virtualmachinereplicasets"}
+
+	ws, err := rest.GroupVersionProxyBase(ctx, v1.GroupVersion)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ws, err = rest.GenericResourceProxy(ws, ctx, vmGVR, &v1.VirtualMachine{}, v1.VirtualMachineGroupVersionKind.Kind, &v1.VirtualMachineList{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ws, err = rest.GenericResourceProxy(ws, ctx, migrationGVR, &v1.Migration{}, v1.MigrationGroupVersionKind.Kind, &v1.MigrationList{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ws, err = rest.GenericResourceProxy(ws, ctx, vmrsGVR, &v1.VirtualMachineReplicaSet{}, v1.VMReplicaSetGroupVersionKind.Kind, &v1.VirtualMachineReplicaSetList{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	virtCli, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//  TODO, allow Encoder and Decoders per type and combine the endpoint logic
+	spice := endpoints.MakeGoRestfulWrapper(endpoints.NewHandlerBuilder().Get().
+		Endpoint(rest.NewSpiceEndpoint(virtCli.RestClient(), vmGVR)).Encoder(
+		endpoints.NewMimeTypeAwareEncoder(endpoints.NewEncodeINIResponse(http.StatusOK),
+			map[string]kithttp.EncodeResponseFunc{
+				mime.MIME_INI:  endpoints.NewEncodeINIResponse(http.StatusOK),
+				mime.MIME_JSON: endpoints.NewEncodeJsonResponse(http.StatusOK),
+				mime.MIME_YAML: endpoints.NewEncodeYamlResponse(http.StatusOK),
+			})).Build(ctx))
+
+	ws.Route(ws.GET(rest.ResourcePath(vmGVR)+rest.SubResourcePath("spice")).
+		To(spice).Produces(mime.MIME_INI, mime.MIME_JSON, mime.MIME_YAML).
+		Param(rest.NamespaceParam(ws)).Param(rest.NameParam(ws)).
+		Operation("spice").
+		Doc("Returns a remote-viewer configuration file. Run `man 1 remote-viewer` to learn more about the configuration format."))
+
+	ws.Route(ws.GET(rest.ResourcePath(vmGVR) + rest.SubResourcePath("console")).
+		To(rest.NewConsoleResource(virtCli, virtCli.CoreV1()).Console).
+		Param(restful.QueryParameter("console", "Name of the serial console to connect to")).
+		Param(rest.NamespaceParam(ws)).Param(rest.NameParam(ws)).
+		Operation("console").
+		Doc("Open a websocket connection to a serial console on the specified VM."))
+
+	restful.Add(ws)
+
+	ws.Route(ws.GET("/healthz").To(healthz.KubeConnectionHealthzFunc).Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON).Doc("Health endpoint"))
+	ws, err = rest.ResourceProxyAutodiscovery(ctx, vmGVR)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	restful.Add(ws)
+
+	restful.Filter(filter.RequestLoggingFilter())
+	restful.Filter(restful.OPTIONSFilter())
+}
+
+func (app *virtAPIApp) ConfigureOpenAPIService() {
+	restful.DefaultContainer.Add(restfulspec.NewOpenAPIService(CreateOpenAPIConfig()))
+	http.Handle("/swagger-ui/", http.StripPrefix("/swagger-ui/", http.FileServer(http.Dir(app.SwaggerUI))))
+}
+
+func CreateOpenAPIConfig() restfulspec.Config {
+	return restfulspec.Config{
+		WebServices:    restful.RegisteredWebServices(),
+		WebServicesURL: "",
+		APIPath:        "/swaggerapi",
+		PostBuildSwaggerObjectHandler: addInfoToSwaggerObject,
+	}
+}
+
+func addInfoToSwaggerObject(swo *openapispec.Swagger) {
+	swo.Info = &openapispec.Info{
+		InfoProps: openapispec.InfoProps{
+			Title:       "KubeVirt API, ",
+			Description: "This is KubeVirt API an add-on for Kubernetes.",
+			Contact: &openapispec.ContactInfo{
+				Name:  "kubevirt-dev",
+				Email: "kubevirt-dev@googlegroups.com",
+				URL:   "https://github.com/kubevirt/kubevirt",
+			},
+			License: &openapispec.License{
+				Name: "Apache 2.0",
+				URL:  "https://www.apache.org/licenses/LICENSE-2.0",
+			},
+		},
+	}
+}
+
+func (app *virtAPIApp) Run() {
+	log.Fatal(http.ListenAndServe(app.Service.Address(), nil))
+}


### PR DESCRIPTION
Remove the need of an extra openapi generate build target and generate
everything as part of the normal "make generate" flow.

Signed-off-by: Roman Mohr <rmohr@redhat.com>