### PR TITLE
Make sure all nodes use the newest images available

### DIFF
--- a/cluster/build.sh
+++ b/cluster/build.sh
@@ -21,7 +21,16 @@
 # We're leaving this file around for people who still reference this
 # specific script in their development workflow.
 
+set -e
+
 PROVIDER=${PROVIDER:-vagrant-kubernetes}
+
+source hack/common.sh
 source cluster/$PROVIDER/provider.sh
+source hack/config.sh
+
+echo "Building ..."
 
 build
+
+echo "Done"


### PR DESCRIPTION
@davidvossel @cynepco3hahue we currently use "IfNotPresent" pull policy in all our containers. If we push new containers to the local registry they won't get pulled in without that change.

This change synchronizes all containers with all nodes. Another possibility would be to to make the pull policy selectable.

What are your thoughts?

Signed-off-by: Roman Mohr <rmohr@redhat.com>