### PR TITLE
Support multiple interface / network definitions

### DIFF
--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -152,12 +152,24 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 	}
 }
 
-func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	networks := obj.Spec.Networks
+func isPodInterfaceConfigured(obj *VirtualMachineInstance) bool {
+	for _, net := range obj.Spec.Networks {
+		if net.Pod != nil {
+			for _, iface := range obj.Spec.Domain.Devices.Interfaces {
+				if iface.Name == net.Name {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return false
+}
 
+func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
 	//TODO: Currently, we support only one interface associated to a network
 	//      This should be improved when we will start supporting multimple interfaces and networks
-	if len(networks) == 0 || networks[0].Pod == nil {
+	if !isPodInterfaceConfigured(obj) {
 		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultNetworkInterface()}
 		obj.Spec.Networks = []Network{*DefaultPodNetwork()}
 	}

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -152,22 +152,23 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 	}
 }
 
-func isPodInterfaceConfigured(obj *VirtualMachineInstance) bool {
+func getNumberOfPodInterfaces(obj *VirtualMachineInstance) int {
+	nPodInterfaces := 0
 	for _, net := range obj.Spec.Networks {
 		if net.Pod != nil {
 			for _, iface := range obj.Spec.Domain.Devices.Interfaces {
 				if iface.Name == net.Name {
-					return true
+					nPodInterfaces++
+					break // we maintain 1-to-1 relationship between networks and interfaces
 				}
 			}
-			return false
 		}
 	}
-	return false
+	return nPodInterfaces
 }
 
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	if !isPodInterfaceConfigured(obj) {
+	if getNumberOfPodInterfaces(obj) == 0 {
 		obj.Spec.Domain.Devices.Interfaces = append(obj.Spec.Domain.Devices.Interfaces, *DefaultNetworkInterface())
 		obj.Spec.Networks = append(obj.Spec.Networks, *DefaultPodNetwork())
 	}

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -152,7 +152,7 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 	}
 }
 
-func getNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
+func GetNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
 	nPodInterfaces := 0
 	for _, net := range spec.Networks {
 		if net.Pod != nil {
@@ -168,7 +168,7 @@ func getNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
 }
 
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	if getNumberOfPodInterfaces(&obj.Spec) == 0 {
+	if GetNumberOfPodInterfaces(&obj.Spec) == 0 {
 		obj.Spec.Domain.Devices.Interfaces = append(obj.Spec.Domain.Devices.Interfaces, *DefaultNetworkInterface())
 		obj.Spec.Networks = append(obj.Spec.Networks, *DefaultPodNetwork())
 	}

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -152,6 +152,7 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 	}
 }
 
+// TODO:(ihar) move to validating-webhook.go and privatize it
 func GetNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
 	nPodInterfaces := 0
 	for _, net := range spec.Networks {
@@ -168,9 +169,10 @@ func GetNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
 }
 
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	if GetNumberOfPodInterfaces(&obj.Spec) == 0 {
-		obj.Spec.Domain.Devices.Interfaces = append(obj.Spec.Domain.Devices.Interfaces, *DefaultNetworkInterface())
-		obj.Spec.Networks = append(obj.Spec.Networks, *DefaultPodNetwork())
+	// Override only when nothing is specified
+	if len(obj.Spec.Networks) == 0 {
+		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultNetworkInterface()}
+		obj.Spec.Networks = []Network{*DefaultPodNetwork()}
 	}
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -152,11 +152,11 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 	}
 }
 
