### PR TITLE
Default KubeVirt view/edit/admin RBAC Roles

### DIFF
--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -309,3 +309,23 @@ rules:
       - get
       - list
       - watch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{.Namespace}}
+  name: kubevirt.io:config
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubevirt-config
+    verbs:
+      - update
+      - get
+      - patch
+      - create
+      - delete

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -254,6 +254,7 @@ rules:
     verbs:
       - get
       - delete
+      - create
       - update
       - patch
       - list
@@ -284,6 +285,7 @@ rules:
     verbs:
       - get
       - delete
+      - create
       - update
       - patch
       - list

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -229,3 +229,81 @@ subjects:
   - kind: ServiceAccount
     name: kubevirt-privileged
     namespace: {{.Namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:admin
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - delete
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:edit
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - delete
+      - update
+      - patch
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:view
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - list
+      - watch

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -260,6 +260,15 @@ rules:
       - list
       - watch
       - deletecollection
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubevirt-config
+    verbs:
+      - update
+      - get
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -309,23 +318,3 @@ rules:
       - get
       - list
       - watch
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{.Namespace}}
-  name: kubevirt.io:config
-  labels:
-    kubevirt.io: ""
-rules:
-  - apiGroups: [""]
-    resources:
-      - configmaps
-    resourceNames:
-      - kubevirt-config
-    verbs:
-      - update
-      - get
-      - patch
-      - create
-      - delete

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -23,6 +23,7 @@ rules:
     verbs:
       - get
       - delete
+      - create
       - update
       - patch
       - list
@@ -53,6 +54,7 @@ rules:
     verbs:
       - get
       - delete
+      - create
       - update
       - patch
       - list

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -79,6 +79,26 @@ rules:
       - list
       - watch
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{.Namespace}}
+  name: kubevirt.io:config
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubevirt-config
+    verbs:
+      - update
+      - get
+      - patch
+      - create
+      - delete
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -1,4 +1,82 @@
 # RBAC
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:admin
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - delete
+      - update
+      - patch
+      - list
+      - watch
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:edit
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachines/console
+      - virtualmachines/vnc
+    verbs:
+      - get
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - delete
+      - update
+      - patch
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kubevirt.io:view
+  labels:
+    kubevirt.io: ""
+rules:
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - offlinevirtualmachines
+      - virtualmachinepresets
+      - virtualmachinereplicasets
+    verbs:
+      - get
+      - list
+      - watch
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -29,6 +29,17 @@ rules:
       - list
       - watch
       - deletecollection
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubevirt-config
+    verbs:
+      - update
+      - get
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -78,26 +89,6 @@ rules:
       - get
       - list
       - watch
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: {{.Namespace}}
-  name: kubevirt.io:config
-  labels:
-    kubevirt.io: ""
-rules:
-  - apiGroups: [""]
-    resources:
-      - configmaps
-    resourceNames:
-      - kubevirt-config
-    verbs:
-      - update
-      - get
-      - patch
-      - create
-      - delete
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -117,6 +117,15 @@ var _ = Describe("User Access", func() {
 				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(ContainSubstring(expectedRes))
+
+				// DEFAULT - the default should always return 'no' for ever verb.
+				// This is primarily a sanity check.
+				By(fmt.Sprintf("verifying DEFAULT sa for verb %s", verb))
+				expectedRes = "no"
+				as = fmt.Sprintf("system:serviceaccount:%s:default", namespace)
+				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring(expectedRes))
 			}
 		},
 			table.Entry("given a vm", "virtualmachines"),

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"flag"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("User Access", func() {
+
+	flag.Parse()
+
+	BeforeEach(func() {
+		tests.BeforeTestCleanup()
+	})
+
+	Describe("With view, edit, and admin kubevirt service accounts", func() {
+		table.DescribeTable("should verify permissions are correct for each", func(resource string) {
+			tests.SkipIfNoKubectl()
+
+			view := tests.ViewServiceAccountName
+			edit := tests.EditServiceAccountName
+			admin := tests.AdminServiceAccountName
+
+			viewVerbs := make(map[string]string)
+			editVerbs := make(map[string]string)
+			adminVerbs := make(map[string]string)
+
+			// GET
+			viewVerbs["get"] = "yes"
+			editVerbs["get"] = "yes"
+			adminVerbs["get"] = "yes"
+
+			// List
+			viewVerbs["list"] = "yes"
+			editVerbs["list"] = "yes"
+			adminVerbs["list"] = "yes"
+
+			// WATCH
+			viewVerbs["watch"] = "yes"
+			editVerbs["watch"] = "yes"
+			adminVerbs["watch"] = "yes"
+
+			// DELETE
+			viewVerbs["delete"] = "no"
+			editVerbs["delete"] = "yes"
+			adminVerbs["delete"] = "yes"
+
+			// CREATE
+			viewVerbs["create"] = "no"
+			editVerbs["create"] = "yes"
+			adminVerbs["create"] = "yes"
+
+			// UPDATE
+			viewVerbs["update"] = "no"
+			editVerbs["update"] = "yes"
+			adminVerbs["update"] = "yes"
+
+			// PATCH
+			viewVerbs["patch"] = "no"
+			editVerbs["patch"] = "yes"
+			adminVerbs["patch"] = "yes"
+
+			// DELETE COllECTION
+			viewVerbs["deleteCollection"] = "no"
+			editVerbs["deleteCollection"] = "no"
+			adminVerbs["deleteCollection"] = "yes"
+
+			namespace := tests.NamespaceTestDefault
+			verbs := []string{"get", "list", "watch", "delete", "create", "update", "patch", "deletecollection"}
+
+			for _, verb := range verbs {
+				// VIEW
+				By(fmt.Sprintf("verifying VIEW sa for verb %s", verb))
+				expectedRes, _ := viewVerbs[verb]
+				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, view)
+				result, err := tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring(expectedRes))
+
+				// EDIT
+				By(fmt.Sprintf("verifying EDIT sa for verb %s", verb))
+				expectedRes, _ = editVerbs[verb]
+				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, edit)
+				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring(expectedRes))
+
+				// ADMIN
+				By(fmt.Sprintf("verifying ADMIN sa for verb %s", verb))
+				expectedRes, _ = adminVerbs[verb]
+				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, admin)
+				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(ContainSubstring(expectedRes))
+			}
+		},
+			table.Entry("given a vm", "virtualmachines"),
+			table.Entry("given an ovm", "offlinevirtualmachines"),
+			table.Entry("given a vm preset", "virtualmachinepresets"),
+			table.Entry("given a vm replica set", "virtualmachinereplicasets"),
+		)
+	})
+})

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -39,33 +39,40 @@ var _ = Describe("User Access", func() {
 	})
 
 	Describe("With default kubevirt service accounts", func() {
-		It("should verify config role has access only to kubevirt-config", func() {
+		It("should verify only admin role has access only to kubevirt-config", func() {
 			tests.SkipIfNoKubectl()
 
-			verbs := []string{"get", "delete", "create", "update", "patch"}
+			verbs := []string{"get", "update", "patch"}
 
-			namespace := tests.KubeVirtInstallNamespace
-			config := tests.ConfigServiceAccountName
+			namespace := tests.NamespaceTestDefault
+			resourceNamespace := tests.KubeVirtInstallNamespace
 
-			// Verifies targetted access to only the kubevirt config
-			By("verifying CONFIG sa for namespace/kubevirt.io:config")
-			for _, verb := range verbs {
-				expectedRes := "yes"
-				resource := "configmaps/kubevirt-config"
-				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, config)
-				result, err := tests.RunKubectlCommand("auth", "can-i", "-n", namespace, "--as", as, verb, resource)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(ContainSubstring(expectedRes))
-			}
+			saNames := []string{tests.ViewServiceAccountName, tests.EditServiceAccountName, tests.AdminServiceAccountName}
 
-			By("verifying CONFIG sa for namespace/kubevirt-madethisup")
-			for _, verb := range verbs {
-				expectedRes := "no"
-				resource := "configmaps/kubevirt-imadethisup"
-				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, config)
-				result, err := tests.RunKubectlCommand("auth", "can-i", "-n", namespace, "--as", as, verb, resource)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(ContainSubstring(expectedRes))
+			for _, saName := range saNames {
+				// Verifies targetted access to only the kubevirt config
+				By(fmt.Sprintf("verifying expected permissions for sa %s for resource configmaps/kubevirt-config", saName))
+				for _, verb := range verbs {
+					expectedRes := "no"
+					if saName == tests.AdminServiceAccountName {
+						expectedRes = "yes"
+					}
+					resource := "configmaps/kubevirt-config"
+					as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, saName)
+					result, err := tests.RunKubectlCommand("auth", "can-i", "-n", resourceNamespace, "--as", as, verb, resource)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(result).To(ContainSubstring(expectedRes))
+				}
+
+				By(fmt.Sprintf("verifying expected permissions for sa %s for resource configmaps/kubevirt-madethisup", saName))
+				for _, verb := range verbs {
+					expectedRes := "no"
+					resource := "configmaps/kubevirt-imadethisup"
+					as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, saName)
+					result, err := tests.RunKubectlCommand("auth", "can-i", "-n", resourceNamespace, "--as", as, verb, resource)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(result).To(ContainSubstring(expectedRes))
+				}
 			}
 		})
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Windows VM", func() {
 
 		It("should succeed to start a vm", func() {
 			By("Starting the vm via kubectl command")
-			err = tests.RunKubectlCommand("create", "-f", yamlFile)
+			_, err = tests.RunKubectlCommand("create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMStartWithTimeout(windowsVm, 120)
@@ -247,13 +247,13 @@ var _ = Describe("Windows VM", func() {
 
 		It("should succeed to stop a vm", func() {
 			By("Starting the vm via kubectl command")
-			err = tests.RunKubectlCommand("create", "-f", yamlFile)
+			_, err = tests.RunKubectlCommand("create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMStartWithTimeout(windowsVm, 120)
 
 			By("Deleting the vm via kubectl command")
-			err = tests.RunKubectlCommand("delete", "-f", yamlFile)
+			_, err = tests.RunKubectlCommand("delete", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the vm does not exist anymore")


### PR DESCRIPTION
This patch adds view/edit/admin KubeVirt related roles to our kubevirt install manifests. These roles can be assigned to users in order to given them targeted access to the KubeVirt apis.

### View Role
**kubevirt.io:view**
Gives users access to getting, listing, and watching all KubeVirt objects

### Edit Role
**kubevirt.io:edit**
Gives users full access to retrieving, creating, and modifying objects. Delete is limited to single objects.

### Admin Role
**kubevirt.io:admin**
All privileges including deletion of collections.

### Applying Roles to Users. 
These roles can be applied to a user across all namespaces by using a **ClusterRoleBinding**, or these roles can be applied to a user in a targeted namespace by using a **RoleBinding**. 

fixes #969 