### PR TITLE
Fixed more misspellings

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -201,7 +201,7 @@ func waitForFinalNotify(deleteNotificationSent chan watch.Event,
 	// don't involve the VM's domain from being deleted from libvirt.
 	//
 	// KillVM is idempotent. Making a call to KillVM here ensures that the deletion
-	// occurs regardless if the VM crashed unexpectidly or if virt-handler requested
+	// occurs regardless if the VM crashed unexpectedly or if virt-handler requested
 	// a graceful shutdown.
 	domainManager.KillVM(vm)
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -879,7 +879,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"running": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Running controlls whether the associatied VirtualMachine is created or not",
+								Description: "Running controls whether the associatied VirtualMachine is created or not",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -704,7 +704,7 @@ type OfflineVirtualMachineList struct {
 // ---
 // +k8s:openapi-gen=true
 type OfflineVirtualMachineSpec struct {
-	// Running controlls whether the associatied VirtualMachine is created or not
+	// Running controls whether the associatied VirtualMachine is created or not
 	Running bool `json:"running"`
 
 	// Template is the direct specification of VirtualMachine

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -140,7 +140,7 @@ func (OfflineVirtualMachineList) SwaggerDoc() map[string]string {
 func (OfflineVirtualMachineSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "OfflineVirtualMachineSpec describes how the proper OfflineVirtualMachine\nshould look like",
-		"running":  "Running controlls whether the associatied VirtualMachine is created or not",
+		"running":  "Running controls whether the associatied VirtualMachine is created or not",
 		"template": "Template is the direct specification of VirtualMachine",
 	}
 }

--- a/pkg/virt-controller/watch/preset_test.go
+++ b/pkg/virt-controller/watch/preset_test.go
@@ -219,12 +219,12 @@ var _ = Describe("VM Initializer", func() {
 			Expect(int(vm.Spec.Domain.CPU.Cores)).To(Equal(4))
 			Expect(len(recorder.events.eventList)).To(Equal(0))
 
-			By("showing an override occured")
+			By("showing an override occurred")
 			preset.Spec.Domain.CPU = &v1.CPU{Cores: 6}
 			err = checkMergeConflicts(preset.Spec.Domain, &vm.Spec.Domain)
 			Expect(err).To(HaveOccurred())
 
-			By("applying overriden preset")
+			By("applying overridden preset")
 			vm.Annotations = map[string]string{}
 			applyPresets(&vm, []v1.VirtualMachinePreset{preset}, recorder)
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -371,7 +371,7 @@ func (c *VMController) sync(vm *virtv1.VirtualMachine, pods []*k8sv1.Pod) (err s
 			c.recorder.Eventf(vm, k8sv1.EventTypeWarning, FailedHandOverPodReason, "Error on handing over pod: %v", err)
 			return &syncErrorImpl{fmt.Errorf("failed to hand over pod to virt-handler: %v", err), FailedHandOverPodReason}
 		}
-		c.recorder.Eventf(vm, k8sv1.EventTypeNormal, SuccessfulHandOverPodReason, "Pod owner ship transfered to the node %s", pod.Name)
+		c.recorder.Eventf(vm, k8sv1.EventTypeNormal, SuccessfulHandOverPodReason, "Pod owner ship transferred to the node %s", pod.Name)
 	}
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -130,7 +130,7 @@ func (l *LibvirtDomainManager) SyncVM(vm *v1.VirtualMachine, allowEmulation bool
 		return nil, err
 	}
 
-	// Set defaults which are not comming from the cluster
+	// Set defaults which are not coming from the cluster
 	api.SetObjectDefaults_Domain(domain)
 
 	dom, err := l.virConn.LookupDomainByName(domain.Spec.Name)

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -50,7 +50,7 @@ var _ = Describe("User Access", func() {
 			saNames := []string{tests.ViewServiceAccountName, tests.EditServiceAccountName, tests.AdminServiceAccountName}
 
 			for _, saName := range saNames {
-				// Verifies targetted access to only the kubevirt config
+				// Verifies targeted access to only the kubevirt config
 				By(fmt.Sprintf("verifying expected permissions for sa %s for resource configmaps/kubevirt-config", saName))
 				for _, verb := range verbs {
 					expectedRes := "no"

--- a/tests/vm_networking_test.go
+++ b/tests/vm_networking_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Networking", func() {
 
 			By("checking the VM can send MTU sized frames to another VM")
 			// NOTE: VM is not directly accessible from inside the pod because
-			// we transfered its IP address under DHCP server control, so the
+			// we transferred its IP address under DHCP server control, so the
 			// only thing we can validate is connectivity between VMs
 			//
 			// NOTE: cirros ping doesn't support -M do that could be used to


### PR DESCRIPTION
- Found the misspell tool (which is run by goreport) and we should
  be able to automatically run it somewhere. Maybe do a git precommit
  hook? misspell -w cmd/** pkg/** tests/** tools/** will automatically
  correct the misspellings.

Signed-off-by: Alexander Wels <awels@redhat.com>