### PR TITLE
virtctl: Permit specifying a custom VNC proxy port

### DIFF
--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -42,6 +42,7 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 	server, _ := flags.GetString("server")
 	kubeconfig, _ := flags.GetString("kubeconfig")
 	namespace, _ := flags.GetString("namespace")
+	listenPort, _ := flags.GetUInt32("listen")
 	if namespace == "" {
 		namespace = kubev1.NamespaceDefault
 	}
@@ -71,7 +72,7 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 	readStop := make(chan error)
 
 	// The local tcp server is used to proxy the podExec websock connection to remote-viewer
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", fmt.Sprintf("vnc://127.0.0.1:%d", listenPort))
 	if err != nil {
 		log.Printf("Can't listen on unix socket: %s", err.Error())
 		return 1


### PR DESCRIPTION
Allow setting a custom local proxy port.
Would allow users to conenct with their own clients.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>