### PR TITLE
configmap informer start fix

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -222,7 +222,6 @@ func (vca *VirtControllerApp) Run() {
 					go vca.rsController.Run(controllerThreads, stop)
 					go vca.vmiPresetController.Run(controllerThreads, stop)
 					go vca.vmController.Run(controllerThreads, stop)
-					go vca.configMapInformer.Run(stop)
 					close(vca.readyChan)
 				},
 				OnStoppedLeading: func() {


### PR DESCRIPTION
All informers are started by the informer factory. We shouldn't be calling configMapInformer.Run() directly. 