### PR TITLE
Add test for creating VM from template via oc CLI

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -24,4 +24,8 @@ source hack/config.sh
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -kubectl-path=${kubectl} -test.timeout 90m ${FUNC_TEST_ARGS}
+if [[ ${TARGET} == openshift* ]]; then
+    oc=${kubectl}
+fi
+
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 90m ${FUNC_TEST_ARGS}

--- a/tests/oc_template_test.go
+++ b/tests/oc_template_test.go
@@ -1,0 +1,300 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/tests"
+)
+
+// template parameters
+const (
+	vmName     = "testvm"
+	vmCpuCores = "2"
+)
+
+const (
+	vmStartPatch = "{\"spec\":{\"running\":true}}"
+	vmStopPatch  = "{\"spec\":{\"running\":false}}"
+)
+
+var _ = Describe("VM Template", func() {
+	flag.Parse()
+
+	vmTemplateFedora := getVmTemplateFedora()
+
+	generateVmJsonFromTemplate := func(vmName string, vmTemplateJsonFile string) string {
+		By("Converting VirtualMachine Template into JSON file via oc-process command")
+		vmTemplateParams := []string{"-p", "NAME=" + vmName, "-p", "CPU_CORES=" + vmCpuCores}
+		args := append([]string{"process", "-f", vmTemplateJsonFile}, vmTemplateParams...)
+		out, err := tests.RunOcCommand(args...)
+		Expect(err).ToNot(HaveOccurred())
+		vmJsonFile, err := tests.WriteJson(vmName, out)
+		Expect(err).ToNot(HaveOccurred())
+		return vmJsonFile
+	}
+
+	createVmFromJson := func(vmName string, vmJsonFile string) {
+		var message = ""
+		By("Creating VirtualMachine from JSON file via oc-create command")
+		out, err := tests.RunOcCommand("create", "-f", vmJsonFile)
+		Expect(err).ToNot(HaveOccurred())
+		message = fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" created\n", vmName)
+		Expect(out).To(Equal(message))
+
+		Eventually(func() bool {
+			out, err := tests.RunOcCommand("get", "vms")
+			Expect(err).ToNot(HaveOccurred())
+			return strings.Contains(out, vmName)
+		}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for vm to appear")
+	}
+
+	patchVm := func(vmName string, patch string) {
+		var message = ""
+		By("Starting VirtualMachine via oc-patch command")
+		out, err := tests.RunOcCommand("patch", "virtualmachine", vmName, "--type", "merge", "-p", patch)
+		Expect(err).ToNot(HaveOccurred())
+		message = fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", vmName)
+		Expect(out).To(Equal(message))
+	}
+
+	deleteVm := func(vmName string) {
+		var message = ""
+		By("Deleting the VirtualMachine via oc-delete command")
+		out, err := tests.RunOcCommand("delete", "vm", vmName)
+		Expect(err).ToNot(HaveOccurred())
+		message = fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" deleted\n", vmName)
+		Expect(out).To(Equal(message))
+
+		Eventually(func() bool {
+			out, err := tests.RunOcCommand("get", "vms")
+			Expect(err).ToNot(HaveOccurred())
+			return out == "No resources found.\n"
+		}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for vm to disappear")
+	}
+
+	Context("with oc command", func() {
+		vmTemplateJsonFile := ""
+		vmJsonFile := ""
+
+		BeforeEach(func() {
+			tests.SkipIfNoOc()
+			// write testing VirtualMachine Template into JSON file
+			var err error
+			vmTemplateJsonFile, err = tests.GenerateVmTemplateJson(vmTemplateFedora)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if vmTemplateJsonFile != "" {
+				// remove testing VirtualMachine Template JSON file
+				err := os.Remove(vmTemplateJsonFile)
+				Expect(err).ToNot(HaveOccurred())
+				vmTemplateJsonFile = ""
+			}
+			if vmJsonFile != "" {
+				// remove testing VirtualMachine JSON file
+				err := os.Remove(vmJsonFile)
+				Expect(err).ToNot(HaveOccurred())
+				vmJsonFile = ""
+			}
+		})
+
+		It("should generate a vm JSON from a template", func() {
+			generateVmJsonFromTemplate(vmName, vmTemplateJsonFile)
+		})
+
+		It("should create a vm from template", func() {
+			vmJsonFile = generateVmJsonFromTemplate(vmName, vmTemplateJsonFile)
+			createVmFromJson(vmName, vmJsonFile)
+			deleteVm(vmName)
+		})
+
+		It("should succeed to start a vmi from template", func() {
+			vmJsonFile = generateVmJsonFromTemplate(vmName, vmTemplateJsonFile)
+			createVmFromJson(vmName, vmJsonFile)
+
+			patchVm(vmName, vmStartPatch)
+
+			Eventually(func() bool {
+				out, err := tests.RunOcCommand("get", "vmis")
+				Expect(err).ToNot(HaveOccurred())
+				return strings.Contains(out, vmName)
+			}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for vmi to appear")
+
+			patchVm(vmName, vmStopPatch)
+
+			Eventually(func() bool {
+				out, err := tests.RunOcCommand("get", "vmis")
+				Expect(err).ToNot(HaveOccurred())
+				return out == "No resources found.\n"
+			}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for vmi to disappear")
+
+			deleteVm(vmName)
+		})
+	})
+})
+
+func getBaseVmTemplate(vm *v1.VirtualMachine, memory string, cores string) *tests.Template {
+
+	obj := toUnstructured(vm)
+	unstructured.SetNestedField(obj.Object, "${{CPU_CORES}}", "spec", "template", "spec", "domain", "cpu", "cores")
+	unstructured.SetNestedField(obj.Object, "${MEMORY}", "spec", "template", "spec", "domain", "resources", "requests", "memory")
+	obj.SetName("${NAME}")
+
+	return &tests.Template{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Template",
+			APIVersion: "v1",
+		},
+		Objects: []runtime.Object{
+			obj,
+		},
+		Parameters: vmTemplateParameters(memory, cores),
+	}
+}
+
+func toUnstructured(object runtime.Object) *unstructured.Unstructured {
+	raw, err := json.Marshal(object)
+	if err != nil {
+		panic(err)
+	}
+	var objmap map[string]interface{}
+	err = json.Unmarshal(raw, &objmap)
+
+	return &unstructured.Unstructured{Object: objmap}
+}
+
+func vmTemplateParameters(memory string, cores string) []tests.Parameter {
+	return []tests.Parameter{
+		{
+			Name:        "NAME",
+			Description: "Name for the new VM",
+		},
+		{
+			Name:        "MEMORY",
+			Description: "Amount of memory",
+			Value:       memory,
+		},
+		{
+			Name:        "CPU_CORES",
+			Description: "Amount of cores",
+			Value:       cores,
+		},
+	}
+}
+
+func getVmTemplateFedora() *tests.Template {
+	gracePeriod := int64(0)
+	vmForTemplate := &v1.VirtualMachine{
+		Spec: v1.VirtualMachineSpec{
+			Template: &v1.VirtualMachineInstanceTemplateSpec{
+				Spec: v1.VirtualMachineInstanceSpec{
+					TerminationGracePeriodSeconds: &gracePeriod,
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							Disks: []v1.Disk{
+								{
+									Name:       "registrydisk",
+									VolumeName: "registryvolume",
+									DiskDevice: v1.DiskDevice{
+										Disk: &v1.DiskTarget{
+											Bus: "virtio",
+										},
+									},
+								},
+								{
+									Name:       "cloudinitdisk",
+									VolumeName: "cloudinitvolume",
+									DiskDevice: v1.DiskDevice{
+										Disk: &v1.DiskTarget{
+											Bus: "virtio",
+										},
+									},
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "registryvolume",
+							VolumeSource: v1.VolumeSource{
+								RegistryDisk: &v1.RegistryDiskSource{
+									Image: "registry:5000/kubevirt/fedora-cloud-registry-disk-demo:latest",
+								},
+							},
+						},
+						{
+							Name: "cloudinitvolume",
+							VolumeSource: v1.VolumeSource{
+								CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+									UserData: "#cloud-config\npassword: fedora\nchpasswd: { expire: False }",
+								},
+							},
+						},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"kubevirt-vm": "vm-${NAME}",
+					},
+				},
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubevirt.io/v1alpha2",
+			Kind:       "VirtualMachine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"kubevirt-vm": "vm-${NAME}",
+			},
+			Name: "${NAME}",
+		},
+	}
+
+	vmTemplate := getBaseVmTemplate(vmForTemplate, "4096Mi", "4")
+	vmTemplate.ObjectMeta = metav1.ObjectMeta{
+		Name: "vm-template-fedora",
+		Annotations: map[string]string{
+			"description": "OCP KubeVirt Fedora 27 VM template",
+			"tags":        "kubevirt,ocp,template,linux,virtualmachine",
+			"iconClass":   "icon-fedora",
+		},
+		Labels: map[string]string{
+			"kubevirt.io/os":                        "fedora27",
+			"miq.github.io/kubevirt-is-vm-template": "true",
+		},
+	}
+	return vmTemplate
+}

