### PR TITLE
Pin kubevirtci client to a specific version

### DIFF
--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -6,7 +6,7 @@ function _main_ip() {
     echo 127.0.0.1
 }
 
-_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest'
+_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli@sha256:bf31833995e4905f9c64ff0e76602b230516455a3ffca559eef17ad2b2b49a4a'
 
 function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
@@ -70,5 +70,5 @@ function _kubectl() {
 }
 
 function down() {
-    docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock rmohr/cli:latest rm
+    ${_cli} rm
 }


### PR DESCRIPTION
In order to allow updating clients and images without interrupting
anyone, use shas for pulling the client and the images.

Signed-off-by: Roman Mohr <rmohr@redhat.com>