### PR TITLE
Improve build speed in dockerized environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export GO15VENDOREXPERIMENT := 1
 
-all: build manifests
+all:
+	hack/dockerized "./hack/check.sh && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT} && ./hack/build-copy-artifacts.sh ${WHAT} && DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build-manifests.sh"
 
 generate:
 	hack/dockerized "./hack/generate.sh"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -60,7 +60,9 @@ fi
 # handle binaries
 
 if [ "${target}" = "install" ]; then
-    rm -rf ${CMD_OUT_DIR}
+    # Delete all binaries which are not present in the binaries variable to avoid branch inconsistencies
+    to_delete=$(comm -23 <(find ${CMD_OUT_DIR} -mindepth 1 -maxdepth 1 -type d | sort) <(echo $binaries | sed -e 's/cmd\///g' -e 's/ /\n/g' | sed -e "s#^#${CMD_OUT_DIR}/#" | sort))
+    rm -rf ${to_delete}
 fi
 
 for arg in $args; do
@@ -80,13 +82,13 @@ for arg in $args; do
 
             # always build and link the linux/amd64 binary
             LINUX_NAME=${ARCH_BASENAME}-linux-amd64
-            GOOS=linux GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)"
+            GOOS=linux GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)"
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
 
             # build virtctl also for darwin and windows
             if [ "${BIN_NAME}" = "virtctl" ]; then
-                GOOS=darwin GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)"
-                GOOS=windows GOARCH=amd64 go build -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)"
+                GOOS=darwin GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)"
+                GOOS=windows GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)"
             fi
         )
     else


### PR DESCRIPTION
Until now we were very conservative and deleted old artifacts to be sure that on branch- or code changes only requested artifacts are left over after a rebuild. Now the difference between currently compiled binaries and binaries which need to be built is detected. Only those which are not going to be built again are deleted. This helps the caching mechanism of go to do its work better. 

To sum up:

* Only delete binaries which are not present on the current branch
 * Run all commands for "make" in one docker run

Time before change on my machine:

```bash
$ time make
[...]

real	0m32.805s
user	0m1.406s
sys	0m0.584s
```

Time after change on my machine:

```bash
$ time make
[...]

real	0m15.794s
user	0m1.207s
sys	0m0.437s
```