### PR TITLE
Fix CPU_CORES type in windows and rhel templates

### DIFF
--- a/cluster/vm-template-rhel7.yaml
+++ b/cluster/vm-template-rhel7.yaml
@@ -18,10 +18,10 @@ objects:
       spec:
         domain:
           cpu:
-            cores: ${CPU_CORES}
+            cores: ${{CPU_CORES}}
           resources:
             requests:
-              memory: ${MEMORY}
+              memory: ${{MEMORY}}
           machine:
             type: q35
           devices:
@@ -53,4 +53,4 @@ parameters:
   value: 4096Mi
 - name: CPU_CORES
   description: Amount of cores
-  value: "4"
+  value: 4

--- a/cluster/vm-template-windows2012r2.yaml
+++ b/cluster/vm-template-windows2012r2.yaml
@@ -36,12 +36,12 @@ objects:
                 tickPolicy: catchup
               hyperv: {}
           cpu:
-            cores: ${CPU_CORES}
+            cores: ${{CPU_CORES}}
           machine:
             type: q35
           resources:
             requests:
-              memory: ${MEMORY}
+              memory: ${{MEMORY}}
           devices:
             disks:
               - name: disk0
@@ -69,4 +69,4 @@ parameters:
   value: 4096Mi
 - name: CPU_CORES
   description: Amount of cores
-  value: "4"
+  value: 4


### PR DESCRIPTION
Prior this fix, the CPU_CORES or MEMORY were handled as strings
causing type-conversion failure within virt-controller's attempt
to create VirtualMachine.

Example:
  oc process -f vm-template-rhel7.yaml -pNAME=vm2 -pMEMORY=128M -pCPU_CORES=5 -o yaml

Prior this fix:
...
  cpu:
    cores: "5"
...

With this fix:
...
  cpu:
    cores: 5
...