### PR TITLE
Fix secretRef resolution for cloud-init

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -168,14 +168,11 @@ func ResolveSecrets(source *v1.CloudInitNoCloudSource, namespace string, clients
 		return err
 	}
 
-	userDataBase64, ok := secret.Data["userdata"]
+	userData, ok := secret.Data["userdata"]
 	if ok == false {
 		return errors.New(fmt.Sprintf("no user-data value found in k8s secret %s %v", secretID, err))
 	}
-	userData, err := base64.StdEncoding.DecodeString(string(userDataBase64))
-	if err != nil {
-		return err
-	}
+
 	source.UserData = string(userData)
 	return nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -549,7 +549,9 @@ func (d *VirtualMachineController) processVmShutdown(vm *v1.VirtualMachine, doma
 
 }
 
-func (d *VirtualMachineController) processVmUpdate(vm *v1.VirtualMachine) error {
+func (d *VirtualMachineController) processVmUpdate(origVM *v1.VirtualMachine) error {
+
+	vm := origVM.DeepCopy()
 
 	isExpired, err := watchdog.WatchdogFileIsExpired(d.watchdogTimeoutSeconds, d.virtShareDir, vm)
 


### PR DESCRIPTION
We had two issues in that area:
 * secrets were double-encoded (our test double-decoded too, therfore it
went unnoticed)
 * we updated  the vm with the resolved cloud-init data on the cluster