### PR TITLE
fix segfault in test utils

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1036,10 +1036,10 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vm *v1.VirtualMachine, t
 	expecterReader, expecterWriter := io.Pipe()
 	resCh := make(chan error)
 	stopChan := make(chan struct{})
-	go func() {
+	go func(vm *v1.VirtualMachine, vmReader *io.PipeReader, expecterWriter *io.PipeWriter, resCh chan error) {
 		err := virtCli.VM(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, vmReader, expecterWriter)
 		resCh <- err
-	}()
+	}(vm, vmReader, expecterWriter, resCh)
 
 	return expect.SpawnGeneric(&expect.GenOptions{
 		In:  vmWriter,


### PR DESCRIPTION
Our test suite had a goroutine closure that used a pointer to a VM that was outside of the scope of the function. A segfault occasionally occurs within the goroutine at the point where the VM object is accessed. This leads me to believe that the VM pointer was no longer pointing to valid memory at the time the goroutine accessed it.

It's unclear what sequence of events lead up to the segfault. Regardless, our usage of closures in combination with a goroutine here isn't safe.

Passing the pointers in as variables to an anonymous function will ensure that the memory references for each pointer will not change during the goroutines execution. This should at least resolve the segfault.

