### PR TITLE
Use v1beta1 for rbac api calls

### DIFF
--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -22,7 +22,7 @@ subjects:
     name: kubevirt-apiserver
     namespace: {{ namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-apiserver-auth-delegator

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -23,7 +23,7 @@ subjects:
     name: kubevirt-apiserver
     namespace: {{ namespace }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-apiserver-auth-delegator


### PR DESCRIPTION
3.7 doesn't have rbac in v1.  Use v1beta1 API version.