### PR TITLE
Expose disk bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ cluster/local/certs
 **.crt
 **.csr
 _out
+vendor/**/*_test.go

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1628,7 +1628,7 @@
    "v1.CDRomTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
       "type": "string"
      },
      "readonly": {
@@ -1775,7 +1775,7 @@
    "v1.DiskTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
       "type": "string"
      },
      "readonly": {
@@ -2148,7 +2148,7 @@
    "v1.LunTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
       "type": "string"
      },
      "readonly": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1628,7 +1628,7 @@
    "v1.CDRomTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
       "type": "string"
      },
      "readonly": {
@@ -1775,7 +1775,7 @@
    "v1.DiskTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
       "type": "string"
      },
      "readonly": {
@@ -2148,7 +2148,7 @@
    "v1.LunTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
       "type": "string"
      },
      "readonly": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1922,10 +1922,6 @@
    },
    "v1.FloppyTarget": {
     "properties": {
-     "bus": {
-      "description": "Bus indicates the type of disk device to emulate.",
-      "type": "string"
-     },
      "readonly": {
       "description": "ReadOnly\nDefaults to false",
       "type": "boolean"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1627,6 +1627,10 @@
    },
    "v1.CDRomTarget": {
     "properties": {
+     "bus": {
+      "description": "Bus indicates the type of disk device to emulate.",
+      "type": "string"
+     },
      "dev": {
       "description": "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
       "type": "string"
@@ -1778,10 +1782,6 @@
       "description": "Bus indicates the type of disk device to emulate.",
       "type": "string"
      },
-     "dev": {
-      "description": "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
-      "type": "string"
-     },
      "readonly": {
       "description": "ReadOnly\nDefaults to false",
       "type": "boolean"
@@ -1926,8 +1926,8 @@
    },
    "v1.FloppyTarget": {
     "properties": {
-     "dev": {
-      "description": "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
+     "bus": {
+      "description": "Bus indicates the type of disk device to emulate.",
       "type": "string"
      },
      "readonly": {
@@ -2151,8 +2151,8 @@
    },
    "v1.LunTarget": {
     "properties": {
-     "dev": {
-      "description": "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
+     "bus": {
+      "description": "Bus indicates the type of disk device to emulate.",
       "type": "string"
      },
      "readonly": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1631,10 +1631,6 @@
       "description": "Bus indicates the type of disk device to emulate.",
       "type": "string"
      },
-     "dev": {
-      "description": "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
-      "type": "string"
-     },
      "readonly": {
       "description": "ReadOnly\nDefaults to true",
       "type": "boolean"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1773,12 +1773,9 @@
     }
    },
    "v1.DiskTarget": {
-    "required": [
-     "bus"
-    ],
     "properties": {
      "bus": {
-      "description": "Bus indicates specifies the type of disk device to emulate.",
+      "description": "Bus indicates the type of disk device to emulate.",
       "type": "string"
      },
      "dev": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1773,7 +1773,14 @@
     }
    },
    "v1.DiskTarget": {
+    "required": [
+     "bus"
+    ],
     "properties": {
+     "bus": {
+      "description": "Bus indicates specifies the type of disk device to emulate.",
+      "type": "string"
+     },
      "dev": {
       "description": "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
       "type": "string"

--- a/cluster/replicaset.yaml
+++ b/cluster/replicaset.yaml
@@ -22,7 +22,7 @@ spec:
           - name: registrydisk
             volumeName: registryvolume
             disk:
-              dev: vda
+              bus: virtio
       volumes:
         - name: registryvolume
           registryDisk:

--- a/cluster/vm-dev-sata.yaml
+++ b/cluster/vm-dev-sata.yaml
@@ -1,0 +1,22 @@
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: testvm-sata
+spec:
+  terminationGracePeriodSeconds: 0
+  domain:
+    resources:
+      requests:
+        memory: 64M
+    devices:
+      disks:
+      - name: mydisk
+        volumeName: myvolume
+        disk:
+          bus: sata
+  volumes:
+    - name: myvolume
+      iscsi:
+        iqn: iqn.2017-01.io.kubevirt:sn.42
+        lun: 2
+        targetPortal: iscsi-demo-target.kube-system.svc.cluster.local

--- a/cluster/vm-ephemeral.yaml
+++ b/cluster/vm-ephemeral.yaml
@@ -12,7 +12,7 @@ spec:
       - name: registrydisk
         volumeName: registryvolume
         disk:
-          dev: vda
+          bus: virtio
   volumes:
     - name: registryvolume
       registryDisk:

--- a/cluster/vm-fedora.yaml
+++ b/cluster/vm-fedora.yaml
@@ -13,11 +13,11 @@ spec:
       - name: registrydisk
         volumeName: registryvolume
         disk:
-          dev: vda
+          bus: virtio
       - name: cloudinitdisk
         volumeName: cloudinitvolume
         disk:
-          dev: vdb
+          bus: virtio
   volumes:
     - name: registryvolume
       registryDisk:

--- a/cluster/vm-iscsi-auth.yaml
+++ b/cluster/vm-iscsi-auth.yaml
@@ -13,7 +13,7 @@ spec:
       - name: mydisk
         volumeName: myvolume
         disk:
-          dev: vda
+          bus: virtio
   volumes:
     - name: myvolume
       iscsi:

--- a/cluster/vm-nocloud.yaml
+++ b/cluster/vm-nocloud.yaml
@@ -13,11 +13,11 @@ spec:
       - name: registrydisk
         volumeName: registryvolume
         disk:
-          dev: vda
+          bus: virtio
       - name: cloudinitdisk
         volumeName: cloudinitvolume
         disk:
-          dev: vdb
+          bus: virtio
   volumes:
     - name: registryvolume
       registryDisk:

--- a/cluster/vm.yaml
+++ b/cluster/vm.yaml
@@ -13,7 +13,7 @@ spec:
       - name: mydisk
         volumeName: myvolume
         disk:
-          dev: vda
+          bus: virtio
   volumes:
     - name: myvolume
       iscsi:

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -332,15 +332,7 @@ func (in *DomainSpec) DeepCopyInto(out *DomainSpec) {
 			**out = **in
 		}
 	}
-	if in.Machine != nil {
-		in, out := &in.Machine, &out.Machine
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(Machine)
-			**out = **in
-		}
-	}
+	out.Machine = in.Machine
 	if in.Firmware != nil {
 		in, out := &in.Firmware, &out.Firmware
 		if *in == nil {

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -119,7 +119,9 @@ func SetDefaults_VirtualMachine(obj *VirtualMachine) {
 	if obj.Spec.Domain.Features == nil {
 		obj.Spec.Domain.Features = &Features{}
 	}
-	obj.Spec.Domain.Machine.Type = "q35"
+	if obj.Spec.Domain.Machine.Type == "" {
+		obj.Spec.Domain.Machine.Type = "q35"
+	}
 	setDefaults_DiskFromMachineType(obj)
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -82,6 +82,24 @@ func SetDefaults_FloppyTarget(obj *FloppyTarget) {
 	}
 }
 
+func SetDefaults_DiskTarget(obj *DiskTarget) {
+	if obj.Bus == "" {
+		obj.Bus = "virtio"
+	}
+	if obj.Device == "" {
+		switch obj.Bus {
+		case "ide":
+			obj.Device = "hda"
+		case "sata", "scsi":
+			obj.Device = "sda"
+		case "virtio":
+			fallthrough
+		default:
+			obj.Device = "vda"
+		}
+	}
+}
+
 func SetDefaults_FeatureSpinlocks(obj *FeatureSpinlocks) {
 	if obj.Enabled == nil {
 		obj.Enabled = _true

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -140,10 +140,6 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachine) {
 		if disk.LUN != nil && disk.LUN.Bus == "" {
 			disk.LUN.Bus = bus
 		}
-		if disk.Floppy != nil && disk.Floppy.Bus == "" {
-			// no real choice here
-			disk.Floppy.Bus = "fd"
-		}
 	}
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -82,24 +82,6 @@ func SetDefaults_FloppyTarget(obj *FloppyTarget) {
 	}
 }
 
-func SetDefaults_DiskTarget(obj *DiskTarget) {
-	if obj.Bus == "" {
-		obj.Bus = "virtio"
-	}
-	if obj.Device == "" {
-		switch obj.Bus {
-		case "ide":
-			obj.Device = "hda"
-		case "sata", "scsi":
-			obj.Device = "sda"
-		case "virtio":
-			fallthrough
-		default:
-			obj.Device = "vda"
-		}
-	}
-}
-
 func SetDefaults_FeatureSpinlocks(obj *FeatureSpinlocks) {
 	if obj.Enabled == nil {
 		obj.Enabled = _true

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -119,10 +119,6 @@ func SetDefaults_VirtualMachine(obj *VirtualMachine) {
 	if obj.Spec.Domain.Features == nil {
 		obj.Spec.Domain.Features = &Features{}
 	}
-	// TODO: not fond of this code, suggestions welcome
-	if obj.Spec.Domain.Machine == nil {
-		obj.Spec.Domain.Machine = &Machine{}
-	}
 	obj.Spec.Domain.Machine.Type = "q35"
 	setDefaults_DiskFromMachineType(obj)
 }

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -128,6 +128,8 @@ type DiskTarget struct {
 	// ReadOnly
 	// Defaults to false
 	ReadOnly bool `json:"readonly,omitempty"`
+	// Bus indicates specifies the type of disk device to emulate.
+	Bus string `json:"bus"`
 }
 
 type LunTarget struct {

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -139,8 +139,6 @@ type LunTarget struct {
 }
 
 type FloppyTarget struct {
-	// Bus indicates the type of disk device to emulate.
-	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
 	ReadOnly bool `json:"readonly,omitempty"`

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -122,6 +122,9 @@ type DiskDevice struct {
 
 type DiskTarget struct {
 	// Bus indicates the type of disk device to emulate.
+	// supported values: virtio, sata, scsi, ide
+	// see libvirt schema here:
+	// https://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693
 	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
@@ -130,6 +133,9 @@ type DiskTarget struct {
 
 type LunTarget struct {
 	// Bus indicates the type of disk device to emulate.
+	// supported values: virtio, sata, scsi, ide
+	// see libvirt schema here:
+	// https://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693
 	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
@@ -161,6 +167,9 @@ const (
 
 type CDRomTarget struct {
 	// Bus indicates the type of disk device to emulate.
+	// supported values: virtio, sata, scsi, ide
+	// see libvirt schema here:
+	// https://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693
 	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to true

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -50,7 +50,7 @@ type DomainSpec struct {
 	CPU *CPU `json:"cpu,omitempty"`
 	// Machine type
 	// +optional
-	Machine *Machine `json:"machine,omitempty"`
+	Machine Machine `json:"machine,omitempty"`
 	// Firmware
 	// +optional
 	Firmware *Firmware `json:"firmware,omitempty"`

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -128,8 +128,8 @@ type DiskTarget struct {
 	// ReadOnly
 	// Defaults to false
 	ReadOnly bool `json:"readonly,omitempty"`
-	// Bus indicates specifies the type of disk device to emulate.
-	Bus string `json:"bus"`
+	// Bus indicates the type of disk device to emulate.
+	Bus string `json:"bus,omitempty"`
 }
 
 type LunTarget struct {

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -123,8 +123,6 @@ type DiskDevice struct {
 type DiskTarget struct {
 	// Bus indicates the type of disk device to emulate.
 	// supported values: virtio, sata, scsi, ide
-	// see libvirt schema here:
-	// https://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693
 	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
@@ -134,8 +132,6 @@ type DiskTarget struct {
 type LunTarget struct {
 	// Bus indicates the type of disk device to emulate.
 	// supported values: virtio, sata, scsi, ide
-	// see libvirt schema here:
-	// https://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693
 	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
@@ -168,8 +164,6 @@ const (
 type CDRomTarget struct {
 	// Bus indicates the type of disk device to emulate.
 	// supported values: virtio, sata, scsi, ide
-	// see libvirt schema here:
-	// https://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693
 	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to true

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -121,32 +121,24 @@ type DiskDevice struct {
 }
 
 type DiskTarget struct {
-	// Device indicates the "logical" device name. The actual device name
-	// specified is not guaranteed to map to the device name in the guest OS. Treat
-	// it as a device ordering hint.
-	Device string `json:"dev,omitempty"`
+	// Bus indicates the type of disk device to emulate.
+	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
 	ReadOnly bool `json:"readonly,omitempty"`
-	// Bus indicates the type of disk device to emulate.
-	Bus string `json:"bus,omitempty"`
 }
 
 type LunTarget struct {
-	// Device indicates the "logical" device name. The actual device name
-	// specified is not guaranteed to map to the device name in the guest OS. Treat
-	// it as a device ordering hint.
-	Device string `json:"dev,omitempty"`
+	// Bus indicates the type of disk device to emulate.
+	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
 	ReadOnly bool `json:"readonly,omitempty"`
 }
 
 type FloppyTarget struct {
-	// Device indicates the "logical" device name. The actual device name
-	// specified is not guaranteed to map to the device name in the guest OS. Treat
-	// it as a device ordering hint.
-	Device string `json:"dev,omitempty"`
+	// Bus indicates the type of disk device to emulate.
+	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to false
 	ReadOnly bool `json:"readonly,omitempty"`
@@ -168,10 +160,8 @@ const (
 )
 
 type CDRomTarget struct {
-	// Device indicates the "logical" device name. The actual device name
-	// specified is not guaranteed to map to the device name in the guest OS. Treat
-	// it as a device ordering hint.
-	Device string `json:"dev,omitempty"`
+	// Bus indicates the type of disk device to emulate.
+	Bus string `json:"bus,omitempty"`
 	// ReadOnly
 	// Defaults to true
 	ReadOnly *bool `json:"readonly,omitempty"`

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -73,14 +73,14 @@ func (DiskDevice) SwaggerDoc() map[string]string {
 
 func (DiskTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
 		"readonly": "ReadOnly\nDefaults to false",
 	}
 }
 
 func (LunTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
 		"readonly": "ReadOnly\nDefaults to false",
 	}
 }
@@ -95,7 +95,7 @@ func (FloppyTarget) SwaggerDoc() map[string]string {
 
 func (CDRomTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
 		"readonly": "ReadOnly\nDefaults to true",
 		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
 	}

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -73,14 +73,14 @@ func (DiskDevice) SwaggerDoc() map[string]string {
 
 func (DiskTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
 		"readonly": "ReadOnly\nDefaults to false",
 	}
 }
 
 func (LunTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
 		"readonly": "ReadOnly\nDefaults to false",
 	}
 }
@@ -95,7 +95,7 @@ func (FloppyTarget) SwaggerDoc() map[string]string {
 
 func (CDRomTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide\nsee libvirt schema here:\nhttps://github.com/libvirt/libvirt/blob/v3.7-maint/docs/schemas/domaincommon.rng#L1693",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
 		"readonly": "ReadOnly\nDefaults to true",
 		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
 	}

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -96,7 +96,6 @@ func (FloppyTarget) SwaggerDoc() map[string]string {
 func (CDRomTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"bus":      "Bus indicates the type of disk device to emulate.",
-		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
 		"readonly": "ReadOnly\nDefaults to true",
 		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
 	}

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -75,7 +75,7 @@ func (DiskTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
 		"readonly": "ReadOnly\nDefaults to false",
-		"bus":      "Bus indicates specifies the type of disk device to emulate.",
+		"bus":      "Bus indicates the type of disk device to emulate.",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -73,22 +73,21 @@ func (DiskDevice) SwaggerDoc() map[string]string {
 
 func (DiskTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
-		"readonly": "ReadOnly\nDefaults to false",
 		"bus":      "Bus indicates the type of disk device to emulate.",
+		"readonly": "ReadOnly\nDefaults to false",
 	}
 }
 
 func (LunTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
+		"bus":      "Bus indicates the type of disk device to emulate.",
 		"readonly": "ReadOnly\nDefaults to false",
 	}
 }
 
 func (FloppyTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
+		"bus":      "Bus indicates the type of disk device to emulate.",
 		"readonly": "ReadOnly\nDefaults to false",
 		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
 	}
@@ -96,6 +95,7 @@ func (FloppyTarget) SwaggerDoc() map[string]string {
 
 func (CDRomTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
+		"bus":      "Bus indicates the type of disk device to emulate.",
 		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
 		"readonly": "ReadOnly\nDefaults to true",
 		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -87,7 +87,6 @@ func (LunTarget) SwaggerDoc() map[string]string {
 
 func (FloppyTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.",
 		"readonly": "ReadOnly\nDefaults to false",
 		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
 	}

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -75,6 +75,7 @@ func (DiskTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"dev":      "Device indicates the \"logical\" device name. The actual device name\nspecified is not guaranteed to map to the device name in the guest OS. Treat\nit as a device ordering hint.",
 		"readonly": "ReadOnly\nDefaults to false",
+		"bus":      "Bus indicates specifies the type of disk device to emulate.",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -46,6 +46,9 @@ var exampleJSON = `{
       "cpu": {
         "cores": 3
       },
+      "machine": {
+        "type": "q35"
+      },
       "firmware": {
         "uuid": "28a42a60-44ef-4428-9c10-1a6aee94627f"
       },
@@ -114,7 +117,6 @@ var exampleJSON = `{
             "name": "disk0",
             "volumeName": "volume0",
             "disk": {
-              "dev": "vda",
               "bus": "virtio"
             }
           },
@@ -122,7 +124,7 @@ var exampleJSON = `{
             "name": "cdrom0",
             "volumeName": "volume1",
             "cdrom": {
-              "dev": "vdb",
+              "bus": "virtio",
               "readonly": true,
               "tray": "open"
             }
@@ -131,7 +133,7 @@ var exampleJSON = `{
             "name": "floppy0",
             "volumeName": "volume2",
             "floppy": {
-              "dev": "vdc",
+              "bus": "fd",
               "readonly": true,
               "tray": "open"
             }
@@ -140,7 +142,7 @@ var exampleJSON = `{
             "name": "lun0",
             "volumeName": "volume3",
             "lun": {
-              "dev": "vdd",
+              "bus": "virtio",
               "readonly": true
             }
           }
@@ -197,7 +199,6 @@ var _ = Describe("Schema", func() {
 				DiskDevice: DiskDevice{
 					Disk: &DiskTarget{
 						Bus:      "virtio",
-						Device:   "vda",
 						ReadOnly: false,
 					},
 				},
@@ -207,7 +208,7 @@ var _ = Describe("Schema", func() {
 				VolumeName: "volume1",
 				DiskDevice: DiskDevice{
 					CDRom: &CDRomTarget{
-						Device:   "vdb",
+						Bus:      "virtio",
 						ReadOnly: _true,
 						Tray:     "open",
 					},
@@ -218,7 +219,6 @@ var _ = Describe("Schema", func() {
 				VolumeName: "volume2",
 				DiskDevice: DiskDevice{
 					Floppy: &FloppyTarget{
-						Device:   "vdc",
 						ReadOnly: true,
 						Tray:     "open",
 					},
@@ -229,7 +229,7 @@ var _ = Describe("Schema", func() {
 				VolumeName: "volume3",
 				DiskDevice: DiskDevice{
 					LUN: &LunTarget{
-						Device:   "vdd",
+						Bus:      "virtio",
 						ReadOnly: true,
 					},
 				},
@@ -315,7 +315,6 @@ var _ = Describe("Schema", func() {
 			newVM := &VirtualMachine{}
 			err := json.Unmarshal([]byte(exampleJSON), newVM)
 			Expect(err).To(BeNil())
-
 			Expect(newVM).To(Equal(exampleVM))
 		})
 		It("Marshal struct into json", func() {

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -114,7 +114,8 @@ var exampleJSON = `{
             "name": "disk0",
             "volumeName": "volume0",
             "disk": {
-              "dev": "vda"
+              "dev": "vda",
+              "bus": "virtio"
             }
           },
           {
@@ -195,6 +196,7 @@ var _ = Describe("Schema", func() {
 				VolumeName: "volume0",
 				DiskDevice: DiskDevice{
 					Disk: &DiskTarget{
+						Bus:      "virtio",
 						Device:   "vda",
 						ReadOnly: false,
 					},

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -133,7 +133,6 @@ var exampleJSON = `{
             "name": "floppy0",
             "volumeName": "volume2",
             "floppy": {
-              "bus": "fd",
               "readonly": true,
               "tray": "open"
             }

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -99,6 +99,9 @@ func SetObjectDefaults_VirtualMachine(in *VirtualMachine) {
 	for i := range in.Spec.Domain.Devices.Disks {
 		a := &in.Spec.Domain.Devices.Disks[i]
 		SetDefaults_DiskDevice(&a.DiskDevice)
+		if a.DiskDevice.Disk != nil {
+			SetDefaults_DiskTarget(a.DiskDevice.Disk)
+		}
 		if a.DiskDevice.Floppy != nil {
 			SetDefaults_FloppyTarget(a.DiskDevice.Floppy)
 		}
@@ -183,6 +186,9 @@ func SetObjectDefaults_VirtualMachineReplicaSet(in *VirtualMachineReplicaSet) {
 		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {
 			a := &in.Spec.Template.Spec.Domain.Devices.Disks[i]
 			SetDefaults_DiskDevice(&a.DiskDevice)
+			if a.DiskDevice.Disk != nil {
+				SetDefaults_DiskTarget(a.DiskDevice.Disk)
+			}
 			if a.DiskDevice.Floppy != nil {
 				SetDefaults_FloppyTarget(a.DiskDevice.Floppy)
 			}

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -99,9 +99,6 @@ func SetObjectDefaults_VirtualMachine(in *VirtualMachine) {
 	for i := range in.Spec.Domain.Devices.Disks {
 		a := &in.Spec.Domain.Devices.Disks[i]
 		SetDefaults_DiskDevice(&a.DiskDevice)
-		if a.DiskDevice.Disk != nil {
-			SetDefaults_DiskTarget(a.DiskDevice.Disk)
-		}
 		if a.DiskDevice.Floppy != nil {
 			SetDefaults_FloppyTarget(a.DiskDevice.Floppy)
 		}
@@ -186,9 +183,6 @@ func SetObjectDefaults_VirtualMachineReplicaSet(in *VirtualMachineReplicaSet) {
 		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {
 			a := &in.Spec.Template.Spec.Domain.Devices.Disks[i]
 			SetDefaults_DiskDevice(&a.DiskDevice)
-			if a.DiskDevice.Disk != nil {
-				SetDefaults_DiskTarget(a.DiskDevice.Disk)
-			}
 			if a.DiskDevice.Floppy != nil {
 				SetDefaults_FloppyTarget(a.DiskDevice.Floppy)
 			}

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -24,6 +24,7 @@ func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk) error {
 
 	if diskDevice.Disk != nil {
 		disk.Device = "disk"
+		disk.Target.Bus = diskDevice.Disk.Bus
 		disk.Target.Device = diskDevice.Disk.Device
 		disk.ReadOnly = toApiReadOnly(diskDevice.Disk.ReadOnly)
 	} else if diskDevice.LUN != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -370,12 +370,10 @@ func Convert_v1_VirtualMachine_To_api_Domain(vm *v1.VirtualMachine, domain *Doma
 			return err
 		}
 	}
-	if vm.Spec.Domain.Machine != nil {
-		apiOst := vm.Spec.Domain.Machine
-		err := Convert_v1_Machine_To_api_OSType(apiOst, &domain.Spec.OS.Type, c)
-		if err != nil {
-			return err
-		}
+	apiOst := &vm.Spec.Domain.Machine
+	err = Convert_v1_Machine_To_api_OSType(apiOst, &domain.Spec.OS.Type, c)
+	if err != nil {
+		return err
 	}
 
 	if vm.Spec.Domain.CPU != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -85,13 +85,13 @@ func diskDeviceFromBusAndIndex(deviceName, bus string, index int) string {
 // port of http://elixir.free-electrons.com/linux/v4.15/source/drivers/scsi/sd.c#L3211
 func formatDeviceName(prefix string, index int) string {
 	base := int('z' - 'a' + 1)
-	name := prefix
+	name := ""
 
 	for index >= 0 {
-		name += string('a' + (index % base))
+		name = string('a'+(index%base)) + name
 		index = (index / base) - 1
 	}
-	return name
+	return prefix + name
 }
 
 func toApiReadOnly(src bool) *ReadOnly {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -35,9 +35,9 @@ func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk, devicePerBus m
 		disk.ReadOnly = toApiReadOnly(diskDevice.LUN.ReadOnly)
 	} else if diskDevice.Floppy != nil {
 		disk.Device = "floppy"
+		disk.Target.Bus = "fdc"
 		disk.Target.Tray = string(diskDevice.Floppy.Tray)
-		disk.Target.Bus = diskDevice.Floppy.Bus
-		disk.Target.Device = makeDeviceName(diskDevice.Floppy.Bus, devicePerBus)
+		disk.Target.Device = makeDeviceName(disk.Target.Bus, devicePerBus)
 		disk.ReadOnly = toApiReadOnly(diskDevice.Floppy.ReadOnly)
 	} else if diskDevice.CDRom != nil {
 		disk.Device = "cdrom"
@@ -65,7 +65,7 @@ func makeDeviceName(bus string, devicePerBus map[string]int) string {
 		prefix = "sd"
 	case "ide":
 		prefix = "hd"
-	case "fd":
+	case "fdc":
 		prefix = "fd"
 	default:
 		log.Log.Errorf("Unrecognized bus '%s'", bus)

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target bus="fd" dev="fda" tray="closed"></target>
+      <target bus="fdc" dev="fda" tray="closed"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="floppy_tray_unspecified"></alias>
     </disk>
@@ -315,7 +315,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target bus="fd" dev="fdb" tray="open"></target>
+      <target bus="fdc" dev="fdb" tray="open"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <readonly></readonly>
       <alias name="floppy_tray_open"></alias>

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -21,7 +21,6 @@ package api
 
 import (
 	"encoding/xml"
-	"log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -49,9 +48,6 @@ var _ = Describe("Converter", func() {
 				},
 			}
 			v1.SetObjectDefaults_VirtualMachine(vm)
-			vm.Spec.Domain.Machine = &v1.Machine{
-				Type: "pc",
-			}
 			vm.Spec.Domain.Devices.Watchdog = &v1.Watchdog{
 				Name: "mywatchdog",
 				WatchdogDevice: v1.WatchdogDevice{
@@ -106,8 +102,7 @@ var _ = Describe("Converter", func() {
 					VolumeName: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus:    "virtio",
-							Device: "vda",
+							Bus: "virtio",
 						},
 					},
 				},
@@ -116,8 +111,7 @@ var _ = Describe("Converter", func() {
 					VolumeName: "nocloud",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
-							Bus:    "virtio",
-							Device: "vdb",
+							Bus: "virtio",
 						},
 					},
 				},
@@ -260,7 +254,7 @@ var _ = Describe("Converter", func() {
   <name>mynamespace_testvm</name>
   <memory unit="MB">9</memory>
   <os>
-    <type machine="pc">hvm</type>
+    <type machine="q35">hvm</type>
   </os>
   <sysinfo type="smbios">
     <system>
@@ -296,7 +290,7 @@ var _ = Describe("Converter", func() {
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvm/noCloud.iso"></source>
-      <target tray="closed"></target>
+      <target bus="sata" dev="sda" tray="closed"></target>
       <driver name="qemu" type="raw"></driver>
       <readonly></readonly>
       <alias name="cdrom_tray_unspecified"></alias>
@@ -305,7 +299,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target tray="open"></target>
+      <target bus="sata" dev="sdb" tray="open"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="cdrom_tray_open"></alias>
     </disk>
@@ -313,7 +307,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target tray="closed"></target>
+      <target bus="fd" dev="fda" tray="closed"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="floppy_tray_unspecified"></alias>
     </disk>
@@ -321,7 +315,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target tray="open"></target>
+      <target bus="fd" dev="fdb" tray="open"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <readonly></readonly>
       <alias name="floppy_tray_open"></alias>
@@ -330,7 +324,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target bus="ide" dev="hdg"></target>
+      <target bus="sata" dev="sdc"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="should_default_to_disk"></alias>
     </disk>
@@ -338,7 +332,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target></target>
+      <target bus="sata" dev="sdd"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <auth username="admin">
         <secret type="iscsi" usage="mysecret-mynamespace-testvm---"></secret>
@@ -406,8 +400,6 @@ var _ = Describe("Converter", func() {
 
 		It("should be converted to a libvirt Domain with vm defaults set", func() {
 			v1.SetObjectDefaults_VirtualMachine(vm)
-			log.Printf(vmToDomainXML(vm, c))
-			log.Printf(convertedDomain)
 			Expect(vmToDomainXML(vm, c)).To(Equal(convertedDomain))
 		})
 		It("should convert CPU cores", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -21,6 +21,7 @@ package api
 
 import (
 	"encoding/xml"
+	"log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -105,6 +106,7 @@ var _ = Describe("Converter", func() {
 					VolumeName: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
+							Bus:    "virtio",
 							Device: "vda",
 						},
 					},
@@ -114,6 +116,7 @@ var _ = Describe("Converter", func() {
 					VolumeName: "nocloud",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
+							Bus:    "virtio",
 							Device: "vdb",
 						},
 					},
@@ -281,13 +284,13 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target dev="vda"></target>
+      <target bus="virtio" dev="vda"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="mydisk"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvm/noCloud.iso"></source>
-      <target dev="vdb"></target>
+      <target bus="virtio" dev="vdb"></target>
       <driver name="qemu" type="raw"></driver>
       <alias name="mydisk1"></alias>
     </disk>
@@ -327,7 +330,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target></target>
+      <target bus="virtio" dev="vda"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="should_default_to_disk"></alias>
     </disk>
@@ -403,6 +406,8 @@ var _ = Describe("Converter", func() {
 
 		It("should be converted to a libvirt Domain with vm defaults set", func() {
 			v1.SetObjectDefaults_VirtualMachine(vm)
+			log.Printf(vmToDomainXML(vm, c))
+			log.Printf(convertedDomain)
 			Expect(vmToDomainXML(vm, c)).To(Equal(convertedDomain))
 		})
 		It("should convert CPU cores", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -330,7 +330,7 @@ var _ = Describe("Converter", func() {
       <source protocol="iscsi" name="iqn.2013-07.com.example:iscsi-nopool/2">
         <host name="example.com" port="3260"></host>
       </source>
-      <target bus="virtio" dev="vda"></target>
+      <target bus="ide" dev="hdg"></target>
       <driver cache="none" name="qemu" type="raw"></driver>
       <alias name="should_default_to_disk"></alias>
     </disk>

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -72,7 +72,7 @@ func SetDomainSpec(virConn cli.Connection, vm *v1.VirtualMachine, wantedSpec api
 		log.Log.Object(vm).Reason(err).Error("Generating the domain XML failed.")
 		return nil, err
 	}
-	log.Log.Object(vm).V(3).With("xml", xmlStr).Info("Domain XML generated.")
+	log.Log.Object(vm).V(3).With("xml", string(xmlStr)).Info("Domain XML generated.")
 	dom, err := virConn.DomainDefineXML(string(xmlStr))
 	if err != nil {
 		log.Log.Object(vm).Reason(err).Error("Defining the VM failed.")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -522,23 +522,29 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 	vm := NewRandomVM()
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+	AddEphemeralDisk(vm, "disk0", "virtio", containerImage)
+	return vm
+}
+
+func AddEphemeralDisk(vm *v1.VirtualMachine, name string, bus string, image string) *v1.VirtualMachine {
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "disk0",
-		VolumeName: "disk0",
+		Name:       name,
+		VolumeName: name,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: "virtio",
+				Bus: bus,
 			},
 		},
 	})
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name: "disk0",
+		Name: name,
 		VolumeSource: v1.VolumeSource{
 			RegistryDisk: &v1.RegistryDiskSource{
-				Image: containerImage,
+				Image: image,
 			},
 		},
 	})
+
 	return vm
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -527,7 +527,7 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 		VolumeName: "vda",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Device: "vda",
+				Bus: "virtio",
 			},
 		},
 	})
@@ -550,7 +550,7 @@ func NewRandomVMWithEphemeralDiskAndUserdata(containerImage string, userData str
 		VolumeName: "vdb",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Device: "vdb",
+				Bus: "virtio",
 			},
 		},
 	})
@@ -573,7 +573,7 @@ func NewRandomVMWithUserData(userData string) *v1.VirtualMachine {
 		VolumeName: "vdb",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Device: "vdb",
+				Bus: "virtio",
 			},
 		},
 	})
@@ -593,8 +593,8 @@ func NewRandomVMWithDirectLunAndDevice(lun int, withAuth bool, diskDev v1.DiskDe
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       diskDev.Disk.Device,
-		VolumeName: diskDev.Disk.Device,
+		Name:       "vda",
+		VolumeName: "vda",
 		DiskDevice: diskDev,
 	})
 
@@ -612,7 +612,7 @@ func NewRandomVMWithDirectLunAndDevice(lun int, withAuth bool, diskDev v1.DiskDe
 	}
 
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name:         diskDev.Disk.Device,
+		Name:         "vdb",
 		VolumeSource: volumeSource,
 	})
 	return vm
@@ -621,7 +621,7 @@ func NewRandomVMWithDirectLunAndDevice(lun int, withAuth bool, diskDev v1.DiskDe
 func NewRandomVMWithDirectLun(lun int, withAuth bool) *v1.VirtualMachine {
 	diskDev := v1.DiskDevice{
 		Disk: &v1.DiskTarget{
-			Device: "vda",
+			Bus: "virtio",
 		},
 	}
 	return NewRandomVMWithDirectLunAndDevice(lun, withAuth, diskDev)
@@ -636,7 +636,7 @@ func NewRandomVMWithPVC(claimName string) *v1.VirtualMachine {
 		VolumeName: "vda",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Device: "vda",
+				Bus: "virtio",
 			},
 		},
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -588,18 +588,14 @@ func NewRandomVMWithUserData(userData string) *v1.VirtualMachine {
 	return vm
 }
 
-func NewRandomVMWithDirectLun(lun int, withAuth bool) *v1.VirtualMachine {
+func NewRandomVMWithDirectLunAndDevice(lun int, withAuth bool, diskDev v1.DiskDevice) *v1.VirtualMachine {
 	vm := NewRandomVM()
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "vda",
-		VolumeName: "vda",
-		DiskDevice: v1.DiskDevice{
-			Disk: &v1.DiskTarget{
-				Device: "vda",
-			},
-		},
+		Name:       diskDev.Disk.Device,
+		VolumeName: diskDev.Disk.Device,
+		DiskDevice: diskDev,
 	})
 
 	volumeSource := v1.VolumeSource{
@@ -616,10 +612,19 @@ func NewRandomVMWithDirectLun(lun int, withAuth bool) *v1.VirtualMachine {
 	}
 
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name:         "vda",
+		Name:         diskDev.Disk.Device,
 		VolumeSource: volumeSource,
 	})
 	return vm
+}
+
+func NewRandomVMWithDirectLun(lun int, withAuth bool) *v1.VirtualMachine {
+	diskDev := v1.DiskDevice{
+		Disk: &v1.DiskTarget{
+			Device: "vda",
+		},
+	}
+	return NewRandomVMWithDirectLunAndDevice(lun, withAuth, diskDev)
 }
 
 func NewRandomVMWithPVC(claimName string) *v1.VirtualMachine {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -523,8 +523,8 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "vda",
-		VolumeName: "vda",
+		Name:       "disk0",
+		VolumeName: "disk0",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",
@@ -532,7 +532,7 @@ func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 		},
 	})
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name: "vda",
+		Name: "disk0",
 		VolumeSource: v1.VolumeSource{
 			RegistryDisk: &v1.RegistryDiskSource{
 				Image: containerImage,
@@ -546,8 +546,8 @@ func NewRandomVMWithEphemeralDiskAndUserdata(containerImage string, userData str
 	vm := NewRandomVMWithEphemeralDisk(containerImage)
 
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "vdb",
-		VolumeName: "vdb",
+		Name:       "disk1",
+		VolumeName: "disk1",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",
@@ -555,7 +555,7 @@ func NewRandomVMWithEphemeralDiskAndUserdata(containerImage string, userData str
 		},
 	})
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name: "vdb",
+		Name: "disk1",
 		VolumeSource: v1.VolumeSource{
 			CloudInitNoCloud: &v1.CloudInitNoCloudSource{
 				UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
@@ -569,8 +569,8 @@ func NewRandomVMWithUserData(userData string) *v1.VirtualMachine {
 	vm := NewRandomVMWithPVC("disk-cirros")
 
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "vdb",
-		VolumeName: "vdb",
+		Name:       "disk1",
+		VolumeName: "disk1",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",
@@ -578,7 +578,7 @@ func NewRandomVMWithUserData(userData string) *v1.VirtualMachine {
 		},
 	})
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name: "vdb",
+		Name: "disk1",
 		VolumeSource: v1.VolumeSource{
 			CloudInitNoCloud: &v1.CloudInitNoCloudSource{
 				UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
@@ -593,8 +593,8 @@ func NewRandomVMWithDirectLunAndDevice(lun int, withAuth bool, diskDev v1.DiskDe
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "vda",
-		VolumeName: "vda",
+		Name:       "disk0",
+		VolumeName: "disk0",
 		DiskDevice: diskDev,
 	})
 
@@ -612,7 +612,7 @@ func NewRandomVMWithDirectLunAndDevice(lun int, withAuth bool, diskDev v1.DiskDe
 	}
 
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name:         "vdb",
+		Name:         "disk0",
 		VolumeSource: volumeSource,
 	})
 	return vm
@@ -632,8 +632,8 @@ func NewRandomVMWithPVC(claimName string) *v1.VirtualMachine {
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "vda",
-		VolumeName: "vda",
+		Name:       "disk0",
+		VolumeName: "disk0",
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",
@@ -641,7 +641,7 @@ func NewRandomVMWithPVC(claimName string) *v1.VirtualMachine {
 		},
 	})
 	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
-		Name: "vda",
+		Name: "disk0",
 		VolumeSource: v1.VolumeSource{
 			PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
 				ClaimName: claimName,

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -548,6 +548,26 @@ func AddEphemeralDisk(vm *v1.VirtualMachine, name string, bus string, image stri
 	return vm
 }
 
+func AddEphemeralFloppy(vm *v1.VirtualMachine, name string, image string) *v1.VirtualMachine {
+	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+		Name:       name,
+		VolumeName: name,
+		DiskDevice: v1.DiskDevice{
+			Floppy: &v1.FloppyTarget{},
+		},
+	})
+	vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			RegistryDisk: &v1.RegistryDiskSource{
+				Image: image,
+			},
+		},
+	})
+
+	return vm
+}
+
 func NewRandomVMWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachine {
 	vm := NewRandomVMWithEphemeralDisk(containerImage)
 

--- a/tests/vm_configuration_test.go
+++ b/tests/vm_configuration_test.go
@@ -84,8 +84,7 @@ var _ = Describe("Configurations", func() {
 		BeforeEach(func() {
 			diskDev = v1.DiskDevice{
 				Disk: &v1.DiskTarget{
-					Device: "vda",
-					Bus:    "virtio",
+					Bus: "virtio",
 				},
 			}
 			vm = tests.NewRandomVMWithDirectLunAndDevice(2, false, diskDev)

--- a/tests/vm_configuration_test.go
+++ b/tests/vm_configuration_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Configurations", func() {
 			}
 			vm = tests.NewRandomVMWithDirectLunAndDevice(2, false, diskDev)
 		})
-		It("should have /dev/vda node", func() {
+		It("should have /dev/sda node", func() {
 			vm, err = virtClient.VM(tests.NamespaceTestDefault).Create(vm)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMStart(vm)

--- a/tests/vm_configuration_test.go
+++ b/tests/vm_configuration_test.go
@@ -75,4 +75,43 @@ var _ = Describe("Configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 		}, 300)
 	})
+
+	Context("New VM with explicitly set VirtIO drives", func() {
+
+		var vm *v1.VirtualMachine
+		var diskDev v1.DiskDevice
+
+		BeforeEach(func() {
+			diskDev = v1.DiskDevice{
+				Disk: &v1.DiskTarget{
+					Device: "vda",
+					Bus:    "virtio",
+				},
+			}
+			vm = tests.NewRandomVMWithDirectLunAndDevice(2, false, diskDev)
+		})
+		It("should have /dev/vda node", func() {
+			vm, err = virtClient.VM(tests.NamespaceTestDefault).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMStart(vm)
+
+			expecter, _, err := tests.NewConsoleExpecter(virtClient, vm, "serial0", 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+			_, err = expecter.ExpectBatch([]expect.Batcher{
+				&expect.BExp{R: "Welcome to Alpine"},
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: "login"},
+				&expect.BSnd{S: "root\n"},
+				&expect.BExp{R: "#"},
+				&expect.BSnd{S: "ls /dev/vda\n"},
+				&expect.BExp{R: "/dev/vda"},
+			}, 150*time.Second)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	// TODO: add the same test for SATA bus -> /dev/sda. Requires Q35 chipset.
+
 })


### PR DESCRIPTION
Make it possible for clients to select the emulated drive exposing the busses supported by libvirt:
ide, scsi/sata, virtio.

Keep the default as virtio, to preserve the current behaviour - bus is related to the device node name, and the old device node name was "vd*", thus virtio.

Pending work: add more tests, and functests for sata. But this require work to make sure the chipset is -or can be set to- Q35.