### PR TITLE
Build kubevirt.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ tags
 hack/gen-swagger-doc/*.adoc
 hack/gen-swagger-doc/*.md
 hack/gen-swagger-doc/html5
+.release-functest
+kubevirt.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
   -service=travis-ci -package=./pkg/... -ignore=$(find -name generated_mock*.go -printf
   "%P\n" | paste -d, -s) ; else make test; fi
 - make apidocs
+- make kubevirt.yaml
 
 cache:
   directories:
@@ -71,6 +72,7 @@ deploy:
   file_glob: true
   file:
   - cmd/virtctl/virtctl-*
+  - kubevirt.yaml
   on:
     tags: true
     repo: kubevirt/kubevirt

--- a/cluster/vagrant/sync_build.sh
+++ b/cluster/vagrant/sync_build.sh
@@ -17,10 +17,11 @@
 #
 set -ex
 
-make all DOCKER_TAG=devel
+export DOCKER_TAG=${DOCKER_TAG:-devel}
+make all DOCKER_TAG=$DOCKER_TAG
 
 for VM in `vagrant status | grep -v "^The Libvirt domain is running." | grep running | cut -d " " -f1`; do
   vagrant rsync $VM # if you do not use NFS
-  vagrant ssh $VM -c "cd /vagrant && export DOCKER_TAG=devel && sudo -E hack/build-docker.sh $@"
+  vagrant ssh $VM -c "cd /vagrant && export DOCKER_TAG=$DOCKER_TAG && sudo -E hack/build-docker.sh $@"
 done
 

--- a/manifests/rbac.authorization.k8s.io.yaml.in
+++ b/manifests/rbac.authorization.k8s.io.yaml.in
@@ -15,13 +15,13 @@ rules:
       - list
       - watch
       - delete
-      - update  
-      - create  
+      - update
+      - create
   - apiGroups:
       - ''
     resources:
       - nodes
-      - persistentvolumeclaims  
+      - persistentvolumeclaims
     verbs:
       - get
       - list
@@ -30,15 +30,15 @@ rules:
       - kubevirt.io
     resources:
       - virtualmachines
-      - migrations  
-      - virtualmachinereplicasets  
+      - migrations
+      - virtualmachinereplicasets
     verbs:
       - get
       - list
       - watch
       - delete
-      - update  
-      - create  
+      - update
+      - create
       - deletecollection
 ---
 apiVersion: v1


### PR DESCRIPTION
Add and build kubevirt.yaml

This patch introduces a patch to build a manifest file for the current git tree.
This is especially helpful if we are at a tag. In that case the manifest will create
a manifest which is refencing the tags which are also used for the containers.
Thus these manifests can then be used to deploy this given release on a cluster.

This patch includes a make target to run the functests against the deployment
based on kubevirt.yaml.
This patch depends on #560.

Flow:

```
$ make kubevirt.yaml
$ minikube start ...
$ kubectl create -f kubevirt.yaml
```

and for tagged releases.

```
$ kubectl create -f https://github.com/kubevirt/kubevirt/releases/download/v0.0.4/kubevirt.yaml
```