### PR TITLE
release-0.6: QEMU PID detection

### DIFF
--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -20,20 +20,26 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 func main() {
+	uuid := flag.String("uuid", "", "some fake arg")
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,
 		syscall.SIGTERM,
 	)
 
-	fmt.Printf("Started fake qemu process\n")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+	fmt.Printf("Started fake qemu process with uuid %s\n", *uuid)
 
 	timeout := time.After(60 * time.Second)
 	select {

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -37,6 +37,8 @@ var _ = Describe("VirtLauncher", func() {
 	var mon *monitor
 	var cmd *exec.Cmd
 
+	uuid := "123-123-123-123"
+
 	tmpDir, _ := ioutil.TempDir("", "monitortest")
 
 	log.Log.SetIOWriter(GinkgoWriter)
@@ -50,7 +52,7 @@ var _ = Describe("VirtLauncher", func() {
 	processStarted := false
 
 	StartProcess := func() {
-		cmd = exec.Command(processPath)
+		cmd = exec.Command(processPath, "--uuid", uuid)
 		err := cmd.Start()
 		Expect(err).ToNot(HaveOccurred())
 
@@ -102,7 +104,7 @@ var _ = Describe("VirtLauncher", func() {
 			syscall.Kill(pid, syscall.SIGTERM)
 		}
 		mon = &monitor{
-			commandPrefix:               "fake-qemu",
+			cmdlineMatchStr:             uuid,
 			gracePeriod:                 30,
 			gracefulShutdownTriggerFile: triggerFile,
 			shutdownCallback:            shutdownCallback,

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -78,7 +78,7 @@ var _ = Describe("VMIlifecycle", func() {
 			Eventually(logs,
 				11*time.Second,
 				500*time.Millisecond).
-				Should(ContainSubstring("Found PID for qemu"))
+				Should(ContainSubstring("Found PID for"))
 		})
 
 		It("should reject POST if schema is invalid", func() {


### PR DESCRIPTION
Detect vm pid by domain uuid in cmd args

(cherry picked from commit adf330e25a7486b17745b5cecb6c156b24b2c0df)
Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Backport of a fix to release-0.6

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/1243

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix qemu process detection after binary reloaction
```