### PR TITLE
Add possibility to specify VM CPU model

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3352,6 +3352,14 @@
      "cores": {
       "description": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
       "type": "integer"
+     },
+     "model": {
+      "description": "Model specifies the CPU model inside the VMI.\n+optional",
+      "type": "string"
+     },
+     "vendor": {
+      "description": "Vendor specifies the CPU vendor inside the VMI.\n+optional",
+      "type": "string"
      }
     }
    },

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3354,7 +3354,7 @@
       "type": "integer"
      },
      "model": {
-      "description": "Model specifies the CPU model inside the VMI.\n+optional",
+      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
       "type": "string"
      }
     }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3356,10 +3356,6 @@
      "model": {
       "description": "Model specifies the CPU model inside the VMI.\n+optional",
       "type": "string"
-     },
-     "vendor": {
-      "description": "Vendor specifies the CPU vendor inside the VMI.\n+optional",
-      "type": "string"
      }
     }
    },

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -56,8 +56,6 @@ spec:
                               type: integer
                             model:
                               type: string
-                            vendor:
-                              type: string
                         devices:
                           properties:
                             disks:

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -54,6 +54,10 @@ spec:
                             cores:
                               format: int64
                               type: integer
+                            model:
+                              type: string
+                            vendor:
+                              type: string
                         devices:
                           properties:
                             disks:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -47,6 +47,10 @@ spec:
                     cores:
                       format: int64
                       type: integer
+                    model:
+                      type: string
+                    vendor:
+                      type: string
                 devices:
                   properties:
                     disks:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -49,8 +49,6 @@ spec:
                       type: integer
                     model:
                       type: string
-                    vendor:
-                      type: string
                 devices:
                   properties:
                     disks:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -44,8 +44,6 @@ spec:
                       type: integer
                     model:
                       type: string
-                    vendor:
-                      type: string
                 devices:
                   properties:
                     disks:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -42,6 +42,10 @@ spec:
                     cores:
                       format: int64
                       type: integer
+                    model:
+                      type: string
+                    vendor:
+                      type: string
                 devices:
                   properties:
                     disks:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -60,8 +60,6 @@ spec:
                               type: integer
                             model:
                               type: string
-                            vendor:
-                              type: string
                         devices:
                           properties:
                             disks:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -58,6 +58,10 @@ spec:
                             cores:
                               format: int64
                               type: integer
+                            model:
+                              type: string
+                            vendor:
+                              type: string
                         devices:
                           properties:
                             disks:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -105,13 +105,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
-						"vendor": {
-							SchemaProps: spec.SchemaProps{
-								Description: "Vendor specifies the CPU vendor inside the VMI.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
 					},
 				},
 			},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -98,6 +98,20 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
+						"model": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Model specifies the CPU model inside the VMI.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
+						"vendor": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Vendor specifies the CPU vendor inside the VMI.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -100,7 +100,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"model": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Model specifies the CPU model inside the VMI.",
+								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -123,6 +123,12 @@ type CPU struct {
 	// Cores specifies the number of cores inside the vmi.
 	// Must be a value greater or equal 1.
 	Cores uint32 `json:"cores,omitempty"`
+	// Model specifies the CPU model inside the VMI.
+	// +optional
+	Model string `json:"model,omitempty"`
+	// Vendor specifies the CPU vendor inside the VMI.
+	// +optional
+	Vendor string `json:"vendor,omitempty"`
 }
 
 // Memory allows specifying the VirtualMachineInstance memory features.

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -126,9 +126,6 @@ type CPU struct {
 	// Model specifies the CPU model inside the VMI.
 	// +optional
 	Model string `json:"model,omitempty"`
-	// Vendor specifies the CPU vendor inside the VMI.
-	// +optional
-	Vendor string `json:"vendor,omitempty"`
 }
 
 // Memory allows specifying the VirtualMachineInstance memory features.

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -124,6 +124,7 @@ type CPU struct {
 	// Must be a value greater or equal 1.
 	Cores uint32 `json:"cores,omitempty"`
 	// Model specifies the CPU model inside the VMI.
+	// List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.
 	// +optional
 	Model string `json:"model,omitempty"`
 }

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -48,7 +48,7 @@ func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":      "CPU allows specifying the CPU topology.",
 		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
