### PR TITLE
VM Controller Race Condition Fix

### DIFF
--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -428,7 +428,7 @@ var _ = Describe("Vmlifecycle", func() {
 				}, 30, 0.5).Should(ContainSubstring(fmt.Sprintf("grace period expired, killing deleted VM %s", vm.GetObjectMeta().GetName())))
 
 				close(done)
-			}, 45)
+			}, 60)
 		})
 	})
 


### PR DESCRIPTION
## Overview

Ever since the OVM and Registry Disk function tests that start/stop the same VM multiple times were introduced, we have seen transient failures in those tests. I identified what I believe is the primary source of these failures. 

Our VM controller is not idempotent during the 'Pending' phase. The result is it's possible under a very complex (yet fairly likely to occur) combination of events that the VM's Pod will get created and immediately destroyed.

I'm not going to outline the flow that causes this condition because it is insane looking and in many ways irrelevant. Instead I'm going to provide a simple explanation of safe logic vs. unsafe logic below. 

## Explanation 

Here's a super stripped down and simple example of logic VM controller execute() function. 

```
func (c *VMController) execute(key string) error {
        vm := c.store.GetByKey(key)

        switch vm.Status.Phase {
        case kubev1.VmPhaseUnset, kubev1.Pending:
                c.vmService.StartVMPod(vm)
                vm.Status.Phase = kubev1.Scheduling
                logger.Info("Handing over the VM to the scheduler succeeded.")
                // STEP 1
                return c.clientset.VM(vm.Namespace).Update(vm)
        case kubev1.Scheduling:
                logger.Infof("VM successfully scheduled to")
                return nil
        }
        return nil
}
```

**Question**

Now looking at that example, after the return statement directly under the comment 'STEP 1' is hit, assuming the update was successful and no other update occurred to the VM object, which case statement would we expect the next execution() call for this VM to take?

**Wrong** Answer:
* The Phase was set to 'Scheduling' before the return statement below 'Step 1', so I'd assume that the next invocation of this function would hit the 'Scheduling' case statement.

**Right** Answer
* Either case statement is possible for the next invocation of execute for the VM object in question. 

**But How ???**
There is no guaranteed that the VM key will not get re-enqueued and processed again before the update we made in 'STEP 1' makes it into our local cache. The update to our local cache is performed asynchronously.

Because of this, we **must** ensure that every action we take in the controller is idempotent. In this example, when we create the VM pod, we have to ensure that we haven't already created the pod first. Otherwise it's possible for multiple pods for a single VM to get created. 

## Result

Our problem was not that we were creating multiple pods per a VM. That was just an easy way to explain the situation. 

Our problem is we were creating the pod for a VM, and then immediately deleting the pod while still moving the VM's phase to 'Scheduling'.  This resulted in the VM getting stuck in 'Scheduling' indefinitely until the VM object is deleted.
