### PR TITLE
Tiny fix for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,10 @@ hack/gen-swagger-doc/*.adoc
 hack/gen-swagger-doc/*.md
 hack/gen-swagger-doc/html5
 cluster/local/certs
-**.swp
-**.pem
-**.crt
-**.csr
+*.swp
+*.pem
+*.crt
+*.csr
 _out
 vendor/**/*_test.go
 **/polarion.xml


### PR DESCRIPTION
The expression `**.xxx` doesn't make sense because '**' makes sense only for
directories.  Since `*.xxx` is relative it already applies for all files in all
directories with the specified extension.

Little background: git actually ignores that, but ripgrep throws a warning about
it so when looking for something I always get 4 lines of warnings.  Even though
they are harmless, they are pretty annoying.

Signed-off-by: Martin Kletzander <mkletzan@redhat.com>