### PR TITLE
[WIP] [BLOCKED] Allow VM's to use block PVC's

### DIFF
--- a/cluster/examples/vmi-pvc-block.yaml
+++ b/cluster/examples/vmi-pvc-block.yaml
@@ -1,0 +1,20 @@
+apiVersion: kubevirt.io/v1alpha2
+kind: VirtualMachineInstance
+metadata:
+  name: vm-pvc
+spec:
+  terminationGracePeriodSeconds: 0
+  domain:
+    resources:
+      requests:
+        memory: 256M
+    devices:
+      disks:
+      - name: mydisk
+        volumeName: pvcblock
+        disk:
+          bus: virtio
+  volumes:
+    - name: pvcblock
+      persistentVolumeClaim:
+        claimName: disk-cirros-block

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -33,6 +33,41 @@ spec:
     path: /tmp/hostImages/alpine
 ---
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: iscsi-disk-cirros-block
+  labels:
+    kubevirt.io: ""
+    os: "cirros-block"
+spec:
+  capacity:
+    storage: 40Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  hostPath:
+      # FIXME: this needs to be provided automatically
+      path: /volumes/cirros.img
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: disk-cirros-block
+  labels:
+    kubevirt.io: ""
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 40Gi
+  selector:
+    matchLabels:
+      os: "cirros-block"
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: disk-custom

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -32,9 +32,11 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/hooks"
+	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
+	//registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
 const configMapName = "kube-system/kubevirt-config"
@@ -70,6 +72,30 @@ func IsEmulationAllowed(store cache.Store) (bool, error) {
 	return useEmulation, nil
 }
 
+// return true if a PersistentVolumeClaim uses VolumeMode = Block
+func isPVCBlock(namespace string, claimName string) (bool, error) {
+	// FIXME: using a client to make synchronous calls is suboptimal
+	// ideally this would be using a cache/informer
+	client, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return false, err
+	}
+	opts := metav1.GetOptions{}
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(claimName, opts)
+	if err != nil {
+		return false, err
+	}
+	if pvc == nil {
+		return false, fmt.Errorf("unknown persistentvolumeclaim: %s", claimName)
+	}
+	// We do not need to consider the data in a PersistentVolume (as of Kubernetes 1.9)
+	// If a PVC does not specify VolumeMode and the PV specifies VolumeMode = Block
+	// the claim will not be bound. So for the sake of a boolean answer, if the PVC's
+	// VolumeMode is Block, that unambiguously answers the question
+	isBlock := pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == k8sv1.PersistentVolumeBlock
+	return isBlock, nil
+}
+
 func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error) {
 	precond.MustNotBeNil(vmi)
 	domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
@@ -82,9 +108,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	failureThreshold := 5
 
 	var volumes []k8sv1.Volume
+	var volumeDevices []k8sv1.VolumeDevice
 	var userId int64 = 0
 	var privileged bool = false
-	var volumesMounts []k8sv1.VolumeMount
+	var volumeMounts []k8sv1.VolumeMount
 	var imagePullSecrets []k8sv1.LocalObjectReference
 
 	gracePeriodSeconds := v1.DefaultGracePeriodSeconds
@@ -92,11 +119,11 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		gracePeriodSeconds = *vmi.Spec.TerminationGracePeriodSeconds
 	}
 
-	volumesMounts = append(volumesMounts, k8sv1.VolumeMount{
+	volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 		Name:      "virt-share-dir",
 		MountPath: t.virtShareDir,
 	})
-	volumesMounts = append(volumesMounts, k8sv1.VolumeMount{
+	volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 		Name:      "libvirt-runtime",
 		MountPath: "/var/run/libvirt",
 	})
@@ -106,7 +133,20 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			MountPath: filepath.Join("/var/run/kubevirt-private", "vmi-disks", volume.Name),
 		}
 		if volume.PersistentVolumeClaim != nil {
-			volumesMounts = append(volumesMounts, volumeMount)
+			isBlock, err := isPVCBlock(namespace, volume.PersistentVolumeClaim.ClaimName)
+			if err != nil {
+				return nil, err
+			}
+			if isBlock {
+				devicePath := filepath.Join(string(filepath.Separator), "dev", volume.Name)
+				device := k8sv1.VolumeDevice{
+					Name:       volume.Name,
+					DevicePath: devicePath,
+				}
+				volumeDevices = append(volumeDevices, device)
+			} else {
+				volumeMounts = append(volumeMounts, volumeMount)
+			}
 			volumes = append(volumes, k8sv1.Volume{
 				Name: volume.Name,
 				VolumeSource: k8sv1.VolumeSource{
@@ -115,7 +155,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			})
 		}
 		if volume.Ephemeral != nil {
-			volumesMounts = append(volumesMounts, volumeMount)
+			volumeMounts = append(volumeMounts, volumeMount)
 			volumes = append(volumes, k8sv1.Volume{
 				Name: volume.Name,
 				VolumeSource: k8sv1.VolumeSource{
@@ -177,7 +217,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		resources.Limits[hugepageType] = resources.Requests[k8sv1.ResourceMemory]
 
 		// Configure hugepages mount on a pod
-		volumesMounts = append(volumesMounts, k8sv1.VolumeMount{
+		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      "hugepages",
 			MountPath: filepath.Join("/dev/hugepages"),
 		})
@@ -220,7 +260,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
 			},
 		})
-		volumesMounts = append(volumesMounts, k8sv1.VolumeMount{
+		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      "hook-sidecar-sockets",
 			MountPath: hooks.HookSocketsSharedDirectory,
 		})
@@ -276,7 +316,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			},
 		},
 		Command:      command,
