### PR TITLE
Manifests: Modify RBAC

### DIFF
--- a/manifests/dev/libvirt.yaml.in
+++ b/manifests/dev/libvirt.yaml.in
@@ -12,7 +12,7 @@ spec:
       labels:
         kubevirt.io: libvirt
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-privileged
       hostNetwork: true
       hostPID: true
       hostIPC: true

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -44,7 +44,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -52,7 +52,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubevirt-admin
+  name: kubevirt-privileged
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -60,23 +60,23 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
 roleRef:
   kind: ClusterRole
-  name: kubevirt-infra
+  name: kubevirt-controller
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: kubevirt-infra
+    name: kubevirt-controller
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubevirt-infra-cluster-admin
+  name: kubevirt-controller-cluster-admin
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -86,5 +86,21 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: kubevirt-infra
+    name: kubevirt-controller
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-privileged-cluster-admin
+  namespace: kube-system
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-privileged
     namespace: kube-system

--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -26,7 +26,7 @@ spec:
       labels:
         kubevirt.io: virt-controller
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-controller
       containers:
         - name: virt-controller
           image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}

--- a/manifests/dev/virt-handler.yaml.in
+++ b/manifests/dev/virt-handler.yaml.in
@@ -12,7 +12,7 @@ spec:
       labels:
         kubevirt.io: virt-handler
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-privileged
       hostPID: true
       containers:
         - name: virt-handler

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -45,7 +45,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -53,7 +53,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kubevirt-admin
+  name: kubevirt-privileged
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -61,23 +61,23 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubevirt-infra
+  name: kubevirt-controller
   namespace: kube-system
   labels:
     kubevirt.io: ""
 roleRef:
   kind: ClusterRole
-  name: kubevirt-infra
+  name: kubevirt-controller
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: kubevirt-infra
+    name: kubevirt-controller
     namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubevirt-infra-cluster-admin
+  name: kubevirt-controller-cluster-admin
   namespace: kube-system
   labels:
     kubevirt.io: ""
@@ -87,7 +87,23 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: kubevirt-infra
+    name: kubevirt-controller
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-privileged-cluster-admin
+  namespace: kube-system
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-privileged
     namespace: kube-system
 ---
 # custom resource definitions
@@ -157,7 +173,7 @@ spec:
       labels:
         kubevirt.io: virt-controller
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-controller
       containers:
         - name: virt-controller
           image: {{ docker_prefix }}/virt-controller:{{ docker_tag }}
@@ -205,7 +221,7 @@ spec:
       labels:
         kubevirt.io: virt-handler
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-privileged
       hostPID: true
       containers:
         - name: virt-handler
@@ -262,7 +278,7 @@ spec:
       labels:
         kubevirt.io: libvirt
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-privileged
       hostNetwork: true
       hostPID: true
       hostIPC: true

--- a/manifests/testing/iscsi-demo-target.yaml.in
+++ b/manifests/testing/iscsi-demo-target.yaml.in
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -132,7 +133,7 @@ spec:
         kubevirt.io: iscsi-demo-target
       name: iscsi-demo-target-tgtd
     spec:
-      serviceAccountName: kubevirt-infra
+      serviceAccountName: kubevirt-testing
       containers:
         - name: target
           image: {{ docker_prefix }}/iscsi-demo-target-tgtd:{{ docker_tag }}

--- a/manifests/testing/rbac-for-testing.yaml.in
+++ b/manifests/testing/rbac-for-testing.yaml.in
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubevirt-testing
+  namespace: kube-system
+  labels:
+    kubevirt.io: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-testing-cluster-admin
+  namespace: kube-system
+  labels:
+    kubevirt.io: ""
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-testing
+    namespace: kube-system


### PR DESCRIPTION
- Change service accounts names to be more meaningful
- Use different service accounts for virt-controller and libvirt,
  virt-handler.

Modify RBAC as follows:

Service account to role:

- kubevirt-privileged -> cluster-admin
- kubevirt-controller -> cluster-admin, kubevirt-controller

Pod to service account:

- libvirt, virt-handler -> kubevirt-privileged
- virt-controller -> kubevirt-controller

Signed-off-by: gbenhaim <galbh2@gmail.com>