### PR TITLE
Fix ovm functional test race condition

### DIFF
--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -356,6 +356,13 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				stopFlags.AddFlagSet((&virtctl.Options{}).FlagSet())
 				stopFlags.Parse(stopCommandLine)
 
+				By("Ensuring OVM is running")
+				Eventually(func() bool {
+					newOVM, err = virtClient.OfflineVirtualMachine(newOVM.Namespace).Get(newOVM.Name, &v12.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return hasCondition(newOVM, v1.OfflineVirtualMachineRunning)
+				}, 360*time.Second, 1*time.Second).Should(BeTrue())
+
 				status := stopCmd.Run(stopFlags)
 				Expect(status).To(Equal(0))
 


### PR DESCRIPTION
The virtctl stop test has a race condition in it that occasionally cause it to fail. 

The race is between the ovm controller updating the object to include the running condition, and the functional test's invocation of the stop command updating the object to Running=false

Occasionally the stop command part will fail because between the time it [retrieves the ovm object, sets Running=false, and updates the object] the controller is updates the object's condition array to include "running". This causes the stop commands update to fail because the object is out of date. 



