### PR TITLE
travis-ci: removing environment constrains for api-reference deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ deploy:
   script: bash hack/gen-swagger-doc/deploy.sh
   on:
     branch: master
-    go: 1.8.3
 
 env:
   global:


### PR DESCRIPTION
since the go matrix was removed, the api-reference deployment wasn't
getting executed.