### PR TITLE
Speedup build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	hack/dockerized "./hack/check.sh && ./hack/build-go.sh install ${WHAT}"
 
 goveralls:
-	hack/dockerized "./hack/check.sh && ./hack/build-go.sh install && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "./hack/check.sh && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
 
 test:
 	SYNC_OUT=false hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ goveralls:
 	hack/dockerized "./hack/check.sh && ./hack/build-go.sh install && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
 
 test:
-	hack/dockerized "./hack/check.sh && ./hack/build-go.sh install ${WHAT} && ./hack/build-go.sh test ${WHAT}"
+	hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"
 
 functest:
 	hack/dockerized "hack/build-func-tests.sh"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ goveralls:
 	hack/dockerized "./hack/check.sh && ./hack/build-go.sh install && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
 
 test:
-	hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"
+	SYNC_OUT=false hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"
 
 functest:
 	hack/dockerized "hack/build-func-tests.sh"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3459,9 +3459,6 @@
     }
    },
    "v1.FeatureVendorID": {
-    "required": [
-     "vendorid"
-    ],
     "properties": {
      "enabled": {
       "description": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -5,7 +5,7 @@ ENV LIBVIRT_VERSION 3.7.0
 RUN dnf -y install libvirt-devel-${LIBVIRT_VERSION} make git mercurial sudo gcc findutils gradle rsync-daemon rsync qemu-img && \
     dnf -y clean all
 
-ENV GIMME_GO_VERSION=1.9.2
+ENV GIMME_GO_VERSION=1.10
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -5,6 +5,8 @@ source $(dirname "$0")/common.sh
 
 DOCKER_DIR=${KUBEVIRT_DIR}/hack/docker-builder
 
+SYNC_OUT=${SYNC_OUT:-true}
+
 BUILDER=${job_prefix}
 
 SYNC_VENDOR=${SYNC_VENDOR:-false}
@@ -26,8 +28,8 @@ docker run -v "${BUILDER}:/root:rw,z" --rm ${BUILDER} mkdir -p /root/go/src/kube
 RSYNC_CID=$(docker run -d -v "${BUILDER}:/root:rw,z" --expose 873 -P ${BUILDER} /usr/bin/rsync --no-detach --daemon --verbose)
 
 function finish() {
-    docker stop ${RSYNC_CID}
-    docker rm -f ${RSYNC_CID}
+    docker stop ${RSYNC_CID} >/dev/null 2>&1 &
+    docker rm -f ${RSYNC_CID} >/dev/null 2>&1 &
 }
 trap finish EXIT
 
@@ -74,4 +76,6 @@ if [ "$SYNC_VENDOR" = "true" ]; then
     _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/vendor" "${VENDOR_DIR}/"
 fi
 # Copy the build output out of the container, make sure that _out exactly matches the build result
-_rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/out" ${OUT_DIR}
+if [ "$SYNC_OUT" = "true" ]; then
+    _rsync --delete "rsync://root@127.0.0.1:${RSYNCD_PORT}/out" ${OUT_DIR}
+fi

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -506,7 +506,7 @@ type FeatureVendorID struct {
 	Enabled *bool `json:"enabled,omitempty"`
 	// VendorID sets the hypervisor vendor id, visible to the vm
 	// String up to twelve characters
-	VendorID string `json:"vendorid, omitempty"`
+	VendorID string `json:"vendorid,omitempty"`
 }
 
 // Hyperv specific features

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -29,38 +29,6 @@ import (
 
 var _ = Describe("PodSelectors", func() {
 	Context("Pod affinity rules", func() {
-		var (
-			pod      = &v1.Pod{}
-			affinity = &v1.Affinity{}
-		)
-
-		BeforeEach(func() {
-			pod = &v1.Pod{
-				Spec: v1.PodSpec{
-					NodeName: "testnode",
-				},
-			}
-			affinity = &v1.Affinity{
-				NodeAffinity: &v1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-						NodeSelectorTerms: []v1.NodeSelectorTerm{
-							{
-								MatchExpressions: []v1.NodeSelectorRequirement{
-									{
-										Key:      "kubernetes.io/hostname",
-										Operator: v1.NodeSelectorOpNotIn,
-										Values:   []string{pod.Spec.NodeName},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-		})
-
-		AfterEach(func() {
-		})
 
 		It("should work", func() {
 			vm := NewMinimalVM("testvm")

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -58,7 +58,6 @@ var _ = Describe("VM", func() {
 	var vmInformer cache.SharedIndexInformer
 	var domainSource *framework.FakeControllerSource
 	var domainInformer cache.SharedIndexInformer
-	var gracefulShutdownSource *framework.FakeControllerSource
 	var gracefulShutdownInformer cache.SharedIndexInformer
 	var mockQueue *testutils.MockWorkQueue
 	var mockWatchdog *MockWatchdog
@@ -86,7 +85,7 @@ var _ = Describe("VM", func() {
 
 		vmInformer, vmSource = testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 		domainInformer, domainSource = testutils.NewFakeInformerFor(&api.Domain{})
-		gracefulShutdownInformer, gracefulShutdownSource = testutils.NewFakeInformerFor(&api.Domain{})
+		gracefulShutdownInformer, _ = testutils.NewFakeInformerFor(&api.Domain{})
 		recorder = record.NewFakeRecorder(100)
 
 		ctrl = gomock.NewController(GinkgoT())

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -48,13 +48,11 @@ var _ = Describe("Domain notify", func() {
 	var deleteNotificationSent chan watch.Event
 	var client *DomainEventClient
 
-	var mockConn *cli.MockConnection
 	var mockDomain *cli.MockVirDomain
 	var ctrl *gomock.Controller
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		mockConn = cli.NewMockConnection(ctrl)
 		mockDomain = cli.NewMockVirDomain(ctrl)
 
 		stop = make(chan struct{})


### PR DESCRIPTION
## build: golang 1.9.3 with docker

```bash
$ time make build
real	1m20.810s
user	0m0.652s
sys	0m0.335s
```
## build: golang 1.10 with docker

```bash
$ time make build
real	0m36.273s
user	0m0.610s
sys	0m0.353s
```

## build: golang 1.10 with docker + don't wait for rsyncd to terminate

```bash
$ time make build
real	0m26.492s
user	0m1.141s
sys	0m0.397s
```

## build: golang 1.10 without docker

```bash
$ time (./hack/check.sh && ./hack/build-go.sh install)
real	0m22.465s
user	0m33.317s
sys	0m4.898s
```

## tests: golang 1.10 check + build (go install build binaries which are not needed for unit tests) + test with docker

```bash
$ time make test
real	0m49.102s
user	0m1.194s
sys	0m0.437s
```

## tests: golang 1.10 check + test in docker (no go install)

```bash
$ time make test
real	0m19.583s
user	0m0.108s
sys	0m0.086s
```

## tests: golang 1.10 check + test without docker (no go install)

```bash
$ time (./hack/check.sh && ./hack/build-go.sh test)
real	0m6.139s
user	0m17.668s
sys	0m2.096s
```

## tests: golang  1.10 check + test with docker (no go install) + don't wait for rsync daemon to be stopped

```bash
$ time make test
real	0m9.888s
user	0m0.084s
sys	0m0.096s
```

## build: golang 1.10 with docker, only build virtcl for my platform

```bash
$ time make build
real	0m31.704s
user	0m0.909s
sys	0m0.330s
```

Not much difference, but it made a huge difference for golang 1.9.3

## Summary

I prepared a PR, which moves to golang 1.10 and does not run "go install" whe you do "make test" to run the unit tests and does not wait for rsyncd to be stopped. We still build virtctl with all client versions, the difference is not significant anymore with golang 1.10

The results for me are: "make build" is about 70% faster on my system, "make test" is about. When already switched to golang 1.10 and not running "go install" during "make test", the test run was about 60% faster compared to just switching to golang 1.10. Finally, our rsync daemon is bound to random ports, so we don't necessarily have to wait for it to be stopped. That improves the speed again. It cuts again 50% when taking all the other optimizations as a starting point.

Fixes #924 

@yuvalif @nertpinx FYI