### PR TITLE
Dockerized build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ cluster/local/certs
 **.pem
 **.crt
 **.csr
+_out

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,43 +11,28 @@ go:
 - 1.8
 - 1.9
 
-before_install:
-- sudo add-apt-repository ppa:jacob/virtualisation -y
-- sudo apt-get update -q
+env:
+- BUILDER_NAME="kubevirt/${TRAVIS_JOB_ID}builder"
 
 install:
- - git reset --hard # we are caching the vendor folder, make sure we see the new vendor.json file
- - go get github.com/mattn/goveralls
- - go get -u github.com/Masterminds/glide
- - go get golang.org/x/tools/cmd/goimports
- - go get -u mvdan.cc/sh/cmd/shfmt
- - go get -u github.com/golang/mock/gomock
- - go get -u github.com/rmohr/mock/mockgen
- - go get -u github.com/rmohr/go-swagger-utils/swagger-doc
- - go get -u github.com/onsi/ginkgo/ginkgo
- - go get -u k8s.io/code-generator/cmd/deepcopy-gen
- - go get -u k8s.io/code-generator/cmd/defaulter-gen
- - sudo apt-get install libvirt-dev make
- - make sync
+ - git reset --hard
+ - ./hack/dockerized make sync
 
 script:
-- make fmt fmt-bash
+- ./hack/dockerized make fmt fmt-bash
 - if git diff --name-only | grep '.*.go'; then echo "It seems like you did not run
   `make fmt fmt-bash`. Please run it and commit the changes"; false; fi
-- make generate
-- make fmt
+- ./hack/dockerized make generate fmt
 - if git diff --name-only | grep 'generated.*.go'; then echo "Content of generated
   files changed. Please regenerate and commit them."; false; fi
 - if git diff --name-only | grep 'swagger.json' ; then echo "Content of generated
   files changed. Please regenerate and commit them." ; false ; fi
 - if diff <(git grep -c '') <(git grep -cI '') | egrep -v 'docs/.*\.png|swagger-ui'
   | grep '^<'; then echo "Binary files are present in git repostory."; false; fi
-- make check
-- make build
-- if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" ]]; then $HOME/gopath/bin/goveralls
-  -service=travis-ci -package=./pkg/... -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go" -printf
-  "%P\n" | paste -d, -s) ; else make test; fi
-- make apidocs
+- ./hack/dockerized make check
+- ./hack/dockerized make build
+- if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" ]]; then ./hack/dockerized make goveralls TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH}; else ./hack/dockerized make test; fi
+- ./hack/dockerized make apidocs
 - make manifests DOCKER_TAG=$TRAVIS_TAG # falls back to latest if not on a tag
 
 cache:
@@ -74,9 +59,8 @@ deploy:
     secure: dy3AlSki7p9sRjItOiWoPv4s28+hZ9wMcuvtZv0bWHbEZ7y/EvzXcwWmn+/Tjjk4Np59LImUjJw1E5Yv2Q16ViuNwKbX7TA7fu+wAcTz4DF4wFLIrJBcCRetiud4175aJ1ylOvmtHOuWHfo6Wx5HRxRT0fLcMFdSoagpe4Dh7BJYfI4Sgu/jghMMJ4wcDsMLZqi6RRM6jywFXQXMmBY87E57/ZLlXZ5Nud5RoWXJxfFfc/vTn/frCBu7r+JW8ayGeGVPEkEMtWX1huWnIvVjNu1twuZnL3zWmLNmpFXfk3j/gLbdIwLn3jgtariNz/Rvigqaj18F0Fa/QNL6VcruqgXd6ryWxmGm9sD6MYC3kk0HoqwSI7WBf88tlfz27FR+cHFZtjTBXnZHBtM5skuzUpT4kUKhLkwcfgA5PmoW/7NcmnN0eKvOQuQYq/8pREwdmYAvYsGPWJZjNYHBCv9KRT1lDRN5jRLMi5wn7NWFMR1p+mbdHyd7i43zM8gnumqvGF/chZ9PEH38hnm835RZAwnzdJ3EQ4YFAaOE2AaUBe9Yw1FP6f22MOC8+N9CY+a1AlGQBmovPjaf+x4f+Jx6y9jjxahJpoXxEKgeFvfSVUoKbkMPMOHxMAb0UL9Rqq3BhlLnPQIjcwdCZU/+wTcV/sFHdcnIqdl9/wb/L+mMjOs=
   file_glob: true
   file:
-  - cmd/virtctl/virtctl-*
+  - _out/cmd/virtctl/virtctl-*
   - manifests/release/kubevirt.yaml
-  - manifests/release/spice-proxy.yaml
   prerelease: true
   on:
     tags: true

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -73,6 +73,7 @@ set -e
 # Build kubevirt
 go get golang.org/x/tools/cmd/goimports
 go get -u github.com/Masterminds/glide
