### PR TITLE
Support UI validation by adding "causes" list to webhook response

### DIFF
--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -144,7 +144,7 @@ func validateDisks(fieldPrefix string, disks []v1.Disk) []metav1.StatusCause {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: fmt.Sprintf("%s[%d] and %sdisks[%d] must not have the same Name.", fieldPrefix, idx, fieldPrefix, otherIdx),
-				Field:   fmt.Sprintf("%s[%d]", fieldPrefix, idx),
+				Field:   fmt.Sprintf("%s[%d].name", fieldPrefix, idx),
 			})
 		}
 		// Verify only a single device type is set.
@@ -198,7 +198,7 @@ func validateVolumes(fieldPrefix string, volumes []v1.Volume) []metav1.StatusCau
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: fmt.Sprintf("%s[%d] and %s[%d] must not have the same Name.", fieldPrefix, idx, fieldPrefix, otherIdx),
-				Field:   fmt.Sprintf("%s[%d]", fieldPrefix, idx),
+				Field:   fmt.Sprintf("%s[%d].name", fieldPrefix, idx),
 			})
 		}
 

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -121,15 +121,15 @@ func serve(resp http.ResponseWriter, req *http.Request, admit admitFunc) {
 	resp.WriteHeader(http.StatusOK)
 }
 
-func validateDisks(disks []v1.Disk) []metav1.StatusCause {
+func validateDisks(fieldPrefix string, disks []v1.Disk) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	nameMap := make(map[string]int)
 
 	if len(disks) > arrayLenMax {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("spec.domain.devices.disks list exceeds the %d element limit in length", arrayLenMax),
-			Field:   "spec.domain.devices.disks",
+			Message: fmt.Sprintf("%s list exceeds the %d element limit in length", fieldPrefix, arrayLenMax),
+			Field:   fmt.Sprintf("%s", fieldPrefix),
 		})
 		// We won't process anything over the limit
 		return causes
@@ -143,8 +143,8 @@ func validateDisks(disks []v1.Disk) []metav1.StatusCause {
 		} else {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.domain.devices.disks[%d] and spec.domain.devices.disks[%d] must not have the same Name.", idx, otherIdx),
-				Field:   fmt.Sprintf("spec.domain.devices.disks[%d]", idx),
+				Message: fmt.Sprintf("%s[%d] and %sdisks[%d] must not have the same Name.", fieldPrefix, idx, fieldPrefix, otherIdx),
+				Field:   fmt.Sprintf("%s[%d]", fieldPrefix, idx),
 			})
 		}
 		// Verify only a single device type is set.
@@ -167,25 +167,24 @@ func validateDisks(disks []v1.Disk) []metav1.StatusCause {
 		if deviceTargetSetCount > 1 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.domain.devices.disks[%d] can only have a single target type defined", idx),
-				Field:   fmt.Sprintf("spec.domain.devices.disks[%d]", idx),
+				Message: fmt.Sprintf("%s[%d] can only have a single target type defined", fieldPrefix, idx),
+				Field:   fmt.Sprintf("%s[%d]", fieldPrefix, idx),
 			})
 		}
-
 	}
 
 	return causes
 }
 
-func validateVolumes(volumes []v1.Volume) []metav1.StatusCause {
+func validateVolumes(fieldPrefix string, volumes []v1.Volume) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	nameMap := make(map[string]int)
 
 	if len(volumes) > arrayLenMax {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("spec.volumes list exceeds the %d element limit in length", arrayLenMax),
-			Field:   "spec.volumes",
+			Message: fmt.Sprintf("%s list exceeds the %d element limit in length", fieldPrefix, arrayLenMax),
+			Field:   fmt.Sprintf("%s", fieldPrefix),
 		})
 		// We won't process anything over the limit
 		return causes
@@ -198,8 +197,8 @@ func validateVolumes(volumes []v1.Volume) []metav1.StatusCause {
 		} else {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.volumes[%d] and spec.volumes[%d] must not have the same Name.", idx, otherIdx),
-				Field:   fmt.Sprintf("spec.volumes[%d]", idx),
+				Message: fmt.Sprintf("%s[%d] and %s[%d] must not have the same Name.", fieldPrefix, idx, fieldPrefix, otherIdx),
+				Field:   fmt.Sprintf("%s[%d]", fieldPrefix, idx),
 			})
 		}
 
