### PR TITLE
Pass labels from vm to pod to make service selectors work like expected

### DIFF
--- a/images/vm-killer/Dockerfile
+++ b/images/vm-killer/Dockerfile
@@ -21,5 +21,5 @@ FROM fedora:27
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 ENV container docker
 
-RUN dnf -y install procps-ng \
+RUN dnf -y install procps-ng nmap-ncat \
     && dnf -y clean all

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -199,16 +199,21 @@ func (t *templateService) RenderLaunchManifest(vm *v1.VirtualMachine) *kubev1.Po
 	}
 	nodeSelector[v1.NodeSchedulable] = "true"
 
+	podLabels := map[string]string{}
+
+	for k, v := range vm.Labels {
+		podLabels[k] = v
+	}
+	podLabels[v1.AppLabel] = "virt-launcher"
+	podLabels[v1.DomainLabel] = domain
+
 	containers = append(containers, container)
 
-	// TODO use constants for labels
+	// TODO use constants for podLabels
 	pod := kubev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "virt-launcher-" + domain + "-",
-			Labels: map[string]string{
-				v1.AppLabel:    "virt-launcher",
-				v1.DomainLabel: domain,
-			},
+			Labels:       podLabels,
 			Annotations: map[string]string{
 				v1.CreatedByAnnotation: string(vm.UID),
 				v1.OwnedByAnnotation:   "virt-controller",

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -113,6 +113,31 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Affinity).To(BeEquivalentTo(&kubev1.Affinity{NodeAffinity: &nodeAffinity}))
 			})
 
