### PR TITLE
[WIP] Add support for backing store

### DIFF
--- a/cluster/vm-backing-store.yaml
+++ b/cluster/vm-backing-store.yaml
@@ -1,0 +1,27 @@
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: testvm-backing-store
+spec:
+  terminationGracePeriodSeconds: 0
+  domain:
+    resources:
+      requests:
+        memory: 64M
+    devices:
+      disks:
+      - name: mydisk
+        volumeName: myvolume
+        disk:
+          dev: vda
+  volumes:
+    - name: myvolume
+      iscsi:
+        iqn: iqn.2017-01.io.kubevirt:sn.42
+        lun: 4
+        targetPortal: iscsi-demo-target.kube-system.svc.cluster.local
+      backedEphemeral:
+        iscsi:
+          iqn: iqn.2017-01.io.kubevirt:sn.42
+          lun: 3
+          targetPortal: iscsi-demo-target.kube-system.svc.cluster.local

--- a/images/iscsi-demo-target-tgtd/Dockerfile
+++ b/images/iscsi-demo-target-tgtd/Dockerfile
@@ -29,14 +29,15 @@ RUN mkdir -p /volume
 # Add alpine image
 RUN curl \
       https://nl.alpinelinux.org/alpine/v3.5/releases/x86_64/alpine-virt-3.5.1-x86_64.iso \
-      > /volume/alpine.iso
+      > /volume/0-alpine.iso
 
 # Add cirros
 RUN curl \
       http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
       > /volume/cirros.img \
-      && qemu-img convert -O raw /volume/cirros.img /volume/cirros.rawa \
-      && rm volume/cirros.img
+      && qemu-img convert -O raw /volume/cirros.img /volume/1-cirros.rawa \
+      && rm volume/cirros.img \
+      && qemu-img create -f qcow2 -b /volume/1-cirros.rawa /volume/2-cirros.qcow2.snap
 
 ADD run-tgt.sh /
 

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -203,6 +203,21 @@ type VolumeSource struct {
 	// More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html
 	// +optional
 	RegistryDisk *RegistryDiskSource `json:"registryDisk,omitempty"`
+	// BackedEphemeral allows sharing a common pre-baked image across
+	// multiple ephemeral vms. Writes of the guest will
+	// not modify the configured volume source and are bound to the vm lifecycle.
+	// +optional
+	BackedEphemeral *BackedEphemeralVolumeSource `json:"backedEphemeral,omitempty"`
+}
+
+type BackedEphemeralVolumeSource struct {
+	// ISCSI represents an ISCSI Disk resource which is directly attached to the vm via qemu.
+	// +optional
+	ISCSI *v1.ISCSIVolumeSource `json:"iscsi,omitempty"`
+	// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.
+	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+	// +optional
+	PersistentVolumeClaim *v1.PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
 }
 
 // Represents a docker image with an embedded disk

--- a/pkg/virt-handler/virtwrap/api/schema.go
+++ b/pkg/virt-handler/virtwrap/api/schema.go
@@ -214,16 +214,27 @@ type Devices struct {
 // BEGIN Disk -----------------------------
 
 type Disk struct {
-	Device   string      `xml:"device,attr"`
-	Snapshot string      `xml:"snapshot,attr,omitempty"`
-	Type     string      `xml:"type,attr"`
-	Source   DiskSource  `xml:"source"`
-	Target   DiskTarget  `xml:"target"`
-	Serial   string      `xml:"serial,omitempty"`
-	Driver   *DiskDriver `xml:"driver,omitempty"`
-	ReadOnly *ReadOnly   `xml:"readonly,omitempty"`
-	Auth     *DiskAuth   `xml:"auth,omitempty"`
-	Alias    *Alias      `xml:"alias,omitmepty"`
+	Device       string        `xml:"device,attr"`
+	Snapshot     string        `xml:"snapshot,attr,omitempty"`
+	Type         string        `xml:"type,attr"`
+	Source       DiskSource    `xml:"source"`
+	Target       DiskTarget    `xml:"target"`
+	Serial       string        `xml:"serial,omitempty"`
+	Driver       *DiskDriver   `xml:"driver,omitempty"`
+	ReadOnly     *ReadOnly     `xml:"readonly,omitempty"`
+	Auth         *DiskAuth     `xml:"auth,omitempty"`
+	Alias        *Alias        `xml:"alias,omitempty"`
+	BackingStore *BackingStore `xml:"backingStore,omitempty"`
+}
+
+type BackingStore struct {
+	Type   string             `xml:"type,attr"`
+	Format BackingStoreFormat `xml:"format"`
+	Source DiskSource         `xml:"source"`
+}
+
+type BackingStoreFormat struct {
+	Type string `xml:"type,attr"`
 }
 
 type DiskAuth struct {

--- a/pkg/virt-handler/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-handler/virtwrap/util/libvirt_helper.go
@@ -14,6 +14,7 @@ import (
 
 func SetDomainSpec(virConn cli.Connection, vm *v1.VirtualMachine, wantedSpec api.DomainSpec) (cli.VirDomain, error) {
 	xmlStr, err := xml.Marshal(&wantedSpec)
+	log.Log.Warning(string(xmlStr))
 	if err != nil {
 		log.Log.Object(vm).Reason(err).Error("Generating the domain XML failed.")
 		return nil, err


### PR DESCRIPTION
Libvirt uses backing stores to describe the detected backing chains of
running domains, for KubeVirt it means that we can use some backed
image as a source and to write on additional image without change the
source image.

Signed-off-by: Lukianov Artyom <alukiano@redhat.com>