-func getNumberOfPodInterfaces(obj *VirtualMachineInstance) int {
+func getNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
 	nPodInterfaces := 0
-	for _, net := range obj.Spec.Networks {
+	for _, net := range spec.Networks {
 		if net.Pod != nil {
-			for _, iface := range obj.Spec.Domain.Devices.Interfaces {
+			for _, iface := range spec.Domain.Devices.Interfaces {
 				if iface.Name == net.Name {
 					nPodInterfaces++
 					break // we maintain 1-to-1 relationship between networks and interfaces
@@ -168,7 +168,7 @@ func getNumberOfPodInterfaces(obj *VirtualMachineInstance) int {
 }
 
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	if getNumberOfPodInterfaces(obj) == 0 {
+	if getNumberOfPodInterfaces(&obj.Spec) == 0 {
 		obj.Spec.Domain.Devices.Interfaces = append(obj.Spec.Domain.Devices.Interfaces, *DefaultNetworkInterface())
 		obj.Spec.Networks = append(obj.Spec.Networks, *DefaultPodNetwork())
 	}

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -152,22 +152,6 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 	}
 }
 
-// TODO:(ihar) move to validating-webhook.go and privatize it
-func GetNumberOfPodInterfaces(spec *VirtualMachineInstanceSpec) int {
-	nPodInterfaces := 0
-	for _, net := range spec.Networks {
-		if net.Pod != nil {
-			for _, iface := range spec.Domain.Devices.Interfaces {
-				if iface.Name == net.Name {
-					nPodInterfaces++
-					break // we maintain 1-to-1 relationship between networks and interfaces
-				}
-			}
-		}
-	}
-	return nPodInterfaces
-}
-
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
 	// Override only when nothing is specified
 	if len(obj.Spec.Networks) == 0 {

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -167,11 +167,9 @@ func isPodInterfaceConfigured(obj *VirtualMachineInstance) bool {
 }
 
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
-	//TODO: Currently, we support only one interface associated to a network
-	//      This should be improved when we will start supporting multimple interfaces and networks
 	if !isPodInterfaceConfigured(obj) {
-		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultNetworkInterface()}
-		obj.Spec.Networks = []Network{*DefaultPodNetwork()}
+		obj.Spec.Domain.Devices.Interfaces = append(obj.Spec.Domain.Devices.Interfaces, *DefaultNetworkInterface())
+		obj.Spec.Networks = append(obj.Spec.Networks, *DefaultPodNetwork())
 	}
 }
 

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -246,67 +246,6 @@ var _ = Describe("Defaults", func() {
 	})
 })
 
-var _ = Describe("Function GetNumberOfPodInterfaces()", func() {
-
-	It("should work for empty network list", func() {
-		spec := &VirtualMachineInstanceSpec{}
-		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(0))
-	})
-
-	It("should work for non-empty network list without pod network", func() {
-		spec := &VirtualMachineInstanceSpec{}
-		net := Network{}
-		spec.Networks = []Network{net}
-		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(0))
-	})
-
-	It("should work for pod network with missing pod interface", func() {
-		spec := &VirtualMachineInstanceSpec{}
-		net := Network{
-			NetworkSource: NetworkSource{
-				Pod: &PodNetwork{},
-			},
-		}
-		spec.Networks = []Network{net}
-		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(0))
-	})
-
-	It("should work for valid pod network / interface combination", func() {
-		spec := &VirtualMachineInstanceSpec{}
-		net := Network{
-			NetworkSource: NetworkSource{
-				Pod: &PodNetwork{},
-			},
-			Name: "testnet",
-		}
-		iface := Interface{Name: net.Name}
-		spec.Networks = []Network{net}
-		spec.Domain.Devices.Interfaces = []Interface{iface}
-		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(1))
-	})
-
-	It("should work for multiple pod network / interface combinations", func() {
-		spec := &VirtualMachineInstanceSpec{}
-		net1 := Network{
-			NetworkSource: NetworkSource{
-				Pod: &PodNetwork{},
-			},
-			Name: "testnet1",
-		}
-		iface1 := Interface{Name: net1.Name}
-		net2 := Network{
-			NetworkSource: NetworkSource{
-				Pod: &PodNetwork{},
-			},
-			Name: "testnet2",
-		}
-		iface2 := Interface{Name: net2.Name}
-		spec.Networks = []Network{net1, net2}
-		spec.Domain.Devices.Interfaces = []Interface{iface1, iface2}
-		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(2))
-	})
-})
-
 var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 
 	It("should append pod interface if interface is not defined", func() {

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -245,3 +245,43 @@ var _ = Describe("Defaults", func() {
 		Expect(*timer.Hyperv.Enabled).To(BeTrue())
 	})
 })
