### PR TITLE
Don't validate origin header on websocket upgrades

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -62,6 +62,9 @@ func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response 
 	var upgrader = websocket.Upgrader{
 		ReadBufferSize:  kubecli.WebsocketMessageBufferSize,
 		WriteBufferSize: kubecli.WebsocketMessageBufferSize,
+		CheckOrigin: func(_ *http.Request) bool {
+			return true
+		},
 	}
 
 	clientSocket, err := upgrader.Upgrade(response.ResponseWriter, request.Request, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

The apiserver does CORS checks for all aggregated servers if it is
configured for CORS checks. The aggregated apiserver does not have to do it and can't do it.

Without this change websockets can't be used from browsers, since they send an origin header and then the request gets rejected by virt-api.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1242 

**Special notes for your reviewer**:

```release-note
Don't validate Origin headers in the aggregated apiserver. It does not have a well known server name to validate against. The k8s apiserver can do that in a central location. This allows browsers to connect to our console and vnc subresources.
```
