### PR TITLE
Don't override reference ovm in case of errors

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -24,4 +24,4 @@ source hack/config.sh
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -kubectl-path=${kubectl} -test.timeout 60m ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -kubectl-path=${kubectl} -test.timeout 90m ${FUNC_TEST_ARGS}

--- a/tests/ovm_test.go
+++ b/tests/ovm_test.go
@@ -139,21 +139,21 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			updatedOVM = updatedOVM.DeepCopy()
 			updatedOVM.Spec.Running = true
 			Eventually(func() error {
-				updatedOVM, err = virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Update(updatedOVM)
+				_, err := virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Update(updatedOVM)
 				return err
 			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 			// Observe the VM created
 			Eventually(func() error {
-				_, err = virtClient.VM(updatedOVM.Namespace).Get(updatedOVM.Name, v12.GetOptions{})
+				_, err := virtClient.VM(updatedOVM.Namespace).Get(updatedOVM.Name, v12.GetOptions{})
 				return err
 			}, 300*time.Second, 1*time.Second).Should(Succeed())
 
 			By("OVM has the running condition")
 			Eventually(func() bool {
-				updatedOVM, err = virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Get(updatedOVM.Name, &v12.GetOptions{})
+				ovm, err := virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Get(updatedOVM.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return updatedOVM.Status.Ready
+				return ovm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeTrue())
 
 			return updatedOVM
@@ -169,7 +169,7 @@ var _ = Describe("OfflineVirtualMachine", func() {
 			updatedOVM = updatedOVM.DeepCopy()
 			updatedOVM.Spec.Running = false
 			Eventually(func() error {
-				updatedOVM, err = virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Update(updatedOVM)
+				_, err := virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Update(updatedOVM)
 				return err
 			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
@@ -184,9 +184,9 @@ var _ = Describe("OfflineVirtualMachine", func() {
 
 			By("OVM has not the running condition")
 			Eventually(func() bool {
-				updatedOVM, err = virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Get(updatedOVM.Name, &v12.GetOptions{})
+				ovm, err := virtClient.OfflineVirtualMachine(updatedOVM.Namespace).Get(updatedOVM.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				return updatedOVM.Status.Ready
+				return ovm.Status.Ready
 			}, 300*time.Second, 1*time.Second).Should(BeFalse())
 
 			return updatedOVM


### PR DESCRIPTION
In some Eventually loops we were overriding the reference ovm with a
fetched entity even in cases where an error was returned. These returned
ovm entities are not properly fetched an mess up the test.

Fixes issues like

```
• Failure [452.107 seconds]
OfflineVirtualMachine
/root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:47
  A valid OfflineVirtualMachine given
  /root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:115
    should start and stop VM multiple times [It]
    /root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:333

    Timed out after 300.000s.
    Expected error:
        <*errors.errorString | 0xc4203a0570>: {
            s: "resource name may not be empty",
        }
        resource name may not be empty
    not to have occurred

    /root/go/src/kubevirt.io/kubevirt/tests/ovm_test.go:144
```