### PR TITLE
Rework OfflineVirtualMachine status

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3931,6 +3931,14 @@
       "items": {
        "$ref": "#/definitions/v1.OfflineVirtualMachineCondition"
       }
+     },
+     "created": {
+      "description": "Created indicates if the virtual machine is created in the cluster",
+      "type": "boolean"
+     },
+     "ready": {
+      "description": "Ready indicates if the virtual machine is running and ready",
+      "type": "boolean"
      }
     }
    },

--- a/docs/devel/offline-virtual-machine.md
+++ b/docs/devel/offline-virtual-machine.md
@@ -206,7 +206,7 @@ is shown below.
 status:
   observedGeneration: 124 # current observed revision
   virtualMachine: my-vm
-  running: true # is the attached VirtualMachine running
+  created: true # is the attached VirtualMachine reated
   ready: true # based on http readiness check libvirt info
   conditions: [] # additional possible states
 ```
@@ -214,7 +214,7 @@ status:
 The status of the VirtualMachine is watched and is reflected in the
 OfflineVirtualMachine status. The info propagated from the VirtualMachine is:
 
-* running state
+* if the vm exists in the cluster
 * readiness of the VM
 * name of the VirtualMachine
 

--- a/manifests/generated/ovm-resource.yaml
+++ b/manifests/generated/ovm-resource.yaml
@@ -394,6 +394,13 @@ spec:
                 - type
                 - status
               type: array
+            created:
+              description: Created indicates if the virtual machine is created in
+                the cluster
+              type: boolean
+            ready:
+              description: Ready indicates if the virtual machine is running and ready
+              type: boolean
   version: v1alpha1
 status:
   acceptedNames:

--- a/pkg/api/v1/deepcopy_test.go
+++ b/pkg/api/v1/deepcopy_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/gofuzz"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -60,12 +61,20 @@ var _ = Describe("Generated deepcopy functions", func() {
 			&VMReplicaSetStatus{},
 			&VMReplicaSetCondition{},
 			&VMTemplateSpec{},
+			&OfflineVirtualMachine{},
+			&OfflineVirtualMachineList{},
+			&OfflineVirtualMachineSpec{},
+			&OfflineVirtualMachineCondition{},
+			&OfflineVirtualMachineStatus{},
+			&VirtualMachinePreset{},
+			&VirtualMachinePresetList{},
+			&VirtualMachinePresetSpec{},
 		}
 	})
 
-	It("should work for fuzzed structs", func() {
+	table.DescribeTable("should work for fuzzed structs with a probability for nils of", func(nilProbability float64) {
 		for _, s := range structs {
-			fuzz.New().NilChance(0).Fuzz(s)
+			fuzz.New().NilChance(nilProbability).Fuzz(s)
 			Expect(reflect.ValueOf(s).MethodByName("DeepCopy").Call(nil)[0].Interface()).To(Equal(s))
 			if reflect.ValueOf(s).MethodByName("DeepCopyObject").IsValid() {
 				Expect(reflect.ValueOf(s).MethodByName("DeepCopyObject").Call(nil)[0].Interface()).To(Equal(s))
@@ -74,6 +83,11 @@ var _ = Describe("Generated deepcopy functions", func() {
 			reflect.ValueOf(s).MethodByName("DeepCopyInto").Call([]reflect.Value{new})
 			Expect(new.Interface()).To(Equal(s))
 		}
-
-	})
+	},
+		table.Entry("0%", float64(0)),
+		table.Entry("10%", float64(0.1)),
+		table.Entry("50%", float64(0.5)),
+		table.Entry("70%", float64(0.7)),
+		table.Entry("100%", float64(1)),
+	)
 })

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -902,6 +902,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "OfflineVirtualMachineStatus represents the status returned by the controller to describe how the OfflineVirtualMachine is doing",
 					Properties: map[string]spec.Schema{
+						"created": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Created indicates if the virtual machine is created in the cluster",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
+						"ready": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Ready indicates if the virtual machine is running and ready",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
 						"conditions": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Hold the state information of the OfflineVirtualMachine and its VirtualMachine",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -707,6 +707,10 @@ type OfflineVirtualMachineSpec struct {
 // ---
 // +k8s:openapi-gen=true
 type OfflineVirtualMachineStatus struct {
+	// Created indicates if the virtual machine is created in the cluster
+	Created bool `json:"created,omitempty"`
+	// Ready indicates if the virtual machine is running and ready
+	Ready bool `json:"ready,omitempty"`
 	// Hold the state information of the OfflineVirtualMachine and its VirtualMachine
 	Conditions []OfflineVirtualMachineCondition `json:"conditions,omitempty" optional:"true"`
 }
@@ -742,8 +746,4 @@ const (
 	// fails to be created due to insufficient quota, limit ranges, pod security policy, node selectors,
 	// etc. or deleted due to kubelet being down or finalizers are failing.
 	OfflineVirtualMachineFailure OfflineVirtualMachineConditionType = "Failure"
-
-	// OfflineVirtualMachineRunning is added in a offline virtual machine when the VM succesfully runs.
-	// After this condition was added, the VM is up and running.
-	OfflineVirtualMachineRunning OfflineVirtualMachineConditionType = "Running"
 )

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -146,6 +146,8 @@ func (OfflineVirtualMachineSpec) SwaggerDoc() map[string]string {
 func (OfflineVirtualMachineStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":           "OfflineVirtualMachineStatus represents the status returned by the\ncontroller to describe how the OfflineVirtualMachine is doing",
+		"created":    "Created indicates if the virtual machine is created in the cluster",
+		"ready":      "Ready indicates if the virtual machine is running and ready",
 		"conditions": "Hold the state information of the OfflineVirtualMachine and its VirtualMachine",
 	}
 }

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -155,7 +155,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			Eventually(func() bool {
 				updatedOVM, err = virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Get(updatedOVM.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return hasCondition(updatedOVM, v1.OfflineVirtualMachineRunning)
+				return updatedOVM.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 
 			return updatedOVM
@@ -188,7 +188,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			Eventually(func() bool {
 				updatedOVM, err = virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Get(updatedOVM.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return hasCondition(updatedOVM, v1.OfflineVirtualMachineRunning)
+				return updatedOVM.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeFalse())
 
 			return updatedOVM
@@ -199,7 +199,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			Eventually(func() bool {
 				ovm, err := virtClient.OfflineVirtualMachine(tests.NamespaceTestDefault).Get(newOVM.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return hasCondition(ovm, v1.OfflineVirtualMachineRunning)
+				return ovm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
@@ -347,7 +347,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			Eventually(func() bool {
 				newOVM, err = virtClient.OfflineVirtualMachine(newOVM.Namespace).Get(newOVM.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return hasCondition(newOVM, v1.OfflineVirtualMachineRunning)
+				return newOVM.Status.Ready
 			}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 			By("Updating the OVM template spec")
@@ -437,7 +437,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				Eventually(func() bool {
 					newOVM, err = virtClient.OfflineVirtualMachine(newOVM.Namespace).Get(newOVM.Name, &v12.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return hasCondition(newOVM, v1.OfflineVirtualMachineRunning)
+					return newOVM.Status.Ready
 				}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Getting the running VM")
@@ -464,7 +464,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				Eventually(func() bool {
 					newOVM, err = virtClient.OfflineVirtualMachine(newOVM.Namespace).Get(newOVM.Name, &v12.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return hasCondition(newOVM, v1.OfflineVirtualMachineRunning)
+					return newOVM.Status.Ready
 				}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 				err = virtctl()
@@ -474,7 +474,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				Eventually(func() bool {
 					newOVM, err = virtClient.OfflineVirtualMachine(newOVM.Namespace).Get(newOVM.Name, &v12.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					return !hasCondition(newOVM, v1.OfflineVirtualMachineRunning)
+					return !newOVM.Status.Ready && !newOVM.Status.Created
 				}, 360*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Ensuring the VM is removed")
@@ -514,14 +514,4 @@ func NewRandomOfflineVirtualMachine(vm *v1.VirtualMachine, running bool) *v1.Off
 		},
 	}
 	return ovm
-}
-
-func hasCondition(ovm *v1.OfflineVirtualMachine, cond v1.OfflineVirtualMachineConditionType) bool {
-	for _, c := range ovm.Status.Conditions {
-		if c.Type == cond {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
The ovm was too much focused on conditions and not enough on the acutal
important states to track. The condition for tracking the vm state got
removed now. Instead "created" and "ready" booleans are tracking the vm
lifecycle, like agreed on in the original design document.