### PR TITLE
Add a new 'external' provider

### DIFF
--- a/cluster/external/README.md
+++ b/cluster/external/README.md
@@ -1,0 +1,29 @@
+# External Kubernetes Provider
+
+This provider works with an existing, provisioned Kubernetes cluster.
+An external Docker registry is recommended for serving images.
+Unlike with other providers, lifecycles of the cluster and registry are not managed.
+The build machine should be a client of the cluster.
+
+## Verifying connectivity
+
+```bash
+export KUBEVIRT_PROVIDER=external
+export DOCKER_PREFIX=myregistry:5000/kubevirt
+export KUBECONFIG=mycluster.conf
+export IMAGE_PULL_POLICY=Always
+make cluster-up
+```
+
+## Building and pushing to the registry
+
+```bash
+make cluster-build
+```
+
+## Installing Kubevirt artifacts on the cluster
+
+```bash
+make cluster-sync
+```
+

--- a/cluster/external/provider.sh
+++ b/cluster/external/provider.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+function _kubectl() {
+    kubectl "$@"
+}
+
+function prepare_config() {
+    cat >hack/config-provider-external.sh <<EOF
+docker_tag=devel
+docker_prefix=${DOCKER_PREFIX}
+manifest_docker_prefix=${DOCKER_PREFIX}/kubevirt
+image_pull_policy=${IMAGE_PULL_POLICY:-Always}
+EOF
+}
+
+# The external cluster is assumed to be up.  Do a simple check
+function up() {
+    prepare_config
+    _kubectl version >/dev/null
+    if [ $? -ne 0 ]; then
+        echo -e "\n*** Unable to reach external cluster.  Please check configuration ***"
+        echo -e "*** Type \"kubectl config view\" for current settings               ***\n"
+        exit 1
+    fi
+    echo "Cluster is up"
+}
+
+function down() {
+    echo "Not supported by this provider"
+}
+
+function build() {
+    # Build code and manifests
+    ${KUBEVIRT_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-manifests.sh"
+    make push
+}

--- a/docs/env-providers.md
+++ b/docs/env-providers.md
@@ -47,6 +47,20 @@ export KUBEVIRT_PROVIDER=local # choose this provider
 make cluster-up
 ```
 
+## External
+
+Uses an existing (external) Kubernetes cluster.
+
+Requires:
+ * A working Kubernetes cluster with properly configured worker nodes.
+ * A running docker daemon
+
+Usage:
+
+```bash
+export KUBEVIRT_PROVIDER=external # choose this provider
+make cluster-up
+```
 ## New Providers
 
  * Create a `cluster/$KUBEVIRT_PROVIDER` directory


### PR DESCRIPTION
Trivial addition - this new provider is just an external, configured Kubernetes cluster.  Along with an external private Docker registry, this allows for a simple build/push/publish/test developer workflow.

Signed-off-by: Ben Warren <bawarren@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds a "provider" for developers who have access to an existing Kubernetes cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
