### PR TITLE
Two stage dockerfiles

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -16,9 +16,31 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+# builder
+FROM pkotas/golang-centos:latest as builder
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+RUN yum -y update &&\
+    yum -y install \
+        gcc \
+        libvirt-client \
+        libvirt-dev 
+
+RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
+    mkdir -p /usr/src/build/pkg && \ 
+    mkdir -p /usr/src/build/bin
+
+ENV GOPATH=/usr/src/build
+
+WORKDIR /usr/src/build/src
+COPY vendor .
+COPY . kubevirt.io/kubevirt/
+
+WORKDIR kubevirt.io/kubevirt/cmd/virt-api
+RUN go build virt-api.go
+
+# production
+FROM centos:latest 
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
 RUN useradd -u 1001 --create-home -s /bin/bash virt-api
@@ -33,6 +55,7 @@ RUN curl -OL https://github.com/swagger-api/swagger-ui/tarball/38f74164a7062edb5
     && sed -e 's@"http://petstore.swagger.io/v2/swagger.json"@"/swaggerapi/"@' -i  third_party/swagger-ui/index.html \
     && rm swagger-ui.tar.gz && rm -rf swagger-ui
 
-COPY virt-api /virt-api
 
-ENTRYPOINT [ "/virt-api" ]
+COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-api/virt-api .
+
+ENTRYPOINT [ "./virt-api"]

--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -16,30 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-# builder
-FROM pkotas/golang-centos:latest as builder
-
-RUN yum -y update &&\
-    yum -y install \
-        gcc \
-        libvirt-client \
-        libvirt-devel
-
-RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
-    mkdir -p /usr/src/build/pkg && \ 
-    mkdir -p /usr/src/build/bin
-
-ENV GOPATH=/usr/src/build
-
-WORKDIR /usr/src/build/src
-COPY vendor .
-COPY . kubevirt.io/kubevirt/
-
-WORKDIR kubevirt.io/kubevirt/cmd/virt-api
-RUN go build virt-api.go
-
-# production
-FROM centos:latest 
+FROM centos:7 
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
@@ -57,6 +34,6 @@ RUN curl -OL https://github.com/swagger-api/swagger-ui/tarball/38f74164a7062edb5
     && rm swagger-ui.tar.gz && rm -rf swagger-ui
 
 
-COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-api/virt-api .
+COPY virt-api .
 
 ENTRYPOINT [ "./virt-api"]

--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -44,8 +44,9 @@ LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
 RUN useradd -u 1001 --create-home -s /bin/bash virt-api
-WORKDIR /home/virt-api
 USER 1001
+
+WORKDIR /usr/local/bin
 
 # Configure swagger
 RUN curl -OL https://github.com/swagger-api/swagger-ui/tarball/38f74164a7062edb5dc80ef2fdddda24f3f6eb85/swagger-ui.tar.gz \

--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -23,7 +23,7 @@ RUN yum -y update &&\
     yum -y install \
         gcc \
         libvirt-client \
-        libvirt-dev 
+        libvirt-devel
 
 RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
     mkdir -p /usr/src/build/pkg && \ 

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -16,30 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-# builder
-FROM pkotas/golang-centos:latest as builder
-
-RUN yum -y update &&\
-    yum -y install \
-        gcc \
-        libvirt-client \
-        libvirt-devel 
-
-RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
-    mkdir -p /usr/src/build/pkg && \ 
-    mkdir -p /usr/src/build/bin
-
-ENV GOPATH=/usr/src/build
-
-WORKDIR /usr/src/build/src
-COPY vendor .
-COPY . kubevirt.io/kubevirt/
-
-WORKDIR kubevirt.io/kubevirt/cmd/virt-controller
-RUN go build virt-controller.go
-
-# production
-FROM centos:latest 
+FROM centos:7 
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
@@ -48,6 +25,6 @@ USER 1001
 
 WORKDIR /usr/local/bin
 
-COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-controller/virt-controller .
+COPY virt-controller .
 
 ENTRYPOINT [ "./virt-controller"]

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -16,14 +16,38 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+# builder
+FROM pkotas/golang-centos:latest as builder
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+RUN yum -y update &&\
+    yum -y install \
+        gcc \
+        libvirt-client \
+        libvirt-dev 
+
+RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
+    mkdir -p /usr/src/build/pkg && \ 
+    mkdir -p /usr/src/build/bin
+
+ENV GOPATH=/usr/src/build
+
+WORKDIR /usr/src/build/src
+COPY vendor .
+COPY . kubevirt.io/kubevirt/
+
+WORKDIR kubevirt.io/kubevirt/cmd/virt-controller
+RUN go build virt-controller.go
+
+# production
+FROM centos:latest 
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
 RUN useradd -u 1001 --create-home -s /bin/bash virt-controller
