### PR TITLE
Fix dp race

### DIFF
--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -173,6 +173,12 @@ func (dpi *GenericDevicePlugin) addNewGenericDevice() {
 }
 
 func (dpi *GenericDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
+	// FIXME: sending an empty list up front should not be needed. This is a workaround for:
+	// https://github.com/kubevirt/kubevirt/issues/1196
+	// This can safely be removed once supported upstream Kubernetes is 1.10.3 or higher.
+	emptyList := []*pluginapi.Device{}
+	s.Send(&pluginapi.ListAndWatchResponse{Devices: emptyList})
+
 	s.Send(&pluginapi.ListAndWatchResponse{Devices: dpi.devs})
 
 	for {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -45,8 +45,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-const dpIssue = "https://github.com/kubevirt/kubevirt/issues/1196"
-
 var _ = Describe("VMIlifecycle", func() {
 
 	flag.Parse()
@@ -305,7 +303,6 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when virt-handler crashes", func() {
 			It("should recover and continue management", func() {
-				tests.SkipIfVersionBelow(fmt.Sprintf("Device plugins have issue %s in these versions", dpIssue), "1.10.3")
 
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(BeNil())
@@ -337,7 +334,6 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when virt-handler is responsive", func() {
 			It("should indicate that a node is ready for vmis", func() {
-				tests.SkipIfVersionBelow(fmt.Sprintf("Device plugins have issue %s in these versions", dpIssue), "1.10.3")
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
 				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true"})
@@ -375,7 +371,6 @@ var _ = Describe("VMIlifecycle", func() {
 			var virtHandlerAvailablePods int32
 
 			BeforeEach(func() {
-				tests.SkipIfVersionBelow(fmt.Sprintf("Device plugins have issue %s in these versions", dpIssue), "1.10.3")
 
 				// Schedule a vmi and make sure that virt-handler gets evicted from the node where the vmi was started
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "echo hi!")


### PR DESCRIPTION
**What this PR does / why we need it**:

Workaround/Fix for https://github.com/kubevirt/kubevirt/issues/1196

By submitting an empty list of devices on startup, Kubernetes appears to forget existing devices. An true upstream fix was provided in Kubernetes 1.10.3.

**Special notes for your reviewer**:

```release-note
NONE
```
