### PR TITLE
Make sure that the VMI replica set will remove VM's in the final state

### DIFF
--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -203,24 +203,34 @@ func (c *VMIReplicaSet) execute(key string) error {
 		return err
 	}
 
+	finishedVmis := c.filterFinishedVMIs(vmis)
+	activeVmis := c.filterActiveVMIs(vmis)
+
 	var scaleErr error
+	var cleanErr error
 
 	// Scale up or down, if all expected creates and deletes were report by the listener
 	if needsSync && !rs.Spec.Paused && rs.ObjectMeta.DeletionTimestamp == nil {
-		scaleErr = c.scale(rs, vmis)
+		if len(finishedVmis) > 0 {
+			cleanErr = c.cleanFinishedVmis(rs, finishedVmis)
+		}
+		scaleErr = c.scale(rs, activeVmis)
 	}
-
 	// If the controller is going to be deleted and the orphan finalizer is the next one, release the VMIs. Don't update the status
 	// TODO: Workaround for https://github.com/kubernetes/kubernetes/issues/56348, remove it once it is fixed
 	if rs.ObjectMeta.DeletionTimestamp != nil && controller.HasFinalizer(rs, v1.FinalizerOrphanDependents) {
-		return c.orphan(cm, rs, vmis)
+		return c.orphan(cm, rs, activeVmis)
+	}
+
+	if cleanErr != nil {
+		logger.Reason(err).Error("Cleaning finished VM's failed.")
 	}
 
 	if scaleErr != nil {
 		logger.Reason(err).Error("Scaling the replicaset failed.")
 	}
 
-	err = c.updateStatus(rs.DeepCopy(), vmis, scaleErr)
+	err = c.updateStatus(rs.DeepCopy(), activeVmis, scaleErr)
 	if err != nil {
 		logger.Reason(err).Error("Updating the replicaset status failed.")
 	}
@@ -257,10 +267,7 @@ func (c *VMIReplicaSet) orphan(cm *controller.VirtualMachineControllerRefManager
 
 func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis []*virtv1.VirtualMachineInstance) error {
 	log.Log.V(4).Object(rs).Info("Scale")
-
-	activeVmis := c.filterActiveVMIs(vmis)
-	diff := c.calcDiff(rs, activeVmis)
-	totalDiff := c.calcDiff(rs, vmis)
+	diff := c.calcDiff(rs, vmis)
 
 	rsKey, err := controller.KeyFunc(rs)
 	if err != nil {
@@ -268,39 +275,29 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 		return nil
 	}
 
-	if totalDiff == 0 && diff == 0 {
+	if diff == 0 {
 		return nil
 	}
 
 	// Make sure that we don't overload the cluster
 	diff = limit(diff, c.burstReplicas)
-	totalDiff = limit(totalDiff, c.burstReplicas)
 
 	// Every delete request can fail, give the channel enough room, to not block the go routines
 	errChan := make(chan error, abs(diff))
 
 	var wg sync.WaitGroup
+	wg.Add(abs(diff))
 
-	if totalDiff > 0 {
+	if diff > 0 {
 		log.Log.V(4).Object(rs).Info("Delete excess VM's")
 		// We have to delete VMIs, use a very simple selection strategy for now
 		// TODO: Possible deletion order: not yet running VMIs < migrating VMIs < other
-		// First we try to delete finished VM's
-		finishedVmis := c.filterFinishedVMIs(vmis)
-		notFinishedVmis := c.filterNotFinishedVMIs(vmis)
-
-		deleteCandidates := append(finishedVmis, notFinishedVmis...)
-		totalDiff = min(totalDiff, len(deleteCandidates))
-		wg.Add(abs(totalDiff))
-
-		c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineKeys(deleteCandidates[0:totalDiff]))
-		for i := 0; i < totalDiff; i++ {
+		deleteCandidates := vmis[0:diff]
+		c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineKeys(deleteCandidates))
+		for i := 0; i < diff; i++ {
 			go func(idx int) {
 				defer wg.Done()
-				deleteCandidate := deleteCandidates[idx]
-				if deleteCandidate.DeletionTimestamp != nil {
-					return
-				}
+				deleteCandidate := vmis[idx]
 				err := c.clientset.VirtualMachineInstance(rs.ObjectMeta.Namespace).Delete(deleteCandidate.ObjectMeta.Name, &v1.DeleteOptions{})
 				// Don't log an error if it is already deleted
 				if err != nil {
@@ -316,7 +313,6 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 
 	} else if diff < 0 {
 		log.Log.V(4).Object(rs).Info("Add missing VM's")
-		wg.Add(abs(diff))
 		// We have to create VMIs
 		c.expectations.ExpectCreations(rsKey, abs(diff))
 		basename := c.getVirtualMachineBaseName(rs)
@@ -356,7 +352,7 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 // filterActiveVMIs takes a list of VMIs and returns all VMIs which are not in a final state
 func (c *VMIReplicaSet) filterActiveVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
-		return !vmi.IsFinal()
+		return !vmi.IsFinal() && vmi.DeletionTimestamp == nil
 	})
 }
 
@@ -370,14 +366,7 @@ func (c *VMIReplicaSet) filterReadyVMIs(vmis []*virtv1.VirtualMachineInstance) [
 // filterFinishedVMIs takes a list of VMIs and returns all VMIs which are in final state.
 func (c *VMIReplicaSet) filterFinishedVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
-		return vmi.IsFinal()
-	})
-}
-
-// filterNotFinishedVMIs takes a list of VMIs and returns all VMIs which are not in final state.
-func (c *VMIReplicaSet) filterNotFinishedVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
-	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
-		return !vmi.IsFinal()
+		return vmi.IsFinal() && vmi.DeletionTimestamp == nil
 	})
 }
 
