### PR TITLE
Fixed VMI phase on shutdown

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -213,6 +213,10 @@ func (v *VirtualMachineInstance) IsRunning() bool {
 	return v.Status.Phase == Running
 }
 
+func (v *VirtualMachineInstance) IsStopping() bool {
+	return v.Status.Phase == Stopping
+}
+
 func (v *VirtualMachineInstance) IsFinal() bool {
 	return v.Status.Phase == Failed || v.Status.Phase == Succeeded
 }
@@ -320,6 +324,8 @@ const (
 	Scheduled VirtualMachineInstancePhase = "Scheduled"
 	// Running means the pod has been bound to a node and the VirtualMachineInstance is started.
 	Running VirtualMachineInstancePhase = "Running"
+	// Stopping means virt-handler detected a deletion timestamp on the VirtualMachineInstance and triggered a shutdown of the vm.
+	Stopping VirtualMachineInstancePhase = "Stopping"
 	// Succeeded means that the VirtualMachineInstance stopped voluntarily, e.g. reacted to SIGTERM or shutdown was invoked from
 	// inside the VirtualMachineInstance.
 	Succeeded VirtualMachineInstancePhase = "Succeeded"

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -274,7 +274,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pods []
 		if !podExists {
 			controller.RemoveFinalizer(vmiCopy, virtv1.VirtualMachineInstanceFinalizer)
 		}
-	case vmi.IsRunning() || vmi.IsScheduled():
+	case vmi.IsRunning() || vmi.IsScheduled() || vmi.IsStopping():
 		// Don't process states where the vmi is clearly owned by virt-handler
 		return nil
 	default:

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -799,6 +799,13 @@ var _ = Describe("VMIlifecycle", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(pods.Items)).To(Equal(1))
 
+				By("Verifying VirtualMachineInstance's status is Running")
+				Eventually(func() v1.VirtualMachineInstancePhase {
+					currVMI, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return currVMI.Status.Phase
+				}, 60, 0.5).Should(Equal(v1.Running))
+
 				By("Deleting the VirtualMachineInstance")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed())
 
@@ -808,6 +815,13 @@ var _ = Describe("VMIlifecycle", func() {
 					Expect(err).ToNot(HaveOccurred())
 					return len(pods.Items)
 				}, 75, 0.5).Should(Equal(0))
+
+				By("Verifying VirtualMachineInstance's status is Succeeded")
+				Eventually(func() v1.VirtualMachineInstancePhase {
+					currVMI, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return currVMI.Status.Phase
+				}, 10, 0.5).Should(Equal(v1.Succeeded))
 			})
 		})
 		Context("with grace period greater than 0", func() {


### PR DESCRIPTION
Before this fix the combination of a non-final vmi and a missing domain
was considered to be unexpected and resulted in a "failed" vmi state,
even when the domain was shut down on purpose.
In order to indicate that a shutdown was triggered, and a missing domain
is a valid thing (it was already deleted), this change introduces a new
vmi phase "stopping", which is set when a shutdown was triggered.
Now we can assume that a vmi without a domain, but in state "stopping",
means that the domain was correctly shut down, and the vmi state can be
set to "succeeded".

Signed-off-by: Marc Sluiter <msluiter@redhat.com>

Fixes #1137

```release-note
Fixed VirtualMachineInstance state on shutdown
```