### PR TITLE
manifests: Adding SCC manifests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,7 @@ deploy:
   file_glob: true
   file:
   - _out/cmd/virtctl/virtctl-*
-  - _out/manifests/release/kubevirt.yaml
-  - _out/manifests/release/demo-content.yaml
+  - _out/manifests/release/*.yaml
   prerelease: true
   overwrite: true
   on:

--- a/manifests/dev/openshift-scc.yaml.in
+++ b/manifests/dev/openshift-scc.yaml.in
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: SecurityContextConstraints
+metadata:
+  name: kubevirt-scc
+  labels:
+    kubevirt.io: scc
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - '*'
+users:
+  - system:serviceaccount:kube-system:kubevirt-privileged
+  - system:serviceaccount:kube-system:kubevirt-controller

--- a/manifests/release/for-openshift.yaml.in
+++ b/manifests/release/for-openshift.yaml.in
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: SecurityContextConstraints
+metadata:
+  name: kubevirt-scc
+  labels:
+    kubevirt.io: scc
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - '*'
+users:
+  - system:serviceaccount:kube-system:kubevirt-privileged
+  - system:serviceaccount:kube-system:kubevirt-controller

--- a/manifests/testing/openshift-testing-scc.yaml.in
+++ b/manifests/testing/openshift-testing-scc.yaml.in
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: SecurityContextConstraints
+metadata:
+  name: kubevirt-testing-scc
+  labels:
+    kubevirt.io: scc
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - '*'
+users:
+  - system:serviceaccount:kube-system:kubevirt-testing


### PR DESCRIPTION
- The SCC manifests are required for the deployment of Kubevirt on
  Openshift.

- Currently, the granted privileges are the same as in the "privileged"
  SCC. Once we stabilize the functional tests on Openshift, we can start to drop
  unneeded privileges from the SCC.

closes https://github.com/kubevirt/kubevirt/issues/573

Signed-off-by: gbenhaim <galbh2@gmail.com>