### PR TITLE
Fix issue with crd validation in OpenShift 3.10

### DIFF
--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -18,39 +18,22 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: VirtualMachine handles the VirtualMachines that are not running
-        or are in a stopped state The VirtualMachine contains the template to create
-        the VirtualMachineInstance. It also mirrors the running state of the created
-        VirtualMachineInstance in its status.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata: {}
         spec:
-          description: VirtualMachineSpec describes how the proper VirtualMachine
-            should look like
           properties:
             running:
-              description: Running controls whether the associatied VirtualMachineInstance
-                is created or not
               type: boolean
             template:
               properties:
                 metadata: {}
                 spec:
-                  description: VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.
                   properties:
                     affinity:
-                      description: Affinity groups all the affinity rules related
-                        to a VirtualMachineInstance
                       properties:
                         nodeAffinity: {}
                         podAffinity: {}
@@ -58,347 +41,188 @@ spec:
                     domain:
                       properties:
                         clock:
-                          description: Represents the clock and timers of a vmi
                           properties:
                             timezone:
-                              description: Timezone sets the guest clock to the specified
-                                timezone. Zone name follows the TZ environment variable
-                                format (e.g. 'America/New_York')
                               type: string
                             utc:
-                              description: UTC sets the guest clock to UTC on each
-                                boot.
                               properties:
                                 offsetSeconds:
-                                  description: OffsetSeconds specifies an offset in
-                                    seconds, relative to UTC. If set, guest changes
-                                    to the clock will be kept during reboots and not
-                                    reset.
                                   format: int32
                                   type: integer
                         cpu:
-                          description: CPU allow specifying the CPU topology
                           properties:
                             cores:
-                              description: Cores specifies the number of cores inside
-                                the vmi. Must be a value greater or equal 1.
                               format: int64
                               type: integer
                         devices:
                           properties:
                             disks:
-                              description: Disks describes disks, cdroms, floppy and
-                                luns which are connected to the vmi
                               items:
                                 properties:
                                   bootOrder:
-                                    description: BootOrder is an integer value > 0,
-                                      used to determine ordering of boot devices.
-                                      Lower values take precedence. Disks without
-                                      a boot order are not tried if a disk with a
-                                      boot order exists.
                                     format: int32
                                     type: integer
                                   cdrom:
                                     properties:
                                       bus:
-                                        description: 'Bus indicates the type of disk
-                                          device to emulate. supported values: virtio,
-                                          sata, scsi, ide'
                                         type: string
                                       readonly:
-                                        description: ReadOnly Defaults to true
                                         type: boolean
                                       tray:
-                                        description: Tray indicates if the tray of
-                                          the device is open or closed. Allowed values
-                                          are "open" and "closed" Defaults to closed
                                         type: string
                                   disk:
                                     properties:
                                       bus:
-                                        description: 'Bus indicates the type of disk
-                                          device to emulate. supported values: virtio,
-                                          sata, scsi, ide'
                                         type: string
                                       readonly:
-                                        description: ReadOnly Defaults to false
                                         type: boolean
                                   floppy:
                                     properties:
                                       readonly:
-                                        description: ReadOnly Defaults to false
                                         type: boolean
                                       tray:
-                                        description: Tray indicates if the tray of
-                                          the device is open or closed. Allowed values
-                                          are "open" and "closed" Defaults to closed
                                         type: string
                                   lun:
                                     properties:
                                       bus:
-                                        description: 'Bus indicates the type of disk
-                                          device to emulate. supported values: virtio,
-                                          sata, scsi, ide'
                                         type: string
                                       readonly:
-                                        description: ReadOnly Defaults to false
                                         type: boolean
                                   name:
-                                    description: Name is the device name
                                     type: string
                                   volumeName:
-                                    description: Name of the volume which is referenced
-                                      Must match the Name of a Volume.
                                     type: string
                                 required:
                                 - name
                                 - volumeName
                               type: array
                             interfaces:
-                              description: Interfaces describe network interfaces
-                                which are added to the vm
                               items:
                                 properties:
                                   bridge: {}
                                   name:
-                                    description: Logical name of the interface as
-                                      well as a reference to the associated networks
-                                      Must match the Name of a Network
                                     type: string
                                 required:
                                 - name
                               type: array
                             watchdog:
-                              description: Named watchdog device
                               properties:
                                 i6300esb:
-                                  description: i6300esb watchdog device
                                   properties:
                                     action:
-                                      description: The action to take. Valid values
-                                        are poweroff, reset, shutdown. Defaults to
-                                        reset
                                       type: string
                                 name:
-                                  description: Name of the watchdog
                                   type: string
                               required:
                               - name
                         features:
                           properties:
                             acpi:
-                              description: Represents if a feature is enabled or disabled
                               properties:
                                 enabled:
-                                  description: Enabled determines if the feature should
-                                    be enabled or disabled on the guest Defaults to
-                                    true
                                   type: boolean
                             apic:
                               properties:
                                 enabled:
-                                  description: Enabled determines if the feature should
-                                    be enabled or disabled on the guest Defaults to
-                                    true
                                   type: boolean
                                 endOfInterrupt:
-                                  description: EndOfInterrupt enables the end of interrupt
-                                    notification in the guest Defaults to false
                                   type: boolean
                             hyperv:
-                              description: Hyperv specific features
                               properties:
                                 relaxed:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 reset:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 runtime:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 spinlocks:
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                     spinlocks:
-                                      description: Retries indicates the number of
-                                        retries Must be a value greater or equal 4096
-                                        Defaults to 4096
                                       format: int64
                                       type: integer
                                 synic:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 synictimer:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 vapic:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 vendorid:
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                     vendorid:
-                                      description: VendorID sets the hypervisor vendor
-                                        id, visible to the vmi String up to twelve
-                                        characters
                                       type: string
                                 vpindex:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                         firmware:
                           properties:
                             uuid:
-                              description: UUID reported by the vmi bios Defaults
-                                to a random generated uid
                               type: string
                         machine:
                           properties:
                             type:
-                              description: QEMU machine type is the actual chipset
-                                of the VirtualMachineInstance.
                               type: string
                           required:
                           - type
                         memory:
-                          description: Memory allow specifying the VirtualMachineInstance
-                            memory features
                           properties:
                             hugepages:
-                              description: Hugepages allow to use hugepages for the
-                                VirtualMachineInstance instead of regular memory.
                               properties:
                                 pageSize:
-                                  description: PageSize specifies the hugepage size,
-                                    for x86_64 architecture valid values are 1Gi and
-                                    2Mi.
                                   type: string
                         resources:
                           properties:
                             limits:
-                              description: Limits describes the maximum amount of
-                                compute resources allowed. Valid resource keys are
-                                "memory" and "cpu".
                               type: object
                             requests:
-                              description: Requests is a description of the initial
-                                vmi resources. Valid resource keys are "memory" and
-                                "cpu".
                               type: object
                       required:
                       - devices
                     hostname:
-                      description: Specifies the hostname of the vmi If not specified,
-                        the hostname will be set to the name of the vmi, if dhcp or
-                        cloud-init is configured properly.
                       type: string
                     networks:
-                      description: List of networks that can be attached to a vm's
-                        virtual interface.
                       items:
-                        description: Network represents a network type and a resource
-                          that should be connected to the vm.
                         properties:
                           name:
-                            description: 'Network name Must be a DNS_LABEL and unique
-                              within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
-                          pod:
-                            description: Represents the stock pod network interface
+                          pod: {}
                         required:
                         - name
                       type: array
                     nodeSelector:
-                      description: 'NodeSelector is a selector which must be true
-                        for the vmi to fit on a node. Selector which must match a
-                        node''s labels for the vmi to be scheduled on that node. More
-                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                       type: object
                     subdomain:
-                      description: If specified, the fully qualified vmi hostname
-                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                        domain>". If not specified, the vmi will not have a domainname
-                        at all. The DNS entry will resolve to the vmi, no matter if
-                        the vmi itself can pick up a hostname.
                       type: string
                     terminationGracePeriodSeconds:
-                      description: Grace period observed after signalling a VirtualMachineInstance
-                        to stop after which the VirtualMachineInstance is force terminated.
                       format: int64
                       type: integer
                     volumes:
-                      description: List of volumes that can be mounted by disks belonging
-                        to the vmi.
                       items:
-                        description: Volume represents a named volume in a vmi.
                         properties:
                           cloudInitNoCloud:
-                            description: 'Represents a cloud-init nocloud user data
-                              source More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
                             properties:
                               secretRef: {}
                               userData:
-                                description: UserData contains NoCloud inline cloud-init
-                                  userdata
                                 type: string
                               userDataBase64:
-                                description: UserDataBase64 contains NoCloud cloud-init
-                                  userdata as a base64 encoded string
                                 type: string
                           emptyDisk:
-                            description: EmptyDisk represents a temporary disk which
-                              shares the vmis lifecycle
                             properties:
                               capacity: {}
                             required:
@@ -407,22 +231,13 @@ spec:
                             properties:
                               persistentVolumeClaim: {}
                           name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and
-                              unique within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           persistentVolumeClaim: {}
                           registryDisk:
-                            description: Represents a docker image with an embedded
-                              disk
                             properties:
                               image:
-                                description: Image is the name of the image with the
-                                  embedded disk
                                 type: string
                               imagePullSecret:
-                                description: ImagePullSecret is the name of the Docker
-                                  registry secret required to pull the image. The
-                                  secret must already exist.
                                 type: string
                             required:
                             - image
@@ -435,14 +250,9 @@ spec:
           - running
           - template
         status:
-          description: VirtualMachineStatus represents the status returned by the
-            controller to describe how the VirtualMachine is doing
           properties:
             conditions:
