### PR TITLE
improve flag (command line option) handling code in services

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	klog "kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/virt-api"
 )
 
@@ -28,7 +29,7 @@ func main() {
 	klog.InitializeLogging("virt-api")
 
 	app := virt_api.VirtAPIApp{}
-	app.AddFlags()
+	service.Setup(&app)
 	app.Compose()
 	app.ConfigureOpenAPIService()
 	app.Run()

--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -20,23 +20,15 @@
 package main
 
 import (
-	"flag"
-
-	"github.com/spf13/pflag"
-
 	klog "kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/virt-api"
 )
 
 func main() {
 	klog.InitializeLogging("virt-api")
-	swaggerui := flag.String("swagger-ui", "third_party/swagger-ui", "swagger-ui location")
-	host := flag.String("listen", "0.0.0.0", "Address and port where to listen on")
-	port := flag.Int("port", 8183, "Port to listen on")
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	pflag.Parse()
 
-	app := virt_api.NewVirtAPIApp(*host, *port, *swaggerui)
+	app := virt_api.VirtAPIApp{}
+	app.AddFlags()
 	app.Compose()
 	app.ConfigureOpenAPIService()
 	app.Run()

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -63,6 +63,15 @@ const (
 
 	// Default address that virt-handler listens on.
 	defaultHost = "0.0.0.0"
+
+	// The URI connection string supplied to libvirt. By default, we connect to system-mode daemon of QEMU.
+	libvirtUri = "qemu:///system"
+
+	hostOverride = ""
+
+	virtShareDir = "/var/run/kubevirt"
+
+	ephemeralDiskDir = "/var/run/libvirt/kubevirt-ephemeral-disk"
 )
 
 type virtHandlerApp struct {
@@ -191,16 +200,16 @@ func (app *virtHandlerApp) AddFlags() {
 
 	app.AddCommonFlags()
 
-	flag.StringVar(&app.LibvirtUri, "libvirt-uri", "qemu:///system",
+	flag.StringVar(&app.LibvirtUri, "libvirt-uri", libvirtUri,
 		"Libvirt connection string")
 
-	flag.StringVar(&app.HostOverride, "hostname-override", "",
-		"Kubernetes pod to monitor for changes")
+	flag.StringVar(&app.HostOverride, "hostname-override", hostOverride,
+		"Name under which the node is registered in kubernetes, where this virt-handler instance is running on")
 
-	flag.StringVar(&app.VirtShareDir, "kubevirt-share-dir", "/var/run/kubevirt",
+	flag.StringVar(&app.VirtShareDir, "kubevirt-share-dir", virtShareDir,
 		"Shared directory between virt-handler and virt-launcher")
 
-	flag.StringVar(&app.EphemeralDiskDir, "ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk",
+	flag.StringVar(&app.EphemeralDiskDir, "ephemeral-disk-dir", ephemeralDiskDir,
 		"Base directory for ephemeral disk data")
 
 	flag.DurationVar(&app.WatchdogTimeoutDuration, "watchdog-timeout", defaultWatchdogTimeout,

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -59,13 +59,15 @@ import (
 const defaultWatchdogTimeout = 30 * time.Second
 
 type virtHandlerApp struct {
-	Service                 *service.Service
+	Service                 *service.ServiceListen
 	HostOverride            string
 	LibvirtUri              string
 	VirtShareDir            string
 	EphemeralDiskDir        string
 	WatchdogTimeoutDuration time.Duration
 }
+
+var _ service.Service = &virtHandlerApp{}
 
 func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri *string, virtShareDir *string, ephemeralDiskDir *string, watchdogTimeoutDuration *time.Duration) *virtHandlerApp {
 	if *hostOverride == "" {
@@ -77,7 +79,7 @@ func newVirtHandlerApp(host *string, port *int, hostOverride *string, libvirtUri
 	}
 
 	return &virtHandlerApp{
-		Service:                 service.NewService("virt-handler", *host, *port),
+		Service:                 service.NewServiceListen("virt-handler", host, port),
 		HostOverride:            *hostOverride,
 		LibvirtUri:              *libvirtUri,
 		VirtShareDir:            *virtShareDir,

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -186,7 +186,7 @@ func (app *virtHandlerApp) Run() {
 func (app *virtHandlerApp) AddFlags() {
 	app.InitFlags()
 
-	app.Host = defaultHost
+	app.BindAddress = defaultHost
 	app.Port = defaultPort
 
 	app.AddCommonFlags()

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -76,8 +76,8 @@ const (
 
 type virtHandlerApp struct {
 	service.ServiceListen
+	service.ServiceLibvirt
 	HostOverride            string
-	LibvirtUri              string
 	VirtShareDir            string
 	EphemeralDiskDir        string
 	WatchdogTimeoutDuration time.Duration
@@ -197,11 +197,10 @@ func (app *virtHandlerApp) AddFlags() {
 
 	app.BindAddress = defaultHost
 	app.Port = defaultPort
+	app.LibvirtUri = libvirtUri
 
 	app.AddCommonFlags()
-
-	flag.StringVar(&app.LibvirtUri, "libvirt-uri", libvirtUri,
-		"Libvirt connection string")
+	app.AddLibvirtFlags()
 
 	flag.StringVar(&app.HostOverride, "hostname-override", hostOverride,
 		"Name under which the node is registered in kubernetes, where this virt-handler instance is running on")

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -45,6 +45,7 @@ const (
 
 type virtManifestApp struct {
 	service.ServiceListen
+	service.ServiceLibvirt
 	LibvirtUri string
 }
 
@@ -84,11 +85,10 @@ func (app *virtManifestApp) AddFlags() {
 
 	app.BindAddress = defaultHost
 	app.Port = defaultPort
+	app.LibvirtUri = libvirtUri
 
 	app.AddCommonFlags()
-
-	flag.StringVar(&app.LibvirtUri, "libvirt-uri", libvirtUri,
-		"Libvirt connection string")
+	app.AddLibvirtFlags()
 
 	flag.Parse()
 }

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -80,7 +80,7 @@ func (app *virtManifestApp) Run() {
 func (app *virtManifestApp) AddFlags() {
 	app.InitFlags()
 
-	app.Host = defaultHost
+	app.BindAddress = defaultHost
 	app.Port = defaultPort
 
 	app.AddCommonFlags()

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/emicklei/go-restful"
-	flag "github.com/spf13/pflag"
 
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/service"
@@ -89,13 +88,11 @@ func (app *virtManifestApp) AddFlags() {
 
 	app.AddCommonFlags()
 	app.AddLibvirtFlags()
-
-	flag.Parse()
 }
 
 func main() {
 	log.InitializeLogging("virt-manifest")
 	app := virtManifestApp{}
-	app.AddFlags()
+	service.Setup(&app)
 	app.Run()
 }

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -35,16 +35,18 @@ import (
 )
 
 type virtManifestApp struct {
-	Service    *service.Service
+	Service    *service.ServiceListen
 	LibvirtUri string
 }
 
 func newVirtManifestApp(host *string, port *int, libvirtUri *string) *virtManifestApp {
 	return &virtManifestApp{
-		Service:    service.NewService("virt-manifest", *host, *port),
+		Service:    service.NewServiceListen("virt-manifest", host, port),
 		LibvirtUri: *libvirtUri,
 	}
 }
+
+var _ service.Service = &virtManifestApp{}
 
 func (app *virtManifestApp) Run() {
 	logger := log.Log

--- a/cmd/virt-manifest/virt-manifest.go
+++ b/cmd/virt-manifest/virt-manifest.go
@@ -39,6 +39,8 @@ const (
 
 	// Default address that virt-manifest listens on.
 	defaultHost = "0.0.0.0"
+
+	libvirtUri = "qemu:///system"
 )
 
 type virtManifestApp struct {
@@ -85,7 +87,7 @@ func (app *virtManifestApp) AddFlags() {
 
 	app.AddCommonFlags()
 
-	flag.StringVar(&app.LibvirtUri, "libvirt-uri", "qemu:///system",
+	flag.StringVar(&app.LibvirtUri, "libvirt-uri", libvirtUri,
 		"Libvirt connection string")
 
 	flag.Parse()

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -33,13 +33,13 @@ type Service interface {
 }
 
 type ServiceListen struct {
-	Name string
-	Host string
-	Port int
+	Name        string
+	BindAddress string
+	Port        int
 }
 
 func (service *ServiceListen) Address() string {
-	return fmt.Sprintf("%s:%s", service.Host, strconv.Itoa(service.Port))
+	return fmt.Sprintf("%s:%s", service.BindAddress, strconv.Itoa(service.Port))
 }
 
 func (service *ServiceListen) InitFlags() {
@@ -47,6 +47,6 @@ func (service *ServiceListen) InitFlags() {
 }
 
 func (service *ServiceListen) AddCommonFlags() {
-	flag.StringVar(&service.Host, "listen", service.Host, "Address where to listen on")
+	flag.StringVar(&service.BindAddress, "listen", service.BindAddress, "Address where to listen on")
 	flag.IntVar(&service.Port, "port", service.Port, "Port to listen on")
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -38,6 +38,10 @@ type ServiceListen struct {
 	Port        int
 }
 
+type ServiceLibvirt struct {
+	LibvirtUri string
+}
+
 func (service *ServiceListen) Address() string {
 	return fmt.Sprintf("%s:%s", service.BindAddress, strconv.Itoa(service.Port))
 }
@@ -49,4 +53,9 @@ func (service *ServiceListen) InitFlags() {
 func (service *ServiceListen) AddCommonFlags() {
 	flag.StringVar(&service.BindAddress, "listen", service.BindAddress, "Address where to listen on")
 	flag.IntVar(&service.Port, "port", service.Port, "Port to listen on")
+}
+
+func (service *ServiceLibvirt) AddLibvirtFlags() {
+	flag.StringVar(&service.Uri, "libvirt-uri", service.Uri, "Libvirt connection string")
+
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -56,6 +56,11 @@ func (service *ServiceListen) AddCommonFlags() {
 }
 
 func (service *ServiceLibvirt) AddLibvirtFlags() {
-	flag.StringVar(&service.Uri, "libvirt-uri", service.Uri, "Libvirt connection string")
+	flag.StringVar(&service.LibvirtUri, "libvirt-uri", service.LibvirtUri, "Libvirt connection string")
 
+}
+
+func Setup(service Service) {
+	service.AddFlags()
+	flag.Parse()
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -24,20 +24,24 @@ import (
 	"strconv"
 )
 
-type Service struct {
+type Service interface {
+	Run()
+}
+
+type ServiceListen struct {
 	Name string
 	Host string
 	Port string
 }
 
-func NewService(name string, host string, port int) *Service {
-	return &Service{
+func NewServiceListen(name string, host *string, port *int) *ServiceListen {
+	return &ServiceListen{
 		Name: name,
 		Host: host,
 		Port: strconv.Itoa(port),
 	}
 }
 
-func (service *Service) Address() string {
+func (service *ServiceListen) Address() string {
 	return fmt.Sprintf("%s:%s", service.Host, service.Port)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -31,17 +31,17 @@ type Service interface {
 type ServiceListen struct {
 	Name string
 	Host string
-	Port string
+	Port int
 }
 
 func NewServiceListen(name string, host *string, port *int) *ServiceListen {
 	return &ServiceListen{
 		Name: name,
-		Host: host,
-		Port: strconv.Itoa(port),
+		Host: *host,
+		Port: *port,
 	}
 }
 
 func (service *ServiceListen) Address() string {
-	return fmt.Sprintf("%s:%s", service.Host, service.Port)
+	return fmt.Sprintf("%s:%s", service.Host, strconv.Itoa(service.Port))
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -29,24 +29,13 @@ import (
 
 type Service interface {
 	Run()
-	// TODO(mpolednik): uncomment initOptions when all services implement it.
-	// AddFlags()
-
+	AddFlags()
 }
 
 type ServiceListen struct {
 	Name string
 	Host string
 	Port int
-}
-
-// TODO(mpolednik): remove this when all affected services use new flag handling.
-func NewServiceListen(name string, host *string, port *int) *ServiceListen {
-	return &ServiceListen{
-		Name: name,
-		Host: *host,
-		Port: *port,
-	}
 }
 
 func (service *ServiceListen) Address() string {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -20,12 +20,18 @@
 package service
 
 import (
+	goflag "flag"
 	"fmt"
 	"strconv"
+
+	flag "github.com/spf13/pflag"
 )
 
 type Service interface {
 	Run()
+	// TODO(mpolednik): uncomment initOptions when all services implement it.
+	// AddFlags()
+
 }
 
 type ServiceListen struct {
@@ -34,6 +40,7 @@ type ServiceListen struct {
 	Port int
 }
 
+// TODO(mpolednik): remove this when all affected services use new flag handling.
 func NewServiceListen(name string, host *string, port *int) *ServiceListen {
 	return &ServiceListen{
 		Name: name,
@@ -44,4 +51,13 @@ func NewServiceListen(name string, host *string, port *int) *ServiceListen {
 
 func (service *ServiceListen) Address() string {
 	return fmt.Sprintf("%s:%s", service.Host, strconv.Itoa(service.Port))
+}
+
+func (service *ServiceListen) InitFlags() {
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+}
+
+func (service *ServiceListen) AddCommonFlags() {
+	flag.StringVar(&service.Host, "listen", service.Host, "Address where to listen on")
+	flag.IntVar(&service.Port, "port", service.Port, "Port to listen on")
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -22,16 +22,18 @@ import (
 )
 
 type virtAPIApp struct {
-	Service   *service.Service
+	Service   *service.ServiceListen
 	SwaggerUI string
 }
 
 func NewVirtAPIApp(host string, port int, swaggerUI string) *virtAPIApp {
 	return &virtAPIApp{
-		Service:   service.NewService("virt-api", host, port),
+		Service:   service.NewServiceListen("virt-api", host, port),
 		SwaggerUI: swaggerUI,
 	}
 }
+
+var _ service.Service = &virtAPIApp{}
 
 func (app *virtAPIApp) Compose() {
 	ctx := context.Background()

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful-openapi"
 	kithttp "github.com/go-kit/kit/transport/http"
 	openapispec "github.com/go-openapi/spec"
 	flag "github.com/spf13/pflag"
@@ -161,6 +162,4 @@ func (app *VirtAPIApp) AddFlags() {
 
 	flag.StringVar(&app.SwaggerUI, "swagger-ui", "third_party/swagger-ui",
 		"swagger-ui location")
-
-	flag.Parse()
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -154,7 +154,7 @@ func (app *VirtAPIApp) Run() {
 func (app *VirtAPIApp) AddFlags() {
 	app.InitFlags()
 
-	app.Host = defaultHost
+	app.BindAddress = defaultHost
 	app.Port = defaultPort
 
 	app.AddCommonFlags()

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/emicklei/go-restful"
-	"github.com/emicklei/go-restful-openapi"
 	kithttp "github.com/go-kit/kit/transport/http"
 	openapispec "github.com/go-openapi/spec"
 	"golang.org/x/net/context"

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -84,7 +84,7 @@ func Execute() {
 
 	app.LeaderElection = leaderelectionconfig.DefaultLeaderElectionConfiguration()
 
-	app.AddFlags()
+	service.Setup(&app)
 
 	app.readyChan = make(chan bool, 1)
 
@@ -251,6 +251,4 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", ephemeralDiskDir,
 		"Base directory for ephemeral disk data")
-
-	flag.Parse()
 }

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -22,6 +22,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/registry-disk"
+	"kubevirt.io/kubevirt/pkg/service"
 	"kubevirt.io/kubevirt/pkg/virt-controller/leaderelectionconfig"
 	"kubevirt.io/kubevirt/pkg/virt-controller/rest"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
@@ -59,6 +60,8 @@ type VirtControllerApp struct {
 	ephemeralDiskDir string
 	readyChan        chan bool
 }
+
+var _ service.Service = &VirtControllerApp{}
 
 func Execute() {
 	var err error

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -33,6 +33,14 @@ const (
 
 	// Default address that virt-manifest listens on.
 	defaultHost = "0.0.0.0"
+
+	launcherImage = "virt-launcher"
+
+	migratorImage = "virt-handler"
+
+	virtShareDir = "/var/run/kubevirt"
+
+	ephemeralDiskDir = "/var/run/libvirt/kubevirt-ephemeral-disk"
 )
 
 type VirtControllerApp struct {
@@ -232,16 +240,16 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	vca.AddCommonFlags()
 
-	flag.StringVar(&vca.launcherImage, "launcher-image", "virt-launcher",
+	flag.StringVar(&vca.launcherImage, "launcher-image", launcherImage,
 		"Shim container for containerized VMs")
 
-	flag.StringVar(&vca.migratorImage, "migrator-image", "virt-handler",
+	flag.StringVar(&vca.migratorImage, "migrator-image", migratorImage,
 		"Container which orchestrates a VM migration")
 
-	flag.StringVar(&vca.virtShareDir, "kubevirt-share-dir", "/var/run/kubevirt",
+	flag.StringVar(&vca.virtShareDir, "kubevirt-share-dir", virtShareDir,
 		"Shared directory between virt-handler and virt-launcher")
 
-	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk",
+	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", ephemeralDiskDir,
 		"Base directory for ephemeral disk data")
 
 	flag.Parse()

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -128,7 +128,7 @@ func (vca *VirtControllerApp) Run() {
 	vca.informerFactory.Start(stop)
 	go func() {
 		httpLogger := logger.With("service", "http")
-		httpLogger.Level(log.INFO).Log("action", "listening", "interface", vca.Host, "port", vca.Port)
+		httpLogger.Level(log.INFO).Log("action", "listening", "interface", vca.BindAddress, "port", vca.Port)
 		if err := http.ListenAndServe(vca.Address(), nil); err != nil {
 			golog.Fatal(err)
 		}
@@ -227,7 +227,7 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	leaderelectionconfig.BindFlags(&vca.LeaderElection)
 
-	vca.Host = defaultHost
+	vca.BindAddress = defaultHost
 	vca.Port = defaultPort
 
 	vca.AddCommonFlags()

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -1,13 +1,12 @@
 package watch
 
 import (
-	"flag"
 	golog "log"
 	"net/http"
 	"os"
-	"strconv"
 
 	"github.com/emicklei/go-restful"
+	flag "github.com/spf13/pflag"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -28,7 +27,17 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
+const (
+	// Default port that virt-manifest listens on.
+	defaultPort = 8182
+
+	// Default address that virt-manifest listens on.
+	defaultHost = "0.0.0.0"
+)
+
 type VirtControllerApp struct {
+	service.ServiceListen
+
 	clientSet       kubecli.KubevirtClient
 	templateService services.TemplateService
 	restClient      *clientrest.RESTClient
@@ -52,8 +61,6 @@ type VirtControllerApp struct {
 
 	LeaderElection leaderelectionconfig.Configuration
 
-	host             string
-	port             int
 	launcherImage    string
 	migratorImage    string
 	virtShareDir     string
@@ -69,7 +76,7 @@ func Execute() {
 
 	app.LeaderElection = leaderelectionconfig.DefaultLeaderElectionConfiguration()
 
-	app.DefineFlags()
+	app.AddFlags()
 
 	app.readyChan = make(chan bool, 1)
 
@@ -121,8 +128,8 @@ func (vca *VirtControllerApp) Run() {
 	vca.informerFactory.Start(stop)
 	go func() {
 		httpLogger := logger.With("service", "http")
-		httpLogger.Level(log.INFO).Log("action", "listening", "interface", vca.host, "port", vca.port)
-		if err := http.ListenAndServe(vca.host+":"+strconv.Itoa(vca.port), nil); err != nil {
+		httpLogger.Level(log.INFO).Log("action", "listening", "interface", vca.Host, "port", vca.Port)
+		if err := http.ListenAndServe(vca.Address(), nil); err != nil {
 			golog.Fatal(err)
 		}
 	}()
@@ -215,13 +222,27 @@ func (vca *VirtControllerApp) readinessProbe(_ *restful.Request, response *restf
 	response.WriteHeaderAndJson(http.StatusServiceUnavailable, res, restful.MIME_JSON)
 }
 
-func (vca *VirtControllerApp) DefineFlags() {
-	flag.StringVar(&vca.host, "listen", "0.0.0.0", "Address and port where to listen on")
-	flag.IntVar(&vca.port, "port", 8182, "Port to listen on")
-	flag.StringVar(&vca.launcherImage, "launcher-image", "virt-launcher", "Shim container for containerized VMs")
-	flag.StringVar(&vca.migratorImage, "migrator-image", "virt-handler", "Container which orchestrates a VM migration")
-	flag.StringVar(&vca.virtShareDir, "kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
-	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk", "Base direcetory for ephemeral disk data")
+func (vca *VirtControllerApp) AddFlags() {
+	vca.InitFlags()
+
 	leaderelectionconfig.BindFlags(&vca.LeaderElection)
+
+	vca.Host = defaultHost
+	vca.Port = defaultPort
+
+	vca.AddCommonFlags()
+
+	flag.StringVar(&vca.launcherImage, "launcher-image", "virt-launcher",
+		"Shim container for containerized VMs")
+
+	flag.StringVar(&vca.migratorImage, "migrator-image", "virt-handler",
+		"Container which orchestrates a VM migration")
+
+	flag.StringVar(&vca.virtShareDir, "kubevirt-share-dir", "/var/run/kubevirt",
+		"Shared directory between virt-handler and virt-launcher")
+
+	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk",
+		"Base directory for ephemeral disk data")
+
 	flag.Parse()
 }

--- a/tools/openapispec/openapispec.go
+++ b/tools/openapispec/openapispec.go
@@ -53,7 +53,7 @@ func main() {
 	pflag.Parse()
 
 	// arguments for NewVirtAPIApp have no influence on the generated spec
-	app := virt_api.NewVirtAPIApp("0.0.0.0", 1234, "/swagger")
+	app := virt_api.VirtAPIApp{}
 	app.Compose()
 	dumpOpenApiSpec(dumpapispecpath)
 }


### PR DESCRIPTION
Current flag handling code is a bit messy: it's split between flag and spf13/pflag, duplicates several flags (--listen, --port) and isn't really standardized in any way. Those problems can be solved by a bit of refactoring and building upon pkg/service:

* switch to spf13/pflag,
* extend service to be able to add common flags,
* add a function to handle flags to all services and
* make that function required by having a service interface with compile time interface compliance.