### PR TITLE
Webhook CRD Validator

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -46,6 +46,7 @@ for i in ${namespaces[@]}; do
     _kubectl -n ${i} delete rs -l 'kubevirt.io'
     _kubectl -n ${i} delete services -l 'kubevirt.io'
     _kubectl -n ${i} delete apiservices -l 'kubevirt.io'
+    _kubectl -n ${i} delete validatingwebhookconfiguration -l 'kubevirt.io'
     _kubectl -n ${i} delete secrets -l 'kubevirt.io'
     _kubectl -n ${i} delete pv -l 'kubevirt.io'
     _kubectl -n ${i} delete pvc -l 'kubevirt.io'

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -88,6 +88,14 @@ metadata:
     kubevirt.io: ""
 rules:
   - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - apiregistration.k8s.io
     resources:
       - apiservices

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -593,8 +593,16 @@ func (app *virtAPIApp) createWebhook() error {
 			return err
 		}
 	} else {
+
+		for _, webhook := range webhookRegistration.Webhooks {
+			if webhook.ClientConfig.Service != nil && webhook.ClientConfig.Service.Namespace != namespace {
+				return fmt.Errorf("ValidatingAdmissionWebhook [%s] is already registered using services endpoints in a different namespace. Existing webhook registration must be deleted before virt-api can proceed.", virtWebhookValidator)
+			}
+		}
+
 		// update registered webhook with our data
 		webhookRegistration.Webhooks = webHooks
+
 		_, err := app.virtCli.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Update(webhookRegistration)
 		if err != nil {
 			return err

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -109,7 +109,8 @@ func validateDisks(disks []v1.Disk) []error {
 
 	if len(disks) > arrayLenMax {
 		errors = append(errors, fmt.Errorf("spec.domain.devices.disks list exceeds the %d element limit in length", arrayLenMax))
-
+		// We won't process anything over the limit
+		return errors
 	}
 
 	for idx, disk := range disks {
@@ -152,6 +153,8 @@ func validateVolumes(volumes []v1.Volume) []error {
 
 	if len(volumes) > arrayLenMax {
 		errors = append(errors, fmt.Errorf("spec.volumes list exceeds the %d element limit in length", arrayLenMax))
+		// We won't process anything over the limit
+		return errors
 	}
 	for idx, volume := range volumes {
 		// verify name is unique
@@ -236,9 +239,12 @@ func validateVirtualMachineSpec(spec *v1.VirtualMachineSpec) []error {
 
 	if len(spec.Domain.Devices.Disks) > arrayLenMax {
 		errors = append(errors, fmt.Errorf("spec.domain.devices.disks list exceeds the %d element limit in length", arrayLenMax))
+		// We won't process anything over the limit
+		return errors
 	} else if len(spec.Volumes) > arrayLenMax {
 		errors = append(errors, fmt.Errorf("spec.volumes list exceeds the %d element limit in length", arrayLenMax))
-
+		// We won't process anything over the limit
+		return errors
 	}
 
 	// Validate disks and VolumeNames match up correctly

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package validating_webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	v1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/log"
+)
+
+func getAdmissionReview(r *http.Request) (*v1beta1.AdmissionReview, error) {
+	var body []byte
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+
+	// verify the content type is accurate
+	contentType := r.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		return nil, fmt.Errorf("contentType=%s, expect application/json", contentType)
+	}
+
+	ar := &v1beta1.AdmissionReview{}
+	err := json.Unmarshal(body, ar)
+	return ar, err
+}
+
+func toAdmissionResponse(err error) *v1beta1.AdmissionResponse {
+	log.Log.Reason(err).Error("admitting vms")
+	return &v1beta1.AdmissionResponse{
+		Result: &metav1.Status{
+			Message: err.Error(),
+		},
+	}
+}
+
+type admitFunc func(*v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
+
+func serve(resp http.ResponseWriter, req *http.Request, admit admitFunc) {
+	response := v1beta1.AdmissionReview{}
+	review, err := getAdmissionReview(req)
+
+	if err != nil {
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	reviewResponse := admit(review)
+	if reviewResponse != nil {
+		response.Response = reviewResponse
+		response.Response.UID = review.Request.UID
+	}
+	// reset the Object and OldObject, they are not needed in a response.
+	review.Request.Object = runtime.RawExtension{}
+	review.Request.OldObject = runtime.RawExtension{}
+
+	responseBytes, err := json.Marshal(response)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed json encode webhook response")
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if _, err := resp.Write(responseBytes); err != nil {
+		log.Log.Reason(err).Errorf("failed to write webhook response")
+		resp.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	resp.WriteHeader(http.StatusOK)
+}
+
+func admitVMs(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	log.Log.Info("admitting vms")
+
+	vmResource := metav1.GroupVersionResource{Group: v1.VirtualMachineGroupVersionKind.Group, Version: v1.VirtualMachineGroupVersionKind.Version, Resource: "virtualmachines"}
+	if ar.Request.Resource != vmResource {
+		err := fmt.Errorf("expect resource to be %s", vmResource)
+		return toAdmissionResponse(err)
+	}
+
+	raw := ar.Request.Object.Raw
+	vm := v1.VirtualMachine{}
+
+	err := json.Unmarshal(raw, &vm)
+	if err != nil {
+		return toAdmissionResponse(err)
+	}
+
+	reviewResponse := v1beta1.AdmissionResponse{}
+	reviewResponse.Allowed = true
+
+	// TODO add a check here for disks and volumes
+
+	return &reviewResponse
+}
+
+func ServeVMs(resp http.ResponseWriter, req *http.Request) {
+	serve(resp, req, admitVMs)
+}

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -63,6 +63,7 @@ func toAdmissionResponse(err error) *v1beta1.AdmissionResponse {
 	return &v1beta1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: err.Error(),
+			Code:    http.StatusUnprocessableEntity,
 		},
 	}
 }

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -1,0 +1,174 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package validating_webhook
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+var _ = Describe("Validating Webhook", func() {
+	Context("with VM disk", func() {
+		It("should accept a valid disk", func() {
+			vm := v1.NewMinimalVM("testvm")
+
+			vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "testdisk",
+				VolumeName: "testvolume",
+			})
+			vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
+				Name: "testvolume",
+				VolumeSource: v1.VolumeSource{
+					RegistryDisk: &v1.RegistryDiskSource{},
+				},
+			})
+
+			errors := validateDisks(vm)
+			Expect(len(errors)).To(Equal(0))
+		})
+		It("should reject disk with missing volume", func() {
+			vm := v1.NewMinimalVM("testvm")
+
+			vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "testdisk",
+				VolumeName: "testvolume",
+			})
+
+			errors := validateDisks(vm)
+			Expect(len(errors)).To(Equal(1))
+		})
+		It("should reject disk with multiple targets ", func() {
+			vm := v1.NewMinimalVM("testvm")
+
+			vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "testdisk",
+				VolumeName: "testvolume",
+				DiskDevice: v1.DiskDevice{
+					Disk:   &v1.DiskTarget{},
+					Floppy: &v1.FloppyTarget{},
+				},
+			})
+
+			errors := validateDisks(vm)
+			// len  == 2 because missing volume and multiple targets set
+			Expect(len(errors)).To(Equal(2))
+		})
+		table.DescribeTable("should verify LUN is mapped to PVC volume",
+			func(volume *v1.Volume, expectedErrors int) {
+				vm := v1.NewMinimalVM("testvm")
+				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+					Name:       "testdisk",
+					VolumeName: "testvolume",
+					DiskDevice: v1.DiskDevice{
+						LUN: &v1.LunTarget{},
+					},
+				})
+				vm.Spec.Volumes = append(vm.Spec.Volumes, *volume)
+
+				errors := validateDisks(vm)
+				Expect(len(errors)).To(Equal(expectedErrors))
+			},
+			table.Entry("and reject non PVC sources",
+				&v1.Volume{
+					Name: "testvolume",
+					VolumeSource: v1.VolumeSource{
+						RegistryDisk: &v1.RegistryDiskSource{},
+					},
+				}, 1),
+			table.Entry("and accept PVC sources",
+				&v1.Volume{
+					Name: "testvolume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{},
+					},
+				}, 0),
+		)
+	})
+	Context("with VM volume", func() {
+		It("should accept valid volume", func() {
+			vm := v1.NewMinimalVM("testvm")
+
+			vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
+				Name: "testvolume",
+				VolumeSource: v1.VolumeSource{
+					RegistryDisk: &v1.RegistryDiskSource{},
+				},
+			})
+
+			errors := validateVolumes(vm)
+			Expect(len(errors)).To(Equal(0))
+		})
+		It("should reject volume no volume source set", func() {
+			vm := v1.NewMinimalVM("testvm")
+
+			vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
+				Name: "testvolume",
+			})
+
+			errors := validateVolumes(vm)
+			Expect(len(errors)).To(Equal(1))
+		})
+		It("should reject volume with multiple volume sources set", func() {
+			vm := v1.NewMinimalVM("testvm")
+
+			vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
+				Name: "testvolume",
+				VolumeSource: v1.VolumeSource{
+					RegistryDisk:          &v1.RegistryDiskSource{},
+					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{},
+				},
+			})
+
+			errors := validateVolumes(vm)
+			Expect(len(errors)).To(Equal(1))
+		})
+		table.DescribeTable("should verify cloud-init userdata length", func(userDataLen int, expectedErrors int) {
+			vm := v1.NewMinimalVM("testvm")
+
+			// generate fake userdata
+			userdata := ""
+			for i := 0; i < userDataLen; i++ {
+				userdata = fmt.Sprintf("%sa", userdata)
+			}
+
+			vm.Spec.Volumes = append(vm.Spec.Volumes, v1.Volume{
+				VolumeSource: v1.VolumeSource{
+					CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+						UserData: userdata,
+					},
+				},
+			})
+
+			errors := validateVolumes(vm)
+			Expect(len(errors)).To(Equal(expectedErrors))
+		},
+			table.Entry("should accept userdata under max limit", 10, 0),
+			table.Entry("should accept userdata equal max limit", cloudInitMaxLen, 0),
+			table.Entry("should reject userdata greater than max limit", cloudInitMaxLen+1, 1),
+		)
+	})
+})

