### PR TITLE
Allow partial search domains (fix #868)

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -42,7 +42,7 @@ const (
 
 // simple domain validation regex. Put it here to avoid compiling each time.
 // Note this requires that unicode domains be presented in their ASCII format
-var searchDomainValidationRegex = regexp.MustCompile(`^(?:[_a-z0-9](?:[_a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)?$`)
+var searchDomainValidationRegex = regexp.MustCompile(`^(?:[_a-z0-9](?:[_a-z0-9-]{0,61}[a-z0-9])?\.)*(?:[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?)?$`)
 
 func SingleClientDHCPServer(
 	clientMAC net.HardwareAddr,

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
@@ -138,5 +138,9 @@ var _ = Describe("DHCP", func() {
 			dom := "example.default.svc.cluster.local."
 			Expect(isValidSearchDomain(dom)).To(BeTrue())
 		})
+
+		It("should accept a partial search domain", func() {
+			Expect(isValidSearchDomain("local")).To(BeTrue())
+		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -217,5 +217,12 @@ var _ = Describe("Network", func() {
 			Expect(searchDomains).To(Equal([]string{defaultSearchDomain}))
 			Expect(err).To(BeNil())
 		})
+
+		It("should allow partial search domains", func() {
+			resolvConf := "search local\nnameserver 8.8.8.8\n"
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{"local"}))
+			Expect(err).To(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
Partial domains are OK as search domains, as they will be prepended with a label.