### PR TITLE
Implement convenience functions to start/stop OfflineVMs in virtctl

### DIFF
--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 

--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -29,6 +29,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/virtctl"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
+	"kubevirt.io/kubevirt/pkg/virtctl/offlinevm"
 	"kubevirt.io/kubevirt/pkg/virtctl/vnc"
 )
 
@@ -41,6 +42,8 @@ func main() {
 		"console": &console.Console{},
 		"options": &virtctl.Options{},
 		"vnc":     &vnc.VNC{},
+		offlinevm.COMMAND_START: offlinevm.NewCommand(offlinevm.COMMAND_START),
+		offlinevm.COMMAND_STOP:  offlinevm.NewCommand(offlinevm.COMMAND_STOP),
 	}
 
 	if len(os.Args) > 1 {
@@ -83,6 +86,8 @@ func Usage() {
 Basic Commands:
   console        Connect to a serial console on a VM
   vnc            Connect to a VNC display of a VM
+  start          Start an OfflineVirtualMachine
+  stop           Stop an OfflineVirtualMachine
 
 Use "virtctl <command> --help" for more information about a given command.
 Use "virtctl options" for a list of global command-line options (applies to all commands).

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 
@@ -31,6 +31,7 @@ import (
 	"k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl"
 )
 
 type Console struct {
@@ -54,7 +55,6 @@ func (c *Console) Usage() string {
 }
 
 func (c *Console) Run(flags *flag.FlagSet) int {
-
 	server, _ := flags.GetString("server")
 	kubeconfig, _ := flags.GetString("kubeconfig")
 	namespace, _ := flags.GetString("namespace")
@@ -64,20 +64,20 @@ func (c *Console) Run(flags *flag.FlagSet) int {
 	}
 	if len(flags.Args()) != 2 {
 		log.Println("VM name is missing")
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 	vm := flags.Arg(1)
 
 	virtCli, err := kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
 	if err != nil {
 		log.Println(err)
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 
 	state, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		log.Printf("Make raw terminal failed: %s", err)
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 	fmt.Fprint(os.Stderr, "Escape sequence is ^]\n")
 
@@ -149,7 +149,7 @@ func (c *Console) Run(flags *flag.FlagSet) int {
 
 	if err != nil {
 		log.Println(err)
-		return 1
+		return virtctl.STATUS_ERROR
 	}
-	return 0
+	return virtctl.STATUS_OK
 }

--- a/pkg/virtctl/offlinevm/offlinevm.go
+++ b/pkg/virtctl/offlinevm/offlinevm.go
@@ -85,8 +85,7 @@ func (o *Command) Run(flags *flag.FlagSet) int {
 
 	if (server != "") && (kubeconfig != "") {
 		virtClient, err = kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
-	} else
-	{
+	} else {
 		virtClient, err = kubecli.GetKubevirtClient()
 	}
 	if err != nil {

--- a/pkg/virtctl/offlinevm/offlinevm.go
+++ b/pkg/virtctl/offlinevm/offlinevm.go
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package offlinevm
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
+)
+
+const (
+	COMMAND_START = "start"
+	COMMAND_STOP  = "stop"
+)
+
+type Command struct {
+	command string
+}
+
+func (c *Command) FlagSet() *flag.FlagSet {
+	cf := flag.NewFlagSet(c.command, flag.ExitOnError)
+
+	return cf
+}
+
+func NewCommand(command string) *Command {
+	return &Command{command: command}
+}
+
+func (c *Command) Usage() string {
+	virtctlCmd := path.Base(os.Args[0])
+	usage := fmt.Sprintf("%s an OfflineVirtualMachine\n\n", strings.Title(c.command))
+	usage += "Example:\n"
+	usage += fmt.Sprintf("%s %s myvm\n", virtctlCmd, c.command)
+	return usage
+}
+
+func (o *Command) Run(flags *flag.FlagSet) int {
+	if flags.NArg() != 2 {
+		log.Println("OfflineVirtualMachine name is missing")
+		return 1
+	}
+	vmName := flags.Arg(1)
+
+	server, _ := flags.GetString("server")
+	kubeconfig, _ := flags.GetString("kubeconfig")
+	namespace, _ := flags.GetString("namespace")
+
+	var running bool
+	command := flags.Arg(0)
+	if command == COMMAND_START {
+		running = true
+	} else if command == COMMAND_STOP {
+		running = false
+	}
+
+	virtCli, err := kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
+	if err != nil {
+		log.Printf("Cannot obtain KubeVirt client: %v", err)
+		return 1
+	}
+
+	options := &k8smetav1.GetOptions{}
+	ovm, err := virtCli.OfflineVirtualMachine(namespace).Get(vmName, options)
+	if err != nil {
+		log.Printf("Error fetching OfflineVirtualMachine: %v", err)
+		return 1
+	}
+
+	if ovm.Spec.Running != running {
+		ovm.Spec.Running = running
+		_, err := virtCli.OfflineVirtualMachine(namespace).Update(ovm)
+		if err != nil {
+			log.Printf("Error updating OfflineVirtualMachine: %v", err)
+			return 1
+		}
+	}
+
+	return 0
+}

--- a/pkg/virtctl/offlinevm/offlinevm_suite_test.go
+++ b/pkg/virtctl/offlinevm/offlinevm_suite_test.go
@@ -1,0 +1,13 @@
+package offlinevm_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOfflinevm(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Offlinevm Suite")
+}

--- a/pkg/virtctl/offlinevm/offlinevm_test.go
+++ b/pkg/virtctl/offlinevm/offlinevm_test.go
@@ -1,0 +1,48 @@
+package offlinevm
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OfflineVirtualMachine", func() {
+
+	Context("OfflineVirtualMachine command invocation", func() {
+		var commandName string
+		var cmd *Command
+
+		BeforeEach(func() {
+			commandName = "test"
+			cmd = NewCommand(commandName)
+		})
+
+		It("should create commands based on given verb", func() {
+			Expect(cmd.command).To(Equal(commandName))
+		})
+
+		It("should use verb in usage", func() {
+			reference := "Test an OfflineVirtualMachine"
+			usage := cmd.Usage()
+			lines := strings.Split(usage, "\n")
+			Expect(lines[0]).To(Equal(reference))
+		})
+
+		It("should use a different verb in usage", func() {
+			commandName = "grok"
+			reference := "Grok an OfflineVirtualMachine"
+			cmd = NewCommand(commandName)
+
+			usage := cmd.Usage()
+			lines := strings.Split(usage, "\n")
+			Expect(lines[0]).To(Equal(reference))
+		})
+	})
+})
+
+func TestOVM(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OfflineVM")
+}

--- a/pkg/virtctl/virtctl.go
+++ b/pkg/virtctl/virtctl.go
@@ -24,8 +24,6 @@ import (
 	"os"
 
 	flag "github.com/spf13/pflag"
-
-	"kubevirt.io/kubevirt/pkg/kubecli"
 )
 
 const (
@@ -60,14 +58,4 @@ func (o *Options) Usage() string {
 	usage := "The following options can be passed to any command:\n\n"
 	usage += o.FlagSet().FlagUsages()
 	return usage
-}
-
-func GetKubevirtClient(flags *flag.FlagSet) (kubecli.KubevirtClient, error) {
-	server, _ := flags.GetString("server")
-	kubeconfig, _ := flags.GetString("kubeconfig")
-	if (server == "") && (kubeconfig == "") {
-		return kubecli.GetKubevirtClient()
-	} else {
-		return kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
-	}
 }

--- a/pkg/virtctl/virtctl.go
+++ b/pkg/virtctl/virtctl.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 
@@ -24,6 +24,13 @@ import (
 	"os"
 
 	flag "github.com/spf13/pflag"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
+)
+
+const (
+	STATUS_OK    = 0
+	STATUS_ERROR = 1
 )
 
 type App interface {
@@ -53,4 +60,14 @@ func (o *Options) Usage() string {
 	usage := "The following options can be passed to any command:\n\n"
 	usage += o.FlagSet().FlagUsages()
 	return usage
+}
+
+func GetKubevirtClient(flags *flag.FlagSet) (kubecli.KubevirtClient, error) {
+	server, _ := flags.GetString("server")
+	kubeconfig, _ := flags.GetString("kubeconfig")
+	if (server == "") && (kubeconfig == "") {
+		return kubecli.GetKubevirtClient()
+	} else {
+		return kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
+	}
 }

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017 Red Hat, Inc.
+ * Copyright 2017, 2018 Red Hat, Inc.
  *
  */
 
@@ -32,6 +32,7 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl"
 )
 
 const FLAG = "vnc"
@@ -48,14 +49,14 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 
 	if len(flags.Args()) != 2 {
 		log.Println("VM name is missing")
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 	vm := flags.Arg(1)
 
 	virtCli, err := kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
 	if err != nil {
 		log.Println(err)
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 
 	//                                       -> pipeInWriter  -> pipeInReader
@@ -74,7 +75,7 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		log.Printf("Can't listen on unix socket: %s", err.Error())
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 
 	port := ln.Addr().(*net.TCPAddr).Port
@@ -99,7 +100,7 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 	fd, err := ln.Accept()
 	if err != nil {
 		log.Printf("Failed to accept unix sock connection. %s", err.Error())
-		return 1
+		return virtctl.STATUS_ERROR
 	}
 	defer fd.Close()
 
@@ -133,9 +134,9 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 
 	if err != nil {
 		log.Printf("Error encountered: %s", err.Error())
-		return 1
+		return virtctl.STATUS_ERROR
 	}
-	return 0
+	return virtctl.STATUS_OK
 }
 
 func (o *VNC) Usage() string {

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -309,7 +309,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 		})
 
 		Context("Using virtctl interface", func() {
-			It("should start a VM", func() {
+			It("should start a VM once", func() {
 				var vm *v1.VirtualMachine
 				var err error
 				By("getting an OVM")
@@ -322,8 +322,8 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				startFlags.AddFlagSet((&virtctl.Options{}).FlagSet())
 				startFlags.Parse(startCommandLine)
 
-				Expect(startFlags.NArg()).To(Equal(2))
-				startCmd.Run(startFlags)
+				status := startCmd.Run(startFlags)
+				Expect(status).To(Equal(0))
 
 				By("Getting the status of the OVM")
 				Eventually(func() bool {
@@ -339,9 +339,12 @@ var _ = Describe("OfflineVirtualMachine", func() {
 					return vm.Status.Phase == v1.Running
 				}, 240*time.Second, 1*time.Second).Should(BeTrue())
 
+				By("Ensuring a second invocation should fail")
+				status = startCmd.Run(startFlags)
+				Expect(status).To(Equal(1))
 			})
 
-			It("should stop a VM", func() {
+			It("should stop a VM once", func() {
 				var err error
 				By("getting an OVM")
 				newOVM := newOfflineVirtualMachine(true)
@@ -352,7 +355,9 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				stopFlags := stopCmd.FlagSet()
 				stopFlags.AddFlagSet((&virtctl.Options{}).FlagSet())
 				stopFlags.Parse(stopCommandLine)
-				stopCmd.Run(stopFlags)
+
+				status := stopCmd.Run(stopFlags)
+				Expect(status).To(Equal(0))
 
 				By("Ensuring OVM is not running")
 				Eventually(func() bool {
@@ -367,6 +372,10 @@ var _ = Describe("OfflineVirtualMachine", func() {
 					// Expect a 404 error
 					return err
 				}, 240*time.Second, 1*time.Second).Should(HaveOccurred())
+
+				By("Ensuring a second invocation should fail")
+				status = stopCmd.Run(stopFlags)
+				Expect(status).To(Equal(1))
 			})
 		})
 	})


### PR DESCRIPTION
Add start and stop commands to virtcli, which will modify the spec of an OfflineVirtualMachine to update `running` to `true` or `false`.

- [x] Unit tests
- [x] Update User Guide