### PR TITLE
Adding git hash to the api-reference doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ deploy:
   skip_cleanup: true
   script: bash hack/gen-swagger-doc/deploy.sh
   on:
+    tags: true
     branch: master
     go: 1.8.3
 

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -29,7 +29,7 @@ Content of this repository is generated from OpenAPI specification of
 
 ## KubeVirt API References
 
-* [master](${GITHUB_IO_FQDN}/index.html)
+* [master](${GITHUB_IO_FQDN}/master/index.html)
 __EOF__
 find * -type d -regex  "^v[0-9.]*" \
     -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" >> README.md \;

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -6,11 +6,16 @@ GITHUB_FQDN=github.com
 API_REF_REPO=kubevirt-incubator/api-reference
 API_REF_DIR=/tmp/api-reference
 
+TARGET_DIR="$TRAVIS_BRANCH"
+if [ "$TRAVIS_TAG" -n ] ; then
+    TARGET_DIR="$TRAVIS_TAG"
+fi
+
 git clone \
     "https://${API_REFERENCE_PUSH_TOKEN}@${GITHUB_FQDN}/${API_REF_REPO}.git" \
     "${API_REF_DIR}" >/dev/null 2>&1
-rm -rf "${API_REF_DIR}/content/"*
-cp -f _out/apidocs/html/*.html "${API_REF_DIR}/content/"
+rm -rf "${API_REF_DIR}/${TARGET_DIR}/"*
+cp -f _out/apidocs/html/*.html "${API_REF_DIR}/${TARGET_DIR}/"
 
 cd "${API_REF_DIR}"
 
@@ -18,11 +23,11 @@ git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis CI"
 
 if git status --porcelain | grep --quiet "^ M"; then
-    git add -A content/*.html
+    git add -A ${TARGET_DIR}/*.html
     git commit --message "API Reference update by Travis Build ${TRAVIS_BUILD_NUMBER}"
 
     git push origin master >/dev/null 2>&1
-    echo "API Reference updated."
+    echo "API Reference updated for ${TARGET_DIR}."
 else
     echo "API Reference hasn't changed."
 fi

--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -5,25 +5,40 @@ set -e
 GITHUB_FQDN=github.com
 API_REF_REPO=kubevirt-incubator/api-reference
 API_REF_DIR=/tmp/api-reference
+GITHUB_IO_FQDN="https://kubevirt-incubator.github.io/api-reference"
 
 TARGET_DIR="$TRAVIS_BRANCH"
-if [ "$TRAVIS_TAG" -n ] ; then
+if [ -n "${TRAVIS_TAG}" ] ; then
     TARGET_DIR="$TRAVIS_TAG"
 fi
 
 git clone \
     "https://${API_REFERENCE_PUSH_TOKEN}@${GITHUB_FQDN}/${API_REF_REPO}.git" \
     "${API_REF_DIR}" >/dev/null 2>&1
-rm -rf "${API_REF_DIR}/${TARGET_DIR}/"*
+rm -rf "${API_REF_DIR}/${TARGET_DIR:?}/"*
 cp -f _out/apidocs/html/*.html "${API_REF_DIR}/${TARGET_DIR}/"
 
 cd "${API_REF_DIR}"
 
+# Generate README.md file
+cat > README.md << __EOF__
+# KubeVirt API Reference
+
+Content of this repository is generated from OpenAPI specification of
+[KubeVirt project](https://github.com/kubevirt/kubevirt) .
+
+## KubeVirt API References
+
+* [master](${GITHUB_IO_FQDN}/index.html)
+__EOF__
+find * -type d -regex  "^v[0-9.]*" \
+    -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" >> README.md \;
+
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis CI"
 
-if git status --porcelain | grep --quiet "^ M"; then
-    git add -A ${TARGET_DIR}/*.html
+if git status --porcelain | grep --quiet "^ [AM]"; then
+    git add -A README.md "${TARGET_DIR}"/*.html
     git commit --message "API Reference update by Travis Build ${TRAVIS_BUILD_NUMBER}"
 
     git push origin master >/dev/null 2>&1

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -68,6 +68,9 @@ if [ "$OUTPUT_FORMAT" = "html" ]; then
     # $$ has special meaning in asciidoc, we need to escape it
     sed -i 's|\$\$|+++$$+++|g' "$WORKDIR/definitions.adoc"
     sed -i '1 i\:last-update-label!:' "$WORKDIR/"*.adoc
+    sed -i -e "/KubeVirt API\$/a\\:revnumber: $(git rev-parse HEAD || echo no-revision)" \
+            -e "/__Terms of service__ :/a\\__Version__ : {revnumber}" \
+            "$WORKDIR/overview.adoc"
 
     # Generate *.html files from *.adoc
     gradle -b $GRADLE_BUILD_FILE asciidoctor --info

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -68,8 +68,9 @@ if [ "$OUTPUT_FORMAT" = "html" ]; then
     # $$ has special meaning in asciidoc, we need to escape it
     sed -i 's|\$\$|+++$$+++|g' "$WORKDIR/definitions.adoc"
     sed -i '1 i\:last-update-label!:' "$WORKDIR/"*.adoc
-    sed -i -e "/KubeVirt API\$/a\\:revnumber: $(git rev-parse HEAD || echo no-revision)" \
-            -e "/__Terms of service__ :/a\\__Version__ : {revnumber}" \
+    gitcommithash="$(git rev-parse HEAD || echo no-revision)"
+    sed -i -e "/KubeVirt API\$/a\\:revnumber: ${gitcommithash}" \
+            -e "/__Terms of service__ :/a\\__Version__ : https://github.com/kubevirt/kubevirt/commit/{revnumber}[{revnumber}]" \
             "$WORKDIR/overview.adoc"
 
     # Generate *.html files from *.adoc


### PR DESCRIPTION

Fixes: kubevirt-incubator/api-reference#5


![kubevirt-api-reference-version](https://user-images.githubusercontent.com/1505684/34782799-098920de-f62a-11e7-8de4-8e90286c1458.png)