### PR TITLE
OpenShift deployment fixes

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -39,7 +39,7 @@ _kubectl create -f ${MANIFESTS_OUT_DIR}/testing -R $i
 
 if [ "$PROVIDER" = "vagrant-openshift" ]; then
     _kubectl adm policy add-scc-to-user privileged -z kubevirt-controller -n kube-system
-    _kubectl adm policy add-scc-to-user hostmount-anyuid -z kubevirt-testing -n kube-system
+    _kubectl adm policy add-scc-to-user privileged -z kubevirt-testing -n kube-system
     _kubectl adm policy add-scc-to-user privileged -z kubevirt-privileged -n kube-system
 fi
 

--- a/cluster/vagrant-openshift/setup_master.sh
+++ b/cluster/vagrant-openshift/setup_master.sh
@@ -56,7 +56,7 @@ openshift_clock_enabled=true
 openshift_master_identity_providers=[{'name': 'allow_all_auth', 'login': 'true', 'challenge': 'true', 'kind': 'AllowAllPasswordIdentityProvider'}]
 openshift_disable_check=memory_availability,disk_availability,docker_storage,package_availability,docker_image_availability
 openshift_repos_enable_testing=True
-openshift_image_tag=latest
+openshift_image_tag=v3.9.0-alpha.4
 containerized=true
 enable_excluders=false
 


### PR DESCRIPTION
- user privileged policy for ISCSI container
- use alpha version instead of latest one

Signed-off-by: Lukianov Artyom <alukiano@redhat.com>