### PR TITLE
manifests: Include registry for release manifests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 - if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" ]]; then make goveralls; else make test; fi
 - make apidocs
 - make client-python
-- make manifests DOCKER_TAG=$TRAVIS_TAG # falls back to latest if not on a tag
+- make manifests DOCKER_PREFIX="docker.io/kubevirt" DOCKER_TAG=$TRAVIS_TAG # falls back to latest if not on a tag
 
 deploy:
 - provider: script

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ publish: docker
 	hack/build-docker.sh push ${WHAT}
 
 manifests:
-	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} ./hack/build-manifests.sh"
+	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build-manifests.sh"
 
 .release-functest:
 	make functest > .release-functest 2>&1

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,6 +1,6 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virtctl cmd/fake-qemu-process cmd/virt-api cmd/subresource-access-test"
 docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api images/iscsi-demo-target-tgtd images/vm-killer cmd/registry-disk-v1alpha images/cirros-registry-disk-demo images/fedora-cloud-registry-disk-demo images/alpine-registry-disk-demo cmd/subresource-access-test images/winrmcli"
-docker_prefix=kubevirt
+docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel


### PR DESCRIPTION
For release manifests this patch introduces the registry.
This is good, because then we have an absolute location in which
registry our images are found.
Some runtimes - like CRI-O - even require the registry to be present,
otherwise they fail to launch the image (without further configuration).

Fixes #871

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>