### PR TITLE
Switch over to use containerized clusters on CI

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -26,53 +26,18 @@
 set -ex
 
 export WORKSPACE="${WORKSPACE:-$PWD}"
+export PROVIDER="k8s-1.9.3"
+export VAGRANT_NUM_NODES=1
 
 kubectl() { cluster/kubectl.sh "$@"; }
 
 export NAMESPACE="${NAMESPACE:-kube-system}"
 
-if [ "$TARGET" = "vagrant-dev"  ]; then
-cat > hack/config-local.sh <<EOF
-master_ip=192.168.1.2
-EOF
-elif [ "$TARGET" = "vagrant-release"  ]; then
-cat > hack/config-local.sh <<EOF
-master_ip=192.168.2.2
-EOF
-fi
-
-export VAGRANT_PREFIX=${VARIABLE:-kubevirt}
-export VAGRANT_NUM_NODES="${VAGRANT_NUM_NODES:-1}"
-# Keep .vagrant files between builds
-export VAGRANT_DOTFILE_PATH="${VAGRANT_DOTFILE_PATH:-$WORKSPACE/.vagrant}"
-
-# Install dockerize
-export DOCKERIZE_VERSION=v0.3.0
-curl -LO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C $WORKSPACE -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
 # Make sure that the VM is properly shut down on exit
 trap '{ make cluster-down; }' EXIT
 
-# TODO handle complete workspace removal on CI
-set +e
+make cluster-down
 make cluster-up
-if [ $? -ne 0 ]; then
-  vagrant destroy
-  set -e
-  make cluster-up
-fi
-set -e
-
-# Build KubeVirt
-make
-
-# Make sure we can connect to kubernetes
-export APISERVER=$(cat cluster/vagrant-kubernetes/.kubeconfig | grep server | sed -e 's# \+server: https://##' | sed -e 's/\r//')
-$WORKSPACE/dockerize -wait tcp://$APISERVER -timeout 300s
-# Make sure we don't try to talk to Vagrant host via a proxy
-export no_proxy="${APISERVER%:*}"
 
 # Wait for nodes to become ready
 while [ -n "$(kubectl get nodes --no-headers | grep -v Ready)" ]; do
@@ -83,27 +48,7 @@ done
 echo "Nodes are ready:"
 kubectl get nodes
 
-# Wait for all kubernetes pods to become ready (dont't wait for kubevirt pods from previous deployments)
-sleep 10
-while [ -n "$(kubectl get pods -n ${NAMESPACE} -l '!kubevirt.io' --no-headers | grep -v Running)" ]; do
-    echo "Waiting for kubernetes pods to become ready ..."
-    kubectl get pods -n ${NAMESPACE} --no-headers | >&2 grep -v Running || true
-    sleep 10
-done
-
-echo "Kubernetes is ready:"
-kubectl get pods -n ${NAMESPACE} -l '!kubevirt.io'
-echo ""
-echo ""
-
-# delete all old traces of kubevirt on the cluster
-make cluster-clean
-
-if [ -z "$TARGET" ] || [ "$TARGET" = "vagrant-dev"  ]; then
-    make cluster-sync
-elif [ "$TARGET" = "vagrant-release"  ]; then
-    make cluster-sync
-fi
+make cluster-sync
 
 # Wait until kubevirt pods are running
 while [ -n "$(kubectl get pods -n ${NAMESPACE} --no-headers | grep -v Running)" ]; do
@@ -129,7 +74,5 @@ done
 kubectl get pods -n ${NAMESPACE}
 kubectl version
 
-# Disable proxy configuration since it causes test issues
-export -n http_proxy
 # Run functional tests
 FUNC_TEST_ARGS="--ginkgo.noColor" make functest

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -17,7 +17,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-# CI considerations: $TARGET is used by the jenkins vagrant build, to distinguish what to test
+# CI considerations: $TARGET is used by the jenkins build, to distinguish what to test
 # Currently considered $TARGET values:
 #     vagrant-dev: Runs all functional tests on a development vagrant setup
 #     vagrant-release: Runs all possible functional tests on a release deployment in vagrant

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -36,12 +36,10 @@ if [ "$TARGET" = "vagrant-dev"  ]; then
 cat > hack/config-local.sh <<EOF
 master_ip=192.168.1.2
 EOF
