### PR TITLE
Change name of monitored process to qemu-system

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -283,7 +283,7 @@ func main() {
 			syscall.Kill(pid, syscall.SIGTERM)
 		}
 	}
-	mon := virtlauncher.NewProcessMonitor("qemu",
+	mon := virtlauncher.NewProcessMonitor("qemu-system",
 		gracefulShutdownTriggerFile,
 		*gracePeriodSeconds,
 		shutdownCallback)


### PR DESCRIPTION
It will help to avoid collision with qemu-img process.

Signed-off-by: Lukianov Artyom <alukiano@redhat.com>