### PR TITLE
Fix templates again

### DIFF
--- a/cluster/examples/vmi-template-fedora.yaml
+++ b/cluster/examples/vmi-template-fedora.yaml
@@ -27,7 +27,7 @@ objects:
           kubevirt-vm: vm-${NAME}
       spec:
         domain:
-          cpu: ${CPU_CORES}
+          cpu: ${{CPU_CORES}}
           devices:
             disks:
             - disk:

--- a/cluster/examples/vmi-template-rhel7.yaml
+++ b/cluster/examples/vmi-template-rhel7.yaml
@@ -27,7 +27,7 @@ objects:
           kubevirt-vm: vm-${NAME}
       spec:
         domain:
-          cpu: ${CPU_CORES}
+          cpu: ${{CPU_CORES}}
           devices:
             disks:
             - disk:

--- a/cluster/examples/vmi-template-windows2012r2.yaml
+++ b/cluster/examples/vmi-template-windows2012r2.yaml
@@ -39,7 +39,7 @@ objects:
               rtc:
                 tickPolicy: catchup
             utc: {}
-          cpu: ${CPU_CORES}
+          cpu: ${{CPU_CORES}}
           devices:
             disks:
             - disk:

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -430,7 +430,7 @@ func getPVCForTemplate(name string) *k8sv1.PersistentVolumeClaim {
 func getBaseTemplate(vm *v1.VirtualMachine, memory string, cores string) *Template {
 
 	obj := toUnstructured(vm)
-	unstructured.SetNestedField(obj.Object, "${CPU_CORES}", "spec", "template", "spec", "domain", "cpu")
+	unstructured.SetNestedField(obj.Object, "${{CPU_CORES}}", "spec", "template", "spec", "domain", "cpu")
 	unstructured.SetNestedField(obj.Object, "${MEMORY}", "spec", "template", "spec", "domain", "resources", "requests", "memory")
 	obj.SetName("${NAME}")
 


### PR DESCRIPTION
Fix a regression in the templates which would set the cpu number as a
string on template instantiation. This was fixed already but broke again with the rename effort.

Fix #1129 again. Related to #1041.