### PR TITLE
don't deploy demo preset

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -31,7 +31,12 @@ echo "Deploying ..."
 if [ -z "$TARGET" ] || [ "$TARGET" = "vagrant-dev" ]; then
     _kubectl create -f ${MANIFESTS_OUT_DIR}/dev -R $i
 elif [ "$TARGET" = "vagrant-release" ]; then
-    _kubectl create -f ${MANIFESTS_OUT_DIR}/release -R $i
+    for manifest in ${MANIFESTS_OUT_DIR}/release/*; do
+        if [[ $manifest =~ .*demo.* ]]; then
+            continue
+        fi
+        _kubectl create -f $manifest
+    done
 fi
 
 # Deploy additional infra for testing


### PR DESCRIPTION
The demo preset we have in the release manifests dir has an ordering dependency on the preset CRD. This causes the release manifests to fail to deploy.

We can keep the demo preset in the release directory to ensure it is part of the release manifests, but not require that the demo preset is installed in our dev environments. This resolves the deploy issue. 