### PR TITLE
Remove forgotten comment in imports

### DIFF
--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
-	// "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION

**What this PR does / why we need it**:

goimports adds a newline now before comments in imports. This change broke travis, since `make generate` on travis added the extra newline.

```release-note
NONE
```
