### PR TITLE
getting started: VMI->virtual machine

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ make cluster-up
 make cluster-sync
 ```
 
-This will create a VMI called `node01` which acts as node and master. To create
+This will create a virtual machine called `node01` which acts as node and master. To create
 more nodes which will register themselves on master, you can use the
 `KUBEVIRT_NUM_NODES` environment variable. This would create a master and one
 node:


### PR DESCRIPTION
**What this PR does / why we need it**:
We do not have a kubevirt VMI serving as a node. it is a non-kubevirt virtual machine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes nothing

**Special notes for your reviewer**:
@rmohr not *every* VM is a VMI!

**Release note**:
```release-note
NONE
```
