### PR TITLE
Get rid of async ginkgo tests

### DIFF
--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -128,7 +128,7 @@ var _ = Describe("RegistryDisk", func() {
 
 	Describe("Starting multiple VMs", func() {
 		Context("with ephemeral registry disk", func() {
-			It("should success", func(done Done) {
+			It("should success", func() {
 				num := 5
 				vms := make([]*v1.VirtualMachine, 0, num)
 				objs := make([]runtime.Object, 0, num)
@@ -151,9 +151,7 @@ var _ = Describe("RegistryDisk", func() {
 					// It just requires virt-handler to retry the Start command at the moment.
 					VerifyRegistryDiskVM(vm, objs[idx], true)
 				}
-
-				close(done)
-			}, 120) // Timeout is long because this test involves multiple parallel VM launches.
+			}) // Timeout is long because this test involves multiple parallel VM launches.
 		})
 	})
 })

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -645,7 +645,9 @@ func cleanNamespaces() {
 		for _, vm := range vms.Items {
 			if controller.HasFinalizer(&vm, v1.VirtualMachineFinalizer) {
 				_, err := virtCli.VM(vm.Namespace).Patch(vm.Name, types.JSONPatchType, []byte("[{ \"op\": \"remove\", \"path\": \"/metadata/finalizers\" }]"))
-				PanicOnError(err)
+				if !errors.IsNotFound(err) {
+					PanicOnError(err)
+				}
 			}
 		}
 

--- a/tests/vm_monitoring_test.go
+++ b/tests/vm_monitoring_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Health Monitoring", func() {
 	})
 
 	Describe("A VM with a watchdog device", func() {
-		It("should be shut down when the watchdog expires", func(done Done) {
+		It("should be shut down when the watchdog expires", func() {
 			vm := tests.NewRandomVMWithWatchdog()
 			Expect(err).ToNot(HaveOccurred())
 			launchVM(vm)
@@ -90,7 +90,6 @@ var _ = Describe("Health Monitoring", func() {
 				return startedVM.Status.Phase
 			}, 40*time.Second).Should(Equal(v1.Failed))
 
-			close(done)
-		}, 300)
+		})
 	})
 })

--- a/tests/vm_userdata_test.go
+++ b/tests/vm_userdata_test.go
@@ -79,7 +79,7 @@ var _ = Describe("CloudInit UserData", func() {
 
 	Describe("A new VM", func() {
 		Context("with cloudInitNoCloud userDataBase64 source", func() {
-			It("should have cloud-init data", func(done Done) {
+			It("should have cloud-init data", func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 
 				vm := tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), userData)
@@ -87,8 +87,7 @@ var _ = Describe("CloudInit UserData", func() {
 				VerifyUserDataVM(vm, []expect.Batcher{
 					&expect.BExp{R: expectedUserData},
 				}, time.Second*120)
-				close(done)
-			}, 180)
+			})
 
 			Context("with injected ssh-key", func() {
 				It("should have ssh-key under authorized keys", func() {
@@ -117,7 +116,7 @@ var _ = Describe("CloudInit UserData", func() {
 		})
 
 		Context("with cloudInitNoCloud userData source", func() {
-			It("should process provided cloud-init data", func(done Done) {
+			It("should process provided cloud-init data", func() {
 				userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 
 				vm := tests.NewRandomVMWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskCirros))
@@ -156,11 +155,10 @@ var _ = Describe("CloudInit UserData", func() {
 				}, time.Second*10)
 				log.DefaultLogger().Object(vm).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
-				close(done)
-			}, 180)
+			})
 		})
 
-		It("should take user-data from k8s secret", func(done Done) {
+		It("should take user-data from k8s secret", func() {
 			userData := fmt.Sprintf("#!/bin/sh\n\necho '%s'\n", expectedUserData)
 			vm := tests.NewRandomVMWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "")
 
@@ -201,8 +199,6 @@ var _ = Describe("CloudInit UserData", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vm.Spec.Volumes[idx].CloudInitNoCloud.UserData).To(BeEmpty())
 			Expect(vm.Spec.Volumes[idx].CloudInitNoCloud.UserDataBase64).To(BeEmpty())
-
-			close(done)
-		}, 180)
+		})
 	})
 })

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -27,10 +27,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"time"
+
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/tests"
-	"time"
 )
 
 var _ = Describe("VNC", func() {


### PR DESCRIPTION
Ginkgo async tests are not working so well. Get rid of them, to avoid
leaking routines which then sometimes run into timeouts after the actual
tes already finished.

Example:

```
•... Timeout [46.099 seconds]
Vmlifecycle
/root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:45
  Creating a VM
  /root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:59
    should start it [It]
    /root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:65

    Timed out

    /root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:65
------------------------------
level=info timestamp=2018-05-17T20:25:25.427146Z pos=utils.go:231 component=tests msg="Created virtual machine pod virt-launcher-testvmzcfmc-hvw76"
• Failure [51.318 seconds]
Vmlifecycle
/root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:45
  Creating a VM
  /root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:59
    should attach virt-launcher to it [It]
    /root/go/src/kubevirt.io/kubevirt/tests/vmlifecycle_test.go:73

    Expected error:
        <*errors.StatusError | 0xc4200fcd80>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {SelfLink: "", ResourceVersion: "", Continue: ""},
                Status: "Failure",
                Message: "virtualmachines.kubevirt.io \"testvmzcfmc\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "testvmzcfmc",
                    Group: "kubevirt.io",
                    Kind: "virtualmachines",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        }
        virtualmachines.kubevirt.io "testvmzcfmc" not found
    not to have occurred

    /root/go/src/kubevirt.io/kubevirt/tests/utils.go:938
```

The first test times out but we see the second test failing because of an asynchronous check which we did in the prevous test.

See also https://github.com/onsi/ginkgo/issues/363#issuecomment-315953647 and https://github.com/onsi/ginkgo/pull/362. It turns out to be hard to write good test with this part of ginkgo. Therefore it might even get deprecated there.