### PR TITLE
Changed virt-controller to DeamonSet

### DIFF
--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -20,9 +20,6 @@ metadata:
   labels:
     kubevirt.io: "virt-controller"
 spec:
-  selector:
-    matchLabels:
-      kubevirt.io: virt-controller
   template:
     metadata:
       annotations:
@@ -38,8 +35,13 @@ spec:
         kubevirt.io: virt-controller
     spec:
       serviceAccountName: kubevirt-controller
-      nodeSelector:
-        node-role.kubernetes.io/master: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -39,7 +39,7 @@ spec:
     spec:
       serviceAccountName: kubevirt-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -13,14 +13,16 @@ spec:
     kubevirt.io: virt-controller
 ---
 apiVersion: extensions/v1beta1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: virt-controller
   namespace: {{.Namespace}}
   labels:
     kubevirt.io: "virt-controller"
 spec:
-  replicas: 2
+  selector:
+    matchLabels:
+      kubevirt.io: virt-controller
   template:
     metadata:
       annotations:
@@ -36,6 +38,11 @@ spec:
         kubevirt.io: virt-controller
     spec:
       serviceAccountName: kubevirt-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: virt-controller
           image: {{.DockerPrefix}}/virt-controller:{{.DockerTag}}

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -417,9 +417,6 @@ metadata:
   labels:
     kubevirt.io: "virt-controller"
 spec:
-  selector:
-    matchLabels:
-      kubevirt.io: virt-controller
   template:
     metadata:
       annotations:
@@ -435,8 +432,13 @@ spec:
         kubevirt.io: virt-controller
     spec:
       serviceAccountName: kubevirt-controller
-      nodeSelector:
-        node-role.kubernetes.io/master: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -410,14 +410,16 @@ spec:
 ---
 # kubevirt controller
 apiVersion: extensions/v1beta1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: virt-controller
   namespace: {{.Namespace}}
   labels:
     kubevirt.io: "virt-controller"
 spec:
-  replicas: 2
+  selector:
+    matchLabels:
+      kubevirt.io: virt-controller
   template:
     metadata:
       annotations:
@@ -433,6 +435,11 @@ spec:
         kubevirt.io: virt-controller
     spec:
       serviceAccountName: kubevirt-controller
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: virt-controller
           image: {{.DockerPrefix}}/virt-controller:{{.DockerTag}}

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -436,7 +436,7 @@ spec:
     spec:
       serviceAccountName: kubevirt-controller
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/master: true
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

**What this PR does / why we need it**:
This PR changes `virt-controller` from `Deployment` to `DeamonSet`, making it to schedule only on the master, and on all masters if there are HA setup with more then one master
**Which issue(s) this PR fixes** *
Fixes #975 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changed virt-controller from Deployment to DeamonSet
```