+
+var _ = Describe("Function isPodInterfaceConfigured()", func() {
+
+	It("should work for empty network list", func() {
+		vmi := &VirtualMachineInstance{}
+		Expect(isPodInterfaceConfigured(vmi)).To(BeFalse())
+	})
+
+	It("should work for non-empty network list without pod network", func() {
+		vmi := &VirtualMachineInstance{}
+		net := Network{}
+		vmi.Spec.Networks = []Network{net}
+		Expect(isPodInterfaceConfigured(vmi)).To(BeFalse())
+	})
+
+	It("should work for pod network with missing pod interface", func() {
+		vmi := &VirtualMachineInstance{}
+		net := Network{
+			NetworkSource: NetworkSource{
+				Pod: &PodNetwork{},
+			},
+		}
+		vmi.Spec.Networks = []Network{net}
+		Expect(isPodInterfaceConfigured(vmi)).To(BeFalse())
+	})
+
+	It("should work for valid pod network / interface combination", func() {
+		vmi := &VirtualMachineInstance{}
+		net := Network{
+			NetworkSource: NetworkSource{
+				Pod: &PodNetwork{},
+			},
+			Name: "testnet",
+		}
+		iface := Interface{Name: net.Name}
+		vmi.Spec.Networks = []Network{net}
+		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface}
+		Expect(isPodInterfaceConfigured(vmi)).To(BeTrue())
+	})
+})

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -249,30 +249,30 @@ var _ = Describe("Defaults", func() {
 var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 	It("should work for empty network list", func() {
-		vmi := &VirtualMachineInstance{}
-		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(0))
+		spec := &VirtualMachineInstanceSpec{}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
 	})
 
 	It("should work for non-empty network list without pod network", func() {
-		vmi := &VirtualMachineInstance{}
+		spec := &VirtualMachineInstanceSpec{}
 		net := Network{}
-		vmi.Spec.Networks = []Network{net}
-		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(0))
+		spec.Networks = []Network{net}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
 	})
 
 	It("should work for pod network with missing pod interface", func() {
-		vmi := &VirtualMachineInstance{}
+		spec := &VirtualMachineInstanceSpec{}
 		net := Network{
 			NetworkSource: NetworkSource{
 				Pod: &PodNetwork{},
 			},
 		}
-		vmi.Spec.Networks = []Network{net}
-		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(0))
+		spec.Networks = []Network{net}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
 	})
 
 	It("should work for valid pod network / interface combination", func() {
-		vmi := &VirtualMachineInstance{}
+		spec := &VirtualMachineInstanceSpec{}
 		net := Network{
 			NetworkSource: NetworkSource{
 				Pod: &PodNetwork{},
@@ -280,13 +280,13 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 			Name: "testnet",
 		}
 		iface := Interface{Name: net.Name}
-		vmi.Spec.Networks = []Network{net}
-		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface}
-		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(1))
+		spec.Networks = []Network{net}
+		spec.Domain.Devices.Interfaces = []Interface{iface}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(1))
 	})
 
 	It("should work for multiple pod network / interface combinations", func() {
-		vmi := &VirtualMachineInstance{}
+		spec := &VirtualMachineInstanceSpec{}
 		net1 := Network{
 			NetworkSource: NetworkSource{
 				Pod: &PodNetwork{},
@@ -301,9 +301,9 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 			Name: "testnet2",
 		}
 		iface2 := Interface{Name: net2.Name}
-		vmi.Spec.Networks = []Network{net1, net2}
-		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface1, iface2}
-		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(2))
+		spec.Networks = []Network{net1, net2}
+		spec.Domain.Devices.Interfaces = []Interface{iface1, iface2}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(2))
 	})
 })
 

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -309,7 +309,16 @@ var _ = Describe("Function GetNumberOfPodInterfaces()", func() {
 
 var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 
-	It("should append pod interface", func() {
+	It("should append pod interface if interface is not defined", func() {
+		vmi := &VirtualMachineInstance{}
+		SetDefaults_NetworkInterface(vmi)
+		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
+		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
+		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
+		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())
+	})
+
+	It("should not append pod interface if interface is defined", func() {
 		vmi := &VirtualMachineInstance{}
 		net := Network{
 			Name: "testnet",
@@ -319,13 +328,9 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface}
 
 		SetDefaults_NetworkInterface(vmi)
-		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(2))
+		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
 		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("testnet"))
 		Expect(vmi.Spec.Networks[0].Name).To(Equal("testnet"))
 		Expect(vmi.Spec.Networks[0].Pod).To(BeNil())
-
-		Expect(vmi.Spec.Domain.Devices.Interfaces[1].Name).To(Equal("default"))
-		Expect(vmi.Spec.Networks[1].Name).To(Equal("default"))
-		Expect(vmi.Spec.Networks[1].Pod).ToNot(BeNil())
 	})
 })

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -246,18 +246,18 @@ var _ = Describe("Defaults", func() {
 	})
 })
 
