### PR TITLE
direct visitors more clearly to user / developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,25 @@ Example:
 [![asciicast](https://asciinema.org/a/96275.png)](https://asciinema.org/a/96275)
 
 
-# Getting Started
+# To start using KubeVirt
 
-**Demo** To try out our demo run
-```bash
-$ curl run.kubevirt.io/demo.sh | bash
-```
-on a recent Fedora or Ubuntu and follow [these steps](https://github.com/kubevirt/demo).
+Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
 
-**Developer** To set up a development environment please read our
+See our user documentation at [docs.kubevirt.io](http://docs.kubevirt.io/).
+
+# To start developing KubeVirt
+
+To set up a development environment please read our
 [Getting Started Guide](docs/getting-started.md). To learn how to contribute, please read our [contribution guide](https://github.com/kubevirt/kubevirt/blob/master/CONTRIBUTING.md).
-
-## Documentation
-
- * [User-Guide](https://www.kubevirt.io/user-guide)
- * [API Reference](https://www.kubevirt.io/api-reference/)
-
-## Architecture
 
 You can learn more about how KubeVirt is designed (and why it is that way),
 and learn more about the major components by taking a look at
-[our documentation](docs/):
+[our developer documentation](docs/):
 
  * [Glossary](docs/glossary.md) - Explaining the most important terms
  * [Architecture](docs/architecture.md) - High-level view on the architecture
  * [Components](docs/components.md) - Detailed look at all components
+ * [API Reference](https://www.kubevirt.io/api-reference/)
 
 
 # Community


### PR DESCRIPTION
* Changes README to adopt the kubernetes/kubernetes style of
"To start using..." "To start developing..." to direct users
and contributors to the correct places.

* Drops the pointer to the demo script to get started as a
user in favor of the quickstart page on the website.