### PR TITLE
No node selectors and separate services

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -124,7 +124,14 @@ while [ "$(kubectl get pods -o'custom-columns=status:status.containerStatuses[*]
     sleep 10
 done
 
-kubectl get pods
+# Wait until all pods are running
+while [ -n "$(kubectl get pods --no-headers --all-namespaces | grep -v Running)" ]; do
+    echo "Waiting for pods in all namespaces to enter the Running state ..."
+    kubectl get pods --no-headers --all-namespaces | >&2 grep -v Running || true
+    sleep 5
+done
+
+kubectl get pods --all-namespaces
 kubectl version
 
 # Disable proxy configuration since it causes test issues

--- a/cluster/vagrant/setup_kubernetes_master.sh
+++ b/cluster/vagrant/setup_kubernetes_master.sh
@@ -50,32 +50,6 @@ else
   kubectl create -f kube-$NETWORK_PROVIDER.yaml
 fi
 
-{
-  pushd /vagrant
-  source hack/config.sh
-  popd
-
-  # Pretty much equivalent to `kubectl expose service ...`
-  for SVC in spice-proxy:3128 virt-controller:8182 virt-api:8182 haproxy:8184 virt-manifest:8186;
-  do
-    IFS=: read NAME PORT <<<$SVC
-    kubectl apply -f - <<EOF
-apiVersion: v1
-kind: Service
-metadata:
-  name: external-$NAME
-spec:
-  externalIPs:
-  - "$master_ip"
-  ports:
-    - port: $PORT
-      targetPort: $PORT
-  selector:
-    app: $NAME
-EOF
-  done
-}
-
 # Allow scheduling pods on master
 # Ignore retval because it might not be dedicated already
 kubectl taint nodes master node-role.kubernetes.io/master:NoSchedule- || :

--- a/images/haproxy/haproxy.cfg
+++ b/images/haproxy/haproxy.cfg
@@ -25,7 +25,7 @@ backend srvs_kubevirt
    timeout connect 10s
    timeout server 1m
    balance roundrobin
-   server host1 virt-api-service:8183 resolvers kubernetes
+   server host1 virt-api:8183 resolvers kubernetes
 
 backend srvs_apiserver
    mode http

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: haproxy-service
+  name: haproxy
 spec:
   ports:
     - port: 8184
       targetPort: haproxy
-  externalIPs :
-    - "{{ master_ip }}"
   selector:
     app: haproxy
 ---

--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -44,5 +44,3 @@ spec:
           periodSeconds: 20
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/iscsi-auth-demo-target.yaml.in
+++ b/manifests/iscsi-auth-demo-target.yaml.in
@@ -50,5 +50,3 @@ spec:
         - name: host
           hostPath:
             path: /
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/iscsi-demo-target.yaml.in
+++ b/manifests/iscsi-demo-target.yaml.in
@@ -133,5 +133,3 @@ spec:
         - name: host
           hostPath:
             path: /
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/squid.yaml.in
+++ b/manifests/squid.yaml.in
@@ -6,8 +6,6 @@ spec:
   ports:
     - port: 3128
       targetPort: spice-proxy
-  externalIPs:
-    - "{{ master_ip }}"
   selector:
     app: spice-proxy
 ---

--- a/manifests/squid.yaml.in
+++ b/manifests/squid.yaml.in
@@ -31,5 +31,3 @@ spec:
               protocol: "TCP"
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -38,5 +38,3 @@ spec:
             protocol: "TCP"
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: virt-api-service
+  name: virt-api
 spec:
   ports:
     - port: 8183
       targetPort: virt-api
-  externalIPs :
-    - "{{ master_ip }}"
   selector:
     app: virt-api
 ---

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: virt-controller-service
+  name: virt-controller
 spec:
   ports:
     - port: 8182
       targetPort: virt-controller
-  externalIPs:
-    - "{{ master_ip }}"
   selector:
     app: virt-controller
 ---

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -54,5 +54,3 @@ spec:
           timeoutSeconds: 10
       securityContext:
         runAsNonRoot: true
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: virt-manifest-service
+  name: virt-manifest
 spec:
   ports:
     - port: 8186
       targetPort: virt-manifest
-  externalIPs:
-    - "{{ master_ip }}"
   selector:
     app: virt-manifest
 ---

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -64,5 +64,3 @@ spec:
       volumes:
       - name: libvirt-runtime
         emptyDir: {}
-      nodeSelector:
-        kubernetes.io/hostname: {{ primary_node_name }}

--- a/pkg/virt-controller/leaderelectionconfig/config.go
+++ b/pkg/virt-controller/leaderelectionconfig/config.go
@@ -32,7 +32,7 @@ const (
 	DefaultRenewDeadline = 10 * time.Second
 	DefaultRetryPeriod   = 2 * time.Second
 	DefaultNamespace     = "default"
-	DefaultEndpointName  = "virt-controller-service"
+	DefaultEndpointName  = "virt-controller"
 )
 
 func DefaultLeaderElectionConfiguration() Configuration {

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -85,7 +85,7 @@ var _ = Describe("RegistryDisk", func() {
 			for i := 0; i < num; i++ {
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
 				Expect(err).To(BeNil())
-				tests.WaitForSuccessfulVMStartWithTimeout(obj, 120)
+				tests.WaitForSuccessfulVMStartWithTimeout(obj, 180)
 				_, err = virtClient.RestClient().Delete().Resource("virtualmachines").Namespace(vm.GetObjectMeta().GetNamespace()).Name(vm.GetObjectMeta().GetName()).Do().Get()
 				Expect(err).To(BeNil())
 				tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -105,7 +105,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 				rs, err := virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(newRS.ObjectMeta.Name, v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return int(rs.Status.ReadyReplicas)
-			}, 60*time.Second, 1*time.Second).Should(Equal(2))
+			}, 120*time.Second, 1*time.Second).Should(Equal(2))
 		})
 
 		It("should not scale when paused and scale when resume", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -752,7 +752,7 @@ func WaitForSuccessfulVMStartWithTimeout(vm runtime.Object, seconds int) (nodeNa
 }
 
 func WaitForSuccessfulVMStart(vm runtime.Object) string {
-	return WaitForSuccessfulVMStartWithTimeout(vm, 5)
+	return WaitForSuccessfulVMStartWithTimeout(vm, 30)
 }
 
 func GetReadyNodes() []k8sv1.Node {

--- a/tests/vm_migration_test.go
+++ b/tests/vm_migration_test.go
@@ -45,7 +45,7 @@ var _ = Describe("VmMigration", func() {
 
 	var sourceVM *v1.VirtualMachine
 
-	var TIMEOUT float64 = 10.0
+	var TIMEOUT float64 = 60.0
 	var POLLING_INTERVAL float64 = 0.1
 
 	BeforeEach(func() {


### PR DESCRIPTION
This is an alternate PR to #538.

Instead of using ingress, separate services are used to grant inbound access.