### PR TITLE
Make sure that kubeadm picks up pod CIDR for flannel

### DIFF
--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,7 +10,7 @@ function up() {
     VAGRANT_NUM_NODES=${VAGRANT_NUM_NODES-0}
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     VAGRANT_NUM_NODES=$((VAGRANT_NUM_NODES + 1))
-    docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest run --nodes ${VAGRANT_NUM_NODES} --tls-port 127.0.0.1:8443 --ssh-port 127.0.0.1:2201 --background --registry-port 127.0.0.1:5000 --prefix kubevirt --registry-volume kubevirt_registry --base "rmohr/kubeadm-1.9.3@sha256:5f9394037a62ee0d5fb8e6005cf248f0b7601e1d0a67c0af79ff8d2f8e9541bb"
+    docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest run --nodes ${VAGRANT_NUM_NODES} --tls-port 127.0.0.1:8443 --ssh-port 127.0.0.1:2201 --background --registry-port 127.0.0.1:5000 --prefix kubevirt --registry-volume kubevirt_registry --base "rmohr/kubeadm-1.9.3@sha256:0c34eb10b2f0a99089529dd16e55efddc3cd313c50e113a7def0e48bae86e697"
     docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest ssh node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/k8s-1.9.3/vagrant.key

--- a/cluster/vagrant-kubernetes/setup_master.sh
+++ b/cluster/vagrant-kubernetes/setup_master.sh
@@ -36,7 +36,8 @@ kind: MasterConfiguration
 apiServerExtraArgs:
   runtime-config: admissionregistration.k8s.io/v1alpha1
 token: abcdef.1234567890123456
-pod-network-cidr: 10.244.0.0/16
+networking:
+  podSubnet: 10.244.0.0/16
 EOF
 
 kubeadm init --config /etc/kubernetes/kubeadm.conf


### PR DESCRIPTION
If the pod network CIDR is not picket up, flannel can't start successfully. @cynepco3hahue merge #756 too fast.

Signed-off-by: Roman Mohr <rmohr@redhat.com>