-var _ = Describe("Function isPodInterfaceConfigured()", func() {
+var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 
 	It("should work for empty network list", func() {
 		vmi := &VirtualMachineInstance{}
-		Expect(isPodInterfaceConfigured(vmi)).To(BeFalse())
+		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(0))
 	})
 
 	It("should work for non-empty network list without pod network", func() {
 		vmi := &VirtualMachineInstance{}
 		net := Network{}
 		vmi.Spec.Networks = []Network{net}
-		Expect(isPodInterfaceConfigured(vmi)).To(BeFalse())
+		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(0))
 	})
 
 	It("should work for pod network with missing pod interface", func() {
@@ -268,7 +268,7 @@ var _ = Describe("Function isPodInterfaceConfigured()", func() {
 			},
 		}
 		vmi.Spec.Networks = []Network{net}
-		Expect(isPodInterfaceConfigured(vmi)).To(BeFalse())
+		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(0))
 	})
 
 	It("should work for valid pod network / interface combination", func() {
@@ -282,7 +282,28 @@ var _ = Describe("Function isPodInterfaceConfigured()", func() {
 		iface := Interface{Name: net.Name}
 		vmi.Spec.Networks = []Network{net}
 		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface}
-		Expect(isPodInterfaceConfigured(vmi)).To(BeTrue())
+		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(1))
+	})
+
+	It("should work for multiple pod network / interface combinations", func() {
+		vmi := &VirtualMachineInstance{}
+		net1 := Network{
+			NetworkSource: NetworkSource{
+				Pod: &PodNetwork{},
+			},
+			Name: "testnet1",
+		}
+		iface1 := Interface{Name: net1.Name}
+		net2 := Network{
+			NetworkSource: NetworkSource{
+				Pod: &PodNetwork{},
+			},
+			Name: "testnet2",
+		}
+		iface2 := Interface{Name: net2.Name}
+		vmi.Spec.Networks = []Network{net1, net2}
+		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface1, iface2}
+		Expect(getNumberOfPodInterfaces(vmi)).To(Equal(2))
 	})
 })
 

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -246,18 +246,18 @@ var _ = Describe("Defaults", func() {
 	})
 })
 
-var _ = Describe("Function getNumberOfPodInterfaces()", func() {
+var _ = Describe("Function GetNumberOfPodInterfaces()", func() {
 
 	It("should work for empty network list", func() {
 		spec := &VirtualMachineInstanceSpec{}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
+		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(0))
 	})
 
 	It("should work for non-empty network list without pod network", func() {
 		spec := &VirtualMachineInstanceSpec{}
 		net := Network{}
 		spec.Networks = []Network{net}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
+		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(0))
 	})
 
 	It("should work for pod network with missing pod interface", func() {
@@ -268,7 +268,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 			},
 		}
 		spec.Networks = []Network{net}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
+		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(0))
 	})
 
 	It("should work for valid pod network / interface combination", func() {
@@ -282,7 +282,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		iface := Interface{Name: net.Name}
 		spec.Networks = []Network{net}
 		spec.Domain.Devices.Interfaces = []Interface{iface}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(1))
+		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(1))
 	})
 
 	It("should work for multiple pod network / interface combinations", func() {
@@ -303,7 +303,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		iface2 := Interface{Name: net2.Name}
 		spec.Networks = []Network{net1, net2}
 		spec.Domain.Devices.Interfaces = []Interface{iface1, iface2}
-		Expect(getNumberOfPodInterfaces(spec)).To(Equal(2))
+		Expect(GetNumberOfPodInterfaces(spec)).To(Equal(2))
 	})
 })
 

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -285,3 +285,26 @@ var _ = Describe("Function isPodInterfaceConfigured()", func() {
 		Expect(isPodInterfaceConfigured(vmi)).To(BeTrue())
 	})
 })
+
+var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
+
+	It("should append pod interface", func() {
+		vmi := &VirtualMachineInstance{}
+		net := Network{
+			Name: "testnet",
+		}
+		iface := Interface{Name: net.Name}
+		vmi.Spec.Networks = []Network{net}
+		vmi.Spec.Domain.Devices.Interfaces = []Interface{iface}
+
+		SetDefaults_NetworkInterface(vmi)
+		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(2))
+		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("testnet"))
+		Expect(vmi.Spec.Networks[0].Name).To(Equal("testnet"))
+		Expect(vmi.Spec.Networks[0].Pod).To(BeNil())
+
+		Expect(vmi.Spec.Domain.Devices.Interfaces[1].Name).To(Equal("default"))
+		Expect(vmi.Spec.Networks[1].Name).To(Equal("default"))
+		Expect(vmi.Spec.Networks[1].Pod).ToNot(BeNil())
+	})
+})

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -42,7 +42,6 @@ import (
 const (
 	cloudInitMaxLen = 2048
 	arrayLenMax     = 256
-	maxNetworks     = 1
 )
 
 func getAdmissionReview(r *http.Request) (*v1beta1.AdmissionReview, error) {
@@ -397,18 +396,17 @@ func validateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		}
 	}
 
