### PR TITLE
images: Add Fedora to demo target

### DIFF
--- a/cluster/vm-fedora.yaml
+++ b/cluster/vm-fedora.yaml
@@ -1,0 +1,26 @@
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: testvm-fedora
+spec:
+  terminationGracePeriodSeconds: 5
+  domain:
+    resources:
+      requests:
+        memory: 1024M
+    devices:
+      disks:
+      - name: root
+        volumeName: fedora
+      - name: cloudinitdisk
+        volumeName: cloudinitvolume
+  volumes:
+    - name: fedora
+      iscsi:
+        iqn: iqn.2017-01.io.kubevirt:sn.42
+        lun: 4
+        targetPortal: iscsi-demo-target.kube-system.svc.cluster.local
+    - name: cloudinitvolume
+      cloudInitNoCloud:
+        # Password: atomic
+        userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==

--- a/images/iscsi-demo-target-tgtd/Dockerfile
+++ b/images/iscsi-demo-target-tgtd/Dockerfile
@@ -26,17 +26,27 @@ RUN dnf -y update && dnf -y install scsi-target-utils bzip2 qemu-img \
 
 RUN mkdir -p /volume
 
-# Add alpine image
+# LUNs:
+# 0. is an internal lun
+# 1. Empty image - for your data
+
+# 2. Add alpine image
 RUN curl \
       https://nl.alpinelinux.org/alpine/v3.5/releases/x86_64/alpine-virt-3.5.1-x86_64.iso \
       > /volume/alpine.iso
 
-# Add cirros
+# 3. Add cirros
 RUN curl \
       http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
       > /volume/cirros.img \
       && qemu-img convert -O raw /volume/cirros.img /volume/cirros.rawa \
       && rm volume/cirros.img
+
+# 4. Add fedora
+# needs cloud init for login
+RUN curl -L \
+      https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.raw.xz \
+      | xz -d > /volume/fedora.img
 
 ADD run-tgt.sh /
 

--- a/images/iscsi-demo-target-tgtd/README.md
+++ b/images/iscsi-demo-target-tgtd/README.md
@@ -11,6 +11,7 @@ Available LUNs:
 1. Empty image - for your data
 2. Alpine
 3. CirrOS
+4. Fedora
 
 
 # Build


### PR DESCRIPTION
The existing images are sometimes limited in their drivers or device initialization.
Fedora is added to have a target which can launch a full blown distro.

Nit: It needs cloud init to set login credentials.

Fixes #659

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>