### PR TITLE
release-0.6: Fix VMIPreset name

### DIFF
--- a/manifests/release/demo-content.yaml.in
+++ b/manifests/release/demo-content.yaml.in
@@ -1,6 +1,6 @@
 # Virtual Machine Presets
 apiVersion: kubevirt.io/v1alpha2
-kind: VirtualMachinePreset
+kind: VirtualMachineInstancePreset
 metadata:
   name: windows-server-2012r2
   selector:


### PR DESCRIPTION
This is also resolved by #115, but that PR contains more fixes which we don't want to pull in.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1594579

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

```release-note
NONE
```