### PR TITLE
Fix inconsistent unit test

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -305,7 +305,7 @@ var _ = Describe("VM", func() {
 			vmInterface.EXPECT().Update(gomock.Any()).Do(func(vm *v1.VirtualMachine) {
 				Expect(vm.Status.Phase).To(Equal(v1.Failed))
 			})
-			time.Sleep(1500 * time.Millisecond)
+			time.Sleep(2 * time.Second)
 			controller.Execute()
 		}, 2)
 


### PR DESCRIPTION
The watchdog expired unit test requires the access time of a file to be > a 1 second timeout. We were waiting 1.5 seconds, which is > that 1 second, however the actual resolution of the file's access time is counted in seconds, not milliseconds. 

So, there is around a 50/50 chance the unit test will fail because the watchdog file will not be detected as expired. To fix this, we just wait a full second over the expire time. 

This PR also addresses a check for the watchdog file in the VM update function. The check implied that the update function needed to wait for the watchdog file to appear. This is not the case. The watchdog file should always be present for a VM before it is scheduled to a local node for virt-handler to process. This is because the watchdog file creation is condition that has to be met before virt-launcher will mark the VM's pod as ready.

I re-wrote the check to better represent the intent. The VM shouldn't be updated if the watchdog is expired, which includes a missing watchdog file as well as an expired one. 