### PR TITLE
publish default route via classless-static-routes

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -395,9 +395,9 @@ func discoverPodNetworkInterface(nic *VIF) (netlink.Link, error) {
 
 // filter out irrelevant routes
 func filterPodNetworkRoutes(routes []netlink.Route, nic *VIF) (filteredRoutes []netlink.Route) {
-	for _, route := range routes[1:] {
-		// don't create static route to default gateway
-		if route.Dst != nil && route.Dst.IP.Equal(nic.Gateway) && route.Src.Equal(nil) {
+	for _, route := range routes {
+		// don't create empty static routes
+		if route.Dst == nil && route.Src.Equal(nil) && route.Gw.Equal(nil) {
 			continue
 		}
 

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -150,17 +150,23 @@ var _ = Describe("Network", func() {
 	})
 
 	Context("func filterPodNetworkRoutes()", func() {
+		defRoute := netlink.Route{
+			Gw: net.IPv4(10, 35, 0, 1),
+		}
 		staticRoute := netlink.Route{
 			Dst: &net.IPNet{IP: net.IPv4(10, 45, 0, 10), Mask: net.CIDRMask(32, 32)},
 			Gw:  net.IPv4(10, 25, 0, 1),
 		}
-		gwRoute := netlink.Route{Dst: &net.IPNet{IP: net.IPv4(10, 35, 0, 1), Mask: net.CIDRMask(32, 32)}}
+		gwRoute := netlink.Route{
+			Dst: &net.IPNet{IP: net.IPv4(10, 35, 0, 1), Mask: net.CIDRMask(32, 32)},
+		}
 		nicRoute := netlink.Route{Src: net.IPv4(10, 35, 0, 6)}
-		staticRouteList := []netlink.Route{routeAddr, gwRoute, nicRoute, staticRoute}
+		emptyRoute := netlink.Route{}
+		staticRouteList := []netlink.Route{defRoute, gwRoute, nicRoute, emptyRoute, staticRoute}
 
-		It("should remove default gateway and source IP from routes, leaving others intact", func() {
-			expected := []netlink.Route{staticRoute}
-			Expect(filterPodNetworkRoutes(staticRouteList, testNic)).To(Equal(expected))
+		It("should remove empty routes, and routes matching nic, leaving others intact", func() {
+			expectedRouteList := []netlink.Route{defRoute, gwRoute, staticRoute}
+			Expect(filterPodNetworkRoutes(staticRouteList, testNic)).To(Equal(expectedRouteList))
 		})
 	})
 


### PR DESCRIPTION
DHCP clients that adhere to RFC3442 will ignore the
option router, leaving us with no default gateway, if
classless static routes are provided. Thus, we publish
the default route via both "options router" and
"options classless-static-routes" rather than filtering
it out, and let the client decide which to obey.

This should fix #845