### PR TITLE
Increate test timeout to 60 minutes

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -24,4 +24,4 @@ source hack/config.sh
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -test.timeout 40m ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -test.timeout 60m ${FUNC_TEST_ARGS}


### PR DESCRIPTION
We are scratching 40 minutes on CI very often. Let's increase the timeout to 60 minutes for all tests.

Signed-off-by: Roman Mohr <rmohr@redhat.com>