### PR TITLE
virtctl.sh: Call appropriate binary by architecture

### DIFF
--- a/cluster/virtctl.sh
+++ b/cluster/virtctl.sh
@@ -24,4 +24,17 @@ source $(dirname "$0")/../hack/common.sh
 source ${KUBEVIRT_DIR}/cluster/$KUBEVIRT_PROVIDER/provider.sh
 source ${KUBEVIRT_DIR}/hack/config.sh
 
-${KUBEVIRT_DIR}/_out/cmd/virtctl/virtctl --kubeconfig=${kubeconfig} "$@"
+CONFIG_ARGS=
+
+if [ -n "$kubeconfig" ]; then
+    CONFIG_ARGS="--kubeconfig=${kubeconfig}"
+elif [ -n "$KUBECONFIG" ]; then
+    CONFIG_ARGS="--kubeconfig=${KUBECONFIG}"
+fi
+
+VIRTCTL=virtctl
+if [ "$(uname -s)" = "Darwin" ]; then
+    VIRTCTL='virtctl-darwin'
+fi
+
+${KUBEVIRT_DIR}/_out/cmd/virtctl/${VIRTCTL} $CONFIG_ARGS "$@"

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -96,6 +96,9 @@ for arg in $args; do
             if [ "${BIN_NAME}" = "virtctl" ]; then
                 GOOS=darwin GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
                 GOOS=windows GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
+                # Create symlinks to the latest binary of each architecture
+                (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-darwin-amd64 ${BIN_NAME}-darwin)
+                (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-windows-amd64.exe ${BIN_NAME}-windows.exe)
             fi
         )
     else


### PR DESCRIPTION
In particular, call the Darwin executable if run in MacOS.

Signed-off-by: Ben Warren <bawarren@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some make targets call the **virtctl.sh** wrapper script, which really only works with Linux.  This fix makes the script work with MacOS as well.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
