### PR TITLE
Use virtio for cirros vms in our functests

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -471,6 +471,23 @@ func Convert_v1_VirtualMachine_To_api_Domain(vm *v1.VirtualMachine, domain *Doma
 		},
 	}
 
+	// Add mandatory interface
+	interfaceType := "e1000"
+	if vm.Annotations["kubevirt.io/os"] == "cirros" {
+		interfaceType = "virtio"
+	}
+
+	// For now connect every virtual machine to the pod network
+	domain.Spec.Devices.Interfaces = []Interface{{
+		Model: &Model{
+			Type: interfaceType,
+		},
+		Type: "bridge",
+		Source: InterfaceSource{
+			Bridge: DefaultBridgeName,
+		}},
+	}
+
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -403,6 +403,13 @@ var _ = Describe("Converter", func() {
 			Expect(vmToDomainXMLToDomainSpec(vm, c).VCPU.CPUs).To(Equal(uint32(3)))
 
 		})
+
+		It("should select virto network model if cirros", func() {
+			v1.SetObjectDefaults_VirtualMachine(vm)
+			vm.Annotations = map[string]string{"kubevirt.io/os": "cirros"}
+			domain := vmToDomain(vm, c)
+			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("virtio"))
+		})
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -17,16 +17,6 @@ func SetDefaults_Devices(devices *Devices) {
 		},
 	}
 
-	// For now connect every virtual machine to the default network
-	devices.Interfaces = []Interface{{
-		Model: &Model{
-			Type: "e1000",
-		},
-		Type: "bridge",
-		Source: InterfaceSource{
-			Bridge: DefaultBridgeName,
-		}},
-	}
 }
 
 func SetDefaults_OSType(ostype *OSType) {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -551,9 +551,6 @@ func NewMinimalDomainSpec(vmName string) *DomainSpec {
 	domain.Name = vmName
 	domain.Memory = Memory{Unit: "MB", Value: 9}
 	domain.Devices = Devices{}
-	domain.Devices.Interfaces = []Interface{
-		{Type: "network", Source: InterfaceSource{Network: "default"}},
-	}
 	return domain
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -40,10 +40,6 @@ var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/doma
     <baseBoard></baseBoard>
   </sysinfo>
   <devices>
-    <interface type="bridge">
-      <source bridge="br1"></source>
-      <model type="e1000"></model>
-    </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>
     </video>

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -312,12 +312,7 @@ func SetupDefaultPodNetwork(domain *api.Domain) error {
 	}
 
 	// TODO:(vladikr) Currently we support only one interface per vm.
-	// Improve this once we'll start supporting more.
-	if len(domain.Spec.Devices.Interfaces) == 0 {
-		domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, defaultIconf)
-	} else {
-		domain.Spec.Devices.Interfaces[0] = defaultIconf
-	}
+	domain.Spec.Devices.Interfaces[0] = defaultIconf
 
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Network", func() {
 		It("should define a new VIF", func() {
 
 			Handler = mockNetwork
-			domain := &api.Domain{}
+			domain := NewDomainWithPodNetwork()
 
 			api.SetObjectDefaults_Domain(domain)
 
@@ -133,7 +133,7 @@ var _ = Describe("Network", func() {
 		It("should panic if pod networking fails to setup", func() {
 			testNetworkPanic := func() {
 				Handler = mockNetwork
-				domain := &api.Domain{}
+				domain := NewDomainWithPodNetwork()
 
 				api.SetObjectDefaults_Domain(domain)
 
@@ -232,3 +232,18 @@ var _ = Describe("Network", func() {
 		})
 	})
 })
+
+func NewDomainWithPodNetwork() *api.Domain {
+
+	domain := &api.Domain{}
+	domain.Spec.Devices.Interfaces = []api.Interface{{
+		Model: &api.Model{
+			Type: "e1000",
+		},
+		Type: "bridge",
+		Source: api.InterfaceSource{
+			Bridge: api.DefaultBridgeName,
+		}},
+	}
+	return domain
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -54,6 +54,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/labels"
 
+	"strings"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
@@ -735,6 +737,7 @@ func NewRandomVM() *v1.VirtualMachine {
 
 func NewRandomVMWithNS(namespace string) *v1.VirtualMachine {
 	vm := v1.NewMinimalVMWithNS(namespace, "testvm"+rand.String(5))
+	vm.Annotations = map[string]string{}
 
 	t := defaultTestGracePeriod
 	vm.Spec.TerminationGracePeriodSeconds = &t
@@ -757,6 +760,10 @@ func NewRandomVMWithEphemeralDiskAndUserdataHighMemory(containerImage string, us
 
 func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
 	vm := NewRandomVM()
+
+	if strings.Contains(containerImage, "cirros") {
+		vm.Annotations["kubevirt.io/os"] = "cirros"
+	}
 
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	AddEphemeralDisk(vm, "disk0", "virtio", containerImage)

--- a/tests/vmpreset_test.go
+++ b/tests/vmpreset_test.go
@@ -260,7 +260,7 @@ var _ = Describe("VMPreset", func() {
 			vm = tests.NewRandomVMWithEphemeralDisk("kubevirt/alpine-registry-disk-demo:devel")
 			vm.Labels = map[string]string{flavorKey: cpuFlavor}
 			exclusionMarking := "virtualmachinepresets.admission.kubevirt.io/exclude"
-			vm.Annotations = map[string]string{exclusionMarking: "true"}
+			vm.Annotations[exclusionMarking] = "true"
 
 			err = virtClient.RestClient().Post().Resource("virtualmachines").Namespace(tests.NamespaceTestDefault).Body(vm).Do().Error()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fixes #936 for our tests. The solution here is intended to buy us some time until we have decided on how to properly represent network devices on the API. If "kubevirt.io/os=cirros" is present in the annotations, kubevirt will choose virtio for the network type.

Using "kubevirt.io/os" for that purpose is not that nice, but it kind of fits into what this label is meant for: Allowing special configurations based on the operating system used. See also https://www.kubevirt.io/user-guide/#/workloads/virtual-machines/guest-operating-system-information?id=guest-operating-system-information for more context.