### PR TITLE
Migrate interface model from annotations to first order attribute

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3701,6 +3701,10 @@
      "bridge": {
       "$ref": "#/definitions/v1.InterfaceBridge"
      },
+     "model": {
+      "description": "Interface model supported by libvirt\nDefaults to virtio",
+      "type": "string"
+     },
      "name": {
       "description": "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
       "type": "string"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3702,7 +3702,7 @@
       "$ref": "#/definitions/v1.InterfaceBridge"
      },
      "model": {
-      "description": "Interface model supported by libvirt\nDefaults to virtio",
+      "description": "Interface model\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio\nDefaults to virtio",
       "type": "string"
      },
      "name": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3702,7 +3702,7 @@
       "$ref": "#/definitions/v1.InterfaceBridge"
      },
      "model": {
-      "description": "Interface model\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio\nDefaults to virtio",
+      "description": "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
       "type": "string"
      },
      "name": {

--- a/cluster/examples/vm-template-windows2012r2.yaml
+++ b/cluster/examples/vm-template-windows2012r2.yaml
@@ -22,8 +22,6 @@ objects:
     running: false
     template:
       metadata:
-        annotations:
-          alpha.kubevirt.io/interface-model: e1000
         creationTimestamp: null
         labels:
           kubevirt-vm: vm-${NAME}
@@ -50,6 +48,10 @@ objects:
                 bus: virtio
               name: disk0
               volumeName: disk0-pvc
+            interfaces:
+            - bridge: {}
+              model: e1000
+              name: default
           features:
             acpi: {}
             apic: {}
@@ -65,6 +67,9 @@ objects:
           resources:
             requests:
               memory: ${MEMORY}
+        networks:
+        - name: default
+          pod: {}
         terminationGracePeriodSeconds: 0
         volumes:
         - name: pvcvolume

--- a/cluster/examples/vmi-windows.yaml
+++ b/cluster/examples/vmi-windows.yaml
@@ -1,8 +1,6 @@
 apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
-  annotations:
-    alpha.kubevirt.io/interface-model: e1000
   creationTimestamp: null
   labels:
     special: vmi-windows
@@ -27,6 +25,10 @@ spec:
           bus: sata
         name: pvcdisk
         volumeName: pvcvolume
+      interfaces:
+      - bridge: {}
+        model: e1000
+        name: default
     features:
       acpi: {}
       apic: {}
@@ -42,6 +44,9 @@ spec:
     resources:
       requests:
         memory: 2Gi
+  networks:
+  - name: default
+    pod: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - name: pvcvolume

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -100,6 +100,8 @@ spec:
                               items:
                                 properties:
                                   bridge: {}
+                                  model:
+                                    type: string
                                   name:
                                     type: string
                                 required:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -93,6 +93,8 @@ spec:
                       items:
                         properties:
                           bridge: {}
+                          model:
+                            type: string
                           name:
                             type: string
                         required:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -88,6 +88,8 @@ spec:
                       items:
                         properties:
                           bridge: {}
+                          model:
+                            type: string
                           name:
                             type: string
                         required:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -104,6 +104,8 @@ spec:
                               items:
                                 properties:
                                   bridge: {}
+                                  model:
+                                    type: string
                                   name:
                                     type: string
                                 required:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -750,6 +750,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"model": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Interface model supported by libvirt Defaults to virtio",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 						"bridge": {
 							SchemaProps: spec.SchemaProps{
 								Ref: ref("kubevirt.io/kubevirt/pkg/api/v1.InterfaceBridge"),

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -752,7 +752,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"model": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Interface model One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio Defaults to virtio",
+								Description: "Interface model. One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -752,7 +752,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"model": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Interface model supported by libvirt Defaults to virtio",
+								Description: "Interface model One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio Defaults to virtio",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -637,9 +637,9 @@ type Interface struct {
 	// Logical name of the interface as well as a reference to the associated networks
 	// Must match the Name of a Network
 	Name string `json:"name"`
-	// Interface model
-	// One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio
-	// Defaults to virtio
+	// Interface model.
+	// One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.
+	// Defaults to virtio.
 	// TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
 	Model string `json:"model,omitempty"`
 	// BindingMethod specifies the method which will be used to connect the interface to the guest

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -637,6 +637,10 @@ type Interface struct {
 	// Logical name of the interface as well as a reference to the associated networks
 	// Must match the Name of a Network
 	Name string `json:"name"`
+	// Interface model supported by libvirt
+	// Defaults to virtio
+	// TODO:(ihar) should we enumerate and enforce allowed values
+	Model string `json:"model,omitempty"`
 	// BindingMethod specifies the method which will be used to connect the interface to the guest
 	// Defaults to Bridge
 	InterfaceBindingMethod `json:",inline"`

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -637,9 +637,10 @@ type Interface struct {
 	// Logical name of the interface as well as a reference to the associated networks
 	// Must match the Name of a Network
 	Name string `json:"name"`
-	// Interface model supported by libvirt
+	// Interface model
+	// One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio
 	// Defaults to virtio
-	// TODO:(ihar) should we enumerate and enforce allowed values
+	// TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
 	Model string `json:"model,omitempty"`
 	// BindingMethod specifies the method which will be used to connect the interface to the guest
 	// Defaults to Bridge

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -300,7 +300,7 @@ func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name":  "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
-		"model": "Interface model supported by libvirt\nDefaults to virtio",
+		"model": "Interface model\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio\nDefaults to virtio",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -299,7 +299,8 @@ func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"name": "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
+		"name":  "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
+		"model": "Interface model supported by libvirt\nDefaults to virtio",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -300,7 +300,7 @@ func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name":  "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
-		"model": "Interface model\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio\nDefaults to virtio",
+		"model": "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
 	}
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -338,8 +338,6 @@ const (
 	NodeNameLabel        string = "kubevirt.io/nodeName"
 	NodeSchedulable      string = "kubevirt.io/schedulable"
 	VirtHandlerHeartbeat string = "kubevirt.io/heartbeat"
-	InterfaceModel       string = "alpha.kubevirt.io/interface-model"
-	// TODO remove InterfaceModel when we have proper api for network models
 
 	VirtualMachineInstanceFinalizer string = "foregroundDeleteVirtualMachine"
 )

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -593,6 +593,28 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(len(causes)).To(Equal(0))
 		})
 
+		It("should accept valid interface models", func() {
+			vmi := v1.NewMinimalVMI("testvm")
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+
+			for _, model := range validInterfaceModels {
+				vmi.Spec.Domain.Devices.Interfaces[0].Model = model
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+				// if this is processed correctly, it should not result in any error
+				Expect(len(causes)).To(Equal(0))
+			}
+		})
+
+		It("should reject invalid interface model", func() {
+			vmi := v1.NewMinimalVMI("testvm")
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+			vmi.Spec.Domain.Devices.Interfaces[0].Model = "invalid_model"
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+		})
+
 		It("should reject interfaces with missing network", func() {
 			vm := v1.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -487,13 +487,11 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		},
 	}
 
-	getInterfaceType := func() string {
-		interfaceType := "virtio"
-		_, ok := vmi.ObjectMeta.Annotations[v1.InterfaceModel]
-		if ok {
-			interfaceType = vmi.ObjectMeta.Annotations[v1.InterfaceModel]
+	getInterfaceType := func(iface *v1.Interface) string {
+		if iface.Model != "" {
+			return iface.Model
 		}
-		return interfaceType
+		return "virtio"
 	}
 
 	findNetwork := func(nets []v1.Network, name string) (*v1.Network, error) {
@@ -517,7 +515,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		// detection into drivers
 		domainIface := Interface{
 			Model: &Model{
-				Type: getInterfaceType(),
+				Type: getInterfaceType(&iface),
 			},
 			Type: "bridge",
 			Source: InterfaceSource{

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -487,7 +487,6 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		},
 	}
 
-	// Add mandatory interface
 	interfaceType := "virtio"
 
 	_, ok := vmi.ObjectMeta.Annotations[v1.InterfaceModel]

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -487,11 +487,13 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		},
 	}
 
-	interfaceType := "virtio"
-
-	_, ok := vmi.ObjectMeta.Annotations[v1.InterfaceModel]
-	if ok {
-		interfaceType = vmi.ObjectMeta.Annotations[v1.InterfaceModel]
+	getInterfaceType := func() string {
+		interfaceType := "virtio"
+		_, ok := vmi.ObjectMeta.Annotations[v1.InterfaceModel]
+		if ok {
+			interfaceType = vmi.ObjectMeta.Annotations[v1.InterfaceModel]
+		}
+		return interfaceType
 	}
 
 	findNetwork := func(nets []v1.Network, name string) (*v1.Network, error) {
@@ -515,7 +517,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		// detection into drivers
 		domainIface := Interface{
 			Model: &Model{
-				Type: interfaceType,
+				Type: getInterfaceType(),
 			},
 			Type: "bridge",
 			Source: InterfaceSource{

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -461,7 +461,7 @@ var _ = Describe("Converter", func() {
 
 		It("should select explicitly chosen network model", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
+			vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 			domain := vmiToDomain(vmi, c)
 			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("e1000"))
 		})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -932,10 +932,16 @@ func NewRandomVMIWithWatchdog() *v1.VirtualMachineInstance {
 	return vmi
 }
 
+func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+}
+
 func NewRandomVMIWithe1000NetworkInterface() *v1.VirtualMachineInstance {
 	// Use alpine because cirros dhcp client starts prematurily before link is ready
 	vmi := NewRandomVMIWithEphemeralDisk(RegistryDiskFor(RegistryDiskAlpine))
-	vmi.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
+	AddExplicitPodNetworkInterface(vmi)
+	vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	return vmi
 }
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -126,7 +126,8 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 		tests.BeforeTestCleanup()
 		windowsVMI = tests.NewRandomVMI()
 		windowsVMI.Spec = windowsVMISpec
-		windowsVMI.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
+		tests.AddExplicitPodNetworkInterface(windowsVMI)
+		windowsVMI.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 	})
 
 	It("should succeed to start a vmi", func() {

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -295,11 +295,15 @@ func getVMIWindows() *v1.VirtualMachineInstance {
 					k8sv1.ResourceMemory: resource.MustParse("2048Mi"),
 				},
 			},
+			Devices: v1.Devices{
+				Interfaces: []v1.Interface{*v1.DefaultNetworkInterface()},
+			},
 		},
+		Networks: []v1.Network{*v1.DefaultPodNetwork()},
 	}
 
 	// pick e1000 network model type for windows machines
-	vmi.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}
+	vmi.Spec.Domain.Devices.Interfaces[0].Model = "e1000"
 
 	addPVCDisk(&vmi.Spec, "disk-windows", busSata, "pvcdisk", "pvcvolume")
 	return vmi


### PR DESCRIPTION
No compatibility layer for annotations left. One question (probably not for this PR) is whether we want to limit the set of allowed values for the model attribute, or leave it open for all values.