### PR TITLE
makefile-clean: remove all tools binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ functest:
 	hack/functests.sh
 
 clean:
-	hack/dockerized "./hack/build-go.sh clean ${WHAT} && rm _out/* -rf && rm tools/openapispec/openapispec -rf"
-	rm tools/openapispec/openapispec -rf
+	hack/dockerized "./hack/build-go.sh clean ${WHAT} && rm _out/* -rf"
+	rm -f tools/openapispec/openapispec tools/crd-generator/crd-generator tools/manifest-templator/manifests-templator tools/vms-generator/vms-generator
 
 distclean: clean
 	hack/dockerized "rm -rf vendor/ && rm -f .glide.*.hash && glide cc"


### PR DESCRIPTION
clean target is removing tools/openapispec/openapispec binary twice,
but leave other tools binaries there.

This commit removes openapispec binary only once and remove also other
tools binaries.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>