@@ -224,8 +223,8 @@ func validateVolumes(volumes []v1.Volume) []metav1.StatusCause {
 		if volumeSourceSetCount != 1 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.volumes[%d] must have exactly one source type set", idx),
-				Field:   fmt.Sprintf("spec.volumes[%d]", idx),
+				Message: fmt.Sprintf("%s[%d] must have exactly one source type set", fieldPrefix, idx),
+				Field:   fmt.Sprintf("%s[%d]", fieldPrefix, idx),
 			})
 		}
 
@@ -244,8 +243,8 @@ func validateVolumes(volumes []v1.Volume) []metav1.StatusCause {
 				if err != nil {
 					causes = append(causes, metav1.StatusCause{
 						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("spec.volumes[%d].cloudInitNoCloud.userDataBase64 is not a valid base64 value.", idx),
-						Field:   fmt.Sprintf("spec.volumes[%d].cloudInitNoCloud.userDataBase64", idx),
+						Message: fmt.Sprintf("%s[%d].cloudInitNoCloud.userDataBase64 is not a valid base64 value.", fieldPrefix, idx),
+						Field:   fmt.Sprintf("%s[%d].cloudInitNoCloud.userDataBase64", fieldPrefix, idx),
 					})
 				}
 				userDataLen = len(userData)
@@ -258,16 +257,16 @@ func validateVolumes(volumes []v1.Volume) []metav1.StatusCause {
 			if userDataSourceCount != 1 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("spec.volumes[%d].cloudInitNoCloud must have one exactly one userdata source set.", idx),
-					Field:   fmt.Sprintf("spec.volumes[%d].cloudInitNoCloud", idx),
+					Message: fmt.Sprintf("%s[%d].cloudInitNoCloud must have one exactly one userdata source set.", fieldPrefix, idx),
+					Field:   fmt.Sprintf("%s[%d].cloudInitNoCloud", fieldPrefix, idx),
 				})
 			}
 
 			if userDataLen > cloudInitMaxLen {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("spec.volumes[%d].cloudInitNoCloud userdata exceeds %d byte limit", idx, cloudInitMaxLen),
-					Field:   fmt.Sprintf("spec.volumes[%d].cloudInitNoCloud", idx),
+					Message: fmt.Sprintf("%s[%d].cloudInitNoCloud userdata exceeds %d byte limit", fieldPrefix, idx, cloudInitMaxLen),
+					Field:   fmt.Sprintf("%s[%d].cloudInitNoCloud", fieldPrefix, idx),
 				})
 			}
 		}
@@ -275,19 +274,19 @@ func validateVolumes(volumes []v1.Volume) []metav1.StatusCause {
 	return causes
 }
 
-func validateDevices(devices *v1.Devices) []metav1.StatusCause {
+func validateDevices(fieldPrefix string, devices *v1.Devices) []metav1.StatusCause {
 	var causes []metav1.StatusCause
-	causes = append(causes, validateDisks(devices.Disks)...)
+	causes = append(causes, validateDisks(fmt.Sprintf("%sdisks", fieldPrefix), devices.Disks)...)
 	return causes
 }
 
-func validateDomainSpec(spec *v1.DomainSpec) []metav1.StatusCause {
+func validateDomainSpec(fieldPrefix string, spec *v1.DomainSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
-	causes = append(causes, validateDevices(&spec.Devices)...)
+	causes = append(causes, validateDevices(fmt.Sprintf("%sdevices.", fieldPrefix), &spec.Devices)...)
 	return causes
 }
 
-func validateVirtualMachineSpec(spec *v1.VirtualMachineSpec) []metav1.StatusCause {
+func validateVirtualMachineSpec(fieldPrefix string, spec *v1.VirtualMachineSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	volumeToDiskIndexMap := make(map[string]int)
 	volumeNameMap := make(map[string]*v1.Volume)
@@ -295,16 +294,16 @@ func validateVirtualMachineSpec(spec *v1.VirtualMachineSpec) []metav1.StatusCaus
 	if len(spec.Domain.Devices.Disks) > arrayLenMax {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("spec.domain.devices.disks list exceeds the %d element limit in length", arrayLenMax),
-			Field:   "spec.domain.devices.disks",
+			Message: fmt.Sprintf("%sdomain.devices.disks list exceeds the %d element limit in length", fieldPrefix, arrayLenMax),
+			Field:   fmt.Sprintf("%sdomain.devices.disks", fieldPrefix),
 		})
 		// We won't process anything over the limit
 		return causes
 	} else if len(spec.Volumes) > arrayLenMax {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("spec.volumes list exceeds the %d element limit in length", arrayLenMax),
-			Field:   "spec.volumes",
+			Message: fmt.Sprintf("%svolumes list exceeds the %d element limit in length", fieldPrefix, arrayLenMax),
+			Field:   fmt.Sprintf("%svolumes", fieldPrefix),
 		})
 		// We won't process anything over the limit
 		return causes
@@ -323,8 +322,8 @@ func validateVirtualMachineSpec(spec *v1.VirtualMachineSpec) []metav1.StatusCaus
 		if !volumeExists {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.domain.devices.disks[%d].volumeName '%s' not found.", idx, disk.VolumeName),
-				Field:   fmt.Sprintf("spec.domain.devices.disks[%d].volumeName", idx),
+				Message: fmt.Sprintf("%sdomain.devices.disks[%d].volumeName '%s' not found.", fieldPrefix, idx, disk.VolumeName),
+				Field:   fmt.Sprintf("%sdomain.devices.disks[%d].volumeName", fieldPrefix, idx),
 			})
 		}
 
