### PR TITLE
Deploy KubeVirt with Ansible

### DIFF
--- a/cluster/ansible/README.md
+++ b/cluster/ansible/README.md
@@ -1,0 +1,18 @@
+
+### KubeVirt deployment with Ansible
+
+#### Inventory
+
+The inventory is fairly simple. First make a copy of the example
+
+```
+cp inventory/hosts.ini{.example,}
+```
+
+Then just replace the kube-master1 with the FQDN or IP address of your kubernetes
+master
+
+#### Run ansible
+```
+ansible-playbook -i inventory/hosts.ini playbooks/main.yml
+```

--- a/cluster/ansible/ansible.cfg
+++ b/cluster/ansible/ansible.cfg
@@ -1,0 +1,44 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# This config file provides examples for running
+# the OpenShift playbooks with the provided
+# inventory scripts.
+
+[defaults]
+# Set the log_path
+#log_path = /tmp/ansible.log
+
+# Additional default options for OpenShift Ansible
+library = library/
+forks = 20
+host_key_checking = False
+retry_files_enabled = False
+retry_files_save_path = ~/ansible-installer-retries
+nocows = True
+remote_user = root
+roles_path = roles/
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = $HOME/ansible/facts
+fact_caching_timeout = 600
+callback_whitelist = profile_tasks
+inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt
+# work around privilege escalation timeouts in ansible:
+timeout = 30
+
+# Uncomment to use the provided BYO inventory
+#inventory = inventory/byo/hosts.example
+
+[inventory]
+# fail more helpfully when the inventory file does not parse (Ansible 2.4+)
+unparsed_is_failed=true
+
+# Additional ssh options for OpenShift Ansible
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+timeout = 10
+# shorten the ControlPath which is often too long; when it is,
+# ssh connection reuse silently fails, making everything slower.
+control_path = %(directory)s/%%h-%%r

--- a/cluster/ansible/inventory/hosts.ini.example
+++ b/cluster/ansible/inventory/hosts.ini.example
@@ -1,0 +1,14 @@
+[master]
+kube-master1.example.com
+
+[master:vars]
+ansible_ssh_username=root
+#ansible_password=
+
+# Expose the KubeVirt services externally so they are accessible from the kubernetes
+# master.
+
+expose_externally=True
+
+# Remove all the kubevirt files that were created when ansible was run
+cleanup_kubevirt_files=True