@@ -662,7 +651,6 @@ func (c *VMIReplicaSet) removeCondition(rs *virtv1.VirtualMachineInstanceReplica
 
 func (c *VMIReplicaSet) updateStatus(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis []*virtv1.VirtualMachineInstance, scaleErr error) error {
 	diff := c.calcDiff(rs, vmis)
-
 	readyReplicas := int32(len(c.filterReadyVMIs(vmis)))
 
 	// check if we have reached the equilibrium
@@ -801,4 +789,49 @@ func (c *VMIReplicaSet) resolveControllerRef(namespace string, controllerRef *v1
 		return nil
 	}
 	return rs.(*virtv1.VirtualMachineInstanceReplicaSet)
+}
+
+func (c *VMIReplicaSet) cleanFinishedVmis(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis []*virtv1.VirtualMachineInstance) error {
+	rsKey, err := controller.KeyFunc(rs)
+	if err != nil {
+		log.Log.Object(rs).Reason(err).Error("Failed to extract rsKey from replicaset.")
+		return nil
+	}
+
+	diff := limit(len(vmis), c.burstReplicas)
+
+	// Every delete request can fail, give the channel enough room, to not block the go routines
+	errChan := make(chan error, abs(diff))
+
+	var wg sync.WaitGroup
+	wg.Add(abs(diff))
+
+	log.Log.V(4).Object(rs).Info("Delete finished VM's")
+	deleteCandidates := vmis[0:diff]
+	c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineKeys(deleteCandidates))
+	for i := 0; i < diff; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			deleteCandidate := vmis[idx]
+			err := c.clientset.VirtualMachineInstance(rs.ObjectMeta.Namespace).Delete(deleteCandidate.ObjectMeta.Name, &v1.DeleteOptions{})
+			// Don't log an error if it is already deleted
+			if err != nil {
+				// We can't observe a delete if it was not accepted by the server
+				c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(deleteCandidate))
+				c.recorder.Eventf(rs, k8score.EventTypeWarning, FailedDeleteVirtualMachineReason, "Error deleting finished virtual machine %s: %v", deleteCandidate.ObjectMeta.Name, err)
+				errChan <- err
+				return
+			}
+			c.recorder.Eventf(rs, k8score.EventTypeNormal, SuccessfulDeleteVirtualMachineReason, "Deleted finished virtual machine: %v", deleteCandidate.ObjectMeta.UID)
+		}(i)
+	}
+	wg.Wait()
+
+	select {
+	case err := <-errChan:
+		// Only return the first error which occurred, the others will most likely be equal errors
+		return err
+	default:
+	}
+	return nil
 }

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -286,15 +286,15 @@ var _ = Describe("Replicaset", func() {
 
 		It("should be woken by a stopped VirtualMachineInstance and create a new one", func() {
 			rs, vmi := DefaultReplicaSet(1)
+			vmi.Status.Phase = v1.Running
 			rs.Status.Replicas = 1
+			rs.Status.ReadyReplicas = 1
 
 			rsCopy := rs.DeepCopy()
-			rsCopy.Status.Replicas = 0
+			rsCopy.Status.ReadyReplicas = 0
 
 			addReplicaSet(rs)
 			vmiFeeder.Add(vmi)
-
-			rsInterface.EXPECT().Update(rsCopy).Times(1)
 
 			// First make sure that we don't have to do anything
 			controller.Execute()
@@ -306,6 +306,7 @@ var _ = Describe("Replicaset", func() {
 			vmiFeeder.Modify(modifiedVMI)
 
 			// Expect the re-crate of the VirtualMachineInstance
+			rsInterface.EXPECT().Update(rsCopy).Times(1)
 			vmiInterface.EXPECT().Create(gomock.Any()).Return(vmi, nil)
 
 			// Run the controller again

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -302,7 +302,7 @@ var _ = Describe("VirtualMachineInstanceReplicaSet", func() {
 				return true
 			}
 			return false
-		}, 60*time.Second, time.Second).Should(Equal(true))
+		}, 120*time.Second, time.Second).Should(Equal(true))
 
 		By("Checking number of RS VM's")
 		vmis, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -77,7 +77,7 @@ var _ = Describe("VirtualMachineInstanceReplicaSet", func() {
 			rs, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Get(name, v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return rs.Status.Replicas
-		}, 60, 1).Should(Equal(int32(scale)))
+		}, 90*time.Second, time.Second).Should(Equal(int32(scale)))
 
 		vmis, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -274,5 +274,39 @@ var _ = Describe("VirtualMachineInstanceReplicaSet", func() {
 			Expect(err).ToNot(HaveOccurred())
 			return rs.Status.Replicas
 		}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))
+	})
+
+	It("should remove the finished VM", func() {
+		By("Creating new replica set")
+		rs := newReplicaSet()
+		doScale(rs.ObjectMeta.Name, int32(2))
+
+		vmis, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmis.Items).ToNot(BeEmpty())
+
+		vmi := vmis.Items[0]
+		pods, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(tests.UnfinishedVMIPodSelector(&vmi))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(pods.Items)).To(Equal(1))
+		pod := pods.Items[0]
+
+		By("Deleting one of the RS VMS pods")
+		err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(pod.Name, &v12.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Checking that the VM dissapeared")
+		Eventually(func() bool {
+			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &v12.GetOptions{})
+			if errors.IsNotFound(err) {
+				return true
+			}
+			return false
+		}, 60*time.Second, time.Second).Should(Equal(true))
+
+		By("Checking number of RS VM's")
+		vmis, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(vmis.Items)).Should(Equal(2))
 	})
 })

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -179,7 +179,7 @@ var _ = Describe("VirtualMachineInstanceReplicaSet", func() {
 			vmis, err := virtClient.VirtualMachineInstance(newRS.ObjectMeta.Namespace).List(&v12.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return len(vmis.Items)
-		}, 60*time.Second, 1*time.Second).Should(BeZero())
+		}, 120*time.Second, 1*time.Second).Should(BeZero())
 	})
 
 	It("should remove owner references on the VirtualMachineInstance if it is orphan deleted", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Now VMI replica set will delete VM's in the final state

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1107 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMI replica set will remove VM's in the final state
```
