### PR TITLE
Add a success message in virtctl

### DIFF
--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -125,5 +125,6 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error: VirtualMachineInstance '%s' is already %s", vmiName, stateMsg)
 	}
 
+	cmd.Printf("VM %s was scheduled to %s\n", vmiName, o.command)
 	return nil
 }

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -1,7 +1,9 @@
 package vm_test
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -36,14 +38,20 @@ var _ = Describe("VirtualMachine", func() {
 
 	Context("should patch VM", func() {
 		It("with spec:running:true", func() {
-			cmd := tests.NewRepeatableVirtctlCommand("start", vmName)
-			Expect(cmd()).To(BeNil())
+			buffer := &bytes.Buffer{}
+			cmd := tests.NewVirtctlCommand("start", vmName)
+			cmd.SetOutput(buffer)
+			Expect(cmd.Execute()).To(BeNil())
+			Expect(buffer.String()).To(Equal(fmt.Sprintf("VM %s was scheduled to start\n", vmName)))
 		})
 
 		It("with spec:running:false", func() {
 			vm.Spec.Running = true
-			cmd := tests.NewRepeatableVirtctlCommand("stop", vmName)
-			Expect(cmd()).To(BeNil())
+			buffer := &bytes.Buffer{}
+			cmd := tests.NewVirtctlCommand("stop", vmName)
+			cmd.SetOutput(buffer)
+			Expect(cmd.Execute()).To(BeNil())
+			Expect(buffer.String()).To(Equal(fmt.Sprintf("VM %s was scheduled to stop\n", vmName)))
 		})
 
 		It("with spec:running:false when it's false already ", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

virtctl-stop/start sends a request to stop/start a given VM.
If there is an error during that process that error is printed.
However, if the request is sent successfully no message
is displayed on the screen.

This patch is supposed to fix that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1221 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
