### PR TITLE
Sync/build func tests during "make functest"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test:
 	hack/dockerized "hack/glide-checksync.sh && ./hack/check.sh && ./hack/build-go.sh install ${WHAT} && ./hack/build-go.sh test ${WHAT}"
 
 functest:
+	hack/dockerized "hack/build-func-tests.sh"
 	hack/functests.sh
 
 clean:

--- a/hack/build-func-tests.sh
+++ b/hack/build-func-tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+set -e
+
+source hack/common.sh
+source hack/config.sh
+
+build_func_tests

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -88,7 +88,5 @@ for arg in $args; do
 done
 
 if [[ "${target}" == "install" && "${build_tests}" == "true" ]]; then
-    mkdir -p ${TESTS_OUT_DIR}/
-    ginkgo build ${KUBEVIRT_DIR}/tests
-    mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
+    build_func_tests
 fi

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -9,3 +9,9 @@ CMD_OUT_DIR=$KUBEVIRT_DIR/_out/cmd/
 TESTS_OUT_DIR=$KUBEVIRT_DIR/_out/tests/
 APIDOCS_OUT_DIR=$KUBEVIRT_DIR/_out/apidocs
 MANIFESTS_OUT_DIR=$KUBEVIRT_DIR/_out/manifests
+
+function build_func_tests() {
+    mkdir -p ${TESTS_OUT_DIR}/
+    ginkgo build ${KUBEVIRT_DIR}/tests
+    mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
+}


### PR DESCRIPTION
I want to be able to quickly iterate on functional tests without having to build all the KubeVirt binaries. 

With this change, 'make functests' will build only the functional tests and sync them to the _out directory before executing the tests. Without this change I had to run 'make build' then 'make functests' for my functional test changes to get picked up. 