### PR TITLE
Add .gitattributes to hide vendor/ in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/* linguist-vendored


### PR DESCRIPTION
See https://github.com/github/linguist#vendored-code

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>