### PR TITLE
Default SOURCE_DATE_EPOCH to avoid using 'git'

### DIFF
--- a/hack/version.sh
+++ b/hack/version.sh
@@ -27,6 +27,9 @@
 #        "dirty" indicates source code changes after the git commit id
 #        "archive" indicates the tree was produced by 'git archive'
 #    KUBEVIRT_GIT_VERSION - "vX.Y" used to indicate the last release version.
+#    KUBEVIRT_SOURCE_DATE_EPOCH - unix timestamp.  Set to ' ' to generate using
+#          'date' instead of 'git'.
+#
 
 # Grovels through git to set a set of env variables.
 
@@ -100,7 +103,7 @@ function kubevirt::version::ldflag() {
 function kubevirt::version::ldflags() {
     kubevirt::version::get_version_vars
 
-    SOURCE_DATE_EPOCH=$(git show -s --format=format:%ct HEAD)
+    SOURCE_DATE_EPOCH=${KUBEVIRT_SOURCE_DATE_EPOCH-$(git show -s --format=format:%ct HEAD)}
 
     local buildDate
     [[ -z ${SOURCE_DATE_EPOCH-} ]] || buildDate="--date=@${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
In downstream builds ```SOURCE_DATE_EPOCH=$(git show -s --format=format:%ct HEAD)``` fails because git isn't installed.  Make it so if this command fails, log the error and continue.  ```SOURCE_DATE_EPOCH``` gets set to "" on a failure.

fixes: https://github.com/kubevirt/kubevirt/issues/1141