### PR TITLE
Ensure qemu process is shutdown if virt-launcher crashes

### DIFF
--- a/cmd/virt-launcher/entrypoint.sh
+++ b/cmd/virt-launcher/entrypoint.sh
@@ -15,15 +15,15 @@ if [ -n "$qemu_pid" ]; then
 	# give the pid 10 seconds to exit. 
 	for x in $(seq 1 10); do
 		if ! [ -d /proc/$qemu_pid ]; then
-			echo "qemu pid exited after after SIGTERM"
+			echo "qemu pid [$qemu_pid] exited after after SIGTERM"
 			exit $rc
 		fi
-		echo "waiting for qemu pid to exit"
+		echo "waiting for qemu pid [$qemu_pid] to exit"
 		sleep 1
 	done
 
 	# if we got here, the pid never exitted gracefully.
-	echo "timed out waiting for qemu pid to exit"
+	echo "timed out waiting for qemu pid [$qemu_pid] to exit"
 fi
 
 exit $rc

--- a/cmd/virt-launcher/entrypoint.sh
+++ b/cmd/virt-launcher/entrypoint.sh
@@ -1,2 +1,29 @@
 #!/bin/bash
 ./virt-launcher $@
+rc=$?
+
+echo "virt-launcher exited with code $rc"
+
+# if the qemu pid outlives virt-launcher because virt-launcher
+# segfaulted/panicked/etc... then make sure we perform a sane
+# shutdown of the qemu process before exitting. 
+qemu_pid=$(pgrep -u qemu)
+if [ -n "$qemu_pid" ]; then
+	echo "qemu pid outlived virt-launcher process. Sending SIGTERM"
+	kill -SIGTERM $qemu_pid
+
+	# give the pid 10 seconds to exit. 
+	for x in $(seq 1 10); do
+		if ! [ -d /proc/$qemu_pid ]; then
+			echo "qemu pid exited after after SIGTERM"
+			exit $rc
+		fi
+		echo "waiting for qemu pid to exit"
+		sleep 1
+	done
+
+	# if we got here, the pid never exitted gracefully.
+	echo "timed out waiting for qemu pid to exit"
+fi
+
+exit $rc


### PR DESCRIPTION
Virt-launcher has an entrypoint.sh script that acts as pid 1. If virt-launcher crashes/panicks/etc... for any reason, we should attempt to SIGTERM the qemu process if it has outlived virt-launcher.