### PR TITLE
Fix oc template samples

### DIFF
--- a/cluster/vm-template-fedora.yaml
+++ b/cluster/vm-template-fedora.yaml
@@ -24,10 +24,10 @@ objects:
       spec:
         domain:
           cpu:
-            cores: ${{CPU_CORES}}
+            cores: ${CPU_CORES}
           resources:
             requests:
-              memory: ${{MEMORY}}
+              memory: ${MEMORY}
           devices:
             disks:
               - name: disk0

--- a/cluster/vm-template-rhel7.yaml
+++ b/cluster/vm-template-rhel7.yaml
@@ -24,10 +24,10 @@ objects:
       spec:
         domain:
           cpu:
-            cores: ${{CPU_CORES}}
+            cores: ${CPU_CORES}
           resources:
             requests:
-              memory: ${{MEMORY}}
+              memory: ${MEMORY}
           machine:
             type: q35
           devices:

--- a/cluster/vm-template-windows2012r2.yaml
+++ b/cluster/vm-template-windows2012r2.yaml
@@ -42,12 +42,12 @@ objects:
                 tickPolicy: catchup
               hyperv: {}
           cpu:
-            cores: ${{CPU_CORES}}
+            cores: ${CPU_CORES}
           machine:
             type: q35
           resources:
             requests:
-              memory: ${{MEMORY}}
+              memory: ${MEMORY}
           devices:
             disks:
               - name: disk0


### PR DESCRIPTION
The template samples within the 'cluster' directory use double curly braces for `CPU_CORES` and `MEMORY` variables and single curly braces for `NAME` variable.  Since a user is not expected to enter JSON string defining a subtree as a value for `CPU_CORES` and `MEMORY` parameters, this is quite confusing, especially for the new *KubeVirt* users.