-WORKDIR /home/virt-controller
 USER 1001
-COPY virt-controller /virt-controller
 
-ENTRYPOINT [ "/virt-controller" ]
+WORKDIR /usr/local/bin
+
+COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-controller/virt-controller .
+
+ENTRYPOINT [ "./virt-controller"]

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -23,7 +23,7 @@ RUN yum -y update &&\
     yum -y install \
         gcc \
         libvirt-client \
-        libvirt-dev 
+        libvirt-devel 
 
 RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
     mkdir -p /usr/src/build/pkg && \ 

--- a/cmd/virt-dhcp/Dockerfile
+++ b/cmd/virt-dhcp/Dockerfile
@@ -16,12 +16,36 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+# builder
+FROM pkotas/golang-centos:latest as builder
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+RUN yum -y update &&\
+    yum -y install \
+        gcc \
+        libvirt-client \
+        libvirt-dev 
 
-RUN dnf -y install dnsmasq
+RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
+    mkdir -p /usr/src/build/pkg && \ 
+    mkdir -p /usr/src/build/bin
 
-COPY virt-dhcp /virt-dhcp
+ENV GOPATH=/usr/src/build
 
-ENTRYPOINT [ "/virt-dhcp" ]
+WORKDIR /usr/src/build/src
+COPY vendor .
+COPY . kubevirt.io/kubevirt/
+
+WORKDIR kubevirt.io/kubevirt/cmd/virt-dhcp
+RUN go build virt-dhcp.go
+
+# production
+FROM centos:latest 
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
+
+RUN yum -y install dnsmasq
+
+WORKDIR /usr/local/bin
+
+COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-dhcp/virt-dhcp .
+
+ENTRYPOINT [ "./virt-dhcp" ]

--- a/cmd/virt-dhcp/Dockerfile
+++ b/cmd/virt-dhcp/Dockerfile
@@ -16,36 +16,13 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-# builder
-FROM pkotas/golang-centos:latest as builder
-
-RUN yum -y update &&\
-    yum -y install \
-        gcc \
-        libvirt-client \
-        libvirt-devel 
-
-RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
-    mkdir -p /usr/src/build/pkg && \ 
-    mkdir -p /usr/src/build/bin
-
-ENV GOPATH=/usr/src/build
-
-WORKDIR /usr/src/build/src
-COPY vendor .
-COPY . kubevirt.io/kubevirt/
-
-WORKDIR kubevirt.io/kubevirt/cmd/virt-dhcp
-RUN go build virt-dhcp.go
-
-# production
-FROM centos:latest 
+FROM centos:7 
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 RUN yum -y install dnsmasq
 
 WORKDIR /usr/local/bin
 
-COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-dhcp/virt-dhcp .
+COPY virt-dhcp .
 
 ENTRYPOINT [ "./virt-dhcp" ]

--- a/cmd/virt-dhcp/Dockerfile
+++ b/cmd/virt-dhcp/Dockerfile
@@ -23,7 +23,7 @@ RUN yum -y update &&\
     yum -y install \
         gcc \
         libvirt-client \
-        libvirt-dev 
+        libvirt-devel 
 
 RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
     mkdir -p /usr/src/build/pkg && \ 

--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -16,30 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-# builder
-FROM pkotas/golang-centos:latest as builder
-
-RUN yum -y update &&\
-    yum -y install \
-        gcc \
-        libvirt-client \
-        libvirt-devel 
-
-RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
-    mkdir -p /usr/src/build/pkg && \ 
-    mkdir -p /usr/src/build/bin
-
-ENV GOPATH=/usr/src/build
-
-WORKDIR /usr/src/build/src
-COPY vendor .
-COPY . kubevirt.io/kubevirt/
-
-WORKDIR kubevirt.io/kubevirt/cmd/virt-handler
-RUN go build virt-handler.go
-
-# production
-FROM centos:latest 
+FROM centos:7 
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 RUN yum -y install libvirt-client genisoimage && \
@@ -49,6 +26,6 @@ RUN yum -y install libvirt-client genisoimage && \
 
 WORKDIR /usr/local/bin
 
-COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-handler/virt-handler .
+COPY virt-handler .
 
 ENTRYPOINT [ "./virt-handler" ]

--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -16,15 +16,39 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+# builder
+FROM pkotas/golang-centos:latest as builder
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+RUN yum -y update &&\
+    yum -y install \
+        gcc \
+        libvirt-client \
+        libvirt-devel 
 
-RUN dnf -y install libvirt-client genisoimage && \
+RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
+    mkdir -p /usr/src/build/pkg && \ 
+    mkdir -p /usr/src/build/bin
+
+ENV GOPATH=/usr/src/build
+
+WORKDIR /usr/src/build/src
+COPY vendor .
+COPY . kubevirt.io/kubevirt/
+
+WORKDIR kubevirt.io/kubevirt/cmd/virt-handler
+RUN go build virt-handler.go
+
+# production
+FROM centos:latest 
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
+
+RUN yum -y install libvirt-client genisoimage && \
     groupadd --gid 107 qemu && \
     useradd --uid 107 --gid 107 qemu && \
-    dnf -y clean all
+    yum -y clean all
 
-COPY virt-handler /virt-handler
+WORKDIR /usr/local/bin
 
-ENTRYPOINT [ "/virt-handler" ]
+COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-handler/virt-handler .
+
+ENTRYPOINT [ "./virt-handler" ]

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -16,10 +16,34 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+# builder
+FROM pkotas/golang-centos:latest as builder
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+RUN yum -y update &&\
+    yum -y install \
+        gcc \
+        libvirt-client \
+        libvirt-devel 
 
-COPY virt-launcher /virt-launcher
+RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
+    mkdir -p /usr/src/build/pkg && \ 
+    mkdir -p /usr/src/build/bin
 
-ENTRYPOINT [ "/virt-launcher" ]
+ENV GOPATH=/usr/src/build
+
+WORKDIR /usr/src/build/src
+COPY vendor .
+COPY . kubevirt.io/kubevirt/
+
+WORKDIR kubevirt.io/kubevirt/cmd/virt-launcher
+RUN go build virt-launcher.go
+
+# production
+FROM centos:latest 
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
+
+WORKDIR /usr/local/bin
+
+COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-launcher/virt-launcher .
+
+ENTRYPOINT [ "./virt-launcher" ]

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -16,34 +16,11 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-# builder
-FROM pkotas/golang-centos:latest as builder
-
-RUN yum -y update &&\
-    yum -y install \
-        gcc \
-        libvirt-client \
-        libvirt-devel 
-
-RUN mkdir -p /usr/src/build/src/kubevirt.io/kubevirt && \
-    mkdir -p /usr/src/build/pkg && \ 
-    mkdir -p /usr/src/build/bin
-
-ENV GOPATH=/usr/src/build
-
-WORKDIR /usr/src/build/src
-COPY vendor .
-COPY . kubevirt.io/kubevirt/
-
-WORKDIR kubevirt.io/kubevirt/cmd/virt-launcher
-RUN go build virt-launcher.go
-
-# production
-FROM centos:latest 
+FROM centos:7 
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 WORKDIR /usr/local/bin
 
-COPY --from=builder /usr/src/build/src/kubevirt.io/kubevirt/cmd/virt-launcher/virt-launcher .
+COPY virt-launcher .
 
 ENTRYPOINT [ "./virt-launcher" ]

--- a/cmd/virt-migrator/Dockerfile
+++ b/cmd/virt-migrator/Dockerfile
@@ -16,13 +16,15 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM centos:7
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
-RUN dnf -y install libvirt-client xmlstarlet \
-    && dnf -y clean all
+RUN yum -y install libvirt-client xmlstarlet \
+    && yum -y clean all
 
-COPY migrate /migrate
+WORKDIR /usr/local/bin
 
-ENTRYPOINT [ "/migrate" ]
+COPY cmd/virt-migrator/migrate .
+
+ENTRYPOINT [ "./migrate" ]


### PR DESCRIPTION
This PR introduces the two-stage builds of docker images. 
With this approach, we eliminate the need for having the same exact environment on the physical machine and in the container.
Furthermore, the base image is changed from Fedora to centos. The centos is a stable distribution and is far less broken than upstream fedora. Therefore this change, which allows us to smoother dev/release cycle.

@rmohr @davidvossel Would you mind looking at it? Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/609)
<!-- Reviewable:end -->
