### PR TITLE
launcher: Default to x86_64

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -240,7 +240,7 @@ var _ = Describe("Converter", func() {
   <name>mynamespace_testvm</name>
   <memory unit="MB">9</memory>
   <os>
-    <type machine="q35">hvm</type>
+    <type arch="x86_64" machine="q35">hvm</type>
   </os>
   <sysinfo type="smbios">
     <system>

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -31,6 +31,11 @@ func SetDefaults_Devices(devices *Devices) {
 
 func SetDefaults_OSType(ostype *OSType) {
 	ostype.OS = "hvm"
+
+	if ostype.Arch == "" {
+		ostype.Arch = "x86_64"
+	}
+
 	// q35 is an alias of the newest q35 machine type.
 	// TODO: we probably want to select concrete type in the future for "future-backwards" compatibility.
 	if ostype.Machine == "" {

--- a/pkg/virt-launcher/virtwrap/api/defaults_test.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults_test.go
@@ -7,6 +7,12 @@ import (
 
 var _ = Describe("Defaults", func() {
 
+	It("should set architecture", func() {
+		domain := &Domain{}
+		SetDefaults_OSType(&domain.Spec.OS.Type)
+		Expect(domain.Spec.OS.Type.Arch).To(Equal("x86_64"))
+	})
+
 	It("should set q35 machine type and hvm domain type", func() {
 		domain := &Domain{}
 		SetDefaults_OSType(&domain.Spec.OS.Type)

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -30,7 +30,7 @@ var exampleXML = `<domain type="qemu" xmlns:qemu="http://libvirt.org/schemas/dom
   <name>mynamespace_testvm</name>
   <memory unit="MB">9</memory>
   <os>
-    <type machine="q35">hvm</type>
+    <type arch="x86_64" machine="q35">hvm</type>
   </os>
   <sysinfo type="smbios">
     <system>


### PR DESCRIPTION
Set the arch in order to avoid that  random one is picked.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>