### PR TITLE
Change DHCP server address to link-local

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -56,7 +56,7 @@ const (
 )
 
 var interfaceCacheFile = "/var/run/kubevirt-private/interface-cache.json"
-var bridgeFakeIP = "10.11.12.13/24"
+var bridgeFakeIP = "169.254.75.86/32"
 
 // only used by unit test suite
 func setInterfaceCacheFile(path string) {


### PR DESCRIPTION
This fixes #857. Using a link-local address reduces the chances
of IP conflict with pod, cluster, or routable networking. Address
is now 169.254.75.86/32. Chosen semi-randomly, as 169.254.'k'.'v'
for KubeVirt.

Tested on os-3.9.0-alpha.4 dev cluster, and vanilla kubernetes. VMs
get DHCP info as before.