### PR TITLE
Remove unused lines from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,15 +2,6 @@ vendor/*
 !vendor/vendor.json
 .idea
 *.iml
-cmd/fake-dnsmasq-process/fake-dnsmasq*
-cmd/fake-qemu-process/fake-qemu*
-cmd/virt-manifest/virt-manifest*
-cmd/virt-controller/virt-controller*
-cmd/virt-launcher/virt-launcher*
-cmd/virt-handler/virt-handler*
-cmd/virt-api/virt-api*
-cmd/virtctl/virtctl*
-cmd/virt-dhcp/virt-dhcp*
 tools/openapispec/openapispec
 manifests/**/*.yaml
 **/bin


### PR DESCRIPTION
Binaries were moved to _out so lines addressing them in .gitignore are no
longer needed.