### PR TITLE
Make functional test configuration more flexible

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -44,14 +44,14 @@ _rsync() {
 rm ${KUBEVIRT_DIR}/.glide*.hash -f
 
 # Copy kubevirt into the persistent docker volume
-_rsync --delete --exclude 'cluster/vagrant*' --exclude "_out" --exclude ".vagrant" ${KUBEVIRT_DIR}/ "rsync://root@127.0.0.1:${RSYNCD_PORT}/build"
+_rsync --delete --exclude 'cluster/**/.kubectl' --exclude 'cluster/**/.oc' --exclude 'cluster/**/.kubeconfig' --exclude "_out" --exclude ".vagrant" ${KUBEVIRT_DIR}/ "rsync://root@127.0.0.1:${RSYNCD_PORT}/build"
 
 # Run the command
 test -t 1 && USE_TTY="-it"
 docker run --rm -v "${BUILDER}:/root:rw,z" ${USE_TTY} -w "/root/go/src/kubevirt.io/kubevirt" ${BUILDER} "$@"
 
 # Copy the whole kubevirt data out to get generated sources and formatting changes
-_rsync --exclude '.glide*' --exclude "_out" --exclude "vendor" --exclude ".vagrant" --exclude ".git" "rsync://root@127.0.0.1:${RSYNCD_PORT}/build" ${KUBEVIRT_DIR}/
+_rsync --exclude '.glide*' --exclude 'cluster/**/.kubectl' --exclude 'cluster/**/.oc' --exclude 'cluster/**/.kubeconfig' --exclude "_out" --exclude "vendor" --exclude ".vagrant" --exclude ".git" "rsync://root@127.0.0.1:${RSYNCD_PORT}/build" ${KUBEVIRT_DIR}/
 if [ "$SYNC_VENDOR" = "true" ]; then
     _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/vendor" ${VENDOR_DIR}
 fi

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -22,4 +22,4 @@ set -e
 source hack/common.sh
 source hack/config.sh
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -test.timeout 40m ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${docker_prefix} -test.timeout 40m ${FUNC_TEST_ARGS}

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Console", func() {
 			Context("with a cirros image", func() {
 				It("should return that we are running cirros", func() {
 					RunVMAndExpectConsoleOutput(
-						"kubevirt/cirros-registry-disk-demo:devel",
+						tests.RegistryDiskFor(tests.RegistryDiskCirros),
 						"checking http://169.254.169.254/2009-04-04/instance-id",
 					)
 				}, 140)
@@ -75,14 +75,14 @@ var _ = Describe("Console", func() {
 			Context("with a fedora image", func() {
 				It("should return that we are running fedora", func() {
 					RunVMAndExpectConsoleOutput(
-						"kubevirt/fedora-cloud-registry-disk-demo:devel",
+						tests.RegistryDiskFor(tests.RegistryDiskFedora),
 						"Welcome to",
 					)
 				}, 140)
 			})
 
 			It("should be able to reconnect to console multiple times", func() {
-				vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
+				vm := tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 
 				By("Creating a new VM")
 				Expect(virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()).To(Succeed())

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -91,7 +91,7 @@ var _ = Describe("RegistryDisk", func() {
 	Describe("Starting and stopping the same VM", func() {
 		Context("with ephemeral registry disk", func() {
 			It("should success multiple times", func(done Done) {
-				vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
+				vm := tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskCirros))
 				num := 2
 				for i := 0; i < num; i++ {
 					By("Starting the VM")
@@ -112,7 +112,7 @@ var _ = Describe("RegistryDisk", func() {
 	Describe("Starting a VM", func() {
 		Context("with ephemeral registry disk", func() {
 			It("should not modify the spec on status update", func() {
-				vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
+				vm := tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskCirros))
 				v1.SetObjectDefaults_VirtualMachine(vm)
 
 				By("Starting the VM")
@@ -134,7 +134,7 @@ var _ = Describe("RegistryDisk", func() {
 				vms := make([]*v1.VirtualMachine, 0, num)
 				objs := make([]runtime.Object, 0, num)
 				for i := 0; i < num; i++ {
-					vm := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
+					vm := tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskCirros))
 					// FIXME if we give too much ram, the vms really boot and eat all our memory (cache?)
 					vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1M")
 					obj := LaunchVM(vm)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -81,7 +81,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 
 	newReplicaSet := func() *v1.VirtualMachineReplicaSet {
 		By("Create a new VM replica set")
-		template := tests.NewRandomVMWithEphemeralDisk("kubevirt/cirros-registry-disk-demo:devel")
+		template := tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskCirros))
 		newRS := tests.NewRandomReplicaSetFromVM(template, int32(0))
 		newRS, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Create(newRS)
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -805,7 +805,7 @@ type RegistryDisk string
 const (
 	RegistryDiskCirros RegistryDisk = "cirros"
 	RegistryDiskAlpine RegistryDisk = "alpine"
-	RegistryDiskFedora RegistryDisk = "fedora"
+	RegistryDiskFedora RegistryDisk = "fedora-cloud"
 )
 
 // RegistryDiskFor takes the name of an image and returns the full

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -744,7 +744,7 @@ func NewBool(x bool) *bool {
 	return &x
 }
 
-func RenderJob(name string, dockerTag string, cmd []string, args []string) *k8sv1.Pod {
+func RenderJob(name string, cmd []string, args []string) *k8sv1.Pod {
 	job := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
@@ -757,7 +757,7 @@ func RenderJob(name string, dockerTag string, cmd []string, args []string) *k8sv
 			Containers: []k8sv1.Container{
 				{
 					Name:    name,
-					Image:   "kubevirt/vm-killer:" + dockerTag,
+					Image:   fmt.Sprintf("%s/vm-killer:%s", KubeVirtRepoPrefix, KubeVirtVersionTag),
 					Command: cmd,
 					Args:    args,
 					SecurityContext: &k8sv1.SecurityContext{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -98,10 +98,6 @@ const (
 )
 
 const (
-	labelNFSPod = "nfs-server-demo"
-)
-
-const (
 	iscsiIqn        = "iqn.2017-01.io.kubevirt:sn.42"
 	iscsiSecretName = "iscsi-demo-secret"
 )
@@ -382,49 +378,6 @@ func newPvISCSI(os string, targetIp string, lun int32, withAuth bool) *k8sv1.Per
 		pv.Spec.PersistentVolumeSource.ISCSI.SecretRef = &k8sv1.LocalObjectReference{
 			Name: iscsiSecretName,
 		}
-	}
-	return pv
-}
-
-func createPvNFS(os string, path string) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-
-	nfsServer := getPodIpByLabel(labelNFSPod)
-
-	_, err = virtCli.CoreV1().PersistentVolumes().Create(newPvNFS(os, nfsServer, path))
-	if !errors.IsAlreadyExists(err) {
-		PanicOnError(err)
-	}
-}
-
-func newPvNFS(os string, nfsServer string, path string) *k8sv1.PersistentVolume {
-	quantity, err := resource.ParseQuantity("1Gi")
-	PanicOnError(err)
-
-	name := fmt.Sprintf("%s-disk-for-tests", os)
-	label := os
-
-	pv := &k8sv1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"kubevirt.io/test": label,
-			},
-		},
-		Spec: k8sv1.PersistentVolumeSpec{
-			AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
-			Capacity: k8sv1.ResourceList{
-				"storage": quantity,
-			},
-			PersistentVolumeReclaimPolicy: k8sv1.PersistentVolumeReclaimRetain,
-			PersistentVolumeSource: k8sv1.PersistentVolumeSource{
-				NFS: &k8sv1.NFSVolumeSource{
-					Server: nfsServer,
-					Path:   path,
-				},
-			},
-		},
 	}
 	return pv
 }

--- a/tests/vm_configuration_test.go
+++ b/tests/vm_configuration_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Configurations", func() {
 			var vm *v1.VirtualMachine
 
 			BeforeEach(func() {
-				vm = tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
+				vm = tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 			})
 			It("should report 3 cpu cores under guest OS", func() {
 				vm.Spec.Domain.CPU = &v1.CPU{
@@ -88,7 +88,7 @@ var _ = Describe("Configurations", func() {
 		BeforeEach(func() {
 			// ordering:
 			// use a small disk for the other ones
-			containerImage := "kubevirt/cirros-registry-disk-demo:devel"
+			containerImage := tests.RegistryDiskFor(tests.RegistryDiskCirros)
 			// virtio - added by NewRandomVMWithEphemeralDisk
 			vm = tests.NewRandomVMWithEphemeralDiskAndUserdata(containerImage, "echo hi!\n")
 			// sata

--- a/tests/vm_networking_test.go
+++ b/tests/vm_networking_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"flag"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -44,10 +43,6 @@ import (
 )
 
 var _ = Describe("Networking", func() {
-	dockerTag := os.Getenv("docker_tag")
-	if dockerTag == "" {
-		dockerTag = "latest"
-	}
 
 	flag.Parse()
 
@@ -153,7 +148,7 @@ var _ = Describe("Networking", func() {
 
 			// Run netcat and give it one second to ghet "Hello World!" back from the VM
 			check := []string{fmt.Sprintf("while read x; do test \"$x\" = \"Hello World!\"; exit $?; done < <(nc %s 1500 -i 1 -w 1)", ip)}
-			job := tests.RenderJob("netcat", dockerTag, []string{"/bin/bash", "-c"}, check)
+			job := tests.RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
 			job.Spec.Affinity = &v12.Affinity{
 				NodeAffinity: &v12.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{

--- a/tests/vm_networking_test.go
+++ b/tests/vm_networking_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Networking", func() {
 		var wg sync.WaitGroup
 
 		createAndLogin := func() (vm *v1.VirtualMachine) {
-			vm = tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", "#!/bin/bash\necho 'hello'\n")
+			vm = tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
 
 			// Start VM
 			vm, err = virtClient.VM(tests.NamespaceTestDefault).Create(vm)

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -78,7 +78,7 @@ var _ = Describe("CloudInit UserData", func() {
 				magicStr := "printed from cloud-init userdata"
 				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)
 
-				vm := tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", userData)
+				vm := tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), userData)
 				obj := LaunchVM(vm)
 				VerifyUserDataVM(vm, obj, magicStr)
 				close(done)
@@ -88,7 +88,7 @@ var _ = Describe("CloudInit UserData", func() {
 		It("should take user-data from k8s secret", func(done Done) {
 			magicStr := "printed from cloud-init userdata"
 			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", magicStr)
-			vm := tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", userData)
+			vm := tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), userData)
 
 			for _, volume := range vm.Spec.Volumes {
 				if volume.CloudInitNoCloud == nil {

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Vmlifecycle", func() {
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
-		vm = tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
+		vm = tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 	})
 
 	Describe("Creating a VM", func() {
@@ -105,7 +105,7 @@ var _ = Describe("Vmlifecycle", func() {
 			Context("without k8s secret", func() {
 				It("should retry starting the VM", func(done Done) {
 					userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
-					vm = tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", userData)
+					vm = tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), userData)
 
 					for _, volume := range vm.Spec.Volumes {
 						if volume.CloudInitNoCloud != nil {
@@ -137,7 +137,7 @@ var _ = Describe("Vmlifecycle", func() {
 				It("should log warning and proceed once the secret is there", func(done Done) {
 					userData := fmt.Sprintf("#!/bin/sh\n\necho 'hi'\n")
 					userData64 := ""
-					vm = tests.NewRandomVMWithEphemeralDiskAndUserdata("kubevirt/cirros-registry-disk-demo:devel", userData)
+					vm = tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), userData)
 
 					for _, volume := range vm.Spec.Volumes {
 						if volume.CloudInitNoCloud != nil {


### PR DESCRIPTION
Add two flags to the test.tests binary:

 * -tag (defaults to "latest")
 * -prefix (defaults to "kubevirt")

"-tag" allows testing specific docer versions,  "-prefix" allow pulling
images from different repos (e.g. "-prefix localhost:5000/kubevirt").

Fixes #717. @gbenhaim FYI

Signed-off-by: Roman Mohr <rmohr@redhat.com>