### PR TITLE
travis: Do pre-releases by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ deploy:
   - cmd/virtctl/virtctl-*
   - manifests/release/kubevirt.yaml
   - manifests/release/spice-proxy.yaml
+  prerelease: true
   on:
     tags: true
     repo: kubevirt/kubevirt


### PR DESCRIPTION
Switching it to a release is then done out-of-band (usually manually)

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>