### PR TITLE
Fedora Cloud Functional Test

### DIFF
--- a/cluster/vm-fedora.yaml
+++ b/cluster/vm-fedora.yaml
@@ -1,0 +1,28 @@
+apiVersion: kubevirt.io/v1alpha1
+kind: VirtualMachine
+metadata:
+  name: fedora-ephemeral
+spec:
+  terminationGracePeriodSeconds: 0
+  domain:
+    resources:
+      requests:
+        memory: 1024M
+    devices:
+      disks:
+      - name: registrydisk
+        volumeName: registryvolume
+        disk:
+          dev: vda
+      - name: cloudinitdisk
+        volumeName: cloudinitvolume
+        disk:
+          dev: vdb
+  volumes:
+    - name: registryvolume
+      registryDisk:
+        image: kubevirt/fedora-cloud-registry-disk-demo:devel
+    - name: cloudinitvolume
+      cloudInitNoCloud:
+        userDataBase64: I2Nsb3VkLWNvbmZpZwpwYXNzd29yZDogYXRvbWljCnNzaF9wd2F1dGg6IFRydWUKY2hwYXNzd2Q6IHsgZXhwaXJlOiBGYWxzZSB9Cg==
+

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,5 +1,5 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virtctl cmd/fake-qemu-process cmd/virt-dhcp cmd/fake-dnsmasq-process"
-docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler images/iscsi-demo-target-tgtd images/vm-killer images/libvirt-kubevirt cmd/virt-migrator cmd/registry-disk-v1alpha images/cirros-registry-disk-demo cmd/virt-dhcp"
+docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler images/iscsi-demo-target-tgtd images/vm-killer images/libvirt-kubevirt cmd/virt-migrator cmd/registry-disk-v1alpha images/cirros-registry-disk-demo cmd/virt-dhcp images/fedora-cloud-registry-disk-demo"
 optional_docker_images="cmd/registry-disk-v1alpha images/fedora-atomic-registry-disk-demo"
 docker_prefix=kubevirt
 docker_tag=${DOCKER_TAG:-latest}

--- a/images/fedora-cloud-registry-disk-demo/Dockerfile
+++ b/images/fedora-cloud-registry-disk-demo/Dockerfile
@@ -21,4 +21,4 @@ FROM kubevirt/registry-disk-v1alpha
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 # Add fedora cloud disk image
-RUN curl -g -L https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2 < /disk/fedora.qcow2
+RUN curl -g -L https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2 > /disk/fedora.qcow2

--- a/images/fedora-cloud-registry-disk-demo/Dockerfile
+++ b/images/fedora-cloud-registry-disk-demo/Dockerfile
@@ -1,0 +1,24 @@
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+FROM kubevirt/registry-disk-v1alpha
+
+MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+
+# Add fedora cloud disk image
+RUN curl -g -L https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2 < /disk/fedora.qcow2

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Console", func() {
 	})
 
 	Context("New VM with a serial console given", func() {
+
 		It("should be returned that we are running cirros", func() {
 			vm := tests.NewRandomVMWithPVC("disk-cirros")
 
@@ -58,6 +59,24 @@ var _ = Describe("Console", func() {
 			}, 60*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should be returned that we are running fedora", func() {
+
+			vm := tests.NewRandomVMWithEphemeralDiskHighMemory("kubevirt/fedora-cloud-registry-disk-demo:devel")
+
+			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
+			tests.WaitForSuccessfulVMStart(vm)
+
+			expecter, _, err := tests.NewConsoleExpecter(virtClient, vm, "serial0", 10*time.Second)
+			defer expecter.Close()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = expecter.ExpectBatch([]expect.Batcher{
+				&expect.BExp{R: "Welcome to"},
+			}, 120*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+		}, 140)
+
 		It("should be able to reconnect to console multiple times", func() {
 			vm := tests.NewRandomVMWithPVC("disk-alpine")
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -514,6 +514,13 @@ func NewRandomVMWithNS(namespace string) *v1.VirtualMachine {
 	return vm
 }
 
+func NewRandomVMWithEphemeralDiskHighMemory(containerImage string) *v1.VirtualMachine {
+	vm := NewRandomVMWithEphemeralDisk(containerImage)
+
+	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+	return vm
+}
+
 func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 	vm := NewRandomVM()
 


### PR DESCRIPTION
We've talked about wanting to begin testing Fedora in our CI environment.

The Fedora Cloud qcow2 image is 222mb. This patch series creates a registry disk container with the qcow2 image and does a simple console test to verify we can boot up Fedora Cloud.

More advanced tests are possible using this image in the future if we want. For now I just wanted to introduce it as an option.

Using the ISCSI demo image for this image would require us to use .raw format. That expands the disk to > 4gb, which makes it somewhat impractical for our functional test suite.  The registry disk with qcow2 keeps the size down to a somewhat respectable level. 