### PR TITLE
Add kubelet dependencies for iscsi and gluster

### DIFF
--- a/cluster/vagrant-kubernetes/setup_common.sh
+++ b/cluster/vagrant-kubernetes/setup_common.sh
@@ -36,6 +36,11 @@ yum -y install jq sshpass
 
 yum -y install bind-utils net-tools
 
+# Install storage requirements for iscsi and cluster
+yum -y install centos-release-gluster
+yum -y install --nogpgcheck -y glusterfs-fuse
+yum -y install iscsi-initiator-utils
+
 # if there is a second disk, use it for docker
 if ls /dev/*db; then
     # We use the loopback docker dm support, and not a VG for now

--- a/cluster/vagrant-openshift/setup_common.sh
+++ b/cluster/vagrant-openshift/setup_common.sh
@@ -27,6 +27,11 @@ for node in $(seq 0 $(($2 - 1))); do
     grep $node_hostname /etc/hosts || echo "$node_ip $node_hostname" >>/etc/hosts
 done
 
+# Install storage requirements for iscsi and cluster
+yum -y install centos-release-gluster
+yum -y install --nogpgcheck -y glusterfs-fuse
+yum -y install iscsi-initiator-utils
+
 # Install OpenShift packages
 yum install -y centos-release-openshift-origin
 yum install -y yum-utils ansible wget git net-tools bind-utils iptables-services bridge-utils bash-completion kexec-tools sos psacct docker


### PR DESCRIPTION
Make sure that kubelet in our vagrant machines has access to all
required storage dependencies.

Signed-off-by: Roman Mohr <rmohr@redhat.com>