@@ -335,8 +334,8 @@ func validateVirtualMachineSpec(spec *v1.VirtualMachineSpec) []metav1.StatusCaus
 		} else {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.domain.devices.disks[%d] and spec.domain.devices.disks[%d] reference the same volumeName.", idx, otherIdx),
-				Field:   fmt.Sprintf("spec.domain.devices.disks[%d].volumeName", idx),
+				Message: fmt.Sprintf("%sdomain.devices.disks[%d] and %sdomain.devices.disks[%d] reference the same volumeName.", fieldPrefix, idx, fieldPrefix, otherIdx),
+				Field:   fmt.Sprintf("%sdomain.devices.disks[%d].volumeName", fieldPrefix, idx),
 			})
 		}
 
@@ -344,58 +343,59 @@ func validateVirtualMachineSpec(spec *v1.VirtualMachineSpec) []metav1.StatusCaus
 		if disk.LUN != nil && volumeExists && matchingVolume.PersistentVolumeClaim == nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("spec.domain.devices.disks[%d].lun can only be mapped to a PersistentVolumeClaim volume.", idx),
-				Field:   fmt.Sprintf("spec.domain.devices.disks[%d].lun", idx),
+				Message: fmt.Sprintf("%sdomain.devices.disks[%d].lun can only be mapped to a PersistentVolumeClaim volume.", fieldPrefix, idx),
+				Field:   fmt.Sprintf("%sdomain.devices.disks[%d].lun", fieldPrefix, idx),
 			})
 		}
 	}
 
-	causes = append(causes, validateDomainSpec(&spec.Domain)...)
-	causes = append(causes, validateVolumes(spec.Volumes)...)
+	causes = append(causes, validateDomainSpec(fmt.Sprintf("%sdomain.", fieldPrefix), &spec.Domain)...)
+	causes = append(causes, validateVolumes(fmt.Sprintf("%svolumes", fieldPrefix), spec.Volumes)...)
 	return causes
 }
 
-func validateOfflineVirtualMachineSpec(spec *v1.OfflineVirtualMachineSpec) []metav1.StatusCause {
+func validateOfflineVirtualMachineSpec(fieldPrefix string, spec *v1.OfflineVirtualMachineSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	if spec.Template == nil {
 		return append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueRequired,
 			Message: fmt.Sprintf("missing virtual machine template."),
-			Field:   "spec.template",
+			Field:   fmt.Sprintf("%stemplate", fieldPrefix),
 		})
 	}
 
-	causes = append(causes, validateVirtualMachineSpec(&spec.Template.Spec)...)
+	causes = append(causes, validateVirtualMachineSpec(fmt.Sprintf("%stemplate.spec.", fieldPrefix), &spec.Template.Spec)...)
 	return causes
 }
 