-export RSYNCD_PORT=${RSYNCD_PORT:-10874}
 elif [ "$TARGET" = "vagrant-release"  ]; then
 cat > hack/config-local.sh <<EOF
 master_ip=192.168.2.2
 EOF
-export RSYNCD_PORT=${RSYNCD_PORT:-10875}
 fi
 
 export VAGRANT_PREFIX=${VARIABLE:-kubevirt}

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -29,7 +29,6 @@ export WORKSPACE="${WORKSPACE:-$PWD}"
 
 kubectl() { cluster/kubectl.sh "$@"; }
 
-export BUILDER_NAME=$TARGET
 export NAMESPACE="${NAMESPACE:-kube-system}"
 
 if [ "$TARGET" = "vagrant-dev"  ]; then

--- a/cluster/build.sh
+++ b/cluster/build.sh
@@ -23,8 +23,6 @@
 
 set -e
 
-PROVIDER=${PROVIDER:-vagrant-kubernetes}
-
 source hack/common.sh
 source cluster/$PROVIDER/provider.sh
 source hack/config.sh

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -19,8 +19,6 @@
 
 set -ex
 
-PROVIDER=${PROVIDER:-vagrant-kubernetes}
-
 source hack/common.sh
 source cluster/$PROVIDER/provider.sh
 source hack/config.sh

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -19,8 +19,6 @@
 
 set -ex
 
-PROVIDER=${PROVIDER:-vagrant-kubernetes}
-
 source hack/common.sh
 source cluster/$PROVIDER/provider.sh
 source hack/config.sh

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-PROVIDER=${PROVIDER:-vagrant-kubernetes}
+source hack/common.sh
 source cluster/$PROVIDER/provider.sh
 down

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -5,7 +5,7 @@ set -e
 _prefix=${JOB_NAME:-${PROVIDER}}
 _prefix=${_prefix}${EXECUTOR_NUMBER}
 
