### PR TITLE
release-0.6: Merge pull request #1249 from cynepco3hahue/cpu_model_support

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3273,6 +3273,10 @@
      "cores": {
       "description": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
       "type": "integer"
+     },
+     "model": {
+      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
+      "type": "string"
      }
     }
    },

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -54,6 +54,8 @@ spec:
                             cores:
                               format: int64
                               type: integer
+                            model:
+                              type: string
                         devices:
                           properties:
                             disks:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -47,6 +47,8 @@ spec:
                     cores:
                       format: int64
                       type: integer
+                    model:
+                      type: string
                 devices:
                   properties:
                     disks:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -42,6 +42,8 @@ spec:
                     cores:
                       format: int64
                       type: integer
+                    model:
+                      type: string
                 devices:
                   properties:
                     disks:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -58,6 +58,8 @@ spec:
                             cores:
                               format: int64
                               type: integer
+                            model:
+                              type: string
                         devices:
                           properties:
                             disks:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -98,6 +98,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int64",
 							},
 						},
+						"model": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -95,6 +95,10 @@ type CPU struct {
 	// Cores specifies the number of cores inside the vmi.
 	// Must be a value greater or equal 1.
 	Cores uint32 `json:"cores,omitempty"`
+	// Model specifies the CPU model inside the VMI.
+	// List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.
+	// +optional
+	Model string `json:"model,omitempty"`
 }
 
 // Memory allow specifying the VirtualMachineInstance memory features

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -35,6 +35,7 @@ func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":      "CPU allow specifying the CPU topology",
 		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
+		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -44,7 +44,8 @@ var exampleJSON = `{
         }
       },
       "cpu": {
-        "cores": 3
+        "cores": 3,
+        "model": "Conroe"
       },
       "machine": {
         "type": "q35"
@@ -296,6 +297,7 @@ var _ = Describe("Schema", func() {
 		}
 		exampleVMI.Spec.Domain.CPU = &CPU{
 			Cores: 3,
+			Model: "Conroe",
 		}
 		exampleVMI.Spec.Domain.Devices.Interfaces = []Interface{
 			Interface{

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -439,15 +439,26 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	}
 
 	if vmi.Spec.Domain.CPU != nil {
-		domain.Spec.CPU.Topology = &CPUTopology{
-			Sockets: 1,
-			Cores:   vmi.Spec.Domain.CPU.Cores,
-			Threads: 1,
+		// Set VM CPU cores
+		if vmi.Spec.Domain.CPU.Cores != 0 {
+			domain.Spec.CPU.Topology = &CPUTopology{
+				Sockets: 1,
+				Cores:   vmi.Spec.Domain.CPU.Cores,
+				Threads: 1,
+			}
+			domain.Spec.VCPU = &VCPU{
+				Placement: "static",
+				CPUs:      vmi.Spec.Domain.CPU.Cores,
+			}
 		}
-		domain.Spec.VCPU = &VCPU{
-			Placement: "static",
-			CPUs:      vmi.Spec.Domain.CPU.Cores,
+
+		// Set VM CPU model and vendor
+		if vmi.Spec.Domain.CPU.Model != "" {
+			domain.Spec.CPU.Mode = "custom"
+			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
 		}
+	} else {
+		domain.Spec.CPU.Mode = "host-model"
 	}
 
 	// Add mandatory console device

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Converter", func() {
       <vendor_id state="off" value="myvendor"></vendor_id>
     </hyperv>
   </features>
-  <cpu></cpu>
+  <cpu mode="host-model"></cpu>
 </domain>`, domainType)
 
 		var c *ConverterContext
@@ -446,17 +446,21 @@ var _ = Describe("Converter", func() {
 			Expect(vmiToDomainXMLToDomainSpec(vmi, c).Type).To(Equal(domainType))
 		})
 
-		It("should convert CPU cores", func() {
+		It("should convert CPU cores and model", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.CPU = &v1.CPU{
 				Cores: 3,
+				Model: "Conroe",
 			}
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).CPU.Topology.Cores).To(Equal(uint32(3)))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).CPU.Topology.Sockets).To(Equal(uint32(1)))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).CPU.Topology.Threads).To(Equal(uint32(1)))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).VCPU.Placement).To(Equal("static"))
-			Expect(vmiToDomainXMLToDomainSpec(vmi, c).VCPU.CPUs).To(Equal(uint32(3)))
+			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
 