+			It("should add vm labels to pod", func() {
+				vm := v1.VirtualMachine{
+					ObjectMeta: metav1.ObjectMeta{Name: "testvm",
+						Namespace: "default",
+						UID:       "1234",
+						Labels: map[string]string{
+							"key1": "val1",
+							"key2": "val2",
+						},
+					},
+					Spec: v1.VirtualMachineSpec{
+						Domain: v1.DomainSpec{},
+					},
+				}
+				pod := svc.RenderLaunchManifest(&vm)
+				Expect(pod.Labels).To(Equal(
+					map[string]string{
+						"key1":         "val1",
+						"key2":         "val2",
+						v1.AppLabel:    "virt-launcher",
+						v1.DomainLabel: "testvm",
+					},
+				))
+			})
+
 			It("should not add empty node affinity to pod", func() {
 				vm := v1.VirtualMachine{
 					ObjectMeta: metav1.ObjectMeta{Name: "testvm", Namespace: "default", UID: "1234"},

--- a/tests/vm_networking_test.go
+++ b/tests/vm_networking_test.go
@@ -37,6 +37,8 @@ import (
 
 	"sync"
 
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
@@ -53,14 +55,43 @@ var _ = Describe("Networking", func() {
 	var inboundVM *v1.VirtualMachine
 	var outboundVM *v1.VirtualMachine
 
+	newHelloWorldJob := func(host string) *v12.Pod {
+		check := []string{fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s 1500 -i 1 -w 1))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host)}
+		job := tests.RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
+
+		return job
+	}
+
+	logPod := func(pod *v12.Pod) {
+		defer GinkgoRecover()
+
+		var s int64 = 500
+		logs := virtClient.CoreV1().Pods(inboundVM.Namespace).GetLogs(pod.Name, &v12.PodLogOptions{SinceSeconds: &s})
+		rawLogs, err := logs.DoRaw()
+		Expect(err).ToNot(HaveOccurred())
+		log.Log.Infof("%v", rawLogs)
+	}
+
+	waitForPodToFinish := func(pod *v12.Pod) v12.PodPhase {
+		Eventually(func() v12.PodPhase {
+			j, err := virtClient.Core().Pods(inboundVM.ObjectMeta.Namespace).Get(pod.ObjectMeta.Name, v13.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return j.Status.Phase
+		}, 30*time.Second, 1*time.Second).Should(Or(Equal(v12.PodSucceeded), Equal(v12.PodFailed)))
+		j, err := virtClient.Core().Pods(inboundVM.ObjectMeta.Namespace).Get(pod.ObjectMeta.Name, v13.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return j.Status.Phase
+	}
+
 	// TODO this is not optimal, since the one test which will initiate this, will look slow
 	tests.BeforeAll(func() {
 		tests.BeforeTestCleanup()
 
 		var wg sync.WaitGroup
 
-		createAndLogin := func() (vm *v1.VirtualMachine) {
+		createAndLogin := func(labels map[string]string) (vm *v1.VirtualMachine) {
 			vm = tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			vm.Labels = labels
 
 			// Start VM
 			vm, err = virtClient.VM(tests.NamespaceTestDefault).Create(vm)
@@ -83,15 +114,19 @@ var _ = Describe("Networking", func() {
 		go func() {
 			defer wg.Done()
 			defer GinkgoRecover()
-			inboundVM = createAndLogin()
+			inboundVM = createAndLogin(map[string]string{"expose": "me"})
 			expecter, _, err := tests.NewConsoleExpecter(virtClient, inboundVM, 10*time.Second)
 			defer expecter.Close()
 			Expect(err).ToNot(HaveOccurred())
-			_, err = expecter.ExpectBatch([]expect.Batcher{
+			resp, err := expecter.ExpectBatch([]expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$ "},
-				&expect.BSnd{S: "nc -klp 1500 -e echo -e \"Hello World!\"\n"},
+				&expect.BSnd{S: "screen -d -m nc -klp 1500 -e echo -e \"Hello World!\"\n"},
+				&expect.BExp{R: "\\$ "},
+				&expect.BSnd{S: "echo $?\n"},
+				&expect.BExp{R: "0"},
 			}, 60*time.Second)
+			log.DefaultLogger().Infof("%v", resp)
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
@@ -99,7 +134,7 @@ var _ = Describe("Networking", func() {
 		go func() {
 			defer wg.Done()
 			defer GinkgoRecover()
-			outboundVM = createAndLogin()
+			outboundVM = createAndLogin(nil)
 		}()
 
 		wg.Wait()
@@ -150,8 +185,7 @@ var _ = Describe("Networking", func() {
 			}
 
 			// Run netcat and give it one second to ghet "Hello World!" back from the VM
-			check := []string{fmt.Sprintf("while read x; do test \"$x\" = \"Hello World!\"; exit $?; done < <(nc %s 1500 -i 1 -w 1)", ip)}
-			job := tests.RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
+			job := newHelloWorldJob(ip)
 			job.Spec.Affinity = &v12.Affinity{
 				NodeAffinity: &v12.NodeAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &v12.NodeSelector{
@@ -169,20 +203,60 @@ var _ = Describe("Networking", func() {
 
 			job, err = virtClient.CoreV1().Pods(inboundVM.ObjectMeta.Namespace).Create(job)
 			Expect(err).ToNot(HaveOccurred())
-
-			Eventually(func() v12.PodPhase {
-				j, err := virtClient.Core().Pods(inboundVM.ObjectMeta.Namespace).Get(job.ObjectMeta.Name, v13.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(j.Status.Phase).ToNot(Equal(v12.PodFailed))
-				return j.Status.Phase
-			}, 30*time.Second, 1*time.Second).Should(Equal(v12.PodSucceeded))
-
+			phase := waitForPodToFinish(job)
+			logPod(job)
+			Expect(phase).To(Equal(v12.PodSucceeded))
 		},
 			table.Entry("on the same node from Pod", v12.NodeSelectorOpIn, false),
 			table.Entry("on a different node from Pod", v12.NodeSelectorOpNotIn, false),
 			table.Entry("on the same node from Node", v12.NodeSelectorOpIn, true),
 			table.Entry("on a different node from Node", v12.NodeSelectorOpNotIn, true),
 		)
+
+		Context("with a service matching the vm exposed", func() {
+			BeforeEach(func() {
+				service := &v12.Service{
+					ObjectMeta: v13.ObjectMeta{
+						Name: "myservice",
+					},
+					Spec: v12.ServiceSpec{
+						Selector: map[string]string{
+							"expose": "me",
+						},
+						Ports: []v12.ServicePort{
+							{Protocol: v12.ProtocolTCP, Port: 1500, TargetPort: intstr.FromInt(1500)},
+						},
+					},
+				}
+
+				_, err := virtClient.CoreV1().Services(inboundVM.Namespace).Create(service)
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+			It(" should be able to reach the vm based on labels specified on the vm", func() {
+
+				job := newHelloWorldJob(fmt.Sprintf("%s.%s", "myservice", inboundVM.Namespace))
+				job, err = virtClient.CoreV1().Pods(inboundVM.Namespace).Create(job)
+				Expect(err).ToNot(HaveOccurred())
+
+				phase := waitForPodToFinish(job)
+				logPod(job)
+				Expect(phase).To(Equal(v12.PodSucceeded))
+			})
+			It("should fail to reach the vm if an invalid servicename is used", func() {
+
+				job := newHelloWorldJob(fmt.Sprintf("%s.%s", "wrongservice", inboundVM.Namespace))
+				job, err = virtClient.CoreV1().Pods(inboundVM.Namespace).Create(job)
+				Expect(err).ToNot(HaveOccurred())
+				phase := waitForPodToFinish(job)
+				logPod(job)
+				Expect(phase).To(Equal(v12.PodFailed))
+			})
+
+			AfterEach(func() {
+				Expect(virtClient.CoreV1().Services(inboundVM.Namespace).Delete("myservice", &v13.DeleteOptions{})).To(Succeed())
+			})
+		})
 	})
 
 })


### PR DESCRIPTION

* Pass vm labels to pods, so that services, network policies and others can rely on vm labels, like they can on pod labels
* Add tests to verify that a service can really select a vm by its label and route the traffic properly
* As a side-effect fix netcat  based network tests which were broken (they always succeeded, no matter what happend)