-func validateVMPresetSpec(spec *v1.VirtualMachinePresetSpec) []metav1.StatusCause {
+func validateVMPresetSpec(fieldPrefix string, spec *v1.VirtualMachinePresetSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	if spec.Domain == nil {
 		return append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueRequired,
 			Message: fmt.Sprintf("missing domain."),
-			Field:   "spec.domain",
+			Field:   fmt.Sprintf("%sdomain", fieldPrefix),
 		})
 	}
 
-	causes = append(causes, validateDomainSpec(spec.Domain)...)
+	causes = append(causes, validateDomainSpec(fmt.Sprintf("%sdomain.", fieldPrefix), spec.Domain)...)
 	return causes
 }
-func validateVMRSSpec(spec *v1.VMReplicaSetSpec) []metav1.StatusCause {
+
+func validateVMRSSpec(fieldPrefix string, spec *v1.VMReplicaSetSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
 	if spec.Template == nil {
 		return append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueRequired,
 			Message: fmt.Sprintf("missing virtual machine template."),
-			Field:   "spec.template",
+			Field:   fmt.Sprintf("%stemplate.", fieldPrefix),
 		})
 	}
 
-	causes = append(causes, validateVirtualMachineSpec(&spec.Template.Spec)...)
+	causes = append(causes, validateVirtualMachineSpec(fmt.Sprintf("%stemplate.spec.", fieldPrefix), &spec.Template.Spec)...)
 	return causes
 }
 
@@ -418,7 +418,7 @@ func admitVMs(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 		return toAdmissionResponseError(err)
 	}
 
-	causes := validateVirtualMachineSpec(&vm.Spec)
+	causes := validateVirtualMachineSpec("spec.", &vm.Spec)
 	if len(causes) > 0 {
 		return toAdmissionResponse(causes)
 	}
@@ -451,7 +451,7 @@ func admitOVMs(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 		return toAdmissionResponseError(err)
 	}
 
-	causes := validateOfflineVirtualMachineSpec(&ovm.Spec)
+	causes := validateOfflineVirtualMachineSpec("spec.", &ovm.Spec)
 	if len(causes) > 0 {
 		return toAdmissionResponse(causes)
 	}
@@ -484,7 +484,7 @@ func admitVMRS(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 		return toAdmissionResponseError(err)
 	}
 
-	causes := validateVMRSSpec(&vmrs.Spec)
+	causes := validateVMRSSpec("spec.", &vmrs.Spec)
 	if len(causes) > 0 {
 		return toAdmissionResponse(causes)
 	}
@@ -516,7 +516,7 @@ func admitVMPreset(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 		return toAdmissionResponseError(err)
 	}
 
-	causes := validateVMPresetSpec(&vmpreset.Spec)
+	causes := validateVMPresetSpec("spec.", &vmpreset.Spec)
 	if len(causes) > 0 {
 		return toAdmissionResponse(causes)
 	}

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Validating Webhook", func() {
 				})
 			}
 
-			causes := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 			Expect(len(causes)).To(Equal(0))
 		})
 		It("should reject disk lists greater than max element length", func() {
@@ -327,7 +327,7 @@ var _ = Describe("Validating Webhook", func() {
 				})
 			}
 
-			causes := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 			// if this is processed correctly, it should result in a single error
 			// If multiple causes occurred, then the spec was processed too far.
 			Expect(len(causes)).To(Equal(1))
@@ -345,7 +345,7 @@ var _ = Describe("Validating Webhook", func() {
 				})
 			}
 
-			causes := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 			// if this is processed correctly, it should result in a single error
 			// If multiple causes occurred, then the spec was processed too far.
 			Expect(len(causes)).To(Equal(1))
@@ -359,7 +359,7 @@ var _ = Describe("Validating Webhook", func() {
 				VolumeName: "testvolume",
 			})
 
-			causes := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject multiple disks referencing same volume", func() {
@@ -381,7 +381,7 @@ var _ = Describe("Validating Webhook", func() {
 					RegistryDisk: &v1.RegistryDiskSource{},
 				},
 			})
-			causes := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 			Expect(len(causes)).To(Equal(1))
 		})
 		It("should generate multiple causes", func() {
@@ -396,7 +396,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			causes := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 			// missing volume and multiple targets set. should result in 2 causes
 			Expect(len(causes)).To(Equal(2))
 		})
@@ -412,7 +412,7 @@ var _ = Describe("Validating Webhook", func() {
 				})
 				vm.Spec.Volumes = append(vm.Spec.Volumes, *volume)
 