+			Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(3)))
+			Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(1)))
+			Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)))
+			Expect(domainSpec.CPU.Mode).To(Equal("custom"))
+			Expect(domainSpec.CPU.Model).To(Equal("Conroe"))
+			Expect(domainSpec.VCPU.Placement).To(Equal("static"))
+			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
 		})
 
 		It("should select explicitly chosen network model", func() {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -121,6 +121,7 @@ type VCPU struct {
 
 type CPU struct {
 	Mode     string       `xml:"mode,attr,omitempty"`
+	Model    string       `xml:"model,omitempty"`
 	Topology *CPUTopology `xml:"topology"`
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema_test.go
+++ b/pkg/virt-launcher/virtwrap/api/schema_test.go
@@ -73,7 +73,8 @@ var exampleXML = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/doma
   <features>
     <acpi></acpi>
   </features>
-  <cpu>
+  <cpu mode="custom">
+    <model>Conroe</model>
     <topology sockets="1" cores="2" threads="1"></topology>
   </cpu>
   <vcpu placement="static">2</vcpu>
@@ -143,6 +144,8 @@ var _ = Describe("Schema", func() {
 		Placement: "static",
 		CPUs:      2,
 	}
+	exampleDomain.Spec.CPU.Mode = "custom"
+	exampleDomain.Spec.CPU.Model = "Conroe"
 	exampleDomain.Spec.Metadata.KubeVirt.UID = "f4686d2c-6e8d-4335-b8fd-81bee22f4814"
 	exampleDomain.Spec.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds = 5
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1363,3 +1363,44 @@ func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.Res
 	}
 	return nil
 }
+
+// GetNodeLibvirtCapabilities returns node libvirt capabilities
+func GetNodeLibvirtCapabilities(nodeName string) string {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	// Create a virt-launcher pod, that can fetch virsh capabilities
+	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(RegistryDiskFor(RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+	vmi.Spec.Affinity = &v1.Affinity{
+		NodeAffinity: &k8sv1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+				NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+					{
+						MatchExpressions: []k8sv1.NodeSelectorRequirement{
+							{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{nodeName}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = virtClient.VirtualMachineInstance(NamespaceTestDefault).Create(vmi)
+	Expect(err).ToNot(HaveOccurred())
+	WaitForSuccessfulVMIStart(vmi)
+
+	pods, err := virtClient.CoreV1().Pods(NamespaceTestDefault).List(UnfinishedVMIPodSelector(vmi))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pods.Items).NotTo(BeEmpty())
+	vmiPod := pods.Items[0]
+
+	output, err := ExecuteCommandOnPod(
+		virtClient,
+		&vmiPod,
+		"compute",
+		[]string{"virsh", "-r", "capabilities"},
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	return output
+}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"flag"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -236,6 +237,94 @@ var _ = Describe("Configurations", func() {
 					Expect(vmiCondition.Message).To(ContainSubstring("Insufficient hugepages-3Mi"))
 					Expect(vmiCondition.Reason).To(Equal("Unschedulable"))
 				})
+			})
+		})
+	})
+
+	Context("with CPU spec", func() {
+		cpuRegexp := regexp.MustCompile(`<model>(\w+)\-*\w*</model>`)
+		vendorRegexp := regexp.MustCompile(`<vendor>(\w+)</vendor>`)
+
+		var cpuModel string
+		var cpuVendor string
+		var cpuVmi *v1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodes.Items).NotTo(BeEmpty())
+
+			virshCaps := tests.GetNodeLibvirtCapabilities(nodes.Items[0].Name)
+
+			model := cpuRegexp.FindStringSubmatch(virshCaps)
+			Expect(len(model)).To(Equal(2))
+			cpuModel = model[1]
+
+			vendor := vendorRegexp.FindStringSubmatch(virshCaps)
+			Expect(len(vendor)).To(Equal(2))
+			cpuVendor = vendor[1]
+
+			cpuVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			cpuVmi.Spec.Affinity = &v1.Affinity{
+				NodeAffinity: &kubev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &kubev1.NodeSelector{
+						NodeSelectorTerms: []kubev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []kubev1.NodeSelectorRequirement{
+									{Key: "kubernetes.io/hostname", Operator: kubev1.NodeSelectorOpIn, Values: []string{nodes.Items[0].Name}},
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		Context("when CPU model definied", func() {
+			It("should report definied CPU model", func() {
+				vmiModel := "Conroe"
+				if cpuVendor == "AMD" {
+					vmiModel = "Opteron_G1"
+				}
+				cpuVmi.Spec.Domain.CPU = &v1.CPU{
+					Model: vmiModel,
+				}
+
+				By("Starting a VirtualMachineInstance")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(cpuVmi)
+
+				By("Expecting the VirtualMachineInstance console")
+				expecter, err := tests.LoggedInCirrosExpecter(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				By("Checking the CPU model under the guest OS")
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", vmiModel)},
+					&expect.BExp{R: "model name"},
+				}, 10*time.Second)
+			})
+		})
+
+		Context("when CPU model not definied", func() {
+			It("should report CPU model from libvirt capabilities", func() {
+				By("Starting a VirtualMachineInstance")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(cpuVmi)
+
+				By("Expecting the VirtualMachineInstance console")
+				expecter, err := tests.LoggedInCirrosExpecter(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				By("Checking the CPU model under the guest OS")
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", cpuModel)},
+					&expect.BExp{R: "model name"},
+				}, 10*time.Second)
 			})
 		})
 	})


### PR DESCRIPTION
Add possibility to specify VM CPU model

(cherry picked from commit cfb1e5c2a866e3f3240c18525f4ab912249c0675)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add possibility to specify a VM CPU model and vendor, if one of them not specified fallback to `host-model` mode.
- add two fields to CPU API, model, and vendor
- fallback to "host-model" mode, if vendor or model not specified

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1256

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Give the possibility to specify VM CPU model and vendor
```