-              description: Hold the state information of the VirtualMachine and its
-                VirtualMachineInstance
               items:
-                description: VirtualMachineCondition represents the state of VirtualMachine
                 properties:
                   lastProbeTime: {}
                   lastTransitionTime: {}
@@ -459,11 +269,8 @@ spec:
                 - status
               type: array
             created:
-              description: Created indicates if the virtual machine is created in
-                the cluster
               type: boolean
             ready:
-              description: Ready indicates if the virtual machine is running and ready
               type: boolean
   version: v1alpha2
 status:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -18,25 +18,15 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: VirtualMachineInstance is *the* VirtualMachineInstance Definition.
-        It represents a virtual machine in the runtime environment of kubernetes.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata: {}
         spec:
-          description: VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.
           properties:
             affinity:
-              description: Affinity groups all the affinity rules related to a VirtualMachineInstance
               properties:
                 nodeAffinity: {}
                 podAffinity: {}
@@ -44,319 +34,188 @@ spec:
             domain:
               properties:
                 clock:
-                  description: Represents the clock and timers of a vmi
                   properties:
                     timezone:
-                      description: Timezone sets the guest clock to the specified
-                        timezone. Zone name follows the TZ environment variable format
-                        (e.g. 'America/New_York')
                       type: string
                     utc:
-                      description: UTC sets the guest clock to UTC on each boot.
                       properties:
                         offsetSeconds:
-                          description: OffsetSeconds specifies an offset in seconds,
-                            relative to UTC. If set, guest changes to the clock will
-                            be kept during reboots and not reset.
                           format: int32
                           type: integer
                 cpu:
-                  description: CPU allow specifying the CPU topology
                   properties:
                     cores:
-                      description: Cores specifies the number of cores inside the
-                        vmi. Must be a value greater or equal 1.
                       format: int64
                       type: integer
                 devices:
                   properties:
                     disks:
-                      description: Disks describes disks, cdroms, floppy and luns
-                        which are connected to the vmi
                       items:
                         properties:
                           bootOrder:
-                            description: BootOrder is an integer value > 0, used to
-                              determine ordering of boot devices. Lower values take
-                              precedence. Disks without a boot order are not tried
-                              if a disk with a boot order exists.
                             format: int32
                             type: integer
                           cdrom:
                             properties:
                               bus:
-                                description: 'Bus indicates the type of disk device
-                                  to emulate. supported values: virtio, sata, scsi,
-                                  ide'
                                 type: string
                               readonly:
-                                description: ReadOnly Defaults to true
                                 type: boolean
                               tray:
-                                description: Tray indicates if the tray of the device
-                                  is open or closed. Allowed values are "open" and
-                                  "closed" Defaults to closed
                                 type: string
                           disk:
                             properties:
                               bus:
-                                description: 'Bus indicates the type of disk device
-                                  to emulate. supported values: virtio, sata, scsi,
-                                  ide'
                                 type: string
                               readonly:
-                                description: ReadOnly Defaults to false
                                 type: boolean
                           floppy:
                             properties:
                               readonly:
-                                description: ReadOnly Defaults to false
                                 type: boolean
                               tray:
-                                description: Tray indicates if the tray of the device
-                                  is open or closed. Allowed values are "open" and
-                                  "closed" Defaults to closed
                                 type: string
                           lun:
                             properties:
                               bus:
-                                description: 'Bus indicates the type of disk device
-                                  to emulate. supported values: virtio, sata, scsi,
-                                  ide'
                                 type: string
                               readonly:
-                                description: ReadOnly Defaults to false
                                 type: boolean
                           name:
-                            description: Name is the device name
                             type: string
                           volumeName:
-                            description: Name of the volume which is referenced Must
-                              match the Name of a Volume.
                             type: string
                         required:
                         - name
                         - volumeName
                       type: array
                     interfaces:
-                      description: Interfaces describe network interfaces which are
-                        added to the vm
                       items:
                         properties:
                           bridge: {}
                           name:
-                            description: Logical name of the interface as well as
-                              a reference to the associated networks Must match the
-                              Name of a Network
                             type: string
                         required:
                         - name
                       type: array
                     watchdog:
-                      description: Named watchdog device
                       properties:
                         i6300esb:
-                          description: i6300esb watchdog device
                           properties:
                             action:
-                              description: The action to take. Valid values are poweroff,
-                                reset, shutdown. Defaults to reset
                               type: string
                         name:
-                          description: Name of the watchdog
                           type: string
                       required:
                       - name
                 features:
                   properties:
                     acpi:
-                      description: Represents if a feature is enabled or disabled
                       properties:
                         enabled:
-                          description: Enabled determines if the feature should be
-                            enabled or disabled on the guest Defaults to true
                           type: boolean
                     apic:
                       properties:
                         enabled:
-                          description: Enabled determines if the feature should be
-                            enabled or disabled on the guest Defaults to true
                           type: boolean
                         endOfInterrupt:
-                          description: EndOfInterrupt enables the end of interrupt
-                            notification in the guest Defaults to false
                           type: boolean
                     hyperv:
-                      description: Hyperv specific features
                       properties:
                         relaxed:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         reset:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         runtime:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         spinlocks:
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                             spinlocks:
-                              description: Retries indicates the number of retries
-                                Must be a value greater or equal 4096 Defaults to
-                                4096
                               format: int64
                               type: integer
                         synic:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         synictimer:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         vapic:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         vendorid:
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                             vendorid:
-                              description: VendorID sets the hypervisor vendor id,
-                                visible to the vmi String up to twelve characters
                               type: string
                         vpindex:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                 firmware:
                   properties:
                     uuid:
-                      description: UUID reported by the vmi bios Defaults to a random
-                        generated uid
                       type: string
                 machine:
                   properties:
                     type:
-                      description: QEMU machine type is the actual chipset of the
-                        VirtualMachineInstance.
                       type: string
                   required:
                   - type
                 memory:
-                  description: Memory allow specifying the VirtualMachineInstance
-                    memory features
                   properties:
                     hugepages:
-                      description: Hugepages allow to use hugepages for the VirtualMachineInstance
-                        instead of regular memory.
                       properties:
                         pageSize:
-                          description: PageSize specifies the hugepage size, for x86_64
-                            architecture valid values are 1Gi and 2Mi.
                           type: string
                 resources:
                   properties:
                     limits:
-                      description: Limits describes the maximum amount of compute
-                        resources allowed. Valid resource keys are "memory" and "cpu".
                       type: object
                     requests:
-                      description: Requests is a description of the initial vmi resources.
-                        Valid resource keys are "memory" and "cpu".
                       type: object
               required:
               - devices
             hostname:
-              description: Specifies the hostname of the vmi If not specified, the
-                hostname will be set to the name of the vmi, if dhcp or cloud-init
-                is configured properly.
               type: string
             networks:
-              description: List of networks that can be attached to a vm's virtual
-                interface.
               items:
-                description: Network represents a network type and a resource that
-                  should be connected to the vm.
                 properties:
                   name:
-                    description: 'Network name Must be a DNS_LABEL and unique within
-                      the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  pod:
-                    description: Represents the stock pod network interface
+                  pod: {}
                 required:
                 - name
               type: array
             nodeSelector:
-              description: 'NodeSelector is a selector which must be true for the
-                vmi to fit on a node. Selector which must match a node''s labels for
-                the vmi to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
               type: object
             subdomain:
-              description: If specified, the fully qualified vmi hostname will be
-                "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If
-                not specified, the vmi will not have a domainname at all. The DNS
-                entry will resolve to the vmi, no matter if the vmi itself can pick
-                up a hostname.
               type: string
             terminationGracePeriodSeconds:
-              description: Grace period observed after signalling a VirtualMachineInstance
-                to stop after which the VirtualMachineInstance is force terminated.
               format: int64
               type: integer
             volumes:
-              description: List of volumes that can be mounted by disks belonging
-                to the vmi.
               items:
-                description: Volume represents a named volume in a vmi.
                 properties:
                   cloudInitNoCloud:
-                    description: 'Represents a cloud-init nocloud user data source
-                      More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
                     properties:
                       secretRef: {}
                       userData:
-                        description: UserData contains NoCloud inline cloud-init userdata
                         type: string
                       userDataBase64:
-                        description: UserDataBase64 contains NoCloud cloud-init userdata
-                          as a base64 encoded string
                         type: string
                   emptyDisk:
-                    description: EmptyDisk represents a temporary disk which shares
-                      the vmis lifecycle
                     properties:
                       capacity: {}
                     required:
@@ -365,21 +224,13 @@ spec:
                     properties:
                       persistentVolumeClaim: {}
                   name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                   persistentVolumeClaim: {}
                   registryDisk:
-                    description: Represents a docker image with an embedded disk
                     properties:
                       image:
-                        description: Image is the name of the image with the embedded
-                          disk
                         type: string
                       imagePullSecret:
-                        description: ImagePullSecret is the name of the Docker registry
-                          secret required to pull the image. The secret must already
-                          exist.
                         type: string
                     required:
                     - image
@@ -389,13 +240,8 @@ spec:
           required:
           - domain
         status:
-          description: VirtualMachineInstanceStatus represents information about the
-            status of a VirtualMachineInstance. Status may trail the actual state
-            of a system.
           properties:
             conditions:
-              description: Conditions are specific points in VirtualMachineInstance's
-                pod runtime.
               items:
                 properties:
                   lastProbeTime: {}
@@ -413,24 +259,16 @@ spec:
                 - status
               type: array
             interfaces:
-              description: Interfaces represent the details of available network interfaces.
               items:
                 properties:
                   ipAddress:
-                    description: IP address of a Virtual Machine interface
                     type: string
                   mac:
-                    description: Hardware address of a Virtual Machine interface
                     type: string
               type: array
             nodeName:
-              description: NodeName is the name where the VirtualMachineInstance is
-                currently running.
               type: string
             phase:
-              description: Phase is the status of the VirtualMachineInstance in kubernetes
-                world. It is not the VirtualMachineInstance status, but partially
-                correlates to it.
               type: string
   version: v1alpha2
 status:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -20,14 +20,8 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata: {}
         spec:
@@ -35,257 +29,156 @@ spec:
             domain:
               properties:
                 clock:
-                  description: Represents the clock and timers of a vmi
                   properties:
                     timezone:
-                      description: Timezone sets the guest clock to the specified
-                        timezone. Zone name follows the TZ environment variable format
-                        (e.g. 'America/New_York')
                       type: string
                     utc:
-                      description: UTC sets the guest clock to UTC on each boot.
                       properties:
                         offsetSeconds:
-                          description: OffsetSeconds specifies an offset in seconds,
-                            relative to UTC. If set, guest changes to the clock will
-                            be kept during reboots and not reset.
                           format: int32
                           type: integer
                 cpu:
-                  description: CPU allow specifying the CPU topology
                   properties:
                     cores:
-                      description: Cores specifies the number of cores inside the
-                        vmi. Must be a value greater or equal 1.
                       format: int64
                       type: integer
                 devices:
                   properties:
                     disks:
-                      description: Disks describes disks, cdroms, floppy and luns
-                        which are connected to the vmi
                       items:
                         properties:
                           bootOrder:
-                            description: BootOrder is an integer value > 0, used to
-                              determine ordering of boot devices. Lower values take
-                              precedence. Disks without a boot order are not tried
-                              if a disk with a boot order exists.
                             format: int32
                             type: integer
                           cdrom:
                             properties:
                               bus:
-                                description: 'Bus indicates the type of disk device
-                                  to emulate. supported values: virtio, sata, scsi,
-                                  ide'
                                 type: string
                               readonly:
-                                description: ReadOnly Defaults to true
                                 type: boolean
                               tray:
-                                description: Tray indicates if the tray of the device
-                                  is open or closed. Allowed values are "open" and
-                                  "closed" Defaults to closed
                                 type: string
                           disk:
                             properties:
                               bus:
-                                description: 'Bus indicates the type of disk device
-                                  to emulate. supported values: virtio, sata, scsi,
-                                  ide'
                                 type: string
                               readonly:
-                                description: ReadOnly Defaults to false
                                 type: boolean
                           floppy:
                             properties:
                               readonly:
-                                description: ReadOnly Defaults to false
                                 type: boolean
                               tray:
-                                description: Tray indicates if the tray of the device
-                                  is open or closed. Allowed values are "open" and
-                                  "closed" Defaults to closed
                                 type: string
                           lun:
                             properties:
                               bus:
-                                description: 'Bus indicates the type of disk device
-                                  to emulate. supported values: virtio, sata, scsi,
-                                  ide'
                                 type: string
                               readonly:
-                                description: ReadOnly Defaults to false
                                 type: boolean
                           name:
-                            description: Name is the device name
                             type: string
                           volumeName:
-                            description: Name of the volume which is referenced Must
-                              match the Name of a Volume.
                             type: string
                         required:
                         - name
                         - volumeName
                       type: array
                     interfaces:
-                      description: Interfaces describe network interfaces which are
-                        added to the vm
                       items:
                         properties:
                           bridge: {}
                           name:
-                            description: Logical name of the interface as well as
-                              a reference to the associated networks Must match the
-                              Name of a Network
                             type: string
                         required:
                         - name
                       type: array
                     watchdog:
-                      description: Named watchdog device
                       properties:
                         i6300esb:
-                          description: i6300esb watchdog device
                           properties:
                             action:
-                              description: The action to take. Valid values are poweroff,
-                                reset, shutdown. Defaults to reset
                               type: string
                         name:
-                          description: Name of the watchdog
                           type: string
                       required:
                       - name
                 features:
                   properties:
                     acpi:
-                      description: Represents if a feature is enabled or disabled
                       properties:
                         enabled:
-                          description: Enabled determines if the feature should be
-                            enabled or disabled on the guest Defaults to true
                           type: boolean
                     apic:
                       properties:
                         enabled:
-                          description: Enabled determines if the feature should be
-                            enabled or disabled on the guest Defaults to true
                           type: boolean
                         endOfInterrupt:
-                          description: EndOfInterrupt enables the end of interrupt
-                            notification in the guest Defaults to false
                           type: boolean
                     hyperv:
-                      description: Hyperv specific features
                       properties:
                         relaxed:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         reset:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         runtime:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         spinlocks:
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                             spinlocks:
-                              description: Retries indicates the number of retries
-                                Must be a value greater or equal 4096 Defaults to
-                                4096
                               format: int64
                               type: integer
                         synic:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         synictimer:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         vapic:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                         vendorid:
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                             vendorid:
-                              description: VendorID sets the hypervisor vendor id,
-                                visible to the vmi String up to twelve characters
                               type: string
                         vpindex:
