### PR TITLE
Perform proper error checking in console tests

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -55,10 +55,10 @@ var _ = Describe("Console", func() {
 			defer expecter.Close()
 			Expect(err).ToNot(HaveOccurred())
 
-			expecter.ExpectBatch([]expect.Batcher{
+			_, err = expecter.ExpectBatch([]expect.Batcher{
 				&expect.BExp{R: "checking http://169.254.169.254/2009-04-04/instance-id"},
 			}, 60*time.Second)
-
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -61,9 +61,10 @@ var _ = Describe("CloudInit UserData", func() {
 		defer expecter.Close()
 		Expect(err).ToNot(HaveOccurred())
 
-		expecter.ExpectBatch([]expect.Batcher{
+		_, err = expecter.ExpectBatch([]expect.Batcher{
 			&expect.BExp{R: magicStr},
 		}, 60*time.Second)
+		Expect(err).ToNot(HaveOccurred())
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
I accidentally left off checking the error for the console expecter tests. This meant they would not time out correctly. 