### PR TITLE
Ensure KVM devices are really allocatable before running test suite

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -359,8 +359,9 @@ func EnsureKVMPresent() {
 			ready := true
 			// cluster is not ready until all nodes are ready.
 			for _, node := range nodeList.Items {
-				_, ok := node.Status.Allocatable[services.KvmDevice]
+				allocatable, ok := node.Status.Allocatable[services.KvmDevice]
 				ready = ready && ok
+				ready = ready && (allocatable.Value() > 0)
 			}
 			return ready
 		}, 120*time.Second, 1*time.Second).Should(BeTrue(),

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -61,6 +61,12 @@ var _ = Describe("VMIlifecycle", func() {
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 	})
 
+	AfterEach(func() {
+		// Not every test causes virt-handler to restart, but a few different contexts do.
+		// This check is fast and non-intrusive if virt-handler is already running.
+		tests.EnsureKVMPresent()
+	})
+
 	Describe("Creating a VirtualMachineInstance", func() {
 		It("should success", func() {
 			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
In concern of the allocatable count issue noted in https://github.com/kubevirt/kubevirt/issues/1196, one thing we can do is check that there really are allocatable KVM devices before running the test suite. If they fail to be marked as allocatable, this will short circuit the doomed test suite run with a helpful message.