### PR TITLE
Fix manifest example names and add fedora template to virtualmachine category

### DIFF
--- a/cluster/examples/vm-template-fedora.yaml
+++ b/cluster/examples/vm-template-fedora.yaml
@@ -4,12 +4,12 @@ metadata:
   annotations:
     description: OCP KubeVirt Fedora 27 VM template
     iconClass: icon-fedora
-    tags: kubevirt,ocp,template,linux
+    tags: kubevirt,ocp,template,linux,virtualmachine
   creationTimestamp: null
   labels:
     kubevirt.io/os: fedora27
     miq.github.io/kubevirt-is-vm-template: "true"
-  name: vmi-template-fedora
+  name: vm-template-fedora
 objects:
 - apiVersion: kubevirt.io/v1alpha2
   kind: VirtualMachine

--- a/cluster/examples/vm-template-rhel7.yaml
+++ b/cluster/examples/vm-template-rhel7.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     kubevirt.io/os: rhel-7.4
     miq.github.io/kubevirt-is-vm-template: "true"
-  name: vmi-template-rhel7
+  name: vm-template-rhel7
 objects:
 - apiVersion: kubevirt.io/v1alpha2
   kind: VirtualMachine

--- a/cluster/examples/vm-template-windows2012r2.yaml
+++ b/cluster/examples/vm-template-windows2012r2.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     kubevirt.io/os: win2k12r2
     miq.github.io/kubevirt-is-vm-template: "true"
-  name: vmi-template-windows2012r2
+  name: vm-template-windows2012r2
 objects:
 - apiVersion: kubevirt.io/v1alpha2
   kind: VirtualMachine

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -48,9 +48,9 @@ const (
 	vmiNoCloud        = "vmi-nocloud"
 	vmiPVC            = "vmi-pvc"
 	vmiWindows        = "vmi-windows"
-	vmTemplateFedora  = "vmi-template-fedora"
-	vmTemplateRHEL7   = "vmi-template-rhel7"
-	vmTemplateWindows = "vmi-template-windows2012r2"
+	vmTemplateFedora  = "vm-template-fedora"
+	vmTemplateRHEL7   = "vm-template-rhel7"
+	vmTemplateWindows = "vm-template-windows2012r2"
 )
 
 const (
@@ -346,7 +346,7 @@ func getTemplateFedora() *Template {
 		Name: vmTemplateFedora,
 		Annotations: map[string]string{
 			"description": "OCP KubeVirt Fedora 27 VM template",
-			"tags":        "kubevirt,ocp,template,linux",
+			"tags":        "kubevirt,ocp,template,linux,virtualmachine",
 			"iconClass":   "icon-fedora",
 		},
 		Labels: map[string]string{


### PR DESCRIPTION
* Rename vm-template examples from vmi-* to vm-*.
* #1135 got lost during the rename effort, adding the `virtualmachine` tag again.

@karmab FYI