+go get -u github.com/onsi/ginkgo/ginkgo
 make
 
 # Make sure we can connect to kubernetes

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 

--- a/cmd/virt-dhcp/Dockerfile
+++ b/cmd/virt-dhcp/Dockerfile
@@ -17,7 +17,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 

--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -16,11 +16,13 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
-RUN dnf -y install libvirt-client genisoimage && \
+ENV LIBVIRT_VERSION 3.7.0
+
+RUN dnf -y install libvirt-client-${LIBVIRT_VERSION} genisoimage && \
     groupadd --gid 107 qemu && \
     useradd --uid 107 --gid 107 qemu && \
     dnf -y clean all

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 

--- a/cmd/virt-migrator/Dockerfile
+++ b/cmd/virt-migrator/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,8 +6,24 @@ A quick start guide to get KubeVirt up and running inside Vagrant.
 
 **Note:** Fedora 24 is known to have a bug which affects our vagrant setup.
 
-
 ## Building
+
+### Dockerized building and code generating
+
+All go-related make targets can be invoked in an included container. To build
+the project within the builder-container, run
+
+```bash
+./hack/dockerized make fmt fmt-bash build
+```
+
+To generate code, run
+
+```bash
+./hack/dockerized make generate
+```
+
+If you want to build KubeVirt without docker, read on.
 
 ### Go (1.8 or higher)
 

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -1,0 +1,33 @@
+FROM fedora:27
+
+ENV LIBVIRT_VERSION 3.7.0
+
+RUN dnf -y install libvirt-devel-${LIBVIRT_VERSION} make git mercurial sudo gcc findutils gradle rsync-daemon rsync && \
+    dnf -y clean all
+
+ENV GIMME_GO_VERSION=1.9.2
+
+RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
+
+ENV GOPATH="/go" GOBIN="/usr/bin"
+
+ADD rsyncd.conf /etc/rsyncd.conf
+
+RUN \
+    mkdir -p /go && \
+    source /etc/profile.d/gimme.sh && \
+    go get github.com/mattn/goveralls && \
+    go get -u github.com/Masterminds/glide && \
+    go get golang.org/x/tools/cmd/goimports && \
+    go get -u mvdan.cc/sh/cmd/shfmt && \
+    go get -u github.com/golang/mock/gomock && \
+    go get -u github.com/rmohr/mock/mockgen && \
+    go get -u github.com/rmohr/go-swagger-utils/swagger-doc && \
+    go get -u github.com/onsi/ginkgo/ginkgo && \
+    go get -u k8s.io/code-generator/cmd/deepcopy-gen && \
+    go get -u k8s.io/code-generator/cmd/defaulter-gen
+
+
+ADD entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/hack/docker-builder/entrypoint.sh
+++ b/hack/docker-builder/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /etc/profile.d/gimme.sh
+export GOPATH="/root/go"
+"$@"

--- a/hack/docker-builder/rsyncd.conf
+++ b/hack/docker-builder/rsyncd.conf
@@ -1,0 +1,14 @@
+gid = 0
+uid = 0
+log file = /dev/stdout
+reverse lookup = no
+[build]
+    hosts allow = *
+    read only = false
+    path = /root/go/src/kubevirt.io/kubevirt/
+    comment = input sources
+[out]
+    hosts allow = *
+    read only = false
+    path = /root/go/src/kubevirt.io/kubevirt/_out
+    comment = build output

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+DIR="$(
+    cd "$(dirname "$0")"
+    pwd
+)"
+DOCKER_DIR=${DIR}/docker-builder
+KUBEVIRT_DIR="$(
+    cd "$DIR/../"
+    pwd
+)"
+
+BUILDER=${BUILDER_NAME:-kubevirtbuilder}
+RSYNCD_PORT=${RSYNCD_PORT:-10873}
+
+# Build the build container
+(cd ${DOCKER_DIR} && docker build . -q -t ${BUILDER})
+
+# Create the persistent docker volume
+if [ -z "$(docker volume list | grep ${BUILDER})" ]; then
+    docker volume create --name ${BUILDER}
+fi
+
+# Make sure that the output directory exists
+docker run -v "${BUILDER}:/root:rw,z" --rm -it ${BUILDER} mkdir -p /root/go/src/kubevirt.io/kubevirt/_out
+
+# Start an rsyncd instance and make sure it gets stopped after the script exits
+RSYNC_CID=$(docker run -d -v "${BUILDER}:/root:rw,z" -p 127.0.0.1:${RSYNCD_PORT}:873 ${BUILDER} /usr/bin/rsync --no-detach --daemon --verbose)
+function finish() {
+    docker stop ${RSYNC_CID}
+    docker rm ${RSYNC_CID}
+}
+trap finish EXIT
+# TODO really check if rsyncd comes up. For now just give it some time to come up
+sleep 1
+
+_rsync() {
+    rsync -avl "$@"
+}
+
+# Copy kubevirt into the persistent docker volume
+_rsync --delete --exclude '.glide*' --exclude "cluster/vagrant/.kubeconfig" --exclude "cluster/vagrant/.kubectl" --exclude "vendor" --exclude "_out" --exclude ".vagrant" ${KUBEVIRT_DIR}/ "rsync://root@127.0.0.1:${RSYNCD_PORT}/build"
+
+# Run the command
+docker run --rm -v "${BUILDER}:/root:rw,z" -w "/root/go/src/kubevirt.io/kubevirt" -it ${BUILDER} "$@"
+
+# Copy the whole kubevirt data out to get generated sources and formatting changes
+_rsync --exclude '.glide*' --exclude "vendor" --exclude "_out" --exclude ".vagrant" --exclude ".git" "rsync://root@127.0.0.1:${RSYNCD_PORT}/build" ${KUBEVIRT_DIR}/
+# Copy the build output out of the container, make sure that _out exactly matches the build result
+_rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/out" $KUBEVIRT_DIR/_out

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+set -e
+
+source hack/config.sh
+KUBEVIRT_DIR="$(
+    cd "$(dirname "$0")/../"
+    pwd
+)"
+
+${KUBEVIRT_DIR}/_out/tests/tests.test -kubeconfig=${kubeconfig} -test.timeout 30m ${FUNC_TEST_ARGS}

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -10,7 +10,7 @@ git clone \
     "https://${API_REFERENCE_PUSH_TOKEN}@${GITHUB_FQDN}/${API_REF_REPO}.git" \
     "${API_REF_DIR}" >/dev/null 2>&1
 rm -rf "${API_REF_DIR}/content/"*
