### PR TITLE
Pass DOCKER_TAG to manifest generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ publish: docker
 	hack/build-docker.sh push ${WHAT}
 
 manifests:
-	hack/dockerized ./hack/build-manifests.sh
+	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} ./hack/build-manifests.sh"
 
 .release-functest:
 	make functest > .release-functest 2>&1


### PR DESCRIPTION
During release, travis passes an extra DOCKER_TAG to the manifest
generator. Make sure that this DOCKER_TAG is visible inside the
dockerized build environment.

Signed-off-by: Roman Mohr <rmohr@redhat.com>