### PR TITLE
Forward KUBEVIRT_PROVIDER to the artifact copier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ client-python:
 	hack/dockerized "./hack/generate.sh && TRAVIS_TAG=${TRAVIS_TAG} ./hack/gen-client-python/generate.sh"
 
 build:
-	hack/dockerized "./hack/check.sh && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT} && ./hack/build-copy-artifacts.sh ${WHAT}"
+	hack/dockerized "./hack/check.sh && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT} && KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-copy-artifacts.sh ${WHAT}"
 
 goveralls:
 	SYNC_OUT=false hack/dockerized "./hack/check.sh && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"


### PR DESCRIPTION
Fixes an issue introduced by #998 