### PR TITLE
Prepare Functional Tests for Network and Storage Changes

### DIFF
--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,5 +1,5 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virtctl cmd/fake-qemu-process"
-docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler images/iscsi-demo-target-tgtd images/vm-killer cmd/registry-disk-v1alpha images/cirros-registry-disk-demo images/fedora-cloud-registry-disk-demo"
+docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler images/iscsi-demo-target-tgtd images/vm-killer cmd/registry-disk-v1alpha images/cirros-registry-disk-demo images/fedora-cloud-registry-disk-demo images/alpine-registry-disk-demo"
 docker_prefix=kubevirt
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -22,4 +22,4 @@ set -e
 source hack/common.sh
 source hack/config.sh
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -test.timeout 30m ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -test.timeout 40m ${FUNC_TEST_ARGS}

--- a/images/alpine-registry-disk-demo/Dockerfile
+++ b/images/alpine-registry-disk-demo/Dockerfile
@@ -1,0 +1,24 @@
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+FROM kubevirt/registry-disk-v1alpha
+
+MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+
+# Add alpine image
+RUN curl http://dl-cdn.alpinelinux.org/alpine/v3.7/releases/x86_64/alpine-virt-3.7.0-x86_64.iso > /disk/alpine.iso

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Console", func() {
 	Context("New VM with a serial console given", func() {
 
 		It("should be returned that we are running cirros", func() {
-			vm := tests.NewRandomVMWithPVC("disk-cirros")
+			vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
 
 			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
 			tests.WaitForSuccessfulVMStart(vm)
@@ -78,7 +78,7 @@ var _ = Describe("Console", func() {
 		}, 140)
 
 		It("should be able to reconnect to console multiple times", func() {
-			vm := tests.NewRandomVMWithPVC("disk-alpine")
+			vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
 
 			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
 			tests.WaitForSuccessfulVMStart(vm)

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Console", func() {
 
 			_, err = expecter.ExpectBatch([]expect.Batcher{
 				&expect.BExp{R: "checking http://169.254.169.254/2009-04-04/instance-id"},
-			}, 60*time.Second)
+			}, 120*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -91,7 +91,7 @@ var _ = Describe("Console", func() {
 				_, err = expecter.ExpectBatch([]expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: "login"},
-				}, 130*time.Second)
+				}, 160*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		}, 220)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Storage", func() {
 	tests.PanicOnError(err)
 
 	BeforeEach(func() {
+		Skip("Direct ISCSI storage access is not supported at the moment.")
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -647,7 +647,7 @@ func NewRandomVMWithPVC(claimName string) *v1.VirtualMachine {
 }
 
 func NewRandomVMWithWatchdog() *v1.VirtualMachine {
-	vm := NewRandomVMWithDirectLun(2, false)
+	vm := NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
 
 	vm.Spec.Domain.Devices.Watchdog = &v1.Watchdog{
 		Name: "mywatchdog",

--- a/tests/vm_configuration_test.go
+++ b/tests/vm_configuration_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Configurations", func() {
 		var vm *v1.VirtualMachine
 
 		BeforeEach(func() {
-			vm = tests.NewRandomVMWithDirectLun(2, false)
+			vm = tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
 		})
 		It("should report 3 cpu cores", func() {
 			vm.Spec.Domain.CPU = &v1.CPU{

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -70,16 +70,6 @@ var _ = Describe("CloudInit UserData", func() {
 	})
 
 	Context("CloudInit Data Source NoCloud", func() {
-		It("should launch vm with cloud-init data source NoCloud", func(done Done) {
-			magicStr := "printed from cloud-init userdata"
-			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)
-
-			vm := tests.NewRandomVMWithUserData(userData)
-			obj := LaunchVM(vm)
-			VerifyUserDataVM(vm, obj, magicStr)
-			close(done)
-		}, 180)
-
 		It("should launch ephemeral vm with cloud-init data source NoCloud", func(done Done) {
 			magicStr := "printed from cloud-init userdata"
 			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)
@@ -93,7 +83,7 @@ var _ = Describe("CloudInit UserData", func() {
 		It("should launch VMs with user-data in k8s secret", func(done Done) {
 			magicStr := "printed from cloud-init userdata"
 			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)
-			vm := tests.NewRandomVMWithUserData(userData)
+			vm := tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", userData)
 
 			for _, volume := range vm.Spec.Volumes {
 				if volume.CloudInitNoCloud == nil {

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Vmlifecycle", func() {
 			tests.WaitForSuccessfulVMStart(obj)
 
 			close(done)
-		}, 30)
+		}, 45)
 
 		It("Virt-launcher should attach to a started VM", func(done Done) {
 			obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
@@ -180,7 +180,7 @@ var _ = Describe("Vmlifecycle", func() {
 					return false
 				})
 				close(done)
-			}, 30)
+			}, 45)
 
 			It("Should log warning if secret is not present, and proceed once the secret is there", func(done Done) {
 				userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
@@ -249,7 +249,7 @@ var _ = Describe("Vmlifecycle", func() {
 				}()).To(Equal(v1.Failed))
 
 				close(done)
-			}, 50)
+			}, 60)
 			It("should be left alone by virt-handler", func(done Done) {
 				obj, err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Get()
 				Expect(err).To(BeNil())

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -448,8 +448,10 @@ func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vm *v1.VirtualMachine) 
 	var tailLines int64 = 100
 	logsRaw, err := virtCli.CoreV1().
 		Pods(namespace).
-		GetLogs(podName,
-			&k8sv1.PodLogOptions{TailLines: &tailLines}).
+		GetLogs(podName, &k8sv1.PodLogOptions{
+			TailLines: &tailLines,
+			Container: "compute",
+		}).
 		DoRaw()
 	Expect(err).To(BeNil())
 

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Vmlifecycle", func() {
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
-		vm = tests.NewRandomVMWithDirectLun(2, true)
+		vm = tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
 	})
 
 	Context("New VM given", func() {

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -49,8 +49,6 @@ var _ = Describe("Vmlifecycle", func() {
 			Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())
 			tests.WaitForSuccessfulVMStart(vm)
 
-			tests.WaitForSuccessfulVMStart(vm)
-
 			pipeInReader, _ := io.Pipe()
 			pipeOutReader, pipeOutWriter := io.Pipe()
 


### PR DESCRIPTION
With #686 the qemu process will no longer have network connectivity to the ISCSI demo target container. 

To account for this...
* All functional tests now use registry disks (alpine, cirros, fedora)
* All ISCSI storage functional tests have been disabled
* The ISCSI target demo container image has been removed

Future support for storage will come from PVs being provided directly to the VM pod through the kublet.

This patch is a prerequisite for merging the network changes.  