### PR TITLE
Use /dev/kvm if possible

### DIFF
--- a/docs/software-emulation.md
+++ b/docs/software-emulation.md
@@ -6,8 +6,8 @@ approach is problematic. For instance, running KubeVirt on a cluster where the
 nodes do not support hardware emulation.
 
 If `allowEmulation` is enabled, hardware emulation via `/dev/kvm` will still be
-attempted first, and only if the device is unavailable will software emulation
-be used.
+attempted first. Software emulation will only be used if the device is
+unavailable.
 
 # Configuration
 
@@ -16,16 +16,16 @@ activated using a ConfigMap in the `kube-system` namespace. It can be enabled
 with the following command:
 
 ```bash
-cluster/kubectl.sh --namespace kube-system create configmap virt-controller \
+cluster/kubectl.sh --namespace kube-system create configmap kubevirt-config \
     --from-literal debug.allowEmulation=true
 ```
 
-If the `kube-system/virt-controller` ConfigMap already exists, the above entry
+If the `kube-system/kubevirt-config` ConfigMap already exists, the above entry
 can be added using:
 
 
 ```bash
-cluster/kubectl.sh --namespace kube-system edit configmap virt-controller
+cluster/kubectl.sh --namespace kube-system edit configmap kubevirt-config
 ```
 
 In this case, add the `debug.allowEmulation: "true"` setting to `data`:
@@ -34,7 +34,7 @@ In this case, add the `debug.allowEmulation: "true"` setting to `data`:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: virt-controller
+  name: kubevirt-config
   namespace: kube-system
 data:
   debug.allowEmulation: "true"

