### PR TITLE
The libvirt image does not need docker anymore

### DIFF
--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -26,8 +26,7 @@ RUN dnf install -y \
   util-linux \
   libcgroup-tools \
   ethtool \
-  sudo \
-  docker && dnf -y clean all && \
+  sudo && dnf -y clean all && \
   test $(id -u qemu) = 107 # make sure that the qemu user really is 107
 
 COPY qemu-kube /usr/local/bin/qemu-system-x86_64

--- a/images/libvirt-kubevirt/qemu-kube
+++ b/images/libvirt-kubevirt/qemu-kube
@@ -1,5 +1,4 @@
 #!/bin/sh
-alias docker="sudo /usr/bin/docker"
 alias log='echo "[$(date)] "'
 
 ARGS="$@"


### PR DESCRIPTION
Don't install docker in the libvirt container. It is not needed anymore.

Signed-off-by: Roman Mohr <rmohr@redhat.com>