### PR TITLE
Add dots between sentences in api definition

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3333,21 +3333,21 @@
    "v1.CDRomTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide.",
       "type": "string"
      },
      "readonly": {
-      "description": "ReadOnly\nDefaults to true",
+      "description": "ReadOnly.\nDefaults to true.",
       "type": "boolean"
      },
      "tray": {
-      "description": "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
+      "description": "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\".\nDefaults to closed.\n+optional",
       "type": "string"
      }
     }
    },
    "v1.CPU": {
-    "description": "CPU allow specifying the CPU topology",
+    "description": "CPU allows specifying the CPU topology.",
     "properties": {
      "cores": {
       "description": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
@@ -3356,17 +3356,17 @@
     }
    },
    "v1.Clock": {
-    "description": "Represents the clock and timers of a vmi",
+    "description": "Represents the clock and timers of a vmi.",
     "required": [
      "timer"
     ],
     "properties": {
      "timer": {
-      "description": "Timer specifies whih timers are attached to the vmi",
+      "description": "Timer specifies whih timers are attached to the vmi.",
       "$ref": "#/definitions/v1.Timer"
      },
      "timezone": {
-      "description": "Timezone sets the guest clock to the specified timezone.\nZone name follows the TZ environment variable format (e.g. 'America/New_York')",
+      "description": "Timezone sets the guest clock to the specified timezone.\nZone name follows the TZ environment variable format (e.g. 'America/New_York').",
       "$ref": "#/definitions/v1.ClockOffsetTimezone"
      },
      "utc": {
@@ -3387,18 +3387,18 @@
     }
    },
    "v1.CloudInitNoCloudSource": {
-    "description": "Represents a cloud-init nocloud user data source\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+    "description": "Represents a cloud-init nocloud user data source.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
     "properties": {
      "secretRef": {
-      "description": "UserDataSecretRef references a k8s secret that contains NoCloud userdata\n+ optional",
+      "description": "UserDataSecretRef references a k8s secret that contains NoCloud userdata.\n+ optional",
       "$ref": "#/definitions/v1.LocalObjectReference"
      },
      "userData": {
-      "description": "UserData contains NoCloud inline cloud-init userdata\n+ optional",
+      "description": "UserData contains NoCloud inline cloud-init userdata.\n+ optional",
       "type": "string"
      },
      "userDataBase64": {
-      "description": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string\n+ optional",
+      "description": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.\n+ optional",
       "type": "string"
      }
     }
@@ -3437,21 +3437,21 @@
    "v1.Devices": {
     "properties": {
      "disks": {
-      "description": "Disks describes disks, cdroms, floppy and luns which are connected to the vmi",
+      "description": "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/v1.Disk"
       }
      },
      "interfaces": {
-      "description": "Interfaces describe network interfaces which are added to the vm",
+      "description": "Interfaces describe network interfaces which are added to the vm.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/v1.Interface"
       }
      },
      "watchdog": {
-      "description": "Watchdog describes a watchdog device which can be added to the vmi",
+      "description": "Watchdog describes a watchdog device which can be added to the vmi.",
       "$ref": "#/definitions/v1.Watchdog"
      }
     }
@@ -3468,19 +3468,19 @@
       "format": "integer"
      },
      "cdrom": {
-      "description": "Attach a volume as a cdrom to the vmi",
+      "description": "Attach a volume as a cdrom to the vmi.",
       "$ref": "#/definitions/v1.CDRomTarget"
      },
      "disk": {
-      "description": "Attach a volume as a disk to the vmi",
+      "description": "Attach a volume as a disk to the vmi.",
       "$ref": "#/definitions/v1.DiskTarget"
      },
      "floppy": {
-      "description": "Attach a volume as a floppy to the vmi",
+      "description": "Attach a volume as a floppy to the vmi.",
       "$ref": "#/definitions/v1.FloppyTarget"
      },
      "lun": {
-      "description": "Attach a volume as a LUN to the vmi",
+      "description": "Attach a volume as a LUN to the vmi.",
       "$ref": "#/definitions/v1.LunTarget"
      },
      "name": {
@@ -3488,7 +3488,7 @@
       "type": "string"
      },
      "volumeName": {
-      "description": "Name of the volume which is referenced\nMust match the Name of a Volume.",
+      "description": "Name of the volume which is referenced.\nMust match the Name of a Volume.",
       "type": "string"
      }
     }
@@ -3496,11 +3496,11 @@
    "v1.DiskTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide.",
       "type": "string"
      },
      "readonly": {
-      "description": "ReadOnly\nDefaults to false",
+      "description": "ReadOnly.\nDefaults to false.",
       "type": "boolean"
      }
     }
