### PR TITLE
Don't crash virt-api if extra user headers are added

### DIFF
--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -84,7 +84,7 @@ func (a *authorizor) getUserName(header http.Header) (string, error) {
 
 func (a *authorizor) getUserExtras(header http.Header) map[string]authorization.ExtraValue {
 
-	var extras map[string]authorization.ExtraValue
+	extras := map[string]authorization.ExtraValue{}
 
 	for _, prefix := range a.userExtraHeaderPrefixes {
 		for k, v := range header {

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -52,6 +52,7 @@ var _ = Describe("VM Subresources", func() {
 		req.Request.Header = make(map[string][]string)
 		req.Request.Header[userHeader] = []string{"user"}
 		req.Request.Header[groupHeader] = []string{"userGroup"}
+		req.Request.Header[userExtraHeaderPrefix+"test"] = []string{"userExtraValue"}
 		req.Request.URL.Path = "/apis/subresources.kubevirt.io/v1alpha1/namespaces/default/virtualmachines/testvm/console"
 
 		server = ghttp.NewServer()


### PR DESCRIPTION
virt-api should not crash if extra user-headers are part of the authentication request.

```
2018/05/23 08:43:24 http: panic serving 10.128.0.1:52912: assignment to entry in nil map
goroutine 4867 [running]:
net/http.(*conn).serve.func1(0xc42042caa0)
	/gimme/.gimme/versions/go1.10.linux.amd64/src/net/http/server.go:1726 +0xd0
panic(0x1007080, 0x123b5b0)
	/gimme/.gimme/versions/go1.10.linux.amd64/src/runtime/panic.go:505 +0x229
kubevirt.io/kubevirt/pkg/virt-api/rest.(*authorizor).getUserExtras(0xc4200cb800, 0xc420361710, 0x11448d6)
	/root/go/src/kubevirt.io/kubevirt/pkg/virt-api/rest/authorizer.go:93 +0x100
kubevirt.io/kubevirt/pkg/virt-api/rest.(*authorizor).generateAccessReview(0xc4200cb800, 0xc420361a10, 0x1148fb8, 0x7, 0xc420455730)
	/root/go/src/kubevirt.io/kubevirt/pkg/virt-api/rest/authorizer.go:152 +0x15f
kubevirt.io/kubevirt/pkg/virt-api/rest.(*authorizor).Authorize(0xc4200cb800, 0xc420361a10, 0x0, 0x1145375, 0x3, 0x0, 0x0)
	/root/go/src/kubevirt.io/kubevirt/pkg/virt-api/rest/authorizer.go:229 +0xa0
kubevirt.io/kubevirt/pkg/virt-api.(*virtAPIApp).Compose.func1(0xc420361a10, 0xc420197420, 0xc420361aa0)
	/root/go/src/kubevirt.io/kubevirt/pkg/virt-api/api.go:300 +0x52
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc420361aa0, 0xc420361a10, 0xc420197420)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/filter.go:19 +0x68
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*Container).OPTIONSFilter(0xc4200ec1b0, 0xc420361a10, 0xc420197420, 0xc420361aa0)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/options_filter.go:15 +0x6d
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*Container).OPTIONSFilter-fm(0xc420361a10, 0xc420197420, 0xc420361aa0)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/options_filter.go:33 +0x48
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc420361aa0, 0xc420361a10, 0xc420197420)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/filter.go:19 +0x68
kubevirt.io/kubevirt/pkg/rest/filter.RequestLoggingFilter.func1(0xc420361a10, 0xc420197420, 0xc420361aa0)
	/root/go/src/kubevirt.io/kubevirt/pkg/rest/filter/filter.go:38 +0x8e
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*FilterChain).ProcessFilter(0xc420361aa0, 0xc420361a10, 0xc420197420)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/filter.go:19 +0x68
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*Container).dispatch(0xc4200ec1b0, 0x1251ce0, 0xc4203ae460, 0xc420509800)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/container.go:279 +0x889
kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.(*Container).(kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful.dispatch)-fm(0x1251ce0, 0xc4203ae460, 0xc420509800)
	/root/go/src/kubevirt.io/kubevirt/vendor/github.com/emicklei/go-restful/container.go:120 +0x48
net/http.HandlerFunc.ServeHTTP(0xc420455960, 0x1251ce0, 0xc4203ae460, 0xc420509800)
	/gimme/.gimme/versions/go1.10.linux.amd64/src/net/http/server.go:1947 +0x44
net/http.(*ServeMux).ServeHTTP(0x1923fe0, 0x1251ce0, 0xc4203ae460, 0xc420509800)
	/gimme/.gimme/versions/go1.10.linux.amd64/src/net/http/server.go:2337 +0x130
net/http.serverHandler.ServeHTTP(0xc4200891e0, 0x1251ce0, 0xc4203ae460, 0xc420509800)
	/gimme/.gimme/versions/go1.10.linux.amd64/src/net/http/server.go:2694 +0xbc
net/http.(*conn).serve(0xc42042caa0, 0x12545a0, 0xc4204bf080)
	/gimme/.gimme/versions/go1.10.linux.amd64/src/net/http/server.go:1830 +0x651
created by net/http.(*Server).Serve
	/gimme/.gimme/versions/go1.10.linux.amd64/src/net/http/server.go:2795 +0x27b
```

Related to #1058. We need logs to see if it fixes the issue there.