### PR TITLE
Change manifests

### DIFF
--- a/manifests/libvirt.yaml.in
+++ b/manifests/libvirt.yaml.in
@@ -59,7 +59,6 @@ spec:
               mountPath: /var/run/libvirt
             - name: virt-share-dir
               mountPath: /var/run/kubevirt
-          command: ["/virt-dhcp"]
       volumes:
         - name: libvirt-data
           hostPath:

--- a/manifests/virt-api.yaml.in
+++ b/manifests/virt-api.yaml.in
@@ -26,8 +26,7 @@ spec:
         - name: virt-api
           image: {{ docker_prefix }}/virt-api:{{ docker_tag }}
           imagePullPolicy: IfNotPresent
-          command:
-              - "/virt-api"
+          args:
               - "--port"
               - "8183"
               - "--spice-proxy"

--- a/manifests/virt-controller.yaml.in
+++ b/manifests/virt-controller.yaml.in
@@ -27,8 +27,7 @@ spec:
         - name: virt-controller
           image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
           imagePullPolicy: IfNotPresent
-          command:
-              - "/virt-controller"
+          args:
               - "--launcher-image"
               - "{{ docker_prefix }}/virt-launcher:{{ docker_tag }}"
               - "--migrator-image"

--- a/manifests/virt-handler.yaml.in
+++ b/manifests/virt-handler.yaml.in
@@ -19,8 +19,7 @@ spec:
               hostPort: 8185
           image: {{ docker_prefix }}/virt-handler:{{ docker_tag }}
           imagePullPolicy: IfNotPresent
-          command:
-            - "/virt-handler"
+          args:
             - "-v"
             - "3"
             - "--libvirt-uri"

--- a/manifests/virt-manifest.yaml.in
+++ b/manifests/virt-manifest.yaml.in
@@ -32,8 +32,7 @@ spec:
           volumeMounts:
             - name: libvirt-runtime
               mountPath: /var/run/libvirt
-          command:
-            - "/virt-manifest"
+          args:
             - "--port"
             - "8186"
           livenessProbe:


### PR DESCRIPTION
**What this PR does / why we need it:**
Removes the use of *command* in the manifests in favor of *args* command.
This simplifies the building of the additional release processes.

For example, the development environment can have completely different dockerfiles, with application in the different folder, but ensure that the entrypoint is correct.
The manifest will than be still OK to use, as the entrypoint is correct and arguments can be passed correctly.

@rmohr @stu-gott @fabiand  Please review and merge.

Thank you

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/600)
<!-- Reviewable:end -->
