### PR TITLE
Fix flaky ovm test

### DIFF
--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -122,20 +122,11 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			var err error
 
 			newOVM = NewRandomOfflineVirtualMachine(template, running)
-			Eventually(func() int {
-				ovms, err := virtClient.OfflineVirtualMachine(newOVM.Namespace).List(&v12.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				return len(ovms.Items)
-			}, 300*time.Second, 2*time.Second).Should(BeZero())
 
-			Eventually(func() error {
-				newOVM, err = virtClient.OfflineVirtualMachine(tests.NamespaceTestDefault).Create(newOVM)
-				return err
-			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
-
-			returnedOVM, err := virtClient.OfflineVirtualMachine(newOVM.Namespace).Get(newOVM.Name, &v12.GetOptions{})
+			newOVM, err = virtClient.OfflineVirtualMachine(tests.NamespaceTestDefault).Create(newOVM)
 			Expect(err).ToNot(HaveOccurred())
-			return returnedOVM
+
+			return newOVM
 		}
 
 		startOVM := func(ovm *v1.OfflineVirtualMachine) *v1.OfflineVirtualMachine {
@@ -189,7 +180,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 					return true
 				}
 				return false
-			}, 300*time.Second, 1*time.Second).Should(BeTrue())
+			}, 300*time.Second, 1*time.Second).Should(BeTrue(), "The vm did not disappear")
 
 			By("OVM has not the running condition")
 			Eventually(func() bool {
@@ -220,7 +211,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				vms, err := virtClient.VM(newOVM.Namespace).List(v12.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return len(vms.Items)
-			}, 300*time.Second, 2*time.Second).Should(BeZero())
+			}, 300*time.Second, 2*time.Second).Should(BeZero(), "The VM did not disappear")
 		})
 
 		It("should remove owner references on the VM if it is orphan deleted", func() {
@@ -252,19 +243,23 @@ var _ = Describe("OfflineVirtualMachine", func() {
 		})
 
 		It("should recreate VM if it gets deleted", func() {
-			newOVM := newOfflineVirtualMachine(true)
-			// Delete the VM
-			Eventually(func() error {
-				return virtClient.VM(newOVM.Namespace).Delete(newOVM.Name, &v12.DeleteOptions{})
-			}, 120*time.Second, 1*time.Second).Should(Succeed())
+			newOVM := startOVM(newOfflineVirtualMachine(false))
+
+			currentVM, err := virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(virtClient.VM(newOVM.Namespace).Delete(newOVM.Name, &v12.DeleteOptions{})).To(Succeed())
 
 			Eventually(func() bool {
-				_, err := virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
+				vm, err := virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
 				if errors.IsNotFound(err) {
 					return false
 				}
-				return true
-			}, 120*time.Second, 1*time.Second).Should(BeTrue())
+				if vm.UID != currentVM.UID {
+					return true
+				}
+				return false
+			}, 240*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
 		It("should recreate VM if the VM's pod gets deleted", func() {
@@ -394,9 +389,11 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			newOVM := newOfflineVirtualMachine(false)
 			newOVM = startOVM(newOVM)
 			var vm *v1.VirtualMachine
-			var err error
 
 			for i := 0; i < 3; i++ {
+				currentVM, err := virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
 				By("Getting the running VM")
 				Eventually(func() bool {
 					vm, err = virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
@@ -416,12 +413,20 @@ var _ = Describe("OfflineVirtualMachine", func() {
 				}, 240*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Testing the VM is not running")
+				By("waiting for the controller to replace the shut-down vm with a new instance")
 				Eventually(func() bool {
 					vm, err = virtClient.VM(newOVM.Namespace).Get(newOVM.Name, v12.GetOptions{})
+					// Almost there, a new instance should be spawned soon
+					if errors.IsNotFound(err) {
+						return false
+					}
 					Expect(err).ToNot(HaveOccurred())
-					return vm.Status.Phase != v1.Running
-				}, 240*time.Second, 1*time.Second).Should(BeTrue())
+					// If the UID of the vm changed we see the new vm
+					if vm.UID != currentVM.UID {
+						return true
+					}
+					return false
+				}, 240*time.Second, 1*time.Second).Should(BeTrue(), "No new VM instance showed up")
 
 				By("OVM should run the VM again")
 			}


### PR DESCRIPTION
The ovm test had wrong assumtions on how to test if a vm gets restarted
or recreated.

Fixes issues like 

```
• Failure [181.980 seconds]
OfflineVirtualMachine
/root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:47
  A valid OfflineVirtualMachine given
  /root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:115
    should survive guest shutdown, multiple times [It]
    /root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:392

    Expected error:
        <*errors.StatusError | 0xc4200dc870>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {SelfLink: "", ResourceVersion: "", Continue: ""},
                Status: "Failure",
                Message: "virtualmachines.kubevirt.io \"testvm774p7\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "testvm774p7",
                    Group: "kubevirt.io",
                    Kind: "virtualmachines",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        }
        virtualmachines.kubevirt.io "testvm774p7" not found
    not to have occurred

    /root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:403
```

The test which repeatedly shuts down vms was doing the following things:
 1. It was checking if  the vm moved to finished with `Eventually` checks. The issues here were:
 2. Once the vm was in finished state, it immediately tried to grab the new vm which the controller should create.

These assumptions are wrong. If `Eventually` is used, there is no guarantee that our test will ever see the vm going to a final state. They can simply miss the final state and check when the controller deleted the finished vm (so we get a 404). Further the new vm could be found which is in a non-final state since it is already the fresh vm (could leat to timeouts). Finally when the checks for the final state succeeded,  then immediately trying to grab the fresh vm could fail, since we could try to grab when the controller was in the middle of creating the new instance (so again 404 was possible).

To overcome this: Simply wait after the shutdown until we get a 404 for the vm, or until we got a vm with a different UID (so new vm already).