-cp -f hack/gen-swagger-doc/html5/content/*.html "${API_REF_DIR}/content/"
+cp -f _out/apidocs/html/*.html "${API_REF_DIR}/content/"
 
 cd "${API_REF_DIR}"
 

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -8,6 +8,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+KUBEVIRT_DIR="$(
+    cd "$(dirname "$0")/../../"
+    pwd
+)"
+
 VERSION="${1:-v1}"
 OUTPUT_FORMAT="${2:-html}"
 if [ "$OUTPUT_FORMAT" = "html" ]; then
@@ -79,4 +84,7 @@ elif [ "$OUTPUT_FORMAT" = "markdown" ]; then
     cd -
 fi
 
+mkdir -p ${KUBEVIRT_DIR}/_out/apidocs/html
+mv ${WORKDIR}/html5/content/* ${KUBEVIRT_DIR}/_out/apidocs/html
+mv ${WORKDIR}/*.adoc ${KUBEVIRT_DIR}/_out/apidocs/
 echo "SUCCESS"

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+goveralls -service=travis-ci -package=./pkg/... -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go" -printf "%P\n" | paste -d, -s) -v

--- a/images/iscsi-demo-target-tgtd/Dockerfile
+++ b/images/iscsi-demo-target-tgtd/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker

--- a/images/libvirt-kubevirt/Dockerfile
+++ b/images/libvirt-kubevirt/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM kubevirt/libvirt
+FROM kubevirt/libvirt:3.7.0
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker

--- a/images/vm-killer/Dockerfile
+++ b/images/vm-killer/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM fedora:26
+FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker

--- a/pkg/virt-dhcp/monitor_test.go
+++ b/pkg/virt-dhcp/monitor_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Virt-DHCP Monitor test", func() {
 	dir := os.Getenv("PWD")
 	dir = strings.TrimSuffix(dir, "pkg/virt-dhcp")
 	processName := "fake-dnsmasq-process"
-	processPath := dir + "/cmd/fake-dnsmasq-process/" + processName
+	processPath := dir + "/_out/cmd/fake-dnsmasq-process/" + processName
 	processArgs := []string{"-k", "-d", "--strict-order", "--bind-dynamic"}
 
 	StartProcess := func() {

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -45,7 +45,7 @@ var _ = Describe("VirtLauncher", func() {
 	dir = strings.TrimSuffix(dir, "pkg/virt-launcher")
 
 	processName := "fake-qemu-process"
-	processPath := dir + "/cmd/fake-qemu-process/" + processName
+	processPath := dir + "/_out/cmd/fake-qemu-process/" + processName
 
 	processStarted := false
 


### PR DESCRIPTION
Allow building kubevirt in a docker container:

```bash
git clone https://github.com/kubevirt/kubevirt
cd kubevirt
./hack/dockerized make generate fmt fmt-bash build
./hack/dockerized make apidocs
```
 * Fixes #628 in a not completely elegant way, since we would still have to make sure that the LIBVIRT_VERSION alligns in the virt-handler Dockerfile and the builder dockerfile.
 * Groud work for #534 .
 * Brings in a new enough mercural version for travis to work
 * The vagrant provider does not yet use the dockerized builder for synchronization

Signed-off-by: Roman Mohr <rmohr@redhat.com>
  
  
  
  