### PR TITLE
Add mercurial to the CI environment

### DIFF
--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -1,5 +1,6 @@
 yum
 git
+mercurial
 https://releases.hashicorp.com/vagrant/1.9.7/vagrant_1.9.7_x86_64.rpm
 libvirt
 libvirt-devel


### PR DESCRIPTION
This seems to be needed by some Go packages

Fixes: #589