### PR TITLE
Reword the recent change regarding focused testing

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,15 +120,10 @@ command line options as follows (run a specified suite):
     FUNC_TEST_ARGS='-ginkgo.focus=vm_networking_test -ginkgo.regexScansFilePath' make functest
 ```
 
-In addition, if you want to run a specific test or tests you can prepend any Describe,
-Context and It statements of your test with an `F` and again use `gingko` command line
-options to run only tests marked with `F` (DON'T FORGET TO REMOVE BEFORE PUSHING):
-
-For example, to run the
-
-```
-    FUNC_TEST_ARGS='-ginkgo.regexScansFilePath' make functest
-```
+In addition, if you want to run a specific test or tests you can prepend any `Describe`,
+`Context` and `It` statements of your test with an `F` and Ginkgo will only run items
+that are marked with the prefix. Also, don't forget to remove the prefix before issuing
+your pull request.
 
 For additional information check out the [Ginkgo focused specs documentation](http://onsi.github.io/ginkgo/#focused-specs)
 


### PR DESCRIPTION
The make args aren't necessary so remove that part,
and it seems that the reminder to remove the prefix
isn't something we care about so remove that too.

Signed-off-by: John Griffith <jgriffith@redhat.com>