### PR TITLE
Add hostname and subdomain field to vms, to allow unique dns-entries per vm

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4499,9 +4499,17 @@
       "description": "Specification of the desired behavior of the VirtualMachine on the host.",
       "$ref": "#/definitions/v1.DomainSpec"
      },
+     "hostname": {
+      "description": "Specifies the hostname of the vm\nIf not specified, the hostname will be set to the name of the vm, if dhcp or cloud-init is configured properly.\n+optional",
+      "type": "string"
+     },
      "nodeSelector": {
       "description": "NodeSelector is a selector which must be true for the vm to fit on a node.\nSelector which must match a node's labels for the vm to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
       "type": "object"
+     },
+     "subdomain": {
+      "description": "If specified, the fully qualified vm hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\".\nIf not specified, the vm will not have a domainname at all. The DNS entry will resolve to the vm,\nno matter if the vm itself can pick up a hostname.\n+optional",
+      "type": "string"
      },
      "terminationGracePeriodSeconds": {
       "description": "Grace period observed after signalling a VM to stop after which the VM is force terminated.",

--- a/cluster/examples/vm-fedora.yaml
+++ b/cluster/examples/vm-fedora.yaml
@@ -26,6 +26,6 @@ spec:
     registryDisk:
       image: kubevirt/fedora-cloud-registry-disk-demo:devel
   - cloudInitNoCloud:
-      userDataBase64: IyEvYmluL3NoCgplY2hvICdwcmludGVkIGZyb20gY2xvdWQtaW5pdCB1c2VyZGF0YScK
+      userDataBase64: IyEvYmluL2Jhc2gKZWNobyAiZmVkb3JhOmZlZG9yYSIgfCBjaHBhc3N3ZAo=
     name: cloudinitvolume
 status: {}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -21,4 +21,4 @@ ${KUBEVIRT_DIR}/tools/crd-generator/crd-generator --crd-type=vmpreset >${KUBEVIR
 ${KUBEVIRT_DIR}/tools/crd-generator/crd-generator --crd-type=ovm >${KUBEVIRT_DIR}/manifests/generated/ovm-resource.yaml
 
 (cd ${KUBEVIRT_DIR}/tools/vms-generator/ && go build)
-${KUBEVIRT_DIR}/tools/vms-generator/vms-generator --docker-prefix=$docker_prefix --generated-vms-dir=${KUBEVIRT_DIR}/cluster/examples
+${KUBEVIRT_DIR}/tools/vms-generator/vms-generator --generated-vms-dir=${KUBEVIRT_DIR}/cluster/examples

--- a/manifests/generated/ovm-resource.yaml
+++ b/manifests/generated/ovm-resource.yaml
@@ -301,12 +301,24 @@ spec:
                               type: object
                       required:
                       - devices
+                    hostname:
+                      description: Specifies the hostname of the vm If not specified,
+                        the hostname will be set to the name of the vm, if dhcp or
+                        cloud-init is configured properly.
+                      type: string
                     nodeSelector:
                       description: 'NodeSelector is a selector which must be true
                         for the vm to fit on a node. Selector which must match a node''s
                         labels for the vm to be scheduled on that node. More info:
                         https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                       type: object
+                    subdomain:
+                      description: If specified, the fully qualified vm hostname will
+                        be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                        If not specified, the vm will not have a domainname at all.
+                        The DNS entry will resolve to the vm, no matter if the vm
+                        itself can pick up a hostname.
+                      type: string
                     terminationGracePeriodSeconds:
                       description: Grace period observed after signalling a VM to
                         stop after which the VM is force terminated.

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -263,11 +263,22 @@ spec:
                       type: object
               required:
               - devices
+            hostname:
+              description: Specifies the hostname of the vm If not specified, the
+                hostname will be set to the name of the vm, if dhcp or cloud-init
+                is configured properly.
+              type: string
             nodeSelector:
               description: 'NodeSelector is a selector which must be true for the
                 vm to fit on a node. Selector which must match a node''s labels for
                 the vm to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
               type: object
+            subdomain:
+              description: If specified, the fully qualified vm hostname will be "<hostname>.<subdomain>.<pod
+                namespace>.svc.<cluster domain>". If not specified, the vm will not
+                have a domainname at all. The DNS entry will resolve to the vm, no
+                matter if the vm itself can pick up a hostname.
+              type: string
             terminationGracePeriodSeconds:
               description: Grace period observed after signalling a VM to stop after
                 which the VM is force terminated.

--- a/manifests/generated/vmrs-resource.yaml
+++ b/manifests/generated/vmrs-resource.yaml
@@ -302,12 +302,24 @@ spec:
                               type: object
                       required:
                       - devices
+                    hostname:
+                      description: Specifies the hostname of the vm If not specified,
+                        the hostname will be set to the name of the vm, if dhcp or
+                        cloud-init is configured properly.
+                      type: string
                     nodeSelector:
                       description: 'NodeSelector is a selector which must be true
                         for the vm to fit on a node. Selector which must match a node''s
                         labels for the vm to be scheduled on that node. More info:
                         https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                       type: object
+                    subdomain:
+                      description: If specified, the fully qualified vm hostname will
+                        be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                        If not specified, the vm will not have a domainname at all.
+                        The DNS entry will resolve to the vm, no matter if the vm
+                        itself can pick up a hostname.
+                      type: string
                     terminationGracePeriodSeconds:
                       description: Grace period observed after signalling a VM to
                         stop after which the VM is force terminated.

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1619,6 +1619,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"hostname": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Specifies the hostname of the vm If not specified, the hostname will be set to the name of the vm, if dhcp or cloud-init is configured properly.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"subdomain": {
+							SchemaProps: spec.SchemaProps{
+								Description: "If specified, the fully qualified vm hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the vm will not have a domainname at all. The DNS entry will resolve to the vm, no matter if the vm itself can pick up a hostname.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"domain"},
 				},

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -144,6 +144,15 @@ type VirtualMachineSpec struct {
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
 	// List of volumes that can be mounted by disks belonging to the vm.
 	Volumes []Volume `json:"volumes,omitempty"`
+	// Specifies the hostname of the vm
+	// If not specified, the hostname will be set to the name of the vm, if dhcp or cloud-init is configured properly.
+	// +optional
+	Hostname string `json:"hostname,omitempty"`
+	// If specified, the fully qualified vm hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+	// If not specified, the vm will not have a domainname at all. The DNS entry will resolve to the vm,
+	// no matter if the vm itself can pick up a hostname.
+	// +optional
+	Subdomain string `json:"subdomain,omitempty"`
 }
 
 // Affinity groups all the affinity rules related to a VM

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -24,6 +24,8 @@ func (VirtualMachineSpec) SwaggerDoc() map[string]string {
 		"affinity":                      "If affinity is specifies, obey all the affinity rules",
 		"terminationGracePeriodSeconds": "Grace period observed after signalling a VM to stop after which the VM is force terminated.",
 		"volumes":                       "List of volumes that can be mounted by disks belonging to the vm.",
+		"hostname":                      "Specifies the hostname of the vm\nIf not specified, the hostname will be set to the name of the vm, if dhcp or cloud-init is configured properly.\n+optional",
+		"subdomain":                     "If specified, the fully qualified vm hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\".\nIf not specified, the vm will not have a domainname at all. The DNS entry will resolve to the vm,\nno matter if the vm itself can pick up a hostname.\n+optional",
 	}
 }
 

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -180,7 +180,7 @@ func ResolveSecrets(source *v1.CloudInitNoCloudSource, namespace string, clients
 	return nil
 }
 
-func GenerateLocalData(vmName string, namespace string, source *v1.CloudInitNoCloudSource) error {
+func GenerateLocalData(vmName string, hostname string, namespace string, source *v1.CloudInitNoCloudSource) error {
 	precond.MustNotBeEmpty(vmName)
 	precond.MustNotBeNil(source)
 
@@ -206,7 +206,7 @@ func GenerateLocalData(vmName string, namespace string, source *v1.CloudInitNoCl
 	} else {
 		return errors.New(fmt.Sprintf("userDataBase64 or userData is required for no-cloud data source"))
 	}
-	metaData := []byte(fmt.Sprintf("{ \"instance-id\": \"%s.%s\", \"local-hostname\": \"%s\" }\n", vmName, namespace, vmName))
+	metaData := []byte(fmt.Sprintf("{ \"instance-id\": \"%s.%s\", \"local-hostname\": \"%s\" }\n", vmName, namespace, hostname))
 
 	diskutils.RemoveFile(userFile)
 	diskutils.RemoveFile(metaFile)

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -114,7 +114,7 @@ var _ = Describe("CloudInit", func() {
 				cloudInitData := &v1.CloudInitNoCloudSource{
 					UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
 				}
-				err := GenerateLocalData(domain, namespace, cloudInitData)
+				err := GenerateLocalData(domain, domain, namespace, cloudInitData)
 				Expect(err).To(HaveOccurred())
 				Expect(timedOut).To(Equal(true))
 			})
@@ -169,7 +169,7 @@ var _ = Describe("CloudInit", func() {
 			verifyCloudInitIso := func(dataSource *v1.CloudInitNoCloudSource) {
 				namespace := "fake-namespace"
 				domain := "fake-domain"
-				err := GenerateLocalData(domain, namespace, dataSource)
+				err := GenerateLocalData(domain, domain, namespace, dataSource)
 				Expect(err).ToNot(HaveOccurred())
 
 				// verify iso is created

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -31,7 +31,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/precond"
-	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
+	"kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
 const configMapName = "kube-system/kubevirt-config"
@@ -244,6 +244,11 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*k8sv1.Po
 
 	containers = append(containers, container)
 
+	hostName := vm.Name
+	if vm.Spec.Hostname != "" {
+		hostName = vm.Spec.Hostname
+	}
+
 	// TODO use constants for podLabels
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -255,6 +260,8 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*k8sv1.Po
 			},
 		},
 		Spec: k8sv1.PodSpec{
+			Hostname:  hostName,
+			Subdomain: vm.Spec.Subdomain,
 			SecurityContext: &k8sv1.PodSecurityContext{
 				RunAsUser: &userId,
 			},

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -85,7 +85,12 @@ func (l *LibvirtDomainManager) preStartHook(vm *v1.VirtualMachine, domain *api.D
 	// generate cloud-init data
 	cloudInitData := cloudinit.GetCloudInitNoCloudSource(vm)
 	if cloudInitData != nil {
-		err := cloudinit.GenerateLocalData(vm.Name, vm.Namespace, cloudInitData)
+		hostname := vm.Name
+		if vm.Spec.Hostname != "" {
+			hostname = vm.Spec.Hostname
+		}
+
+		err := cloudinit.GenerateLocalData(vm.Name, hostname, vm.Namespace, cloudInitData)
 		if err != nil {
 			return domain, err
 		}

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -31,6 +31,8 @@ import (
 	dhcpConn "github.com/krolaw/dhcp4/conn"
 	"github.com/vishvananda/netlink"
 
+	"os"
+
 	"kubevirt.io/kubevirt/pkg/log"
 )
 
@@ -76,6 +78,12 @@ func SingleClientDHCPServer(
 	if searchDomainBytes != nil {
 		dhcpOptions[dhcp.OptionDomainSearch] = searchDomainBytes
 	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return fmt.Errorf("reading the pods hostname failed: %v", err)
+	}
+	dhcpOptions[dhcp.OptionHostName] = []byte(hostname)
 
 	handler := &DHCPHandler{
 		clientIP:      clientIP,

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -998,12 +998,16 @@ func LoggedInCirrosExpecter(vm *v1.VirtualMachine) (expect.Expecter, error) {
 	if err != nil {
 		return nil, err
 	}
+	vmName := vm.Name
+	if vm.Spec.Hostname != "" {
+		vmName = vm.Spec.Hostname
+	}
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "login as 'cirros' user. default password: 'gocubsgo'. use 'sudo' for root."},
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: vm.Name + " login:"},
+		&expect.BExp{R: vmName + " login:"},
 		&expect.BSnd{S: "cirros\n"},
 		&expect.BExp{R: "Password:"},
 		&expect.BSnd{S: "gocubsgo\n"},


### PR DESCRIPTION
Add `spec.hostname` and `spec.subdomain` to the VirtualMachine API.

This allows creating per-vm dns entries in kubedns. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods for further details.

If `spec.hostname` is set:
 * it is reflected in `local-hostname` in cloud-init metadata.
 * hostname is offered via the dhcp hostname option (12).
 * the hostname of the pod is set to the hostname on the vm.

if `spec.subdomain` is set to e.g. "default-subdomain", it is possible to create a headless service with the same name:

```yaml
apiVersion: v1
kind: Service
metadata:
  name: default-subdomain
spec:
  selector:
    expose: me
  clusterIP: None
  ports:
  - name: foo # In general ports are not needed, but there is a bug in k8s in some versions
    port: 1234
    targetPort: 1234
```

Each vm with then reachable via `<vm.name>.<vm.subdomain>.<vm.namespace>.svc.cluster.local`, or `<vm.spec.hostname>.<vm.subdomain>.<vm.namespace>.svc.cluster.local` if `vm.spec.hostname` is set.

A test which verifies the connectivity via this unique dns-entry is included.