### PR TITLE
Make virtio the default interface model, and allow to change it with a label

### DIFF
--- a/cluster/examples/vm-windows.yaml
+++ b/cluster/examples/vm-windows.yaml
@@ -2,6 +2,8 @@ apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachine
 metadata:
   creationTimestamp: null
+  labels:
+    alpha.kubevirt.io/interface-model: e1000
   name: vm-windows
 spec:
   domain:

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -330,6 +330,8 @@ const (
 	NodeNameLabel        string = "kubevirt.io/nodeName"
 	NodeSchedulable      string = "kubevirt.io/schedulable"
 	VirtHandlerHeartbeat string = "kubevirt.io/heartbeat"
+	InterfaceModel       string = "alpha.kubevirt.io/interface-model"
+	// TODO remove InterfaceModel when we have proper api for network models
 
 	VirtualMachineFinalizer string = "foregroundDeleteVirtualMachine"
 )

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -475,6 +475,25 @@ func Convert_v1_VirtualMachine_To_api_Domain(vm *v1.VirtualMachine, domain *Doma
 		},
 	}
 
+	// Add mandatory interface
+	interfaceType := "virtio"
+
+	_, ok := vm.ObjectMeta.Labels[v1.InterfaceModel]
+	if ok {
+		interfaceType = vm.ObjectMeta.Labels[v1.InterfaceModel]
+	}
+
+	// For now connect every virtual machine to the pod network
+	domain.Spec.Devices.Interfaces = []Interface{{
+		Model: &Model{
+			Type: interfaceType,
+		},
+		Type: "bridge",
+		Source: InterfaceSource{
+			Bridge: DefaultBridgeName,
+		}},
+	}
+
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Converter", func() {
   <devices>
     <interface type="bridge">
       <source bridge="br1"></source>
-      <model type="e1000"></model>
+      <model type="virtio"></model>
     </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>
@@ -403,6 +403,13 @@ var _ = Describe("Converter", func() {
 			Expect(vmToDomainXMLToDomainSpec(vm, c).VCPU.Placement).To(Equal("static"))
 			Expect(vmToDomainXMLToDomainSpec(vm, c).VCPU.CPUs).To(Equal(uint32(3)))
 
+		})
+
+		It("should select explicitly chosen network model", func() {
+			v1.SetObjectDefaults_VirtualMachine(vm)
+			vm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+			domain := vmToDomain(vm, c)
+			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("e1000"))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -17,16 +17,6 @@ func SetDefaults_Devices(devices *Devices) {
 		},
 	}
 
-	// For now connect every virtual machine to the default network
-	devices.Interfaces = []Interface{{
-		Model: &Model{
-			Type: "e1000",
-		},
-		Type: "bridge",
-		Source: InterfaceSource{
-			Bridge: DefaultBridgeName,
-		}},
-	}
 }
 
 func SetDefaults_OSType(ostype *OSType) {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -551,9 +551,6 @@ func NewMinimalDomainSpec(vmName string) *DomainSpec {
 	domain.Name = vmName
 	domain.Memory = Memory{Unit: "MB", Value: 9}
 	domain.Devices = Devices{}
-	domain.Devices.Interfaces = []Interface{
-		{Type: "network", Source: InterfaceSource{Network: "default"}},
-	}
 	return domain
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -40,10 +40,6 @@ var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/doma
     <baseBoard></baseBoard>
   </sysinfo>
   <devices>
-    <interface type="bridge">
-      <source bridge="br1"></source>
-      <model type="e1000"></model>
-    </interface>
     <video>
       <model type="vga" heads="1" vram="16384"></model>
     </video>

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -314,12 +314,7 @@ func SetupDefaultPodNetwork(domain *api.Domain) error {
 	}
 
 	// TODO:(vladikr) Currently we support only one interface per vm.
-	// Improve this once we'll start supporting more.
-	if len(domain.Spec.Devices.Interfaces) == 0 {
-		domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, defaultIconf)
-	} else {
-		domain.Spec.Devices.Interfaces[0] = defaultIconf
-	}
+	domain.Spec.Devices.Interfaces[0] = defaultIconf
 
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Network", func() {
 			IP:      fakeAddr,
 			MAC:     fakeMac,
 			Gateway: gw}
