### PR TITLE
Move interface-model annotation to annotations

### DIFF
--- a/cluster/examples/vm-windows.yaml
+++ b/cluster/examples/vm-windows.yaml
@@ -1,9 +1,9 @@
 apiVersion: kubevirt.io/v1alpha1
 kind: VirtualMachine
 metadata:
-  creationTimestamp: null
-  labels:
+  annotations:
     alpha.kubevirt.io/interface-model: e1000
+  creationTimestamp: null
   name: vm-windows
 spec:
   domain:

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -478,9 +478,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vm *v1.VirtualMachine, domain *Doma
 	// Add mandatory interface
 	interfaceType := "virtio"
 
-	_, ok := vm.ObjectMeta.Labels[v1.InterfaceModel]
+	_, ok := vm.ObjectMeta.Annotations[v1.InterfaceModel]
 	if ok {
-		interfaceType = vm.ObjectMeta.Labels[v1.InterfaceModel]
+		interfaceType = vm.ObjectMeta.Annotations[v1.InterfaceModel]
 	}
 
 	// For now connect every virtual machine to the pod network

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Converter", func() {
 
 		It("should select explicitly chosen network model", func() {
 			v1.SetObjectDefaults_VirtualMachine(vm)
-			vm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+			vm.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
 			domain := vmToDomain(vm, c)
 			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("e1000"))
 		})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -946,7 +946,7 @@ func NewRandomVMWithWatchdog() *v1.VirtualMachine {
 func NewRandomVMWithe1000NetworkInterface() *v1.VirtualMachine {
 	// Use alpine because cirros dhcp client starts prematurily before link is ready
 	vm := NewRandomVMWithEphemeralDisk(RegistryDiskFor(RegistryDiskAlpine))
-	vm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+	vm.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
 	return vm
 }
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Windows VM", func() {
 		tests.BeforeTestCleanup()
 		windowsVm = tests.NewRandomVM()
 		windowsVm.Spec = windowsVmSpec
-		windowsVm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+		windowsVm.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
 	})
 
 	It("should succeed to start a vm", func() {

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -286,7 +286,7 @@ func getVmWindows() *v1.VirtualMachine {
 	}
 
 	// pick e1000 network model type for windows machines
-	vm.ObjectMeta.Labels = map[string]string{v1.InterfaceModel: "e1000"}
+	vm.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
 
 	addPvcDisk(&vm.Spec, "disk-windows", busSata, "pvcdisk", "pvcvolume")
 	return vm


### PR DESCRIPTION
The kubevirt.io/interface-model annotation was accidentally implemented as
a label. This would influence commands like `virtctl expose` in an
unexpected way.