### PR TITLE
Build virtctl also for darwin and windows

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -71,13 +71,27 @@ for arg in $args; do
     elif [ "${target}" = "install" ]; then
         eval "$(go env)"
         BIN_NAME=$(basename $arg)
-        ARCHBIN=${BIN_NAME}-$(git describe --always --tags)-${GOHOSTOS}-${GOHOSTARCH}
+        ARCH_BASENAME=${BIN_NAME}-$(git describe --always --tags)
+        ARCHBIN=${ARCH_BASENAME}-${GOHOSTOS}-${GOHOSTARCH}
         mkdir -p ${CMD_OUT_DIR}/${BIN_NAME}
         (
             cd $arg
             go vet ./...
             go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCHBIN}
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCHBIN} ${BIN_NAME})
+
+            # build virtctl binaries for other operating systems
+            if [ "${BIN_NAME}" = "virtctl" ]; then
+                if [[ "${GOHOSTOS}" != "linux" ]] || [[ "${GOHOSTARCH}" != "amd64" ]]; then
+                    GOOS=linux GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-linux-amd64
+                fi
+                if [[ "${GOHOSTOS}" != "darwin" ]] || [[ "${GOHOSTARCH}" != "amd64" ]]; then
+                    GOOS=darwin GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64
+                fi
+                if [[ "${GOHOSTOS}" != "windows" ]] || [[ "${GOHOSTARCH}" != "amd64" ]]; then
+                    GOOS=windows GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe
+                fi
+            fi
         )
     else
         (

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -72,25 +72,20 @@ for arg in $args; do
         eval "$(go env)"
         BIN_NAME=$(basename $arg)
         ARCH_BASENAME=${BIN_NAME}-$(git describe --always --tags)
-        ARCHBIN=${ARCH_BASENAME}-${GOHOSTOS}-${GOHOSTARCH}
         mkdir -p ${CMD_OUT_DIR}/${BIN_NAME}
         (
             cd $arg
             go vet ./...
-            go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCHBIN}
-            (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCHBIN} ${BIN_NAME})
 
-            # build virtctl binaries for other operating systems
+            # always build and link the linux/amd64 binary
+            LINUX_NAME=${ARCH_BASENAME}-linux-amd64
+            GOOS=linux GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME}
+            (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
+
+            # build virtctl also for darwin and windows
             if [ "${BIN_NAME}" = "virtctl" ]; then
-                if [[ "${GOHOSTOS}" != "linux" ]] || [[ "${GOHOSTARCH}" != "amd64" ]]; then
-                    GOOS=linux GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-linux-amd64
-                fi
-                if [[ "${GOHOSTOS}" != "darwin" ]] || [[ "${GOHOSTARCH}" != "amd64" ]]; then
-                    GOOS=darwin GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64
-                fi
-                if [[ "${GOHOSTOS}" != "windows" ]] || [[ "${GOHOSTARCH}" != "amd64" ]]; then
-                    GOOS=windows GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe
-                fi
+                GOOS=darwin GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64
+                GOOS=windows GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe
             fi
         )
     else


### PR DESCRIPTION
This change ensures that `virtctl` binaries are build for `linux`, `darwin` and `windows` (all `amd64`), regardless on which platform the build was triggered. When I understand the travis configuration correct, all binaries will automatically be released because of the `virtctl-*` pattern.

Fixes #810 