--- a/cluster/ansible/playbooks/main.yml
+++ b/cluster/ansible/playbooks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Deploy KubeVirt
+  gather_facts: True
+  hosts: master
+  roles:
+    - { role: kubevirt, master_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4'].address }}" }

--- a/cluster/ansible/roles/kubevirt/defaults/main.yml
+++ b/cluster/ansible/roles/kubevirt/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+docker_tag: latest
+docker_prefix: kubevirt
+primary_nic: eth0
+
+

--- a/cluster/ansible/roles/kubevirt/tasks/main.yml
+++ b/cluster/ansible/roles/kubevirt/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+
+- name: Create temporary director for kubevirt files
+  file:
+    path: /tmp/kubevirt/
+    state: directory
+
+- name: Template Authorization
+  template:
+    src: rbac.authorization.k8s.io.yaml.j2
+    dest: /tmp/kubevirt/rbac.authorization.k8s.io.yaml
+  register: output_file
+
+- command: "kubectl apply -f {{ output_file.dest | default(output_file.path) }}"
+  when: output_file | changed
+
+- name: Template KubeVirt Dependant Services
+  template:
+    src: "{{ item }}.j2"
+    dest: "/tmp/kubevirt/{{ item }}"
+  register: output_file
+  with_items:
+    - haproxy.yaml
+    - squid.yaml
+    - libvirt.yaml
+
+- command: "kubectl apply -f {{ item.dest | default(item.path) }}"
+  when: item | changed
+  with_items: "{{ output_file.results }}"
+
+- name: Template Custom Resource Defintions
+  template:
+    src: "{{ item }}.j2"
+    dest: "/tmp/kubevirt/{{ item }}"
+  register: output_file
+  with_items:
+    - migration-resource.yaml
+    - replicase-resource.yaml
+    - vm-resource.yaml
+
+- command: "kubectl apply -f {{ item.dest | default(item.path) }}"
+  when: item | changed
+  with_items: "{{ output_file.results }}"
+
+- name: Template kubeVirt Deployments
+  template:
+    src: "{{ item }}.j2"
+    dest: "/tmp/kubevirt/{{ item }}"
+  register: output_file
+  with_items:
+    - virt-api.yaml
+    - virt-controller.yaml
+    - virt-handler.yaml
+    - virt-manifest.yaml
+
+- command: "kubectl apply -f {{ item.dest | default(item.path) }}"
+  ignore_errors: True
+  when: item | changed
+  with_items: "{{ output_file.results }}"
+
+- name: Expose KubeVirt Services
+  template:
+    src: "external-services.yaml.j2"
+    dest: "/tmp/kubevirt/external-{{ item.service_name }}.yaml"
+  register: output_file
+  vars:
+    service_name: "{{ item.service_name }}"
+    service_port: "{{ item.service_port }}"
+  with_items: "{{ kubevirt_services }}"
+  when: expose_externally
+
+- command: "kubectl apply -f {{ item.dest | default(item.path) }}"
+  ignore_errors: True
+  when: (item | changed) and expose_externally
+  with_items: "{{ output_file.results }}"
+
+- name: Clean up kubevirt files
+  file:
+    path: /tmp/kubevirt/
+    state: absent
+  when: cleanup_kubevirt_files
+

--- a/cluster/ansible/roles/kubevirt/templates/external-services.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/external-services.yaml.j2
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-{{ service_name }}
+  namespace: kube-system
+spec:
+  externalIPs:
+  - {{ master_ip }}
+  ports:
+  - port: {{ service_port }}
+    targetPort: {{ service_port }}
+  selector:
+    app: {{ service_name }}

--- a/cluster/ansible/roles/kubevirt/templates/haproxy.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/haproxy.yaml.j2
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: haproxy
+  namespace: kube-system
+spec:
+  ports:
+    - port: 8184
+      targetPort: haproxy
+  selector:
+    app: haproxy
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: haproxy
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: haproxy
+    spec:
+      serviceAccountName: kubevirt-infra
+      containers:
+      - name: haproxy
+        image: {{ docker_prefix }}/haproxy:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8184
+            name: "haproxy"
+            protocol: "TCP"
+        livenessProbe:
+          httpGet:
+            path: /apis/kubevirt.io/v1alpha1/healthz
+            port: 8184
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /apis/kubevirt.io/v1alpha1/healthz
+            port: 8184
+          initialDelaySeconds: 10
+          periodSeconds: 20
+      securityContext:
+        runAsNonRoot: true

--- a/cluster/ansible/roles/kubevirt/templates/iscsi-auth-demo-target.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/iscsi-auth-demo-target.yaml.j2
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iscsi-auth-demo-secret
+  namespace: kube-system
+type: "kubernetes.io/iscsi-chap"  
+data:
+  node.session.auth.username: ZGVtb3VzZXI=
+  node.session.auth.password: ZGVtb3Bhc3N3b3Jk
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: iscsi-auth-demo-target
+  namespace: kube-system
+spec:
+  ports:
+    - name: iscsi
+      port: 3260
+      targetPort: 3260
+  selector:
+    app: iscsi-auth-demo-target
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: iscsi-auth-demo-target-tgtd
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        name: iscsi-auth-demo-target-tgtd
+        app: iscsi-auth-demo-target
+      name: iscsi-auth-demo-target-tgtd
+    spec:
+      containers:
+        - name: target
+          image: {{ docker_prefix }}/iscsi-demo-target-tgtd:{{ docker_tag }}
+          ports:
+            - containerPort: 3260
+          volumeMounts:
+          - name: host
+            mountPath: /host
+          env:
+            - name: EXPORT_HOST_PATHS
+              value:
+            - name: PASSWORD
+              value: demopassword
+            - name: USERNAME
+              value: demouser
+      volumes:
+        - name: host
+          hostPath:
+            path: /

--- a/cluster/ansible/roles/kubevirt/templates/iscsi-demo-target.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/iscsi-demo-target.yaml.j2
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: disk-custom
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+  selector:
+    matchLabels:
+      os: "none"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: disk-alpine
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+  selector:
+    matchLabels:
+      os: "alpine"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: disk-cirros
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchLabels:
+      os: "cirros"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: iscsi-disk-custom
+  labels:
+    os: "none"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  iscsi:
+    iqn: iqn.2017-01.io.kubevirt:sn.42
+    lun: 1
+    targetPortal: iscsi-demo-target.kube-system.svc.cluster.local
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: iscsi-disk-alpine
+  labels:
+    os: "alpine"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  iscsi:
+    iqn: iqn.2017-01.io.kubevirt:sn.42
+    lun: 2
+    targetPortal: iscsi-demo-target.kube-system.svc.cluster.local
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: iscsi-disk-cirros
+  labels:
+    os: "cirros"
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  iscsi:
+    iqn: iqn.2017-01.io.kubevirt:sn.42
+    lun: 3
+    targetPortal: iscsi-demo-target.kube-system.svc.cluster.local
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: iscsi-demo-target
+  namespace: kube-system
+spec:
+  ports:
+    - name: iscsi
+      port: 3260
+      targetPort: 3260
+  selector:
+    app: iscsi-demo-target
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: iscsi-demo-target-tgtd
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        name: iscsi-demo-target-tgtd
+        app: iscsi-demo-target
+      name: iscsi-demo-target-tgtd
+    spec:
+      serviceAccountName: kubevirt-infra
+      containers:
+        - name: target
+          image: {{ docker_prefix }}/iscsi-demo-target-tgtd:{{ docker_tag }}
+          ports:
+            - containerPort: 3260
+          volumeMounts:
+          - name: host
+            mountPath: /host
+          env:
+            - name: EXPORT_HOST_PATHS
+              value:
+      volumes:
+        - name: host
+          hostPath:
+            path: /

--- a/cluster/ansible/roles/kubevirt/templates/libvirt.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/libvirt.yaml.j2
@@ -1,0 +1,78 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: libvirt
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      name: libvirt
+      labels:
+        daemon: libvirt
+    spec:
+      serviceAccountName: kubevirt-infra
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      securityContext:
+        runAsUser: 0
+      containers:
+      - name: libvirtd
+        ports:
+          - containerPort: 16509
+            hostPort: 16509
+        image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        env:
+        - name: LIBVIRTD_DEFAULT_NETWORK_DEVICE
+          value: {{ primary_nic }}
+        volumeMounts:
+          - mountPath: /host-dev
+            name: host-dev
+          - mountPath: /host-sys
+            name: host-sys
+          - name: libvirt-data
+            mountPath: /var/lib/libvirt
+          - name: libvirt-runtime
+            mountPath: /var/run/libvirt
+          - name: virt-share-dir
+            mountPath: /var/run/kubevirt
+        command: ["/libvirtd.sh"]
+      - name: virtlogd
+        image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - name: libvirt-runtime
+            mountPath: /var/run/libvirt
+        command: ["/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf"]
+      - name: virt-dhcp
+        image: {{ docker_prefix }}/virt-dhcp:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+          - name: libvirt-runtime
+            mountPath: /var/run/libvirt
+          - name: virt-share-dir
+            mountPath: /var/run/kubevirt
+        command: ["/virt-dhcp"]
+      volumes:
+      - name: libvirt-data
+        hostPath:
+          path: /var/lib/libvirt-container
+      - name: libvirt-runtime
+        hostPath:
+          path: /var/run/libvirt
+      - name: host-dev
+        hostPath:
+          path: /dev
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: virt-share-dir
+        hostPath:
+          path: /var/run/kubevirt

--- a/cluster/ansible/roles/kubevirt/templates/migration-resource.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/migration-resource.yaml.j2
@@ -1,0 +1,12 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: migrations.kubevirt.io
+spec:
+  scope: Namespaced
+  group: kubevirt.io
+  version: v1alpha1
+  names:
+    kind: Migration
+    plural: migrations
+    singular: migration

--- a/cluster/ansible/roles/kubevirt/templates/rbac.authorization.k8s.io.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/rbac.authorization.k8s.io.yaml.j2
@@ -1,0 +1,90 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt-infra
+  namespace: kube-system
+  labels:
+    name: kubevirt
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update  
+      - create  
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+      - persistentvolumeclaims  
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - migrations  
+      - virtualmachinereplicasets  
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update  
+      - create  
+      - deletecollection
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-infra
+  namespace: kube-system
+  labels:
+    name: kubevirt
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-admin
+  namespace: kube-system
+  labels:
+    name: kubevirt-admin
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-infra
+  namespace: kube-system
+  labels:
+    name: kubevirt
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-infra
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-infra
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-infra-cluster-admin
+  namespace: kube-system
+  labels:
+    name: kubevirt
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-infra
+    namespace: kube-system

--- a/cluster/ansible/roles/kubevirt/templates/replicase-resource.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/replicase-resource.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: virtualmachinereplicasets.kubevirt.io
+spec:
+  scope: Namespaced
+  group: kubevirt.io
+  version: v1alpha1
+  names:
+    kind: VirtualMachineReplicaSet
+    plural: virtualmachinereplicasets
+    singular: virtualmachinereplicaset
+    shortNames:
+    - vmrs
+    - vmrss

--- a/cluster/ansible/roles/kubevirt/templates/squid.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/squid.yaml.j2
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spice-proxy
+  namespace: kube-system
+spec:
+  ports:
+    - port: 3128
+      targetPort: spice-proxy
+  selector:
+    app: spice-proxy
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: spice-proxy
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: spice-proxy
+    spec:
+      containers:
+        - name: spice-proxy
+          image: {{ docker_prefix }}/spice-proxy:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3128
+              name: "spice-proxy"
+              protocol: "TCP"
+      securityContext:
+        runAsNonRoot: true

--- a/cluster/ansible/roles/kubevirt/templates/virt-api.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/virt-api.yaml.j2
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: virt-api
+  namespace: kube-system
+spec:
+  ports:
+    - port: 8183
+      targetPort: virt-api
+  selector:
+    app: virt-api
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: virt-api
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: virt-api
+    spec:
+      serviceAccountName: kubevirt-infra
+      containers:
+      - name: virt-api
+        image: {{ docker_prefix }}/virt-api:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        command:
+            - "/virt-api"
+            - "--port"
+            - "8183"
+            - "--spice-proxy"
+            - "{{ master_ip }}:3128"
+        ports:
+          - containerPort: 8183
+            name: "virt-api"
+            protocol: "TCP"
+      securityContext:
+        runAsNonRoot: true

--- a/cluster/ansible/roles/kubevirt/templates/virt-controller.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/virt-controller.yaml.j2
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: virt-controller
+  namespace: kube-system
+spec:
+  ports:
+    - port: 8182
+      targetPort: virt-controller
+  selector:
+    app: virt-controller
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: virt-controller
+  namespace: kube-system
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: virt-controller
+    spec:
+      serviceAccountName: kubevirt-infra
+      containers:
+      - name: virt-controller
+        image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        command:
+            - "/virt-controller"
+            - "--launcher-image"
+            - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
+            - "--migrator-image"
+            - "{{ docker_prefix }}/virt-migrator:{{ docker_tag }}"
+            - "--port"
+            - "8182"
+        ports:
+          - containerPort: 8182
+            name: "virt-controller"
+            protocol: "TCP"
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            port: 8182
+            path: /healthz
+          initialDelaySeconds: 15
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            port: 8182
+            path: /leader
+          initialDelaySeconds: 15
+          timeoutSeconds: 10
+      securityContext:
+        runAsNonRoot: true

--- a/cluster/ansible/roles/kubevirt/templates/virt-handler.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/virt-handler.yaml.j2
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: virt-handler
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      name: virt-handler
+      labels:
+        daemon: virt-handler
+    spec:
+      serviceAccountName: kubevirt-infra
+      hostPID: true
+      containers:
+      - name: virt-handler
+        ports:
+          - containerPort: 8185
+            hostPort: 8185
+        image: {{ docker_prefix }}/virt-handler:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        command:
+          - "/virt-handler"
+          - "-v"
+          - "3"
+          - "--libvirt-uri"
+          - "qemu+tcp://$(NODE_NAME)/system"
+          - "--hostname-override"
+          - "$(NODE_NAME)"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: libvirt-runtime
+          mountPath: /var/run/libvirt
+        - name: virt-share-dir
+          mountPath: /var/run/kubevirt
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+      volumes:
+      - name: libvirt-runtime
+        hostPath:
+          path: /var/run/libvirt
+      - name: virt-share-dir
+        hostPath:
+          path: /var/run/kubevirt

--- a/cluster/ansible/roles/kubevirt/templates/virt-manifest.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/virt-manifest.yaml.j2
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: virt-manifest
+  namespace: kube-system
+spec:
+  ports:
+    - port: 8186
+      targetPort: virt-manifest
+  selector:
+    app: virt-manifest
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: virt-manifest
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: virt-manifest
+    spec:
+      containers:
+      - name: virt-manifest
+        image: {{ docker_prefix }}/virt-manifest:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        ports:
+          - containerPort: 8186
+            name: "virt-manifest"
+            protocol: "TCP"
+        volumeMounts:
+          - name: libvirt-runtime
+            mountPath: /var/run/libvirt
+        command:
+          - "/virt-manifest"
+          - "--port"
+          - "8186"
+        livenessProbe:
+          httpGet:
+            path: /api/v1/status
+            port: 8186
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /api/v1/status
+            port: 8186
+          initialDelaySeconds: 10
+          periodSeconds: 3
+      - name: manifest-libvirtd
+        image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+          runAsUser: 0
+        env:
+        - name: LIBVIRTD_DEFAULT_NETWORK_DEVICE
+          value: {{ primary_nic }}
+        volumeMounts:
+          - name: libvirt-runtime
+            mountPath: /var/run/libvirt
+        command: ["/libvirtd-limited.sh"]
+      volumes:
+      - name: libvirt-runtime
+        emptyDir: {}

--- a/cluster/ansible/roles/kubevirt/templates/vm-resource.yaml.j2
+++ b/cluster/ansible/roles/kubevirt/templates/vm-resource.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: virtualmachines.kubevirt.io
+spec:
+  group: kubevirt.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: virtualmachines
+    singular: virtualmachine
+    kind: VirtualMachine
+    shortNames:
+    - vm
+    - vms

--- a/cluster/ansible/roles/kubevirt/vars/main.yml
+++ b/cluster/ansible/roles/kubevirt/vars/main.yml
@@ -1,0 +1,9 @@
+---
+
+kubevirt_services:
+  - { service_name: "spice-proxy", service_port: 3128 }
+  - { service_name: "virt-api", service_port: 8182 }
+  - { service_name: "haproxy", service_port: 8184 }
+  - { service_name: "virt-manifest", service_port: 8186 }
+
+


### PR DESCRIPTION
This PR adds the ability to deploy KubeVirt with Ansible instead of using minikube or vagrant.

Tested and Installed Kubernetes 1.8.4 with kubeadm on CentOS 7.4

```
> $ ansible-playbook -i inventory/hosts.ini playbooks/main.yml                                                                                                     [±ansible ●] 
                                                                                                                                                                                
PLAY [Deploy KubeVirt] *********************************************************************************************************************************************************

*** [OUTPUT REMOVED] ***

PLAY RECAP *********************************************************************************************************************************************************************
km1.virtomation.com        : ok=13   changed=12   unreachable=0    failed=0             

Saturday 25 November 2017  15:40:49 -0500 (0:00:00.336)       0:00:30.366 *****         
===============================================================================         
kubevirt : command ------------------------------------------------------------------------------------------------------------------------------------------------------ 3.88s 
kubevirt : command ------------------------------------------------------------------------------------------------------------------------------------------------------ 3.57s 
kubevirt : Expose KubeVirt Services ------------------------------------------------------------------------------------------------------------------------------------- 3.21s 
kubevirt : Template kubeVirt Deployments -------------------------------------------------------------------------------------------------------------------------------- 3.20s 
kubevirt : command ------------------------------------------------------------------------------------------------------------------------------------------------------ 2.80s 
kubevirt : command ------------------------------------------------------------------------------------------------------------------------------------------------------ 2.79s 
kubevirt : Template Custom Resource Defintions -------------------------------------------------------------------------------------------------------------------------- 2.55s 
kubevirt : Template KubeVirt Dependant Services ------------------------------------------------------------------------------------------------------------------------- 2.42s 
kubevirt : command ------------------------------------------------------------------------------------------------------------------------------------------------------ 2.34s 
Gathering Facts --------------------------------------------------------------------------------------------------------------------------------------------------------- 1.53s 
kubevirt : Template Authorization --------------------------------------------------------------------------------------------------------------------------------------- 1.19s 
kubevirt : Create temporary director for kubevirt files ----------------------------------------------------------------------------------------------------------------- 0.48s 
kubevirt : Clean up kubevirt files -------------------------------------------------------------------------------------------------------------------------------------- 0.34s 

```

**KubeVirt objects**

```
➜  ~ kubectl get pod -n kube-system
NAME                                          READY     STATUS    RESTARTS   AGE
etcd-km1.virtomation.com                      1/1       Running   1          2d
haproxy-58bc6b6d6b-hlq5q                      1/1       Running   5          2d
kube-apiserver-km1.virtomation.com            1/1       Running   1          2d
kube-controller-manager-km1.virtomation.com   1/1       Running   1          2d
kube-dns-545bc4bfd4-5zgwq                     3/3       Running   3          2d
kube-proxy-crkfj                              1/1       Running   1          2d
kube-proxy-pf6wl                              1/1       Running   1          2d
kube-proxy-txn6g                              1/1       Running   1          2d
kube-scheduler-km1.virtomation.com            1/1       Running   1          2d
kubernetes-dashboard-747c4f7cf-thbnz          1/1       Running   1          2d
libvirt-2wbfm                                 3/3       Running   3          2d
libvirt-mt76f                                 3/3       Running   3          2d
spice-proxy-55c7bf6794-t6gd5                  1/1       Running   0          2d
virt-api-76fbb94f49-t7x6n                     1/1       Running   0          2d
virt-controller-56bf959b77-9p74n              1/1       Running   2          2d
virt-controller-56bf959b77-rkz5l              0/1       Running   0          2d
virt-handler-6qqtl                            1/1       Running   0          2d
virt-handler-xzc5d                            1/1       Running   0          2d
virt-manifest-84c6cf6d77-ccwcj                2/2       Running   1          2d
weave-net-4h6nj                               2/2       Running   3          2d
weave-net-9ksw4                               2/2       Running   3          2d
weave-net-dqfbv                               2/2       Running   3          2d
➜  ~ kubectl get deployments -n kube-system
NAME                   DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
haproxy                1         1         1            1           2d
kube-dns               1         1         1            1           2d
kubernetes-dashboard   1         1         1            1           2d
spice-proxy            1         1         1            1           2d
virt-api               1         1         1            1           2d
virt-controller        2         2         2            1           2d
virt-manifest          1         1         1            1           2d
➜  ~ kubectl get svc -n kube-system
NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)         AGE
external-haproxy         ClusterIP   10.97.62.206     10.53.250.5   8184/TCP        1h
external-spice-proxy     ClusterIP   10.98.19.116     10.53.250.5   3128/TCP        1h
external-virt-api        ClusterIP   10.101.163.148   10.53.250.5   8182/TCP        1h
external-virt-manifest   ClusterIP   10.106.174.115   10.53.250.5   8186/TCP        1h
haproxy                  ClusterIP   10.102.40.225    <none>        8184/TCP        2d
kube-dns                 ClusterIP   10.96.0.10       <none>        53/UDP,53/TCP   2d
kubernetes-dashboard     ClusterIP   10.99.249.49     <none>        443/TCP         2d
spice-proxy              ClusterIP   10.103.51.229    <none>        3128/TCP        5h
virt-api                 ClusterIP   10.108.21.122    <none>        8183/TCP        2d
virt-controller          ClusterIP   10.106.61.110    <none>        8182/TCP        2d
virt-manifest            ClusterIP   10.103.254.98    <none>        8186/TCP        2d
```

**Using the testvm-ephemeral modified example (replaced devel tag with latest)**
```
➜  ~ kubectl get vm -n virtual
NAME               AGE
testvm-ephemeral   2d

➜  ~ kubectl get pod -n virtual
NAME                                       READY     STATUS      RESTARTS   AGE
virt-launcher-testvm-ephemeral-----pmkvj   1/2       Completed   0          2d
```

**Virtual machine console** 
```
➜  ~ ./virtctl-v0.0.4-linux-amd64 console -s http://10.53.250.5:8184 -n virtual testvm-ephemeral
Escape sequence is ^]
$ cat /proc/cpuinfo
processor       : 0
vendor_id       : AuthenticAMD
cpu family      : 6
model           : 6
model name      : QEMU Virtual CPU version 2.5+
stepping        : 3
cpu MHz         : 0.000
cache size      : 512 KB
fpu             : yes
fpu_exception   : yes
cpuid level     : 13
wp              : yes
flags           : fpu de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx lm up nopl pni cx16 hypervisor lahf_lm svm vmmcall
bogomips        : 244.73
TLB size        : 1024 4K pages
clflush size    : 64
cache_alignment : 64
address sizes   : 40 bits physical, 48 bits virtual
power management:

$ ping 8.8.8.8
PING 8.8.8.8 (8.8.8.8): 56 data bytes
64 bytes from 8.8.8.8: seq=0 ttl=57 time=48.003 ms

--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 48.003/48.003/48.003 ms
$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 16436 qdisc noqueue
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
    link/ether 52:54:00:20:94:12 brd ff:ff:ff:ff:ff:ff
    inet 10.53.250.161/24 brd 10.53.250.255 scope global eth0
    inet6 fe80::5054:ff:fe20:9412/64 scope link
       valid_lft forever preferred_lft forever
```