### PR TITLE
docs: Add a note how to do stable branch cherry-picking

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -100,7 +100,7 @@ Those pull requests should be limited to bug fixes and must not be
 enhancements.
 
 Cherry picking can be used to pick a merge commit from the master branch
-to a stable branch:
+to a stable branch. An example:
 
 ```bash
 git checkout release-0.6
@@ -109,4 +109,9 @@ git cherry-pick $THE_MERGE_COMMIT_ID -m 1 -sx
  Author: Bob Builder <builder@bob.com>
  Date: Thu Jun 28 17:50:05 2018 +0300
  5 files changed, 55 insertions(+), 22 deletions(-)
+git push $YOUR_REMOTE release-0.6:release-0.6-aParticularFix
 ```
+
+After pushing the branch, you'll need to make sure to create a pull request
+against the correct target branch in GitHub (in this case the target branch
+is `release-0.6`).

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,6 +93,10 @@ The release process is mostly automatic and consists of the following steps:
 Stable Branches
 ---------------
 
+> **Note:** Before a bug is fixed in a stable branch, the same bug must be fixed
+> in the `master` branch. The only exception is when a bug exists in a stable
+> branch only.
+
 For every release a barnch will be created following the pattern `release-x.y`.
 For now, community members can propose pull requests to be included into a
 stable branch.

--- a/docs/release.md
+++ b/docs/release.md
@@ -89,3 +89,24 @@ The release process is mostly automatic and consists of the following steps:
 5. Adjust the release details (draft, pre-release) as necessary at
    <https://github.com/kubevirt/kubevirt/releases/tag/$TAG>
 6. Sent a friendly announcement email to <kubevirt-dev@googlegroups.com>
+
+Stable Branches
+---------------
+
+For every release a barnch will be created following the pattern `release-x.y`.
+For now, community members can propose pull requests to be included into a
+stable branch.
+Those pull requests should be limited to bug fixes and must not be
+enhancements.
+
+Cherry picking can be used to pick a merge commit from the master branch
+to a stable branch:
+
+```bash
+git checkout release-0.6
+git cherry-pick $THE_MERGE_COMMIT_ID -m 1 -sx
+[release-0.6 acd756040] Merge pull request #1234 from great_person
+ Author: Bob Builder <builder@bob.com>
+ Date: Thu Jun 28 17:50:05 2018 +0300
+ 5 files changed, 55 insertions(+), 22 deletions(-)
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,7 +97,7 @@ Stable Branches
 > in the `master` branch. The only exception is when a bug exists in a stable
 > branch only.
 
-For every release a barnch will be created following the pattern `release-x.y`.
+For every release a branch will be created following the pattern `release-x.y`.
 For now, community members can propose pull requests to be included into a
 stable branch.
 Those pull requests should be limited to bug fixes and must not be


### PR DESCRIPTION
Stable branches were introduced. This change will add a small hint on how
patches can be picked into stable branches.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
