### PR TITLE
Update go version in automation script

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -40,7 +40,8 @@ fi
 VAGRANT_PREFIX=${VARIABLE:-kubevirt}
 
 # Install GO
-eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=stable bash)"
+export GIMME_GO_VERSION=1.9.2
+eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | bash)"
 export WORKSPACE="${WORKSPACE:-$PWD}"
 export GOPATH="${GOPATH:-$WORKSPACE/go}"
 export GOBIN="${GOBIN:-$GOPATH/bin}"


### PR DESCRIPTION
Kubernetes api machinery only support go 1.8 onwards anymore. Update the
CI go version from 1.7 to 1.9.

Signed-off-by: Travis CI <travis@travis-ci.org>