@@ -3520,15 +3520,15 @@
       "$ref": "#/definitions/v1.Devices"
      },
      "features": {
-      "description": "Features like acpi, apic, hyperv\n+optional",
+      "description": "Features like acpi, apic, hyperv.\n+optional",
       "$ref": "#/definitions/v1.Features"
      },
      "firmware": {
-      "description": "Firmware\n+optional",
+      "description": "Firmware.\n+optional",
       "$ref": "#/definitions/v1.Firmware"
      },
      "machine": {
-      "description": "Machine type\n+optional",
+      "description": "Machine type.\n+optional",
       "$ref": "#/definitions/v1.Machine"
      },
      "memory": {
@@ -3559,15 +3559,15 @@
       "$ref": "#/definitions/v1.Devices"
      },
      "features": {
-      "description": "Features like acpi, apic, hyperv\n+optional",
+      "description": "Features like acpi, apic, hyperv.\n+optional",
       "$ref": "#/definitions/v1.Features"
      },
      "firmware": {
-      "description": "Firmware\n+optional",
+      "description": "Firmware.\n+optional",
       "$ref": "#/definitions/v1.Firmware"
      },
      "machine": {
-      "description": "Machine type\n+optional",
+      "description": "Machine type.\n+optional",
       "$ref": "#/definitions/v1.Machine"
      },
      "memory": {
@@ -3581,7 +3581,7 @@
     }
    },
    "v1.EmptyDiskSource": {
-    "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle",
+    "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle.",
     "required": [
      "capacity"
     ],
@@ -3603,52 +3603,52 @@
    "v1.FeatureAPIC": {
     "properties": {
      "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
       "type": "boolean"
      },
      "endOfInterrupt": {
-      "description": "EndOfInterrupt enables the end of interrupt notification in the guest\nDefaults to false\n+optional",
+      "description": "EndOfInterrupt enables the end of interrupt notification in the guest.\nDefaults to false.\n+optional",
       "type": "boolean"
      }
     }
    },
    "v1.FeatureHyperv": {
-    "description": "Hyperv specific features",
+    "description": "Hyperv specific features.",
     "properties": {
      "relaxed": {
-      "description": "Relaxed relaxes constraints on timer\nDefaults to the machine type setting\n+optional",
+      "description": "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "reset": {
-      "description": "Reset enables Hyperv reboot/reset for the vmi\nDefaults to the machine type setting\n+optional",
+      "description": "Reset enables Hyperv reboot/reset for the vmi.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "runtime": {
-      "description": "Runtime\nDefaults to the machine type setting\n+optional",
+      "description": "Runtime.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "spinlocks": {
-      "description": "Spinlocks indicates if spinlocks should be made available to the guest\n+optional",
+      "description": "Spinlocks indicates if spinlocks should be made available to the guest.\n+optional",
       "$ref": "#/definitions/v1.FeatureSpinlocks"
      },
      "synic": {
-      "description": "SyNIC enable Synthetic Interrupt Controller\nDefaults to the machine type setting\n+optional",
+      "description": "SyNIC enable Synthetic Interrupt Controller.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "synictimer": {
-      "description": "SyNICTimer enable Synthetic Interrupt Controller timer\nDefaults to the machine type setting\n+optional",
+      "description": "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "vapic": {
-      "description": "VAPIC indicates whether virtual APIC is enabled\nDefaults to the machine type setting\n+optional",
+      "description": "VAPIC indicates whether virtual APIC is enabled.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "vendorid": {
-      "description": "VendorID allows setting the hypervisor vendor id\nDefaults to the machine type setting\n+optional",
+      "description": "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureVendorID"
      },
      "vpindex": {
-      "description": "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors\nDefaults to the machine type setting\n+optional",
+      "description": "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      }
     }
@@ -3656,20 +3656,20 @@
    "v1.FeatureSpinlocks": {
     "properties": {
      "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
       "type": "boolean"
      },
      "spinlocks": {
-      "description": "Retries indicates the number of retries\nMust be a value greater or equal 4096\nDefaults to 4096\n+optional",
+      "description": "Retries indicates the number of retries.\nMust be a value greater or equal 4096.\nDefaults to 4096.\n+optional",
       "type": "integer"
      }
     }
    },
    "v1.FeatureState": {
-    "description": "Represents if a feature is enabled or disabled",
+    "description": "Represents if a feature is enabled or disabled.",
     "properties": {
      "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
       "type": "boolean"
      }
     }
@@ -3677,11 +3677,11 @@
    "v1.FeatureVendorID": {
     "properties": {
      "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
       "type": "boolean"
      },
      "vendorid": {
-      "description": "VendorID sets the hypervisor vendor id, visible to the vmi\nString up to twelve characters",
+      "description": "VendorID sets the hypervisor vendor id, visible to the vmi.\nString up to twelve characters.",
       "type": "string"
      }
     }
@@ -3689,15 +3689,15 @@
    "v1.Features": {
     "properties": {
      "acpi": {
-      "description": "ACPI enables/disables ACPI insidejsondata guest\nDefaults to enabled\n+optional",
+      "description": "ACPI enables/disables ACPI insidejsondata guest.\nDefaults to enabled.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "apic": {
-      "description": "Defaults to the machine type setting\n+optional",
+      "description": "Defaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureAPIC"
      },
      "hyperv": {
-      "description": "Defaults to the machine type setting\n+optional",
+      "description": "Defaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureHyperv"
      }
     }
@@ -3705,7 +3705,7 @@
    "v1.Firmware": {
     "properties": {
      "uuid": {
-      "description": "UUID reported by the vmi bios\nDefaults to a random generated uid",
+      "description": "UUID reported by the vmi bios.\nDefaults to a random generated uid.",
       "type": "string"
      }
     }
@@ -3713,11 +3713,11 @@
    "v1.FloppyTarget": {
     "properties": {
      "readonly": {
-      "description": "ReadOnly\nDefaults to false",
+      "description": "ReadOnly.\nDefaults to false.",
       "type": "boolean"
      },
      "tray": {
-      "description": "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
+      "description": "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\".\nDefaults to closed.\n+optional",
       "type": "string"
      }
     }
@@ -3742,11 +3742,11 @@
    "v1.HPETTimer": {
     "properties": {
      "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
       "type": "boolean"
      },
      "tickPolicy": {
-      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest\nOne of \"delay\", \"catchup\", \"merge\", \"discard\"",
+      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.\nOne of \"delay\", \"catchup\", \"merge\", \"discard\".",
       "type": "string"
      }
     }
@@ -3763,16 +3763,16 @@
    "v1.HypervTimer": {
     "properties": {
      "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
       "type": "boolean"
      }
     }
    },
    "v1.I6300ESBWatchdog": {
-    "description": "i6300esb watchdog device",
+    "description": "i6300esb watchdog device.",
     "properties": {
      "action": {
-      "description": "The action to take. Valid values are poweroff, reset, shutdown.\nDefaults to reset",
+      "description": "The action to take. Valid values are poweroff, reset, shutdown.\nDefaults to reset.",
       "type": "string"
      }
     }
@@ -3844,7 +3844,7 @@
    "v1.KVMTimer": {
     "properties": {
      "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
       "type": "boolean"
      }
     }
@@ -3921,11 +3921,11 @@
    "v1.LunTarget": {
     "properties": {
      "bus": {
-      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
+      "description": "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide.",
       "type": "string"
      },
      "readonly": {
-      "description": "ReadOnly\nDefaults to false",
+      "description": "ReadOnly.\nDefaults to false.",
       "type": "boolean"
      }
     }
@@ -3942,7 +3942,7 @@
     }
    },
    "v1.Memory": {
-    "description": "Memory allow specifying the VirtualMachineInstance memory features",
+    "description": "Memory allows specifying the VirtualMachineInstance memory features.",
     "properties": {
      "hugepages": {
       "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.\n+optional",
@@ -4156,11 +4156,11 @@
    "v1.PITTimer": {
     "properties": {
      "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
       "type": "boolean"
      },
      "tickPolicy": {
-      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest\nOne of \"delay\", \"catchup\", \"discard\"",
+      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.\nOne of \"delay\", \"catchup\", \"discard\".",
       "type": "string"
      }
     }
@@ -4306,27 +4306,27 @@
    "v1.RTCTimer": {
     "properties": {
      "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
       "type": "boolean"
      },
      "tickPolicy": {
-      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest\nOne of \"delay\", \"catchup\"",
+      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.\nOne of \"delay\", \"catchup\".",
       "type": "string"
      },
      "track": {
-      "description": "Track the guest or the wall clock",
+      "description": "Track the guest or the wall clock.",
       "type": "string"
      }
     }
    },
    "v1.RegistryDiskSource": {
-    "description": "Represents a docker image with an embedded disk",
+    "description": "Represents a docker image with an embedded disk.",
     "required": [
      "image"
     ],
     "properties": {
      "image": {
-      "description": "Image is the name of the image with the embedded disk",
+      "description": "Image is the name of the image with the embedded disk.",
       "type": "string"
      },
      "imagePullSecret": {
@@ -4459,7 +4459,7 @@
     }
    },
    "v1.Timer": {
-    "description": "Represents all available timers in a vmi",
+    "description": "Represents all available timers in a vmi.",
     "properties": {
      "hpet": {
       "description": "HPET (High Precision Event Timer) - multiple timers with periodic interrupts.",
@@ -4963,7 +4963,7 @@
       "$ref": "#/definitions/v1.CloudInitNoCloudSource"
      },
      "emptyDisk": {
-      "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle\nMore info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html\n+optional",
+      "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle.\nMore info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html\n+optional",
       "$ref": "#/definitions/v1.EmptyDiskSource"
      },
      "ephemeral": {
@@ -4979,7 +4979,7 @@
       "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
      },
      "registryDisk": {
-      "description": "RegistryDisk references a docker image, embedding a qcow or raw disk\nMore info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html\n+optional",
+      "description": "RegistryDisk references a docker image, embedding a qcow or raw disk.\nMore info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html\n+optional",
       "$ref": "#/definitions/v1.RegistryDiskSource"
      }
     }
@@ -4999,17 +4999,17 @@
     }
    },
    "v1.Watchdog": {
-    "description": "Named watchdog device",
+    "description": "Named watchdog device.",
     "required": [
      "name"
     ],
     "properties": {
      "i6300esb": {
-      "description": "i6300esb watchdog device\n+optional",
+      "description": "i6300esb watchdog device.\n+optional",
       "$ref": "#/definitions/v1.I6300ESBWatchdog"
      },
      "name": {
-      "description": "Name of the watchdog",
+      "description": "Name of the watchdog.",
       "type": "string"
      }
     }

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -62,21 +62,21 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"bus": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, ide",
+								Description: "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, ide.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"readonly": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ReadOnly Defaults to true",
+								Description: "ReadOnly. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
 						},
 						"tray": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\" Defaults to closed",
+								Description: "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -89,7 +89,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.CPU": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "CPU allow specifying the CPU topology",
+					Description: "CPU allows specifying the CPU topology.",
 					Properties: map[string]spec.Schema{
 						"cores": {
 							SchemaProps: spec.SchemaProps{
@@ -106,7 +106,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.Clock": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Represents the clock and timers of a vmi",
+					Description: "Represents the clock and timers of a vmi.",
 					Properties: map[string]spec.Schema{
 						"utc": {
 							SchemaProps: spec.SchemaProps{
@@ -116,7 +116,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"timezone": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York')",
+								Description: "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -140,7 +140,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"timezone": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York')",
+								Description: "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -171,24 +171,24 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.CloudInitNoCloudSource": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Represents a cloud-init nocloud user data source More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+					Description: "Represents a cloud-init nocloud user data source. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
 					Properties: map[string]spec.Schema{
 						"secretRef": {
 							SchemaProps: spec.SchemaProps{
-								Description: "UserDataSecretRef references a k8s secret that contains NoCloud userdata",
+								Description: "UserDataSecretRef references a k8s secret that contains NoCloud userdata.",
 								Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 							},
 						},
 						"userDataBase64": {
 							SchemaProps: spec.SchemaProps{
-								Description: "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string",
+								Description: "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"userData": {
 							SchemaProps: spec.SchemaProps{
-								Description: "UserData contains NoCloud inline cloud-init userdata",
+								Description: "UserData contains NoCloud inline cloud-init userdata.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -205,7 +205,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"disks": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Disks describes disks, cdroms, floppy and luns which are connected to the vmi",
+								Description: "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{
@@ -218,13 +218,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"watchdog": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Watchdog describes a watchdog device which can be added to the vmi",
+								Description: "Watchdog describes a watchdog device which can be added to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Watchdog"),
 							},
 						},
 						"interfaces": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Interfaces describe network interfaces which are added to the vm",
+								Description: "Interfaces describe network interfaces which are added to the vm.",
 								Type:        []string{"array"},
 								Items: &spec.SchemaOrArray{
 									Schema: &spec.Schema{
@@ -254,32 +254,32 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"volumeName": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Name of the volume which is referenced Must match the Name of a Volume.",
+								Description: "Name of the volume which is referenced. Must match the Name of a Volume.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"disk": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a disk to the vmi",
+								Description: "Attach a volume as a disk to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.DiskTarget"),
 							},
 						},
 						"lun": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a LUN to the vmi",
+								Description: "Attach a volume as a LUN to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.LunTarget"),
 							},
 						},
 						"floppy": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a floppy to the vmi",
+								Description: "Attach a volume as a floppy to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FloppyTarget"),
 							},
 						},
 						"cdrom": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a cdrom to the vmi",
+								Description: "Attach a volume as a cdrom to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.CDRomTarget"),
 							},
 						},
@@ -304,25 +304,25 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"disk": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a disk to the vmi",
+								Description: "Attach a volume as a disk to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.DiskTarget"),
 							},
 						},
 						"lun": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a LUN to the vmi",