-				causes := validateVirtualMachineSpec(&vm.Spec)
+				causes := validateVirtualMachineSpec("fake.", &vm.Spec)
 				Expect(len(causes)).To(Equal(expectedErrors))
 			},
 			table.Entry("and reject non PVC sources",
@@ -441,7 +441,7 @@ var _ = Describe("Validating Webhook", func() {
 					VolumeSource: volumeSource,
 				})
 
-				causes := validateVolumes(vm.Spec.Volumes)
+				causes := validateVolumes("fake.", vm.Spec.Volumes)
 				Expect(len(causes)).To(Equal(0))
 			},
 			table.Entry("with pvc volume source", v1.VolumeSource{PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{}}),
@@ -457,7 +457,7 @@ var _ = Describe("Validating Webhook", func() {
 				Name: "testvolume",
 			})
 
-			causes := validateVolumes(vm.Spec.Volumes)
+			causes := validateVolumes("fake.", vm.Spec.Volumes)
 			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject volume with multiple volume sources set", func() {
@@ -471,7 +471,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			causes := validateVolumes(vm.Spec.Volumes)
+			causes := validateVolumes("fake.", vm.Spec.Volumes)
 			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject volumes with duplicate names", func() {
@@ -490,7 +490,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			causes := validateVolumes(vm.Spec.Volumes)
+			causes := validateVolumes("fake.", vm.Spec.Volumes)
 			Expect(len(causes)).To(Equal(1))
 		})
 		table.DescribeTable("should verify cloud-init userdata length", func(userDataLen int, expectedErrors int, base64Encode bool) {
@@ -510,7 +510,7 @@ var _ = Describe("Validating Webhook", func() {
 				vm.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.UserData = userdata
 			}
 
-			causes := validateVolumes(vm.Spec.Volumes)
+			causes := validateVolumes("fake.", vm.Spec.Volumes)
 			Expect(len(causes)).To(Equal(expectedErrors))
 		},
 			table.Entry("should accept userdata under max limit", 10, 0, false),
@@ -532,7 +532,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			causes := validateVolumes(vm.Spec.Volumes)
+			causes := validateVolumes("fake.", vm.Spec.Volumes)
 			Expect(len(causes)).To(Equal(1))
 		})
 	})
@@ -543,7 +543,7 @@ var _ = Describe("Validating Webhook", func() {
 
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, disk)
 
-				causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+				causes := validateDisks("fake.", vm.Spec.Domain.Devices.Disks)
 				Expect(len(causes)).To(Equal(0))
 
 			},
@@ -575,7 +575,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+			causes := validateDisks("fake.", vm.Spec.Domain.Devices.Disks)
 			Expect(len(causes)).To(Equal(0))
 		})
 		It("should reject disks with duplicate names ", func() {
@@ -595,7 +595,7 @@ var _ = Describe("Validating Webhook", func() {
 					Disk: &v1.DiskTarget{},
 				},
 			})
-			causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+			causes := validateDisks("fake.", vm.Spec.Domain.Devices.Disks)
 			Expect(len(causes)).To(Equal(1))
 		})
 
@@ -617,7 +617,7 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+			causes := validateDisks("fake.", vm.Spec.Domain.Devices.Disks)
 			Expect(len(causes)).To(Equal(1))
 		})
 	})

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -312,8 +312,8 @@ var _ = Describe("Validating Webhook", func() {
 				})
 			}
 
-			errors := validateVirtualMachineSpec(&vm.Spec)
-			Expect(len(errors)).To(Equal(0))
+			causes := validateVirtualMachineSpec(&vm.Spec)
+			Expect(len(causes)).To(Equal(0))
 		})
 		It("should reject disk lists greater than max element length", func() {
 			vm := v1.NewMinimalVM("testvm")
@@ -327,10 +327,10 @@ var _ = Describe("Validating Webhook", func() {
 				})
 			}
 
-			errors := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec(&vm.Spec)
 			// if this is processed correctly, it should result in a single error
-			// If multiple errors occurred, then the spec was processed too far.
-			Expect(len(errors)).To(Equal(1))
+			// If multiple causes occurred, then the spec was processed too far.
+			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject volume lists greater than max element length", func() {
 			vm := v1.NewMinimalVM("testvm")
@@ -345,10 +345,10 @@ var _ = Describe("Validating Webhook", func() {
 				})
 			}
 
