### PR TITLE
Always remove scheduled error conditions from vms if pod gets scheduled

### DIFF
--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -48,7 +48,7 @@ func (d *VirtualMachineConditionManager) RemoveCondition(vmi *v1.VirtualMachineI
 }
 
 // AddPodCondition add pod condition to the VM.
-func (d *VirtualMachineConditionManager) AddPodCondition(vmi *v1.VirtualMachineInstance, cond k8sv1.PodCondition) {
+func (d *VirtualMachineConditionManager) AddPodCondition(vmi *v1.VirtualMachineInstance, cond *k8sv1.PodCondition) {
 	if !d.HasCondition(vmi, v1.VirtualMachineInstanceConditionType(cond.Type)) {
 		vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
 			LastProbeTime:      cond.LastProbeTime,
@@ -59,6 +59,32 @@ func (d *VirtualMachineConditionManager) AddPodCondition(vmi *v1.VirtualMachineI
 			Type:               v1.VirtualMachineInstanceConditionType(cond.Type),
 		})
 	}
+}
+
+func (d *VirtualMachineConditionManager) PodHasCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == conditionType {
+			if cond.Status == status {
+				return true
+			} else {
+				return false
+			}
+		}
+	}
+	return false
+}
+
+func (d *VirtualMachineConditionManager) GetPodCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) *k8sv1.PodCondition {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == conditionType {
+			if cond.Status == status {
+				return &cond
+			} else {
+				return nil
+			}
+		}
+	}
+	return nil
 }
 
 func NewVirtualMachineInstanceConditionManager() *VirtualMachineConditionManager {

--- a/pkg/testutils/matchers.go
+++ b/pkg/testutils/matchers.go
@@ -183,6 +183,18 @@ func (matcher *haveStatusCodeMatcher) NegatedFailureMessage(actual interface{}) 
 	return fmt.Sprintf("Expected status code \n\t%#v\nnot to be\n\t%#v", matcher.statusCode, matcher.expected)
 }
 
+// In case we don't care about emitted events, we simply consume all of them and return.
+func IgnoreEvents(recorder *record.FakeRecorder) {
+loop:
+	for {
+		select {
+		case <-recorder.Events:
+		default:
+			break loop
+		}
+	}
+}
+
 func ExpectEvent(recorder *record.FakeRecorder, reason string) {
 	gomega.Expect(recorder.Events).To(gomega.Receive(gomega.ContainSubstring(reason)))
 }


### PR DESCRIPTION
Whenever the vm is in the scheduling phase, check the pod scheduled
condition and react to it. Previously the condition only got removed
after the Pod was scheduled and ready. It can take a lot of time for a
Pod to become ready, therefore always check the condition.

Fixes #1175 