### PR TITLE
Fix two vm-shutdown issues

### DIFF
--- a/cmd/virt-launcher/sh.sh
+++ b/cmd/virt-launcher/sh.sh
@@ -4,7 +4,7 @@ args="$@"
 if [ "$args" = "-i -c TERM=xterm /bin/sh" ] ; then
   namespace="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
   name="$(ls /var/run/kubevirt-private/${namespace}/)"
-  /usr/bin/sh.orig -c "/sock-connector /var/run/kubevirt-private/${namespace}/${name}/virt-serial0"
+  exec /usr/bin/sh.orig -c "/sock-connector /var/run/kubevirt-private/${namespace}/${name}/virt-serial0"
 else
-  /usr/bin/sh.orig "$@"
+  exec /usr/bin/sh.orig "$@"
 fi

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -121,8 +121,10 @@ func (c *VMController) execute(key string) error {
 		vm = obj.(*kubev1.VirtualMachine)
 	}
 
-	// don't process VM's that aren't fully initialized
-	if !isVirtualMachineInitialized(vm) {
+	// If the VM is exists still, don't process the VM until it is fully initialized.
+	// Initialization is handled by the initialization controller and must take place
+	// before the VM is acted upon.
+	if exists && !isVirtualMachineInitialized(vm) {
 		return nil
 	}
 


### PR DESCRIPTION
* If exec is missing libvirt kills the nested sh script instead of the
domain.
* If a vm got deleted, process it in virt-controller, even if it is not marked to be fully initialized

Fixes #876 
Fixes #881 

Signed-off-by: Roman Mohr <rmohr@redhat.com>