### PR TITLE
Enable initializerregistration for our providers

### DIFF
--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,7 +10,7 @@ function up() {
     VAGRANT_NUM_NODES=${VAGRANT_NUM_NODES-0}
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     VAGRANT_NUM_NODES=$((VAGRANT_NUM_NODES + 1))
-    docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest run --nodes ${VAGRANT_NUM_NODES} --tls-port 127.0.0.1:8443 --ssh-port 127.0.0.1:2201 --background --registry-port 127.0.0.1:5000 --prefix kubevirt --registry-volume kubevirt_registry --base rmohr/kubeadm-1.9.3
+    docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest run --nodes ${VAGRANT_NUM_NODES} --tls-port 127.0.0.1:8443 --ssh-port 127.0.0.1:2201 --background --registry-port 127.0.0.1:5000 --prefix kubevirt --registry-volume kubevirt_registry --base "rmohr/kubeadm-1.9.3@sha256:5f9394037a62ee0d5fb8e6005cf248f0b7601e1d0a67c0af79ff8d2f8e9541bb"
     docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest ssh node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/k8s-1.9.3/vagrant.key

--- a/cluster/vagrant-kubernetes/setup_master.sh
+++ b/cluster/vagrant-kubernetes/setup_master.sh
@@ -30,7 +30,16 @@ systemctl enable cockpit.socket && systemctl start cockpit.socket
 rm -rf /var/lib/kubelet
 
 # Create the master
-kubeadm init --pod-network-cidr=10.244.0.0/16 --token abcdef.1234567890123456
+cat >/etc/kubernetes/kubeadm.conf <<EOF
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+apiServerExtraArgs:
+  runtime-config: admissionregistration.k8s.io/v1alpha1
+token: abcdef.1234567890123456
+pod-network-cidr: 10.244.0.0/16
+EOF
+
+kubeadm init --config /etc/kubernetes/kubeadm.conf
 
 # Tell kubectl which config to use
 export KUBECONFIG=/etc/kubernetes/admin.conf


### PR DESCRIPTION
 * k8s-1.9.3 provider uses now an image with the feature enabled
 * after a vagrant recreate the vagrant provider has the feature enabled

This is a prerequisite for #652.

Signed-off-by: Roman Mohr <rmohr@redhat.com>