### PR TITLE
Detect vm pid by domain uuid in cmd args

### DIFF
--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -20,20 +20,26 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 func main() {
+	uuid := flag.String("uuid", "", "some fake arg")
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,
 		syscall.SIGTERM,
 	)
 
-	fmt.Printf("Started fake qemu process\n")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	fmt.Printf("Started fake qemu process with uuid %s\n", *uuid)
 
 	timeout := time.After(60 * time.Second)
 	select {

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -37,6 +37,8 @@ var _ = Describe("VirtLauncher", func() {
 	var mon *monitor
 	var cmd *exec.Cmd
 
+	uuid := "123-123-123-123"
+
 	tmpDir, _ := ioutil.TempDir("", "monitortest")
 
 	log.Log.SetIOWriter(GinkgoWriter)
@@ -50,7 +52,7 @@ var _ = Describe("VirtLauncher", func() {
 	processStarted := false
 
 	StartProcess := func() {
-		cmd = exec.Command(processPath)
+		cmd = exec.Command(processPath, "--uuid", uuid)
 		err := cmd.Start()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -102,7 +104,7 @@ var _ = Describe("VirtLauncher", func() {
 			syscall.Kill(pid, syscall.SIGTERM)
 		}
 		mon = &monitor{
-			commandPrefix:               "fake-qemu",
+			cmdlineMatchStr:             uuid,
 			gracePeriod:                 30,
 			gracefulShutdownTriggerFile: triggerFile,
 			shutdownCallback:            shutdownCallback,

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -85,7 +85,7 @@ var _ = Describe("VMIlifecycle", func() {
 			Eventually(logs,
 				11*time.Second,
 				500*time.Millisecond).
-				Should(ContainSubstring("Found PID for qemu"))
+				Should(ContainSubstring("Found PID for"))
 		})
 
 		It("should reject POST if schema is invalid", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
virt-launcher detects vm pid by searching for pids with the qemu-system* command line prefix.  A change in the virt-launcher container resulted in the pid having qemu-kvm as the command line prefix which meant virt-launcher never found the VM. 

Now we search for the pid using the domain's UUID which is also present in the qemu cli args regardless of what binary is used. 

**Which issue(s) this PR fixes** 
Fixes #1236 

**Release note**:
```release-note
NONE
```
