### PR TITLE
Fix PROVIDER lines for vagrant-kubernetes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ if ARGV.first == "up" && ENV['USING_KUBE_SCRIPTS'] != 'true'
   raise Vagrant::Errors::VagrantError.new, <<END
 Calling 'vagrant up' directly is not supported.  Instead, please run the following:
 
-  export PROVIDER=vagrant
+  export PROVIDER=vagrant-kubernetes
   make cluster-up
 END
 end

--- a/docs/env-providers.md
+++ b/docs/env-providers.md
@@ -25,7 +25,7 @@ Requires:
 Usage:
 
 ```bash
-export PROVIDER=vagrant # choose this provider
+export PROVIDER=vagrant-kubernetes # choose this provider
 export VAGRANT_NUM_NODES=2 # master + two nodes
 make cluster-up
 ```


### PR DESCRIPTION
A couple of lines still point the user to `PROVIDER=vagrant`