### PR TITLE
testing-manifest: add missing SA for iscsi-auth-demo-target

### DIFF
--- a/manifests/testing/iscsi-auth-demo-target.yaml.in
+++ b/manifests/testing/iscsi-auth-demo-target.yaml.in
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     kubevirt.io: ""
-type: "kubernetes.io/iscsi-chap"  
+type: "kubernetes.io/iscsi-chap"
 data:
   node.session.auth.username: ZGVtb3VzZXI=
   node.session.auth.password: ZGVtb3Bhc3N3b3Jk
@@ -40,6 +40,7 @@ spec:
         kubevirt.io: iscsi-auth-demo-target
       name: iscsi-auth-demo-target-tgtd
     spec:
+      serviceAccountName: kubevirt-testing
       containers:
         - name: target
           image: {{ docker_prefix }}/iscsi-demo-target-tgtd:{{ docker_tag }}


### PR DESCRIPTION
relevant replica set doesn't rollout without kubevirt-testing service
account.

it fixes following issue:
```
Events:
  FirstSeen	LastSeen	Count	From			SubObjectPath	Type		Reason		Message
  ---------	--------	-----	----			-------------	--------	------		-------
  28s		8s		13	replicaset-controller			Warning		FailedCreate	Error creating: pods "iscsi-auth-demo-target-tgtd-3174869877-" is forbidden: unable to validate against any security context constraint: [spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used]
```