### PR TITLE
Fixed "unknown flag: --max-args" error on build

### DIFF
--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -59,8 +59,8 @@ function build() {
         container_alias="${container_alias} ${manifest_docker_prefix}/${name}:${docker_tag} kubevirt/${name}:${docker_tag}"
     done
     for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
-        ${_cli} ssh --prefix $provider_prefix "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs --max-args=1 sudo docker pull"
-        ${_cli} ssh --prefix $provider_prefix "node$(printf "%02d" ${i})" "echo \"${container_alias}\" | xargs --max-args=2 sudo docker tag"
+        ${_cli} ssh --prefix $provider_prefix "node$(printf "%02d" ${i})" "echo \"${container}\" | xargs \-\-max-args=1 sudo docker pull"
+        ${_cli} ssh --prefix $provider_prefix "node$(printf "%02d" ${i})" "echo \"${container_alias}\" | xargs \-\-max-args=2 sudo docker tag"
     done
 }
 


### PR DESCRIPTION
When executing make cluster-sync, I get the error. This apparently happens
because --max-args argument is parsed, and acted upon, by 'ssh' inside the CI
container.

To fix the issue, I escape all dashes in --max-args arguments, which makes
'ssh' ignore and pass them to the node remote execution.

Closes #992