--- a/pkg/virt-api/validating-webhook/validating_webhook_suite_test.go
+++ b/pkg/virt-api/validating-webhook/validating_webhook_suite_test.go
@@ -1,0 +1,13 @@
+package validating_webhook_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidatingWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ValidatingWebhook Suite")
+}

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -95,10 +95,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				Kind:       "OfflineVirtualMachine",
 			}
 
-			jsonBytes, err := json.Marshal(newOVM)
-			Expect(err).To(BeNil())
-
-			result := virtClient.RestClient().Post().Resource("offlinevirtualmachines").Namespace(tests.NamespaceTestDefault).Body(jsonBytes).SetHeader("Content-Type", "application/json").Do()
+			result := virtClient.RestClient().Post().Resource("offlinevirtualmachines").Namespace(tests.NamespaceTestDefault).Body(newOVM).Do()
 
 			// Verify validation failed.
 			statusCode := 0

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -80,6 +80,32 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
 		})
+		FIt("should reject POST if validation webhoook deems the spec is invalid", func() {
+			vmImage := tests.RegistryDiskFor(tests.RegistryDiskCirros)
+			template := tests.NewRandomVMWithEphemeralDiskAndUserdata(vmImage, "echo Hi\n")
+			// Add a disk that doesn't map to a volume.
+			// This should get rejected which tells us the webhook validator is working.
+			template.Spec.Domain.Devices.Disks = append(template.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "testdisk",
+				VolumeName: "testvolume",
+			})
+			newOVM := NewRandomOfflineVirtualMachine(template, false)
+			newOVM.TypeMeta = v12.TypeMeta{
+				APIVersion: v1.GroupVersion.String(),
+				Kind:       "OfflineVirtualMachine",
+			}
+
+			jsonBytes, err := json.Marshal(newOVM)
+			Expect(err).To(BeNil())
+
+			result := virtClient.RestClient().Post().Resource("offlinevirtualmachines").Namespace(tests.NamespaceTestDefault).Body(jsonBytes).SetHeader("Content-Type", "application/json").Do()
+
+			// Verify validation failed.
+			statusCode := 0
+			result.StatusCode(&statusCode)
+			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+
+		})
 	})
 
 	Context("A valid OfflineVirtualMachine given", func() {

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -80,7 +80,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
 		})