-		VolumeMounts: volumesMounts,
+		VolumeMounts: volumeMounts,
 		ReadinessProbe: &k8sv1.Probe{
 			Handler: k8sv1.Handler{
 				Exec: &k8sv1.ExecAction{

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -146,7 +146,7 @@ func Convert_v1_Volume_To_api_Disk(source *v1.Volume, disk *Disk, c *ConverterCo
 	}
 
 	if source.PersistentVolumeClaim != nil {
-		return Convert_v1_FilesystemVolumeSource_To_api_Disk(source.Name, disk, c)
+		return Convert_v1_PersistentVolumeClaim_To_api_Disk(source.Name, source.PersistentVolumeClaim.ClaimName, disk, c)
 	}
 
 	if source.Ephemeral != nil {
@@ -159,16 +159,54 @@ func Convert_v1_Volume_To_api_Disk(source *v1.Volume, disk *Disk, c *ConverterCo
 	return fmt.Errorf("disk %s references an unsupported source", disk.Alias.Name)
 }
 
+func getFilesystemVolumePath(volumeName string) string {
+	return filepath.Join(string(filepath.Separator), "var", "run", "kubevirt-private", "vm-disks", volumeName, "disk.img")
+}
+
+func isFilesystemVolume(volumeName string) (bool, error) {
+	path := getFilesystemVolumePath(volumeName)
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func Convert_v1_PersistentVolumeClaim_To_api_Disk(name string, claimName string, disk *Disk, c *ConverterContext) error {
+	isFilesystem, err := isFilesystemVolume(name)
+	if err != nil {
+		return err
+	}
+	// FIXME: need to decide how to detect devices vs filesystems
+	if isFilesystem {
+		return Convert_v1_FilesystemVolumeSource_To_api_Disk(name, disk, c)
+
+	}
+	return Convert_v1_BlockVolumeSource_To_api_Disk(name, disk, c)
+}
+
 // Convert_v1_FilesystemVolumeSource_To_api_Disk takes a FS source and builds the KVM Disk representation
 func Convert_v1_FilesystemVolumeSource_To_api_Disk(volumeName string, disk *Disk, c *ConverterContext) error {
 
 	disk.Type = "file"
 	disk.Driver.Type = "raw"
-	disk.Source.File = filepath.Join(
-		"/var/run/kubevirt-private",
-		"vmi-disks",
-		volumeName,
-		"disk.img")
+	disk.Source.File = getFilesystemVolumePath(volumeName)
+	return nil
+}
+
+func Convert_v1_BlockVolumeSource_To_api_Disk(volumeName string, disk *Disk, c *ConverterContext) error {
+	// A bug in Kubernetes prevents this from working. But there's a fix already merged:
+	// https://github.com/kubernetes/kubernetes/pull/61549
+	// See also:
+	// https://github.com/kubernetes/kubernetes/issues/62560
+	// https://github.com/kubernetes/kubernetes/issues/54108
+	// https://github.com/kubernetes/kubernetes/issues/58251
+	disk.Type = "block"
+	disk.Driver.Type = "raw"
+	disk.Source.Dev = filepath.Join(string(filepath.Separator), "dev", volumeName)
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -280,6 +280,7 @@ type DiskSecret struct {
 type ReadOnly struct{}
 
 type DiskSource struct {
+	Dev           string          `xml:"dev,attr,omitempty"`
 	File          string          `xml:"file,attr,omitempty"`
 	StartupPolicy string          `xml:"startupPolicy,attr,omitempty"`
 	Protocol      string          `xml:"protocol,attr,omitempty"`


### PR DESCRIPTION
This feature is incomplete, but it's worth pushing for review early as there were some design related discoveries noted along the way -- that might need further review.
- virt-launcher cannot be responsible for mapping block devices (it's too late! the pod already exists)
- virt-launcher cannot contact Kubernetes to look up PVC information (it doesn't have permission to, by design)
- How do we communicate the proper device path from virt-controller to virt-launcher?
- We'll need another cache/informer to track PVC's in virt-controller