### PR TITLE
Allow setting custom pkgdirs for cross-compilation

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -57,6 +57,13 @@ if [ $# -eq 0 ]; then
     fi
 fi
 
+# Return a pkgdir parameter based on os and arch
+function pkg_dir() {
+    if [ -n "${KUBEVIRT_GO_BASE_PKGDIR}" ]; then
+        echo "-pkgdir ${KUBEVIRT_GO_BASE_PKGDIR}/$1-$2"
+    fi
+}
+
 # handle binaries
 
 if [ "${target}" = "install" ]; then
@@ -82,13 +89,13 @@ for arg in $args; do
 
             # always build and link the linux/amd64 binary
             LINUX_NAME=${ARCH_BASENAME}-linux-amd64
-            GOOS=linux GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)"
+            GOOS=linux GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
 
             # build virtctl also for darwin and windows
             if [ "${BIN_NAME}" = "virtctl" ]; then
-                GOOS=darwin GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)"
-                GOOS=windows GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)"
+                GOOS=darwin GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
+                GOOS=windows GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
             fi
         )
     else

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -18,13 +18,12 @@ function build_func_tests() {
     mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
 }
 
-# For backward compatibility
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.3}
-
-# For backward compatibility
-KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-${VAGRANT_NUM_NODES}}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
+
+# Use this environment variable to set a custom pkgdir path
+# Useful for cross-compilation where the default -pkdir for cross-builds may not be writable
+#KUBEVIRT_GO_BASE_PKGDIR="${GOPATH}/crossbuild-cache-root/"
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 if [ -z "${JOB_NAME}" ]; then


### PR DESCRIPTION
If building outside of our container environment, it can happen that
builds fail because the user does not have permissions to create the
default pkgdir locations uder ${GOROOT}. To overcome this limitation
allow setting an optional KUBEVIRT_GO_BASE_PKGDIR variable.

Example of what one can see if it can't write the standard locations:

```
go install runtime/internal/sys: mkdir /usr/lib/golang/pkg/darwin_amd64: permission denied
```

```release-note
NONE
```