### PR TITLE
Make cirros and alpine ready for q35

### DIFF
--- a/images/cirros-registry-disk-demo/Dockerfile
+++ b/images/cirros-registry-disk-demo/Dockerfile
@@ -21,4 +21,4 @@ FROM kubevirt/registry-disk-v1alpha
 MAINTAINER "David Vossel" \<dvossel@redhat.com\>
 
 # Add cirros
-RUN curl http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img > /disk/cirros.img
+RUN curl https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img > /disk/cirros.img

--- a/images/iscsi-demo-target-tgtd/Dockerfile
+++ b/images/iscsi-demo-target-tgtd/Dockerfile
@@ -28,12 +28,12 @@ RUN mkdir -p /volume
 
 # Add alpine image
 RUN curl \
-      https://nl.alpinelinux.org/alpine/v3.5/releases/x86_64/alpine-virt-3.5.1-x86_64.iso \
+      http://dl-cdn.alpinelinux.org/alpine/v3.7/releases/x86_64/alpine-virt-3.7.0-x86_64.iso \
       > /volume/alpine.iso
 
 # Add cirros
 RUN curl \
-      http://download.cirros-cloud.net/0.3.5/cirros-0.3.5-x86_64-disk.img \
+      https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img \
       > /volume/cirros.img \
       && qemu-img convert -O raw /volume/cirros.img /volume/cirros.rawa \
       && rm volume/cirros.img

--- a/pkg/virt-handler/virtwrap/api/converter_test.go
+++ b/pkg/virt-handler/virtwrap/api/converter_test.go
@@ -269,6 +269,7 @@ var _ = Describe("Converter", func() {
   <devices>
     <interface type="network">
       <source network="default"></source>
+      <model type="e1000"></model>
     </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>

--- a/pkg/virt-handler/virtwrap/api/defaults.go
+++ b/pkg/virt-handler/virtwrap/api/defaults.go
@@ -17,6 +17,9 @@ func SetDefaults_Devices(devices *Devices) {
 
 	// For now connect every virtual machine to the default network
 	devices.Interfaces = []Interface{{
+		Model: &Model{
+			Type: "e1000",
+		},
 		Type: "network",
 		Source: InterfaceSource{
 			Network: "default",

--- a/pkg/virt-handler/virtwrap/api/schema_test.go
+++ b/pkg/virt-handler/virtwrap/api/schema_test.go
@@ -42,6 +42,7 @@ var exampleXML = `<domain type="qemu" xmlns:qemu="http://libvirt.org/schemas/dom
   <devices>
     <interface type="network">
       <source network="default"></source>
+      <model type="e1000"></model>
     </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -524,9 +524,6 @@ func NewRandomVMWithEphemeralDiskHighMemory(containerImage string) *v1.VirtualMa
 func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 	vm := NewRandomVM()
 
-	vm.Spec.Domain.Machine = &v1.Machine{
-		Type: "pc",
-	}
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
 		Name:       "vda",
@@ -597,9 +594,6 @@ func NewRandomVMWithUserData(userData string) *v1.VirtualMachine {
 func NewRandomVMWithDirectLun(lun int, withAuth bool) *v1.VirtualMachine {
 	vm := NewRandomVM()
 
-	vm.Spec.Domain.Machine = &v1.Machine{
-		Type: "pc",
-	}
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
 		Name:       "vda",
@@ -634,9 +628,6 @@ func NewRandomVMWithDirectLun(lun int, withAuth bool) *v1.VirtualMachine {
 func NewRandomVMWithPVC(claimName string) *v1.VirtualMachine {
 	vm := NewRandomVM()
 
-	vm.Spec.Domain.Machine = &v1.Machine{
-		Type: "pc",
-	}
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
 		Name:       "vda",


### PR DESCRIPTION
* Use e1000 as default interface
* Update to cirros 4.0
* Update to alpine 3.7

Signed-off-by: Roman Mohr <rmohr@redhat.com>