### PR TITLE
images: SHM is not available on all OSses

### DIFF
--- a/images/libvirt-kubevirt/libvirtd.sh
+++ b/images/libvirt-kubevirt/libvirtd.sh
@@ -27,7 +27,7 @@ mkdir /dev.container && {
 
   # Keep some devices from the containerinal /dev
   keep() { mount --rbind /dev.container/$1 /dev/$1 ; }
-  keep shm
+  keep shm || :
   keep mqueue
   # Keep ptmx/pts for pty creation
   keep pts


### PR DESCRIPTION
Thus ignore if the bind mount fails:

```
+ mount --rbind /dev.container/shm /dev/shm
mount: mount point /dev/shm is a symbolic link to nowhere
```

See https://travis-ci.org/kubevirt/demo/builds/319223542

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>