-		"model": "Model specifies the CPU model inside the VMI.\n+optional",
+		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -46,8 +46,10 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 
 func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":      "CPU allows specifying the CPU topology.",
-		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
+		"":       "CPU allows specifying the CPU topology.",
+		"cores":  "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
+		"model":  "Model specifies the CPU model inside the VMI.\n+optional",
+		"vendor": "Vendor specifies the CPU vendor inside the VMI.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -46,10 +46,9 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 
 func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":       "CPU allows specifying the CPU topology.",
-		"cores":  "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
-		"model":  "Model specifies the CPU model inside the VMI.\n+optional",
-		"vendor": "Vendor specifies the CPU vendor inside the VMI.\n+optional",
+		"":      "CPU allows specifying the CPU topology.",
+		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
+		"model": "Model specifies the CPU model inside the VMI.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -22,6 +22,7 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"text/template"
 
 	. "github.com/onsi/ginkgo"
@@ -50,7 +51,8 @@ var exampleJSON = `{
         }
       },
       "cpu": {
-        "cores": 3
+        "cores": 3,
+        "model": "Conroe"
       },
       "machine": {
         "type": "q35"
@@ -321,6 +323,7 @@ var _ = Describe("Schema", func() {
 		}
 		exampleVMI.Spec.Domain.CPU = &CPU{
 			Cores: 3,
+			Model: "Conroe",
 		}
 		exampleVMI.Spec.Networks = []Network{
 			Network{
@@ -373,6 +376,8 @@ var _ = Describe("Schema", func() {
 			exampleJSONParsed := tpl.String()
 			buf, err := json.MarshalIndent(*exampleVMI, "", "  ")
 			Expect(err).To(BeNil())
+			fmt.Println(string(buf))
+			fmt.Println(exampleJSONParsed)
 			Expect(string(buf)).To(Equal(exampleJSONParsed))
 		})
 	})

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -22,7 +22,6 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"text/template"
 
 	. "github.com/onsi/ginkgo"
@@ -376,8 +375,6 @@ var _ = Describe("Schema", func() {
 			exampleJSONParsed := tpl.String()
 			buf, err := json.MarshalIndent(*exampleVMI, "", "  ")
 			Expect(err).To(BeNil())
-			fmt.Println(string(buf))
-			fmt.Println(exampleJSONParsed)
 			Expect(string(buf)).To(Equal(exampleJSONParsed))
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -445,14 +445,26 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	}
 
 	if vmi.Spec.Domain.CPU != nil {
-		domain.Spec.CPU.Topology = &CPUTopology{
-			Sockets: 1,
-			Cores:   vmi.Spec.Domain.CPU.Cores,
-			Threads: 1,
+		// Set VM CPU cores
+		if vmi.Spec.Domain.CPU.Cores != 0 {
+			domain.Spec.CPU.Topology = &CPUTopology{
+				Sockets: 1,
+				Cores:   vmi.Spec.Domain.CPU.Cores,
+				Threads: 1,
+			}
+			domain.Spec.VCPU = &VCPU{
+				Placement: "static",
+				CPUs:      vmi.Spec.Domain.CPU.Cores,
+			}
 		}
-		domain.Spec.VCPU = &VCPU{
-			Placement: "static",
-			CPUs:      vmi.Spec.Domain.CPU.Cores,
+
+		// Set VM CPU model and vendor
+		if vmi.Spec.Domain.CPU.Model != "" && vmi.Spec.Domain.CPU.Vendor != "" {
+			domain.Spec.CPU.Mode = "custom"
+			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+			domain.Spec.CPU.Vendor = vmi.Spec.Domain.CPU.Vendor
+		} else {
+			domain.Spec.CPU.Mode = "host-model"
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -459,13 +459,12 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		}
 
 		// Set VM CPU model and vendor
-		if vmi.Spec.Domain.CPU.Model != "" && vmi.Spec.Domain.CPU.Vendor != "" {
+		if vmi.Spec.Domain.CPU.Model != "" {
 			domain.Spec.CPU.Mode = "custom"
 			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
-			domain.Spec.CPU.Vendor = vmi.Spec.Domain.CPU.Vendor
-		} else {
-			domain.Spec.CPU.Mode = "host-model"
 		}
+	} else {
+		domain.Spec.CPU.Mode = "host-model"
 	}
 
 	// Add mandatory console device

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -418,7 +418,7 @@ var _ = Describe("Converter", func() {
       <vendor_id state="off" value="myvendor"></vendor_id>
     </hyperv>
   </features>
-  <cpu></cpu>
+  <cpu mode="host-model"></cpu>
 </domain>`, domainType)
 
 		var c *ConverterContext
