### PR TITLE
WIP RFC api: let user select volume mode

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3547,6 +3547,10 @@
      "name"
     ],
     "properties": {
+     "mode": {
+      "description": "Mode indicates how the volume should be accessed by the VM. Supported values: block, filesystem (default).\n+optional",
+      "type": "string"
+     },
      "cloudInitNoCloud": {
       "description": "CloudInitNoCloud represents a cloud-init NoCloud user-data source.\nThe NoCloud data will be added as a disk to the vm. A proper cloud-init installation is required inside the guest.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html\n+optional",
       "$ref": "#/definitions/v1.CloudInitNoCloudSource"

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -211,6 +211,9 @@ type VolumeSource struct {
 	// Ephemeral is a special volume source that "wraps" specified source and provides copy-on-write image on top of it.
 	// +optional
 	Ephemeral *EphemeralVolumeSource `json:"ephemeral,omitempty"`
+	// Mode indicates how the volume should be accessed by the VM. Supported values: block, filesystem (default).
+	// +optional
+	Mode string `json:"mode,omitempty"`
 }
 
 type EphemeralVolumeSource struct {

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -116,6 +116,7 @@ func (VolumeSource) SwaggerDoc() map[string]string {
 		"cloudInitNoCloud":      "CloudInitNoCloud represents a cloud-init NoCloud user-data source.\nThe NoCloud data will be added as a disk to the vm. A proper cloud-init installation is required inside the guest.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html\n+optional",
 		"registryDisk":          "RegistryDisk references a docker image, embedding a qcow or raw disk\nMore info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html\n+optional",
 		"ephemeral":             "Ephemeral is a special volume source that \"wraps\" specified source and provides copy-on-write image on top of it.\n+optional",
+		"Mode":                  "Mode indicates how the volume should be accessed by the VM. Supported values: block, filesystem (default).\n+optional",
 	}
 }
 


### PR DESCRIPTION
Reviewers: This PR is by no means complete. I'm using it as vessel to discuss few design topics. Feel free to suggest a better venue for this discussion.

Topics for discussion:
- per https://kubernetes.io/docs/reference/feature-gates/ , the whole blockvolume support is behind a feature gate which is disabled per default in 1.9. Do we want/need instead to assume this feature is enabled in kubevirt installations?
- per https://schd.ws/hosted_files/kccncna17/8e/Mitsuhiro_Tanino_Block_Volume_KC_CNC_NA17.pdf looks like that the only block volume supported in 1.9 is FC. ISCSI (and more) is planned for 1.10.
Does this make this feature less desirable for the short term
- API wise, do which is the best way to expose this feature? I choose the simplest, minimal change approach as described below, but I'm not sure this is what we want.

+++

Starting with version 1.9, k8s gained the option to expose the volumes
as raw block device, instead of always creating filesystem on them.
We want to expose this feature for consumption to VMs running into PODs.

This patch implements the minimal API change, adding one optional
parameter to volumes, to turn them in raw block devices.

We should have this feature opt-in because it is alpha-stage in
kubernetes 1.9, enabled using the feature gate. Furthermore,
changes may likely happen during the k8s 1.10 cycle.

Further references:
- https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/raw-block-pv.md
- https://schd.ws/hosted_files/kccncna17/8e/Mitsuhiro_Tanino_Block_Volume_KC_CNC_NA17.pdf

Fixes #816

Signed-off-by: Francesco Romani <fromani@redhat.com>