### PR TITLE
Don't abort build if shfmt fails

### DIFF
--- a/hack/check.sh
+++ b/hack/check.sh
@@ -3,6 +3,6 @@ set -e
 
 source hack/common.sh
 
-shfmt -i 4 -w ${KUBEVIRT_DIR}/cluster/ ${KUBEVIRT_DIR}/hack/ ${KUBEVIRT_DIR}/images/
+shfmt -i 4 -w ${KUBEVIRT_DIR}/cluster/ ${KUBEVIRT_DIR}/hack/ ${KUBEVIRT_DIR}/images/ || true
 goimports -w -local kubevirt.io ${KUBEVIRT_DIR}/cmd/ ${KUBEVIRT_DIR}/pkg/ ${KUBEVIRT_DIR}/tests/
 (cd ${KUBEVIRT_DIR} && go vet ./cmd/... ./pkg/... ./tests/...)


### PR DESCRIPTION
shfmt doesn't like bash default values for parameters (see
http://wiki.bash-hackers.org/syntax/pe#use_a_default_value)

  $ shfmt -i 4 -w hack/
  hack/gen-swagger-doc/gen-swagger-docs.sh:13:13: a special parameter name can never be unset or null
  hack/release-announce.sh:104:11: a special parameter name can never be unset or null

  $ shfmt -version
  v2.2.0

Until that is fixed, we should not abort the build.
Another alternative could be avoid to run shfmt during the builds.

Signed-off-by: Francesco Romani <fromani@redhat.com>