-	// TODO: Currently, we support only a single network interface attached to a single pod network
-	if len(spec.Domain.Devices.Interfaces) > maxNetworks {
+	if len(spec.Domain.Devices.Interfaces) > arrayLenMax {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s list exceeds the %d element limit in length", field.Child("domain", "devices", "interfaces").String(), maxNetworks),
+			Message: fmt.Sprintf("%s list exceeds the %d element limit in length", field.Child("domain", "devices", "interfaces").String(), arrayLenMax),
 			Field:   field.Child("domain", "devices", "interfaces").String(),
 		})
 		return causes
-	} else if len(spec.Networks) > maxNetworks {
+	} else if len(spec.Networks) > arrayLenMax {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%s list exceeds the %d element limit in length", field.Child("networks").String(), maxNetworks),
+			Message: fmt.Sprintf("%s list exceeds the %d element limit in length", field.Child("networks").String(), arrayLenMax),
 			Field:   field.Child("networks").String(),
 		})
 		return causes

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -410,6 +410,13 @@ func validateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			Field:   field.Child("networks").String(),
 		})
 		return causes
+	} else if v1.GetNumberOfPodInterfaces(spec) > 1 {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueDuplicate,
+			Message: fmt.Sprintf("multiple pod interfaces in %s", field.Child("interfaces").String()),
+			Field:   field.Child("interfaces").String(),
+		})
+		return causes
 	}
 
 	for _, volume := range spec.Volumes {

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -879,6 +879,67 @@ var _ = Describe("Validating Webhook", func() {
 	})
 })
 
