### PR TITLE
schema: update json tag to allow bootOrder be empty

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2585,8 +2585,7 @@
    },
    "v1.OS": {
     "required": [
-     "type",
-     "bootOrder"
+     "type"
     ],
     "properties": {
      "bios": {

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -211,7 +211,7 @@ type Alias struct {
 type OS struct {
 	Type      OSType    `json:"type"`
 	SMBios    *SMBios   `json:"smBIOS,omitempty"`
-	BootOrder []Boot    `json:"bootOrder"`
+	BootOrder []Boot    `json:"bootOrder,omitempty"`
 	BootMenu  *BootMenu `json:"bootMenu,omitempty"`
 	BIOS      *BIOS     `json:"bios,omitempty"`
 }

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -35,8 +35,7 @@ var exampleJSON = `{
   "os": {
     "type": {
       "os": "hvm"
-    },
-    "bootOrder": null
+    }
   },
   "devices": {
     "interfaces": [


### PR DESCRIPTION
Related to #547 

It causes problem to me when I am using generated PySDK from OpenAPI.
The json tag for bootOrder in OS structure says that bootOrder can not be empty,
but apparently KubeVirt returns Vm object which has bootOrder empty ...