### PR TITLE
api: Add security definition to openapispec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4598,5 +4598,18 @@
      }
     }
    }
-  }
+  },
+  "securityDefinitions": {
+   "BearerToken": {
+    "description": "Bearer Token authentication",
+    "type": "apiKey",
+    "name": "authorization",
+    "in": "header"
+   }
+  },
+  "security": [
+   {
+    "BearerToken": []
+   }
+  ]
  }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -342,6 +342,18 @@ func addInfoToSwaggerObject(swo *openapispec.Swagger) {
 			},
 		},
 	}
+	swo.SecurityDefinitions = openapispec.SecurityDefinitions{
+		"BearerToken": &openapispec.SecurityScheme{
+			SecuritySchemeProps: openapispec.SecuritySchemeProps{
+				Type:        "apiKey",
+				Name:        "authorization",
+				In:          "header",
+				Description: "Bearer Token authentication",
+			},
+		},
+	}
+	swo.Security = make([]map[string][]string, 1)
+	swo.Security[0] = map[string][]string{"BearerToken": []string{}}
 }
 
 func deserializeStrings(in string) ([]string, error) {


### PR DESCRIPTION
Fixes: kubevirt/client-python#11

Signed-off-by: Lukas Bednar <lbednar@redhat.com>