### PR TITLE
virt-launcher: Update libvirt to 4.2.0

### DIFF
--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -16,7 +16,7 @@
 # Copyright 2017 Red Hat, Inc.
 #
 
-FROM kubevirt/libvirt:3.7.0
+FROM kubevirt/libvirt:4.2.0
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 


### PR DESCRIPTION
This accompanies https://github.com/kubevirt/libvirt/pull/14 to fix #956.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>