### PR TITLE
cleanup of apiservices objects

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -34,13 +34,14 @@ _kubectl delete pods -n ${namespace} -l="kubevirt.io=virt-handler" --force --gra
 # Delete all traces of kubevirt
 namespaces=(default ${namespace})
 for i in ${namespaces[@]}; do
+    _kubectl -n ${i} delete apiservices -l 'kubevirt.io'
     _kubectl -n ${i} delete deployment -l 'kubevirt.io'
     _kubectl -n ${i} delete rs -l 'kubevirt.io'
     _kubectl -n ${i} delete services -l 'kubevirt.io'
     _kubectl -n ${i} delete pv -l 'kubevirt.io'
     _kubectl -n ${i} delete pvc -l 'kubevirt.io'
     _kubectl -n ${i} delete ds -l 'kubevirt.io'
-    _kubectl -n ${i} delete crd -l 'kubevirt.io'
+    _kubectl -n ${i} delete customresourcedefinitions -l 'kubevirt.io'
     _kubectl -n ${i} delete pods -l 'kubevirt.io'
     _kubectl -n ${i} delete clusterrolebinding -l 'kubevirt.io'
     _kubectl -n ${i} delete clusterroles -l 'kubevirt.io'


### PR DESCRIPTION
I want re-enable CI for PR #770. This change needs to go in first so apiservices objects will get removed between CI test runs. 

I'm 90% sure the issue that was causing #770 to break CRD cleanup has been resolved in that PR. This patch changes the kubectl command to use the customresourcedefinitions full name in order to avoid CI issues in the future just in case though.

Also, clearing the kubectl cache shouldn't be required. 