### PR TITLE
Skip virt-handler crush test on k8s version < 1.10.3

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -45,6 +45,8 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
+const dpIssue = "https://github.com/kubevirt/kubevirt/issues/1196"
+
 var _ = Describe("VMIlifecycle", func() {
 
 	flag.Parse()
@@ -297,7 +299,7 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when virt-handler crashes", func() {
 			It("should recover and continue management", func() {
-				tests.SkipIfNoVersion(virtClient)
+				tests.SkipIfVersionBelow(fmt.Sprintf("Device plugins have issue %s in these versions", dpIssue), "1.10.3")
 
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil())
@@ -329,7 +331,7 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when virt-handler is responsive", func() {
 			It("should indicate that a node is ready for vmis", func() {
-				tests.SkipIfNoVersion(virtClient)
+				tests.SkipIfVersionBelow(fmt.Sprintf("Device plugins have issue %s in these versions", dpIssue), "1.10.3")
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
 				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true"})
@@ -367,7 +369,7 @@ var _ = Describe("VMIlifecycle", func() {
 			var virtHandlerAvailablePods int32
 
 			BeforeEach(func() {
-				tests.SkipIfNoVersion(virtClient)
+				tests.SkipIfVersionBelow(fmt.Sprintf("Device plugins have issue %s in these versions", dpIssue), "1.10.3")
 
 				// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "echo hi!")

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -297,6 +297,8 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when virt-handler crashes", func() {
 			It("should recover and continue management", func() {
+				tests.SkipIfNoVersion(virtClient)
+
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil())
 
@@ -327,6 +329,7 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when virt-handler is responsive", func() {
 			It("should indicate that a node is ready for vmis", func() {
+				tests.SkipIfNoVersion(virtClient)
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
 				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true"})
@@ -364,6 +367,8 @@ var _ = Describe("VMIlifecycle", func() {
 			var virtHandlerAvailablePods int32
 
 			BeforeEach(func() {
+				tests.SkipIfNoVersion(virtClient)
+
 				// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "echo hi!")
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`kubelet` does not update allocated device if device plugin was restarted on k8s version < `1.10.3`, so we need to skip `virt-handler` crash tests under specific k8s version.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
