### PR TITLE
Remove kubevirt-config from kubevirt admin rbac role

### DIFF
--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -262,15 +262,6 @@ rules:
       - list
       - watch
       - deletecollection
-  - apiGroups: [""]
-    resources:
-      - configmaps
-    resourceNames:
-      - kubevirt-config
-    verbs:
-      - update
-      - get
-      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -29,17 +29,6 @@ rules:
       - list
       - watch
       - deletecollection
-  - apiGroups: [""]
-    resources:
-      - configmaps
-    resourceNames:
-      - kubevirt-config
-    verbs:
-      - update
-      - get
-      - patch
-      - create
-      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -39,43 +39,6 @@ var _ = Describe("User Access", func() {
 	})
 
 	Describe("With default kubevirt service accounts", func() {
-		It("should verify only admin role has access only to kubevirt-config", func() {
-			tests.SkipIfNoKubectl()
-
-			verbs := []string{"get", "update", "patch"}
-
-			namespace := tests.NamespaceTestDefault
-			resourceNamespace := tests.KubeVirtInstallNamespace
-
-			saNames := []string{tests.ViewServiceAccountName, tests.EditServiceAccountName, tests.AdminServiceAccountName}
-
-			for _, saName := range saNames {
-				// Verifies targeted access to only the kubevirt config
-				By(fmt.Sprintf("verifying expected permissions for sa %s for resource configmaps/kubevirt-config", saName))
-				for _, verb := range verbs {
-					expectedRes := "no"
-					if saName == tests.AdminServiceAccountName {
-						expectedRes = "yes"
-					}
-					resource := "configmaps/kubevirt-config"
-					as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, saName)
-					result, err := tests.RunKubectlCommand("auth", "can-i", "-n", resourceNamespace, "--as", as, verb, resource)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(ContainSubstring(expectedRes))
-				}
-
-				By(fmt.Sprintf("verifying expected permissions for sa %s for resource configmaps/kubevirt-madethisup", saName))
-				for _, verb := range verbs {
-					expectedRes := "no"
-					resource := "configmaps/kubevirt-imadethisup"
-					as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, saName)
-					result, err := tests.RunKubectlCommand("auth", "can-i", "-n", resourceNamespace, "--as", as, verb, resource)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(ContainSubstring(expectedRes))
-				}
-			}
-		})
-
 		table.DescribeTable("should verify permissions are correct for view, edit, and admin", func(resource string) {
 			tests.SkipIfNoKubectl()
 


### PR DESCRIPTION
The kubevirt admin rbac role will be aggregated with the default
k8s admin role, which gives users access to the config-map.

related to #1105