### PR TITLE
Mark spec.selector in VMRS as required

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4237,6 +4237,7 @@
    },
    "v1.VMReplicaSetSpec": {
     "required": [
+     "selector",
      "template"
     ],
     "properties": {
@@ -4250,7 +4251,7 @@
       "format": "int32"
      },
      "selector": {
-      "description": "Label selector for pods. Existing ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.\n+optional",
+      "description": "Label selector for pods. Existing ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.",
       "$ref": "#/definitions/v1.LabelSelector"
      },
      "template": {

--- a/manifests/generated/vmrs-resource.yaml
+++ b/manifests/generated/vmrs-resource.yaml
@@ -380,6 +380,7 @@ spec:
                   required:
                   - domain
           required:
+          - selector
           - template
         status:
           properties:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1166,7 +1166,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 							},
 						},
 					},
-					Required: []string{"template"},
+					Required: []string{"selector", "template"},
 				},
 			},
 			Dependencies: []string{

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -486,8 +486,7 @@ type VMReplicaSetSpec struct {
 
 	// Label selector for pods. Existing ReplicaSets whose pods are
 	// selected by this will be the ones affected by this deployment.
-	// +optional
-	Selector *metav1.LabelSelector `json:"selector,omitempty" valid:"required"`
+	Selector *metav1.LabelSelector `json:"selector" valid:"required"`
 
 	// Template describes the pods that will be created.
 	Template *VMTemplateSpec `json:"template" valid:"required"`

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -80,7 +80,7 @@ func (VirtualMachineReplicaSetList) SwaggerDoc() map[string]string {
 func (VMReplicaSetSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"replicas": "Number of desired pods. This is a pointer to distinguish between explicit\nzero and not specified. Defaults to 1.\n+optional",
-		"selector": "Label selector for pods. Existing ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.\n+optional",
+		"selector": "Label selector for pods. Existing ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.",
 		"template": "Template describes the pods that will be created.",
 		"paused":   "Indicates that the replica set is paused.\n+optional",
 	}


### PR DESCRIPTION
* `spec.template` and `spec.selector` are both required on the VirtualMachineReplicaSet.
* `spec.selector` must match `spec.template.metadata.labels`

Fixes #957 