### PR TITLE
Fixes build errors

### DIFF
--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -10,8 +10,11 @@ set -o pipefail
 
 source $(dirname "$0")/../../hack/common.sh
 
-VERSION="${1:-v1}"
-OUTPUT_FORMAT="${2:-html}"
+VERSION="$1"
+OUTPUT_FORMAT="$2"
+
+VERSION="${VERSION:-v1}"
+OUTPUT_FORMAT="${OUTPUT_FORMAT:-html}"
 GIT_REPO_LINK="https://github.com/kubevirt/kubevirt"
 if [ "$OUTPUT_FORMAT" = "html" ]; then
     SUFFIX="adoc"

--- a/hack/release-announce.sh
+++ b/hack/release-announce.sh
@@ -101,8 +101,10 @@ EOF
 #
 # Let's get the party started
 #
-RELREF=${1:-$(git describe --abbrev=0 --tags)}
-PREREF=${2:-$(git describe --abbrev=0 --tags $RELREF^)}
+RELREF="$1"
+PREREF="$2"
+RELREF=${RELREF:-$(git describe --abbrev=0 --tags)}
+PREREF=${PREREF:-$(git describe --abbrev=0 --tags $RELREF^)}
 RELSPANREF=$PREREF..$RELREF
 
 main


### PR DESCRIPTION
Without this change, I get this error when running 'make build'

/root/go/src/kubevirt.io/kubevirt/hack/gen-swagger-doc/gen-swagger-docs.sh:13:13: a special parameter name can never be unset or null
/root/go/src/kubevirt.io/kubevirt/hack/release-announce.sh:104:11: a special parameter name can never be unset or null

Signed-off-by: David Vossel <davidvossel@gmail.com>