### PR TITLE
Let the VM controller only delete VMIs once

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -295,7 +295,7 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) error {
 }
 
 func (c *VMController) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
-	if vmi == nil {
+	if vmi == nil || vmi.DeletionTimestamp != nil {
 		// nothing to do
 		return nil
 	}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -167,6 +167,18 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
 
+		It("should not delete the VirtualMachineInstance again if it is already marked for deletion", func() {
+			vm, vmi := DefaultVirtualMachine(false)
+			vmi.DeletionTimestamp = now()
+
+			addVirtualMachine(vm)
+			vmiFeeder.Add(vmi)
+
+			vmInterface.EXPECT().Update(gomock.Any()).Times(1).Return(vm, nil)
+
+			controller.Execute()
+		})
+
 		It("should ignore non-matching VMIs", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If a VMI is already marked for deletion, the VM controller is not
allowed to delete the VMI again. If it does we can end up in a rhythm
where the vmi controller is always behind the latest modification of the
object and can never remove our finalizer once the vmi pod is gone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

That might also have occured in #1112.

I think we also have another bug report regarding to this behavour. I can't find it.

**Release note**:

```release-note
Prevent that the VMI controller is starving because of indefinite VMI delete requests from the VM controller.
```
