### PR TITLE
Support interface.macAddress

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3820,6 +3820,10 @@
      "bridge": {
       "$ref": "#/definitions/v1.InterfaceBridge"
      },
+     "macAddress": {
+      "description": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
+      "type": "string"
+     },
      "model": {
       "description": "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
       "type": "string"

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -102,6 +102,8 @@ spec:
                               items:
                                 properties:
                                   bridge: {}
+                                  macAddress:
+                                    type: string
                                   model:
                                     type: string
                                   name:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -95,6 +95,8 @@ spec:
                       items:
                         properties:
                           bridge: {}
+                          macAddress:
+                            type: string
                           model:
                             type: string
                           name:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -90,6 +90,8 @@ spec:
                       items:
                         properties:
                           bridge: {}
+                          macAddress:
+                            type: string
                           model:
                             type: string
                           name:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -106,6 +106,8 @@ spec:
                               items:
                                 properties:
                                   bridge: {}
+                                  macAddress:
+                                    type: string
                                   model:
                                     type: string
                                   name:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -832,6 +832,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref: ref("kubevirt.io/kubevirt/pkg/api/v1.InterfaceSlirp"),
 							},
 						},
+						"macAddress": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"name"},
 				},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -676,6 +676,8 @@ type Interface struct {
 	// BindingMethod specifies the method which will be used to connect the interface to the guest.
 	// Defaults to Bridge.
 	InterfaceBindingMethod `json:",inline"`
+	// Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.
+	MacAddress string `json:"macAddress,omitempty"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -313,8 +313,9 @@ func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"name":  "Logical name of the interface as well as a reference to the associated networks.\nMust match the Name of a Network.",
-		"model": "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
+		"name":       "Logical name of the interface as well as a reference to the associated networks.\nMust match the Name of a Network.",
+		"model":      "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
+		"macAddress": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
 	}
 }
 

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -613,11 +613,18 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 
 			// verify that selected macAddress is valid
 			if iface.MacAddress != "" {
-				_, err := net.ParseMAC(iface.MacAddress)
+				mac, err := net.ParseMAC(iface.MacAddress)
 				if err != nil {
 					causes = append(causes, metav1.StatusCause{
 						Type:    metav1.CauseTypeFieldValueInvalid,
 						Message: fmt.Sprintf("interface %s has malformed MAC address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
+					})
+				}
+				if len(mac) > 6 {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: fmt.Sprintf("interface %s has MAC address (%s) that is too long.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
 						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
 					})
 				}

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -606,6 +607,18 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 						Type:    metav1.CauseTypeFieldValueNotSupported,
 						Message: fmt.Sprintf("interface %s uses model %s that is not supported.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.Model),
 						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("model").String(),
+					})
+				}
+			}
+
+			// verify that selected macAddress is valid
+			if iface.MacAddress != "" {
+				_, err := net.ParseMAC(iface.MacAddress)
+				if err != nil {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: fmt.Sprintf("interface %s has malformed MAC address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
 					})
 				}
 			}

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -812,6 +812,15 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(causes[0].Field).To(Equal("fake.interfaces"))
 		})
 
+		It("should accept valid MAC address", func() {
+			vmi := v1.NewMinimalVMI("testvm")
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			// if this is processed correctly, it should not result in any error
+			Expect(len(causes)).To(Equal(0))
+		})
 	})
 	Context("with Volume", func() {
 		table.DescribeTable("should accept valid volumes",

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -828,8 +828,8 @@ var _ = Describe("Validating Webhook", func() {
 			vmi := v1.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			for _, macAddress := range []string{"de:ad:00:00:be", "de-ad-00-00-be"} {
-				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress // missing octet
+			for _, macAddress := range []string{"de:ad:00:00:be", "de-ad-00-00-be", "de:ad:00:00:be:af:be:af"} {
+				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
 				Expect(len(causes)).To(Equal(1))
 				Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].macAddress"))

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -303,7 +303,6 @@ func (b *BridgePodInterface) createDefaultBridge() error {
 }
 
 type SlirpPodInterface struct {
-	// TODO:(ihar) implement custom MAC address support
 	iface           *v1.Interface
 	domain          *api.Domain
 	podInterfaceNum int
@@ -327,6 +326,10 @@ func (s *SlirpPodInterface) preparePodNetworkInterfaces() error {
 
 func (s *SlirpPodInterface) decorateConfig() error {
 	s.domain.Spec.QEMUCmd.QEMUArg[s.podInterfaceNum].Value += fmt.Sprintf(",id=%s", s.iface.Name)
+	if s.iface.MacAddress != "" {
+		// We assume address was already validated in API layer so just pass it to libvirt as-is.
+		s.domain.Spec.QEMUCmd.QEMUArg[s.podInterfaceNum].Value += fmt.Sprintf(",mac=%s", s.iface.MacAddress)
+	}
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -23,6 +23,7 @@ package network
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/vishvananda/netlink"
 
@@ -111,8 +112,20 @@ func getBinding(iface *v1.Interface, domain *api.Domain) (BindMechanism, error) 
 		return nil, err
 	}
 
+	populateMacAddress := func(vif *VIF, iface *v1.Interface) error {
+		if iface.MacAddress != "" {
+			macAddress, err := net.ParseMAC(iface.MacAddress)
+			if err != nil {
+				return err
+			}
+			vif.MAC = macAddress
+		}
+		return nil
+	}
+
 	if iface.Bridge != nil {
 		vif := &VIF{Name: podInterface}
+		populateMacAddress(vif, iface)
 		return &BridgePodInterface{iface: iface, vif: vif, domain: domain, podInterfaceNum: podInterfaceNum}, nil
 	}
 	if iface.Slirp != nil {
@@ -153,13 +166,15 @@ func (b *BridgePodInterface) discoverPodNetworkInterface() error {
 		return err
 	}
 
-	// Get interface MAC address
-	mac, err := Handler.GetMacDetails(podInterface)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to get MAC for %s", podInterface)
-		return err
+	if len(b.vif.MAC) == 0 {
+		// Get interface MAC address
+		mac, err := Handler.GetMacDetails(podInterface)
+		if err != nil {
+			log.Log.Reason(err).Errorf("failed to get MAC for %s", podInterface)
+			return err
+		}
+		b.vif.MAC = mac
 	}
-	b.vif.MAC = mac
 
 	// Get interface MTU
 	b.vif.Mtu = uint16(b.podNicLink.Attrs().MTU)
@@ -288,6 +303,7 @@ func (b *BridgePodInterface) createDefaultBridge() error {
 }
 
 type SlirpPodInterface struct {
+	// TODO:(ihar) implement custom MAC address support
 	iface           *v1.Interface
 	domain          *api.Domain
 	podInterfaceNum int

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -264,41 +264,43 @@ var _ = Describe("Pod Network", func() {
 				Expect(idx).To(Equal(2))
 			})
 		})
-		It("Should create an interface in the qemu command line and remove it from the interfaces", func() {
-			domain := NewDomainWithSlirpInterface()
-			vmi := newVMISlirpInterface("testnamespace", "testVmName")
+		Context("Slirp Plug", func() {
+			It("Should create an interface in the qemu command line and remove it from the interfaces", func() {
+				domain := NewDomainWithSlirpInterface()
+				vmi := newVMISlirpInterface("testnamespace", "testVmName")
 
-			api.SetObjectDefaults_Domain(domain)
+				api.SetObjectDefaults_Domain(domain)
 
-			driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
-			Expect(err).ToNot(HaveOccurred())
-			TestRunPlug(driver)
-			Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
-			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
-		})
-		It("Should create an interface in the qemu command line, remove it from the interfaces and leave the other interfaces inplace", func() {
-			domain := NewDomainWithSlirpInterface()
-			vmi := newVMISlirpInterface("testnamespace", "testVmName")
+				driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
+				Expect(err).ToNot(HaveOccurred())
+				TestRunPlug(driver)
+				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
+				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+			})
+			It("Should create an interface in the qemu command line, remove it from the interfaces and leave the other interfaces inplace", func() {
+				domain := NewDomainWithSlirpInterface()
+				vmi := newVMISlirpInterface("testnamespace", "testVmName")
 
-			api.SetObjectDefaults_Domain(domain)
+				api.SetObjectDefaults_Domain(domain)
 
-			domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, api.Interface{
-				Model: &api.Model{
-					Type: "virtio",
-				},
-				Type: "bridge",
-				Source: api.InterfaceSource{
-					Bridge: api.DefaultBridgeName,
-				},
-				Alias: &api.Alias{
-					Name: "default",
-				}})
+				domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, api.Interface{
+					Model: &api.Model{
+						Type: "virtio",
+					},
+					Type: "bridge",
+					Source: api.InterfaceSource{
+						Bridge: api.DefaultBridgeName,
+					},
+					Alias: &api.Alias{
+						Name: "default",
+					}})
 
-			driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
-			Expect(err).ToNot(HaveOccurred())
-			TestRunPlug(driver)
-			Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(1))
-			Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
+				Expect(err).ToNot(HaveOccurred())
+				TestRunPlug(driver)
+				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(1))
+				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+			})
 		})
 	})
 })

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -294,6 +294,21 @@ var _ = Describe("Pod Network", func() {
 				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
 				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default"}))
 			})
+			It("Should append MAC address to qemu arguments if set", func() {
+				domain := NewDomainWithSlirpInterface()
+				vmi := newVMISlirpInterface("testnamespace", "testVmName")
+
+				api.SetObjectDefaults_Domain(domain)
+				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
+
+				driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
+				Expect(err).ToNot(HaveOccurred())
+				TestRunPlug(driver)
+				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
+				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
+				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default,mac=de-ad-00-00-be-af"}))
+			})
 			It("Should create an interface in the qemu command line, remove it from the interfaces and leave the other interfaces inplace", func() {
 				domain := NewDomainWithSlirpInterface()
 				vmi := newVMISlirpInterface("testnamespace", "testVmName")

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -291,6 +291,8 @@ var _ = Describe("Pod Network", func() {
 				TestRunPlug(driver)
 				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
 				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
+				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default"}))
 			})
 			It("Should create an interface in the qemu command line, remove it from the interfaces and leave the other interfaces inplace", func() {
 				domain := NewDomainWithSlirpInterface()
@@ -315,6 +317,8 @@ var _ = Describe("Pod Network", func() {
 				TestRunPlug(driver)
 				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(1))
 				Expect(len(domain.Spec.QEMUCmd.QEMUArg)).To(Equal(2))
+				Expect(domain.Spec.QEMUCmd.QEMUArg[0]).To(Equal(api.Arg{Value: "-device"}))
+				Expect(domain.Spec.QEMUCmd.QEMUArg[1]).To(Equal(api.Arg{Value: "e1000,netdev=default,id=default"}))
 			})
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -264,6 +264,21 @@ var _ = Describe("Pod Network", func() {
 				Expect(idx).To(Equal(2))
 			})
 		})
+		Context("getBinding", func() {
+			Context("for Bridge", func() {
+				It("should populate MAC address", func() {
+					domain := NewDomainWithBridgeInterface()
+					vmi := newVMIBridgeInterface("testnamespace", "testVmName")
+					api.SetObjectDefaults_Domain(domain)
+					vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
+					driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], domain)
+					Expect(err).ToNot(HaveOccurred())
+					bridge, ok := driver.(*BridgePodInterface)
+					Expect(ok).To(BeTrue())
+					Expect(bridge.vif.MAC.String()).To(Equal("de:ad:00:00:be:af"))
+				})
+			})
+		})
 		Context("Slirp Plug", func() {
 			It("Should create an interface in the qemu command line and remove it from the interfaces", func() {
 				domain := NewDomainWithSlirpInterface()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -997,6 +997,13 @@ func NewRandomVMIWithe1000NetworkInterface() *v1.VirtualMachineInstance {
 	return vmi
 }
 
+func NewRandomVMIWithCustomMacAddress() *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithEphemeralDisk(RegistryDiskFor(RegistryDiskAlpine))
+	AddExplicitPodNetworkInterface(vmi)
+	vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
+	return vmi
+}
+
 // Block until the specified VirtualMachineInstance started and return the target node name.
 func waitForVMIStart(obj runtime.Object, seconds int, ignoreWarnings bool) (nodeName string) {
 	vmi, ok := obj.(*v1.VirtualMachineInstance)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -402,4 +402,16 @@ var _ = Describe("Networking", func() {
 		})
 	})
 
+	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
+		It("should configure custom MAC address", func() {
+			By("checking eth0 MAC address")
+			deadbeafVMI := tests.NewRandomVMIWithSlirpInterfaceEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskAlpine), "#!/bin/bash\necho 'hello'\n", []v1.Port{})
+			deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
+			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(deadbeafVMI)
+			Expect(err).ToNot(HaveOccurred())
+
+			waitUntilVMIReady(deadbeafVMI, tests.LoggedInAlpineExpecter)
+			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress, "localhost:~#")
+		})
+	})
 })

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -155,7 +155,6 @@ var _ = Describe("Networking", func() {
 		ipHeaderSize := 28 // IPv4 specific
 		payloadSize := expectedMtu - ipHeaderSize
 
-		// Wait until the VirtualMachineInstance is booted, ping google and check if we can reach the internet
 		switch destination {
 		case "Internet":
 			addr = "kubevirt.io"

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -402,6 +402,19 @@ var _ = Describe("Networking", func() {
 		})
 	})
 
+	Context("VirtualMachineInstance with custom MAC address in non-conventional format", func() {
+		It("should configure custom MAC address", func() {
+			By("checking eth0 MAC address")
+			beafdeadVMI := tests.NewRandomVMIWithCustomMacAddress()
+			beafdeadVMI.Spec.Domain.Devices.Interfaces[0].MacAddress = "BE-AF-00-00-DE-AD"
+			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(beafdeadVMI)
+			Expect(err).ToNot(HaveOccurred())
+
+			waitUntilVMIReady(beafdeadVMI, tests.LoggedInAlpineExpecter)
+			checkMacAddress(beafdeadVMI, "be:af:00:00:de:ad", "localhost:~#")
+		})
+	})
+
 	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
 		It("should configure custom MAC address", func() {
 			By("checking eth0 MAC address")

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -214,6 +214,17 @@ var _ = Describe("Networking", func() {
 			&expect.BExp{R: "0"},
 		}, 180)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("checking the VirtualMachineInstance can fetch via HTTP")
+		err = tests.CheckForTextExpecter(outboundVMI, []expect.Batcher{
+			&expect.BSnd{S: "\n"},
+			&expect.BExp{R: "\\$ "},
+			&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
+			&expect.BExp{R: "\\$ "},
+			&expect.BSnd{S: "echo $?\n"},
+			&expect.BExp{R: "0"},
+		}, 15)
+		Expect(err).ToNot(HaveOccurred())
 	},
 		table.Entry("the Inbound VirtualMachineInstance", "InboundVMI"),
 		table.Entry("the Inbound VirtualMachineInstance with pod network connectivity explicitly set", "InboundVMIWithPodNetworkSet"),

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -27,6 +27,7 @@ import (
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
@@ -59,67 +60,57 @@ var _ = Describe("Slirp", func() {
 		}
 	})
 
-	declareTestCases := func(vmiRef **v1.VirtualMachineInstance) {
-		It("should start the virtual machine with slirp interface", func() {
-			vmi := *vmiRef
-			vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
-			output, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[1].Name,
-				[]string{"netstat", "-tnlp"},
-			)
-			log.Log.Infof("%v", output)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.Contains(output, "0.0.0.0:80")).To(BeTrue())
-		})
-		It("should return \"Hello World!\" when connecting to localhost on port 80", func() {
-			vmi := *vmiRef
-			vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
-			output, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[1].Name,
-				[]string{"curl", "-s", "--retry", "30", "--retry-delay", "30", "127.0.0.1"},
-			)
-			fmt.Println(err)
-			log.Log.Infof("%v", output)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.Contains(output, "Hello World!")).To(BeTrue())
-		})
-		It("should reject connecting to localhost and port different than 80", func() {
-			vmi := *vmiRef
-			vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
-			output, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				vmiPod.Spec.Containers[1].Name,
-				[]string{"curl", "127.0.0.1:9080"},
-			)
-			log.Log.Infof("%v", output)
-			Expect(err).To(HaveOccurred())
-		})
-		It("should be able to communicate with the outside world", func() {
-			vmi := *vmiRef
-			expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-			defer expecter.Close()
-			Expect(err).ToNot(HaveOccurred())
+	table.DescribeTable("should be able to", func(vmiRef **v1.VirtualMachineInstance) {
+		By("start the virtual machine with slirp interface")
+		vmi := *vmiRef
+		vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
+		output, err := tests.ExecuteCommandOnPod(
+			virtClient,
+			vmiPod,
+			vmiPod.Spec.Containers[1].Name,
+			[]string{"netstat", "-tnlp"},
+		)
+		log.Log.Infof("%v", output)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Contains(output, "0.0.0.0:80")).To(BeTrue())
 
-			out, err := expecter.ExpectBatch([]expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "\\$ "},
-				&expect.BSnd{S: "curl -o /dev/null -s -w \"%{http_code}\\n\" -k https://google.com\n"},
-				&expect.BExp{R: "301"},
-			}, 180*time.Second)
-			log.Log.Infof("%v", out)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	}
+		By("return \"Hello World!\" when connecting to localhost on port 80")
+		output, err = tests.ExecuteCommandOnPod(
+			virtClient,
+			vmiPod,
+			vmiPod.Spec.Containers[1].Name,
+			[]string{"curl", "-s", "--retry", "30", "--retry-delay", "30", "127.0.0.1"},
+		)
+		fmt.Println(err)
+		log.Log.Infof("%v", output)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(strings.Contains(output, "Hello World!")).To(BeTrue())
 
-	Context("VirtualMachineInstance with slirp interface", func() {
-		declareTestCases(&genericVmi)
-	})
-	Context("VirtualMachineInstance with slirp interface with custom MAC address", func() {
-		declareTestCases(&deadbeafVmi)
-	})
+		By("reject connecting to localhost and port different than 80")
+		output, err = tests.ExecuteCommandOnPod(
+			virtClient,
+			vmiPod,
+			vmiPod.Spec.Containers[1].Name,
+			[]string{"curl", "127.0.0.1:9080"},
+		)
+		log.Log.Infof("%v", output)
+		Expect(err).To(HaveOccurred())
+
+		By("communicate with the outside world")
+		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+		defer expecter.Close()
+		Expect(err).ToNot(HaveOccurred())
+
+		out, err := expecter.ExpectBatch([]expect.Batcher{
+			&expect.BSnd{S: "\n"},
+			&expect.BExp{R: "\\$ "},
+			&expect.BSnd{S: "curl -o /dev/null -s -w \"%{http_code}\\n\" -k https://google.com\n"},
+			&expect.BExp{R: "301"},
+		}, 180*time.Second)
+		log.Log.Infof("%v", out)
+		Expect(err).ToNot(HaveOccurred())
+	},
+		table.Entry("VirtualMachineInstance with slirp interface", &genericVmi),
+		table.Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
+	)
 })

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Slirp", func() {
 			generateHelloWorldServer(vmi, virtClient, 80, "tcp")
 		})
 
-		It("should start the virtial machine with slirp interface", func() {
+		It("should start the virtual machine with slirp interface", func() {
 			vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
 			output, err := tests.ExecuteCommandOnPod(
 				virtClient,
@@ -66,7 +66,7 @@ var _ = Describe("Slirp", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Contains(output, "0.0.0.0:80")).To(BeTrue())
 		})
-		It("should return \"Hello World\" when connecting to localhost on port 80", func() {
+		It("should return \"Hello World!\" when connecting to localhost on port 80", func() {
 			vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
 			output, err := tests.ExecuteCommandOnPod(
 				virtClient,
@@ -79,7 +79,7 @@ var _ = Describe("Slirp", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.Contains(output, "Hello World!")).To(BeTrue())
 		})
-		It("should reject the connecting to localhost and port different than 80", func() {
+		It("should reject connecting to localhost and port different than 80", func() {
 			vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
 			output, err := tests.ExecuteCommandOnPod(
 				virtClient,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: support interface.macAddress field for pod network types supported so far (slirp and bridge).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1069
Fixes #1251

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support interface.macAddress field to override MAC address exposed to the guest.
```

Documentation update: https://github.com/kubevirt/user-guide/pull/94