### PR TITLE
Fix unit tests on master

### DIFF
--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 go test -cover -v -coverprofile=.coverprofile $(go list ./pkg/...)
 goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -151,7 +151,7 @@ var exampleJSON = `{
               "readonly": true
             }
           },
-		  {
+          {
             "name": "disk1",
             "volumeName": "volume4",
             "disk": {


### PR DESCRIPTION
Two issues are fixed:

 1. On master only, the goveralls upload can hide failed tests
 2. Two tabs slipped into schema conversion tests and broke unit tests

**Release note**:

```release-note
NONE
```
