### PR TITLE
Add owner reference support to VirtualMachineReplicaSet

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -405,6 +405,14 @@
      "operationId": "deleteNamespacedMigration",
      "parameters": [
       {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.DeleteOptions"
+       }
+      },
+      {
        "pattern": "[a-z0-9][a-z0-9\\-]*",
        "type": "string",
        "description": "Object name and auth scope, such as for teams and projects",
@@ -724,6 +732,14 @@
      "operationId": "deleteNamespacedVirtualMachineReplicaSet",
      "parameters": [
       {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.DeleteOptions"
+       }
+      },
+      {
        "pattern": "[a-z0-9][a-z0-9\\-]*",
        "type": "string",
        "description": "Object name and auth scope, such as for teams and projects",
@@ -1042,6 +1058,14 @@
      "summary": "Delete a VirtualMachine object.",
      "operationId": "deleteNamespacedVirtualMachine",
      "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.DeleteOptions"
+       }
+      },
       {
        "pattern": "[a-z0-9][a-z0-9\\-]*",
        "type": "string",
@@ -1951,6 +1975,37 @@
      }
     }
    },
+   "v1.DeleteOptions": {
+    "description": "DeleteOptions may be provided when deleting an API object.",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+      "type": "string"
+     },
+     "gracePeriodSeconds": {
+      "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "orphanDependents": {
+      "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+      "type": "boolean"
+     },
+     "preconditions": {
+      "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+      "$ref": "#/definitions/v1.Preconditions"
+     },
+     "propagationPolicy": {
+      "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy.",
+      "$ref": "#/definitions/v1.DeletionPropagation"
+     }
+    }
+   },
+   "v1.DeletionPropagation": {},
    "v1.Devices": {
     "properties": {
      "channels": {
@@ -2741,6 +2796,15 @@
      "uid": {
       "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
       "type": "string"
+     }
+    }
+   },
+   "v1.Preconditions": {
+    "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+    "properties": {
+     "uid": {
+      "description": "Specifies the target UID.",
+      "$ref": "#/definitions/types.UID"
      }
     }
    },

--- a/cluster/replicaset.yaml
+++ b/cluster/replicaset.yaml
@@ -24,7 +24,7 @@ spec:
           video:
           - type: qxl
           disks:
