### PR TITLE
Domain.Features mistakenly used the wrong type for APIC

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1819,6 +1819,18 @@
      }
     }
    },
+   "v1.FeatureAPIC": {
+    "properties": {
+     "enabled": {
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
+      "type": "boolean"
+     },
+     "endOfInterrupt": {
+      "description": "EndOfInterrupt enables the end of interrupt notification in the guest\nDefaults to false\n+optional",
+      "type": "boolean"
+     }
+    }
+   },
    "v1.FeatureHyperv": {
     "description": "Hyperv specific features",
     "properties": {
@@ -1904,7 +1916,7 @@
      },
      "apic": {
       "description": "Defaults to the machine type setting\n+optional",
-      "$ref": "#/definitions/v1.FeatureState"
+      "$ref": "#/definitions/v1.FeatureAPIC"
      },
      "hyperv": {
       "description": "Defaults to the machine type setting\n+optional",

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -597,7 +597,7 @@ func (in *Features) DeepCopyInto(out *Features) {
 		if *in == nil {
 			*out = nil
 		} else {
-			*out = new(FeatureState)
+			*out = new(FeatureAPIC)
 			(*in).DeepCopyInto(*out)
 		}
 	}

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -46,6 +46,12 @@ func SetDefaults_FeatureState(obj *FeatureState) {
 	}
 }
 
+func SetDefaults_FeatureAPIC(obj *FeatureAPIC) {
+	if obj.Enabled == nil {
+		obj.Enabled = _true
+	}
+}
+
 func SetDefaults_FeatureVendorID(obj *FeatureVendorID) {
 	if obj.Enabled == nil {
 		obj.Enabled = _true

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Defaults", func() {
 		}
 		vm.Spec.Domain.Features = &Features{
 			ACPI: FeatureState{},
-			APIC: &FeatureState{},
+			APIC: &FeatureAPIC{},
 			Hyperv: &FeatureHyperv{
 				Relaxed:    &FeatureState{},
 				VAPIC:      &FeatureState{},
@@ -68,7 +68,7 @@ var _ = Describe("Defaults", func() {
 		}
 		vm.Spec.Domain.Features = &Features{
 			ACPI: FeatureState{Enabled: _true},
-			APIC: &FeatureState{Enabled: _false},
+			APIC: &FeatureAPIC{Enabled: _false},
 			Hyperv: &FeatureHyperv{
 				Relaxed:    &FeatureState{Enabled: _true},
 				VAPIC:      &FeatureState{Enabled: _false},
@@ -101,7 +101,7 @@ var _ = Describe("Defaults", func() {
 
 		vm.Spec.Domain.Features = &Features{
 			ACPI: FeatureState{Enabled: _false},
-			APIC: &FeatureState{Enabled: _true},
+			APIC: &FeatureAPIC{Enabled: _true},
 			Hyperv: &FeatureHyperv{
 				Relaxed:    &FeatureState{Enabled: _false},
 				VAPIC:      &FeatureState{Enabled: _true},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -365,7 +365,7 @@ type Features struct {
 	ACPI FeatureState `json:"acpi,omitempty"`
 	// Defaults to the machine type setting
 	// +optional
-	APIC *FeatureState `json:"apic,omitempty"`
+	APIC *FeatureAPIC `json:"apic,omitempty"`
 	// Defaults to the machine type setting
 	// +optional
 	Hyperv *FeatureHyperv `json:"hyperv,omitempty"`

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -275,7 +275,7 @@ var _ = Describe("Schema", func() {
 		}
 		exampleVM.Spec.Domain.Features = &Features{
 			ACPI: FeatureState{Enabled: _false},
-			APIC: &FeatureState{Enabled: _true},
+			APIC: &FeatureAPIC{Enabled: _true},
 			Hyperv: &FeatureHyperv{
 				Relaxed:    &FeatureState{Enabled: _true},
 				VAPIC:      &FeatureState{Enabled: _false},

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -64,7 +64,7 @@ func SetObjectDefaults_VirtualMachine(in *VirtualMachine) {
 	if in.Spec.Domain.Features != nil {
 		SetDefaults_FeatureState(&in.Spec.Domain.Features.ACPI)
 		if in.Spec.Domain.Features.APIC != nil {
-			SetDefaults_FeatureState(in.Spec.Domain.Features.APIC)
+			SetDefaults_FeatureAPIC(in.Spec.Domain.Features.APIC)
 		}
 		if in.Spec.Domain.Features.Hyperv != nil {
 			if in.Spec.Domain.Features.Hyperv.Relaxed != nil {
@@ -148,7 +148,7 @@ func SetObjectDefaults_VirtualMachineReplicaSet(in *VirtualMachineReplicaSet) {
 		if in.Spec.Template.Spec.Domain.Features != nil {
 			SetDefaults_FeatureState(&in.Spec.Template.Spec.Domain.Features.ACPI)
 			if in.Spec.Template.Spec.Domain.Features.APIC != nil {
-				SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.APIC)
+				SetDefaults_FeatureAPIC(in.Spec.Template.Spec.Domain.Features.APIC)
 			}
 			if in.Spec.Template.Spec.Domain.Features.Hyperv != nil {
 				if in.Spec.Template.Spec.Domain.Features.Hyperv.Relaxed != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Converter", func() {
 				},
 			}
 			vm.Spec.Domain.Features = &v1.Features{
-				APIC: &v1.FeatureState{},
+				APIC: &v1.FeatureAPIC{},
 				Hyperv: &v1.FeatureHyperv{
 					Relaxed:    &v1.FeatureState{Enabled: &_false},
 					VAPIC:      &v1.FeatureState{Enabled: &_true},


### PR DESCRIPTION
APIC used FeatureState instead of the struct specifically designed to track this feature.