### PR TITLE
Add KubeVirt custom fail handler

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -21,6 +21,7 @@ package tests_test
 
 import (
 	. "github.com/onsi/ginkgo"
+
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -31,7 +32,7 @@ import (
 )
 
 func TestTests(t *testing.T) {
-	RegisterFailHandler(Fail)
+	RegisterFailHandler(tests.KubevirtFailHandler)
 	reporters := make([]Reporter, 0)
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Custom Fail handler will print cluster status and 15 last line from kubevirt pods logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>
