### PR TITLE
Fix yaml syntax in manifests

### DIFF
--- a/manifests/haproxy.yaml.in
+++ b/manifests/haproxy.yaml.in
@@ -23,24 +23,24 @@ spec:
     spec:
       serviceAccountName: kubevirt-infra
       containers:
-      - name: haproxy
-        image: {{ docker_prefix }}/haproxy:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        ports:
-          - containerPort: 8184
-            name: "haproxy"
-            protocol: "TCP"
-        livenessProbe:
-          httpGet:
-            path: /apis/kubevirt.io/v1alpha1/healthz
-            port: 8184
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /apis/kubevirt.io/v1alpha1/healthz
-            port: 8184
-          initialDelaySeconds: 10
-          periodSeconds: 20
+        - name: haproxy
+          image: {{ docker_prefix }}/haproxy:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8184
+              name: "haproxy"
+              protocol: "TCP"
+          livenessProbe:
+            httpGet:
+              path: /apis/kubevirt.io/v1alpha1/healthz
+              port: 8184
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /apis/kubevirt.io/v1alpha1/healthz
+              port: 8184
+            initialDelaySeconds: 10
+            periodSeconds: 20
       securityContext:
         runAsNonRoot: true

--- a/manifests/libvirt.yaml.in
+++ b/manifests/libvirt.yaml.in
@@ -17,62 +17,62 @@ spec:
       securityContext:
         runAsUser: 0
       containers:
-      - name: libvirtd
-        ports:
-          - containerPort: 16509
-            hostPort: 16509
-        image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        env:
-        - name: LIBVIRTD_DEFAULT_NETWORK_DEVICE
-          value: {{ primary_nic }}
-        volumeMounts:
-          - mountPath: /host-dev
-            name: host-dev
-          - mountPath: /host-sys
-            name: host-sys
-          - name: libvirt-data
-            mountPath: /var/lib/libvirt
-          - name: libvirt-runtime
-            mountPath: /var/run/libvirt
-          - name: virt-share-dir
-            mountPath: /var/run/kubevirt
-        command: ["/libvirtd.sh"]
-      - name: virtlogd
-        image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-          - name: libvirt-runtime
-            mountPath: /var/run/libvirt
-        command: ["/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf"]
-      - name: virt-dhcp
-        image: {{ docker_prefix }}/virt-dhcp:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        volumeMounts:
-          - name: libvirt-runtime
-            mountPath: /var/run/libvirt
-          - name: virt-share-dir
-            mountPath: /var/run/kubevirt
-        command: ["/virt-dhcp"]
+        - name: libvirtd
+          ports:
+            - containerPort: 16509
+              hostPort: 16509
+          image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: LIBVIRTD_DEFAULT_NETWORK_DEVICE
+              value: {{ primary_nic }}
+          volumeMounts:
+            - mountPath: /host-dev
+              name: host-dev
+            - mountPath: /host-sys
+              name: host-sys
+            - name: libvirt-data
+              mountPath: /var/lib/libvirt
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+            - name: virt-share-dir
+              mountPath: /var/run/kubevirt
+          command: ["/libvirtd.sh"]
+        - name: virtlogd
+          image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+          command: ["/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf"]
+        - name: virt-dhcp
+          image: {{ docker_prefix }}/virt-dhcp:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          volumeMounts:
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+            - name: virt-share-dir
+              mountPath: /var/run/kubevirt
+          command: ["/virt-dhcp"]
       volumes:
-      - name: libvirt-data
-        hostPath:
-          path: /var/lib/libvirt-container
-      - name: libvirt-runtime
-        hostPath:
-          path: /var/run/libvirt
-      - name: host-dev
-        hostPath:
-          path: /dev
-      - name: host-sys
-        hostPath:
-          path: /sys
-      - name: virt-share-dir
-        hostPath:
-          path: /var/run/kubevirt
+        - name: libvirt-data
+          hostPath:
+            path: /var/lib/libvirt-container
+        - name: libvirt-runtime
+          hostPath:
+            path: /var/run/libvirt
+        - name: host-dev
+          hostPath:
+            path: /dev
+        - name: host-sys
+          hostPath:
+            path: /sys
+        - name: virt-share-dir
+          hostPath:
+            path: /var/run/kubevirt

--- a/manifests/replicase-resource.yaml.in
+++ b/manifests/replicase-resource.yaml.in
@@ -11,5 +11,5 @@ spec:
     plural: virtualmachinereplicasets
     singular: virtualmachinereplicaset
     shortNames:
-    - vmrs
-    - vmrss
+      - vmrs
+      - vmrss

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -23,18 +23,18 @@ spec:
     spec:
       serviceAccountName: kubevirt-infra
       containers:
-      - name: virt-api
-        image: {{ docker_prefix }}/virt-api:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-            - "/virt-api"
-            - "--port"
-            - "8183"
-            - "--spice-proxy"
-            - "{{ master_ip }}:3128"
-        ports:
-          - containerPort: 8183
-            name: "virt-api"
-            protocol: "TCP"
+        - name: virt-api
+          image: {{ docker_prefix }}/virt-api:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+              - "/virt-api"
+              - "--port"
+              - "8183"
+              - "--spice-proxy"
+              - "{{ master_ip }}:3128"
+          ports:
+            - containerPort: 8183
+              name: "virt-api"
+              protocol: "TCP"
       securityContext:
         runAsNonRoot: true

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -24,33 +24,33 @@ spec:
     spec:
       serviceAccountName: kubevirt-infra
       containers:
