### PR TITLE
Add paused reason to domain states

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -69,6 +69,22 @@ const (
 
 	// NoState reasons
 	ReasonNonExistent StateChangeReason = "NonExistent"
+
+	// Pause reasons
+	ReasonPausedUnknown        StateChangeReason = "Unknown"
+	ReasonPausedUser           StateChangeReason = "User"
+	ReasonPausedMigration      StateChangeReason = "Migration"
+	ReasonPausedSave           StateChangeReason = "Save"
+	ReasonPausedDump           StateChangeReason = "Dump"
+	ReasonPausedIOError        StateChangeReason = "IOError"
+	ReasonPausedWatchdog       StateChangeReason = "Watchdog"
+	ReasonPausedFromSnapshot   StateChangeReason = "FromSnapshot"
+	ReasonPausedShuttingDown   StateChangeReason = "ShuttingDown"
+	ReasonPausedSnapshot       StateChangeReason = "Snapshot"
+	ReasonPausedCrashed        StateChangeReason = "Crashed"
+	ReasonPausedStartingUp     StateChangeReason = "StartingUp"
+	ReasonPausedPostcopy       StateChangeReason = "Postcopy"
+	ReasonPausedPostcopyFailed StateChangeReason = "PostcopyFailed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -166,9 +166,9 @@ var _ = Describe("Manager", func() {
 	})
 
 	table.DescribeTable("on successful list all domains",
-		func(state libvirt.DomainState, kubevirtState api.LifeCycle) {
+		func(state libvirt.DomainState, kubevirtState api.LifeCycle, libvirtReason int, kubevirtReason api.StateChangeReason) {
 
-			mockDomain.EXPECT().GetState().Return(state, -1, nil)
+			mockDomain.EXPECT().GetState().Return(state, libvirtReason, nil)
 			mockDomain.EXPECT().GetName().Return("test", nil)
 			x, err := xml.Marshal(api.NewMinimalDomainSpec("test"))
 			Expect(err).To(BeNil())
@@ -186,12 +186,14 @@ var _ = Describe("Manager", func() {
 
 			Expect(&domain.Spec).To(Equal(api.NewMinimalDomainSpec("test")))
 			Expect(domain.Status.Status).To(Equal(kubevirtState))
+			Expect(domain.Status.Reason).To(Equal(kubevirtReason))
 		},
-		table.Entry("crashed", libvirt.DOMAIN_CRASHED, api.Crashed),
-		table.Entry("shutoff", libvirt.DOMAIN_SHUTOFF, api.Shutoff),
-		table.Entry("shutdown", libvirt.DOMAIN_SHUTDOWN, api.Shutdown),
-		table.Entry("unknown", libvirt.DOMAIN_NOSTATE, api.NoState),
-		table.Entry("running", libvirt.DOMAIN_RUNNING, api.Running),
+		table.Entry("crashed", libvirt.DOMAIN_CRASHED, api.Crashed, int(libvirt.DOMAIN_CRASHED_UNKNOWN), api.ReasonUnknown),
+		table.Entry("shutoff", libvirt.DOMAIN_SHUTOFF, api.Shutoff, int(libvirt.DOMAIN_SHUTOFF_DESTROYED), api.ReasonDestroyed),
+		table.Entry("shutdown", libvirt.DOMAIN_SHUTDOWN, api.Shutdown, int(libvirt.DOMAIN_SHUTDOWN_USER), api.ReasonUser),
+		table.Entry("unknown", libvirt.DOMAIN_NOSTATE, api.NoState, int(libvirt.DOMAIN_NOSTATE_UNKNOWN), api.ReasonUnknown),
+		table.Entry("running", libvirt.DOMAIN_RUNNING, api.Running, int(libvirt.DOMAIN_RUNNING_UNKNOWN), api.ReasonUnknown),
+		table.Entry("paused", libvirt.DOMAIN_PAUSED, api.Paused, int(libvirt.DOMAIN_PAUSED_STARTING_UP), api.ReasonPausedStartingUp),
 	)
 
 	// TODO: test error reporting on non successful VirtualMachineInstance syncs and kill attempts

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -49,6 +49,23 @@ var CrashedReasonTranslationMap = map[libvirt.DomainCrashedReason]api.StateChang
 	libvirt.DOMAIN_CRASHED_PANICKED: api.ReasonPanicked,
 }
 
+var PausedReasonTranslationMap = map[libvirt.DomainPausedReason]api.StateChangeReason{
+	libvirt.DOMAIN_PAUSED_UNKNOWN:         api.ReasonPausedUnknown,
+	libvirt.DOMAIN_PAUSED_USER:            api.ReasonPausedUser,
+	libvirt.DOMAIN_PAUSED_MIGRATION:       api.ReasonPausedMigration,
+	libvirt.DOMAIN_PAUSED_SAVE:            api.ReasonPausedSave,
+	libvirt.DOMAIN_PAUSED_DUMP:            api.ReasonPausedDump,
+	libvirt.DOMAIN_PAUSED_IOERROR:         api.ReasonPausedIOError,
+	libvirt.DOMAIN_PAUSED_WATCHDOG:        api.ReasonPausedWatchdog,
+	libvirt.DOMAIN_PAUSED_FROM_SNAPSHOT:   api.ReasonPausedFromSnapshot,
+	libvirt.DOMAIN_PAUSED_SHUTTING_DOWN:   api.ReasonPausedShuttingDown,
+	libvirt.DOMAIN_PAUSED_SNAPSHOT:        api.ReasonPausedSnapshot,
+	libvirt.DOMAIN_PAUSED_CRASHED:         api.ReasonPausedCrashed,
+	libvirt.DOMAIN_PAUSED_STARTING_UP:     api.ReasonPausedStartingUp,
+	libvirt.DOMAIN_PAUSED_POSTCOPY:        api.ReasonPausedPostcopy,
+	libvirt.DOMAIN_PAUSED_POSTCOPY_FAILED: api.ReasonPausedPostcopyFailed,
+}
+
 func ConvState(status libvirt.DomainState) api.LifeCycle {
 	return LifeCycleTranslationMap[status]
 }
@@ -61,6 +78,8 @@ func ConvReason(status libvirt.DomainState, reason int) api.StateChangeReason {
 		return ShutoffReasonTranslationMap[libvirt.DomainShutoffReason(reason)]
 	case libvirt.DOMAIN_CRASHED:
 		return CrashedReasonTranslationMap[libvirt.DomainCrashedReason(reason)]
+	case libvirt.DOMAIN_PAUSED:
+		return PausedReasonTranslationMap[libvirt.DomainPausedReason(reason)]
 	default:
 		return api.ReasonUnknown
 	}


### PR DESCRIPTION
Up until now if a domain was in a "paused" state,
the reason that was reported in virt-handler log was "Unknown".
This commit adds support for reporting the reason for the pause state.
Extended "list all domains" test to support this change.

Part of #1261

```release-note
Add support for reporting the reason when a domain is in a paused state.
```

Signed-off-by: gbenhaim <galbh2@gmail.com>
Signed-off-by: Yuval Turgeman <yturgema@redhat.com>