### PR TITLE
Fix hanging console sessions

### DIFF
--- a/cmd/virt-launcher/sock-connector
+++ b/cmd/virt-launcher/sock-connector
@@ -1,4 +1,28 @@
 #!/bin/bash
-stty -echo
+
 SOCKET=$1
+function serial_cleanup() {
+	local pid_file=${SOCKET}.pid
+	local file_name=$(basename $SOCKET)
+
+	# if this is a serial connection, see if there is a previous
+	# connection that must be cleaned up before starting a new one.
+	if [[ $file_name =~ .*serial.* ]]; then
+		local pid=$(cat ${SOCKET}.pid 2>/dev/null)
+		local my_pid=$$
+		if [ -n "$pid" ] && [ -f "/proc/$pid/cmdline" ]; then
+			local cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr -d '\0')
+			local my_cmdline=$(cat /proc/$my_pid/cmdline 2>/dev/null | tr -d '\0')
+			if [ "$cmdline" = "$my_cmdline" ]; then
+				kill $pid > /dev/null 2>&1
+			fi
+		fi
+		echo "$$" > $pid_file
+	fi
+}
+
+# only one serial connection can exist at a time.
+serial_cleanup
+
+stty -echo
 socat unix-connect:/$SOCKET stdio,cfmakeraw

--- a/cmd/virt-launcher/sock-connector
+++ b/cmd/virt-launcher/sock-connector
@@ -8,7 +8,7 @@ function serial_cleanup() {
 	# if this is a serial connection, see if there is a previous
 	# connection that must be cleaned up before starting a new one.
 	if [[ $file_name =~ .*serial.* ]]; then
-		local pid=$(cat ${SOCKET}.pid 2>/dev/null)
+		local pid=$(cat $pid_file 2>/dev/null)
 		local my_pid=$$
 		if [ -n "$pid" ] && [ -f "/proc/$pid/cmdline" ]; then
 			local cmdline=$(cat /proc/$pid/cmdline 2>/dev/null | tr -d '\0')

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Console", func() {
 			}, 60*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		FIt("should be able to reconnect to console multiple times", func() {
+		It("should be able to reconnect to console multiple times", func() {
 			vm := tests.NewRandomVMWithPVC("disk-alpine")
 
 			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
@@ -72,9 +72,9 @@ var _ = Describe("Console", func() {
 				_, err = expecter.ExpectBatch([]expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: "login"},
-				}, 60*time.Second)
+				}, 100*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			}
-		})
+		}, 140)
 	})
 })

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -58,5 +58,23 @@ var _ = Describe("Console", func() {
 			}, 60*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		FIt("should be able to reconnect to console multiple times", func() {
+			vm := tests.NewRandomVMWithPVC("disk-alpine")
+
+			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
+			tests.WaitForSuccessfulVMStart(vm)
+
+			for i := 0; i < 5; i++ {
+				expecter, _, err := tests.NewConsoleExpecter(virtClient, vm, "serial0", 10*time.Second)
+				defer expecter.Close()
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: "login"},
+				}, 60*time.Second)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
 	})
 })


### PR DESCRIPTION
Only one console connection works at a time per a serial port. This patch cleans up a previous serial console connection before starting a new one. 