-      - name: virt-controller
-        image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-            - "/virt-controller"
-            - "--launcher-image"
-            - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
-            - "--migrator-image"
-            - "{{ docker_prefix }}/virt-migrator:{{ docker_tag }}"
-            - "--port"
-            - "8182"
-        ports:
-          - containerPort: 8182
-            name: "virt-controller"
-            protocol: "TCP"
-        livenessProbe:
-          failureThreshold: 8
-          httpGet:
-            port: 8182
-            path: /healthz
-          initialDelaySeconds: 15
-          timeoutSeconds: 10
-        readinessProbe:
-          httpGet:
-            port: 8182
-            path: /leader
-          initialDelaySeconds: 15
-          timeoutSeconds: 10
-      securityContext:
-        runAsNonRoot: true
+        - name: virt-controller
+          image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+              - "/virt-controller"
+              - "--launcher-image"
+              - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
+              - "--migrator-image"
+              - "{{ docker_prefix }}/virt-migrator:{{ docker_tag }}"
+              - "--port"
+              - "8182"
+          ports:
+            - containerPort: 8182
+              name: "virt-controller"
+              protocol: "TCP"
+          livenessProbe:
+            failureThreshold: 8
+            httpGet:
+              port: 8182
+              path: /healthz
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              port: 8182
+              path: /leader
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
+        securityContext:
+          runAsNonRoot: true

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -52,5 +52,5 @@ spec:
               path: /leader
             initialDelaySeconds: 15
             timeoutSeconds: 10
-        securityContext:
-          runAsNonRoot: true
+          securityContext:
+            runAsNonRoot: true

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -13,36 +13,36 @@ spec:
       serviceAccountName: kubevirt-infra
       hostPID: true
       containers:
-      - name: virt-handler
-        ports:
-          - containerPort: 8185
-            hostPort: 8185
-        image: {{ docker_prefix }}/virt-handler:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        command:
-          - "/virt-handler"
-          - "-v"
-          - "3"
-          - "--libvirt-uri"
-          - "qemu:///system"
-          - "--hostname-override"
-          - "$(NODE_NAME)"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: libvirt-runtime
-          mountPath: /var/run/libvirt
-        - name: virt-share-dir
-          mountPath: /var/run/kubevirt
-        env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+        - name: virt-handler
+          ports:
+            - containerPort: 8185
+              hostPort: 8185
+          image: {{ docker_prefix }}/virt-handler:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/virt-handler"
+            - "-v"
+            - "3"
+            - "--libvirt-uri"
+            - "qemu:///system"
+            - "--hostname-override"
+            - "$(NODE_NAME)"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+            - name: virt-share-dir
+              mountPath: /var/run/kubevirt
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
       volumes:
-      - name: libvirt-runtime
-        hostPath:
-          path: /var/run/libvirt
-      - name: virt-share-dir
-        hostPath:
-          path: /var/run/kubevirt
+        - name: libvirt-runtime
+          hostPath:
+            path: /var/run/libvirt
+        - name: virt-share-dir
+          hostPath:
+            path: /var/run/kubevirt

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -22,45 +22,45 @@ spec:
         app: virt-manifest
     spec:
       containers:
-      - name: virt-manifest
-        image: {{ docker_prefix }}/virt-manifest:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        ports:
-          - containerPort: 8186
-            name: "virt-manifest"
-            protocol: "TCP"
-        volumeMounts:
-          - name: libvirt-runtime
-            mountPath: /var/run/libvirt
-        command:
-          - "/virt-manifest"
-          - "--port"
-          - "8186"
-        livenessProbe:
-          httpGet:
-            path: /api/v1/status
-            port: 8186
-          initialDelaySeconds: 10
-          periodSeconds: 3
-        readinessProbe:
-          httpGet:
-            path: /api/v1/status
-            port: 8186
-          initialDelaySeconds: 10
-          periodSeconds: 3
-      - name: manifest-libvirtd
-        image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: true
-          runAsUser: 0
-        env:
-        - name: LIBVIRTD_DEFAULT_NETWORK_DEVICE
-          value: {{ primary_nic }}
-        volumeMounts:
-          - name: libvirt-runtime
-            mountPath: /var/run/libvirt
-        command: ["/libvirtd-limited.sh"]
+        - name: virt-manifest
+          image: {{ docker_prefix }}/virt-manifest:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8186
+              name: "virt-manifest"
+              protocol: "TCP"
+          volumeMounts:
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+          command:
+            - "/virt-manifest"
+            - "--port"
+            - "8186"
+          livenessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: 8186
+            initialDelaySeconds: 10
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/status
+              port: 8186
+            initialDelaySeconds: 10
+            periodSeconds: 3
+        - name: manifest-libvirtd
+          image: {{ docker_prefix }}/libvirt-kubevirt:{{ docker_tag }}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+          - name: LIBVIRTD_DEFAULT_NETWORK_DEVICE
+            value: {{ primary_nic }}
+          volumeMounts:
+            - name: libvirt-runtime
+              mountPath: /var/run/libvirt
+          command: ["/libvirtd-limited.sh"]
       volumes:
-      - name: libvirt-runtime
-        emptyDir: {}
+        - name: libvirt-runtime
+          emptyDir: {}

--- a/manifests/vm-resource.yaml.in
+++ b/manifests/vm-resource.yaml.in
@@ -11,5 +11,5 @@ spec:
     singular: virtualmachine
     kind: VirtualMachine
     shortNames:
-    - vm
-    - vms
+      - vm
+      - vms


### PR DESCRIPTION
This is a maintenance fix that corrects the syntax of YAML files used in the manifests folder.

@rmohr @stu-gott please review and merge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/595)
<!-- Reviewable:end -->
