### PR TITLE
Merge pull request #1269 from cynepco3hahue/cpu_model_small_fixes

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -457,7 +457,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			domain.Spec.CPU.Mode = "custom"
 			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
 		}
-	} else {
+	}
+
+	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
 		domain.Spec.CPU.Mode = "host-model"
 	}
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -463,6 +463,27 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
 		})
 
+		Context("when CPU spec defined and model not", func() {
+			It("should set host-model CPU mode", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Cores: 3,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Mode).To(Equal("host-model"))
+			})
+		})
+
+		Context("when CPU spec not defined", func() {
+			It("should set host-model CPU mode", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Mode).To(Equal("host-model"))
+			})
+		})
+
 		It("should select explicitly chosen network model", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.ObjectMeta.Annotations = map[string]string{v1.InterfaceModel: "e1000"}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -280,8 +280,8 @@ var _ = Describe("Configurations", func() {
 			}
 		})
 
-		Context("when CPU model definied", func() {
-			It("should report definied CPU model", func() {
+		Context("when CPU model defined", func() {
+			It("should report defined CPU model", func() {
 				vmiModel := "Conroe"
 				if cpuVendor == "AMD" {
 					vmiModel = "Opteron_G1"
@@ -308,7 +308,7 @@ var _ = Describe("Configurations", func() {
 			})
 		})
 
-		Context("when CPU model not definied", func() {
+		Context("when CPU model not defined", func() {
 			It("should report CPU model from libvirt capabilities", func() {
 				By("Starting a VirtualMachineInstance")
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)


### PR DESCRIPTION
Set host-model CPU mode when CPU spec defined but model not

(cherry picked from commit b5b91243f540739eb5db61af89b2f1e5ba449dfa)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1256

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