-                          description: Represents if a feature is enabled or disabled
                           properties:
                             enabled:
-                              description: Enabled determines if the feature should
-                                be enabled or disabled on the guest Defaults to true
                               type: boolean
                 firmware:
                   properties:
                     uuid:
-                      description: UUID reported by the vmi bios Defaults to a random
-                        generated uid
                       type: string
                 machine:
                   properties:
                     type:
-                      description: QEMU machine type is the actual chipset of the
-                        VirtualMachineInstance.
                       type: string
                   required:
                   - type
                 memory:
-                  description: Memory allow specifying the VirtualMachineInstance
-                    memory features
                   properties:
                     hugepages:
-                      description: Hugepages allow to use hugepages for the VirtualMachineInstance
-                        instead of regular memory.
                       properties:
                         pageSize:
-                          description: PageSize specifies the hugepage size, for x86_64
-                            architecture valid values are 1Gi and 2Mi.
                           type: string
                 resources:
                   properties:
                     limits:
-                      description: Limits describes the maximum amount of compute
-                        resources allowed. Valid resource keys are "memory" and "cpu".
                       type: object
                     requests:
-                      description: Requests is a description of the initial vmi resources.
-                        Valid resource keys are "memory" and "cpu".
                       type: object
               required:
               - devices

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -18,28 +18,17 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: VirtualMachineInstance is *the* VirtualMachineInstance Definition.
-        It represents a virtual machine in the runtime environment of kubernetes.
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata: {}
         spec:
           properties:
             paused:
-              description: Indicates that the replica set is paused.
               type: boolean
             replicas:
-              description: Number of desired pods. This is a pointer to distinguish
-                between explicit zero and not specified. Defaults to 1.
               format: int32
               type: integer
             selector: {}
@@ -47,11 +36,8 @@ spec:
               properties:
                 metadata: {}
                 spec:
-                  description: VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.
                   properties:
                     affinity:
-                      description: Affinity groups all the affinity rules related
-                        to a VirtualMachineInstance
                       properties:
                         nodeAffinity: {}
                         podAffinity: {}
@@ -59,347 +45,188 @@ spec:
                     domain:
                       properties:
                         clock:
-                          description: Represents the clock and timers of a vmi
                           properties:
                             timezone:
-                              description: Timezone sets the guest clock to the specified
-                                timezone. Zone name follows the TZ environment variable
-                                format (e.g. 'America/New_York')
                               type: string
                             utc:
-                              description: UTC sets the guest clock to UTC on each
-                                boot.
                               properties:
                                 offsetSeconds:
-                                  description: OffsetSeconds specifies an offset in
-                                    seconds, relative to UTC. If set, guest changes
-                                    to the clock will be kept during reboots and not
-                                    reset.
                                   format: int32
                                   type: integer
                         cpu:
-                          description: CPU allow specifying the CPU topology
                           properties:
                             cores:
-                              description: Cores specifies the number of cores inside
-                                the vmi. Must be a value greater or equal 1.
                               format: int64
                               type: integer
                         devices:
                           properties:
                             disks:
-                              description: Disks describes disks, cdroms, floppy and
-                                luns which are connected to the vmi
                               items:
                                 properties:
                                   bootOrder:
-                                    description: BootOrder is an integer value > 0,
-                                      used to determine ordering of boot devices.
-                                      Lower values take precedence. Disks without
-                                      a boot order are not tried if a disk with a
-                                      boot order exists.
                                     format: int32
                                     type: integer
                                   cdrom:
                                     properties:
                                       bus:
-                                        description: 'Bus indicates the type of disk
-                                          device to emulate. supported values: virtio,
-                                          sata, scsi, ide'
                                         type: string
                                       readonly:
-                                        description: ReadOnly Defaults to true
                                         type: boolean
                                       tray:
-                                        description: Tray indicates if the tray of
-                                          the device is open or closed. Allowed values
-                                          are "open" and "closed" Defaults to closed
                                         type: string
                                   disk:
                                     properties:
                                       bus:
-                                        description: 'Bus indicates the type of disk
-                                          device to emulate. supported values: virtio,
-                                          sata, scsi, ide'
                                         type: string
                                       readonly:
-                                        description: ReadOnly Defaults to false
                                         type: boolean
                                   floppy:
                                     properties:
                                       readonly:
-                                        description: ReadOnly Defaults to false
                                         type: boolean
                                       tray:
-                                        description: Tray indicates if the tray of
-                                          the device is open or closed. Allowed values
-                                          are "open" and "closed" Defaults to closed
                                         type: string
                                   lun:
                                     properties:
                                       bus:
