### PR TITLE
tests: Add a timeout to cluster creation

### DIFF
--- a/cluster/vagrant-kubernetes/setup_master.sh
+++ b/cluster/vagrant-kubernetes/setup_master.sh
@@ -19,6 +19,27 @@
 master_ip=$1
 network_provider=$3
 
+wait_for_kubernetes() {
+    local timeout="$1"
+    local start_time=$(date +%s)
+    local time_left=$timeout
+    local current_time
+
+    while [[ $time_left -gt 0 ]]; do
+        kubectl version && return 0
+        sleep 60
+        current_time=$(date +%s)
+        time_left=$((timeout - (current_time - start_time)))
+        echo \
+            "Waiting for Kubernetes cluster to become functional," \
+            "$time_left seconds left..."
+    done
+
+    echo "Failed to create Kubernetes cluster in $timeout seconds, aborting"
+
+    return 1
+}
+
 export KUBERNETES_MASTER=true
 bash /vagrant/cluster/vagrant-kubernetes/setup_common.sh
 
@@ -43,16 +64,7 @@ kubeadm init --config /etc/kubernetes/kubeadm.conf
 # Tell kubectl which config to use
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
-set +e
-
-kubectl version
-while [ $? -ne 0 ]; do
-    sleep 60
-    echo 'Waiting for Kubernetes cluster to become functional...'
-    kubectl version
-done
-
-set -e
+wait_for_kubernetes $((60 * 15))
 
 # Additional network providers are available from
 # https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network


### PR DESCRIPTION
Fail the tests if the cluster isn't ready in 15 minutes.

Will help to avoid an infinite loop, for example:

```
09:44:23 [check-patch.el7.x86_64] ==> master: setup_kubernetes_master.sh: line 42: kubectl: command not found
09:45:19 [check-patch.el7.x86_64] ==> master: Waiting for Kubernetes cluster to become functional...
09:45:19 [check-patch.el7.x86_64] ==> master: setup_kubernetes_master.sh: line 42: kubectl: command not found
09:46:15 [check-patch.el7.x86_64] ==> master: Waiting for Kubernetes cluster to become functional...
```

Signed-off-by: gbenhaim <galbh2@gmail.com>