### PR TITLE
Allow build-time configuration of Image Pull Policy

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -44,6 +44,7 @@ for arg in $args; do
         --namespace=${namespace} \
         --docker-prefix=${manifest_docker_prefix} \
         --docker-tag=${docker_tag} \
+        --image-pull-policy=${image_pull_policy} \
         --generated-manifests-dir=${KUBEVIRT_DIR}/manifests/generated/ \
         --input-file=${KUBEVIRT_DIR}/manifests/$arg >${outfile}
 
@@ -51,6 +52,7 @@ for arg in $args; do
         --namespace="{{ namespace }}" \
         --docker-prefix="{{ docker_prefix }}" \
         --docker-tag="{{ docker_tag }}" \
+        --image-pull-policy="{{ image_pull_policy }}" \
         --generated-manifests-dir=${KUBEVIRT_DIR}/manifests/generated/ \
         --input-file=${KUBEVIRT_DIR}/manifests/$arg >${template_outfile}
 done
@@ -63,6 +65,7 @@ find ${MANIFEST_TEMPLATES_OUT_DIR}/ -type f -exec sed -i {} -e '${/^$/d;}' \;
 export namespace=${namespace}
 export docker_tag=${docker_tag}
 export docker_prefix=${manifest_docker_prefix}
+export image_pull_policy=${image_pull_policy}
 
 TMP_DIR=$(mktemp -d)
 cleanup() {

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -5,3 +5,4 @@ docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel
 namespace=kube-system
+image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,5 +1,5 @@
 unset binaries docker_images docker_prefix docker_tag manifest_templates \
-    master_ip network_provider kubeconfig manifest_docker_prefix namespace
+    master_ip network_provider kubeconfig manifest_docker_prefix namespace image_pull_policy
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.3}
@@ -14,4 +14,4 @@ test -f "hack/config-provider-${KUBEVIRT_PROVIDER}.sh" && source hack/config-pro
 test -f "hack/config-local.sh" && source hack/config-local.sh
 
 export binaries docker_images docker_prefix docker_tag manifest_templates \
-    master_ip network_provider kubeconfig namespace
+    master_ip network_provider kubeconfig namespace image_pull_policy

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -14,7 +14,7 @@ SYNC_VENDOR=${SYNC_VENDOR:-false}
 TEMPFILE=".rsynctemp"
 
 # Build the build container
-(cd ${DOCKER_DIR} && docker build . -q -t ${BUILDER})
+(cd ${DOCKER_DIR} && docker build . -t ${BUILDER})
 
 # Create the persistent docker volume
 if [ -z "$(docker volume list | grep ${BUILDER})" ]; then

