### PR TITLE
virtctl: vnc: report errors from remote-viewers

### DIFF
--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -4,8 +4,6 @@
 package kubecli
 
 import (
-	io "io"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -564,6 +562,45 @@ func (_mr *_MockKubevirtClientRecorder) StorageV1alpha1() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StorageV1alpha1")
 }
 
+// Mock of StreamInterface interface
+type MockStreamInterface struct {
+	ctrl     *gomock.Controller
+	recorder *_MockStreamInterfaceRecorder
+}
+
+// Recorder for MockStreamInterface (not exported)
+type _MockStreamInterfaceRecorder struct {
+	mock *MockStreamInterface
+}
+
+func NewMockStreamInterface(ctrl *gomock.Controller) *MockStreamInterface {
+	mock := &MockStreamInterface{ctrl: ctrl}
+	mock.recorder = &_MockStreamInterfaceRecorder{mock}
+	return mock
+}
+
+func (_m *MockStreamInterface) EXPECT() *_MockStreamInterfaceRecorder {
+	return _m.recorder
+}
+
+func (_m *MockStreamInterface) Stream(options StreamOptions) error {
+	ret := _m.ctrl.Call(_m, "Stream", options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockStreamInterfaceRecorder) Stream(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stream", arg0)
+}
+
+func (_m *MockStreamInterface) Done() {
+	_m.ctrl.Call(_m, "Done")
+}
+
+func (_mr *_MockStreamInterfaceRecorder) Done() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Done")
+}
+
 // Mock of VMInterface interface
 type MockVMInterface struct {
 	ctrl     *gomock.Controller
@@ -655,24 +692,26 @@ func (_mr *_MockVMInterfaceRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ..
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockVMInterface) SerialConsole(name string, in io.Reader, out io.Writer) error {
-	ret := _m.ctrl.Call(_m, "SerialConsole", name, in, out)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (_m *MockVMInterface) SerialConsole(name string) (StreamInterface, error) {
+	ret := _m.ctrl.Call(_m, "SerialConsole", name)
+	ret0, _ := ret[0].(StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-func (_mr *_MockVMInterfaceRecorder) SerialConsole(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SerialConsole", arg0, arg1, arg2)
+func (_mr *_MockVMInterfaceRecorder) SerialConsole(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SerialConsole", arg0)
 }
 
-func (_m *MockVMInterface) VNC(name string, in io.Reader, out io.Writer) error {
-	ret := _m.ctrl.Call(_m, "VNC", name, in, out)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (_m *MockVMInterface) VNC(name string) (StreamInterface, error) {
+	ret := _m.ctrl.Call(_m, "VNC", name)
+	ret0, _ := ret[0].(StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-func (_mr *_MockVMInterfaceRecorder) VNC(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "VNC", arg0, arg1, arg2)
+func (_mr *_MockVMInterfaceRecorder) VNC(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VNC", arg0)
 }
 
 // Mock of ReplicaSetInterface interface

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -593,14 +593,6 @@ func (_mr *_MockStreamInterfaceRecorder) Stream(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stream", arg0)
 }
 
-func (_m *MockStreamInterface) Done() {
-	_m.ctrl.Call(_m, "Done")
-}
-
-func (_mr *_MockStreamInterfaceRecorder) Done() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Done")
-}
-
 // Mock of VMInterface interface
 type MockVMInterface struct {
 	ctrl     *gomock.Controller

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -58,6 +58,16 @@ func (k kubevirt) RestClient() *rest.RESTClient {
 	return k.restClient
 }
 
+type StreamOptions struct {
+	In  io.Reader
+	Out io.Writer
+}
+
+type StreamInterface interface {
+	Stream(options StreamOptions) error
+	Done()
+}
+
 type VMInterface interface {
 	Get(name string, options k8smetav1.GetOptions) (*v1.VirtualMachine, error)
 	List(opts k8smetav1.ListOptions) (*v1.VirtualMachineList, error)
@@ -65,8 +75,8 @@ type VMInterface interface {
 	Update(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachine, err error)
-	SerialConsole(name string, in io.Reader, out io.Writer) error
-	VNC(name string, in io.Reader, out io.Writer) error
+	SerialConsole(name string) (StreamInterface, error)
+	VNC(name string) (StreamInterface, error)
 }
 
 type ReplicaSetInterface interface {

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -65,7 +65,6 @@ type StreamOptions struct {
 
 type StreamInterface interface {
 	Stream(options StreamOptions) error
-	Done()
 }
 
 type VMInterface interface {

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -234,11 +234,8 @@ func (ws *wsStreamer) Stream(options StreamOptions) error {
 		copyErr <- err
 	}()
 
-	return <-copyErr
-}
-
-func (ws *wsStreamer) Done() {
 	close(ws.done)
+	return <-copyErr
 }
 
 func (v *vms) VNC(name string) (StreamInterface, error) {

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -219,6 +219,10 @@ type wsStreamer struct {
 	done chan struct{}
 }
 
+func (ws *wsStreamer) streamDone() {
+	close(ws.done)
+}
+
 func (ws *wsStreamer) Stream(options StreamOptions) error {
 	wsReadWriter := &BinaryReadWriter{Conn: ws.conn}
 
@@ -234,7 +238,7 @@ func (ws *wsStreamer) Stream(options StreamOptions) error {
 		copyErr <- err
 	}()
 
-	close(ws.done)
+	defer ws.streamDone()
 	return <-copyErr
 }
 

--- a/pkg/kubecli/vm_test.go
+++ b/pkg/kubecli/vm_test.go
@@ -20,6 +20,8 @@
 package kubecli
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/websocket"
@@ -154,6 +156,68 @@ var _ = Describe("Kubevirt VM Client", func() {
 		))
 		_, err := client.VM(k8sv1.NamespaceDefault).VNC("testvm")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("should exchange data with the VM", func() {
+		vncPath := "/apis/subresources.kubevirt.io/v1alpha1/namespaces/default/virtualmachines/testvm/vnc"
+
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", vncPath),
+			func(w http.ResponseWriter, r *http.Request) {
+				c, err := upgrader.Upgrade(w, r, nil)
+				if err != nil {
+					panic("server upgrader failed")
+				}
+				defer c.Close()
+
+				for {
+					mt, message, err := c.ReadMessage()
+					if err != nil {
+						io.WriteString(GinkgoWriter, fmt.Sprintf("server read failed: %v\n", err))
+						break
+					}
+
+					err = c.WriteMessage(mt, message)
+					if err != nil {
+						io.WriteString(GinkgoWriter, fmt.Sprintf("server write failed: %v\n", err))
+						break
+					}
+				}
+			},
+		))
+
+		By("establishing connection")
+
+		vnc, err := client.VM(k8sv1.NamespaceDefault).VNC("testvm")
+		Expect(err).ToNot(HaveOccurred())
+
+		By("wiring the pipes")
+
+		pipeInReader, pipeInWriter := io.Pipe()
+		pipeOutReader, pipeOutWriter := io.Pipe()
+
+		go func() {
+			vnc.Stream(StreamOptions{
+				In:  pipeInReader,
+				Out: pipeOutWriter,
+			})
+		}()
+
+		By("sending data around")
+		msg := "hello, vnc!"
+		bufIn := make([]byte, 64)
+		copy(bufIn[:], msg)
+
+		_, err = pipeInWriter.Write(bufIn)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("reading back data")
+		bufOut := make([]byte, 64)
+		_, err = pipeOutReader.Read(bufOut)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("checking the result")
+		Expect(bufOut).To(Equal(bufIn))
 	})
 
 	AfterEach(func() {

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -99,7 +99,6 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 			resChan <- err
 			return
 		}
-		defer con.Done()
 
 		resChan <- con.Stream(kubecli.StreamOptions{
 			In:  stdinReader,

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -94,8 +94,17 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 	readStop := make(chan error)
 
 	go func() {
-		err := virtCli.VM(namespace).SerialConsole(vm, stdinReader, stdoutWriter)
-		resChan <- err
+		con, err := virtCli.VM(namespace).SerialConsole(vm)
+		if err != nil {
+			resChan <- err
+			return
+		}
+		defer con.Done()
+
+		resChan <- con.Stream(kubecli.StreamOptions{
+			In:  stdinReader,
+			Out: stdoutWriter,
+		})
 	}()
 
 	go func() {

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -116,6 +116,8 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 		output, err := cmnd.CombinedOutput()
 		if err != nil {
 			glog.Errorf("remote-viewer execution encountered an error: %v", err)
+		}
+		if err != nil || glog.V(2) {
 			glog.Errorf("remote-viewer: %v", string(output))
 		}
 		viewResChan <- err

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -37,8 +37,6 @@ import (
 
 const FLAG = "vnc"
 
-var debug bool
-
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "vnc (vm)",
@@ -51,7 +49,6 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		},
 	}
 	cmd.SetUsageTemplate(templates.UsageTemplate())
-	cmd.Flags().BoolVarP(&debug, "debug", "D", false, "enable debug output")
 	return cmd
 }
 
@@ -101,8 +98,9 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	// execute remote viewer
 	go func() {
 		args := []string{fmt.Sprintf("vnc://127.0.0.1:%d", port)}
-		if debug {
+		if glog.V(4) {
 			args = append(args, "--debug")
+			glog.Infof("remote-viewer commandline: %v", args)
 		}
 
 		cmnd := exec.Command("remote-viewer", args...)
@@ -164,6 +162,6 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 
 func usage() string {
 	usage := "# Connect to testvm via remote-viewer:\n"
-	usage += "./virtctl vnc testvm [--debug]"
+	usage += "./virtctl vnc testvm"
 	return usage
 }

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -111,7 +111,6 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 			In:  pipeInReader,
 			Out: pipeOutWriter,
 		})
-		vnc.Done()
 	}()
 
 	// wait for remote-viewer to connect to our local proxy server

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -98,7 +98,6 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	port := ln.Addr().(*net.TCPAddr).Port
-	var cmnd *exec.Cmd
 
 	// setup connection with VM
 	go func() {
@@ -146,7 +145,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 			glog.Infof("remote-viewer commandline: %v", args)
 		}
 
-		cmnd = exec.Command("remote-viewer", args...)
+		cmnd := exec.Command("remote-viewer", args...)
 
 		output, err := cmnd.CombinedOutput()
 		if err != nil {
@@ -173,8 +172,6 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 	case err = <-viewResChan:
 	case err = <-listenResChan:
 	}
-
-	cmnd.Process.Kill() // avoid leak remote-viewer
 
 	if err != nil {
 		return fmt.Errorf("Error encountered: %s", err.Error())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1077,7 +1077,6 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vm *v1.VirtualMachine, t
 			resCh <- err
 			return
 		}
-		defer con.Done()
 
 		resCh <- con.Stream(kubecli.StreamOptions{
 			In:  vmReader,

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -68,7 +68,6 @@ var _ = Describe("VNC", func() {
 						k8ResChan <- err
 						return
 					}
-					defer vnc.Done()
 
 					k8ResChan <- vnc.Stream(kubecli.StreamOptions{
 						In:  pipeInReader,


### PR DESCRIPTION
Related to issue https://github.com/kubevirt/kubevirt/issues/905 ,
already partially addressed in commit ce3a3188

Make it easier to understand what's wrong running

  virtctl vnc $VM

Since virtctl uses remote-viewer under the hood, this patch improves
the usability in three ways:
1. add --debug flag and pass it to remote-viewer, to have more
   informations about what's going on
2. if the invokation of remote-viewer fails, relay the output.
   It was swallowed and dropped before this patch
3. avoid the command to hang if remote-viewer fails too early.