### PR TITLE
Validate and sanitize hostname for DNS entries

### DIFF
--- a/pkg/util/net/dns/sanitize.go
+++ b/pkg/util/net/dns/sanitize.go
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package dns
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+// Sanitize hostname according to DNS label rules
+// If the hostname is taken from vmi.Spec.Hostname
+// then it already passed DNS label validations.
+func SanitizeHostname(vmi *v1.VirtualMachineInstance) string {
+
+	hostName := strings.Split(vmi.Name, ".")[0]
+	if len(hostName) > validation.DNS1123LabelMaxLength {
+		hostName = hostName[:validation.DNS1123LabelMaxLength]
+	}
+	if vmi.Spec.Hostname != "" {
+		hostName = vmi.Spec.Hostname
+	}
+
+	return hostName
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -32,6 +32,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/registry-disk"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 )
 
 const configMapName = "kube-system/kubevirt-config"
@@ -303,10 +304,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	containers = append(containers, container)
 
-	hostName := vmi.Name
-	if vmi.Spec.Hostname != "" {
-		hostName = vmi.Spec.Hostname
-	}
+	hostName := dns.SanitizeHostname(vmi)
 
 	// TODO use constants for podLabels
 	pod := k8sv1.Pod{

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/ephemeral-disk"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/registry-disk"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 	domainerrors "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
@@ -85,10 +86,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 	// generate cloud-init data
 	cloudInitData := cloudinit.GetCloudInitNoCloudSource(vmi)
 	if cloudInitData != nil {
-		hostname := vmi.Name
-		if vmi.Spec.Hostname != "" {
-			hostname = vmi.Spec.Hostname
-		}
+		hostname := dns.SanitizeHostname(vmi)
 
 		err := cloudinit.GenerateLocalData(vmi.Name, hostname, vmi.Namespace, cloudInitData)
 		if err != nil {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -62,6 +62,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virtctl"
 )
@@ -1184,10 +1185,7 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 	if err != nil {
 		return nil, err
 	}
-	vmiName := vmi.Name
-	if vmi.Spec.Hostname != "" {
-		vmiName = vmi.Spec.Hostname
-	}
+	hostName := dns.SanitizeHostname(vmi)
 
 	// Do not login, if we already logged in
 	err = expecter.Send("\n")
@@ -1205,7 +1203,7 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "login as 'cirros' user. default password: 'gocubsgo'. use 'sudo' for root."},
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: vmiName + " login:"},
+		&expect.BExp{R: hostName + " login:"},
 		&expect.BSnd{S: "cirros\n"},
 		&expect.BExp{R: "Password:"},
 		&expect.BSnd{S: "gocubsgo\n"},


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating a vm, sanitize hostname field and cloud-init if no hostname was specified on the vm spec.
If hostname was specified then validate it according to DNS label rules. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1092 

**Special notes for your reviewer**:
This also handles #1223 once its not blocked by #1222 . 

**Release note**:
```release-note
NONE
```