-          - type: ContainerRegistryDisk:v1alpha
+          - type: RegistryDisk:v1alpha
             source:
               name: kubevirt/cirros-registry-disk-demo:devel
             target:

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -106,8 +106,8 @@ func init() {
 
 // VirtualMachine is *the* VM Definition. It represents a virtual machine in the runtime environment of kubernetes.
 type VirtualMachine struct {
-	metav1.TypeMeta `json:",inline"`
-	ObjectMeta      metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VM Spec contains the VM specification.
 	Spec VMSpec `json:"spec,omitempty" valid:"required"`
 	// Status is the high level overview of how the VM is doing. It contains information available to controllers and users.
@@ -696,8 +696,8 @@ func PrepareVMNodeAntiAffinitySelectorRequirement(vm *VirtualMachine) k8sv1.Node
 
 // VM is *the* VM Definition. It represents a virtual machine in the runtime environment of kubernetes.
 type VirtualMachineReplicaSet struct {
-	metav1.TypeMeta `json:",inline"`
-	ObjectMeta      metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// VM Spec contains the VM specification.
 	Spec VMReplicaSetSpec `json:"spec,omitempty" valid:"required"`
 	// Status is the high level overview of how the VM is doing. It contains information available to controllers and users.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -122,3 +122,12 @@ func VirtualMachineKeys(vms []*v1.VirtualMachine) []string {
 	}
 	return keys
 }
+
+func HasFinalizer(object metav1.Object, finalizer string) bool {
+	for _, f := range object.GetFinalizers() {
+		if f == finalizer {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -115,10 +115,10 @@ func VirtualMachineKey(vm *v1.VirtualMachine) string {
 	return fmt.Sprintf("%v/%v", vm.ObjectMeta.Namespace, vm.ObjectMeta.Name)
 }
 
-func VirtualMachineKeys(vms []v1.VirtualMachine) []string {
+func VirtualMachineKeys(vms []*v1.VirtualMachine) []string {
 	keys := []string{}
 	for _, vm := range vms {
-		keys = append(keys, VirtualMachineKey(&vm))
+		keys = append(keys, VirtualMachineKey(vm))
 	}
 	return keys
 }

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/log"
+)
+
+// GetControllerOf returns the controllerRef if controllee has a controller,
+// otherwise returns nil.
+func GetControllerOf(controllee metav1.Object) *metav1.OwnerReference {
+	ownerRefs := controllee.GetOwnerReferences()
+	for i := range ownerRefs {
+		owner := &ownerRefs[i]
+		if owner.Controller != nil && *owner.Controller == true {
+			return owner
+		}
+	}
+	return nil
+}
+
+type BaseControllerRefManager struct {
+	Controller metav1.Object
+	Selector   labels.Selector
+
+	canAdoptErr  error
+	canAdoptOnce sync.Once
+	CanAdoptFunc func() error
+}
+
+func (m *BaseControllerRefManager) CanAdopt() error {
+	m.canAdoptOnce.Do(func() {
+		if m.CanAdoptFunc != nil {
+			m.canAdoptErr = m.CanAdoptFunc()
+		}
+	})
+	return m.canAdoptErr
+}
+
+// ClaimObject tries to take ownership of an object for this controller.
+//
+// It will reconcile the following:
+//   * Adopt orphans if the match function returns true.
+//   * Release owned objects if the match function returns false.
+//
+// A non-nil error is returned if some form of reconciliation was attempted and
+// failed. Usually, controllers should try again later in case reconciliation
+// is still needed.
+//
+// If the error is nil, either the reconciliation succeeded, or no
+// reconciliation was necessary. The returned boolean indicates whether you now
+// own the object.
+//
+// No reconciliation will be attempted if the controller is being deleted.
+func (m *BaseControllerRefManager) ClaimObject(obj metav1.Object, match func(metav1.Object) bool, adopt, release func(metav1.Object) error) (bool, error) {
+	controllerRef := GetControllerOf(obj)
+	if controllerRef != nil {
+		if controllerRef.UID != m.Controller.GetUID() {
+			// Owned by someone else. Ignore.
+			return false, nil
+		}
+		if match(obj) {
+			// We already own it and the selector matches.
+			// Return true (successfully claimed) before checking deletion timestamp.
+			// We're still allowed to claim things we already own while being deleted
+			// because doing so requires taking no actions.
+			return true, nil
+		}
+		// Owned by us but selector doesn't match.
+		// Try to release, unless we're being deleted.
+		if m.Controller.GetDeletionTimestamp() != nil {
+			return false, nil
+		}
+		if err := release(obj); err != nil {
+			// If the object no longer exists, ignore the error.
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			// Either someone else released it, or there was a transient error.
+			// The controller should requeue and try again if it's still stale.
+			return false, err
+		}
+		// Successfully released.
+		return false, nil
+	}
+
+	// It's an orphan.
+	if m.Controller.GetDeletionTimestamp() != nil || !match(obj) {
+		// Ignore if we're being deleted or selector doesn't match.
+		return false, nil
+	}
+	if obj.GetDeletionTimestamp() != nil {
+		// Ignore if the object is being deleted
+		return false, nil
+	}
+	// Selector matches. Try to adopt.
+	if err := adopt(obj); err != nil {
+		// If the object no longer exists, ignore the error.
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		// Either someone else claimed it first, or there was a transient error.
+		// The controller should requeue and try again if it's still orphaned.
+		return false, err
+	}
+	// Successfully adopted.
+	return true, nil
+}
+
+type VirtualMachineControllerRefManager struct {
+	BaseControllerRefManager
+	controllerKind        schema.GroupVersionKind
+	virtualMachineControl VirtualMachineControlInterface
+}
+
+// NewVirtualMachineControllerRefManager returns a VirtualMachineControllerRefManager that exposes
+// methods to manage the controllerRef of virtual machines.
+//
+// The CanAdopt() function can be used to perform a potentially expensive check
+// (such as a live GET from the API server) prior to the first adoption.
+// It will only be called (at most once) if an adoption is actually attempted.
+// If CanAdopt() returns a non-nil error, all adoptions will fail.
+//
+// NOTE: Once CanAdopt() is called, it will not be called again by the same
+//       VirtualMachineControllerRefManager instance. Create a new instance if it makes
+//       sense to check CanAdopt() again (e.g. in a different sync pass).
+func NewVirtualMachineControllerRefManager(
+	virtualMachineControl VirtualMachineControlInterface,
+	controller metav1.Object,
+	selector labels.Selector,
+	controllerKind schema.GroupVersionKind,
+	canAdopt func() error,
+) *VirtualMachineControllerRefManager {
+	return &VirtualMachineControllerRefManager{
+		BaseControllerRefManager: BaseControllerRefManager{
+			Controller:   controller,
+			Selector:     selector,
+			CanAdoptFunc: canAdopt,
+		},
+		controllerKind:        controllerKind,
+		virtualMachineControl: virtualMachineControl,
+	}
+}
+
+// ClaimVirtualMachines tries to take ownership of a list of VirtualMachines.
+//
+// It will reconcile the following:
+//   * Adopt orphans if the selector matches.
+//   * Release owned objects if the selector no longer matches.
+//
+// Optional: If one or more filters are specified, a VirtualMachine will only be claimed if
+// all filters return true.
+//
+// A non-nil error is returned if some form of reconciliation was attempted and
+// failed. Usually, controllers should try again later in case reconciliation
+// is still needed.
+//
+// If the error is nil, either the reconciliation succeeded, or no
+// reconciliation was necessary. The list of VirtualMachines that you now own is returned.
+func (m *VirtualMachineControllerRefManager) ClaimVirtualMachines(vms []*virtv1.VirtualMachine, filters ...func(machine *virtv1.VirtualMachine) bool) ([]*virtv1.VirtualMachine, error) {
+	var claimed []*virtv1.VirtualMachine
+	var errlist []error
+
+	match := func(obj metav1.Object) bool {
+		vm := obj.(*virtv1.VirtualMachine)
+		// Check selector first so filters only run on potentially matching VirtualMachines.
+		if !m.Selector.Matches(labels.Set(vm.Labels)) {
+			return false
+		}
+		for _, filter := range filters {
+			if !filter(vm) {
+				return false
+			}
+		}
+		return true
+	}
+	adopt := func(obj metav1.Object) error {
+		return m.AdoptVirtualMachine(obj.(*virtv1.VirtualMachine))
+	}
+	release := func(obj metav1.Object) error {
+		return m.ReleaseVirtualMachine(obj.(*virtv1.VirtualMachine))
+	}
+
+	for _, vm := range vms {
+		ok, err := m.ClaimObject(vm, match, adopt, release)
+		if err != nil {
+			errlist = append(errlist, err)
+			continue
+		}
+		if ok {
+			claimed = append(claimed, vm)
+		}
+	}
+	return claimed, utilerrors.NewAggregate(errlist)
+}
+
+// AdoptVirtualMachine sends a patch to take control of the vm. It returns the error if
+// the patching fails.
+func (m *VirtualMachineControllerRefManager) AdoptVirtualMachine(vm *virtv1.VirtualMachine) error {
+	if err := m.CanAdopt(); err != nil {
+		return fmt.Errorf("can't adopt VirtualMachine %v/%v (%v): %v", vm.Namespace, vm.Name, vm.UID, err)
+	}
+	// Note that ValidateOwnerReferences() will reject this patch if another
+	// OwnerReference exists with controller=true.
+	addControllerPatch := fmt.Sprintf(
+		`{"metadata":{"ownerReferences":[{"apiVersion":"%s","kind":"%s","name":"%s","uid":"%s","controller":true,"blockOwnerDeletion":true}],"uid":"%s"}}`,
+		m.controllerKind.GroupVersion(), m.controllerKind.Kind,
+		m.Controller.GetName(), m.Controller.GetUID(), vm.UID)
+	return m.virtualMachineControl.PatchVirtualMachine(vm.Namespace, vm.Name, []byte(addControllerPatch))
+}
+
+// ReleaseVirtualMachine sends a patch to free the virtual machine from the control of the controller.
+// It returns the error if the patching fails. 404 and 422 errors are ignored.
+func (m *VirtualMachineControllerRefManager) ReleaseVirtualMachine(vm *virtv1.VirtualMachine) error {
+	log.Log.V(2).Object(vm).Infof("patching vm to remove its controllerRef to %s/%s:%s",
+		m.controllerKind.GroupVersion(), m.controllerKind.Kind, m.Controller.GetName())
+	// TODO CRDs don't support strategic merge, therefore replace the onwerReferences list with a merge patch
+	deleteOwnerRefPatch := fmt.Sprint(`{"metadata":{"ownerReferences":[]}}`)
+	err := m.virtualMachineControl.PatchVirtualMachine(vm.Namespace, vm.Name, []byte(deleteOwnerRefPatch))
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// If the vm no longer exists, ignore it.
+			return nil
+		}
+		if errors.IsInvalid(err) {
+			// Invalid error will be returned in two cases: 1. the vm
+			// has no owner reference, 2. the uid of the vm doesn't
+			// match, which means the vm is deleted and then recreated.
+			// In both cases, the error can be ignored.
+
+			// TODO: If the vm has owner references, but none of them
+			// has the owner.UID, server will silently ignore the patch.
+			// Investigate why.
+			return nil
+		}
+	}
+	return err
+}
+
+type VirtualMachineControlInterface interface {
+	PatchVirtualMachine(namespace, name string, data []byte) error
+}
+
+type RealVirtualMachineControl struct {
+	Clientset kubecli.KubevirtClient
+}
+
+func (r RealVirtualMachineControl) PatchVirtualMachine(namespace, name string, data []byte) error {
+	// TODO should be a strategic merge patch, but not possible until https://github.com/kubernetes/kubernetes/issues/56348 is resolved
+	_, err := r.Clientset.VM(namespace).Patch(name, types.MergePatchType, data)
+	return err
+}
+
+// RecheckDeletionTimestamp returns a CanAdopt() function to recheck deletion.
+//
+// The CanAdopt() function calls getObject() to fetch the latest value,
+// and denies adoption attempts if that object has a non-nil DeletionTimestamp.
+func RecheckDeletionTimestamp(getObject func() (metav1.Object, error)) func() error {
+	return func() error {
+		obj, err := getObject()
+		if err != nil {
+			return fmt.Errorf("can't recheck DeletionTimestamp: %v", err)
+		}
+		if obj.GetDeletionTimestamp() != nil {
+			return fmt.Errorf("%v/%v has just been deleted at %v", obj.GetNamespace(), obj.GetName(), obj.GetDeletionTimestamp())
+		}
+		return nil
+	}
+}

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -13,6 +13,9 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+Taken from https://github.com/kubernetes/kubernetes/blob/b28a83a4cf779189d72a87e847441888e7918e5d/pkg/controller/controller_ref_manager.go
+and adapted for KubeVirt.
 */
 
 package controller

--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Copyright 2017 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	"sync"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+var (
+	productionLabel         = map[string]string{"type": "production"}
+	testLabel               = map[string]string{"type": "testing"}
+	productionLabelSelector = labels.Set{"type": "production"}.AsSelector()
+	testLabelSelector       = labels.Set{"type": "testing"}.AsSelector()
+	controllerUID           = "123"
+)
+
+func newControllerRef(controller metav1.Object) *metav1.OwnerReference {
+	var controllerKind = v1beta1.SchemeGroupVersion.WithKind("Fake")
+	blockOwnerDeletion := true
+	isController := true
+	return &metav1.OwnerReference{
+		APIVersion:         controllerKind.GroupVersion().String(),
+		Kind:               controllerKind.Kind,
+		Name:               "Fake",
+		UID:                controller.GetUID(),
+		BlockOwnerDeletion: &blockOwnerDeletion,
+		Controller:         &isController,
+	}
+}
+
+func newVirtualMachine(virtualmachineName string, label map[string]string, owner metav1.Object) *virtv1.VirtualMachine {
+	vm := &virtv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      virtualmachineName,
+			Labels:    label,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: virtv1.VMSpec{},
+	}
+	if owner != nil {
+		vm.OwnerReferences = []metav1.OwnerReference{*newControllerRef(owner)}
+	}
+	return vm
+}
+
+func TestClaimPods(t *testing.T) {
+	controllerKind := schema.GroupVersionKind{}
+	type test struct {
+		name            string
+		manager         *VirtualMachineControllerRefManager
+		virtualmachines []*virtv1.VirtualMachine
+		filters         []func(*virtv1.VirtualMachine) bool
+		claimed         []*virtv1.VirtualMachine
+		released        []*virtv1.VirtualMachine
+		expectError     bool
+	}
+	var tests = []test{
+		{
+			name: "Claim virtualmachines with correct label",
+			manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+				&v1.ReplicationController{},
+				productionLabelSelector,
+				controllerKind,
+				func() error { return nil }),
+			virtualmachines: []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, nil), newVirtualMachine("virtualmachine2", testLabel, nil)},
+			claimed:         []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, nil)},
+		},
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			now := metav1.Now()
+			controller.DeletionTimestamp = &now
+			return test{
+				name: "Controller marked for deletion can not claim virtualmachines",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				virtualmachines: []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, nil), newVirtualMachine("virtualmachine2", productionLabel, nil)},
+				claimed:         nil,
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			now := metav1.Now()
+			controller.DeletionTimestamp = &now
+			return test{
+				name: "Controller marked for deletion can not claim new virtualmachines",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				virtualmachines: []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, &controller), newVirtualMachine("virtualmachine2", productionLabel, nil)},
+				claimed:         []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, &controller)},
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller2 := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			controller2.UID = types.UID("AAAAA")
+			return test{
+				name: "Controller can not claim virtualmachines owned by another controller",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				virtualmachines: []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, &controller), newVirtualMachine("virtualmachine2", productionLabel, &controller2)},
+				claimed:         []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, &controller)},
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			return test{
+				name: "Controller releases claimed virtualmachines when selector doesn't match",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				virtualmachines: []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, &controller), newVirtualMachine("virtualmachine2", testLabel, &controller)},
+				claimed:         []*virtv1.VirtualMachine{newVirtualMachine("virtualmachine1", productionLabel, &controller)},
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			virtualmachineToDelete1 := newVirtualMachine("virtualmachine1", productionLabel, &controller)
+			virtualmachineToDelete2 := newVirtualMachine("virtualmachine2", productionLabel, nil)
+			now := metav1.Now()
+			virtualmachineToDelete1.DeletionTimestamp = &now
+			virtualmachineToDelete2.DeletionTimestamp = &now
+
+			return test{
+				name: "Controller does not claim orphaned virtualmachines marked for deletion",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				virtualmachines: []*virtv1.VirtualMachine{virtualmachineToDelete1, virtualmachineToDelete2},
+				claimed:         []*virtv1.VirtualMachine{virtualmachineToDelete1},
+			}
+		}(),
+	}
+	for _, test := range tests {
+		claimed, err := test.manager.ClaimVirtualMachines(test.virtualmachines)
+		if test.expectError && err == nil {
+			t.Errorf("Test case `%s`, expected error but got nil", test.name)
+		} else if !reflect.DeepEqual(test.claimed, claimed) {
+			t.Errorf("Test case `%s`, claimed wrong virtualmachines. Expected %v, got %v", test.name, virtualmachineToStringSlice(test.claimed), virtualmachineToStringSlice(claimed))
+		}
+
+	}
+}
+
+func virtualmachineToStringSlice(virtualmachines []*virtv1.VirtualMachine) []string {
+	var names []string
+	for _, virtualmachine := range virtualmachines {
+		names = append(names, virtualmachine.Name)
+	}
+	return names
+}
+
+type FakeVirtualMachineControl struct {
+	sync.Mutex
+	ControllerRefs []metav1.OwnerReference
+	Patches        [][]byte
+	Err            error
+}
+
+var _ VirtualMachineControlInterface = &FakeVirtualMachineControl{}
+
+func (f *FakeVirtualMachineControl) PatchVirtualMachine(namespace, name string, data []byte) error {
+	f.Lock()
+	defer f.Unlock()
+	f.Patches = append(f.Patches, data)
+	if f.Err != nil {
+		return f.Err
+	}
+	return nil
+}

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -6,6 +6,7 @@ package kubecli
 import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
 	discovery "k8s.io/client-go/discovery"
 	v1alpha1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1"
 	v1beta1 "k8s.io/client-go/kubernetes/typed/apps/v1beta1"
