### PR TITLE
Fix DHCP server options to allow Windows accept offered IP

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -46,12 +46,12 @@ func SingleClientDHCPServer(
 	handler := &DHCPHandler{
 		clientIP:      clientIP,
 		clientMAC:     clientMAC,
-		serverIP:      serverIP,
+		serverIP:      serverIP.To4(),
 		leaseDuration: infiniteLease,
 		options: dhcp.Options{
 			dhcp.OptionSubnetMask:       []byte(clientMask),
 			dhcp.OptionRouter:           []byte(routerIP),
-			dhcp.OptionDomainNameServer: []byte(dnsIP),
+			dhcp.OptionDomainNameServer: []byte(dnsIP.To4()),
 		},
 	}
 


### PR DESCRIPTION
Server-ID Option 54 and Domain-Name-Server Option 6
should have length 4 instead of 16

Signed-off-by: Vladik Romanovsky <vromanso@redhat.com>