### PR TITLE
Remove default kubeconfig value

### DIFF
--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -4,5 +4,4 @@ docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel
-kubeconfig=cluster/vagrant/.kubeconfig
 namespace=kube-system


### PR DESCRIPTION
Default points to vagrant, which is now invalid. Default is not used
by any provider.

/release-note-none

