### PR TITLE
Backport clusterrole aggregation to release-0.6

### DIFF
--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -238,6 +238,7 @@ metadata:
   name: kubevirt.io:admin
   labels:
     kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups:
       - subresources.kubevirt.io
@@ -278,6 +279,7 @@ metadata:
   name: kubevirt.io:edit
   labels:
     kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - subresources.kubevirt.io
@@ -308,6 +310,7 @@ metadata:
   name: kubevirt.io:view
   labels:
     kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
       - kubevirt.io

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -5,6 +5,7 @@ metadata:
   name: kubevirt.io:admin
   labels:
     kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
   - apiGroups:
       - subresources.kubevirt.io
@@ -47,6 +48,7 @@ metadata:
   name: kubevirt.io:edit
   labels:
     kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
       - subresources.kubevirt.io
@@ -77,6 +79,7 @@ metadata:
   name: kubevirt.io:view
   labels:
     kubevirt.io: ""
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
       - kubevirt.io


### PR DESCRIPTION
Add clusterrole aggregation for kubevirt CRDs

(cherry picked from commit d7dd22ab01fc6abd91f7d1a40598c6b408127243)
Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Aggregate cluster-wide view, edit, and admin roles to KubeVirt CRDs
```
