### PR TITLE
Fix offlinevm selector

### DIFF
--- a/cluster/my-ovm.yaml
+++ b/cluster/my-ovm.yaml
@@ -6,9 +6,6 @@ metadata:
     my: label
 spec:
   running: false # equivalent to replicas 0
-  selector:
-    matchLabels:
-      my: label
   template:
     metadata:
       labels: 

--- a/cluster/vm-template-rhel7.yaml
+++ b/cluster/vm-template-rhel7.yaml
@@ -16,9 +16,6 @@ objects:
     labels:
       kubevirt-ovm: ovm-${NAME}
   spec:
-    selector:
-      matchLabels:
-        kubevirt-ovm: ovm-${NAME}
     template:
       metadata:
         labels:

--- a/cluster/vm-template-windows2012r2.yaml
+++ b/cluster/vm-template-windows2012r2.yaml
@@ -16,9 +16,6 @@ objects:
     labels:
       kubevirt-ovm: ovm-${NAME}
   spec:
-    selector:
-      matchLabels:
-        kubevirt-ovm: ovm-${NAME}
     template:
       metadata:
         labels:


### PR DESCRIPTION
This PR removes the not necessary label selector from example offline virtual machine. It is confusing for the users.

@fabiand @rmohr PRM

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/799)
<!-- Reviewable:end -->
