### PR TITLE
Set correct logs verbose level

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -234,9 +234,9 @@ func (app *virtHandlerApp) AddFlags() {
 }
 
 func main() {
-	log.InitializeLogging("virt-handler")
 	libvirt.EventRegisterDefaultImpl()
 	app := &virtHandlerApp{}
 	service.Setup(app)
+	log.InitializeLogging("virt-handler")
 	app.Run()
 }

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -70,7 +70,6 @@ func createSocket(virtShareDir string, namespace string, name string) net.Listen
 }
 
 func main() {
-	log.InitializeLogging("virt-launcher")
 	qemuTimeout := flag.Duration("qemu-timeout", defaultStartTimeout, "Amount of time to wait for qemu")
 	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	name := flag.String("name", "", "Name of the VM")
@@ -80,6 +79,8 @@ func main() {
 	gracePeriodSeconds := flag.Int("grace-period-seconds", 30, "Grace period to observe before sending SIGTERM to vm process.")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+
+	log.InitializeLogging("virt-launcher")
 
 	socket := createSocket(*virtShareDir, *namespace, *name)
 	defer socket.Close()

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,7 +21,6 @@ package log
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -30,6 +29,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/go-kit/kit/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,7 +75,7 @@ type FilteredLogger struct {
 var Log = DefaultLogger()
 
 func InitializeLogging(comp string) {
-	flag.StringVar(&defaultComponent, "component", comp, "Default component for logs")
+	defaultComponent = comp
 	Log = DefaultLogger()
 }
 

--- a/tools/openapispec/openapispec.go
+++ b/tools/openapispec/openapispec.go
@@ -45,12 +45,13 @@ func dumpOpenApiSpec(dumppath *string) {
 }
 
 func main() {
-	klog.InitializeLogging("openapispec")
 	dumpapispecpath := flag.String("dump-api-spec-path", "openapi.json", "Path to OpenApi dump.")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	// client-go requires a config or a master to be set in order to configure a client
 	pflag.Set("master", "http://127.0.0.1:4321")
 	pflag.Parse()
+
+	klog.InitializeLogging("openapispec")
 
 	// arguments for NewVirtAPIApp have no influence on the generated spec
 	app := virt_api.VirtAPIApp{}


### PR DESCRIPTION
We need to set correct order for flags parsing and call
to `InitializeLogging()`, otherwise, we will have always default
verbosity level.

Signed-off-by: Lukianov Artyom <alukiano@redhat.com>