### PR TITLE
Take into account namespace memory limits when starting a Virtual Machine

### DIFF
--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -189,7 +189,7 @@ func (f *kubeInformerFactory) LimitRanges() cache.SharedIndexInformer {
 	return f.getInformer("limitrangeInformer", func() cache.SharedIndexInformer {
 		restClient := f.clientSet.CoreV1().RESTClient()
 		lw := cache.NewListWatchFromClient(restClient, "limitranges", k8sv1.NamespaceAll, fields.Everything())
-		return cache.NewSharedIndexInformer(lw, &k8sv1.LimitRangeList{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		return cache.NewSharedIndexInformer(lw, &k8sv1.LimitRange{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -65,6 +65,9 @@ type KubeInformerFactory interface {
 
 	// Watches for ConfigMap objects
 	ConfigMap() cache.SharedIndexInformer
+
+	// Watches for LimitRange objects
+	LimitRanges() cache.SharedIndexInformer
 }
 
 type kubeInformerFactory struct {
@@ -179,6 +182,14 @@ func (f *kubeInformerFactory) ConfigMap() cache.SharedIndexInformer {
 		fieldSelector := fields.OneTermEqualSelector("metadata.name", "kubevirt-config")
 		lw := cache.NewListWatchFromClient(restClient, "configmaps", systemNamespace, fieldSelector)
 		return cache.NewSharedIndexInformer(lw, &k8sv1.ConfigMap{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	})
+}
+
+func (f *kubeInformerFactory) LimitRanges() cache.SharedIndexInformer {
+	return f.getInformer("limitrangeInformer", func() cache.SharedIndexInformer {
+		restClient := f.clientSet.CoreV1().RESTClient()
+		lw := cache.NewListWatchFromClient(restClient, "limitranges", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &k8sv1.LimitRangeList{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -255,7 +255,7 @@ func (vca *VirtControllerApp) initCommon() {
 	}
 	vca.templateService = services.NewTemplateService(vca.launcherImage, vca.virtShareDir, vca.imagePullSecret, vca.configMapCache)
 	vca.vmiController = NewVMIController(vca.templateService, vca.vmiInformer, vca.podInformer, vca.vmiRecorder, vca.clientSet, vca.configMapInformer)
-	vca.vmiPresetController = NewVirtualMachinePresetController(vca.vmiPresetInformer, vca.vmiInformer, vca.vmiPresetQueue, vca.vmiPresetCache, vca.clientSet, vca.vmiPresetRecorder)
+	vca.vmiPresetController = NewVirtualMachinePresetController(vca.vmiPresetInformer, vca.vmiInformer, vca.vmiPresetQueue, vca.vmiPresetCache, vca.clientSet, vca.vmiPresetRecorder, vca.limitrangeInformer)
 	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, nil)
 }
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -99,6 +99,8 @@ type VirtControllerApp struct {
 	vmController *VMController
 	vmInformer   cache.SharedIndexInformer
 
+	limitrangeInformer cache.SharedIndexInformer
+
 	LeaderElection leaderelectionconfig.Configuration
 
 	launcherImage    string
@@ -158,6 +160,7 @@ func Execute() {
 	app.configMapCache = app.configMapInformer.GetStore()
 
 	app.vmInformer = app.informerFactory.VirtualMachine()
+	app.limitrangeInformer = app.informerFactory.LimitRanges()
 
 	app.initCommon()
 	app.initReplicaSet()

--- a/pkg/virt-controller/watch/preset.go
+++ b/pkg/virt-controller/watch/preset.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -42,25 +43,27 @@ import (
 )
 
 type VirtualMachinePresetController struct {
-	vmiPresetInformer cache.SharedIndexInformer
-	vmiInitInformer   cache.SharedIndexInformer
-	clientset         kubecli.KubevirtClient
-	queue             workqueue.RateLimitingInterface
-	recorder          record.EventRecorder
-	store             cache.Store
+	vmiPresetInformer  cache.SharedIndexInformer
+	vmiInitInformer    cache.SharedIndexInformer
+	clientset          kubecli.KubevirtClient
+	queue              workqueue.RateLimitingInterface
+	recorder           record.EventRecorder
+	store              cache.Store
+	limitrangeInformer cache.SharedIndexInformer
 }
 
 const initializerMarking = "presets.virtualmachines." + kubev1.GroupName + "/presets-applied"
 const exclusionMarking = "virtualmachineinstancepresets.admission.kubevirt.io/exclude"
 
-func NewVirtualMachinePresetController(vmiPresetInformer cache.SharedIndexInformer, vmiInitInformer cache.SharedIndexInformer, queue workqueue.RateLimitingInterface, vmiInitCache cache.Store, clientset kubecli.KubevirtClient, recorder record.EventRecorder) *VirtualMachinePresetController {
+func NewVirtualMachinePresetController(vmiPresetInformer cache.SharedIndexInformer, vmiInitInformer cache.SharedIndexInformer, queue workqueue.RateLimitingInterface, vmiInitCache cache.Store, clientset kubecli.KubevirtClient, recorder record.EventRecorder, limitrangeInformer cache.SharedIndexInformer) *VirtualMachinePresetController {
 	vmii := VirtualMachinePresetController{
-		vmiPresetInformer: vmiPresetInformer,
-		vmiInitInformer:   vmiInitInformer,
-		clientset:         clientset,
-		queue:             queue,
-		recorder:          recorder,
-		store:             vmiInitCache,
+		vmiPresetInformer:  vmiPresetInformer,
+		vmiInitInformer:    vmiInitInformer,
+		clientset:          clientset,
+		queue:              queue,
+		recorder:           recorder,
+		store:              vmiInitCache,
+		limitrangeInformer: limitrangeInformer,
 	}
 	return &vmii
 }
@@ -156,6 +159,9 @@ func (c *VirtualMachinePresetController) initializeVirtualMachine(vmi *kubev1.Vi
 		} else {
 			logger.Object(vmi).V(4).Info("Setting default values on VirtualMachine")
 			kubev1.SetObjectDefaults_VirtualMachineInstance(vmi)
+
+			// handle namespace limitrange default values
+			applyNamespaceLimitRangeValues(vmi, c.limitrangeInformer)
 		}
 	} else {
 		logger.Object(vmi).Infof("VirtualMachineInstance is excluded from VirtualMachinePresets")
@@ -170,6 +176,56 @@ func (c *VirtualMachinePresetController) initializeVirtualMachine(vmi *kubev1.Vi
 		return err
 	}
 	return nil
+}
+
+func applyNamespaceLimitRangeValues(vmi *kubev1.VirtualMachineInstance, limitrangeInformer cache.SharedIndexInformer) {
+	isMemoryFieldExist := func(resource k8sv1.ResourceList) bool {
+		_, ok := resource[k8sv1.ResourceMemory]
+		return ok
+	}
+
+	vmiResources := vmi.Spec.Domain.Resources
+
+	// Copy namespace memory limits (if exists) to the VM spec
+	if vmiResources.Limits == nil || !isMemoryFieldExist(vmiResources.Limits) {
+
+		namespaceMemLimit, err := getNamespaceLimits(vmi.Namespace, limitrangeInformer)
+		if err == nil {
+			if vmiResources.Limits == nil {
+				vmi.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
+			}
+			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory] = *namespaceMemLimit
+		}
+	}
+
+}
+
+func getNamespaceLimits(namespace string, limitrangeInformer cache.SharedIndexInformer) (*resource.Quantity, error) {
+	finalLimit := &resource.Quantity{Format: resource.BinarySI}
+
+	// there can be multiple LimitRange values set for the same resource in
+	// a namespace, we need to find the minimal
+	limits, err := limitrangeInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, limit := range limits {
+		for _, val := range limit.(*k8sv1.LimitRange).Spec.Limits {
+			mem := val.Default.Memory()
+			if val.Type == k8sv1.LimitTypeContainer {
+				if !mem.IsZero() {
+					if finalLimit.IsZero() != (mem.Cmp(*finalLimit) < 0) {
+						finalLimit = mem
+					}
+				}
+			}
+		}
+	}
+	if finalLimit.IsZero() {
+		return nil, fmt.Errorf("failed to find namespace memory limits")
+	}
+	return finalLimit, nil
 }
 
 // listPresets returns all VirtualMachinePresets by namespace

--- a/pkg/virt-controller/watch/preset.go
+++ b/pkg/virt-controller/watch/preset.go
@@ -190,7 +190,7 @@ func applyNamespaceLimitRangeValues(vmi *kubev1.VirtualMachineInstance, limitran
 	if vmiResources.Limits == nil || !isMemoryFieldExist(vmiResources.Limits) {
 
 		namespaceMemLimit, err := getNamespaceLimits(vmi.Namespace, limitrangeInformer)
-		if err == nil {
+		if err == nil && !namespaceMemLimit.IsZero() {
 			if vmiResources.Limits == nil {
 				vmi.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
 			}
@@ -221,9 +221,6 @@ func getNamespaceLimits(namespace string, limitrangeInformer cache.SharedIndexIn
 				}
 			}
 		}
-	}
-	if finalLimit.IsZero() {
-		return nil, fmt.Errorf("failed to find namespace memory limits")
 	}
 	return finalLimit, nil
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -710,6 +710,8 @@ func cleanNamespaces() {
 
 		// Remove all VirtualMachineInstance Presets
 		PanicOnError(virtCli.RestClient().Delete().Namespace(namespace).Resource("virtualmachineinstancepresets").Do().Error())
+		// Remove all limit ranges
+		PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("limitranges").Do().Error())
 	}
 }
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -104,6 +104,62 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}, 300)
 		})
+		Context("with namespace memory limits", func() {
+			var vmi *v1.VirtualMachineInstance
+			It("should failed to schedule the pod, copy limits to vm spec", func() {
+				// create a namespace default limit
+				limitRangeObj := kubev1.LimitRange{
+
+					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: tests.NamespaceTestDefault},
+					Spec: kubev1.LimitRangeSpec{
+						Limits: []kubev1.LimitRangeItem{
+							{
+								Type: kubev1.LimitTypeContainer,
+								Default: kubev1.ResourceList{
+									kubev1.ResourceMemory: resource.MustParse("32Mi"),
+								},
+							},
+						},
+					},
+				}
+				_, err := virtClient.Core().LimitRanges(tests.NamespaceTestDefault).Create(&limitRangeObj)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Starting a VirtualMachineInstance")
+				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceMemory: resource.MustParse("64M"),
+					},
+				}
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				var vmiCondition v1.VirtualMachineInstanceCondition
+				Eventually(func() bool {
+					vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+
+					if len(vmi.Status.Conditions) > 0 {
+						for _, cond := range vmi.Status.Conditions {
+							if cond.Type == v1.VirtualMachineInstanceSynchronized && cond.Status == kubev1.ConditionFalse {
+								vmiCondition = vmi.Status.Conditions[0]
+								return true
+							}
+						}
+					}
+					return false
+				}, 30*time.Second, time.Second).Should(BeTrue())
+				Expect(vmiCondition.Message).To(ContainSubstring("must be less than or equal to memory limit"))
+				Expect(vmiCondition.Reason).To(Equal("FailedCreate"))
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vmi.Spec.Domain.Resources.Limits.Memory().IsZero()).ShouldNot(BeTrue())
+				err = virtClient.Core().LimitRanges(tests.NamespaceTestDefault).Delete(limitRangeObj.Name, &metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+		})
 
 		Context("with hugepages", func() {
 			var hugepagesVmi *v1.VirtualMachineInstance


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch simply copies the relevant default namespace memory limits value to the Virtual Machine spec, if it hasn't been provided by the user.
This value is also being taken into account during the VM memory overhead calculation.
This is particularly useful for the users to see this value on the VM spec, when namespace defaults prevent the VM from starting. 


**Which issue(s) this PR fixes** :
Fixes #970 

**Special notes for your reviewer**:
Apparently, k8s allows setting multiple namespace defaults for the same value. Eventually, it applies the minimal value to the container.
```
Resource Limits
 Type       Resource  Min  Max  Default Request  Default Limit  Max Limit/Request Ratio
 ----       --------  ---  ---  ---------------  -------------  -----------------------
 Container  memory    -    -    32Mi             64Mi           -
 Container  memory    -    -    32Mi             32Mi           -
 Container  cpu       -    -    1                1              -
```

```release-note
Make resource memory limits, set for namespaces, visible on VMIs
```