### PR TITLE
Move binaries to /usr/bin

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -25,6 +25,6 @@ RUN useradd -u 1001 --create-home -s /bin/bash virt-api
 WORKDIR /home/virt-api
 USER 1001
 
-COPY virt-api /virt-api
+COPY virt-api /usr/bin/virt-api
 
-ENTRYPOINT [ "/virt-api" ]
+ENTRYPOINT [ "/usr/bin/virt-api" ]

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -24,6 +24,6 @@ MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 RUN useradd -u 1001 --create-home -s /bin/bash virt-controller
 WORKDIR /home/virt-controller
 USER 1001
-COPY virt-controller /virt-controller
+COPY virt-controller /usr/bin/virt-controller
 
-ENTRYPOINT [ "/virt-controller" ]
+ENTRYPOINT [ "/usr/bin/virt-controller" ]

--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -20,6 +20,6 @@ FROM fedora:27
 
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
-COPY virt-handler /virt-handler
+COPY virt-handler /usr/bin/virt-handler
 
-ENTRYPOINT [ "/virt-handler" ]
+ENTRYPOINT [ "/usr/bin/virt-handler" ]

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -30,21 +30,14 @@ RUN dnf -y install \
   sudo && dnf -y clean all && \
   test $(id -u qemu) = 107 # make sure that the qemu user really is 107
 
-COPY sock-connector /sock-connector
-COPY sh.sh /sh.sh
-COPY virt-launcher /virt-launcher
-
+COPY virt-launcher /usr/bin/virt-launcher
 COPY kubevirt-sudo /etc/sudoers.d/kubevirt
-RUN chmod 0640 /etc/sudoers.d/kubevirt
 
 # Allow qemu to bind privileged ports
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/qemu-system-x86_64
 
 # libvirtd.sh in this image differs from upstream
-RUN rm -f /libvirtd.sh
-COPY libvirtd.sh /libvirtd.sh
-RUN chmod a+x /libvirtd.sh
+RUN mkdir -p /usr/share/kubevirt/virt-launcher
+COPY entrypoint.sh libvirtd.sh sh.sh sock-connector /usr/share/kubevirt/virt-launcher/
 
-COPY entrypoint.sh /entrypoint.sh
-
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "/usr/share/kubevirt/virt-launcher/entrypoint.sh" ]

--- a/cmd/virt-launcher/entrypoint.sh
+++ b/cmd/virt-launcher/entrypoint.sh
@@ -15,10 +15,10 @@ chmod 660 /dev/kvm
 
 # Cockpit/OCP hack to all shoing the vm terminal
 mv /usr/bin/sh /usr/bin/sh.orig
-mv /sh.sh /usr/bin/sh
+mv /usr/share/kubevirt/virt-launcher/sh.sh /usr/bin/sh
 chmod +x /usr/bin/sh
 
-./virt-launcher $@ &
+virt-launcher $@ &
 virt_launcher_pid=$!
 while true; do
 	if ! [ -d /proc/$virt_launcher_pid ]; then

--- a/cmd/virt-launcher/sh.sh
+++ b/cmd/virt-launcher/sh.sh
@@ -4,7 +4,7 @@ args="$@"
 if [ "$args" = "-i -c TERM=xterm /bin/sh" ] ; then
   namespace="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
   name="$(ls /var/run/kubevirt-private/${namespace}/)"
-  exec /usr/bin/sh.orig -c "/sock-connector /var/run/kubevirt-private/${namespace}/${name}/virt-serial0"
+  exec /usr/bin/sh.orig -c "/usr/share/kubevirt/virt-launcher/sock-connector /var/run/kubevirt-private/${namespace}/${name}/virt-serial0"
 else
   exec /usr/bin/sh.orig "$@"
 fi

--- a/manifests/dev/virt-api.yaml.in
+++ b/manifests/dev/virt-api.yaml.in
@@ -42,7 +42,7 @@ spec:
           image: {{.DockerPrefix}}/virt-api:{{.DockerTag}}
           imagePullPolicy: IfNotPresent
           command:
-              - "/virt-api"
+              - "virt-api"
               - "--port"
               - "8443"
               - "--subresources-only"

--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -41,7 +41,7 @@ spec:
           image: {{.DockerPrefix}}/virt-controller:{{.DockerTag}}
           imagePullPolicy: IfNotPresent
           command:
-              - "/virt-controller"
+              - "virt-controller"
               - "--launcher-image"
               - "{{.DockerPrefix}}/virt-launcher:{{.DockerTag}}"
               - "--port"

--- a/manifests/dev/virt-handler.yaml.in
+++ b/manifests/dev/virt-handler.yaml.in
@@ -33,7 +33,7 @@ spec:
           image: {{.DockerPrefix}}/virt-handler:{{.DockerTag}}
           imagePullPolicy: IfNotPresent
           command:
-            - "/virt-handler"
+            - "virt-handler"
             - "-v"
             - "3"
             - "--hostname-override"

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -392,7 +392,7 @@ spec:
           image: {{.DockerPrefix}}/virt-api:{{.DockerTag}}
           imagePullPolicy: IfNotPresent
           command:
-              - "/virt-api"
+              - "virt-api"
               - "--port"
               - "8443"
               - "--subresources-only"
@@ -438,7 +438,7 @@ spec:
           image: {{.DockerPrefix}}/virt-controller:{{.DockerTag}}
           imagePullPolicy: IfNotPresent
           command:
-              - "/virt-controller"
+              - "virt-controller"
               - "--launcher-image"
               - "{{.DockerPrefix}}/virt-launcher:{{.DockerTag}}"
               - "--port"
@@ -499,7 +499,7 @@ spec:
           image: {{.DockerPrefix}}/virt-handler:{{.DockerTag}}
           imagePullPolicy: IfNotPresent
           command:
-            - "/virt-handler"
+            - "virt-handler"
             - "-v"
             - "3"
             - "--hostname-override"

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -115,7 +115,7 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 	vmiName := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
 
-	cmd := []string{"/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-%s", namespace, vmiName, "vnc")}
+	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-%s", namespace, vmiName, "vnc")}
 	app.requestHandler(request, response, cmd)
 }
 
@@ -123,7 +123,7 @@ func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, re
 	vmiName := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
 
-	cmd := []string{"/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-%s", namespace, vmiName, "serial0")}
+	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-%s", namespace, vmiName, "serial0")}
 
 	app.requestHandler(request, response, cmd)
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -204,7 +204,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 	}
 
-	command := []string{"/entrypoint.sh",
+	command := []string{"/usr/share/kubevirt/virt-launcher/entrypoint.sh",
 		"--qemu-timeout", "5m",
 		"--name", domain,
 		"--namespace", namespace,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
 					v1.NodeSchedulable: "true",
 				}))
-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/entrypoint.sh",
+				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/share/kubevirt/virt-launcher/entrypoint.sh",
 					"--qemu-timeout", "5m",
 					"--name", "testvmi",
 					"--namespace", "testns",
@@ -99,7 +99,7 @@ var _ = Describe("Template", func() {
 					"kubernetes.io/hostname": "master",
 					v1.NodeSchedulable:       "true",
 				}))
-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/entrypoint.sh",
+				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/share/kubevirt/virt-launcher/entrypoint.sh",
 					"--qemu-timeout", "5m",
 					"--name", "testvmi",
 					"--namespace", "default",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -125,7 +125,7 @@ func StartLibvirt(stopChan chan struct{}) {
 	go func() {
 		for {
 			exitChan := make(chan struct{})
-			cmd := exec.Command("/libvirtd.sh")
+			cmd := exec.Command("/usr/share/kubevirt/virt-launcher/libvirtd.sh")
 
 			err := cmd.Start()
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Move binaries to /usr/bin to line up with downstream builds.
- Move virt-launcher scripts to ```/usr/share/kubevirt/virt-launcher/```
- Remove chown commands in the Dockerfile since the scripts have the proper permissions
- Condense the COPY scripts into a single layer

```release-note
NONE
```