@@ -570,6 +571,22 @@ func (_m *MockVMInterface) Delete(name string, options *v1.DeleteOptions) error 
 
 func (_mr *_MockVMInterfaceRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+}
+
+func (_m *MockVMInterface) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (*v18.VirtualMachine, error) {
+	_s := []interface{}{name, pt, data}
+	for _, _x := range subresources {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "Patch", _s...)
+	ret0, _ := ret[0].(*v18.VirtualMachine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVMInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
 // Mock of ReplicaSetInterface interface

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 
@@ -56,6 +58,7 @@ type VMInterface interface {
 	Create(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Update(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
+	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachine, err error)
 }
 
 type ReplicaSetInterface interface {

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 
@@ -98,4 +100,17 @@ func (v *vms) Delete(name string, options *k8smetav1.DeleteOptions) error {
 		Body(options).
 		Do().
 		Error()
+}
+
+func (v *vms) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachine, err error) {
+	result = &v1.VirtualMachine{}
+	err = v.restClient.Patch(pt).
+		Namespace(v.namespace).
+		Resource(v.resource).
+		SubResource(subresources...).
+		Name(name).
+		Body(data).
+		Do().
+		Into(result)
+	return
 }

--- a/pkg/rest/endpoints/builder.go
+++ b/pkg/rest/endpoints/builder.go
@@ -27,6 +27,8 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/rest"
 )
@@ -93,7 +95,7 @@ func (h *handlerBuilder) Get() HandlerBuilder {
 }
 
 func (h *handlerBuilder) Delete() HandlerBuilder {
-	h.decoder = NameNamespaceDecodeRequestFunc
+	h.decoder = NewJsonDeleteDecodeRequestFunc(&v1.DeleteOptions{})
 	h.encoder = NewMimeTypeAwareEncoder(NewEncodeJsonResponse(http.StatusOK),
 		map[string]kithttp.EncodeResponseFunc{
 			rest.MIME_JSON: NewEncodeJsonResponse(http.StatusOK),

--- a/pkg/rest/endpoints/delete_test.go
+++ b/pkg/rest/endpoints/delete_test.go
@@ -41,8 +41,8 @@ func newValidDeleteRequest() *http.Request {
 }
 
 func testDeleteEndpoint(_ context.Context, request interface{}) (interface{}, error) {
-	Expect(request.(*Metadata).Name).To(Equal("test"))
-	return payload{Name: request.(*Metadata).Name, Metadata: *request.(*Metadata)}, nil
+	Expect(request.(*PutObject).Metadata.Name).To(Equal("test"))
+	return payload{Name: request.(*PutObject).Metadata.Name, Metadata: request.(*PutObject).Metadata}, nil
 }
 
 var _ = Describe("Delete", func() {

--- a/pkg/virt-api/rest/kubeproxy.go
+++ b/pkg/virt-api/rest/kubeproxy.go
@@ -115,7 +115,7 @@ func GenericResourceProxy(ws *restful.WebService, ctx context.Context, gvr schem
 			Produces(mime.MIME_JSON, mime.MIME_YAML).
 			Consumes(mime.MIME_JSON, mime.MIME_YAML).
 			Operation("deleteNamespaced"+objKind).
-			To(endpoints.MakeGoRestfulWrapper(delete)).Writes(objExample).
+			To(endpoints.MakeGoRestfulWrapper(delete)).Reads(metav1.DeleteOptions{}).
 			Doc("Delete a "+objKind+" object.").
 			Returns(http.StatusOK, "Deleted", objExample).
 			Returns(http.StatusNotFound, "Not Found", nil), ws,
@@ -274,8 +274,12 @@ func fieldSelectorParam(ws *restful.WebService) *restful.Parameter {
 
 func NewGenericDeleteEndpoint(cli *rest.RESTClient, gvr schema.GroupVersionResource, response ResponseHandlerFunc) endpoint.Endpoint {
 	return func(ctx context.Context, payload interface{}) (interface{}, error) {
-		metadata := payload.(*endpoints.Metadata)
-		result := cli.Delete().Namespace(metadata.Namespace).Resource(gvr.Resource).Name(metadata.Name).Do()
+		p := payload.(*endpoints.PutObject)
+		del := p.Payload
+		if p.Payload == nil {
+			del = &metav1.DeleteOptions{}
+		}
+		result := cli.Delete().Namespace(p.Metadata.Namespace).Resource(gvr.Resource).Name(p.Metadata.Name).Body(del).Do()
 		return response(result)
 	}
 }

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -34,8 +34,9 @@ import (
 
 	k8score "k8s.io/api/core/v1"
 
-	"k8s.io/api/apps/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	"fmt"
+
+	"reflect"
 
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
@@ -109,7 +110,7 @@ func (c *VMReplicaSet) Run(threadiness int, stopCh chan struct{}) {
 	defer c.Queue.ShutDown()
 	log.Log.Info("Starting VirtualMachineReplicaSet controller.")
 
-	// Wait for cache sync before we start the pod controller
+	// Wait for cache sync before we start the controller
 	cache.WaitForCacheSync(stopCh, c.vmInformer.HasSynced, c.vmRSInformer.HasSynced)
 
 	// Start the actual work
@@ -184,16 +185,36 @@ func (c *VMReplicaSet) execute(key string) error {
 		return err
 	}
 
-	// make sure we only consider active VMs
 	vms = c.filterActiveVMs(vms)
 
-	// make sure the selector of the controller matches and the VMs match
-	vms = c.filterMatchingVMs(selector, vms)
+	// If any adoptions are attempted, we should first recheck for deletion with
+	// an uncached quorum read sometime after listing VirtualMachines (see kubernetes/kubernetes#42639).
+	canAdoptFunc := controller.RecheckDeletionTimestamp(func() (v1.Object, error) {
+		fresh, err := c.clientset.ReplicaSet(rs.ObjectMeta.Namespace).Get(rs.ObjectMeta.Name, v1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		if fresh.ObjectMeta.UID != rs.ObjectMeta.UID {
+			return nil, fmt.Errorf("original ReplicaSet %v/%v is gone: got uid %v, wanted %v", rs.Namespace, rs.Name, fresh.UID, rs.UID)
+		}
+		return fresh, nil
+	})
+	cm := controller.NewVirtualMachineControllerRefManager(controller.RealVirtualMachineControl{Clientset: c.clientset}, rs, selector, virtv1.VMReplicaSetGroupVersionKind, canAdoptFunc)
+	vms, err = cm.ClaimVirtualMachines(vms)
+	if err != nil {
+		return err
+	}
+
+	var scaleErr error
 
 	// Scale up or down, if all expected creates and deletes were report by the listener
-	var scaleErr error
-	if needsSync && !rs.Spec.Paused {
+	if needsSync && !rs.Spec.Paused && rs.ObjectMeta.DeletionTimestamp == nil {
 		scaleErr = c.scale(rs, vms)
+	}
+
+	// If the controller is going to be deleted and the orphan finalizer is the next one, release the VMs. Don't update the status
+	if rs.ObjectMeta.DeletionTimestamp != nil && len(rs.ObjectMeta.Finalizers) > 0 && rs.ObjectMeta.Finalizers[0] == v1.FinalizerOrphanDependents {
+		return c.orphan(cm, rs, vms)
 	}
 
 	if scaleErr != nil {
@@ -208,7 +229,33 @@ func (c *VMReplicaSet) execute(key string) error {
 	return err
 }
 
-func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine) error {
+// orphan removes the owner reference of all VMs which are owned by the controller instance.
+// Workaround for https://github.com/kubernetes/kubernetes/issues/56348 to make no-cascading deletes possible
+func (c *VMReplicaSet) orphan(cm *controller.VirtualMachineControllerRefManager, rs *virtv1.VirtualMachineReplicaSet, vms []*virtv1.VirtualMachine) error {
+
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(vms))
+	wg.Add(len(vms))
+
+	for _, vm := range vms {
+		go func(vm *virtv1.VirtualMachine) {
+			defer wg.Done()
+			err := cm.ReleaseVirtualMachine(vm)
+			if err != nil {
+				errChan <- err
+			}
+		}(vm)
+	}
+	wg.Wait()
+	select {
+	case err := <-errChan:
+		return err
+	default:
+	}
+	return nil
+}
+
+func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []*virtv1.VirtualMachine) error {
 
 	diff := c.calcDiff(rs, vms)
 	rsKey, err := controller.KeyFunc(rs)
@@ -238,8 +285,7 @@ func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.V
 		for i := 0; i < diff; i++ {
 			go func(idx int) {
 				defer wg.Done()
-				deleteCandidate := &vms[idx]
-				// TODO graceful delete
+				deleteCandidate := vms[idx]
 				err := c.clientset.VM(rs.ObjectMeta.Namespace).Delete(deleteCandidate.ObjectMeta.Name, &v1.DeleteOptions{})
 				// Don't log an error if it is already deleted
 				if err != nil {
@@ -267,6 +313,7 @@ func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.V
 				vm.Spec = rs.Spec.Template.Spec
 				// TODO check if vm labels exist, and when make sure that they match. For now just override them
 				vm.ObjectMeta.Labels = rs.Spec.Template.ObjectMeta.Labels
+				vm.ObjectMeta.OwnerReferences = []v1.OwnerReference{OwnerRef(rs)}
 				vm, err := c.clientset.VM(rs.ObjectMeta.Namespace).Create(vm)
 				if err != nil {
 					c.expectations.CreationObserved(rsKey)
@@ -290,33 +337,23 @@ func (c *VMReplicaSet) scale(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.V
 }
 
 // filterActiveVMs takes a list of VMs and returns all VMs which are not in a final state
-// Note that vms which have a deletion timestamp set, are still treated as active.
-// This is a difference to Pod ReplicaSets
-func (c *VMReplicaSet) filterActiveVMs(vms []virtv1.VirtualMachine) []virtv1.VirtualMachine {
+func (c *VMReplicaSet) filterActiveVMs(vms []*virtv1.VirtualMachine) []*virtv1.VirtualMachine {
 	return filter(vms, func(vm *virtv1.VirtualMachine) bool {
 		return !vm.IsFinal()
 	})
 }
 
 // filterReadyVMs takes a list of VMs and returns all VMs which are in ready state.
-func (c *VMReplicaSet) filterReadyVMs(vms []virtv1.VirtualMachine) []virtv1.VirtualMachine {
+func (c *VMReplicaSet) filterReadyVMs(vms []*virtv1.VirtualMachine) []*virtv1.VirtualMachine {
 	return filter(vms, func(vm *virtv1.VirtualMachine) bool {
 		return vm.IsReady()
 	})
 }
 
-// filterMatchingVMs takes a selector and a list of VMs. If the VM labels match the selector it is added to the filtered collection.
-// Returns the list of all VMs which match the selector
-func (c *VMReplicaSet) filterMatchingVMs(selector labels.Selector, vms []virtv1.VirtualMachine) []virtv1.VirtualMachine {
-	return filter(vms, func(vm *virtv1.VirtualMachine) bool {
-		return selector.Matches(labels.Set(vm.ObjectMeta.Labels))
-	})
-}
-
-func filter(vms []virtv1.VirtualMachine, f func(vm *virtv1.VirtualMachine) bool) []virtv1.VirtualMachine {
-	filtered := []virtv1.VirtualMachine{}
+func filter(vms []*virtv1.VirtualMachine, f func(vm *virtv1.VirtualMachine) bool) []*virtv1.VirtualMachine {
+	filtered := []*virtv1.VirtualMachine{}
 	for _, vm := range vms {
-		if f(&vm) {
+		if f(vm) {
 			filtered = append(filtered, vm)
 		}
 	}
@@ -324,39 +361,39 @@ func filter(vms []virtv1.VirtualMachine, f func(vm *virtv1.VirtualMachine) bool)
 }
 
 // listVMsFromNamespace takes a namespace and returns all VMs from the VM cache which run in this namespace
-func (c *VMReplicaSet) listVMsFromNamespace(namespace string) ([]virtv1.VirtualMachine, error) {
+func (c *VMReplicaSet) listVMsFromNamespace(namespace string) ([]*virtv1.VirtualMachine, error) {
 	objs, err := c.vmInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}
-	vms := []virtv1.VirtualMachine{}
+	vms := []*virtv1.VirtualMachine{}
 	for _, obj := range objs {
-		vms = append(vms, *obj.(*virtv1.VirtualMachine))
+		vms = append(vms, obj.(*virtv1.VirtualMachine))
 	}
 	return vms, nil
 }
 
 // listControllerFromNamespace takes a namespace and returns all VMReplicaSets from the ReplicaSet cache which run in this namespace
-func (c *VMReplicaSet) listControllerFromNamespace(namespace string) ([]virtv1.VirtualMachineReplicaSet, error) {
+func (c *VMReplicaSet) listControllerFromNamespace(namespace string) ([]*virtv1.VirtualMachineReplicaSet, error) {
 	objs, err := c.vmRSInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
 	if err != nil {
 		return nil, err
 	}
-	replicaSets := []virtv1.VirtualMachineReplicaSet{}
+	replicaSets := []*virtv1.VirtualMachineReplicaSet{}
 	for _, obj := range objs {
 		rs := obj.(*virtv1.VirtualMachineReplicaSet)
-		replicaSets = append(replicaSets, *rs)
+		replicaSets = append(replicaSets, rs)
 	}
 	return replicaSets, nil
 }
 
 // getMatchingController returns the first VMReplicaSet which matches the labels of the VM from the listener cache.
 // If there are no matching controllers, a NotFound error is returned.
-func (c *VMReplicaSet) getMatchingController(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachineReplicaSet, error) {
+func (c *VMReplicaSet) getMatchingControllers(vm *virtv1.VirtualMachine) (rss []*virtv1.VirtualMachineReplicaSet) {
 	logger := log.Log
 	controllers, err := c.listControllerFromNamespace(vm.ObjectMeta.Namespace)
 	if err != nil {
-		return nil, err
+		return nil
 	}
 
 	// TODO check owner reference, if we have an existing controller which owns this one
@@ -364,57 +401,160 @@ func (c *VMReplicaSet) getMatchingController(vm *virtv1.VirtualMachine) (*virtv1
 	for _, rs := range controllers {
 		selector, err := v1.LabelSelectorAsSelector(rs.Spec.Selector)
 		if err != nil {
-			logger.Object(&rs).Reason(err).Error("Failed to parse label selector from replicaset.")
+			logger.Object(rs).Reason(err).Error("Failed to parse label selector from replicaset.")
 			continue
 		}
 
 		if selector.Matches(labels.Set(vm.ObjectMeta.Labels)) {
-			// The first matching rs will be returned
-			return &rs, nil
+			rss = append(rss, rs)
 		}
 
 	}
-	return nil, errors.NewNotFound(v1beta1.Resource("virtualmachinereplicaset"), "")
+	return rss
 }
 
-// addVirtualMachine searches for a matching VMReplicaSet, updates it's expectations and wakes it up
+// When a vm is created, enqueue the replica set that manages it and update its expectations.
 func (c *VMReplicaSet) addVirtualMachine(obj interface{}) {
-
-	rsKey := c.getMatchingControllerKey(obj.(*virtv1.VirtualMachine))
-	if rsKey == "" {
-		return
-	}
-
-	// In case the controller is waiting for a creation, tell it that we observed one
-	c.expectations.CreationObserved(rsKey)
-	c.Queue.Add(rsKey)
-	return
-}
-
-// deleteVirtualMachine searches for a matching VMReplicaSet, updates it's expectations and wakes it up
-func (c *VMReplicaSet) deleteVirtualMachine(obj interface{}) {
 	vm := obj.(*virtv1.VirtualMachine)
 
-	rsKey := c.getMatchingControllerKey(vm)
-	if rsKey == "" {
+	if vm.DeletionTimestamp != nil {
+		// on a restart of the controller manager, it's possible a new vm shows up in a state that
+		// is already pending deletion. Prevent the vm from being a creation observation.
+		c.deleteVirtualMachine(vm)
 		return
 	}
 
-	// In case the controller is waiting for a deletion, tell it that we observed one
-	c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(vm))
-	c.Queue.Add(rsKey)
-	return
+	// If it has a ControllerRef, that's all that matters.
+	if controllerRef := controller.GetControllerOf(vm); controllerRef != nil {
+		rs := c.resolveControllerRef(vm.Namespace, controllerRef)
+		if rs == nil {
+			return
+		}
+		rsKey, err := controller.KeyFunc(rs)
+		if err != nil {
+			return
+		}
+		log.Log.V(4).Object(vm).Infof("VirtualMachine created")
+		c.expectations.CreationObserved(rsKey)
+		c.enqueueReplicaSet(rs)
+		return
+	}
+
+	// Otherwise, it's an orphan. Get a list of all matching ReplicaSets and sync
+	// them to see if anyone wants to adopt it.
+	// DO NOT observe creation because no controller should be waiting for an
+	// orphan.
+	rss := c.getMatchingControllers(vm)
+	if len(rss) == 0 {
+		return
+	}
+	log.Log.V(4).Object(vm).Infof("Orphan VirtualMachine created")
+	for _, rs := range rss {
+		c.enqueueReplicaSet(rs)
+	}
 }
 
-// deleteVirtualMachine searchs for a matching VMReplicaSet and wakes it up
-func (c *VMReplicaSet) updateVirtualMachine(old, curr interface{}) {
-	rsKey := c.getMatchingControllerKey(curr.(*virtv1.VirtualMachine))
-	if rsKey == "" {
+// When a vm is updated, figure out what replica set/s manage it and wake them
+// up. If the labels of the vm have changed we need to awaken both the old
+// and new replica set. old and cur must be *v1.VirtualMachine types.
+func (c *VMReplicaSet) updateVirtualMachine(old, cur interface{}) {
+	curVM := cur.(*virtv1.VirtualMachine)
+	oldVM := old.(*virtv1.VirtualMachine)
+	if curVM.ResourceVersion == oldVM.ResourceVersion {
+		// Periodic resync will send update events for all known vms.
+		// Two different versions of the same vm will always have different RVs.
 		return
 	}
 
-	c.Queue.Add(rsKey)
-	return
+	labelChanged := !reflect.DeepEqual(curVM.Labels, oldVM.Labels)
+	if curVM.DeletionTimestamp != nil {
+		// when a vm is deleted gracefully it's deletion timestamp is first modified to reflect a grace period,
+		// and after such time has passed, the virt-handler actually deletes it from the store. We receive an update
+		// for modification of the deletion timestamp and expect an rs to create more replicas asap, not wait
+		// until the virt-handler actually deletes the vm. This is different from the Phase of a vm changing, because
+		// an rs never initiates a phase change, and so is never asleep waiting for the same.
+		c.deleteVirtualMachine(curVM)
+		if labelChanged {
+			// we don't need to check the oldVM.DeletionTimestamp because DeletionTimestamp cannot be unset.
+			c.deleteVirtualMachine(oldVM)
+		}
+		return
+	}
+
+	curControllerRef := controller.GetControllerOf(curVM)
+	oldControllerRef := controller.GetControllerOf(oldVM)
+	controllerRefChanged := !reflect.DeepEqual(curControllerRef, oldControllerRef)
+	if controllerRefChanged && oldControllerRef != nil {
+		// The ControllerRef was changed. Sync the old controller, if any.
+		if rs := c.resolveControllerRef(oldVM.Namespace, oldControllerRef); rs != nil {
+			c.enqueueReplicaSet(rs)
+		}
+	}
+
+	// If it has a ControllerRef, that's all that matters.
+	if curControllerRef != nil {
+		rs := c.resolveControllerRef(curVM.Namespace, curControllerRef)
+		if rs == nil {
+			return
+		}
+		log.Log.V(4).Object(curVM).Infof("VirtualMachine updated")
+		c.enqueueReplicaSet(rs)
+		// TODO: MinReadySeconds in the VM will generate an Available condition to be added in
+		// Update once we support the available conect on the rs
+		return
+	}
+
+	// Otherwise, it's an orphan. If anything changed, sync matching controllers
+	// to see if anyone wants to adopt it now.
+	if labelChanged || controllerRefChanged {
+		rss := c.getMatchingControllers(curVM)
+		if len(rss) == 0 {
+			return
+		}
+		log.Log.V(4).Object(curVM).Infof("Orphan VirtualMachine updated")
+		for _, rs := range rss {
+			c.enqueueReplicaSet(rs)
+		}
+	}
+}
+
+// When a vm is deleted, enqueue the replica set that manages the vm and update its expectations.
+// obj could be an *v1.VirtualMachine, or a DeletionFinalStateUnknown marker item.
+func (c *VMReplicaSet) deleteVirtualMachine(obj interface{}) {
+	vm, ok := obj.(*virtv1.VirtualMachine)
+
+	// When a delete is dropped, the relist will notice a vm in the store not
+	// in the list, leading to the insertion of a tombstone object which contains
+	// the deleted key/value. Note that this value might be stale. If the vm
+	// changed labels the new ReplicaSet will not be woken up till the periodic resync.
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.Log.Reason(fmt.Errorf("couldn't get object from tombstone %+v", obj)).Error("Failed to process delete notification")
+			return
+		}
+		vm, ok = tombstone.Obj.(*virtv1.VirtualMachine)
+		if !ok {
+			log.Log.Reason(fmt.Errorf("tombstone contained object that is not a vm %#v", obj)).Error("Failed to process delete notification")
+			return
+		}
+	}
+
+	controllerRef := controller.GetControllerOf(vm)
+	if controllerRef == nil {
+		// No controller should care about orphans being deleted.
+		return
+	}
+	rs := c.resolveControllerRef(vm.Namespace, controllerRef)
+	if rs == nil {
+		return
+	}
+	rsKey, err := controller.KeyFunc(rs)
+	if err != nil {
+		return
+	}
+	c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(vm))
+	c.enqueueReplicaSet(rs)
 }
 
 func (c *VMReplicaSet) addReplicaSet(obj interface{}) {
@@ -437,34 +577,6 @@ func (c *VMReplicaSet) enqueueReplicaSet(obj interface{}) {
 		logger.Object(rs).Reason(err).Error("Failed to extract rsKey from replicaset.")
 	}
 	c.Queue.Add(key)
-}
-
-// getMatchingControllerKey takes a VirtualMachine and returns a the key of a macthing VMReplicaSet, if one exists.
-// Returns an empty string if no matching controller exists
-func (c *VMReplicaSet) getMatchingControllerKey(vm *virtv1.VirtualMachine) string {
-	logger := log.Log
-
-	// Let's search for a matching controller
-	rs, err := c.getMatchingController(vm)
-
-	// If none exists, ignore
-	if errors.IsNotFound(err) {
-		return ""
-	}
-
-	// If an unexpected error occurred, log it and ignore
-	if err != nil {
-		logger.Object(vm).Reason(err).Error("Searching for matching replicasets failed.")
-		return ""
-	}
-
-	// If we can't extract the key, log it and ignore
-	rsKey, err := controller.KeyFunc(rs)
-	if err != nil {
-		logger.Object(rs).Reason(err).Error("Failed to extract rsKey from replicaset.")
-		return ""
-	}
-	return rsKey
 }
 
 func abs(x int) int {
@@ -517,7 +629,7 @@ func (c *VMReplicaSet) removeCondition(rs *virtv1.VirtualMachineReplicaSet, cond
 	rs.Status.Conditions = conds
 }
 
-func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine, scaleErr error) error {
+func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []*virtv1.VirtualMachine, scaleErr error) error {
 
 	diff := c.calcDiff(rs, vms)
 
@@ -563,7 +675,7 @@ func (c *VMReplicaSet) updateStatus(rs *virtv1.VirtualMachineReplicaSet, vms []v
 	return nil
 }
 
-func (c *VMReplicaSet) calcDiff(rs *virtv1.VirtualMachineReplicaSet, vms []virtv1.VirtualMachine) int {
+func (c *VMReplicaSet) calcDiff(rs *virtv1.VirtualMachineReplicaSet, vms []*virtv1.VirtualMachine) int {
 	// TODO default this on the aggregated api server
 	wantedReplicas := int32(1)
 	if rs.Spec.Replicas != nil {
@@ -621,4 +733,42 @@ func (c *VMReplicaSet) checkFailure(rs *virtv1.VirtualMachineReplicaSet, diff in
 	} else if scaleErr == nil && c.hasCondition(rs, virtv1.VMReplicaSetReplicaFailure) {
 		c.removeCondition(rs, virtv1.VMReplicaSetReplicaFailure)
 	}
+}
+
+func OwnerRef(rs *virtv1.VirtualMachineReplicaSet) v1.OwnerReference {
+	t := true
+	gvk := virtv1.VMReplicaSetGroupVersionKind
+	return v1.OwnerReference{
+		APIVersion:         gvk.Version,
+		Kind:               gvk.Kind,
+		Name:               rs.ObjectMeta.Name,
+		UID:                rs.ObjectMeta.UID,
+		Controller:         &t,
+		BlockOwnerDeletion: &t,
+	}
+}
+
+// resolveControllerRef returns the controller referenced by a ControllerRef,
+// or nil if the ControllerRef could not be resolved to a matching controller
+// of the correct Kind.
+func (c *VMReplicaSet) resolveControllerRef(namespace string, controllerRef *v1.OwnerReference) *virtv1.VirtualMachineReplicaSet {
+	// We can't look up by UID, so look up by Name and then verify UID.
+	// Don't even try to look up by Name if it's the wrong Kind.
+	if controllerRef.Kind != virtv1.VMReplicaSetGroupVersionKind.Kind {
+		return nil
+	}
+	rs, exists, err := c.vmRSInformer.GetStore().GetByKey(namespace + "/" + controllerRef.Name)
+	if err != nil {
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+
+	if rs.(*virtv1.VirtualMachineReplicaSet).UID != controllerRef.UID {
+		// The controller we found with this Name is not the same one that the
+		// ControllerRef points to.
+		return nil
+	}
+	return rs.(*virtv1.VirtualMachineReplicaSet)
 }

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -213,6 +213,7 @@ func (c *VMReplicaSet) execute(key string) error {
 	}
 
 	// If the controller is going to be deleted and the orphan finalizer is the next one, release the VMs. Don't update the status
+	// TODO: Workaround for https://github.com/kubernetes/kubernetes/issues/56348, remove it once it is fixed
 	if rs.ObjectMeta.DeletionTimestamp != nil && controller.HasFinalizer(rs, v1.FinalizerOrphanDependents) {
 		return c.orphan(cm, rs, vms)
 	}

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -213,7 +213,7 @@ func (c *VMReplicaSet) execute(key string) error {
 	}
 
 	// If the controller is going to be deleted and the orphan finalizer is the next one, release the VMs. Don't update the status
-	if rs.ObjectMeta.DeletionTimestamp != nil && len(rs.ObjectMeta.Finalizers) > 0 && rs.ObjectMeta.Finalizers[0] == v1.FinalizerOrphanDependents {
+	if rs.ObjectMeta.DeletionTimestamp != nil && controller.HasFinalizer(rs, v1.FinalizerOrphanDependents) {
 		return c.orphan(cm, rs, vms)
 	}
 
@@ -231,6 +231,7 @@ func (c *VMReplicaSet) execute(key string) error {
 
 // orphan removes the owner reference of all VMs which are owned by the controller instance.
 // Workaround for https://github.com/kubernetes/kubernetes/issues/56348 to make no-cascading deletes possible
+// We don't have to remove the finalizer. This part of the gc is not affected by the mentioned bug
 func (c *VMReplicaSet) orphan(cm *controller.VirtualMachineControllerRefManager, rs *virtv1.VirtualMachineReplicaSet, vms []*virtv1.VirtualMachine) error {
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
This adds full support for all kinds of deletion strategies
(foregroud, background, orphan) and --cascade=true/false for kubectl.

Fixes #590.