### PR TITLE
getting-started: state the obvious

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,7 +6,8 @@ development cluster.
 ## Building
 
 The KubeVirt build system runs completely inside docker. In order to build
-KubeVirt you need to have `docker` and `rsync` installed.
+KubeVirt you need to have `docker` and `rsync` installed. You also need to have `docker`
+running, and have the permissions to access it.
 
 **Note:** For running KubeVirt in the dockerized cluster, **nested
 virtualization** must be enabled. As an alternative [software
@@ -25,8 +26,8 @@ for scheduling and memory are missing or incompatible with previous versions.
 
 ### Compile and run it
 
-Build all required artifacts and launch the
-dockerizied environment:
+To build all required artifacts and launch the
+dockerizied environment, clone the KubeVirt repository, `cd` into it, and:
 
 ```bash
 # Build and deploy KubeVirt on Kubernetes 1.10.4 in our vms inside containers


### PR DESCRIPTION
using docker requires a running and accessible docker daemon; calling `make cluster-up` requires a local copy of the code.
it is obvious, but should appear in a "getting started" page.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
