### PR TITLE
Consider VM CPU and Memory requirements for POD scheduling

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2365,6 +2365,10 @@
    },
    "v1.ResourceRequirements": {
     "properties": {
+     "limits": {
+      "description": "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+      "type": "object"
+     },
      "requests": {
       "description": "Requests is a description of the initial vm resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
       "type": "object"

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -846,6 +846,13 @@ func (in *ResourceRequirements) DeepCopyInto(out *ResourceRequirements) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.Limits != nil {
+		in, out := &in.Limits, &out.Limits
+		*out = make(core_v1.ResourceList, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val.DeepCopy()
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -69,6 +69,10 @@ type ResourceRequirements struct {
 	// Valid resource keys are "memory" and "cpu".
 	// +optional
 	Requests v1.ResourceList `json:"requests,omitempty"`
+	// Limits describes the maximum amount of compute resources allowed.
+	// Valid resource keys are "cpu".
+	// +optional
+	Limits v1.ResourceList `json:"limits,omitempty"`
 }
 
 // CPU allow specifying the CPU topology

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -70,7 +70,7 @@ type ResourceRequirements struct {
 	// +optional
 	Requests v1.ResourceList `json:"requests,omitempty"`
 	// Limits describes the maximum amount of compute resources allowed.
-	// Valid resource keys are "cpu".
+	// Valid resource keys are "memory" and "cpu".
 	// +optional
 	Limits v1.ResourceList `json:"limits,omitempty"`
 }

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -25,6 +25,7 @@ func (DomainSpec) SwaggerDoc() map[string]string {
 func (ResourceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"requests": "Requests is a description of the initial vm resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"limits":   "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -97,6 +97,12 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	gracePeriodSeconds = gracePeriodSeconds + int64(15)
 	gracePeriodKillAfter := gracePeriodSeconds + int64(15)
 
+	// Consider CPU and memory requests and limits for pod scheduling
+	resources := kubev1.ResourceRequirements{}
+	vmResources := vm.Spec.Domain.Resources
+	resources.Requests = vmResources.Requests
+	resources.Limits = vmResources.Limits
+
 	// VM target container
 	container := kubev1.Container{
 		Name:            "compute",
@@ -132,6 +138,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 			SuccessThreshold:    int32(successThreshold),
 			FailureThreshold:    int32(failureThreshold),
 		},
+		Resources: resources,
 	}
 
 	containers, err := registrydisk.GenerateContainers(vm, "libvirt-runtime", "/var/run/libvirt")

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	kubev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
@@ -100,8 +101,24 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	// Consider CPU and memory requests and limits for pod scheduling
 	resources := kubev1.ResourceRequirements{}
 	vmResources := vm.Spec.Domain.Resources
-	resources.Requests = vmResources.Requests
-	resources.Limits = vmResources.Limits
+
+	resources.Requests = make(kubev1.ResourceList)
+
+	// Copy vm resources requests to a container
+	for key, value := range vmResources.Requests {
+		resources.Requests[key] = value
+	}
+
+	// Copy vm resources limits to a container
+	if vmResources.Limits != nil {
+		resources.Limits = make(kubev1.ResourceList)
+	}
+	for key, value := range vmResources.Limits {
+		resources.Limits[key] = value
+	}
+
+	// Add memory overhead
+	setMemoryOverhead(vm.Spec.Domain, &resources)
 
 	// VM target container
 	container := kubev1.Container{
@@ -202,6 +219,57 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 	}
 
 	return &pod, nil
+}
+
+// setMemoryOverhead computes the estimation of total
+// memory needed for the domain to operate properly.
+// This includes the memory needed for the guest and memory
+// for Qemu and OS overhead.
+//
+// The return values are requested memory and limit memory quantities
+//
+// Note: This is the best estimation we were able to come up with
+//       and is still not 100% accurate
+func setMemoryOverhead(domain v1.DomainSpec, resources *kubev1.ResourceRequirements) error {
+	vmMemoryReq := domain.Resources.Requests.Memory()
+
+	overhead := resource.NewScaledQuantity(0, resource.Kilo)
+
+	// Add the memory needed for pagetables (one bit for every 512b of RAM size)
+	pagetableMemory := resource.NewScaledQuantity(vmMemoryReq.ScaledValue(resource.Kilo), resource.Kilo)
+	pagetableMemory.Set(pagetableMemory.Value() / 512)
+	overhead.Add(*pagetableMemory)
+
+	// Add fixed overhead for shared libraries and such
+	// TODO account for the overhead of kubevirt components running in the pod
+	overhead.Add(resource.MustParse("64M"))
+
+	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
+	// overhead per vcpu in MiB
+	coresMemory := uint32(8)
+	if domain.CPU != nil {
+		coresMemory *= domain.CPU.Cores
+	}
+	overhead.Add(resource.MustParse(strconv.Itoa(int(coresMemory)) + "Mi"))
+
+	// static overhead for IOThread
+	overhead.Add(resource.MustParse("8Mi"))
+
+	// Add video RAM overhead
+	overhead.Add(resource.MustParse("16Mi"))
+
+	// Add overhead to memory request
+	memoryRequest := resources.Requests[kubev1.ResourceMemory]
+	memoryRequest.Add(*overhead)
+	resources.Requests[kubev1.ResourceMemory] = memoryRequest
+
+	// Add overhead to memory limits, if exists
+	if memoryLimit, ok := resources.Limits[kubev1.ResourceMemory]; ok {
+		memoryLimit.Add(*overhead)
+		resources.Limits[kubev1.ResourceMemory] = memoryLimit
+	}
+
+	return nil
 }
 
 func NewTemplateService(launcherImage string, virtShareDir string) (TemplateService, error) {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -138,11 +138,11 @@ var _ = Describe("Template", func() {
 							Resources: v1.ResourceRequirements{
 								Requests: kubev1.ResourceList{
 									kubev1.ResourceCPU:    resource.MustParse("1m"),
-									kubev1.ResourceMemory: resource.MustParse("1Gi"),
+									kubev1.ResourceMemory: resource.MustParse("1G"),
 								},
 								Limits: kubev1.ResourceList{
 									kubev1.ResourceCPU:    resource.MustParse("2m"),
-									kubev1.ResourceMemory: resource.MustParse("2Gi"),
+									kubev1.ResourceMemory: resource.MustParse("2G"),
 								},
 							},
 						},
@@ -154,8 +154,8 @@ var _ = Describe("Template", func() {
 				Expect(err).To(BeNil())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1m"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("2m"))
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1Gi"))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2Gi"))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1099507557"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2099507557"))
 			})
 			It("should not add unset resources", func() {
 
@@ -167,10 +167,11 @@ var _ = Describe("Template", func() {
 					},
 					Spec: v1.VirtualMachineSpec{
 						Domain: v1.DomainSpec{
+							CPU: &v1.CPU{Cores: 3},
 							Resources: v1.ResourceRequirements{
 								Requests: kubev1.ResourceList{
 									kubev1.ResourceCPU:    resource.MustParse("1m"),
-									kubev1.ResourceMemory: resource.MustParse("1Gi"),
+									kubev1.ResourceMemory: resource.MustParse("64M"),
 								},
 							},
 						},
@@ -180,12 +181,12 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vm)
 
 				Expect(err).To(BeNil())
+				Expect(vm.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("64M"))
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1m"))
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1Gi"))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179)))
 				Expect(pod.Spec.Containers[0].Resources.Limits).To(BeNil())
 			})
 		})
-	})
 
 		Context("with pvc source", func() {
 			It("should add pvc to template", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -412,12 +412,17 @@ func deletePV(os string, withAuth bool) {
 }
 
 func getPodIpByLabel(label string) string {
+	pod := GetRunningPodByLabel(label, v1.AppLabel, metav1.NamespaceSystem)
+	return pod.Status.PodIP
+}
+
+func GetRunningPodByLabel(label string, labelType string, namespace string) *k8sv1.Pod {
 	virtCli, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 
-	labelSelector := fmt.Sprintf("%s=%s", v1.AppLabel, label)
+	labelSelector := fmt.Sprintf("%s=%s", labelType, label)
 	fieldSelector := fmt.Sprintf("status.phase==%s", k8sv1.PodRunning)
-	pods, err := virtCli.CoreV1().Pods(metav1.NamespaceSystem).List(
+	pods, err := virtCli.CoreV1().Pods(namespace).List(
 		metav1.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector},
 	)
 	PanicOnError(err)
@@ -442,7 +447,8 @@ func getPodIpByLabel(label string) string {
 	if readyPod == nil {
 		PanicOnError(fmt.Errorf("no ready pods with the label %s", label))
 	}
-	return readyPod.Status.PodIP
+
+	return readyPod
 }
 
 func cleanNamespaces() {


### PR DESCRIPTION
The following changes will allow users to express CPU and Memory requirements and constraints for scheduling purposes.  Such as:

```yaml
    resources:
   requests:
        memory: "1Gi"
        cpu: "1"
      limits:
        memory: "2Gi"
        cpu: "2"
```
 
The VM requirements will be translated to a POD resources request, including a VM memory overhead that will be calculated and added to the POD memory request.


