### PR TITLE
restructure firmware in VMSpec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2612,8 +2612,8 @@
    },
    "v1.Firmware": {
     "properties": {
-     "uid": {
-      "description": "UID reported by the vm bios\nDefaults to a random generated uid",
+     "uuid": {
+      "description": "UUID reported by the vm bios\nDefaults to a random generated uid",
       "type": "string"
      }
     }

--- a/cluster/windows-demo.yaml
+++ b/cluster/windows-demo.yaml
@@ -26,7 +26,7 @@ spec:
           tickPolicy: catchup
         hyperv: {}
     firmware:
-      uid: 5d307ca9-b3ef-428c-8861-06e72d69f223
+      uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
     resources:
       requests:
         memory: 512M

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -98,8 +98,8 @@ func SetDefaults_I6300ESBWatchdog(obj *I6300ESBWatchdog) {
 }
 
 func SetDefaults_Firmware(obj *Firmware) {
-	if obj.UID == "" {
-		obj.UID = types.UID(uuid.NewRandom().String())
+	if obj.UUID == "" {
+		obj.UUID = types.UID(uuid.NewRandom().String())
 	}
 }
 

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -84,9 +84,9 @@ type Machine struct {
 }
 
 type Firmware struct {
-	// UID reported by the vm bios
+	// UUID reported by the vm bios
 	// Defaults to a random generated uid
-	UID types.UID `json:"uid,omitempty"`
+	UUID types.UID `json:"uuid,omitempty"`
 }
 
 type Devices struct {

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -43,7 +43,7 @@ func (Machine) SwaggerDoc() map[string]string {
 
 func (Firmware) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"uid": "UID reported by the vm bios\nDefaults to a random generated uid",
+		"uuid": "UUID reported by the vm bios\nDefaults to a random generated uid",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -47,7 +47,7 @@ var exampleJSON = `{
         "cores": 3
       },
       "firmware": {
-        "uid": "28a42a60-44ef-4428-9c10-1a6aee94627f"
+        "uuid": "28a42a60-44ef-4428-9c10-1a6aee94627f"
       },
       "clock": {
         "utc": {},
@@ -301,7 +301,7 @@ var _ = Describe("Schema", func() {
 			},
 		}
 		exampleVM.Spec.Domain.Firmware = &Firmware{
-			UID: "28a42a60-44ef-4428-9c10-1a6aee94627f",
+			UUID: "28a42a60-44ef-4428-9c10-1a6aee94627f",
 		}
 		exampleVM.Spec.Domain.CPU = &CPU{
 			Cores: 3,

--- a/pkg/virt-handler/virtwrap/api/converter.go
+++ b/pkg/virt-handler/virtwrap/api/converter.go
@@ -273,7 +273,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vm *v1.VirtualMachine, domain *Doma
 		domain.Spec.SysInfo.System = []Entry{
 			{
 				Name:  "uuid",
-				Value: string(vm.Spec.Domain.Firmware.UID),
+				Value: string(vm.Spec.Domain.Firmware.UUID),
 			},
 		}
 	}

--- a/pkg/virt-handler/virtwrap/api/converter_test.go
+++ b/pkg/virt-handler/virtwrap/api/converter_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Converter", func() {
 				},
 			}
 			vm.Spec.Domain.Firmware = &v1.Firmware{
-				UID: "e4686d2c-6e8d-4335-b8fd-81bee22f4814",
+				UUID: "e4686d2c-6e8d-4335-b8fd-81bee22f4814",
 			}
 
 			gracePerod := int64(5)


### PR DESCRIPTION
Right now the SMBIOS UUID is represented at as:

```
firmware:
  uid: nnnn-nnnn-nnnn-nnnn
```

To better align with libvirt, we want representation such as this:

```
firmware:
  uuid: nnn-nnnn-nnnn-nnnn
```

Signed-off-by: Martin Polednik <mpolednik@redhat.com>