-		FIt("should reject POST if validation webhoook deems the spec is invalid", func() {
+		It("should reject POST if validation webhoook deems the spec is invalid", func() {
 			vmImage := tests.RegistryDiskFor(tests.RegistryDiskCirros)
 			template := tests.NewRandomVMWithEphemeralDiskAndUserdata(vmImage, "echo Hi\n")
 			// Add a disk that doesn't map to a volume.

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -125,6 +125,30 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 		Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
 	})
+	FIt("should reject POST if validation webhoook deems the spec is invalid", func() {
+		newRS := newReplicaSet()
+		newRS.TypeMeta = v12.TypeMeta{
+			APIVersion: v1.GroupVersion.String(),
+			Kind:       "VirtualMachineReplicaSet",
+		}
+
+		// Add a disk that doesn't map to a volume.
+		// This should get rejected which tells us the webhook validator is working.
+		newRS.Spec.Template.Spec.Domain.Devices.Disks = append(newRS.Spec.Template.Spec.Domain.Devices.Disks, v1.Disk{
+			Name:       "testdisk",
+			VolumeName: "testvolume",
+		})
+		jsonBytes, err := json.Marshal(newRS)
+		Expect(err).To(BeNil())
+
+		result := virtClient.RestClient().Post().Resource("virtualmachinereplicasets").Namespace(tests.NamespaceTestDefault).Body(jsonBytes).SetHeader("Content-Type", "application/json").Do()
+
+		// Verify validation failed.
+		statusCode := 0
+		result.StatusCode(&statusCode)
+		Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+
+	})
 	It("should update readyReplicas once VMs are up", func() {
 		newRS := newReplicaSet()
 		doScale(newRS.ObjectMeta.Name, 2)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -138,10 +138,8 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 			Name:       "testdisk",
 			VolumeName: "testvolume",
 		})
-		jsonBytes, err := json.Marshal(newRS)
-		Expect(err).To(BeNil())
 
-		result := virtClient.RestClient().Post().Resource("virtualmachinereplicasets").Namespace(tests.NamespaceTestDefault).Body(jsonBytes).SetHeader("Content-Type", "application/json").Do()
+		result := virtClient.RestClient().Post().Resource("virtualmachinereplicasets").Namespace(tests.NamespaceTestDefault).Body(newRS).Do()
 
 		// Verify validation failed.
 		statusCode := 0

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -125,7 +125,7 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 		Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
 	})
