### PR TITLE
makefile: use md5 for Darwin instead of md5sum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 export GO15VENDOREXPERIMENT := 1
 
-HASH := md5sum
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+    HASH := md5
+else
+    HASH := md5sum
+endif
 
 all: build manifests
 


### PR DESCRIPTION
Darwin uses `md5`, this allows running (at least) `make generate` on
Darwin based systems.

Signed-off-by: Martin Polednik <mpolednik@redhat.com>