-		interfaceXml = []byte(`<Interface type="bridge"><source bridge="br1"></source><model type="e1000"></model><mac address="12:34:56:78:9a:bc"></mac></Interface>`)
+		interfaceXml = []byte(`<Interface type="bridge"><source bridge="br1"></source><model type="virtio"></model><mac address="12:34:56:78:9a:bc"></mac></Interface>`)
 	})
 
 	AfterEach(func() {
@@ -93,7 +93,7 @@ var _ = Describe("Network", func() {
 		It("should define a new VIF", func() {
 
 			Handler = mockNetwork
-			domain := &api.Domain{}
+			domain := NewDomainWithPodNetwork()
 
 			api.SetObjectDefaults_Domain(domain)
 
@@ -133,7 +133,7 @@ var _ = Describe("Network", func() {
 		It("should panic if pod networking fails to setup", func() {
 			testNetworkPanic := func() {
 				Handler = mockNetwork
-				domain := &api.Domain{}
+				domain := NewDomainWithPodNetwork()
 
 				api.SetObjectDefaults_Domain(domain)
 
@@ -232,3 +232,18 @@ var _ = Describe("Network", func() {
 		})
 	})
 })
+
+func NewDomainWithPodNetwork() *api.Domain {
+
+	domain := &api.Domain{}
+	domain.Spec.Devices.Interfaces = []api.Interface{{
+		Model: &api.Model{
+			Type: "virtio",
+		},
+		Type: "bridge",
+		Source: api.InterfaceSource{
+			Bridge: api.DefaultBridgeName,
+		}},
+	}
+	return domain
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -943,6 +943,13 @@ func NewRandomVMWithWatchdog() *v1.VirtualMachine {
 	return vm
 }
 
+func NewRandomVMWithe1000NetworkInterface() *v1.VirtualMachine {
+	// Use alpine because cirros dhcp client starts prematurily before link is ready
+	vm := NewRandomVMWithEphemeralDisk(RegistryDiskFor(RegistryDiskAlpine))
+	vm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+	return vm
+}
+
 // Block until the specified VM started and return the target node name.
 func waitForVmStart(vm runtime.Object, seconds int, ignoreWarnings bool) (nodeName string) {
 	_, ok := vm.(*v1.VirtualMachine)
@@ -1127,6 +1134,26 @@ func LoggedInCirrosExpecter(vm *v1.VirtualMachine) (expect.Expecter, error) {
 	log.DefaultLogger().Object(vm).V(4).Infof("%v", res)
 	return expecter, err
 }
+
+func LoggedInAlpineExpecter(vm *v1.VirtualMachine) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vm, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	b := append([]expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: "localhost login:"},
+		&expect.BSnd{S: "root\n"},
+		&expect.BExp{R: "localhost:~#"}})
+	res, err := expecter.ExpectBatch(b, 180*time.Second)
+	log.DefaultLogger().Object(vm).V(4).Infof("%v", res)
+	return expecter, err
+}
+
+type VmExpecterFactory func(*v1.VirtualMachine) (expect.Expecter, error)
 
 func NewVirtctlCommand(args ...string) *cobra.Command {
 	commandline := []string{}

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -126,6 +126,7 @@ var _ = Describe("Windows VM", func() {
 		tests.BeforeTestCleanup()
 		windowsVm = tests.NewRandomVM()
 		windowsVm.Spec = windowsVmSpec
+		windowsVm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
 	})
 
 	It("should succeed to start a vm", func() {

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -285,6 +285,9 @@ func getVmWindows() *v1.VirtualMachine {
 		},
 	}
 
+	// pick e1000 network model type for windows machines
+	vm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+
 	addPvcDisk(&vm.Spec, "disk-windows", busSata, "pvcdisk", "pvcvolume")
 	return vm
 }


### PR DESCRIPTION
This is another attempt to make all machines happy with their network model type. This PR is a spin on the other PR that is closed now: https://github.com/kubevirt/kubevirt/pull/990 The difference here is that instead of leaving all images but cirros at e1000, we make virtio the default model type and fall back to e1000 for win* annotations.