### PR TITLE
Add tag alias to k8s 1.9.3 provider containers

### DIFF
--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -50,14 +50,17 @@ function build() {
 
     # Make sure that all nodes use the newest images
     container=""
+    container_alias=""
     for arg in ${docker_images}; do
         local name=$(basename $arg)
         container="${container} ${manifest_docker_prefix}/${name}:${docker_tag}"
+        container_alias="${container_alias} ${manifest_docker_prefix}/${name}:${docker_tag} kubevirt/${name}:${docker_tag}"
     done
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
     for i in $(seq 1 ${num_nodes}); do
         ${_cli} ssh "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs --max-args=1 sudo docker pull"
+        ${_cli} ssh "node$(printf "%02d" ${i})" "echo \"${container_alias}\" | xargs --max-args=2 sudo docker tag"
     done
 }
 


### PR DESCRIPTION
This gives the 1.9.3 provider consistent tags for containers. Without this change, the sample manifests (like cluster/vm.yaml) fail because the registry disk container image won't be found. 

For example, the cluster will be building something like registry:5000/kubevirt/cirros-registry-disk-demo:devel when the sample vm.yaml references kubevirt/cirros-registry-disk-demo:devel. 

An easy way to fix this is to just to create a tag alias for **registry:5000/kubevirt/cirros-registry-disk-demo:devel** so **kubevirt/cirros-registry-disk-demo:devel** works too for the same container image. 