-			errors := validateVirtualMachineSpec(&vm.Spec)
+			causes := validateVirtualMachineSpec(&vm.Spec)
 			// if this is processed correctly, it should result in a single error
-			// If multiple errors occurred, then the spec was processed too far.
-			Expect(len(errors)).To(Equal(1))
+			// If multiple causes occurred, then the spec was processed too far.
+			Expect(len(causes)).To(Equal(1))
 		})
 
 		It("should reject disk with missing volume", func() {
@@ -359,8 +359,8 @@ var _ = Describe("Validating Webhook", func() {
 				VolumeName: "testvolume",
 			})
 
-			errors := validateVirtualMachineSpec(&vm.Spec)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateVirtualMachineSpec(&vm.Spec)
+			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject multiple disks referencing same volume", func() {
 			vm := v1.NewMinimalVM("testvm")
@@ -381,10 +381,10 @@ var _ = Describe("Validating Webhook", func() {
 					RegistryDisk: &v1.RegistryDiskSource{},
 				},
 			})
-			errors := validateVirtualMachineSpec(&vm.Spec)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateVirtualMachineSpec(&vm.Spec)
+			Expect(len(causes)).To(Equal(1))
 		})
-		It("should generate multiple errors", func() {
+		It("should generate multiple causes", func() {
 			vm := v1.NewMinimalVM("testvm")
 
 			vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, v1.Disk{
@@ -396,9 +396,9 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			errors := validateVirtualMachineSpec(&vm.Spec)
-			// missing volume and multiple targets set. should result in 2 errors
-			Expect(len(errors)).To(Equal(2))
+			causes := validateVirtualMachineSpec(&vm.Spec)
+			// missing volume and multiple targets set. should result in 2 causes
+			Expect(len(causes)).To(Equal(2))
 		})
 		table.DescribeTable("should verify LUN is mapped to PVC volume",
 			func(volume *v1.Volume, expectedErrors int) {
@@ -412,8 +412,8 @@ var _ = Describe("Validating Webhook", func() {
 				})
 				vm.Spec.Volumes = append(vm.Spec.Volumes, *volume)
 
-				errors := validateVirtualMachineSpec(&vm.Spec)
-				Expect(len(errors)).To(Equal(expectedErrors))
+				causes := validateVirtualMachineSpec(&vm.Spec)
+				Expect(len(causes)).To(Equal(expectedErrors))
 			},
 			table.Entry("and reject non PVC sources",
 				&v1.Volume{
@@ -441,8 +441,8 @@ var _ = Describe("Validating Webhook", func() {
 					VolumeSource: volumeSource,
 				})
 
-				errors := validateVolumes(vm.Spec.Volumes)
-				Expect(len(errors)).To(Equal(0))
+				causes := validateVolumes(vm.Spec.Volumes)
+				Expect(len(causes)).To(Equal(0))
 			},
 			table.Entry("with pvc volume source", v1.VolumeSource{PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{}}),
 			table.Entry("with cloud-init volume source", v1.VolumeSource{CloudInitNoCloud: &v1.CloudInitNoCloudSource{UserData: "fake"}}),
@@ -457,8 +457,8 @@ var _ = Describe("Validating Webhook", func() {
 				Name: "testvolume",
 			})
 
-			errors := validateVolumes(vm.Spec.Volumes)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateVolumes(vm.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject volume with multiple volume sources set", func() {
 			vm := v1.NewMinimalVM("testvm")
@@ -471,8 +471,8 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			errors := validateVolumes(vm.Spec.Volumes)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateVolumes(vm.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
 		})
 		It("should reject volumes with duplicate names", func() {
 			vm := v1.NewMinimalVM("testvm")
@@ -490,8 +490,8 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			errors := validateVolumes(vm.Spec.Volumes)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateVolumes(vm.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
 		})
 		table.DescribeTable("should verify cloud-init userdata length", func(userDataLen int, expectedErrors int, base64Encode bool) {
 			vm := v1.NewMinimalVM("testvm")
@@ -510,8 +510,8 @@ var _ = Describe("Validating Webhook", func() {
 				vm.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.UserData = userdata
 			}
 
-			errors := validateVolumes(vm.Spec.Volumes)
-			Expect(len(errors)).To(Equal(expectedErrors))
+			causes := validateVolumes(vm.Spec.Volumes)
+			Expect(len(causes)).To(Equal(expectedErrors))
 		},
 			table.Entry("should accept userdata under max limit", 10, 0, false),
 			table.Entry("should accept userdata equal max limit", cloudInitMaxLen, 0, false),
@@ -532,8 +532,8 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			errors := validateVolumes(vm.Spec.Volumes)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateVolumes(vm.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
 		})
 	})
 	Context("with Disk", func() {
@@ -543,8 +543,8 @@ var _ = Describe("Validating Webhook", func() {
 
 				vm.Spec.Domain.Devices.Disks = append(vm.Spec.Domain.Devices.Disks, disk)
 
-				errors := validateDisks(vm.Spec.Domain.Devices.Disks)
-				Expect(len(errors)).To(Equal(0))
+				causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+				Expect(len(causes)).To(Equal(0))
 
 			},
 			table.Entry("with Disk target",
@@ -575,8 +575,8 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			errors := validateDisks(vm.Spec.Domain.Devices.Disks)
-			Expect(len(errors)).To(Equal(0))
+			causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(0))
 		})
 		It("should reject disks with duplicate names ", func() {
 			vm := v1.NewMinimalVM("testvm")
@@ -595,8 +595,8 @@ var _ = Describe("Validating Webhook", func() {
 					Disk: &v1.DiskTarget{},
 				},
 			})
-			errors := validateDisks(vm.Spec.Domain.Devices.Disks)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(1))
 		})
 
 		It("should reject disk with multiple targets ", func() {
@@ -617,8 +617,8 @@ var _ = Describe("Validating Webhook", func() {
 				},
 			})
 
-			errors := validateDisks(vm.Spec.Domain.Devices.Disks)
-			Expect(len(errors)).To(Equal(1))
+			causes := validateDisks(vm.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(1))
 		})
 	})
 })

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -102,6 +102,13 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			result.StatusCode(&statusCode)
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
+			reviewResponse := &v12.Status{}
+			body, _ := result.Raw()
+			err = json.Unmarshal(body, reviewResponse)
+			Expect(err).To(BeNil())
+
+			Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
+			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].volumeName"))
 		})
 	})
 

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -146,6 +146,13 @@ var _ = Describe("VirtualMachineReplicaSet", func() {
 		result.StatusCode(&statusCode)
 		Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
 
+		reviewResponse := &v12.Status{}
+		body, _ := result.Raw()
+		err = json.Unmarshal(body, reviewResponse)
+		Expect(err).To(BeNil())
+
+		Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
+		Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[1].volumeName"))
 	})
 	It("should update readyReplicas once VMs are up", func() {
 		newRS := newReplicaSet()

--- a/tests/vmpreset_test.go
+++ b/tests/vmpreset_test.go
@@ -122,6 +122,14 @@ var _ = Describe("VMPreset", func() {
 			statusCode := 0
 			result.StatusCode(&statusCode)
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+
+			reviewResponse := &k8smetav1.Status{}
+			body, _ := result.Raw()
+			err = json.Unmarshal(body, reviewResponse)
+			Expect(err).To(BeNil())
+
+			Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
+			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.domain.devices.disks[1]"))
 		})
 	})
 	Context("Preset Matching", func() {


### PR DESCRIPTION
The UI needs a standardized way of determine what validation errors occurred and exactly what fields were involved. 

With this PR, the metav1.Status{} structure returned in the validation webhook's Admission Review Response contains a list of information about every field that failed validation. 

Example:

```
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "admission webhook \"virtualmachine-validator.kubevirt.io\" denied the request: spec.domain.devices.disks[1].volumeName testvolume not found.",
  "details": {
    "causes": [
      {
        "message": "testvolume not found",
        "field": spec.domain.devices.disks[1],
      },
      {
        "message": "testvolume2 not found",
        "field": spec.domain.devices.disks[2],
      },
    ]
  },
  "code": 422
}
```

A UI can iterate over the causes list to identify which field is invalid. There's also a human readable string associated with each validation error. 

Unit and Functional tests have been updated to ensure the field values are both set and accurate for consumption. 

fixes #959

