### PR TITLE
Use UID instead of username for virt-api and virt-controller pods

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -21,9 +21,9 @@ FROM fedora:26
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 # Create non-root user
-RUN useradd --create-home -s /bin/bash virt-api
+RUN useradd -u 1001 --create-home -s /bin/bash virt-api
 WORKDIR /home/virt-api
-USER virt-api
+USER 1001
 
 # Configure swagger
 RUN curl -OL https://github.com/swagger-api/swagger-ui/tarball/38f74164a7062edb5dc80ef2fdddda24f3f6eb85/swagger-ui.tar.gz \

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -21,9 +21,9 @@ FROM fedora:26
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 # Create non-root user
-RUN useradd --create-home -s /bin/bash virt-controller
+RUN useradd -u 1001 --create-home -s /bin/bash virt-controller
 WORKDIR /home/virt-controller
-USER virt-controller
+USER 1001
 COPY virt-controller /virt-controller
 
 ENTRYPOINT [ "/virt-controller" ]


### PR DESCRIPTION
The fix is mentioned in the openshift guidelines:

    https://docs.openshift.org/latest/creating_images/guidelines.html

Without this the pods fail to start with the following error:

    Error: container has runAsNonRoot and image has non-numeric user (virt-api),
    cannot verify user is non-root

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>