-                                        description: 'Bus indicates the type of disk
-                                          device to emulate. supported values: virtio,
-                                          sata, scsi, ide'
                                         type: string
                                       readonly:
-                                        description: ReadOnly Defaults to false
                                         type: boolean
                                   name:
-                                    description: Name is the device name
                                     type: string
                                   volumeName:
-                                    description: Name of the volume which is referenced
-                                      Must match the Name of a Volume.
                                     type: string
                                 required:
                                 - name
                                 - volumeName
                               type: array
                             interfaces:
-                              description: Interfaces describe network interfaces
-                                which are added to the vm
                               items:
                                 properties:
                                   bridge: {}
                                   name:
-                                    description: Logical name of the interface as
-                                      well as a reference to the associated networks
-                                      Must match the Name of a Network
                                     type: string
                                 required:
                                 - name
                               type: array
                             watchdog:
-                              description: Named watchdog device
                               properties:
                                 i6300esb:
-                                  description: i6300esb watchdog device
                                   properties:
                                     action:
-                                      description: The action to take. Valid values
-                                        are poweroff, reset, shutdown. Defaults to
-                                        reset
                                       type: string
                                 name:
-                                  description: Name of the watchdog
                                   type: string
                               required:
                               - name
                         features:
                           properties:
                             acpi:
-                              description: Represents if a feature is enabled or disabled
                               properties:
                                 enabled:
-                                  description: Enabled determines if the feature should
-                                    be enabled or disabled on the guest Defaults to
-                                    true
                                   type: boolean
                             apic:
                               properties:
                                 enabled:
-                                  description: Enabled determines if the feature should
-                                    be enabled or disabled on the guest Defaults to
-                                    true
                                   type: boolean
                                 endOfInterrupt:
-                                  description: EndOfInterrupt enables the end of interrupt
-                                    notification in the guest Defaults to false
                                   type: boolean
                             hyperv:
-                              description: Hyperv specific features
                               properties:
                                 relaxed:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 reset:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 runtime:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 spinlocks:
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                     spinlocks:
-                                      description: Retries indicates the number of
-                                        retries Must be a value greater or equal 4096
-                                        Defaults to 4096
                                       format: int64
                                       type: integer
                                 synic:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 synictimer:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 vapic:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                 vendorid:
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                                     vendorid:
-                                      description: VendorID sets the hypervisor vendor
-                                        id, visible to the vmi String up to twelve
-                                        characters
                                       type: string
                                 vpindex:
-                                  description: Represents if a feature is enabled
-                                    or disabled
                                   properties:
                                     enabled:
-                                      description: Enabled determines if the feature
-                                        should be enabled or disabled on the guest
-                                        Defaults to true
                                       type: boolean
                         firmware:
                           properties:
                             uuid:
-                              description: UUID reported by the vmi bios Defaults
-                                to a random generated uid
                               type: string
                         machine:
                           properties:
                             type:
-                              description: QEMU machine type is the actual chipset
-                                of the VirtualMachineInstance.
                               type: string
                           required:
                           - type
                         memory:
-                          description: Memory allow specifying the VirtualMachineInstance
-                            memory features
                           properties:
                             hugepages:
-                              description: Hugepages allow to use hugepages for the
-                                VirtualMachineInstance instead of regular memory.
                               properties:
                                 pageSize:
-                                  description: PageSize specifies the hugepage size,
-                                    for x86_64 architecture valid values are 1Gi and
-                                    2Mi.
                                   type: string
                         resources:
                           properties:
                             limits:
-                              description: Limits describes the maximum amount of
-                                compute resources allowed. Valid resource keys are
-                                "memory" and "cpu".
                               type: object
                             requests:
-                              description: Requests is a description of the initial
-                                vmi resources. Valid resource keys are "memory" and
-                                "cpu".
                               type: object
                       required:
                       - devices
                     hostname:
-                      description: Specifies the hostname of the vmi If not specified,
-                        the hostname will be set to the name of the vmi, if dhcp or
-                        cloud-init is configured properly.
                       type: string
                     networks:
-                      description: List of networks that can be attached to a vm's
-                        virtual interface.
                       items:
-                        description: Network represents a network type and a resource
-                          that should be connected to the vm.
                         properties:
                           name:
-                            description: 'Network name Must be a DNS_LABEL and unique
-                              within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
-                          pod:
-                            description: Represents the stock pod network interface
+                          pod: {}
                         required:
                         - name
                       type: array
                     nodeSelector:
-                      description: 'NodeSelector is a selector which must be true
-                        for the vmi to fit on a node. Selector which must match a
-                        node''s labels for the vmi to be scheduled on that node. More
-                        info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                       type: object
                     subdomain:
-                      description: If specified, the fully qualified vmi hostname
-                        will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
-                        domain>". If not specified, the vmi will not have a domainname
-                        at all. The DNS entry will resolve to the vmi, no matter if
-                        the vmi itself can pick up a hostname.
                       type: string
                     terminationGracePeriodSeconds:
