### PR TITLE
remove /sys host shared mount from virt-launcher

### DIFF
--- a/cmd/virt-launcher/libvirtd.sh
+++ b/cmd/virt-launcher/libvirtd.sh
@@ -36,16 +36,6 @@ mkdir -p /dev.container && {
     [[ -e /dev.container/kvm ]] && keep kvm
 }
 
-mkdir -p /sys.net.container && {
-    mount --rbind /sys/class/net /sys.net.container
-    mount --rbind /host-sys/class/net /sys/class/net
-}
-
-mkdir -p /sys.devices.container && {
-    mount --rbind /sys/devices /sys.devices.container
-    mount --rbind /host-sys/devices /sys/devices
-}
-
 mkdir -p /var/log/kubevirt
 touch /var/log/kubevirt/qemu-kube.log
 chown qemu:qemu /var/log/kubevirt/qemu-kube.log

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -74,10 +74,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		Name:      "host-dev",
 		MountPath: "/host-dev",
 	})
-	volumesMounts = append(volumesMounts, kubev1.VolumeMount{
-		Name:      "host-sys",
-		MountPath: "/host-sys",
-	})
 	for _, volume := range vm.Spec.Volumes {
 		volumeMount := kubev1.VolumeMount{
 			Name:      volume.Name,
@@ -163,14 +159,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		VolumeSource: kubev1.VolumeSource{
 			HostPath: &kubev1.HostPathVolumeSource{
 				Path: "/dev",
-			},
-		},
-	})
-	volumes = append(volumes, kubev1.Volume{
-		Name: "host-sys",
-		VolumeSource: kubev1.VolumeSource{
-			HostPath: &kubev1.HostPathVolumeSource{
-				Path: "/sys",
 			},
 		},
 	})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Template", func() {
 				Expect(err).To(BeNil())
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
-				Expect(len(pod.Spec.Volumes)).To(Equal(5))
+				Expect(len(pod.Spec.Volumes)).To(Equal(4))
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("nfs-pvc"))
 			})


### PR DESCRIPTION
Now that the network changes have landed, this is an area where we can pair down the permissions required to run libvirt.

There might be some additional work we can do in the future to further limit what devices the virt-launcher pod sees from the host as well. 