### PR TITLE
Force docker container and volume removal on cluster-down

### DIFF
--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:04ccd0e7da458fdb4947937df07ecce1431b01c89edeb0ed0e4a11c5036639a6'
+_cli='docker run --privileged --rm -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/cli@sha256:b0023d1863338ef04fa0b8a8ee5956ae08616200d89ffd2e230668ea3deeaff4'
 
 function _main_ip() {
     echo 127.0.0.1

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -27,7 +27,7 @@ RSYNC_CID=$(docker run -d -v "${BUILDER}:/root:rw,z" --expose 873 -P ${BUILDER} 
 
 function finish() {
     docker stop ${RSYNC_CID}
-    docker rm ${RSYNC_CID}
+    docker rm -f ${RSYNC_CID}
 }
 trap finish EXIT
 


### PR DESCRIPTION
We sometimes see errors like 

```
Error response from daemon: You cannot remove a running container 01ef874a629c7f143219c17b9b555d31ffc9570d7437576ac576d234ec003806. Stop the container before attempting removal or use -f
```

in two scenarios. First sometimes on when we run cluster-down, a container may not be removed because it is not yet completely stopped. That can lead to failing cluster-up calls afterwards. Second our dockerized builder stopps and removes its rsync server-container after each build. There the same can happen which can be misinterpreted as a build error.

To resolve this, two fixes:

* https://github.com/rmohr/qemu-dockerized/pull/25 contains a fix to make sure that cluster-down will remove containers and volumes by force
* hack/dockerized will also use more force when removing the container