-                      description: Grace period observed after signalling a VirtualMachineInstance
-                        to stop after which the VirtualMachineInstance is force terminated.
                       format: int64
                       type: integer
                     volumes:
-                      description: List of volumes that can be mounted by disks belonging
-                        to the vmi.
                       items:
-                        description: Volume represents a named volume in a vmi.
                         properties:
                           cloudInitNoCloud:
-                            description: 'Represents a cloud-init nocloud user data
-                              source More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html'
                             properties:
                               secretRef: {}
                               userData:
-                                description: UserData contains NoCloud inline cloud-init
-                                  userdata
                                 type: string
                               userDataBase64:
-                                description: UserDataBase64 contains NoCloud cloud-init
-                                  userdata as a base64 encoded string
                                 type: string
                           emptyDisk:
-                            description: EmptyDisk represents a temporary disk which
-                              shares the vmis lifecycle
                             properties:
                               capacity: {}
                             required:
@@ -408,22 +235,13 @@ spec:
                             properties:
                               persistentVolumeClaim: {}
                           name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and
-                              unique within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           persistentVolumeClaim: {}
                           registryDisk:
-                            description: Represents a docker image with an embedded
-                              disk
                             properties:
                               image:
-                                description: Image is the name of the image with the
-                                  embedded disk
                                 type: string
                               imagePullSecret:
-                                description: ImagePullSecret is the name of the Docker
-                                  registry secret required to pull the image. The
-                                  secret must already exist.
                                 type: string
                             required:
                             - image
@@ -455,12 +273,9 @@ spec:
                 - status
               type: array
             readyReplicas:
-              description: The number of ready replicas for this replica set.
               format: int32
               type: integer
             replicas:
-              description: Total number of non-terminated pods targeted by this deployment
-                (their labels match the selector).
               format: int32
               type: integer
   version: v1alpha2

--- a/tools/crd-generator/crd-generator.go
+++ b/tools/crd-generator/crd-generator.go
@@ -24,9 +24,11 @@ import (
 	"fmt"
 
 	crdutils "github.com/ant31/crd-validation/pkg"
+	"github.com/go-openapi/spec"
 
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	common "k8s.io/kube-openapi/pkg/common"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
@@ -60,10 +62,30 @@ func generateVirtualMachineCrd() {
 			Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 			ShortNames: []string{"vm", "vms"},
 		},
-		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachine", v1.GetOpenAPIDefinitions),
+		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachine", definitionWrapper),
 	}
 
 	crdutils.MarshallCrd(crd, "yaml")
+}
+
+func stripDescription(schema spec.Schema) spec.Schema {
+	schema.SchemaProps.Description = ""
+
+	for key, val := range schema.SchemaProps.Properties {
+		schema.SchemaProps.Properties[key] = stripDescription(val)
+	}
+	return schema
+}
+
+func definitionWrapper(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
+	definitions := v1.GetOpenAPIDefinitions(ref)
+
+	for key, val := range definitions {
+		val.Schema = stripDescription(val.Schema)
+		definitions[key] = val
+	}
+
+	return definitions
 }
 
 func generatePresetCrd() {
@@ -81,7 +103,7 @@ func generatePresetCrd() {
 			Kind:       v1.VirtualMachineInstancePresetGroupVersionKind.Kind,
 			ShortNames: []string{"vmipreset", "vmipresets"},
 		},
-		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachineInstancePreset", v1.GetOpenAPIDefinitions),
+		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachineInstancePreset", definitionWrapper),
 	}
 
 	crdutils.MarshallCrd(crd, "yaml")
@@ -102,7 +124,7 @@ func generateReplicaSetCrd() {
 			Kind:       v1.VirtualMachineInstanceReplicaSetGroupVersionKind.Kind,
 			ShortNames: []string{"vmirs", "vmirss"},
 		},
-		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachineInstanceReplicaSet", v1.GetOpenAPIDefinitions),
+		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachineInstanceReplicaSet", definitionWrapper),
 	}
 
 	crdutils.MarshallCrd(crd, "yaml")
@@ -123,7 +145,7 @@ func generateVirtualMachineInstanceCrd() {
 			Kind:       v1.VirtualMachineInstanceGroupVersionKind.Kind,
 			ShortNames: []string{"vmi", "vmis"},
 		},
-		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachineInstance", v1.GetOpenAPIDefinitions),
+		Validation: crdutils.GetCustomResourceValidation("kubevirt.io/kubevirt/pkg/api/v1.VirtualMachineInstance", definitionWrapper),
 	}
 
 	crdutils.MarshallCrd(crd, "yaml")


### PR DESCRIPTION
OpenShift 3.10 doesn't like that the openapiv3 validation schema has "descriptions" in it. This is preventing KubeVirt from installing in 3.10.

The crd validation schema isn't user facing, so removing the description shouldn't negatively impact usability. 

fixes #1140