### PR TITLE
Use correct libvirt image for virt-launcher

### DIFF
--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM kubevirt/libvirt
+FROM kubevirt/libvirt:3.7.0
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 


### PR DESCRIPTION
@cynepco3hahue that should fix the issue you experienced with #751. It seems like with the switch to the decentralized libvirt pods we lost the tag in the Dockerfile. 

Signed-off-by: Roman Mohr <rmohr@redhat.com>