### PR TITLE
virtctl should pickup kubectl config

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl"
 )
 
 type Console struct {
@@ -56,7 +57,7 @@ func (c *Console) Usage() string {
 func (c *Console) Run(flags *flag.FlagSet) int {
 
 	server, _ := flags.GetString("server")
-	kubeconfig, _ := flags.GetString("kubeconfig")
+	kubeconfig := virtctl.GetKubeConfig(flags)
 	namespace, _ := flags.GetString("namespace")
 	device := "serial0"
 	if namespace == "" {

--- a/pkg/virtctl/virtctl.go
+++ b/pkg/virtctl/virtctl.go
@@ -35,6 +35,20 @@ type App interface {
 type Options struct {
 }
 
+func GetKubeConfig(flags *flag.FlagSet) string {
+	kubeConfig, err := flags.GetString("kubeconfig")
+	if kubeConfig == "" || err != nil {
+		kubeConfig := os.Getenv("kubeconfig")
+		if kubeConfig == "" {
+			kubeConfig = os.Getenv("KUBECONFIG")
+		}
+		if kubeConfig == "" {
+			kubeConfig = os.Getenv("HOME") + "./kube/config"
+		}
+	}
+	return kubeConfig
+}
+
 func (o *Options) FlagSet() *flag.FlagSet {
 
 	cf := flag.NewFlagSet("options", flag.ExitOnError)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -32,6 +32,7 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl"
 )
 
 const FLAG = "vnc"
@@ -40,7 +41,7 @@ type VNC struct{}
 
 func (o *VNC) Run(flags *flag.FlagSet) int {
 	server, _ := flags.GetString("server")
-	kubeconfig, _ := flags.GetString("kubeconfig")
+	kubeconfig := virtctl.GetKubeConfig(flags)
 	namespace, _ := flags.GetString("namespace")
 	if namespace == "" {
 		namespace = kubev1.NamespaceDefault


### PR DESCRIPTION
- Use environment KUBECONFIG if no kubeconfig is specified in virtctl arguments
- Use $HOME/.kube/kubeconfig if no environment variable is set.
- If none of the above are true return an empty string and let kubernetes figure it out.

fixes #635 

Signed-off-by: Alexander Wels <alexanderwels4@gmail.com>