### PR TITLE
Filter pod route destined to default gateway

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -337,7 +337,7 @@ func discoverPodNetworkInterface(nic *VIF) (netlink.Link, error) {
 	if len(routes) > 1 {
 		// Filter out irrelevant routes
 		for _, route := range routes[1:] {
-			if !route.Src.Equal(nic.IP.IP) {
+			if !route.Src.Equal(nic.IP.IP) && !route.Dst.IP.Equal(nic.Gateway) {
 				dhcpRoutes = append(dhcpRoutes, route)
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -337,7 +337,11 @@ func discoverPodNetworkInterface(nic *VIF) (netlink.Link, error) {
 	if len(routes) > 1 {
 		// Filter out irrelevant routes
 		for _, route := range routes[1:] {
-			if !route.Src.Equal(nic.IP.IP) && !route.Dst.IP.Equal(nic.Gateway) {
+			if route.Dst.IP.Equal(nic.Gateway) && route.Src.Equal(nil) {
+				continue
+			}
+
+			if !route.Src.Equal(nic.IP.IP) {
 				dhcpRoutes = append(dhcpRoutes, route)
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -333,18 +333,8 @@ func discoverPodNetworkInterface(nic *VIF) (netlink.Link, error) {
 		return nil, fmt.Errorf("No gateway address found in routes for %s", podInterface)
 	}
 	nic.Gateway = routes[0].Gw
-	var dhcpRoutes []netlink.Route
 	if len(routes) > 1 {
-		// Filter out irrelevant routes
-		for _, route := range routes[1:] {
-			if route.Dst.IP.Equal(nic.Gateway) && route.Src.Equal(nil) {
-				continue
-			}
-
-			if !route.Src.Equal(nic.IP.IP) {
-				dhcpRoutes = append(dhcpRoutes, route)
-			}
-		}
+		dhcpRoutes := filterPodNetworkRoutes(routes, nic)
 		nic.Routes = &dhcpRoutes
 	}
 
@@ -356,6 +346,24 @@ func discoverPodNetworkInterface(nic *VIF) (netlink.Link, error) {
 	}
 	nic.MAC = mac
 	return nicLink, nil
+}
+
+// filter out irrelevant routes
+func filterPodNetworkRoutes(routes []netlink.Route, nic *VIF) (filteredRoutes []netlink.Route) {
+	for _, route := range routes[1:] {
+		// don't create static route to default gateway
+		if route.Dst != nil && route.Dst.IP.Equal(nic.Gateway) && route.Src.Equal(nil) {
+			continue
+		}
+
+		// don't create static route for src == nic
+		if route.Src != nil && route.Src.Equal(nic.IP.IP) {
+			continue
+		}
+
+		filteredRoutes = append(filteredRoutes, route)
+	}
+	return
 }
 
 func preparePodNetworkInterfaces(nic *VIF, nicLink netlink.Link) error {

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -40,7 +40,6 @@ var _ = Describe("Network", func() {
 	var ctrl *gomock.Controller
 	var dummy *netlink.Dummy
 	var addrList []netlink.Addr
-	var staticRoute netlink.Route
 	var routeList []netlink.Route
 	var routeAddr netlink.Route
 	var fakeMac net.HardwareAddr
@@ -69,13 +68,7 @@ var _ = Describe("Network", func() {
 		fakeAddr = netlink.Addr{IPNet: address}
 		addrList = []netlink.Addr{fakeAddr}
 		routeAddr = netlink.Route{Gw: gw}
-		staticRoute = netlink.Route{
-			Dst: &net.IPNet{IP: net.IPv4(10, 45, 0, 10), Mask: net.CIDRMask(32, 32)},
-			Gw:  net.IPv4(10, 25, 0, 1),
-		}
-		gwRoute := netlink.Route{Dst: &net.IPNet{IP: gw, Mask: net.CIDRMask(32, 32)}}
-		nicRoute := netlink.Route{Src: address.IP}
-		routeList = []netlink.Route{routeAddr, gwRoute, nicRoute, staticRoute}
+		routeList = []netlink.Route{routeAddr}
 
 		// Create a bridge
 		bridgeTest = &netlink.Bridge{
@@ -156,9 +149,17 @@ var _ = Describe("Network", func() {
 	})
 
 	Context("func filterPodNetworkRoutes()", func() {
+		staticRoute := netlink.Route{
+			Dst: &net.IPNet{IP: net.IPv4(10, 45, 0, 10), Mask: net.CIDRMask(32, 32)},
+			Gw:  net.IPv4(10, 25, 0, 1),
+		}
+		gwRoute := netlink.Route{Dst: &net.IPNet{IP: net.IPv4(10, 35, 0, 1), Mask: net.CIDRMask(32, 32)}}
+		nicRoute := netlink.Route{Src: net.IPv4(10, 35, 0, 6)}
+		staticRouteList := []netlink.Route{routeAddr, gwRoute, nicRoute, staticRoute}
+
 		It("should remove default gateway and source IP from routes, leaving others intact", func() {
 			expected := []netlink.Route{staticRoute}
-			Expect(filterPodNetworkRoutes(routeList, testNic)).To(Equal(expected))
+			Expect(filterPodNetworkRoutes(staticRouteList, testNic)).To(Equal(expected))
 		})
 	})
 


### PR DESCRIPTION
Do not pass a static route that has destination IP
of the default gateway. This commit fixes #845