--- a/tests/types.go
+++ b/tests/types.go
@@ -1,0 +1,255 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ * This file was derived from 'pkg/template/apis/template/types.go' that is
+ * part of the OpenShift Origin project.  It is required by tests covering
+ * OpenShift integration test scenarios and for generating example template
+ * files.  You may obtain a copy of the original file at
+ *
+ *     https://github.com/openshift/origin
+ *
+ */
+
+package tests
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// Template contains the inputs needed to produce a Config.
+type Template struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// message is an optional instructional message that will
+	// be displayed when this template is instantiated.
+	// This field should inform the user how to utilize the newly created resources.
+	// Parameter substitution will be performed on the message before being
+	// displayed so that generated credentials and other parameters can be
+	// included in the output.
+	Message string `json:"message,omitempty"`
+
+	// parameters is an optional array of Parameters used during the
+	// Template to Config transformation.
+	Parameters []Parameter `json:"parameters"`
+
+	// objects is an array of resources to include in this template.
+	// If a namespace value is hardcoded in the object, it will be removed
+	// during template instantiation, however if the namespace value
+	// is, or contains, a ${PARAMETER_REFERENCE}, the resolved
+	// value after parameter substitution will be respected and the object
+	// will be created in that namespace.
+	Objects []runtime.Object `json:"objects"`
+
+	// objectLabels is an optional set of labels that are applied to every
+	// object during the Template to Config transformation.
+	ObjectLabels map[string]string `json:"labels,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TemplateList is a list of Template objects.
+type TemplateList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+	Items []Template
+}
+
+// Parameter defines a name/value variable that is to be processed during
+// the Template to Config transformation.
+type Parameter struct {
+	// Required: Parameter name must be set and it can be referenced in Template
+	// Items using ${PARAMETER_NAME}
+	Name string `json:"name"`
+
+	// Optional: The name that will show in UI instead of parameter 'Name'
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Optional: Parameter can have description
+	Description string `json:"description,omitempty"`
+
+	// Optional: Value holds the Parameter data. If specified, the generator
+	// will be ignored. The value replaces all occurrences of the Parameter
+	// ${Name} expression during the Template to Config transformation.
+	Value string `json:"value,omitempty"`
+
+	// Optional: Generate specifies the generator to be used to generate
+	// random string from an input value specified by From field. The result
+	// string is stored into Value field. If empty, no generator is being
+	// used, leaving the result Value untouched.
+	Generate string `json:"generate,omitempty"`
+
+	// Optional: From is an input value for the generator.
+	From string `json:"from,omitempty"`
+
+	// Optional: Indicates the parameter must have a value.  Defaults to false.
+	Required bool `json:"required,omitempty"`
+}
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TemplateInstance requests and records the instantiation of a Template.
+// TemplateInstance is part of an experimental API.
+type TemplateInstance struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+
+	// Spec describes the desired state of this TemplateInstance.
+	Spec TemplateInstanceSpec
+
+	// Status describes the current state of this TemplateInstance.
+	Status TemplateInstanceStatus
+}
+
+// TemplateInstanceSpec describes the desired state of a TemplateInstance.
+type TemplateInstanceSpec struct {
+	// Template is a full copy of the template for instantiation.
+	Template Template
+
+	// Secret is a reference to a Secret object containing the necessary
+	// template parameters.
+	Secret *k8sv1.LocalObjectReference
+
+	// Requester holds the identity of the agent requesting the template
+	// instantiation.
+	Requester *TemplateInstanceRequester
+}
+
+// TemplateInstanceRequester holds the identity of an agent requesting a
+// template instantiation.
+type TemplateInstanceRequester struct {
+	// username uniquely identifies this user among all active users.
+	Username string
+
+	// uid is a unique value that identifies this user across time; if this user is
+	// deleted and another user by the same name is added, they will have
+	// different UIDs.
+	UID string
+
+	// groups represent the groups this user is a part of.
+	Groups []string
+
+	// extra holds additional information provided by the authenticator.
+	Extra map[string]ExtraValue
+}
+
+// ExtraValue masks the value so protobuf can generate
+type ExtraValue []string
+
+// TemplateInstanceStatus describes the current state of a TemplateInstance.
+type TemplateInstanceStatus struct {
+	// Conditions represent the latest available observations of a
+	// TemplateInstance's current state.
+	Conditions []TemplateInstanceCondition
+
+	// Objects references the objects created by the TemplateInstance.
+	Objects []TemplateInstanceObject
+}
+
+// TemplateInstanceCondition contains condition information for a
+// TemplateInstance.
+type TemplateInstanceCondition struct {
+	// Type of the condition, currently Ready or InstantiateFailure.
+	Type TemplateInstanceConditionType
+	// Status of the condition, one of True, False or Unknown.
+	Status k8sv1.ConditionStatus
+	// LastTransitionTime is the last time a condition status transitioned from
+	// one state to another.
+	LastTransitionTime metav1.Time
+	// Reason is a brief machine readable explanation for the condition's last
+	// transition.
+	Reason string
+	// Message is a human readable description of the details of the last
+	// transition, complementing reason.
+	Message string
+}
+
+// TemplateInstanceConditionType is the type of condition pertaining to a
+// TemplateInstance.
+type TemplateInstanceConditionType string
+
+const (
+	// TemplateInstanceReady indicates the readiness of the template
+	// instantiation.
+	TemplateInstanceReady TemplateInstanceConditionType = "Ready"
+	// TemplateInstanceInstantiateFailure indicates the failure of the template
+	// instantiation
+	TemplateInstanceInstantiateFailure TemplateInstanceConditionType = "InstantiateFailure"
+)
+
+// TemplateInstanceObject references an object created by a TemplateInstance.
+type TemplateInstanceObject struct {
+	// ref is a reference to the created object.
+	Ref k8sv1.ObjectReference
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TemplateInstanceList is a list of TemplateInstance objects.
+type TemplateInstanceList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+
+	// Items is a list of Templateinstances
+	Items []TemplateInstance
+}
+
+// +genclient
+// +genclient:nonNamespaced
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BrokerTemplateInstance holds the service broker-related state associated with
+// a TemplateInstance.  BrokerTemplateInstance is part of an experimental API.
+type BrokerTemplateInstance struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+
+	// Spec describes the state of this BrokerTemplateInstance.
+	Spec BrokerTemplateInstanceSpec
+}
+
+// BrokerTemplateInstanceSpec describes the state of a BrokerTemplateInstance.
+type BrokerTemplateInstanceSpec struct {
+	// TemplateInstance is a reference to a TemplateInstance object residing
+	// in a namespace.
+	TemplateInstance k8sv1.ObjectReference
+
+	// Secret is a reference to a Secret object residing in a namespace,
+	// containing the necessary template parameters.
+	Secret k8sv1.ObjectReference
+
+	// BindingIDs is a list of 'binding_id's provided during successive bind
+	// calls to the template service broker.
+	BindingIDs []string
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// BrokerTemplateInstanceList is a list of BrokerTemplateInstance objects.
+type BrokerTemplateInstanceList struct {
+	metav1.TypeMeta
+	metav1.ListMeta
+
+	// Items is a list of BrokerTemplateInstances
+	Items []BrokerTemplateInstance
+}


### PR DESCRIPTION
# Test for creating and running VM from a template via external oc command

## Goal

Provide test automation covering creation and execution of a VM created from an *OpenShift Template*. The test has to use the external `oc` command.

## Test cases covered

1. Generate VM JSON file from a Template via `oc-process` command.
2. Create VM from a template via `oc-create` command.
3. Spawn VMI of the VM via `oc-patch` command.