### PR TITLE
Pod eviction functional tests

### DIFF
--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -494,14 +494,19 @@ var _ = Describe("OfflineVirtualMachine", func() {
 // NewRandomOfflineVirtualMachine creates new OfflineVirtualMachine
 func NewRandomOfflineVirtualMachine(vm *v1.VirtualMachine, running bool) *v1.OfflineVirtualMachine {
 	name := vm.Name
+	namespace := vm.Namespace
 	ovm := &v1.OfflineVirtualMachine{
-		ObjectMeta: v12.ObjectMeta{Name: name},
+		ObjectMeta: v12.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
 		Spec: v1.OfflineVirtualMachineSpec{
 			Running: running,
 			Template: &v1.VMTemplateSpec{
 				ObjectMeta: v12.ObjectMeta{
-					Labels: map[string]string{"name": name},
-					Name:   vm.ObjectMeta.Name,
+					Labels:    map[string]string{"name": name},
+					Name:      name,
+					Namespace: namespace,
 				},
 				Spec: vm.Spec,
 			},

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -270,18 +270,19 @@ var _ = Describe("OfflineVirtualMachine", func() {
 
 			// wait for a running VM.
 			By("Waiting for the OVM's VM to start")
-			Eventually(func() bool {
+			Eventually(func() error {
 				firstVM, err = virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				}
 				if !firstVM.IsRunning() {
-					return false
+					return fmt.Errorf("vm still isn't running")
 				}
-				return true
-			}, 120*time.Second, 1*time.Second).Should(BeTrue())
+				return nil
+			}, 120*time.Second, 1*time.Second).Should(Succeed())
 
 			// get the pod backing the VM
+			By("Getting the pod backing the VM")
 			pods, err := virtClient.CoreV1().Pods(newOVM.Namespace).List(tests.UnfinishedVMPodSelector(firstVM))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods.Items)).To(Equal(1))

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -494,15 +494,15 @@ var _ = Describe("Vmlifecycle", func() {
 
 			// Wait for VM to finalize
 			By("Waiting for the VM to move to a finalized state")
-			Eventually(func() bool {
+			Eventually(func() error {
 				curVm, err := virtClient.VM(vm.Namespace).Get(vm.Name, metav1.GetOptions{})
 				if err != nil {
-					return false
+					return err
 				} else if !curVm.IsFinal() {
-					return false
+					return fmt.Errorf("VM has not reached a finalized state yet")
 				}
-				return true
-			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+				return nil
+			}, 60*time.Second, 1*time.Second).Should(Succeed())
 			close(done)
 		}, 90)
 	})

--- a/tests/vmlifecycle_test.go
+++ b/tests/vmlifecycle_test.go
@@ -473,6 +473,39 @@ var _ = Describe("Vmlifecycle", func() {
 		})
 	})
 
+	Describe("Delete a VM's Pod", func() {
+		It("should result in the VM moving to a finalized state", func(done Done) {
+			By("Creating the VM")
+			obj, err := virtClient.VM(tests.NamespaceTestDefault).Create(vm)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMStart(obj)
+
+			By("Verifying VM's pod is active")
+			pods, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(tests.UnfinishedVMPodSelector(vm))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(pods.Items)).To(Equal(1))
+			pod := pods.Items[0]
+
+			// Delete the Pod
+			By("Deleting the VM's pod")
+			Eventually(func() error {
+				return virtClient.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
+			}, 10*time.Second, 1*time.Second).Should(Succeed())
+
+			// Wait for VM to finalize
+			By("Waiting for the VM to move to a finalized state")
+			Eventually(func() bool {
+				curVm, err := virtClient.VM(vm.Namespace).Get(vm.Name, metav1.GetOptions{})
+				if err != nil {
+					return false
+				} else if !curVm.IsFinal() {
+					return false
+				}
+				return true
+			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+			close(done)
+		}, 90)
+	})
 	Describe("Delete a VM", func() {
 		Context("with an active pod.", func() {
 			It("should result in pod being terminated", func(done Done) {


### PR DESCRIPTION
These tests verify OVM and VM behavior when the pods are terminated outside of our controllers. A common situation where this occurs is during the process of draining a node for deletion. 

The expected behavior is...
- OVMs with 'running=true' should result in a new VM being scheduled.
- VMs not owned by a OVM or VMRS should move to a finalized state.

related to: https://github.com/kubevirt/user-guide/pull/56