### PR TITLE
Switch default libvirt interface model type to e1000e

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Converter", func() {
   <devices>
     <interface type="bridge">
       <source bridge="br1"></source>
-      <model type="e1000"></model>
+      <model type="e1000e"></model>
     </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -20,7 +20,7 @@ func SetDefaults_Devices(devices *Devices) {
 	// For now connect every virtual machine to the default network
 	devices.Interfaces = []Interface{{
 		Model: &Model{
-			Type: "e1000",
+			Type: "e1000e",
 		},
 		Type: "bridge",
 		Source: InterfaceSource{

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -42,7 +42,7 @@ var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/doma
   <devices>
     <interface type="bridge">
       <source bridge="br1"></source>
-      <model type="e1000"></model>
+      <model type="e1000e"></model>
     </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Network", func() {
 			IP:      fakeAddr,
 			MAC:     fakeMac,
 			Gateway: gw}
-		interfaceXml = []byte(`<Interface type="bridge"><source bridge="br1"></source><model type="e1000"></model><mac address="12:34:56:78:9a:bc"></mac></Interface>`)
+		interfaceXml = []byte(`<Interface type="bridge"><source bridge="br1"></source><model type="e1000e"></model><mac address="12:34:56:78:9a:bc"></mac></Interface>`)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
This is an Express version of e1000 NIC type. The new type is default for q35
x86 machines starting qemu 2.12. (We currently use 2.10, but the fact they
changed defaults suggests the new type is well maintained.)

This change of kubevirt defaults helps to mitigate the issue of slow eth0 link
establishment inside cirros guest that is unique to e1000 driver.

Note: In span of the fix, we also explored alternative model types, but decided
they were worse candidates to become kubevirt defaults. For example, `virtio`
type doesn't have drivers shipped with Windows images by default; rtl8139 is
not well maintained by upstream.

Closes #936