+								Description: "Attach a volume as a LUN to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.LunTarget"),
 							},
 						},
 						"floppy": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a floppy to the vmi",
+								Description: "Attach a volume as a floppy to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FloppyTarget"),
 							},
 						},
 						"cdrom": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Attach a volume as a cdrom to the vmi",
+								Description: "Attach a volume as a cdrom to the vmi.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.CDRomTarget"),
 							},
 						},
@@ -338,14 +338,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"bus": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, ide",
+								Description: "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, ide.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"readonly": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ReadOnly Defaults to false",
+								Description: "ReadOnly. Defaults to false.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -379,13 +379,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"machine": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Machine type",
+								Description: "Machine type.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Machine"),
 							},
 						},
 						"firmware": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Firmware",
+								Description: "Firmware.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Firmware"),
 							},
 						},
@@ -397,7 +397,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"features": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Features like acpi, apic, hyperv",
+								Description: "Features like acpi, apic, hyperv.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Features"),
 							},
 						},
@@ -437,13 +437,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"machine": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Machine type",
+								Description: "Machine type.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Machine"),
 							},
 						},
 						"firmware": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Firmware",
+								Description: "Firmware.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Firmware"),
 							},
 						},
@@ -455,7 +455,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"features": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Features like acpi, apic, hyperv",
+								Description: "Features like acpi, apic, hyperv.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Features"),
 							},
 						},
@@ -475,7 +475,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.EmptyDiskSource": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "EmptyDisk represents a temporary disk which shares the vmis lifecycle",
+					Description: "EmptyDisk represents a temporary disk which shares the vmis lifecycle.",
 					Properties: map[string]spec.Schema{
 						"capacity": {
 							SchemaProps: spec.SchemaProps{
@@ -512,14 +512,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"enabled": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled determines if the feature should be enabled or disabled on the guest Defaults to true",
+								Description: "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
 						},
 						"endOfInterrupt": {
 							SchemaProps: spec.SchemaProps{
-								Description: "EndOfInterrupt enables the end of interrupt notification in the guest Defaults to false",
+								Description: "EndOfInterrupt enables the end of interrupt notification in the guest. Defaults to false.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -532,59 +532,59 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.FeatureHyperv": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Hyperv specific features",
+					Description: "Hyperv specific features.",
 					Properties: map[string]spec.Schema{
 						"relaxed": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Relaxed relaxes constraints on timer Defaults to the machine type setting",
+								Description: "Relaxed relaxes constraints on timer. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"vapic": {
 							SchemaProps: spec.SchemaProps{
-								Description: "VAPIC indicates whether virtual APIC is enabled Defaults to the machine type setting",
+								Description: "VAPIC indicates whether virtual APIC is enabled. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"spinlocks": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Spinlocks indicates if spinlocks should be made available to the guest",
+								Description: "Spinlocks indicates if spinlocks should be made available to the guest.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureSpinlocks"),
 							},
 						},
 						"vpindex": {
 							SchemaProps: spec.SchemaProps{
-								Description: "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors Defaults to the machine type setting",
+								Description: "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"runtime": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Runtime Defaults to the machine type setting",
+								Description: "Runtime. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"synic": {
 							SchemaProps: spec.SchemaProps{
-								Description: "SyNIC enable Synthetic Interrupt Controller Defaults to the machine type setting",
+								Description: "SyNIC enable Synthetic Interrupt Controller. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"synictimer": {
 							SchemaProps: spec.SchemaProps{
-								Description: "SyNICTimer enable Synthetic Interrupt Controller timer Defaults to the machine type setting",
+								Description: "SyNICTimer enable Synthetic Interrupt Controller timer. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"reset": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Reset enables Hyperv reboot/reset for the vmi Defaults to the machine type setting",
+								Description: "Reset enables Hyperv reboot/reset for the vmi. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"vendorid": {
 							SchemaProps: spec.SchemaProps{
-								Description: "VendorID allows setting the hypervisor vendor id Defaults to the machine type setting",
+								Description: "VendorID allows setting the hypervisor vendor id. Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureVendorID"),
 							},
 						},
@@ -600,14 +600,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"enabled": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled determines if the feature should be enabled or disabled on the guest Defaults to true",
+								Description: "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
 						},
 						"spinlocks": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Retries indicates the number of retries Must be a value greater or equal 4096 Defaults to 4096",
+								Description: "Retries indicates the number of retries. Must be a value greater or equal 4096. Defaults to 4096.",
 								Type:        []string{"integer"},
 								Format:      "int64",
 							},
@@ -620,11 +620,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.FeatureState": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Represents if a feature is enabled or disabled",
+					Description: "Represents if a feature is enabled or disabled.",
 					Properties: map[string]spec.Schema{
 						"enabled": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled determines if the feature should be enabled or disabled on the guest Defaults to true",
+								Description: "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -640,14 +640,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"enabled": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled determines if the feature should be enabled or disabled on the guest Defaults to true",
+								Description: "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
 						},
 						"vendorid": {
 							SchemaProps: spec.SchemaProps{
-								Description: "VendorID sets the hypervisor vendor id, visible to the vmi String up to twelve characters",
+								Description: "VendorID sets the hypervisor vendor id, visible to the vmi. String up to twelve characters.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -663,19 +663,19 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"acpi": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ACPI enables/disables ACPI insidejsondata guest Defaults to enabled",
+								Description: "ACPI enables/disables ACPI insidejsondata guest. Defaults to enabled.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 							},
 						},
 						"apic": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Defaults to the machine type setting",
+								Description: "Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureAPIC"),
 							},
 						},
 						"hyperv": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Defaults to the machine type setting",
+								Description: "Defaults to the machine type setting.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureHyperv"),
 							},
 						},