-_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:4f49fc59d3f79aa9873324b22de66aaf117eaa1431981205277181f58a5cd084'
+_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:6d7380015a2743992a1b3e61dfe4e79925e825e40a93e4594c125822d36c56fc'
 
 function _main_ip() {
     echo 127.0.0.1
@@ -38,7 +38,7 @@ function build() {
     # Let's first prune old images, keep the last 5 iterations to improve the cache hit chance
     for arg in ${docker_images}; do
         local name=$(basename $arg)
-        images_to_prune= $(docker images --filter "label=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}" --filter "label=${name}" -q | cat -n | sort -uk2 | sort -nk1 | cut -f2- | tail -n +6)
+        images_to_prune="$(docker images --filter "label=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}" --filter "label=${name}" --format="{{.ID}} {{.Repository}}:{{.Tag}}" | cat -n | sort -uk2,2 | sort -k1 | tr -s ' ' | grep -v "<none>" | cut -d' ' -f3 | tail -n +6)"
         if [ -n "${images_to_prune}" ]; then
             docker rmi ${images_to_prune}
         fi

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+_prefix=${JOB_NAME:-${PROVIDER}}
+_prefix=${_prefix}${EXECUTOR_NUMBER}
+
 _cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:c42004c9626e6a6e723a2107410694cb80864f3456725fdf945b1ca148ed6eaa'
 
 function _main_ip() {
@@ -43,8 +46,8 @@ function build() {
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
     for i in $(seq 1 ${num_nodes}); do
-        ${_cli} ssh --prefix $PROVIDER "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs --max-args=1 sudo docker pull"
-        ${_cli} ssh --prefix $PROVIDER "node$(printf "%02d" ${i})" "echo \"${container_alias}\" | xargs --max-args=2 sudo docker tag"
+        ${_cli} ssh --prefix $_prefix "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs --max-args=1 sudo docker pull"
+        ${_cli} ssh --prefix $_prefix "node$(printf "%02d" ${i})" "echo \"${container_alias}\" | xargs --max-args=2 sudo docker tag"
     done
 }
 
@@ -54,5 +57,5 @@ function _kubectl() {
 }
 
 function down() {
-    ${_cli} rm --prefix $PROVIDER
+    ${_cli} rm --prefix $_prefix
 }

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -5,10 +5,14 @@ set -e
 _prefix=${JOB_NAME:-${PROVIDER}}
 _prefix=${_prefix}${EXECUTOR_NUMBER}
 
-_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:c42004c9626e6a6e723a2107410694cb80864f3456725fdf945b1ca148ed6eaa'
+_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:4f49fc59d3f79aa9873324b22de66aaf117eaa1431981205277181f58a5cd084'
 
 function _main_ip() {
     echo 127.0.0.1
+}
+
+function _port() {
+    ${_cli} port --prefix $_prefix "$@"
 }
 
 function prepare_config() {
@@ -17,17 +21,17 @@ function prepare_config() {
 master_ip=$(_main_ip)
 docker_tag=devel
 kubeconfig=${BASE_PATH}/cluster/$PROVIDER/.kubeconfig
-docker_prefix=localhost:5000/kubevirt
+docker_prefix=localhost:$(_port registry)/kubevirt
 manifest_docker_prefix=registry:5000/kubevirt
 EOF
 }
 
 function _registry_volume() {
-  if [ -n "${JOB_NAME}" ]; then
-    echo "${JOB_NAME}_${EXECUTOR_NUMBER}_registry"
-  else
-    echo "kubevirt_registry"
-  fi
+    if [ -n "${JOB_NAME}" ]; then
+        echo "${JOB_NAME}_${EXECUTOR_NUMBER}_registry"
+    else
+        echo "kubevirt_registry"
+    fi
 }
 
 function build() {

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -19,6 +19,14 @@ manifest_docker_prefix=registry:5000/kubevirt
 EOF
 }
 
+function _registry_volume() {
+  if [ -n "${JOB_NAME}" ]; then
+    echo "${JOB_NAME}_${EXECUTOR_NUMBER}_registry"
+  else
+    echo "kubevirt_registry"
+  fi
+}
+
 function build() {
     # Build everyting and publish it
     ${KUBEVIRT_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG} PROVIDER=${PROVIDER} ./hack/build-manifests.sh"

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -11,7 +11,6 @@ function up() {
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
     ${_cli} run --nodes ${num_nodes} --random-ports --background --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
-    echo lala
     ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,20 +10,21 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --random-ports --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
+    ${_cli} run --nodes ${num_nodes} --random-ports --background --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
+    echo lala
     ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
-    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(${_cli} port ssh)"
+    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(_port ssh)"
 
     # Copy k8s config and kubectl
-    scp ${OPTIONS} vagrant@$(_master_ip):/usr/bin/kubectl ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
+    scp ${OPTIONS} vagrant@$(_main_ip):/usr/bin/kubectl ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
     chmod u+x cluster/vagrant-kubernetes/.kubectl
-    scp ${OPTIONS} vagrant@$(_master_ip):/etc/kubernetes/admin.conf ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
+    scp ${OPTIONS} vagrant@$(_main_ip):/etc/kubernetes/admin.conf ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
-    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(${_cli} port k8s)
+    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(_port k8s)
     ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,20 +10,20 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --k8s-port 127.0.0.1:8443 --ssh-port 127.0.0.1:2201 --background --registry-port 127.0.0.1:5000 --prefix $PROVIDER --registry-volume kubevirt_registry --base "kubevirtci/${image}"
+    ${_cli} run --nodes ${num_nodes} --random-ports --prefix $PROVIDER --registry-volume kubevirt_registry --base "kubevirtci/${image}"
     ${_cli} ssh --prefix $PROVIDER node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
-    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P 2201"
+    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(${_cli} port ssh)"
 
     # Copy k8s config and kubectl
-    scp ${OPTIONS} vagrant@127.0.0.1:/usr/bin/kubectl ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
+    scp ${OPTIONS} vagrant@$(_master_ip):/usr/bin/kubectl ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
     chmod u+x cluster/vagrant-kubernetes/.kubectl
-    scp ${OPTIONS} vagrant@127.0.0.1:/etc/kubernetes/admin.conf ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
+    scp ${OPTIONS} vagrant@$(_master_ip):/etc/kubernetes/admin.conf ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
 
     # Set server and disable tls check
     export KUBECONFIG=${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
-    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):8443
+    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster kubernetes --server=https://$(_main_ip):$(${_cli} port k8s)
     ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster kubernetes --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.9.3@sha256:ead8cbdf16e205acfe66ec4b03e31974217e07808da1d9127409337d4959ace7"
+image="k8s-1.9.3@sha256:2f1600681800f70de293d2d35fa129bfd2c64e14ea01bab0284e4cafcc330662"
 
 source cluster/ephemeral-provider-common.sh
 
@@ -18,7 +18,7 @@ function up() {
 
     # Copy k8s config and kubectl
     scp ${OPTIONS} vagrant@$(_main_ip):/usr/bin/kubectl ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
-    chmod u+x cluster/vagrant-kubernetes/.kubectl
+    chmod u+x ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
     scp ${OPTIONS} vagrant@$(_main_ip):/etc/kubernetes/admin.conf ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
 
     # Set server and disable tls check

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,8 +10,8 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --random-ports --prefix $PROVIDER --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
-    ${_cli} ssh --prefix $PROVIDER node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
+    ${_cli} run --nodes ${num_nodes} --random-ports --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
+    ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
     OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(${_cli} port ssh)"

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,8 +10,8 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --random-ports --background --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
-    ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
+    ${_cli} run --nodes ${num_nodes} --random-ports --nfs-data /home/rmohr --background --prefix $provider_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
+    ${_cli} ssh --prefix $provider_prefix node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
     OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(_port ssh)"

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -10,7 +10,7 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --random-ports --prefix $PROVIDER --registry-volume kubevirt_registry --base "kubevirtci/${image}"
+    ${_cli} run --nodes ${num_nodes} --random-ports --prefix $PROVIDER --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
     ${_cli} ssh --prefix $PROVIDER node01 sudo chown vagrant:vagrant /etc/kubernetes/admin.conf
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -21,7 +21,6 @@ set -e
 
 source $(dirname "$0")/../hack/common.sh
 
-PROVIDER=${PROVIDER:-vagrant-kubernetes}
 source ${KUBEVIRT_DIR}/cluster/$PROVIDER/provider.sh
 source ${KUBEVIRT_DIR}/hack/config.sh
 

--- a/cluster/os-3.9.0-alpha.4/provider.sh
+++ b/cluster/os-3.9.0-alpha.4/provider.sh
@@ -10,9 +10,9 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
-    ${_cli} ssh --prefix $_prefix node01 sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
-    ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
+    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
+    ${_cli} ssh --prefix $provider_prefix node01 sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
+    ${_cli} ssh --prefix $provider_prefix node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
     OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(_port ssh)"

--- a/cluster/os-3.9.0-alpha.4/provider.sh
+++ b/cluster/os-3.9.0-alpha.4/provider.sh
@@ -15,16 +15,16 @@ function up() {
     ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
-    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(${_cli} port ssh)"
+    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(_port ssh)"
 
     # Copy oc tool and configuration file
-    scp ${OPTIONS} vagrant@$(_master_ip):/usr/local/bin/oc ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
+    scp ${OPTIONS} vagrant@$(_main_ip):/usr/local/bin/oc ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
     chmod u+x ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
-    scp ${OPTIONS} vagrant@$(_master_ip):~vagrant/admin.kubeconfig ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
+    scp ${OPTIONS} vagrant@$(_main_ip):~vagrant/admin.kubeconfig ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
 
     # Update Kube config to support unsecured connection
     export KUBECONFIG=${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
-    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster node01:8443 --server=https://$(_main_ip):$(${_cli} port osp)
+    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster node01:8443 --server=https://$(_main_ip):$(_port osp)
     ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster node01:8443 --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct

--- a/cluster/os-3.9.0-alpha.4/provider.sh
+++ b/cluster/os-3.9.0-alpha.4/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.9@sha256:a3c66710e0f4d55e81d5b2d32e89c074074cc14b216941818bde0d68cf4b0a12"
+image="os-3.9@sha256:03671c22bd5b08224926852fcb821dc11ed928044f2310e13c751edb7d0ce9a4"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/os-3.9.0-alpha.4/provider.sh
+++ b/cluster/os-3.9.0-alpha.4/provider.sh
@@ -10,21 +10,21 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --reverse --osp-port 127.0.0.1:8443 --ssh-port 127.0.0.1:2201 --background --registry-port 127.0.0.1:5000 --prefix $PROVIDER --registry-volume kubevirt_registry --base "kubevirtci/${image}"
+    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $PROVIDER --registry-volume kubevirt_registry --base "kubevirtci/${image}"
     ${_cli} ssh --prefix $PROVIDER node01 sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
     ${_cli} ssh --prefix $PROVIDER node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
-    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P 2201"
+    OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(${_cli} port ssh)"
 
     # Copy oc tool and configuration file
-    scp ${OPTIONS} vagrant@127.0.0.1:/usr/local/bin/oc ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
+    scp ${OPTIONS} vagrant@$(_master_ip):/usr/local/bin/oc ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
     chmod u+x ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl
-    scp ${OPTIONS} vagrant@127.0.0.1:~vagrant/admin.kubeconfig ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
+    scp ${OPTIONS} vagrant@$(_master_ip):~vagrant/admin.kubeconfig ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
 
     # Update Kube config to support unsecured connection
     export KUBECONFIG=${KUBEVIRT_PATH}cluster/$PROVIDER/.kubeconfig
-    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster node01:8443 --server=https://$(_main_ip):8443
+    ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster node01:8443 --server=https://$(_main_ip):$(${_cli} port osp)
     ${KUBEVIRT_PATH}cluster/$PROVIDER/.kubectl config set-cluster node01:8443 --insecure-skip-tls-verify=true
 
     # Make sure that local config is correct

--- a/cluster/os-3.9.0-alpha.4/provider.sh
+++ b/cluster/os-3.9.0-alpha.4/provider.sh
@@ -10,7 +10,7 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $PROVIDER --registry-volume kubevirt_registry --base "kubevirtci/${image}"
+    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $PROVIDER --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
     ${_cli} ssh --prefix $PROVIDER node01 sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
     ${_cli} ssh --prefix $PROVIDER node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
 

--- a/cluster/os-3.9.0-alpha.4/provider.sh
+++ b/cluster/os-3.9.0-alpha.4/provider.sh
@@ -10,9 +10,9 @@ function up() {
     # Add one, 0 here means no node at all, but in the kubevirt repo it means master-only
     local num_nodes=${VAGRANT_NUM_NODES-0}
     num_nodes=$((num_nodes + 1))
-    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $PROVIDER --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
-    ${_cli} ssh --prefix $PROVIDER node01 sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
-    ${_cli} ssh --prefix $PROVIDER node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
+    ${_cli} run --nodes ${num_nodes} --reverse --random-ports --background --prefix $_prefix --registry-volume $(_registry_volume) --base "kubevirtci/${image}"
+    ${_cli} ssh --prefix $_prefix node01 sudo cp /etc/origin/master/admin.kubeconfig ~vagrant/
+    ${_cli} ssh --prefix $_prefix node01 sudo chown vagrant:vagrant ~vagrant/admin.kubeconfig
 
     chmod 0600 ${KUBEVIRT_PATH}cluster/vagrant.key
     OPTIONS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBEVIRT_PATH}cluster/vagrant.key -P $(${_cli} port ssh)"

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-PROVIDER=${PROVIDER:-vagrant-kubernetes}
+source hack/common.sh
 source cluster/$PROVIDER/provider.sh
 up

--- a/cmd/virt-launcher/entrypoint.sh
+++ b/cmd/virt-launcher/entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+set +e
+
+# HACK
+# Try to create /dev/kvm if not present
+if [ ! -e /dev/kvm ]; then
+   mknod /dev/kvm c 10 $(grep '\<kvm\>' /proc/misc | cut -f 1 -d' ')
+fi
+
+chown :qemu /dev/kvm
+chmod 660 /dev/kvm
+
 ./virt-launcher $@
 rc=$?
 

--- a/cmd/virt-launcher/libvirtd.sh
+++ b/cmd/virt-launcher/libvirtd.sh
@@ -19,23 +19,6 @@
 
 set -xe
 
-# HACK
-# Use hosts's /dev to see new devices and allow macvtap
-mkdir -p /dev.container && {
-    mount --rbind /dev /dev.container
-    mount --rbind /host-dev /dev
-
-    # Keep some devices from the containerinal /dev
-    keep() { mount --rbind /dev.container/$1 /dev/$1; }
-    keep shm || :
-    keep mqueue
-    # Keep ptmx/pts for pty creation
-    keep pts
-    mount --rbind /dev/pts/ptmx /dev/ptmx
-    # Use the container /dev/kvm if available
-    [[ -e /dev.container/kvm ]] && keep kvm
-}
-
 mkdir -p /var/log/kubevirt
 touch /var/log/kubevirt/qemu-kube.log
 chown qemu:qemu /var/log/kubevirt/qemu-kube.log

--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -47,7 +47,7 @@ for arg in $args; do
         cat $arg/Dockerfile | sed -e "s#kubevirt/registry-disk-v1alpha#${docker_prefix}/registry-disk-v1alpha\:${docker_tag}#g" >${CMD_OUT_DIR}/${BIN_NAME}/Dockerfile
         (
             cd ${CMD_OUT_DIR}/${BIN_NAME}/
-            docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER} --label ${BIN_NAME} .
+            docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${job_prefix} --label ${BIN_NAME} .
         )
     elif [ "${target}" = "push" ]; then
         (

--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -47,7 +47,7 @@ for arg in $args; do
         cat $arg/Dockerfile | sed -e "s#kubevirt/registry-disk-v1alpha#${docker_prefix}/registry-disk-v1alpha\:${docker_tag}#g" >${CMD_OUT_DIR}/${BIN_NAME}/Dockerfile
         (
             cd ${CMD_OUT_DIR}/${BIN_NAME}/
-            docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} .
+            docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER} --label ${BIN_NAME} .
         )
     elif [ "${target}" = "push" ]; then
         (

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -17,3 +17,9 @@ function build_func_tests() {
     ginkgo build ${KUBEVIRT_DIR}/tests
     mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
 }
+
+#If run on jenkins, let us create isolated environments based on the job and
+# the executor number
+PROVIDER=${PROVIDER:-vagrant-kubernetes}
+provider_prefix=${JOB_NAME:-${PROVIDER}}${EXECUTOR_NUMBER}
+job_prefix=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -5,8 +5,7 @@ source $(dirname "$0")/common.sh
 
 DOCKER_DIR=${KUBEVIRT_DIR}/hack/docker-builder
 
-BUILDER=${JOB_NAME:-kubevirtbuilder}
-BUILDER=${BUILDER}${EXECUTOR_NUMBER}
+BUILDER=${job_prefix}
 
 SYNC_VENDOR=${SYNC_VENDOR:-false}
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -5,7 +5,9 @@ source $(dirname "$0")/common.sh
 
 DOCKER_DIR=${KUBEVIRT_DIR}/hack/docker-builder
 
-BUILDER=${BUILDER_NAME:-kubevirtbuilder}
+BUILDER=${JOB_NAME:-kubevirtbuilder}
+BUILDER=${BUILDER}${EXECUTOR_NUMBER}
+
 SYNC_VENDOR=${SYNC_VENDOR:-false}
 
 TEMPFILE=".rsynctemp"

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -7,7 +7,6 @@ DOCKER_DIR=${KUBEVIRT_DIR}/hack/docker-builder
 
 BUILDER=${BUILDER_NAME:-kubevirtbuilder}
 SYNC_VENDOR=${SYNC_VENDOR:-false}
-RSYNCD_PORT=${RSYNCD_PORT:-10873}
 
 TEMPFILE=".rsynctemp"
 
@@ -23,12 +22,15 @@ fi
 docker run -v "${BUILDER}:/root:rw,z" --rm ${BUILDER} mkdir -p /root/go/src/kubevirt.io/kubevirt/_out
 
 # Start an rsyncd instance and make sure it gets stopped after the script exits
-RSYNC_CID=$(docker run -d -v "${BUILDER}:/root:rw,z" -p 127.0.0.1:${RSYNCD_PORT}:873 ${BUILDER} /usr/bin/rsync --no-detach --daemon --verbose)
+RSYNC_CID=$(docker run -d -v "${BUILDER}:/root:rw,z" --expose 873 -P ${BUILDER} /usr/bin/rsync --no-detach --daemon --verbose)
+
 function finish() {
     docker stop ${RSYNC_CID}
     docker rm ${RSYNC_CID}
 }
 trap finish EXIT
+
+RSYNCD_PORT=$(docker port $RSYNC_CID 873 | cut -d':' -f2)
 
 while ! rsync ${KUBEVIRT_DIR}/${RSYNCTEMP} "rsync://root@127.0.0.1:${RSYNCD_PORT}/build/${RSYNCTEMP}"; do
     echo "Waiting for rsyncd to be ready"

--- a/hack/gen-client-python/generate.sh
+++ b/hack/gen-client-python/generate.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
+source $(dirname "$0")/../common.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
-
-source $(dirname "$0")/../common.sh
 
 SWAGGER_CODEGEN_CLI_SRC=http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar
 SWAGGER_CODEGEN_CLI="/tmp/swagger-codegen-cli.jar"

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -4,11 +4,11 @@
 # API_VERSION=v1
 # OUTPUT_FORMAT=html|markdown
 
+source $(dirname "$0")/../../hack/common.sh
+
 set -o errexit
 set -o nounset
 set -o pipefail
-
-source $(dirname "$0")/../../hack/common.sh
 
 VERSION="$1"
 OUTPUT_FORMAT="$2"

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -71,10 +71,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		Name:      "libvirt-runtime",
 		MountPath: "/var/run/libvirt",
 	})
-	volumesMounts = append(volumesMounts, kubev1.VolumeMount{
-		Name:      "host-dev",
-		MountPath: "/host-dev",
-	})
 	for _, volume := range vm.Spec.Volumes {
 		volumeMount := kubev1.VolumeMount{
 			Name:      volume.Name,
@@ -187,14 +183,6 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) (*kubev1.P
 		},
 	})
 
-	volumes = append(volumes, kubev1.Volume{
-		Name: "host-dev",
-		VolumeSource: kubev1.VolumeSource{
-			HostPath: &kubev1.HostPathVolumeSource{
-				Path: "/dev",
-			},
-		},
-	})
 	containers = append(containers, container)
 
 	// TODO use constants for labels

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Template", func() {
 				Expect(err).To(BeNil())
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
-				Expect(len(pod.Spec.Volumes)).To(Equal(4))
+				Expect(len(pod.Spec.Volumes)).To(Equal(3))
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("nfs-pvc"))
 			})

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -9,6 +9,8 @@ import (
 
 	"strconv"
 
+	"os"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/ephemeral-disk"
@@ -296,6 +298,14 @@ func Convert_v1_VirtualMachine_To_api_Domain(vm *v1.VirtualMachine, domain *Doma
 	domain.Spec.Name = VMNamespaceKeyFunc(vm)
 	domain.ObjectMeta.Name = vm.ObjectMeta.Name
 	domain.ObjectMeta.Namespace = vm.ObjectMeta.Namespace
+
+	// XXX Fix me properly we don't want automatic fallback to qemu
+	// We will solve this properly in https://github.com/kubevirt/kubevirt/pull/804
+	if _, err := os.Stat("/dev/kvm"); os.IsNotExist(err) {
+		domain.Spec.Type = "qemu"
+	} else if err != nil {
+		return err
+	}
 
 	// Spec metadata
 	domain.Spec.Metadata.KubeVirt.UID = vm.UID

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -45,7 +45,9 @@ func SetDefaults_OSType(ostype *OSType) {
 
 func SetDefaults_DomainSpec(spec *DomainSpec) {
 	spec.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
-	spec.Type = "qemu"
+	if spec.Type == "" {
+		spec.Type = "kvm"
+	}
 }
 
 func SetDefaults_SysInfo(sysinfo *SysInfo) {

--- a/pkg/virt-launcher/virtwrap/api/defaults_test.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults_test.go
@@ -24,6 +24,6 @@ var _ = Describe("Defaults", func() {
 		domain := &Domain{}
 		SetDefaults_DomainSpec(&domain.Spec)
 		Expect(domain.Spec.XmlNS).To(Equal("http://libvirt.org/schemas/domain/qemu/1.0"))
-		Expect(domain.Spec.Type).To(Equal("qemu"))
+		Expect(domain.Spec.Type).To(Equal("kvm"))
 	})
 })

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var exampleXML = `<domain type="qemu" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
   <name>mynamespace_testvm</name>
   <memory unit="MB">9</memory>
   <os>


### PR DESCRIPTION
* Use k8s-1.9.3 instead of vagrant
* Make sure that all components select random ports during the whole testing phase, to allow parallel builds
* Make sure that each build slot only keeps tags for the latest 5 builds. Older builds are untagged and deleted.
* If /dev/kvm is present in the container, use it. Otherwise fall back to emulation.

One TODO  remaining: Detect if the docker registry volume reaches a critical size and delete it, to avoid fillling up the whole space.