### PR TITLE
[WIP] Add graceful-delete support to virt-handler [skip ci]

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -279,6 +279,15 @@ const (
 	VirtualMachineSynchronized VirtualMachineConditionType = "Synchronized"
 )
 
+// KubeVirt finalizers on vms
+const (
+	// Once a VirtualMachine is scheduled, virt-handler is responsible for cleaning
+	// the craces of the VirtualMachine on the node. After the vm go scheduled, the
+	// controller adds this finalizer. On graceful-delete, virt-handler will remove
+	// the vm on the node and then remove this finalizer.
+	FinalizerDeleteVirtualMachine = "deleteVirtualMachine"
+)
+
 type VMCondition struct {
 	Type               VirtualMachineConditionType `json:"type"`
 	Status             k8sv1.ConditionStatus       `json:"status"`

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -240,12 +240,13 @@ func (c *VMController) execute(key string) error {
 		// VM got scheduled
 		vmCopy.Status.Phase = kubev1.Scheduled
 
-		// FIXME we store this in the metadata since field selectors are currently not working for TPRs
+		// FIXME we store this in the metadata since field selectors are currently not working for CRDs
 		if vmCopy.GetObjectMeta().GetLabels() == nil {
 			vmCopy.ObjectMeta.Labels = map[string]string{}
 		}
 		vmCopy.ObjectMeta.Labels[kubev1.NodeNameLabel] = pods.Items[0].Spec.NodeName
 		vmCopy.Status.NodeName = pods.Items[0].Spec.NodeName
+		vmCopy.ObjectMeta.Finalizers = append(vmCopy.ObjectMeta.Finalizers, kubev1.FinalizerDeleteVirtualMachine)
 		if _, err := c.vmService.PutVm(&vmCopy); err != nil {
 			logger.Reason(err).Error("Updating the VM state to 'Scheduled' failed.")
 			return err

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -219,6 +219,7 @@ var _ = Describe("VM watcher", func() {
 			expectedVM.Status.Phase = v1.Scheduled
 			expectedVM.Status.NodeName = pod.Spec.NodeName
 			expectedVM.ObjectMeta.Labels = map[string]string{v1.NodeNameLabel: pod.Spec.NodeName}
+			expectedVM.ObjectMeta.Finalizers = []string{v1.FinalizerDeleteVirtualMachine}
 
 			// Register the expected REST call
 			server.AppendHandlers(


### PR DESCRIPTION
Start supporting graceful-delete and hand over the responsibility for
the deletion to virt-handler.


There is one issue remaining: to clean up between tests, we need to ensure that all VMs are deleted. If there is no controller present which can remove the finalizer, CRDs can't be deleted. One  option for clean-up, is first marking all VMs as deleted and then go over all VMs and remove the finalizer by hand.

Signed-off-by: Roman Mohr <rmohr@redhat.com>