### PR TITLE
Add edge case tests for VMIRS when vms go down

### DIFF
--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -344,7 +344,7 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 	return nil
 }
 
-// filterActiveVMIs takes a list of VMIs and returns all VMIs which are not in a final state
+// filterActiveVMIs takes a list of VMIs and returns all VMIs which are not in a final state and not terminating
 func (c *VMIReplicaSet) filterActiveVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
 		return !vmi.IsFinal() && vmi.DeletionTimestamp == nil


### PR DESCRIPTION
Tests two cases:
 * Replicasets are meant for availability. Test that as soon as a vmi is
marked for deletion we will create a replacement.
 * If a VMI is already marked for deletion, don't delete it again

Adds test for changes in #1237.

```release-note
NONE
```