--- a/docs/software-emulation.md
+++ b/docs/software-emulation.md
@@ -1,0 +1,45 @@
+# Software Emulation
+
+By default KubeVirt uses the `/dev/kvm` device to enable hardware emulation.
+This is almost always desirable, however there are a few exceptions where this
+approach is problematic. For instance, running KubeVirt on a cluster where the
+nodes do not support hardware emulation.
+
+If `allowEmulation` is enabled, hardware emulation via `/dev/kvm` will still be
+attempted first, and only if the device is unavailable will software emulation
+be used.
+
+# Configuration
+
+Enabling software emulation as a fallback is a cluster-wide setting, and is
+activated using a ConfigMap in the `kube-system` namespace. It can be enabled
+with the following command:
+
+```bash
+cluster/kubectl.sh --namespace kube-system create configmap virt-controller \
+    --from-literal debug.allowEmulation=true
+```
+
+If the `kube-system/virt-controller` ConfigMap already exists, the above entry
+can be added using:
+
+
+```bash
+cluster/kubectl.sh --namespace kube-system edit configmap virt-controller
+```
+
+In this case, add the `debug.allowEmulation: "true"` setting to `data`:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: virt-controller
+  namespace: kube-system
+data:
+  debug.allowEmulation: "true"
+
+```
+
+**NOTE**: The values of `ConfigMap.data` are **strings**. Yaml requires the use of
+quotes around `"true"` to distinguish the value from a boolean.

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -70,14 +70,16 @@ rules:
       - get
       - list
       - delete
-      - update  
-      - create  
+      - update
+      - create
   - apiGroups:
       - ''
     resources:
       - configmaps
     verbs:
       - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -133,13 +135,13 @@ rules:
       - list
       - watch
       - delete
-      - update  
-      - create  
+      - update
+      - create
   - apiGroups:
       - ''
     resources:
       - nodes
-      - persistentvolumeclaims  
+      - persistentvolumeclaims
     verbs:
       - get
       - list
@@ -148,14 +150,14 @@ rules:
       - kubevirt.io
     resources:
       - virtualmachines
-      - virtualmachinereplicasets  
+      - virtualmachinereplicasets
     verbs:
       - get
       - list
       - watch
       - delete
-      - update  
-      - create  
+      - update
+      - create
       - deletecollection
 ---
 apiVersion: v1

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -71,14 +71,16 @@ rules:
       - get
       - list
       - delete
-      - update  
-      - create  
+      - update
+      - create
   - apiGroups:
       - ''
     resources:
       - configmaps
     verbs:
       - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -176,7 +176,8 @@ func (f *kubeInformerFactory) ConfigMap() cache.SharedIndexInformer {
 	// We currently only monitor configmaps in the kube-system namespace
 	return f.getInformer("configMapInformer", func() cache.SharedIndexInformer {
 		restClient := f.clientSet.CoreV1().RESTClient()
-		lw := cache.NewListWatchFromClient(restClient, "configmaps", systemNamespace, fields.Everything())
+		fieldSelector := fields.OneTermEqualSelector("metadata.name", "kubevirt-config")
+		lw := cache.NewListWatchFromClient(restClient, "configmaps", systemNamespace, fieldSelector)
 		return cache.NewSharedIndexInformer(lw, &k8sv1.ConfigMap{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -55,7 +55,8 @@ var _ = Describe("VM Subresources", func() {
 			vm.ObjectMeta.SetUID(uuid.NewUUID())
 			templateService := services.NewTemplateService("whatever", "whatever", "whatever", configCache)
 
-			pod := templateService.RenderLaunchManifest(vm)
+			pod, err := templateService.RenderLaunchManifest(vm)
+			Expect(err).ToNot(HaveOccurred())
 			pod.ObjectMeta.Name = "madeup-name"
 
 			pod.Spec.NodeName = "mynode"

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -28,6 +28,7 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
@@ -40,6 +41,7 @@ var _ = Describe("VM Subresources", func() {
 
 	log.Log.SetIOWriter(GinkgoWriter)
 
+	configCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 	app := SubresourceAPIApp{}
 	BeforeEach(func() {
 		server = ghttp.NewServer()
@@ -51,7 +53,7 @@ var _ = Describe("VM Subresources", func() {
 			vm := v1.NewMinimalVM("testvm")
 			vm.Status.Phase = v1.Running
 			vm.ObjectMeta.SetUID(uuid.NewUUID())
-			templateService := services.NewTemplateService("whatever", "whatever", "whatever")
+			templateService := services.NewTemplateService("whatever", "whatever", "whatever", configCache)
 
 			pod := templateService.RenderLaunchManifest(vm)
 			pod.ObjectMeta.Name = "madeup-name"

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -38,7 +38,7 @@ const configMapName = "kube-system/virt-controller"
 const allowEmulationKey = "debug.allowEmulation"
 
 type TemplateService interface {
-	RenderLaunchManifest(*v1.VirtualMachine) *k8sv1.Pod
+	RenderLaunchManifest(*v1.VirtualMachine) (*k8sv1.Pod, error)
 }
 
 type templateService struct {
@@ -67,7 +67,7 @@ func IsEmulationAllowed(store cache.Store) (bool, error) {
 	return allowEmulation, nil
 }
 
-func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) *k8sv1.Pod {
+func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*k8sv1.Pod, error) {
 	precond.MustNotBeNil(vm)
 	domain := precond.MustNotBeEmpty(vm.GetObjectMeta().GetName())
 	namespace := precond.MustNotBeEmpty(vm.GetObjectMeta().GetNamespace())
@@ -172,6 +172,9 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) *k8sv1.Pod
 	}
 
 	allowEmulation, err := IsEmulationAllowed(t.store)
+	if err != nil {
+		return nil, err
+	}
 	if allowEmulation {
 		command = append(command, "--allow-emulation")
 	}
@@ -272,7 +275,7 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) *k8sv1.Pod
 		}
 	}
 
-	return &pod
+	return &pod, nil
 }
 
 func appendUniqueImagePullSecret(secrets []k8sv1.LocalObjectReference, newsecret k8sv1.LocalObjectReference) []k8sv1.LocalObjectReference {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -34,7 +34,7 @@ import (
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
-const configMapName = "kube-system/virt-controller"
+const configMapName = "kube-system/kubevirt-config"
 const allowEmulationKey = "debug.allowEmulation"
 
 type TemplateService interface {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -34,7 +34,7 @@ import (
 	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
-const configMapKey = "kube-system/virt-controller"
+const configMapName = "kube-system/virt-controller"
 const allowEmulationKey = "debug.allowEmulation"
 
 type TemplateService interface {
@@ -49,7 +49,7 @@ type templateService struct {
 }
 
 func IsEmulationAllowed(store cache.Store) (bool, error) {
-	obj, exists, err := store.GetByKey(configMapKey)
+	obj, exists, err := store.GetByKey(configMapName)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -56,9 +56,8 @@ func IsEmulationAllowed(store cache.Store) (bool, error) {
 	if !exists {
 		return exists, nil
 	}
-	var cm *k8sv1.ConfigMap
 	allowEmulation := false
-	cm = obj.(*k8sv1.ConfigMap)
+	cm := obj.(*k8sv1.ConfigMap)
 	emu, ok := cm.Data[allowEmulationKey]
 	if ok {
 		// TODO: is this too specific? should we just look for the existence of

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -27,6 +27,7 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
@@ -35,7 +36,7 @@ import (
 var _ = Describe("Template", func() {
 
 	log.Log.SetIOWriter(GinkgoWriter)
-	svc := NewTemplateService("kubevirt/virt-launcher", "/var/run/kubevirt", "pull-secret-1")
+	svc := NewTemplateService("kubevirt/virt-launcher", "/var/run/kubevirt", "pull-secret-1", configCache)
 
 	Describe("Rendering", func() {
 		Context("launch template with correct parameters", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -343,6 +343,7 @@ var _ = Describe("Template", func() {
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 			cmStore = cmInformer.GetStore()
 			go cmInformer.Run(stopChan)
+			cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
 
 			result, err := IsEmulationAllowed(cmStore)
 			Expect(err).ToNot(HaveOccurred())
@@ -358,6 +359,7 @@ var _ = Describe("Template", func() {
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 			cmStore = cmInformer.GetStore()
 			go cmInformer.Run(stopChan)
+			cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
 
 			result, err := IsEmulationAllowed(cmStore)
 			Expect(err).ToNot(HaveOccurred())
@@ -373,6 +375,7 @@ var _ = Describe("Template", func() {
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 			cmStore = cmInformer.GetStore()
 			go cmInformer.Run(stopChan)
+			cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
 
 			result, err := IsEmulationAllowed(cmStore)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -352,8 +352,11 @@ var _ = Describe("Template", func() {
 
 		It("Should return false if configmap doesn't have allowEmulation set", func() {
 			cfgMap := kubev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "kube-system/virt-controller"},
-				Data:       map[string]string{},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Name:      "kubevirt-config",
+				},
+				Data: map[string]string{},
 			}
 			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
@@ -368,8 +371,11 @@ var _ = Describe("Template", func() {
 
 		It("Should return true if allowEmulation = true", func() {
 			cfgMap := kubev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "kube-system/virt-controller"},
-				Data:       map[string]string{"debug.allowEmulation": "true"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Name:      "kubevirt-config",
+				},
+				Data: map[string]string{"debug.allowEmulation": "true"},
 			}
 			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -20,6 +20,8 @@
 package services_test
 
 import (
+	"time"
+
 	. "kubevirt.io/kubevirt/pkg/virt-controller/services"
 
 	. "github.com/onsi/ginkgo"
@@ -27,6 +29,8 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
@@ -307,4 +311,75 @@ var _ = Describe("Template", func() {
 			})
 		})
 	})
+	Describe("ConfigMap", func() {
+		var cmListWatch *cache.ListWatch
+		var cmInformer cache.SharedIndexInformer
+		var cmStore cache.Store
+		var stopChan chan struct{}
+
+		BeforeEach(func() {
+			stopChan = make(chan struct{})
+		})
+
+		AfterEach(func() {
+			close(stopChan)
+		})
+
+		It("Should return false if configmap is not present", func() {
+			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{})
+			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			cmStore = cmInformer.GetStore()
+			go cmInformer.Run(stopChan)
+
+			result, err := IsEmulationAllowed(cmStore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("Should return false if configmap doesn't have allowEmulation set", func() {
+			cfgMap := kubev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-system/virt-controller"},
+				Data: map[string]string{},
+			}
+			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
+			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			cmStore = cmInformer.GetStore()
+			go cmInformer.Run(stopChan)
+
+			result, err := IsEmulationAllowed(cmStore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+
+		It("Should return true if allowEmulation = true", func() {
+			cfgMap := kubev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-system/virt-controller"},
+				Data: map[string]string{"debug.allowEmulation": "true"},
+			}
+			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
+			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			cmStore = cmInformer.GetStore()
+			go cmInformer.Run(stopChan)
+
+			result, err := IsEmulationAllowed(cmStore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
 })
+
+func MakeFakeConfigMapWatcher(configMaps []kubev1.ConfigMap) *cache.ListWatch {
+	cmListWatch := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return &kubev1.ConfigMapList{Items: configMaps}, nil
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			fakeWatch := watch.NewFake()
+			for _, cfgMap := range configMaps {
+				fakeWatch.Add(&cfgMap)
+			}
+			return watch.NewFake(), nil
+		},
+	}
+	return cmListWatch
+}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -339,7 +339,7 @@ var _ = Describe("Template", func() {
 		It("Should return false if configmap doesn't have allowEmulation set", func() {
 			cfgMap := kubev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "kube-system/virt-controller"},
-				Data: map[string]string{},
+				Data:       map[string]string{},
 			}
 			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
@@ -354,7 +354,7 @@ var _ = Describe("Template", func() {
 		It("Should return true if allowEmulation = true", func() {
 			cfgMap := kubev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "kube-system/virt-controller"},
-				Data: map[string]string{"debug.allowEmulation": "true"},
+				Data:       map[string]string{"debug.allowEmulation": "true"},
 			}
 			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachine{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -349,7 +349,10 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, pods []*k8sv1.Pod) (err s
 			return nil
 		}
 		c.podExpectations.ExpectCreations(vmKey, 1)
-		templatePod := c.templateService.RenderLaunchManifest(vm)
+		templatePod, err := c.templateService.RenderLaunchManifest(vm)
+		if err != nil {
+			return &syncErrorImpl{fmt.Errorf("failed to render launch manifest: %v", err), FailedCreatePodReason}
+		}
 		pod, err := c.clientset.CoreV1().Pods(vm.GetNamespace()).Create(templatePod)
 		if err != nil {
 			c.recorder.Eventf(vm, k8sv1.EventTypeWarning, FailedCreatePodReason, "Error creating pod: %v", err)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 
@@ -65,7 +65,7 @@ const (
 	SuccessfulHandOverPodReason = "SuccessfulHandOver"
 )
 
-func NewVMController(templateService services.TemplateService, vmInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer, recorder record.EventRecorder, clientset kubecli.KubevirtClient) *VMController {
+func NewVMController(templateService services.TemplateService, vmInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer, recorder record.EventRecorder, clientset kubecli.KubevirtClient, configMapInformer cache.SharedIndexInformer) *VMController {
 	c := &VMController{
 		templateService:      templateService,
 		Queue:                workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
@@ -75,6 +75,7 @@ func NewVMController(templateService services.TemplateService, vmInformer cache.
 		clientset:            clientset,
 		podExpectations:      controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		handoverExpectations: controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		configMapInformer:    configMapInformer,
 	}
 
 	c.vmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -119,6 +120,7 @@ type VMController struct {
 	recorder             record.EventRecorder
 	podExpectations      *controller.UIDTrackingControllerExpectations
 	handoverExpectations *controller.UIDTrackingControllerExpectations
+	configMapInformer    cache.SharedIndexInformer
 }
 
 func (c *VMController) Run(threadiness int, stopCh chan struct{}) {
@@ -127,7 +129,7 @@ func (c *VMController) Run(threadiness int, stopCh chan struct{}) {
 	log.Log.Info("Starting vm controller.")
 
 	// Wait for cache sync before we start the pod controller
-	cache.WaitForCacheSync(stopCh, c.vmInformer.HasSynced, c.podInformer.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.vmInformer.HasSynced, c.podInformer.HasSynced, c.configMapInformer.HasSynced)
 
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -63,7 +63,7 @@ var _ = Describe("VM watcher", func() {
 	var podFeeder *testutils.PodFeeder
 	var virtClient *kubecli.MockKubevirtClient
 	var kubeClient *fake.Clientset
-        var configMapCache cache.Indexer
+	var configMapInformer cache.SharedIndexInformer
 
 	shouldExpectPodCreation := func(uid types.UID) {
 		// Expect pod creation
@@ -136,8 +136,8 @@ var _ = Describe("VM watcher", func() {
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(100)
 
-		configMapCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
-		controller = NewVMController(services.NewTemplateService("a", "b", "c", configMapCache), vmInformer, podInformer, recorder, virtClient)
+		configMapInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+		controller = NewVMController(services.NewTemplateService("a", "b", "c", configMapInformer.GetStore()), vmInformer, podInformer, recorder, virtClient, configMapInformer)
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -63,6 +63,7 @@ var _ = Describe("VM watcher", func() {
 	var podFeeder *testutils.PodFeeder
 	var virtClient *kubecli.MockKubevirtClient
 	var kubeClient *fake.Clientset
+        var configMapCache cache.Indexer
 
 	shouldExpectPodCreation := func(uid types.UID) {
 		// Expect pod creation
@@ -135,7 +136,8 @@ var _ = Describe("VM watcher", func() {
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(100)
 
-		controller = NewVMController(services.NewTemplateService("a", "b", "c"), vmInformer, podInformer, recorder, virtClient)
+		configMapCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
+		controller = NewVMController(services.NewTemplateService("a", "b", "c", configMapCache), vmInformer, podInformer, recorder, virtClient)
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Domain informer", func() {
 			socketPath := filepath.Join(socketsDir, "default_testvm1_sock")
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 
-			cmdserver.RunServer(socketPath, domainManager, stopChan)
+			cmdserver.RunServer(socketPath, domainManager, stopChan, nil)
 
 			// ensure we can connect to the server first.
 			client, err := cmdclient.GetClient(socketPath)
@@ -124,7 +124,7 @@ var _ = Describe("Domain informer", func() {
 			socketPath := filepath.Join(socketsDir, "default_test_sock")
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
 
-			cmdserver.RunServer(socketPath, domainManager, stopChan)
+			cmdserver.RunServer(socketPath, domainManager, stopChan, nil)
 
 			// ensure we can connect to the server first.
 			client, err := cmdclient.GetClient(socketPath)
@@ -183,7 +183,7 @@ var _ = Describe("Domain informer", func() {
 			// verify list still completes regardless
 			f, err := os.Create(filepath.Join(socketsDir, "default_fakevm_sock"))
 			f.Close()
-			cmdserver.RunServer(socketPath, domainManager, stopChan)
+			cmdserver.RunServer(socketPath, domainManager, stopChan, nil)
 
 			// ensure we can connect to the server first.
 			client, err := cmdclient.GetClient(socketPath)

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 
@@ -377,6 +377,7 @@ var _ = Describe("Converter", func() {
 						},
 					},
 				},
+				AllowEmulation: true,
 			}
 		})
 

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -45,6 +45,8 @@ var _ = Describe("Virt remote commands", func() {
 	var shareDir string
 	var stop chan struct{}
 	var stopped bool
+	var allowEmulation bool
+	var options *ServerOptions
 
 	log.Log.SetIOWriter(GinkgoWriter)
 
@@ -57,7 +59,9 @@ var _ = Describe("Virt remote commands", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		domainManager = virtwrap.NewMockDomainManager(ctrl)
 
-		RunServer(shareDir+"/server.sock", domainManager, stop)
+		allowEmulation = true
+		options = NewServerOptions(allowEmulation)
+		RunServer(shareDir+"/server.sock", domainManager, stop, options)
 		client, err = cmdclient.GetClient(shareDir + "/server.sock")
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -74,7 +78,7 @@ var _ = Describe("Virt remote commands", func() {
 		It("should start a vm", func() {
 			vm := v1.NewVMReferenceFromName("testvm")
 			domain := api.NewMinimalDomain("testvm")
-			domainManager.EXPECT().SyncVM(vm).Return(&domain.Spec, nil)
+			domainManager.EXPECT().SyncVM(vm, allowEmulation).Return(&domain.Spec, nil)
 
 			err := client.SyncVirtualMachine(vm)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -31,15 +31,15 @@ func (_m *MockDomainManager) EXPECT() *_MockDomainManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDomainManager) SyncVM(_param0 *v1.VirtualMachine) (*api.DomainSpec, error) {
-	ret := _m.ctrl.Call(_m, "SyncVM", _param0)
+func (_m *MockDomainManager) SyncVM(_param0 *v1.VirtualMachine, _param1 bool) (*api.DomainSpec, error) {
+	ret := _m.ctrl.Call(_m, "SyncVM", _param0, _param1)
 	ret0, _ := ret[0].(*api.DomainSpec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockDomainManagerRecorder) SyncVM(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncVM", arg0)
+func (_mr *_MockDomainManagerRecorder) SyncVM(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncVM", arg0, arg1)
 }
 
 func (_m *MockDomainManager) KillVM(_param0 *v1.VirtualMachine) error {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 
@@ -47,7 +47,7 @@ import (
 )
 
 type DomainManager interface {
-	SyncVM(*v1.VirtualMachine) (*api.DomainSpec, error)
+	SyncVM(*v1.VirtualMachine, bool) (*api.DomainSpec, error)
 	KillVM(*v1.VirtualMachine) error
 	SignalShutdownVM(*v1.VirtualMachine) error
 	ListAllDomains() ([]*api.Domain, error)
@@ -110,7 +110,7 @@ func (l *LibvirtDomainManager) preStartHook(vm *v1.VirtualMachine, domain *api.D
 	return domain, err
 }
 
-func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine) (*api.DomainSpec, error) {
+func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine, allowEmulation bool) (*api.DomainSpec, error) {
 	logger := log.Log.Object(vm)
 
 	domain := &api.Domain{}
@@ -118,6 +118,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine) (*api.DomainSpec, e
 	// Map the VirtualMachine to the Domain
 	c := &api.ConverterContext{
 		VirtualMachine: vm,
+		AllowEmulation: allowEmulation,
 	}
 	if err := api.Convert_v1_VirtualMachine_To_api_Domain(vm, domain, c); err != nil {
 		logger.Error("Conversion failed.")

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Manager", func() {
 		domain := &api.Domain{}
 		c := &api.ConverterContext{
 			VirtualMachine: vm,
+			AllowEmulation: true,
 		}
 		Expect(api.Convert_v1_VirtualMachine_To_api_Domain(vm, domain, c)).To(Succeed())
 		api.SetObjectDefaults_Domain(domain)
@@ -81,7 +82,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn)
-			newspec, err := manager.SyncVM(vm)
+			newspec, err := manager.SyncVM(vm, true)
 			Expect(newspec).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
@@ -94,7 +95,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn)
-			newspec, err := manager.SyncVM(vm)
+			newspec, err := manager.SyncVM(vm, true)
 			Expect(newspec).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})
@@ -110,7 +111,7 @@ var _ = Describe("Manager", func() {
 				mockDomain.EXPECT().Create().Return(nil)
 				mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 				manager, _ := NewLibvirtDomainManager(mockConn)
-				newspec, err := manager.SyncVM(vm)
+				newspec, err := manager.SyncVM(vm, true)
 				Expect(newspec).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			},
@@ -129,7 +130,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Resume().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
 			manager, _ := NewLibvirtDomainManager(mockConn)
-			newspec, err := manager.SyncVM(vm)
+			newspec, err := manager.SyncVM(vm, true)
 			Expect(newspec).ToNot(BeNil())
 			Expect(err).To(BeNil())
 		})


### PR DESCRIPTION
Fixes #802 

* Always use /dev/kvm by default.
* Allow fallback to emulation if the `hack.kubevirt.io/emulate: true` annotation is added to the VM.

Signed-off-by: Roman Mohr <rmohr@redhat.com>