-	FIt("should reject POST if validation webhoook deems the spec is invalid", func() {
+	It("should reject POST if validation webhoook deems the spec is invalid", func() {
 		newRS := newReplicaSet()
 		newRS.TypeMeta = v12.TypeMeta{
 			APIVersion: v1.GroupVersion.String(),

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -106,10 +106,8 @@ var _ = Describe("Vmlifecycle", func() {
 				Name:       "testdisk",
 				VolumeName: "testvolume",
 			})
-			jsonBytes, err := json.Marshal(vm)
-			Expect(err).To(BeNil())
 
-			result := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(jsonBytes).SetHeader("Content-Type", "application/json").Do()
+			result := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do()
 
 			// Verify validation failed.
 			statusCode := 0

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -98,6 +98,24 @@ var _ = Describe("Vmlifecycle", func() {
 			result.StatusCode(&statusCode)
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 		})
+		It("should reject POST if validation webhook deems the spec invalid", func() {
+
+			// Add a disk that doesn't map to a volume.
+			// This should get rejected which tells us the webhook validator is working.
+			vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "testdisk",
+				VolumeName: "testvolume",
+			})
+			jsonBytes, err := json.Marshal(vm)
+			Expect(err).To(BeNil())
+
+			result := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(jsonBytes).SetHeader("Content-Type", "application/json").Do()
+
+			// Verify validation failed.
+			statusCode := 0
+			result.StatusCode(&statusCode)
+			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+		})
 
 		It("should reject PATCH if schema is invalid", func() {
 			err := virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()


### PR DESCRIPTION
## Overview 
This patch adds a Validation Admission Control webhook that inspects our KubeVirt CRD objects before they are persisted into storage. This lets us catch advanced API configuration issues before allowing objects to be posted to the cluster. 

### Webhook Registration

The validation webhook endpoint has been added to the virt-api component, and uses both the same CABundle and service endpoint as the subresources apiserver.

At initialization, virt-api now registers webhooks for all of our CRD objects (vm, ovm, vmpresets, vmrs). When a CRD is posted to the cluster, the k8s apiserver forwards the request to our handlers in virt-api to perform an admission review.  From there we choose to accept or reject the object based on any custom logic we implement.

### Initial Validation Logic

The purpose of this patch is to provide the framework for us to add more advanced validation to later. Essentially we want to make it easy to add additional validation features in the future by introducing the webhook registration and a small subset of validation checks.

For now, this patch only validates the following
- Disks have a single target set
- Volumes have a single source set
- Disks reference a valid volume name in the DomainSpec
- Disk with LUN target are mapped to a network storage volume.
- CloudInit userdata does not exceed a maximum length of 2k bytes
- CloudInit userdatabase64 is valid base64 encoded data

Any CRD that contains these fields (whether it be an ovm, preset, vm, vmrs) will be validated. The code is structured in a hierarchical way ensuring that as new validations are added, all CRD objects will pick up the new validation checks if they apply to the fields within those objects. 

## Testing 
- Unit tests exercise all the validation checks as well as admission review/response paths for each CRD object.
- Functional tests simply perform a single validation check for each object type (ovm, vm, preset, vmrs) to verify webhooks are functioning correctly at the cluster level.

fixes #404 
