### PR TITLE
Make sure that daemon-sets update pods on upgrade

### DIFF
--- a/manifests/dev/virt-handler.yaml.in
+++ b/manifests/dev/virt-handler.yaml.in
@@ -6,6 +6,8 @@ metadata:
   labels:
     kubevirt.io: "virt-handler"
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       name: virt-handler

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -331,6 +331,8 @@ metadata:
   labels:
     kubevirt.io: "virt-handler"
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       name: virt-handler


### PR DESCRIPTION
When upgrading kubevirt, we apply the new virt-handler template to the
daemonset. In order to make sure that it gets roled out, we need to add
a RollingUpdate strategy to the daemonset.

Resolves #997 