### PR TITLE
[WIP] Make flag usage consistent with Kubernetes

### DIFF
--- a/pkg/kubecli/ovm_test.go
+++ b/pkg/kubecli/ovm_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Kubevirt OfflineVirtualMachine Client", func() {
 	BeforeEach(func() {
 		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
+		client, err = GetKubevirtClientFromConfig(server.URL(), "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/kubecli/replicaset_test.go
+++ b/pkg/kubecli/replicaset_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Kubevirt VirtualMachineReplicaSet Client", func() {
 	BeforeEach(func() {
 		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
+		client, err = GetKubevirtClientFromConfig(server.URL(), "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/kubecli/vm_test.go
+++ b/pkg/kubecli/vm_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Kubevirt VM Client", func() {
 	BeforeEach(func() {
 		var err error
 		server = ghttp.NewServer()
-		client, err = GetKubevirtClientFromFlags(server.URL(), "")
+		client, err = GetKubevirtClientFromConfig(server.URL(), "")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/virt-api/rest/kubeproxy_test.go
+++ b/pkg/virt-api/rest/kubeproxy_test.go
@@ -20,9 +20,10 @@
 package rest_test
 
 import (
-	"flag"
 	"net/http"
 	"net/http/httptest"
+
+	flag "github.com/spf13/pflag"
 
 	"encoding/json"
 	"fmt"
@@ -71,7 +72,7 @@ var _ = Describe("Kubeproxy", func() {
 
 	BeforeSuite(func() {
 		apiserverMock = ghttp.NewServer()
-		flag.Lookup("master").Value.Set(apiserverMock.URL())
+		flag.Lookup("server").Value.Set(apiserverMock.URL())
 
 		ws, err := GroupVersionProxyBase(ctx, v1.GroupVersion)
 		Expect(err).ToNot(HaveOccurred())
@@ -83,7 +84,7 @@ var _ = Describe("Kubeproxy", func() {
 	BeforeEach(func() {
 		kubeproxy = httptest.NewServer(restful.DefaultContainer)
 		var err error
-		virtClient, err := kubecli.GetKubevirtClientFromFlags(kubeproxy.URL, "")
+		virtClient, err := kubecli.GetKubevirtClientFromConfig(kubeproxy.URL, "")
 		if err != nil {
 			Expect(err).ToNot(HaveOccurred())
 		}

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -45,7 +45,7 @@ var _ = Describe("VM", func() {
 
 		flag.Parse()
 		server = ghttp.NewServer()
-		virtClient, _ := kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+		virtClient, _ := kubecli.GetKubevirtClientFromConfig(server.URL(), "")
 		templateService, _ := NewTemplateService("kubevirt/virt-launcher", "/var/run/libvirt")
 		restClient = virtClient.RestClient()
 		vmService = NewVMService(virtClient, restClient, templateService)

--- a/pkg/virt-controller/watch/preset_test.go
+++ b/pkg/virt-controller/watch/preset_test.go
@@ -392,7 +392,7 @@ var _ = Describe("VM Initializer", func() {
 			stopChan = make(chan struct{})
 
 			server = ghttp.NewServer()
-			app.clientSet, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+			app.clientSet, _ = kubecli.GetKubevirtClientFromConfig(server.URL(), "")
 			app.restClient = app.clientSet.RestClient()
 
 			// create a reference preset

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -51,7 +51,7 @@ var _ = Describe("VM watcher", func() {
 	BeforeEach(func() {
 
 		server = ghttp.NewServer()
-		app.clientSet, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+		app.clientSet, _ = kubecli.GetKubevirtClientFromConfig(server.URL(), "")
 		app.restClient = app.clientSet.RestClient()
 		app.vmCache = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
 		app.vmQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -68,7 +68,7 @@ func (c *Console) Run(flags *flag.FlagSet) int {
 	}
 	vm := flags.Arg(1)
 
-	virtCli, err := kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
+	virtCli, err := kubecli.GetKubevirtClientFromConfig(server, kubeconfig)
 	if err != nil {
 		log.Println(err)
 		return 1

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -52,7 +52,7 @@ func (o *VNC) Run(flags *flag.FlagSet) int {
 	}
 	vm := flags.Arg(1)
 
-	virtCli, err := kubecli.GetKubevirtClientFromFlags(server, kubeconfig)
+	virtCli, err := kubecli.GetKubevirtClientFromConfig(server, kubeconfig)
 	if err != nil {
 		log.Println(err)
 		return 1


### PR DESCRIPTION
Make modules that import kubecli use the same command line flags as kubectl.