### PR TITLE
api-reference: deploy doc on annotated tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,11 @@ deploy:
     branch: master
 - provider: script
   skip_cleanup: true
+  script: bash hack/gen-swagger-doc/deploy.sh
+  on:
+    tags: true
+- provider: script
+  skip_cleanup: true
   script: bash hack/gen-client-python/deploy.sh
   on:
     branch: master


### PR DESCRIPTION
Fixes: kubevirt/api-reference#11

Signed-off-by: Lukas Bednar <lbednar@redhat.com.com>