### PR TITLE
openapi-spec: add name and namespaces param for patch operation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -544,6 +544,22 @@
        "schema": {
         "$ref": "#/definitions/v1.Patch"
        }
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
       }
      ],
      "responses": {
@@ -994,6 +1010,22 @@
        "schema": {
         "$ref": "#/definitions/v1.Patch"
        }
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
       }
      ],
      "responses": {
@@ -1444,6 +1476,22 @@
        "schema": {
         "$ref": "#/definitions/v1.Patch"
        }
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
       }
      ],
      "responses": {
@@ -1894,6 +1942,22 @@
        "schema": {
         "$ref": "#/definitions/v1.Patch"
        }
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
       }
      ],
      "responses": {

--- a/pkg/virt-api/rest/kubeproxy.go
+++ b/pkg/virt-api/rest/kubeproxy.go
@@ -145,7 +145,7 @@ func GenericResourceProxy(ws *restful.WebService, ctx context.Context, gvr schem
 			Returns(http.StatusUnauthorized, "Unauthorized", nil), ws,
 	))
 
-	ws.Route(
+	ws.Route(addPatchParams(
 		ws.PATCH(ResourcePath(gvr)).
 			Consumes(mime.MIME_JSON_PATCH, mime.MIME_MERGE_PATCH).
 			Produces(mime.MIME_JSON).
@@ -154,8 +154,8 @@ func GenericResourceProxy(ws *restful.WebService, ctx context.Context, gvr schem
 			Writes(objExample).Reads(metav1.Patch{}).
 			Doc("Patch a "+objKind+" object.").
 			Returns(http.StatusOK, "OK", objExample).
-			Returns(http.StatusUnauthorized, "Unauthorized", nil),
-	)
+			Returns(http.StatusUnauthorized, "Unauthorized", nil), ws,
+	))
 
 	// TODO, implement watch. For now it is here to provide swagger doc only
 	ws.Route(addWatchGetListParams(


### PR DESCRIPTION
Fixes: kubevirt/client-python#20

Signed-off-by: Lukas Bednar <lbednar@redhat.com>