### PR TITLE
Ignore generated openapi specification in test coverage

### DIFF
--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 go test -cover -v -coverprofile=.coverprofile $(go list ./pkg/...)
-goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go" -printf "%P\n" | paste -d, -s)
+goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)


### PR DESCRIPTION
Related to #972