### PR TITLE
[WIP] Add virtctl autocomplete support for bash and zsh

### DIFF
--- a/pkg/virtctl/completion/completion.go
+++ b/pkg/virtctl/completion/completion.go
@@ -1,0 +1,33 @@
+package completion
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion SHELL",
+		Short: "Output shell completion code for the specified shell (bash or zsh)",
+		Example: `# Load the virtctl completion code for bash into the current shell
+source <(virtctl completion bash)
+
+# Load the virtctl completion code for zsh[1] into the current shell
+source <(virtctl completion zsh)`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if args[0] == "bash" {
+				return cmd.Parent().GenBashCompletion(os.Stdout)
+			} else if args[0] == "zsh" {
+				return cmd.Parent().GenZshCompletion(os.Stdout)
+			}
+			return nil
+		},
+		ValidArgs: []string{"bash", "zsh"},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -9,6 +9,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/virtctl/completion"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 	"kubevirt.io/kubevirt/pkg/virtctl/imageupload"
@@ -49,6 +50,7 @@ func NewVirtctlCommand() *cobra.Command {
 		expose.NewExposeCommand(clientConfig),
 		version.VersionCommand(clientConfig),
 		imageupload.NewImageUploadCommand(clientConfig),
+		completion.NewCommand(),
 		optionsCmd,
 	)
 	return rootCmd


### PR DESCRIPTION
Type "virtctl completion --help" to find out on how to install bash and
zsh completion for virtctl.

Signed-off-by: Roman Mohr <rmohr@redhat.com>