@@ -447,17 +447,21 @@ var _ = Describe("Converter", func() {
 			Expect(vmiToDomainXMLToDomainSpec(vmi, c).Type).To(Equal(domainType))
 		})
 
-		It("should convert CPU cores", func() {
+		It("should convert CPU cores and model", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.CPU = &v1.CPU{
 				Cores: 3,
+				Model: "Conroe",
 			}
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).CPU.Topology.Cores).To(Equal(uint32(3)))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).CPU.Topology.Sockets).To(Equal(uint32(1)))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).CPU.Topology.Threads).To(Equal(uint32(1)))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).VCPU.Placement).To(Equal("static"))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).VCPU.CPUs).To(Equal(uint32(3)))
+			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
 
+			Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(3)))
+			Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(1)))
+			Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)))
+			Expect(domainSpec.CPU.Mode).To(Equal("custom"))
+			Expect(domainSpec.CPU.Model).To(Equal("Conroe"))
+			Expect(domainSpec.VCPU.Placement).To(Equal("static"))
+			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
 		})
 
 		It("should select explicitly chosen network model", func() {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -122,7 +122,6 @@ type VCPU struct {
 type CPU struct {
 	Mode     string       `xml:"mode,attr,omitempty"`
 	Model    string       `xml:"model,omitempty"`
-	Vendor   string       `xml:"vendor,omitempty"`
 	Topology *CPUTopology `xml:"topology"`
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -121,6 +121,8 @@ type VCPU struct {
 
 type CPU struct {
 	Mode     string       `xml:"mode,attr,omitempty"`
+	Model    string       `xml:"model,omitempty"`
+	Vendor   string       `xml:"vendor,omitempty"`
 	Topology *CPUTopology `xml:"topology"`
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -73,7 +73,8 @@ var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/doma
   <features>
     <acpi></acpi>
   </features>
-  <cpu>
+  <cpu mode="custom">
+    <model>Conroe</model>
     <topology sockets="1" cores="2" threads="1"></topology>
   </cpu>
   <vcpu placement="static">2</vcpu>
@@ -143,6 +144,8 @@ var _ = Describe("Schema", func() {
 		Placement: "static",
 		CPUs:      2,
 	}
+	exampleDomain.Spec.CPU.Mode = "custom"
+	exampleDomain.Spec.CPU.Model = "Conroe"
 	exampleDomain.Spec.Metadata.KubeVirt.UID = "f4686d2c-6e8d-4335-b8fd-81bee22f4814"
 	exampleDomain.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds = 5
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add possibility to specify a VM CPU model and vendor, if one of them not specified fallback to `host-model` mode.
- add two fields to CPU API, model, and vendor
- fallback to "host-model" mode, if vendor or model not specified

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1229

**Special notes for your reviewer**:
- [x] add unittests
- [x] add functional tests

I do not have any validation for CPU model under this PR, will need to add it in following PR's.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Give the possibility to specify VM CPU model and vendor
```
