### PR TITLE
Also mark non-leading controller instances as ready

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -107,7 +107,7 @@ func Execute() {
 	app.restClient = app.clientSet.RestClient()
 
 	webService := rest.WebService
-	webService.Route(webService.GET("/leader").To(app.readinessProbe).Doc("Leader endpoint"))
+	webService.Route(webService.GET("/leader").To(app.leaderProbe).Doc("Leader endpoint"))
 	restful.Add(webService)
 
 	// Bootstrapping. From here on the initialization order is important
@@ -242,7 +242,7 @@ func (vca *VirtControllerApp) initOfflineVirtualMachines() {
 	vca.ovmController = NewOVMController(vca.vmInformer, vca.ovmInformer, recorder, vca.clientSet)
 }
 
-func (vca *VirtControllerApp) readinessProbe(_ *restful.Request, response *restful.Response) {
+func (vca *VirtControllerApp) leaderProbe(_ *restful.Request, response *restful.Response) {
 	res := map[string]interface{}{}
 
 	select {
@@ -254,8 +254,8 @@ func (vca *VirtControllerApp) readinessProbe(_ *restful.Request, response *restf
 		}
 	default:
 	}
-	res["apiserver"] = map[string]interface{}{"leader": "false", "error": "current pod is not leader"}
-	response.WriteHeaderAndJson(http.StatusServiceUnavailable, res, restful.MIME_JSON)
+	res["apiserver"] = map[string]interface{}{"leader": "false"}
+	response.WriteHeaderAndJson(http.StatusOK, res, restful.MIME_JSON)
 }
 
 func (vca *VirtControllerApp) AddFlags() {

--- a/tests/controller_leader_election_test.go
+++ b/tests/controller_leader_election_test.go
@@ -72,7 +72,7 @@ var _ = Describe("LeaderElection", func() {
 					return leaderPod.Name
 				}, 90*time.Second, 5*time.Second).Should(Equal(newLeaderPod.Name))
 
-				Eventually(func() k8sv1.ConditionStatus {
+				Expect(func() k8sv1.ConditionStatus {
 					leaderPod, err := virtClient.CoreV1().Pods(leaderelectionconfig.DefaultNamespace).Get(newLeaderPod.Name, metav1.GetOptions{})
 					Expect(err).To(BeNil())
 
@@ -82,9 +82,7 @@ var _ = Describe("LeaderElection", func() {
 						}
 					}
 					return k8sv1.ConditionUnknown
-				},
-					30*time.Second,
-					5*time.Second).Should(Equal(k8sv1.ConditionTrue))
+				}()).To(Equal(k8sv1.ConditionTrue))
 
 				vm := tests.NewRandomVM()
 


### PR DESCRIPTION
A lot of tools and UIs are confused if the not leading controller
instance is not marked as ready, although it is completely fine and
healthy. Therefore, keep the information in the /leader REST endpoint,
but always return 200, no matter if the instance is a leader or not.

Fixes #890.

Signed-off-by: Roman Mohr <rmohr@redhat.com>