### PR TITLE
Update os-3.9.0 image to enable webhook admission control

### DIFF
--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.9.3@sha256:f1506a8aebfb5b5fbf37cd8c9f060bc1f05db683fca15eb11f9fe9e9a58ec9e5"
+image="k8s-1.9.3@sha256:2ea1e772b13067617a7fc14f14105cfec5f97dd6e55db1827c3e877ba293fa8d"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/os-3.9.0/provider.sh
+++ b/cluster/os-3.9.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.9.0@sha256:416e63f01ede46bd669f58b6e65c403dc5d1c560159950943491a7d06683321b"
+image="os-3.9.0@sha256:507263b67ddad581b086418d443c4fd1b2a30954e8fddff12254e0061a529410"
 
 source cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
related to https://github.com/rmohr/qemu-dockerized/pull/35 and https://github.com/rmohr/qemu-dockerized/pull/34