### PR TITLE
Make virt-api debugable again

### DIFF
--- a/cmd/virt-api/virt-api.go
+++ b/cmd/virt-api/virt-api.go
@@ -30,7 +30,5 @@ func main() {
 
 	app := virt_api.NewVirtApi()
 	service.Setup(app)
-	app.Compose()
-	app.ConfigureOpenAPIService()
-	app.Run()
+	app.Execute()
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -84,6 +84,7 @@ type VirtApi interface {
 	Run()
 	AddFlags()
 	ConfigureOpenAPIService()
+	Execute()
 }
 
 type virtAPIApp struct {
@@ -106,7 +107,13 @@ var _ service.Service = &virtAPIApp{}
 func NewVirtApi() VirtApi {
 
 	app := &virtAPIApp{}
+	app.BindAddress = defaultHost
+	app.Port = defaultPort
 
+	return app
+}
+
+func (app *virtAPIApp) Execute() {
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		panic(err)
@@ -120,15 +127,15 @@ func NewVirtApi() VirtApi {
 	app.authorizor = authorizor
 
 	app.virtCli = virtCli
-	app.BindAddress = defaultHost
-	app.Port = defaultPort
 
 	app.certsDirectory, err = ioutil.TempDir("", "certsdir")
 	if err != nil {
 		panic(err)
 	}
 
-	return app
+	app.Compose()
+	app.ConfigureOpenAPIService()
+	app.Run()
 }
 
 func (app *virtAPIApp) composeResources(ctx context.Context) {


### PR DESCRIPTION
By accient the commandline flags were parsed to late. As a result it was
not possible to provide kubeconfig via commandline flags.

To debug it e.g. via a UI, simply point virt-api to your cluster-config and specify your desired port:

```bash
--kubeconfig cluster/k8s-1.9.3/.kubeconfig --port 1234
```