### PR TITLE
Update vagrant CentOS build

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,7 @@ SCRIPT
 
 Vagrant.configure(2) do |config|
   config.vm.box = "centos7"
-  config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1608_01.LibVirt.box"
+  config.vm.box_url = "http://cloud.centos.org/centos/7/vagrant/x86_64/images/CentOS-7-x86_64-Vagrant-1802_01.Libvirt.box"
 
   if Vagrant.has_plugin?("vagrant-cachier") and $cache_rpm then
       config.cache.scope = :machine


### PR DESCRIPTION
Latest docker packages have check on overlay2 and selinux options
and this check failed on recent kernels.
To get the new image you need:
- delete all stuff from `/home/alukiano/.vagrant.d/boxes/centos7/0/libvirt/*`
- delete KubeVirt VM's images(default location `/var/lib/libvirt/images`)
- restart libvirt service

Signed-off-by: Lukianov Artyom <alukiano@redhat.com>