### PR TITLE
Pin k8s generator versions in the docker builder

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -24,9 +24,14 @@ RUN \
     go get -u github.com/rmohr/mock/mockgen && \
     go get -u github.com/rmohr/go-swagger-utils/swagger-doc && \
     go get -u github.com/onsi/ginkgo/ginkgo && \
-    go get -u k8s.io/code-generator/cmd/deepcopy-gen && \
-    go get -u k8s.io/code-generator/cmd/defaulter-gen
-
+    go get -u -d k8s.io/code-generator/cmd/deepcopy-gen && \
+    go get -u -d k8s.io/code-generator/cmd/defaulter-gen && \
+    cd /go/src/k8s.io/code-generator/cmd/deepcopy-gen && \
+    git checkout release-1.9 && \
+    go install && \
+    cd /go/src/k8s.io/code-generator/cmd/defaulter-gen && \
+    git checkout release-1.9 && \
+    go install
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
The generators need to be pinned to avoid different output between
developer machines and CI.

Fixes #777 

Signed-off-by: Roman Mohr <rmohr@redhat.com>