### PR TITLE
Fix goveralls

### DIFF
--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-goveralls -service=travis-ci -package=./pkg/... -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go" -printf "%P\n" | paste -d, -s) -v
+go test -cover -v -coverprofile=.coverprofile $(go list ./pkg/...)
+goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go" -printf "%P\n" | paste -d, -s)


### PR DESCRIPTION
In go 1.10 the results seems to look different if not all packages are
passed in expanded. As a result not all data is generated and uploaded.

Fixes #972 