### PR TITLE
Remove defined and stopping event

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -541,7 +541,6 @@ func (d *VirtualMachineController) processVmShutdown(vm *v1.VirtualMachine, doma
 			return err
 		}
 	}
-	d.recorder.Event(vm, k8sv1.EventTypeNormal, v1.Deleted.String(), "VM stopping")
 
 	return d.processVmCleanup(vm)
 
@@ -574,8 +573,6 @@ func (d *VirtualMachineController) processVmUpdate(vm *v1.VirtualMachine) error 
 	if err != nil {
 		return err
 	}
-	d.recorder.Event(vm, k8sv1.EventTypeNormal, v1.Created.String(), "VM defined.")
-
 	return err
 }
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -41,8 +41,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	virtlauncher "kubevirt.io/kubevirt/pkg/virt-launcher"
+	"kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	"kubevirt.io/kubevirt/pkg/virt-launcher"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/watchdog"
 )
@@ -67,7 +67,7 @@ var _ = Describe("VM", func() {
 	var vmFeeder *testutils.VirtualMachineFeeder
 	var domainFeeder *testutils.DomainFeeder
 
-	var recorder record.EventRecorder
+	var recorder *record.FakeRecorder
 
 	var err error
 	var shareDir string
@@ -125,6 +125,13 @@ var _ = Describe("VM", func() {
 		close(stop)
 		ctrl.Finish()
 		os.RemoveAll(shareDir)
+		Expect(recorder.Events).To(BeEmpty())
+		/*
+			if len(recorder.Events) > 0 {
+				fmt.Println(<-recorder.Events)
+				Expect(true).To(Equal(false))
+			}
+		*/
 	})
 
 	initGracePeriodHelper := func(gracePeriod int64, vm *v1.VirtualMachine, dom *api.Domain) {
@@ -178,6 +185,8 @@ var _ = Describe("VM", func() {
 			domainFeeder.Add(domain)
 
 			controller.Execute()
+
+			testutils.ExpectEvent(recorder, "Signaled Graceful Shutdown")
 		}, 3)
 
 		It("should attempt graceful shutdown of Domain if no cluster wide equivalent exists", func() {
@@ -193,6 +202,8 @@ var _ = Describe("VM", func() {
 			domainFeeder.Add(domain)
 
 			controller.Execute()
+
+			testutils.ExpectEvent(recorder, "Signaled Graceful Shutdown")
 		}, 3)
 
 		It("should attempt force terminate Domain if grace period expires", func() {
@@ -239,7 +250,7 @@ var _ = Describe("VM", func() {
 			Expect(mockQueue.NumRequeues("a/b/c/d/e")).To(Equal(1))
 		})
 
-		It("should create the Domain if it sees the first time on a new VM", func() {
+		It("should create the Domain if it sees the first time a new VM", func() {
 			vm := v1.NewMinimalVM("testvm")
 			vm.ObjectMeta.ResourceVersion = "1"
 			vm.Status.Phase = v1.Scheduled
@@ -282,6 +293,52 @@ var _ = Describe("VM", func() {
 			virtClient.EXPECT().CoreV1().Return(fakeClient).AnyTimes()
 
 			controller.Execute()
+
+			testutils.ExpectEvent(recorder, "VM started")
+		})
+
+		It("should update from Running to Succeeded, if it sees a successful Domain shutdown", func() {
+			vm := v1.NewMinimalVM("testvm")
+			vm.ObjectMeta.ResourceVersion = "1"
+			vm.Status.Phase = v1.Running
+
+			updatedVM := vm.DeepCopy()
+			updatedVM.Status.Phase = v1.Succeeded
+
+			mockWatchdog.CreateFile(vm)
+			domain := api.NewMinimalDomain("testvm")
+			domain.Status.Status = api.Shutoff
+			domain.Status.Reason = api.ReasonShutdown
+			vmFeeder.Add(vm)
+			domainFeeder.Add(domain)
+
+			vmInterface.EXPECT().Update(updatedVM)
+
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, "The VM was shut down.")
+		})
+
+		It("should update from Running to Crashed, if it sees a crash", func() {
+			vm := v1.NewMinimalVM("testvm")
+			vm.ObjectMeta.ResourceVersion = "1"
+			vm.Status.Phase = v1.Running
+
+			updatedVM := vm.DeepCopy()
+			updatedVM.Status.Phase = v1.Failed
+
+			mockWatchdog.CreateFile(vm)
+			domain := api.NewMinimalDomain("testvm")
+			domain.Status.Status = api.Shutoff
+			domain.Status.Reason = api.ReasonCrashed
+			vmFeeder.Add(vm)
+			domainFeeder.Add(domain)
+
+			vmInterface.EXPECT().Update(updatedVM)
+
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, "The VM crashed.")
 		})
 
 		It("should detect a missing watchdog file and report the error on the VM", func() {
@@ -294,6 +351,8 @@ var _ = Describe("VM", func() {
 				Expect(vm.Status.Conditions).To(HaveLen(1))
 			})
 			controller.Execute()
+
+			testutils.ExpectEvent(recorder, "No watchdog file found for vm")
 		})
 
 		It("should remove an error condition if a synchronization run succeeds", func() {


### PR DESCRIPTION
The defined and stopping event where not directly related to the
matching libvirt event. They were just triggered when specific
conditions were met. IN case of "defined" it got triggered on every
sync.

Further add tests to ensure that all other events, namepley "Started",
"Stopped" and "Crashed" are triggered when we expect it.

Fixes #894 

Signed-off-by: Roman Mohr <rmohr@redhat.com>