@@ -691,7 +691,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"uuid": {
 							SchemaProps: spec.SchemaProps{
-								Description: "UUID reported by the vmi bios Defaults to a random generated uid",
+								Description: "UUID reported by the vmi bios. Defaults to a random generated uid.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -707,14 +707,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"readonly": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ReadOnly Defaults to false",
+								Description: "ReadOnly. Defaults to false.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
 						},
 						"tray": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\" Defaults to closed",
+								Description: "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -730,14 +730,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"tickPolicy": {
 							SchemaProps: spec.SchemaProps{
-								Description: "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest One of \"delay\", \"catchup\", \"merge\", \"discard\"",
+								Description: "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"merge\", \"discard\".",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"present": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true",
+								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -770,7 +770,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"present": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true",
+								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -783,11 +783,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.I6300ESBWatchdog": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "i6300esb watchdog device",
+					Description: "i6300esb watchdog device.",
 					Properties: map[string]spec.Schema{
 						"action": {
 							SchemaProps: spec.SchemaProps{
-								Description: "The action to take. Valid values are poweroff, reset, shutdown. Defaults to reset",
+								Description: "The action to take. Valid values are poweroff, reset, shutdown. Defaults to reset.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -890,7 +890,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"present": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true",
+								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -906,14 +906,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"bus": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, ide",
+								Description: "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi, ide.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"readonly": {
 							SchemaProps: spec.SchemaProps{
-								Description: "ReadOnly Defaults to false",
+								Description: "ReadOnly. Defaults to false.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -943,7 +943,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.Memory": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Memory allow specifying the VirtualMachineInstance memory features",
+					Description: "Memory allows specifying the VirtualMachineInstance memory features.",
 					Properties: map[string]spec.Schema{
 						"hugepages": {
 							SchemaProps: spec.SchemaProps{
@@ -1003,14 +1003,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"tickPolicy": {
 							SchemaProps: spec.SchemaProps{
-								Description: "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest One of \"delay\", \"catchup\", \"discard\"",
+								Description: "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"discard\".",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"present": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true",
+								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
@@ -1078,21 +1078,21 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"tickPolicy": {
 							SchemaProps: spec.SchemaProps{
-								Description: "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest One of \"delay\", \"catchup\"",
+								Description: "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\".",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"present": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true",
+								Description: "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
 								Type:        []string{"boolean"},
 								Format:      "",
 							},
 						},
 						"track": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Track the guest or the wall clock",
+								Description: "Track the guest or the wall clock.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -1105,11 +1105,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.RegistryDiskSource": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Represents a docker image with an embedded disk",
+					Description: "Represents a docker image with an embedded disk.",
 					Properties: map[string]spec.Schema{
 						"image": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Image is the name of the image with the embedded disk",
+								Description: "Image is the name of the image with the embedded disk.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
@@ -1166,7 +1166,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.Timer": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Represents all available timers in a vmi",
+					Description: "Represents all available timers in a vmi.",
 					Properties: map[string]spec.Schema{
 						"hpet": {
 							SchemaProps: spec.SchemaProps{
@@ -2039,7 +2039,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"registryDisk": {
 							SchemaProps: spec.SchemaProps{
-								Description: "RegistryDisk references a docker image, embedding a qcow or raw disk More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html",
+								Description: "RegistryDisk references a docker image, embedding a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.RegistryDiskSource"),
 							},
 						},
@@ -2051,7 +2051,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"emptyDisk": {
 							SchemaProps: spec.SchemaProps{
-								Description: "EmptyDisk represents a temporary disk which shares the vmis lifecycle More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html",
+								Description: "EmptyDisk represents a temporary disk which shares the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.EmptyDiskSource"),
 							},
 						},
@@ -2081,7 +2081,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"registryDisk": {
 							SchemaProps: spec.SchemaProps{
-								Description: "RegistryDisk references a docker image, embedding a qcow or raw disk More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html",
+								Description: "RegistryDisk references a docker image, embedding a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.RegistryDiskSource"),
 							},
 						},
@@ -2093,7 +2093,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"emptyDisk": {
 							SchemaProps: spec.SchemaProps{
-								Description: "EmptyDisk represents a temporary disk which shares the vmis lifecycle More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html",
+								Description: "EmptyDisk represents a temporary disk which shares the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.EmptyDiskSource"),
 							},
 						},
@@ -2106,18 +2106,18 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.Watchdog": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Named watchdog device",
+					Description: "Named watchdog device.",
 					Properties: map[string]spec.Schema{
 						"name": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Name of the watchdog",
+								Description: "Name of the watchdog.",
 								Type:        []string{"string"},
 								Format:      "",
 							},
 						},
 						"i6300esb": {
 							SchemaProps: spec.SchemaProps{
-								Description: "i6300esb watchdog device",
+								Description: "i6300esb watchdog device.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.I6300ESBWatchdog"),
 							},
 						},
@@ -2131,11 +2131,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"kubevirt.io/kubevirt/pkg/api/v1.WatchdogDevice": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Description: "Hardware watchdog device Exactly one of its members must be set.",
+					Description: "Hardware watchdog device. Exactly one of its members must be set.",
 					Properties: map[string]spec.Schema{
 						"i6300esb": {
 							SchemaProps: spec.SchemaProps{
-								Description: "i6300esb watchdog device",
+								Description: "i6300esb watchdog device.",
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.I6300ESBWatchdog"),
 							},
 						},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -32,18 +32,18 @@ import (
  ATTENTION: Rerun code generators when comments on structs or fields are modified.
 */
 
-// Represents a cloud-init nocloud user data source
+// Represents a cloud-init nocloud user data source.
 // More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html
 // ---
 // +k8s:openapi-gen=true
 type CloudInitNoCloudSource struct {
-	// UserDataSecretRef references a k8s secret that contains NoCloud userdata
+	// UserDataSecretRef references a k8s secret that contains NoCloud userdata.
 	// + optional
 	UserDataSecretRef *v1.LocalObjectReference `json:"secretRef,omitempty"`
-	// UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string
+	// UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.
 	// + optional
 	UserDataBase64 string `json:"userDataBase64,omitempty"`
-	// UserData contains NoCloud inline cloud-init userdata
+	// UserData contains NoCloud inline cloud-init userdata.
 	// + optional
 	UserData string `json:"userData,omitempty"`
 }
@@ -59,16 +59,16 @@ type DomainSpec struct {
 	// Memory allow specifying the VMI memory features.
 	// +optional
 	Memory *Memory `json:"memory,omitempty"`
-	// Machine type
+	// Machine type.
 	// +optional
 	Machine Machine `json:"machine,omitempty"`
-	// Firmware
+	// Firmware.
 	// +optional
 	Firmware *Firmware `json:"firmware,omitempty"`
 	// Clock sets the clock and timers of the vmi.
 	// +optional
 	Clock *Clock `json:"clock,omitempty"`
-	// Features like acpi, apic, hyperv
+	// Features like acpi, apic, hyperv.
 	// +optional
 	Features *Features `json:"features,omitempty"`
 	// Devices allows adding disks, network interfaces, ...
@@ -86,16 +86,16 @@ type DomainPresetSpec struct {
 	// Memory allow specifying the VMI memory features.
 	// +optional
 	Memory *Memory `json:"memory,omitempty"`
-	// Machine type
+	// Machine type.
 	// +optional
 	Machine Machine `json:"machine,omitempty"`
-	// Firmware
+	// Firmware.
 	// +optional
 	Firmware *Firmware `json:"firmware,omitempty"`
 	// Clock sets the clock and timers of the vmi.
 	// +optional
 	Clock *Clock `json:"clock,omitempty"`
-	// Features like acpi, apic, hyperv
+	// Features like acpi, apic, hyperv.
 	// +optional
 	Features *Features `json:"features,omitempty"`
 	// Devices allows adding disks, network interfaces, ...
@@ -116,7 +116,7 @@ type ResourceRequirements struct {
 	Limits v1.ResourceList `json:"limits,omitempty"`
 }
 
-// CPU allow specifying the CPU topology
+// CPU allows specifying the CPU topology.
 // ---
 // +k8s:openapi-gen=true
 type CPU struct {
@@ -125,7 +125,7 @@ type CPU struct {
 	Cores uint32 `json:"cores,omitempty"`
 }
 
-// Memory allow specifying the VirtualMachineInstance memory features
+// Memory allows specifying the VirtualMachineInstance memory features.
 // ---
 // +k8s:openapi-gen=true
 type Memory struct {
@@ -152,19 +152,19 @@ type Machine struct {
 // ---
 // +k8s:openapi-gen=true
 type Firmware struct {
-	// UUID reported by the vmi bios
-	// Defaults to a random generated uid
+	// UUID reported by the vmi bios.
+	// Defaults to a random generated uid.
 	UUID types.UID `json:"uuid,omitempty"`
 }
 
 // ---
 // +k8s:openapi-gen=true
 type Devices struct {
-	// Disks describes disks, cdroms, floppy and luns which are connected to the vmi
+	// Disks describes disks, cdroms, floppy and luns which are connected to the vmi.
 	Disks []Disk `json:"disks,omitempty"`
-	// Watchdog describes a watchdog device which can be added to the vmi
+	// Watchdog describes a watchdog device which can be added to the vmi.
 	Watchdog *Watchdog `json:"watchdog,omitempty"`
-	// Interfaces describe network interfaces which are added to the vm
+	// Interfaces describe network interfaces which are added to the vm.
 	Interfaces []Interface `json:"interfaces,omitempty"`
 }
 
@@ -173,11 +173,11 @@ type Devices struct {
 type Disk struct {
 	// Name is the device name
 	Name string `json:"name"`
-	// Name of the volume which is referenced
+	// Name of the volume which is referenced.
 	// Must match the Name of a Volume.
 	VolumeName string `json:"volumeName"`
-	// DiskDevice specifies as which device the disk should be added to the guest
-	// Defaults to Disk
+	// DiskDevice specifies as which device the disk should be added to the guest.
+	// Defaults to Disk.
 	DiskDevice `json:",inline"`
 	// BootOrder is an integer value > 0, used to determine ordering of boot devices.
 	// Lower values take precedence.
@@ -191,13 +191,13 @@ type Disk struct {
 // ---
 // +k8s:openapi-gen=true
 type DiskDevice struct {
-	// Attach a volume as a disk to the vmi
+	// Attach a volume as a disk to the vmi.
 	Disk *DiskTarget `json:"disk,omitempty"`
-	// Attach a volume as a LUN to the vmi
+	// Attach a volume as a LUN to the vmi.
 	LUN *LunTarget `json:"lun,omitempty"`
-	// Attach a volume as a floppy to the vmi
+	// Attach a volume as a floppy to the vmi.
 	Floppy *FloppyTarget `json:"floppy,omitempty"`
-	// Attach a volume as a cdrom to the vmi
+	// Attach a volume as a cdrom to the vmi.
 	CDRom *CDRomTarget `json:"cdrom,omitempty"`
 }
 
@@ -205,10 +205,10 @@ type DiskDevice struct {
 // +k8s:openapi-gen=true
 type DiskTarget struct {
 	// Bus indicates the type of disk device to emulate.
-	// supported values: virtio, sata, scsi, ide
+	// supported values: virtio, sata, scsi, ide.
 	Bus string `json:"bus,omitempty"`
-	// ReadOnly
-	// Defaults to false
+	// ReadOnly.
+	// Defaults to false.
 	ReadOnly bool `json:"readonly,omitempty"`
 }
 
@@ -216,35 +216,35 @@ type DiskTarget struct {
 // +k8s:openapi-gen=true
 type LunTarget struct {
 	// Bus indicates the type of disk device to emulate.
-	// supported values: virtio, sata, scsi, ide
+	// supported values: virtio, sata, scsi, ide.
 	Bus string `json:"bus,omitempty"`
-	// ReadOnly
-	// Defaults to false
+	// ReadOnly.
+	// Defaults to false.
 	ReadOnly bool `json:"readonly,omitempty"`
 }
 
 // ---
 // +k8s:openapi-gen=true
 type FloppyTarget struct {
-	// ReadOnly
-	// Defaults to false
+	// ReadOnly.
+	// Defaults to false.
 	ReadOnly bool `json:"readonly,omitempty"`
 	// Tray indicates if the tray of the device is open or closed.
-	// Allowed values are "open" and "closed"
-	// Defaults to closed
+	// Allowed values are "open" and "closed".
+	// Defaults to closed.
 	// +optional
 	Tray TrayState `json:"tray,omitempty"`
 }
 
-// TrayState indicates if a tray of a cdrom or floppy is open or closed
+// TrayState indicates if a tray of a cdrom or floppy is open or closed.
 // ---
 // +k8s:openapi-gen=true
 type TrayState string
 
 const (
-	// TrayStateOpen indicates that the tray of a cdrom or floppy is open
+	// TrayStateOpen indicates that the tray of a cdrom or floppy is open.
 	TrayStateOpen TrayState = "open"
-	// TrayStateClosed indicates that the tray of a cdrom or floppy is closed
+	// TrayStateClosed indicates that the tray of a cdrom or floppy is closed.
 	TrayStateClosed TrayState = "closed"
 )
 
@@ -252,14 +252,14 @@ const (
 // +k8s:openapi-gen=true
 type CDRomTarget struct {
 	// Bus indicates the type of disk device to emulate.
-	// supported values: virtio, sata, scsi, ide
+	// supported values: virtio, sata, scsi, ide.
 	Bus string `json:"bus,omitempty"`
-	// ReadOnly
-	// Defaults to true
+	// ReadOnly.
+	// Defaults to true.
 	ReadOnly *bool `json:"readonly,omitempty"`
 	// Tray indicates if the tray of the device is open or closed.
-	// Allowed values are "open" and "closed"
-	// Defaults to closed
+	// Allowed values are "open" and "closed".
+	// Defaults to closed.
 	// +optional
 	Tray TrayState `json:"tray,omitempty"`
 }
@@ -273,7 +273,7 @@ type Volume struct {
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	Name string `json:"name"`
 	// VolumeSource represents the location and type of the mounted volume.
-	// Defaults to Disk, if no type is specified
+	// Defaults to Disk, if no type is specified.
 	VolumeSource `json:",inline"`
 }
 
@@ -292,14 +292,14 @@ type VolumeSource struct {
 	// More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html
 	// +optional
 	CloudInitNoCloud *CloudInitNoCloudSource `json:"cloudInitNoCloud,omitempty"`
-	// RegistryDisk references a docker image, embedding a qcow or raw disk
+	// RegistryDisk references a docker image, embedding a qcow or raw disk.
 	// More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html
 	// +optional
 	RegistryDisk *RegistryDiskSource `json:"registryDisk,omitempty"`
 	// Ephemeral is a special volume source that "wraps" specified source and provides copy-on-write image on top of it.
 	// +optional
 	Ephemeral *EphemeralVolumeSource `json:"ephemeral,omitempty"`
-	// EmptyDisk represents a temporary disk which shares the vmis lifecycle
+	// EmptyDisk represents a temporary disk which shares the vmis lifecycle.
 	// More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html
 	// +optional
 	EmptyDisk *EmptyDiskSource `json:"emptyDisk,omitempty"`
@@ -315,7 +315,7 @@ type EphemeralVolumeSource struct {
 	PersistentVolumeClaim *v1.PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
 }
 
-// EmptyDisk represents a temporary disk which shares the vmis lifecycle
+// EmptyDisk represents a temporary disk which shares the vmis lifecycle.
 // ---
 // +k8s:openapi-gen=true
 type EmptyDiskSource struct {
@@ -323,11 +323,11 @@ type EmptyDiskSource struct {
 	Capacity resource.Quantity `json:"capacity"`
 }
 
-// Represents a docker image with an embedded disk
+// Represents a docker image with an embedded disk.
 // ---
 // +k8s:openapi-gen=true
 type RegistryDiskSource struct {
-	// Image is the name of the image with the embedded disk
+	// Image is the name of the image with the embedded disk.
 	Image string `json:"image"`
 	// ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
@@ -341,7 +341,7 @@ type ClockOffset struct {
 	// guest changes to the clock will be kept during reboots and are not reset.
 	UTC *ClockOffsetUTC `json:"utc,omitempty"`
 	// Timezone sets the guest clock to the specified timezone.
-	// Zone name follows the TZ environment variable format (e.g. 'America/New_York')
+	// Zone name follows the TZ environment variable format (e.g. 'America/New_York').
 	Timezone *ClockOffsetTimezone `json:"timezone,omitempty"`
 }
 
@@ -355,22 +355,22 @@ type ClockOffsetUTC struct {
 }
 
 // ClockOffsetTimezone sets the guest clock to the specified timezone.
-// Zone name follows the TZ environment variable format (e.g. 'America/New_York')
+// Zone name follows the TZ environment variable format (e.g. 'America/New_York').
 // ---
 // +k8s:openapi-gen=true
 type ClockOffsetTimezone string
 
-// Represents the clock and timers of a vmi
+// Represents the clock and timers of a vmi.
 // ---
 // +k8s:openapi-gen=true
 type Clock struct {
-	// ClockOffset allows specifying the UTC offset or the timezone of the guest clock
+	// ClockOffset allows specifying the UTC offset or the timezone of the guest clock.
 	ClockOffset `json:",inline"`
-	// Timer specifies whih timers are attached to the vmi
+	// Timer specifies whih timers are attached to the vmi.
 	Timer *Timer `json:"timer,inline"`
 }
 
-// Represents all available timers in a vmi
+// Represents all available timers in a vmi.
 // ---
 // +k8s:openapi-gen=true
 type Timer struct {
@@ -386,17 +386,17 @@ type Timer struct {
 	Hyperv *HypervTimer `json:"hyperv,omitempty"`
 }
 
-// HPETTickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest
+// HPETTickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
 // ---
 // +k8s:openapi-gen=true
 type HPETTickPolicy string
 
-// PITTickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest
+// PITTickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
 // ---
 // +k8s:openapi-gen=true
 type PITTickPolicy string
 
-// RTCTickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest
+// RTCTickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
 // ---
 // +k8s:openapi-gen=true
 type RTCTickPolicy string
@@ -410,62 +410,62 @@ const (
 	HPETTickPolicyCatchup HPETTickPolicy = "catchup"
 	// HPETTickPolicyMerge merges the missed tick(s) into one tick and inject. The
 	// guest time may be delayed, depending on how the OS reacts to the merging
-	// of ticks
+	// of ticks.
 	HPETTickPolicyMerge HPETTickPolicy = "merge"
 	// HPETTickPolicyDiscard discards all missed ticks.
 	HPETTickPolicyDiscard HPETTickPolicy = "discard"
 
 	// PITTickPolicyDelay delivers ticks at a constant rate. The guest time will
-	// be delayed due to the late tick
+	// be delayed due to the late tick.
 	PITTickPolicyDelay PITTickPolicy = "delay"
 	// PITTickPolicyCatchup Delivers ticks at a higher rate to catch up with the
-	// missed tick. The guest time should not be delayed once catchup is complete
+	// missed tick. The guest time should not be delayed once catchup is complete.
 	PITTickPolicyCatchup PITTickPolicy = "catchup"
 	// PITTickPolicyDiscard discards all missed ticks.
 	PITTickPolicyDiscard PITTickPolicy = "discard"
 
 	// RTCTickPolicyDelay delivers ticks at a constant rate. The guest time will
-	// be delayed due to the late tick
+	// be delayed due to the late tick.
 	RTCTickPolicyDelay RTCTickPolicy = "delay"
 	// RTCTickPolicyCatchup Delivers ticks at a higher rate to catch up with the
-	// missed tick. The guest time should not be delayed once catchup is complete
+	// missed tick. The guest time should not be delayed once catchup is complete.
 	RTCTickPolicyCatchup RTCTickPolicy = "catchup"
 )
 
-// RTCTimerTrack specifies from which source to track the time
+// RTCTimerTrack specifies from which source to track the time.
 // ---
 // +k8s:openapi-gen=true
 type RTCTimerTrack string
 
 const (
-	// TrackGuest tracks the guest time
+	// TrackGuest tracks the guest time.
 	TrackGuest RTCTimerTrack = "guest"
-	// TrackWall tracks the host time
+	// TrackWall tracks the host time.
 	TrackWall RTCTimerTrack = "wall"
 )
 
 // ---
 // +k8s:openapi-gen=true
 type RTCTimer struct {
-	// TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest
-	// One of "delay", "catchup"
+	// TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
+	// One of "delay", "catchup".
 	TickPolicy RTCTickPolicy `json:"tickPolicy,omitempty"`
 	// Enabled set to false makes sure that the machine type or a preset can't add the timer.
-	// Defaults to true
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"present,omitempty"`
-	// Track the guest or the wall clock
+	// Track the guest or the wall clock.
 	Track RTCTimerTrack `json:"track,omitempty"`
 }
 
 // ---
 // +k8s:openapi-gen=true
 type HPETTimer struct {
-	// TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest
-	// One of "delay", "catchup", "merge", "discard"
+	// TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
+	// One of "delay", "catchup", "merge", "discard".
 	TickPolicy HPETTickPolicy `json:"tickPolicy,omitempty"`
 	// Enabled set to false makes sure that the machine type or a preset can't add the timer.
-	// Defaults to true
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"present,omitempty"`
 }
@@ -473,11 +473,11 @@ type HPETTimer struct {
 // ---
 // +k8s:openapi-gen=true
 type PITTimer struct {
-	// TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest
-	// One of "delay", "catchup", "discard"
+	// TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.
+	// One of "delay", "catchup", "discard".
 	TickPolicy PITTickPolicy `json:"tickPolicy,omitempty"`
 	// Enabled set to false makes sure that the machine type or a preset can't add the timer.
-	// Defaults to true
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"present,omitempty"`
 }
@@ -486,7 +486,7 @@ type PITTimer struct {
 // +k8s:openapi-gen=true
 type KVMTimer struct {
 	// Enabled set to false makes sure that the machine type or a preset can't add the timer.
-	// Defaults to true
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"present,omitempty"`
 }
@@ -495,7 +495,7 @@ type KVMTimer struct {
 // +k8s:openapi-gen=true
 type HypervTimer struct {
 	// Enabled set to false makes sure that the machine type or a preset can't add the timer.
-	// Defaults to true
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"present,omitempty"`
 }
@@ -503,24 +503,24 @@ type HypervTimer struct {
 // ---
 // +k8s:openapi-gen=true
 type Features struct {
-	// ACPI enables/disables ACPI insidejsondata guest
-	// Defaults to enabled
+	// ACPI enables/disables ACPI insidejsondata guest.
+	// Defaults to enabled.
 	// +optional
 	ACPI FeatureState `json:"acpi,omitempty"`
-	// Defaults to the machine type setting
+	// Defaults to the machine type setting.
 	// +optional
 	APIC *FeatureAPIC `json:"apic,omitempty"`
-	// Defaults to the machine type setting
+	// Defaults to the machine type setting.
 	// +optional
 	Hyperv *FeatureHyperv `json:"hyperv,omitempty"`
 }
 
-// Represents if a feature is enabled or disabled
+// Represents if a feature is enabled or disabled.
 // ---
 // +k8s:openapi-gen=true
 type FeatureState struct {
-	// Enabled determines if the feature should be enabled or disabled on the guest
-	// Defaults to true
+	// Enabled determines if the feature should be enabled or disabled on the guest.
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 }
@@ -528,12 +528,12 @@ type FeatureState struct {
 // ---
 // +k8s:openapi-gen=true
 type FeatureAPIC struct {
-	// Enabled determines if the feature should be enabled or disabled on the guest
-	// Defaults to true
+	// Enabled determines if the feature should be enabled or disabled on the guest.
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
-	// EndOfInterrupt enables the end of interrupt notification in the guest
-	// Defaults to false
+	// EndOfInterrupt enables the end of interrupt notification in the guest.
+	// Defaults to false.
 	// +optional
 	EndOfInterrupt bool `json:"endOfInterrupt,omitempty"`
 }
@@ -541,13 +541,13 @@ type FeatureAPIC struct {
 // ---
 // +k8s:openapi-gen=true
 type FeatureSpinlocks struct {
-	// Enabled determines if the feature should be enabled or disabled on the guest
-	// Defaults to true
+	// Enabled determines if the feature should be enabled or disabled on the guest.
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
-	// Retries indicates the number of retries
-	// Must be a value greater or equal 4096
-	// Defaults to 4096
+	// Retries indicates the number of retries.
+	// Must be a value greater or equal 4096.
+	// Defaults to 4096.
 	// +optional
 	Retries *uint32 `json:"spinlocks,omitempty"`
 }
@@ -555,97 +555,97 @@ type FeatureSpinlocks struct {
 // ---
 // +k8s:openapi-gen=true
 type FeatureVendorID struct {
-	// Enabled determines if the feature should be enabled or disabled on the guest
-	// Defaults to true
+	// Enabled determines if the feature should be enabled or disabled on the guest.
+	// Defaults to true.
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
-	// VendorID sets the hypervisor vendor id, visible to the vmi
-	// String up to twelve characters
+	// VendorID sets the hypervisor vendor id, visible to the vmi.
+	// String up to twelve characters.
 	VendorID string `json:"vendorid,omitempty"`
 }
 
-// Hyperv specific features
+// Hyperv specific features.
 // ---
 // +k8s:openapi-gen=true
 type FeatureHyperv struct {
-	// Relaxed relaxes constraints on timer
-	// Defaults to the machine type setting
+	// Relaxed relaxes constraints on timer.
+	// Defaults to the machine type setting.
 	// +optional
 	Relaxed *FeatureState `json:"relaxed,omitempty"`
-	// VAPIC indicates whether virtual APIC is enabled
-	// Defaults to the machine type setting
+	// VAPIC indicates whether virtual APIC is enabled.
+	// Defaults to the machine type setting.
 	// +optional
 	VAPIC *FeatureState `json:"vapic,omitempty"`
-	// Spinlocks indicates if spinlocks should be made available to the guest
+	// Spinlocks indicates if spinlocks should be made available to the guest.
 	// +optional
 	Spinlocks *FeatureSpinlocks `json:"spinlocks,omitempty"`
-	// VPIndex enables the Virtual Processor Index to help windows identifying virtual processors
-	// Defaults to the machine type setting
+	// VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.
+	// Defaults to the machine type setting.
 	// +optional
 	VPIndex *FeatureState `json:"vpindex,omitempty"`
-	// Runtime
-	// Defaults to the machine type setting
+	// Runtime.
+	// Defaults to the machine type setting.
 	// +optional
 	Runtime *FeatureState `json:"runtime,omitempty"`
-	// SyNIC enable Synthetic Interrupt Controller
-	// Defaults to the machine type setting
+	// SyNIC enable Synthetic Interrupt Controller.
+	// Defaults to the machine type setting.
 	// +optional
 	SyNIC *FeatureState `json:"synic,omitempty"`
-	// SyNICTimer enable Synthetic Interrupt Controller timer
-	// Defaults to the machine type setting
+	// SyNICTimer enable Synthetic Interrupt Controller timer.
+	// Defaults to the machine type setting.
 	// +optional
 	SyNICTimer *FeatureState `json:"synictimer,omitempty"`
-	// Reset enables Hyperv reboot/reset for the vmi
-	// Defaults to the machine type setting
+	// Reset enables Hyperv reboot/reset for the vmi.
+	// Defaults to the machine type setting.
 	// +optional
 	Reset *FeatureState `json:"reset,omitempty"`
-	// VendorID allows setting the hypervisor vendor id
-	// Defaults to the machine type setting
+	// VendorID allows setting the hypervisor vendor id.
+	// Defaults to the machine type setting.
 	// +optional
 	VendorID *FeatureVendorID `json:"vendorid,omitempty"`
 }
 
-// WatchdogAction defines the watchdog action, if a watchdog gets triggered
+// WatchdogAction defines the watchdog action, if a watchdog gets triggered.
 // ---
 // +k8s:openapi-gen=true
 type WatchdogAction string
 
 const (
-	// WatchdogActionPoweroff will poweroff the vmi if the watchdog gets triggered
+	// WatchdogActionPoweroff will poweroff the vmi if the watchdog gets triggered.
 	WatchdogActionPoweroff WatchdogAction = "poweroff"
-	// WatchdogActionReset will reset the vmi if the watchdog gets triggered
+	// WatchdogActionReset will reset the vmi if the watchdog gets triggered.
 	WatchdogActionReset WatchdogAction = "reset"
-	// WatchdogActionShutdown will shutdown the vmi if the watchdog gets triggered
+	// WatchdogActionShutdown will shutdown the vmi if the watchdog gets triggered.
 	WatchdogActionShutdown WatchdogAction = "shutdown"
 )
 
-// Named watchdog device
+// Named watchdog device.
 // ---
 // +k8s:openapi-gen=true
 type Watchdog struct {
-	// Name of the watchdog
+	// Name of the watchdog.
 	Name string `json:"name"`
-	// WatchdogDevice contains the watchdog type and actions
-	// Defaults to i6300esb
+	// WatchdogDevice contains the watchdog type and actions.
+	// Defaults to i6300esb.
 	WatchdogDevice `json:",inline"`
 }
 
-// Hardware watchdog device
+// Hardware watchdog device.
 // Exactly one of its members must be set.
 // ---
 // +k8s:openapi-gen=true
 type WatchdogDevice struct {
-	// i6300esb watchdog device
+	// i6300esb watchdog device.
 	// +optional
 	I6300ESB *I6300ESBWatchdog `json:"i6300esb,omitempty"`
 }
 
-// i6300esb watchdog device
+// i6300esb watchdog device.
 // ---
 // +k8s:openapi-gen=true
 type I6300ESBWatchdog struct {
 	// The action to take. Valid values are poweroff, reset, shutdown.
-	// Defaults to reset
+	// Defaults to reset.
 	Action WatchdogAction `json:"action,omitempty"`
 }
 
@@ -670,8 +670,8 @@ type Interface struct {
 	// Defaults to virtio.
 	// TODO:(ihar) switch to enums once opengen-api supports them. See: https://github.com/kubernetes/kube-openapi/issues/51
 	Model string `json:"model,omitempty"`
-	// BindingMethod specifies the method which will be used to connect the interface to the guest
-	// Defaults to Bridge
+	// BindingMethod specifies the method which will be used to connect the interface to the guest.
+	// Defaults to Bridge.
 	InterfaceBindingMethod `json:",inline"`
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -4,10 +4,10 @@ package v1
 
 func (CloudInitNoCloudSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":               "Represents a cloud-init nocloud user data source\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
-		"secretRef":      "UserDataSecretRef references a k8s secret that contains NoCloud userdata\n+ optional",
-		"userDataBase64": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string\n+ optional",
-		"userData":       "UserData contains NoCloud inline cloud-init userdata\n+ optional",
+		"":               "Represents a cloud-init nocloud user data source.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+		"secretRef":      "UserDataSecretRef references a k8s secret that contains NoCloud userdata.\n+ optional",
+		"userDataBase64": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.\n+ optional",
+		"userData":       "UserData contains NoCloud inline cloud-init userdata.\n+ optional",
 	}
 }
 
@@ -16,10 +16,10 @@ func (DomainSpec) SwaggerDoc() map[string]string {
 		"resources": "Resources describes the Compute Resources required by this vmi.",
 		"cpu":       "CPU allow specified the detailed CPU topology inside the vmi.\n+optional",
 		"memory":    "Memory allow specifying the VMI memory features.\n+optional",
-		"machine":   "Machine type\n+optional",
-		"firmware":  "Firmware\n+optional",
+		"machine":   "Machine type.\n+optional",
+		"firmware":  "Firmware.\n+optional",
 		"clock":     "Clock sets the clock and timers of the vmi.\n+optional",
-		"features":  "Features like acpi, apic, hyperv\n+optional",
+		"features":  "Features like acpi, apic, hyperv.\n+optional",
 		"devices":   "Devices allows adding disks, network interfaces, ...",
 	}
 }
@@ -29,10 +29,10 @@ func (DomainPresetSpec) SwaggerDoc() map[string]string {
 		"resources": "Resources describes the Compute Resources required by this vmi.",
 		"cpu":       "CPU allow specified the detailed CPU topology inside the vmi.\n+optional",
 		"memory":    "Memory allow specifying the VMI memory features.\n+optional",
-		"machine":   "Machine type\n+optional",
-		"firmware":  "Firmware\n+optional",
+		"machine":   "Machine type.\n+optional",
+		"firmware":  "Firmware.\n+optional",
 		"clock":     "Clock sets the clock and timers of the vmi.\n+optional",
-		"features":  "Features like acpi, apic, hyperv\n+optional",
+		"features":  "Features like acpi, apic, hyperv.\n+optional",
 		"devices":   "Devices allows adding disks, network interfaces, ...\n+optional",
 	}
 }
@@ -46,14 +46,14 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 
 func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":      "CPU allow specifying the CPU topology",
+		"":      "CPU allows specifying the CPU topology.",
 		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
 	}
 }
 
 func (Memory) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":          "Memory allow specifying the VirtualMachineInstance memory features",
+		"":          "Memory allows specifying the VirtualMachineInstance memory features.",
 		"hugepages": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.\n+optional",
 	}
 }
@@ -73,22 +73,22 @@ func (Machine) SwaggerDoc() map[string]string {
 
 func (Firmware) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"uuid": "UUID reported by the vmi bios\nDefaults to a random generated uid",
+		"uuid": "UUID reported by the vmi bios.\nDefaults to a random generated uid.",
 	}
 }
 
 func (Devices) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"disks":      "Disks describes disks, cdroms, floppy and luns which are connected to the vmi",
-		"watchdog":   "Watchdog describes a watchdog device which can be added to the vmi",
-		"interfaces": "Interfaces describe network interfaces which are added to the vm",
+		"disks":      "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
+		"watchdog":   "Watchdog describes a watchdog device which can be added to the vmi.",
+		"interfaces": "Interfaces describe network interfaces which are added to the vm.",
 	}
 }
 
 func (Disk) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name":       "Name is the device name",
-		"volumeName": "Name of the volume which is referenced\nMust match the Name of a Volume.",
+		"volumeName": "Name of the volume which is referenced.\nMust match the Name of a Volume.",
 		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 	}
 }
@@ -96,39 +96,39 @@ func (Disk) SwaggerDoc() map[string]string {
 func (DiskDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":       "Represents the target of a volume to mount.\nOnly one of its members may be specified.",
-		"disk":   "Attach a volume as a disk to the vmi",
-		"lun":    "Attach a volume as a LUN to the vmi",
-		"floppy": "Attach a volume as a floppy to the vmi",
-		"cdrom":  "Attach a volume as a cdrom to the vmi",
+		"disk":   "Attach a volume as a disk to the vmi.",
+		"lun":    "Attach a volume as a LUN to the vmi.",
+		"floppy": "Attach a volume as a floppy to the vmi.",
+		"cdrom":  "Attach a volume as a cdrom to the vmi.",
 	}
 }
 
 func (DiskTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
-		"readonly": "ReadOnly\nDefaults to false",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide.",
+		"readonly": "ReadOnly.\nDefaults to false.",
 	}
 }
 
 func (LunTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
-		"readonly": "ReadOnly\nDefaults to false",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide.",
+		"readonly": "ReadOnly.\nDefaults to false.",
 	}
 }
 
 func (FloppyTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"readonly": "ReadOnly\nDefaults to false",
-		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
+		"readonly": "ReadOnly.\nDefaults to false.",
+		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\".\nDefaults to closed.\n+optional",
 	}
 }
 
 func (CDRomTarget) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide",
-		"readonly": "ReadOnly\nDefaults to true",
-		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\"\nDefaults to closed\n+optional",
+		"bus":      "Bus indicates the type of disk device to emulate.\nsupported values: virtio, sata, scsi, ide.",
+		"readonly": "ReadOnly.\nDefaults to true.",
+		"tray":     "Tray indicates if the tray of the device is open or closed.\nAllowed values are \"open\" and \"closed\".\nDefaults to closed.\n+optional",
 	}
 }
 
@@ -144,9 +144,9 @@ func (VolumeSource) SwaggerDoc() map[string]string {
 		"": "Represents the source of a volume to mount.\nOnly one of its members may be specified.",
 		"persistentVolumeClaim": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace.\nDirectly attached to the vmi via qemu.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims\n+optional",
 		"cloudInitNoCloud":      "CloudInitNoCloud represents a cloud-init NoCloud user-data source.\nThe NoCloud data will be added as a disk to the vmi. A proper cloud-init installation is required inside the guest.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html\n+optional",
-		"registryDisk":          "RegistryDisk references a docker image, embedding a qcow or raw disk\nMore info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html\n+optional",
+		"registryDisk":          "RegistryDisk references a docker image, embedding a qcow or raw disk.\nMore info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html\n+optional",
 		"ephemeral":             "Ephemeral is a special volume source that \"wraps\" specified source and provides copy-on-write image on top of it.\n+optional",
-		"emptyDisk":             "EmptyDisk represents a temporary disk which shares the vmis lifecycle\nMore info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html\n+optional",
+		"emptyDisk":             "EmptyDisk represents a temporary disk which shares the vmis lifecycle.\nMore info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html\n+optional",
 	}
 }
 
@@ -158,15 +158,15 @@ func (EphemeralVolumeSource) SwaggerDoc() map[string]string {
 
 func (EmptyDiskSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":         "EmptyDisk represents a temporary disk which shares the vmis lifecycle",
+		"":         "EmptyDisk represents a temporary disk which shares the vmis lifecycle.",
 		"capacity": "Capacity of the sparse disk.",
 	}
 }
 
 func (RegistryDiskSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                "Represents a docker image with an embedded disk",
-		"image":           "Image is the name of the image with the embedded disk",
+		"":                "Represents a docker image with an embedded disk.",
+		"image":           "Image is the name of the image with the embedded disk.",
 		"imagePullSecret": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
 	}
 }
@@ -175,7 +175,7 @@ func (ClockOffset) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "Exactly one of its members must be set.",
 		"utc":      "UTC sets the guest clock to UTC on each boot. If an offset is specified,\nguest changes to the clock will be kept during reboots and are not reset.",
-		"timezone": "Timezone sets the guest clock to the specified timezone.\nZone name follows the TZ environment variable format (e.g. 'America/New_York')",
+		"timezone": "Timezone sets the guest clock to the specified timezone.\nZone name follows the TZ environment variable format (e.g. 'America/New_York').",
 	}
 }
 
@@ -188,14 +188,14 @@ func (ClockOffsetUTC) SwaggerDoc() map[string]string {
 
 func (Clock) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":      "Represents the clock and timers of a vmi",
-		"timer": "Timer specifies whih timers are attached to the vmi",
+		"":      "Represents the clock and timers of a vmi.",
+		"timer": "Timer specifies whih timers are attached to the vmi.",
 	}
 }
 
 func (Timer) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":       "Represents all available timers in a vmi",
+		"":       "Represents all available timers in a vmi.",
 		"hpet":   "HPET (High Precision Event Timer) - multiple timers with periodic interrupts.",
 		"kvm":    "KVM \t(KVM clock) - lets guests read the host’s wall clock time (paravirtualized). For linux guests.",
 		"pit":    "PIT (Programmable Interval Timer) - a timer with periodic interrupts.",
@@ -206,107 +206,107 @@ func (Timer) SwaggerDoc() map[string]string {
 
 func (RTCTimer) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"tickPolicy": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest\nOne of \"delay\", \"catchup\"",
-		"present":    "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
-		"track":      "Track the guest or the wall clock",
+		"tickPolicy": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.\nOne of \"delay\", \"catchup\".",
+		"present":    "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
+		"track":      "Track the guest or the wall clock.",
 	}
 }
 
 func (HPETTimer) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"tickPolicy": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest\nOne of \"delay\", \"catchup\", \"merge\", \"discard\"",
-		"present":    "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+		"tickPolicy": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.\nOne of \"delay\", \"catchup\", \"merge\", \"discard\".",
+		"present":    "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
 	}
 }
 
 func (PITTimer) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"tickPolicy": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest\nOne of \"delay\", \"catchup\", \"discard\"",
-		"present":    "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+		"tickPolicy": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest.\nOne of \"delay\", \"catchup\", \"discard\".",
+		"present":    "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
 	}
 }
 
 func (KVMTimer) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"present": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+		"present": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
 	}
 }
 
 func (HypervTimer) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"present": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true\n+optional",
+		"present": "Enabled set to false makes sure that the machine type or a preset can't add the timer.\nDefaults to true.\n+optional",
 	}
 }
 
 func (Features) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"acpi":   "ACPI enables/disables ACPI insidejsondata guest\nDefaults to enabled\n+optional",
-		"apic":   "Defaults to the machine type setting\n+optional",
-		"hyperv": "Defaults to the machine type setting\n+optional",
+		"acpi":   "ACPI enables/disables ACPI insidejsondata guest.\nDefaults to enabled.\n+optional",
+		"apic":   "Defaults to the machine type setting.\n+optional",
+		"hyperv": "Defaults to the machine type setting.\n+optional",
 	}
 }
 
 func (FeatureState) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":        "Represents if a feature is enabled or disabled",
-		"enabled": "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
+		"":        "Represents if a feature is enabled or disabled.",
+		"enabled": "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
 	}
 }
 
 func (FeatureAPIC) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"enabled":        "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
-		"endOfInterrupt": "EndOfInterrupt enables the end of interrupt notification in the guest\nDefaults to false\n+optional",
+		"enabled":        "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
+		"endOfInterrupt": "EndOfInterrupt enables the end of interrupt notification in the guest.\nDefaults to false.\n+optional",
 	}
 }
 
 func (FeatureSpinlocks) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"enabled":   "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
-		"spinlocks": "Retries indicates the number of retries\nMust be a value greater or equal 4096\nDefaults to 4096\n+optional",
+		"enabled":   "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
+		"spinlocks": "Retries indicates the number of retries.\nMust be a value greater or equal 4096.\nDefaults to 4096.\n+optional",
 	}
 }
 
 func (FeatureVendorID) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"enabled":  "Enabled determines if the feature should be enabled or disabled on the guest\nDefaults to true\n+optional",
-		"vendorid": "VendorID sets the hypervisor vendor id, visible to the vmi\nString up to twelve characters",
+		"enabled":  "Enabled determines if the feature should be enabled or disabled on the guest.\nDefaults to true.\n+optional",
+		"vendorid": "VendorID sets the hypervisor vendor id, visible to the vmi.\nString up to twelve characters.",
 	}
 }
 
 func (FeatureHyperv) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":           "Hyperv specific features",
-		"relaxed":    "Relaxed relaxes constraints on timer\nDefaults to the machine type setting\n+optional",
-		"vapic":      "VAPIC indicates whether virtual APIC is enabled\nDefaults to the machine type setting\n+optional",
-		"spinlocks":  "Spinlocks indicates if spinlocks should be made available to the guest\n+optional",
-		"vpindex":    "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors\nDefaults to the machine type setting\n+optional",
-		"runtime":    "Runtime\nDefaults to the machine type setting\n+optional",
-		"synic":      "SyNIC enable Synthetic Interrupt Controller\nDefaults to the machine type setting\n+optional",
-		"synictimer": "SyNICTimer enable Synthetic Interrupt Controller timer\nDefaults to the machine type setting\n+optional",
-		"reset":      "Reset enables Hyperv reboot/reset for the vmi\nDefaults to the machine type setting\n+optional",
-		"vendorid":   "VendorID allows setting the hypervisor vendor id\nDefaults to the machine type setting\n+optional",
+		"":           "Hyperv specific features.",
+		"relaxed":    "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
+		"vapic":      "VAPIC indicates whether virtual APIC is enabled.\nDefaults to the machine type setting.\n+optional",
+		"spinlocks":  "Spinlocks indicates if spinlocks should be made available to the guest.\n+optional",
+		"vpindex":    "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.\nDefaults to the machine type setting.\n+optional",
+		"runtime":    "Runtime.\nDefaults to the machine type setting.\n+optional",
+		"synic":      "SyNIC enable Synthetic Interrupt Controller.\nDefaults to the machine type setting.\n+optional",
+		"synictimer": "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
+		"reset":      "Reset enables Hyperv reboot/reset for the vmi.\nDefaults to the machine type setting.\n+optional",
+		"vendorid":   "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
 	}
 }
 
 func (Watchdog) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":     "Named watchdog device",
-		"name": "Name of the watchdog",
+		"":     "Named watchdog device.",
+		"name": "Name of the watchdog.",
 	}
 }
 
 func (WatchdogDevice) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":         "Hardware watchdog device\nExactly one of its members must be set.",
-		"i6300esb": "i6300esb watchdog device\n+optional",
+		"":         "Hardware watchdog device.\nExactly one of its members must be set.",
+		"i6300esb": "i6300esb watchdog device.\n+optional",
 	}
 }
 
 func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":       "i6300esb watchdog device",
-		"action": "The action to take. Valid values are poweroff, reset, shutdown.\nDefaults to reset",
+		"":       "i6300esb watchdog device.",
+		"action": "The action to take. Valid values are poweroff, reset, shutdown.\nDefaults to reset.",
 	}
 }
 


### PR DESCRIPTION
It seems like a common mistake to miss dots between sentences which results in
descriptions like: "ReadOnly Defaults to true". Which is sad.

This patch rights all the wrong. It consistently updates all descriptions for
all fields and structures to always end all sentences with dots, even if it's
just a single sentence.

While at it, several typos were fixed for affected descriptions, but fixing all
of them is not a goal of this patch.

Note: this patch doesn't guarantee new descriptions won't have this issue.
Reviewer, stay vigilant!