### PR TITLE
Overwrite already existing files on prereleases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ deploy:
   - _out/cmd/virtctl/virtctl-*
   - _out/manifests/release/kubevirt.yaml
   prerelease: true
+  overwrite: true
   on:
     tags: true
     repo: kubevirt/kubevirt

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -71,7 +71,7 @@ for arg in $args; do
     elif [ "${target}" = "install" ]; then
         eval "$(go env)"
         BIN_NAME=$(basename $arg)
-        ARCHBIN=${BIN_NAME}-$(git describe --always)-${GOHOSTOS}-${GOHOSTARCH}
+        ARCHBIN=${BIN_NAME}-$(git describe --always --tags)-${GOHOSTOS}-${GOHOSTARCH}
         mkdir -p ${CMD_OUT_DIR}/${BIN_NAME}
         (
             cd $arg


### PR DESCRIPTION
In order to allow moving tags in the code and still producing correct
releases, we need to overwrite build artifacts which are already part of
a release.

With this change we can e.g. tag specific commits as demo-targets and reference them in a demo environment.

Further also consider lightweight tags for the binary naming, since travis does not make any difference either.

Signed-off-by: Roman Mohr <rmohr@redhat.com>