### PR TITLE
Allow manifest namespace to be configurable

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -27,12 +27,12 @@ source hack/config.sh
 
 echo "Cleaning up ..."
 # Work around https://github.com/kubernetes/kubernetes/issues/33517
-_kubectl delete ds -l "kubevirt.io" -n kube-system --cascade=false --grace-period 0 2>/dev/null || :
-_kubectl delete pods -n kube-system -l="kubevirt.io=libvirt" --force --grace-period 0 2>/dev/null || :
-_kubectl delete pods -n kube-system -l="kubevirt.io=virt-handler" --force --grace-period 0 2>/dev/null || :
+_kubectl delete ds -l "kubevirt.io" -n ${namespace} --cascade=false --grace-period 0 2>/dev/null || :
+_kubectl delete pods -n ${namespace} -l="kubevirt.io=libvirt" --force --grace-period 0 2>/dev/null || :
+_kubectl delete pods -n ${namespace} -l="kubevirt.io=virt-handler" --force --grace-period 0 2>/dev/null || :
 
 # Delete all traces of kubevirt
-namespaces=(default kube-system)
+namespaces=(default ${namespace})
 for i in ${namespaces[@]}; do
     _kubectl -n ${i} delete deployment -l 'kubevirt.io'
     _kubectl -n ${i} delete rs -l 'kubevirt.io'

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -38,9 +38,9 @@ fi
 _kubectl create -f ${MANIFESTS_OUT_DIR}/testing -R $i
 
 if [ "$PROVIDER" = "vagrant-openshift" ]; then
-    _kubectl adm policy add-scc-to-user privileged -z kubevirt-controller -n kube-system
-    _kubectl adm policy add-scc-to-user privileged -z kubevirt-testing -n kube-system
-    _kubectl adm policy add-scc-to-user privileged -z kubevirt-privileged -n kube-system
+    _kubectl adm policy add-scc-to-user privileged -z kubevirt-controller -n ${namespace}
+    _kubectl adm policy add-scc-to-user privileged -z kubevirt-testing -n ${namespace}
+    _kubectl adm policy add-scc-to-user privileged -z kubevirt-privileged -n ${namespace}
 fi
 
 echo "Done"

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -34,5 +34,6 @@ for arg in $args; do
     manifest=$(basename -s .in ${arg})
     sed -e "s#{{ docker_tag }}#${docker_tag}#g" \
         -e "s#{{ docker_prefix }}#${manifest_docker_prefix}#g" \
+        -e "s#{{ namespace }}#${namespace}#g" \
         ${KUBEVIRT_DIR}/manifests/$arg >${final_out_dir}/${manifest}
 done

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -5,3 +5,4 @@ docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel
 kubeconfig=cluster/vagrant/.kubeconfig
+namespace=kube-system

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,5 +1,5 @@
 unset binaries docker_images docker_prefix docker_tag manifest_templates \
-    master_ip network_provider kubeconfig manifest_docker_prefix
+    master_ip network_provider kubeconfig manifest_docker_prefix namespace
 
 PROVIDER=${PROVIDER:-vagrant-kubernetes}
 
@@ -13,4 +13,4 @@ test -f "hack/config-provider-${PROVIDER}.sh" && source hack/config-provider-${P
 test -f "hack/config-local.sh" && source hack/config-local.sh
 
 export binaries docker_images docker_prefix docker_tag manifest_templates \
-    master_ip network_provider kubeconfig
+    master_ip network_provider kubeconfig namespace

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kubevirt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 rules:
@@ -44,7 +44,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubevirt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 ---
@@ -52,7 +52,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubevirt-privileged
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 ---
@@ -60,7 +60,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -70,13 +70,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-controller
-    namespace: kube-system
+    namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-controller-cluster-admin
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -86,13 +86,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-controller
-    namespace: kube-system
+    namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-privileged-cluster-admin
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -102,4 +102,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-privileged
-    namespace: kube-system
+    namespace: {{ namespace }}

--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: virt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: "virt-controller"
 spec:
@@ -16,7 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: virt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: "virt-controller"
 spec:

--- a/manifests/dev/virt-handler.yaml.in
+++ b/manifests/dev/virt-handler.yaml.in
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: virt-handler
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: "virt-handler"
 spec:

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: kubevirt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 rules:
@@ -46,7 +46,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubevirt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 ---
@@ -54,7 +54,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubevirt-privileged
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 ---
@@ -62,7 +62,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -72,13 +72,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-controller
-    namespace: kube-system
+    namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-controller-cluster-admin
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -88,13 +88,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-controller
-    namespace: kube-system
+    namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-privileged-cluster-admin
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -104,7 +104,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-privileged
-    namespace: kube-system
+    namespace: {{ namespace }}
 ---
 # custom resource definitions
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -148,7 +148,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: virt-controller
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: "virt-controller"
 spec:
@@ -194,7 +194,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: virt-handler
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: "virt-handler"
 spec:

--- a/manifests/testing/iscsi-demo-target.yaml.in
+++ b/manifests/testing/iscsi-demo-target.yaml.in
@@ -38,7 +38,7 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: iscsi-demo-target-tgtd
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: "iscsi-demo-target"
 spec:

--- a/manifests/testing/rbac-for-testing.yaml.in
+++ b/manifests/testing/rbac-for-testing.yaml.in
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubevirt-testing
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 ---
@@ -11,7 +11,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-testing-cluster-admin
-  namespace: kube-system
+  namespace: {{ namespace }}
   labels:
     kubevirt.io: ""
 roleRef:
@@ -21,4 +21,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kubevirt-testing
-    namespace: kube-system
+    namespace: {{ namespace }}

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -149,12 +149,16 @@ func (vca *VirtControllerApp) Run() {
 		golog.Fatalf("unable to get hostname: %v", err)
 	}
 
-	// TODO: Replace leaderelectionconfig.DefaultNamespace with a flag
-	namespace := leaderelectionconfig.DefaultNamespace
+	var namespace string
 	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
 			namespace = ns
 		}
+	} else if os.IsNotExist(err) {
+		// TODO: Replace leaderelectionconfig.DefaultNamespace with a flag
+		namespace = leaderelectionconfig.DefaultNamespace
+	} else {
+		golog.Fatalf("Error searching for namespace in /var/run/secrets/kubernetes.io/serviceaccount/namespace: %v", err)
 	}
 
 	rl, err := resourcelock.New(vca.LeaderElection.ResourceLock,

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -1,9 +1,11 @@
 package watch
 
 import (
+	"io/ioutil"
 	golog "log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/emicklei/go-restful"
@@ -147,8 +149,16 @@ func (vca *VirtControllerApp) Run() {
 		golog.Fatalf("unable to get hostname: %v", err)
 	}
 
+	// TODO: Replace leaderelectionconfig.DefaultNamespace with a flag
+	namespace := leaderelectionconfig.DefaultNamespace
+	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			namespace = ns
+		}
+	}
+
 	rl, err := resourcelock.New(vca.LeaderElection.ResourceLock,
-		leaderelectionconfig.DefaultNamespace,
+		namespace,
 		leaderelectionconfig.DefaultEndpointName,
 		vca.clientSet.CoreV1(),
 		resourcelock.ResourceLockConfig{


### PR DESCRIPTION
The manifests hardcode the kube-system namespace.  Make it configurable.

One thing I'm worried about in ```pkg/virt-controller/leaderelectionconfig/config.go``` is the ```DefaultNamespace``` var is set to kube-system.  Can folks advise on that?

```go
const (
        DefaultNamespace     = "kube-system"
)
```