--- a/manifests/dev/virt-api.yaml.in
+++ b/manifests/dev/virt-api.yaml.in
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: virt-api
           image: {{.DockerPrefix}}/virt-api:{{.DockerTag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command:
               - "virt-api"
               - "--port"

--- a/manifests/dev/virt-controller.yaml.in
+++ b/manifests/dev/virt-controller.yaml.in
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: virt-controller
           image: {{.DockerPrefix}}/virt-controller:{{.DockerTag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command:
               - "virt-controller"
               - "--launcher-image"

--- a/manifests/dev/virt-handler.yaml.in
+++ b/manifests/dev/virt-handler.yaml.in
@@ -31,7 +31,7 @@ spec:
             - containerPort: 8185
               hostPort: 8185
           image: {{.DockerPrefix}}/virt-handler:{{.DockerTag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command:
             - "virt-handler"
             - "-v"

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -390,7 +390,7 @@ spec:
       containers:
         - name: virt-api
           image: {{.DockerPrefix}}/virt-api:{{.DockerTag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command:
               - "virt-api"
               - "--port"
@@ -436,7 +436,7 @@ spec:
       containers:
         - name: virt-controller
           image: {{.DockerPrefix}}/virt-controller:{{.DockerTag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command:
               - "virt-controller"
               - "--launcher-image"
@@ -497,7 +497,7 @@ spec:
             - containerPort: 8185
               hostPort: 8185
           image: {{.DockerPrefix}}/virt-handler:{{.DockerTag}}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{.ImagePullPolicy}}
           command:
             - "virt-handler"
             - "-v"

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -38,7 +38,8 @@ import (
 )
 
 const configMapName = "kube-system/kubevirt-config"
-const useEmulationKey = "debug.useEmulation"
+const UseEmulationKey = "debug.useEmulation"
+const ImagePullPolicyKey = "dev.imagePullPolicy"
 const KvmDevice = "devices.kubevirt.io/kvm"
 const TunDevice = "devices.kubevirt.io/tun"
 
@@ -53,21 +54,43 @@ type templateService struct {
 	store           cache.Store
 }
 
-func IsEmulationAllowed(store cache.Store) (bool, error) {
-	obj, exists, err := store.GetByKey(configMapName)
-	if err != nil {
-		return false, err
+func getConfigMapEntry(store cache.Store, key string) (string, error) {
+
+	if obj, exists, err := store.GetByKey(configMapName); err != nil {
+		return "", err
+	} else if !exists {
+		return "", nil
+	} else {
+		return obj.(*k8sv1.ConfigMap).Data[key], nil
 	}
-	if !exists {
-		return exists, nil
+}
+
+func IsEmulationAllowed(store cache.Store) (useEmulation bool, err error) {
+	var value string
+	value, err = getConfigMapEntry(store, UseEmulationKey)
+	if strings.ToLower(value) == "true" {
+		useEmulation = true
 	}
-	useEmulation := false
-	cm := obj.(*k8sv1.ConfigMap)
-	emu, ok := cm.Data[useEmulationKey]
-	if ok {
-		useEmulation = (strings.ToLower(emu) == "true")
+	return
+}
+
+func GetImagePullPolicy(store cache.Store) (policy k8sv1.PullPolicy, err error) {
+	var value string
+	if value, err = getConfigMapEntry(store, ImagePullPolicyKey); err != nil || value == "" {
+		policy = k8sv1.PullIfNotPresent // Default if not specified
+	} else {
+		switch value {
+		case "Always":
+			policy = k8sv1.PullAlways
+		case "Never":
+			policy = k8sv1.PullNever
+		case "IfNotPresent":
+			policy = k8sv1.PullIfNotPresent
+		default:
+			err = fmt.Errorf("Invalid ImagePullPolicy in ConfigMap: %s", value)
+		}
 	}
-	return useEmulation, nil
+	return
 }
 
 func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (*k8sv1.Pod, error) {
@@ -241,6 +264,11 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		return nil, err
 	}
 
+	imagePullPolicy, err := GetImagePullPolicy(t.store)
+	if err != nil {
+		return nil, err
+	}
+
 	if resources.Limits == nil {
 		resources.Limits = make(k8sv1.ResourceList)
 	}
@@ -265,7 +293,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	container := k8sv1.Container{
 		Name:            "compute",
 		Image:           t.launcherImage,
-		ImagePullPolicy: k8sv1.PullIfNotPresent,
+		ImagePullPolicy: imagePullPolicy,
 		SecurityContext: &k8sv1.SecurityContext{
 			RunAsUser: &userId,
 			// Privileged mode is disabled.

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -582,7 +582,7 @@ var _ = Describe("Template", func() {
 					Namespace: "kube-system",
 					Name:      "kubevirt-config",
 				},
-				Data: map[string]string{"debug.useEmulation": "true"},
+				Data: map[string]string{UseEmulationKey: "true"},
 			}
 			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
 			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachineInstance{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
@@ -593,6 +593,62 @@ var _ = Describe("Template", func() {
 			result, err := IsEmulationAllowed(cmStore)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeTrue())
+		})
+
+		It("Should return IfNotPresent if configmap doesn't have imagePullPolicy set", func() {
+			cfgMap := kubev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Name:      "kubevirt-config",
+				},
+				Data: map[string]string{},
+			}
+			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
+			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachineInstance{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			cmStore = cmInformer.GetStore()
+			go cmInformer.Run(stopChan)
+			cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
+
+			result, err := GetImagePullPolicy(cmStore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(kubev1.PullIfNotPresent))
+		})
+
+		It("Should return Always if imagePullPolicy = Always", func() {
+			cfgMap := kubev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Name:      "kubevirt-config",
+				},
+				Data: map[string]string{ImagePullPolicyKey: "Always"},
+			}
+			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
+			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachineInstance{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			cmStore = cmInformer.GetStore()
+			go cmInformer.Run(stopChan)
+			cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
+
+			result, err := GetImagePullPolicy(cmStore)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(kubev1.PullAlways))
+		})
+
+		It("Should return an error if imagePullPolicy is not valid", func() {
+			cfgMap := kubev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Name:      "kubevirt-config",
+				},
+				Data: map[string]string{ImagePullPolicyKey: "IHaveNoStrongFeelingsOneWayOrTheOther"},
+			}
+			cmListWatch = MakeFakeConfigMapWatcher([]kubev1.ConfigMap{cfgMap})
+			cmInformer = cache.NewSharedIndexInformer(cmListWatch, &v1.VirtualMachineInstance{}, time.Second, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			cmStore = cmInformer.GetStore()
+			go cmInformer.Run(stopChan)
+			cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
+
+			_, err := GetImagePullPolicy(cmStore)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -31,6 +31,7 @@ type templateData struct {
 	Namespace          string
 	DockerTag          string
 	DockerPrefix       string
+	ImagePullPolicy    string
 	GeneratedManifests map[string]string
 }
 
@@ -38,6 +39,7 @@ func main() {
 	namespace := flag.String("namespace", "", "")
 	dockerPrefix := flag.String("docker-prefix", "", "")
 	dockerTag := flag.String("docker-tag", "", "")
+	imagePullPolicy := flag.String("image-pull-policy", "IfNotPresent", "")
 	genDir := flag.String("generated-manifests-dir", "", "")
 	inputFile := flag.String("input-file", "", "")
 	flag.Parse()
@@ -46,6 +48,7 @@ func main() {
 		Namespace:          *namespace,
 		DockerTag:          *dockerTag,
 		DockerPrefix:       *dockerPrefix,
+		ImagePullPolicy:    *imagePullPolicy,
 		GeneratedManifests: make(map[string]string),
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the ability to set container "Image Pull Policy" at build time.  This can be helpful in a developer workflow by setting the policy to "Always".  In such a case worker nodes will always pull the latest kubevirt images, removing the need for the developer to either use ephemeral Docker tags or to explicitly pull on each worker node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

```release-note
User can set the ImagePullPolicy that will be applied to manifests by setting the IMAGE_PULL_POLICY environment variable.
This defaults to "IfNotPresent" (previous behavior)
```