### PR TITLE
Revert "Fix oc template samples"

### DIFF
--- a/cluster/vm-template-fedora.yaml
+++ b/cluster/vm-template-fedora.yaml
@@ -24,10 +24,10 @@ objects:
       spec:
         domain:
           cpu:
-            cores: ${CPU_CORES}
+            cores: ${{CPU_CORES}}
           resources:
             requests:
-              memory: ${MEMORY}
+              memory: ${{MEMORY}}
           devices:
             disks:
               - name: disk0

--- a/cluster/vm-template-rhel7.yaml
+++ b/cluster/vm-template-rhel7.yaml
@@ -24,10 +24,10 @@ objects:
       spec:
         domain:
           cpu:
-            cores: ${CPU_CORES}
+            cores: ${{CPU_CORES}}
           resources:
             requests:
-              memory: ${MEMORY}
+              memory: ${{MEMORY}}
           machine:
             type: q35
           devices:

--- a/cluster/vm-template-windows2012r2.yaml
+++ b/cluster/vm-template-windows2012r2.yaml
@@ -42,12 +42,12 @@ objects:
                 tickPolicy: catchup
               hyperv: {}
           cpu:
-            cores: ${CPU_CORES}
+            cores: ${{CPU_CORES}}
           machine:
             type: q35
           resources:
             requests:
-              memory: ${MEMORY}
+              memory: ${{MEMORY}}
           devices:
             disks:
               - name: disk0


### PR DESCRIPTION
This reverts commit 37526cb24720dbc11e65f65ddc46b21399323850.

This commit led to expanding integers as strings which causes validation
errors when using the templates.

Fixes #1129 