### PR TITLE
[POC] POC to demonstrate subresources via aggregation [skip ci]

### DIFF
--- a/manifests/dev/virt-api.yaml.in
+++ b/manifests/dev/virt-api.yaml.in
@@ -9,8 +9,28 @@ spec:
   ports:
     - port: 8183
       targetPort: virt-api
+      name: default
+    - port: 443
+      targetPort: 8443
+      name: tls
   selector:
     kubevirt.io: virt-api
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.subresources.kubevirt.io
+  labels:
+    kubevirt.io: "virt-api-aggregator"
+spec:
+  insecureSkipTLSVerify: true
+  group: subresources.kubevirt.io
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: virt-api
+    namespace: kube-system
+  version: v1alpha1
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
@davidvossel hacked in the subresources aggregation for virt-api. I wanted to check it as an alternative to #618. This way, we get spice and console the "subresources.kubevirt.io" api group.

This works for me:
```
curl -H "Authorization: Bearer $TOKEN" https://192.168.121.216:6443/apis/subresources.kubevirt.io/v1alpha1/namespaces/default/virtualmachines/testvm/spice -k
```
I did not remove haproxy here and did not prepare the right rest client for the tests, but it is not needed anymore and it would also give me /reset and /restart subresources. Also note that the whole virt-api implementation, except the subresources can be removed. When creating a sign reuest with a bootstrap token, k8s would also provide a signed ceritificate which virt-api could use in the future (the whole code is in client-go, only fetching and storing in secrets needs to be implemented by us).

@davidvossel what do you think?

Signed-off-by: Roman Mohr <rmohr@redhat.com>