### PR TITLE
Improve console and vnc connection errors

### DIFF
--- a/cmd/virt-launcher/sock-connector
+++ b/cmd/virt-launcher/sock-connector
@@ -24,5 +24,10 @@ function serial_cleanup() {
 # only one serial connection can exist at a time.
 serial_cleanup
 
+if ! [ -S "$SOCKET" ]; then
+	echo "Virtual Machine's $SOCKET socket is currently unavailable"
+	exit 1
+fi
+
 stty -echo
 socat unix-connect:/$SOCKET stdio,cfmakeraw

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -79,7 +79,7 @@ func (c *Console) Run(flags *flag.FlagSet) int {
 		log.Printf("Make raw terminal failed: %s", err)
 		return 1
 	}
-	fmt.Fprint(os.Stderr, "Escape sequence is ^]")
+	fmt.Fprint(os.Stderr, "Escape sequence is ^]\n")
 
 	in := os.Stdin
 	out := os.Stdout


### PR DESCRIPTION
If a VM's console/vnc is being accessed before or after the VM has completed running, the error output is confusing and not helpful. This patch makes it much more obvious what the problem is for the user. 

Fixes #697