### PR TITLE
Create and publish a jinja2 template of kubevirt.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ deploy:
   file:
   - _out/cmd/virtctl/virtctl-*
   - _out/manifests/release/kubevirt.yaml
+  - _out/templates/manifests/release/kubevirt.yaml.j2
   - _out/manifests/release/demo-content.yaml
   prerelease: true
   overwrite: true

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -10,6 +10,7 @@ CMD_OUT_DIR=$OUT_DIR/cmd
 TESTS_OUT_DIR=$OUT_DIR/tests
 APIDOCS_OUT_DIR=$OUT_DIR/apidocs
 MANIFESTS_OUT_DIR=$OUT_DIR/manifests
+MANIFEST_TEMPLATES_OUT_DIR=$OUT_DIR/templates/manifests
 PYTHON_CLIENT_OUT_DIR=$OUT_DIR/client-python
 
 function build_func_tests() {

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -40,6 +40,8 @@ RUN \
     git checkout release-1.9 && \
     go install
 
+RUN pip install j2cli
+
 ADD entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]


### PR DESCRIPTION
It allows substitutiong:

 * the docker registry
 * the image release tag
 * the target namespace of our extensions

Further, a very simple test based on diff to ensure that the jinja2 templates stay
in sync with the release manifests is added. Because j2cli tends to
"clean" files unasked and it is very easy to write too much newlines in
go templates the input cleaning for "diff" looks a little complex.