### PR TITLE
use fedora 25 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,8 @@ $master_ip = $config["master_ip"]
 $network_provider = $config["network_provider"]
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "centos7"
-  config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1608_01.LibVirt.box"
+  config.vm.box = "fedora25"
+  config.vm.box_url = "https://mirrors.lug.mtu.edu/fedora/linux/releases/25/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-25-1.3.x86_64.vagrant-libvirt.box"
 
   if Vagrant.has_plugin?("vagrant-cachier") and $cache_rpm then
       config.cache.scope = :machine


### PR DESCRIPTION
To use gluster-block for iSCSI storage, we need gluster-block, which depends on tcmu-runner that needs target_core_user kernel module available on fedora 25 and forward