+var _ = Describe("Function getNumberOfPodInterfaces()", func() {
+
+	It("should work for empty network list", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
+	})
+
+	It("should work for non-empty network list without pod network", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{}
+		spec.Networks = []v1.Network{net}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
+	})
+
+	It("should work for pod network with missing pod interface", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+		}
+		spec.Networks = []v1.Network{net}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(0))
+	})
+
+	It("should work for valid pod network / interface combination", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet",
+		}
+		iface := v1.Interface{Name: net.Name}
+		spec.Networks = []v1.Network{net}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(1))
+	})
+
+	It("should work for multiple pod network / interface combinations", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net1 := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet1",
+		}
+		iface1 := v1.Interface{Name: net1.Name}
+		net2 := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet2",
+		}
+		iface2 := v1.Interface{Name: net2.Name}
+		spec.Networks = []v1.Network{net1, net2}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface1, iface2}
+		Expect(getNumberOfPodInterfaces(spec)).To(Equal(2))
+	})
+})
+
 type virtualMachineBuilder struct {
 	disks   []v1.Disk
 	volumes []v1.Volume

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -572,28 +572,25 @@ var _ = Describe("Validating Webhook", func() {
 			causes := validateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
 			Expect(len(causes)).To(Equal(0))
 		})
-		It("should reject interface lists with more than one element", func() {
+		It("should accept interface lists with more than one element", func() {
 			vm := v1.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
 				*v1.DefaultNetworkInterface(),
 				*v1.DefaultNetworkInterface()}
+			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			causes := validateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
-			// if this is processed correctly, it should result in a single error
-			// If multiple causes occurred, then the spec was processed too far.
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces"))
+			// if this is processed correctly, it should not result in any error
+			Expect(len(causes)).To(Equal(0))
 		})
-		It("should reject network lists with more than one element", func() {
+		It("should accept network lists with more than one element", func() {
 			vm := v1.NewMinimalVMI("testvm")
 			vm.Spec.Networks = []v1.Network{
 				*v1.DefaultPodNetwork(),
 				*v1.DefaultPodNetwork()}
 			causes := validateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
-			// if this is processed correctly, it should result in a single error
-			// If multiple causes occurred, then the spec was processed too far.
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.networks"))
+			// if this is processed correctly, it should not result in any error
+			Expect(len(causes)).To(Equal(0))
 		})
 
 		It("should reject interfaces with missing network", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -512,6 +512,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		if net.Pod == nil {
 			return fmt.Errorf("network interface type not supported for %s", iface.Name)
 		}
+		// TODO:(ihar) consider abstracting interface type conversion /
+		// detection into drivers
 		domainIface := Interface{
 			Model: &Model{
 				Type: interfaceType,
@@ -519,6 +521,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			Type: "bridge",
 			Source: InterfaceSource{
 				Bridge: DefaultBridgeName,
+			},
+			Alias: &Alias{
+				Name: iface.Name,
 			},
 		}
 		domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, domainIface)

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -502,6 +502,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		},
 		Type: "bridge",
 		Source: InterfaceSource{
+			// If it is ever allowed to change, we may need to adjust
+			// findPodInterface
 			Bridge: DefaultBridgeName,
 		}},
 	}

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -170,20 +170,24 @@ func initHandler() {
 	}
 }
 
-func setCachedInterface(ifconf *api.Interface) error {
+func getInterfaceCacheFile(name string) string {
+	return fmt.Sprintf(interfaceCacheFile, name)
+}
+
+func setCachedInterface(name string, ifconf *api.Interface) error {
 	buf, err := json.MarshalIndent(&ifconf, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling interface cache: %v", err)
 	}
-	err = ioutil.WriteFile(interfaceCacheFile, buf, 0644)
+	err = ioutil.WriteFile(getInterfaceCacheFile(name), buf, 0644)
 	if err != nil {
 		return fmt.Errorf("error writing interface cache %v", err)
 	}
 	return nil
 }
 
-func getCachedInterface() (*api.Interface, error) {
-	buf, err := ioutil.ReadFile(interfaceCacheFile)
+func getCachedInterface(name string) (*api.Interface, error) {
+	buf, err := ioutil.ReadFile(getInterfaceCacheFile(name))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -21,10 +21,13 @@ package network
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 var _ = Describe("Common Network Methods", func() {
@@ -87,6 +90,22 @@ var _ = Describe("Common Network Methods", func() {
 			searchDomains, err := ParseSearchDomains(resolvConf)
 			Expect(searchDomains).To(Equal([]string{"local"}))
 			Expect(err).To(BeNil())
+		})
+	})
+	Context("Function setCachedInterface()", func() {
+		It("should persist interface payload", func() {
+			tmpDir, _ := ioutil.TempDir("", "commontest")
+			setInterfaceCacheFile(tmpDir + "/cache-%s.json")
+
+			ifaceName := "iface_name"
+			iface := api.Interface{Type: "fake_type", Source: api.InterfaceSource{Bridge: "fake_br"}}
+			err := setCachedInterface(ifaceName, &iface)
+			Expect(err).ToNot(HaveOccurred())
+
+			cached_iface, err := getCachedInterface(ifaceName)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(iface).To(Equal(*cached_iface))
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -41,7 +41,7 @@ const (
 	nameserverPrefix    = "nameserver"
 )
 
-var interfaceCacheFile = "/var/run/kubevirt-private/interface-cache.json"
+var interfaceCacheFile = "/var/run/kubevirt-private/interface-cache-%s.json"
 var NetworkInterfaceFactory = getNetworkClass
 
 type NetworkInterface interface {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -67,6 +67,9 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 		return err
 	}
 
+	// TODO:(ihar) don't assume pod interface is single / first
+	podInterfaceNum := 0
+
 	if ifconf == nil {
 		err := driver.discoverPodNetworkInterface()
 		if err != nil {
@@ -77,7 +80,7 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 			panic(err)
 		}
 
-		defaultIconf := interfaces[0]
+		defaultIconf := interfaces[podInterfaceNum]
 		driver.startDHCPServer()
 
 		// After the network is configured, cache the result
@@ -91,7 +94,7 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 	}
 
 	// TODO:(vladikr) Currently we support only one interface per vm.
-	interfaces[0] = *ifconf
+	interfaces[podInterfaceNum] = *ifconf
 
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -62,7 +62,7 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 		return fmt.Errorf("failed to find a default interface configuration")
 	}
 
-	ifconf, err := getCachedInterface()
+	ifconf, err := getCachedInterface(iface.Name)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 		// After the network is configured, cache the result
 		// in case this function is called again.
 		driver.decorateInterfaceConfig(&defaultIconf)
-		err = setCachedInterface(&defaultIconf)
+		err = setCachedInterface(iface.Name, &defaultIconf)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -61,7 +61,6 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 	if len(interfaces) == 0 {
 		return fmt.Errorf("failed to find a default interface configuration")
 	}
-	defaultIconf := interfaces[0]
 
 	ifconf, err := getCachedInterface()
 	if err != nil {
@@ -78,6 +77,7 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 			panic(err)
 		}
 
+		defaultIconf := interfaces[0]
 		driver.startDHCPServer()
 
 		// After the network is configured, cache the result

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -45,14 +45,13 @@ type PodInterface struct{}
 
 func (l *PodInterface) Unplug() {}
 
-func findPodInterface(ifaces []api.Interface) (int, error) {
+func findInterfaceByName(ifaces []api.Interface, name string) (int, error) {
 	for i, iface := range ifaces {
-		// TODO:(ihar) find a more robust way to detect pod interface
-		if iface.Type == "bridge" && iface.Source.Bridge == api.DefaultBridgeName {
+		if iface.Alias.Name == name {
 			return i, nil
 		}
 	}
-	return 0, fmt.Errorf("failed to find a default interface configuration")
+	return 0, fmt.Errorf("failed to find interface with alias set to %s", name)
 }
 
 // Plug connect a Pod network device to the virtual machine
@@ -71,7 +70,7 @@ func (l *PodInterface) Plug(iface *v1.Interface, network *v1.Network, domain *ap
 	}
 
 	interfaces := domain.Spec.Devices.Interfaces
-	podInterfaceNum, err := findPodInterface(interfaces)
+	podInterfaceNum, err := findInterfaceByName(interfaces, iface.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -173,6 +173,38 @@ var _ = Describe("Pod Network", func() {
 				Expect(filterPodNetworkRoutes(staticRouteList, testNic)).To(Equal(expectedRouteList))
 			})
 		})
+		Context("func findPodInterface()", func() {
+			It("should fail on empty interface list", func() {
+				_, err := findPodInterface([]api.Interface{})
+				Expect(err).To(HaveOccurred())
+			})
+			It("should fail when pod interface is missing", func() {
+				interfaces := []api.Interface{
+					api.Interface{Type: "not-bridge", Source: api.InterfaceSource{Bridge: api.DefaultBridgeName}},
+					api.Interface{Type: "bridge", Source: api.InterfaceSource{Bridge: "other_br"}},
+				}
+				_, err := findPodInterface(interfaces)
+				Expect(err).To(HaveOccurred())
+			})
+			It("should pass when pod interface is single", func() {
+				interfaces := []api.Interface{
+					api.Interface{Type: "bridge", Source: api.InterfaceSource{Bridge: api.DefaultBridgeName}},
+				}
+				idx, err := findPodInterface(interfaces)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idx).To(Equal(0))
+			})
+			It("should pass when pod interface is not the first in the list", func() {
+				interfaces := []api.Interface{
+					api.Interface{Type: "not-bridge", Source: api.InterfaceSource{Bridge: api.DefaultBridgeName}},
+					api.Interface{Type: "bridge", Source: api.InterfaceSource{Bridge: "other_br"}},
+					api.Interface{Type: "bridge", Source: api.InterfaceSource{Bridge: api.DefaultBridgeName}},
+				}
+				idx, err := findPodInterface(interfaces)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(idx).To(Equal(2))
+			})
+		})
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Pod Network", func() {
 
 	BeforeEach(func() {
 		tmpDir, _ := ioutil.TempDir("", "networktest")
-		setInterfaceCacheFile(tmpDir + "/cache.json")
+		setInterfaceCacheFile(tmpDir + "/cache-%s.json")
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockNetwork = NewMockNetworkHandler(ctrl)


### PR DESCRIPTION
This is a partial solution to support multiple interfaces. Note that the PR does *not* enable a way to specify multiple interfaces in the spec since we don't have any interface types but pod at this time.

The reason why this PR does not include new integration tests is because we can't at the moment validate multiple interfaces end to end due to reasons described above. To facilitate testing, the PR includes some unit tests though. Later PRs to support additional interface types will need to include integration tests with multiple interfaces.

The reason why we don't want to hold off the PR before we have all code to validate multiple interfaces support end to end is because multiple authors will need to work on different new interface types in parallel (proxy, dp...), and this basic bit is commonly needed for all of them, and we don't want to duplicate it in these parallel efforts.