### PR TITLE
Allow for registry secrets to be provided for RegistryDisk and virt-launcher

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -224,7 +224,8 @@ type EphemeralVolumeSource struct {
 // Represents a docker image with an embedded disk
 type RegistryDiskSource struct {
 	// Image is the name of the image with the embedded disk
-	Image string `json:"image"`
+	Image           string `json:"image"`
+	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 }
 
 // Exactly one of its members must be set.

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Template", func() {
 
 	log.Log.SetIOWriter(GinkgoWriter)
-	svc, err := NewTemplateService("kubevirt/virt-launcher", "/var/run/kubevirt")
+	svc, err := NewTemplateService("kubevirt/virt-launcher", "/var/run/kubevirt", "pull-secret-1")
 
 	Describe("Rendering", func() {
 		Context("launch template with correct parameters", func() {
@@ -212,6 +212,55 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Volumes)).To(Equal(3))
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("nfs-pvc"))
+			})
+		})
+
+		Context("with launcher's pull secret", func() {
+			It("should contain launcher's secret in pod spec", func() {
+				vm := v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testvm", Namespace: "default", UID: "1234",
+					},
+					Spec: v1.VirtualMachineSpec{Domain: v1.DomainSpec{}},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vm)
+				Expect(err).To(BeNil())
+
+				Expect(len(pod.Spec.ImagePullSecrets)).To(Equal(1))
+				Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("pull-secret-1"))
+			})
+
+		})
+
+		Context("with RegistryDisk pull secrets", func() {
+			It("should add secret to pod spec", func() {
+				volumes := []v1.Volume{
+					{
+						Name: "registrydisk1",
+						VolumeSource: v1.VolumeSource{
+							RegistryDisk: &v1.RegistryDiskSource{
+								Image:           "my-image",
+								ImagePullSecret: "pull-secret-2",
+							},
+						},
+					},
+				}
+				vm := v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testvm", Namespace: "default", UID: "1234",
+					},
+					Spec: v1.VirtualMachineSpec{Volumes: volumes, Domain: v1.DomainSpec{}},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vm)
+				Expect(err).To(BeNil())
+
+				Expect(len(pod.Spec.ImagePullSecrets)).To(Equal(2))
+
+				// RegistryDisk secrets come first
+				Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("pull-secret-2"))
+				Expect(pod.Spec.ImagePullSecrets[1].Name).To(Equal("pull-secret-1"))
 			})
 		})
 	})

--- a/pkg/virt-controller/services/vm_test.go
+++ b/pkg/virt-controller/services/vm_test.go
@@ -46,7 +46,7 @@ var _ = Describe("VM", func() {
 		flag.Parse()
 		server = ghttp.NewServer()
 		virtClient, _ := kubecli.GetKubevirtClientFromFlags(server.URL(), "")
-		templateService, _ := NewTemplateService("kubevirt/virt-launcher", "/var/run/libvirt")
+		templateService, _ := NewTemplateService("kubevirt/virt-launcher", "/var/run/libvirt", "imagesecret")
 		restClient = virtClient.RestClient()
 		vmService = NewVMService(virtClient, restClient, templateService)
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -37,6 +37,8 @@ const (
 
 	launcherImage = "virt-launcher"
 
+	imagePullSecret = ""
+
 	virtShareDir = "/var/run/kubevirt"
 
 	ephemeralDiskDir = "/var/run/libvirt/kubevirt-ephemeral-disk"
@@ -76,6 +78,7 @@ type VirtControllerApp struct {
 	LeaderElection leaderelectionconfig.Configuration
 
 	launcherImage    string
+	imagePullSecret  string
 	virtShareDir     string
 	ephemeralDiskDir string
 	readyChan        chan bool
@@ -220,7 +223,7 @@ func (vca *VirtControllerApp) initCommon() {
 	if err != nil {
 		golog.Fatal(err)
 	}
-	vca.templateService, err = services.NewTemplateService(vca.launcherImage, vca.virtShareDir)
+	vca.templateService, err = services.NewTemplateService(vca.launcherImage, vca.virtShareDir, vca.imagePullSecret)
 	if err != nil {
 		golog.Fatal(err)
 	}
@@ -267,6 +270,9 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.StringVar(&vca.launcherImage, "launcher-image", launcherImage,
 		"Shim container for containerized VMs")
+
+	flag.StringVar(&vca.imagePullSecret, "image-pull-secret", imagePullSecret,
+		"Secret to use for pulling virt-launcher and/or registry disks")
 
 	flag.StringVar(&vca.virtShareDir, "kubevirt-share-dir", virtShareDir,
 		"Shared directory between virt-handler and virt-launcher")

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -103,7 +103,7 @@ var _ = Describe("VM watcher", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Create a Pod for the VM
-			temlateService, err := services.NewTemplateService("whatever", "whatever")
+			temlateService, err := services.NewTemplateService("whatever", "whatever", "whatever")
 			Expect(err).ToNot(HaveOccurred())
 			pod, err := temlateService.RenderLaunchManifest(vm)
 			Expect(err).ToNot(HaveOccurred())
@@ -169,7 +169,7 @@ var _ = Describe("VM watcher", func() {
 			addInitializedAnnotation(vm)
 
 			// Create a Pod for the VM
-			templateService, err := services.NewTemplateService("whatever", "whatever")
+			templateService, err := services.NewTemplateService("whatever", "whatever", "whatever")
 			Expect(err).ToNot(HaveOccurred())
 
 			// We want to ensure the vm object we initially post
@@ -232,7 +232,7 @@ var _ = Describe("VM watcher", func() {
 			addInitializedAnnotation(vm)
 
 			// Create a target Pod for the VM
-			temlateService, err := services.NewTemplateService("whatever", "whatever")
+			temlateService, err := services.NewTemplateService("whatever", "whatever", "whatever")
 			Expect(err).ToNot(HaveOccurred())
 			var pod *kubev1.Pod
 			pod, err = temlateService.RenderLaunchManifest(vm)


### PR DESCRIPTION
This allows for RegistryDisk to contain an imagePullSecret for authentication to private repos. It also allows for the virt-launcher pod generated by virt-controller to contain a named secret.