### PR TITLE
Fix Interface name validation

### DIFF
--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -577,7 +577,7 @@ var _ = Describe("Validating Webhook", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
 			Expect(len(causes)).To(Equal(0))
 		})
-		It("should accept interface lists with more than one element", func() {
+		It("should reject interface lists with more than one interface with the same name", func() {
 			vm := v1.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
 				*v1.DefaultNetworkInterface(),
@@ -585,17 +585,20 @@ var _ = Describe("Validating Webhook", func() {
 			vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
-			// if this is processed correctly, it should not result in any error
-			Expect(len(causes)).To(Equal(0))
+			// if this is processed correctly, it should result an error
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
 		})
 		It("should accept network lists with more than one element", func() {
 			vm := v1.NewMinimalVMI("testvm")
-			vm.Spec.Networks = []v1.Network{
-				*v1.DefaultPodNetwork(),
-				*v1.DefaultPodNetwork()}
+			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+				{Name: "default2", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+			vm.Spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+				{Name: "default2", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
-			// if this is processed correctly, it should not result in any error
-			Expect(len(causes)).To(Equal(0))
+			// if this is processed correctly, it should result an error only about duplicate pod network configuration
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Message).To(Equal("more than one interface is connected to a pod network in fake.interfaces"))
 		})
 
 		It("should accept valid interface models", func() {
@@ -821,8 +824,9 @@ var _ = Describe("Validating Webhook", func() {
 			}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].ports[0].name"))
+			Expect(len(causes)).To(Equal(2))
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
+			Expect(causes[1].Field).To(Equal("fake.domain.devices.interfaces[1].ports[0].name"))
 		})
 		It("should allow interface with two same ports and protocol", func() {
 			vm := v1.NewMinimalVMI("testvm")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reject non unique interface names by the virt-api webhook validation. 

**Special notes for your reviewer**:
Just open a new pull request because the force push disable the option to reopen my preview [PR](https://github.com/kubevirt/kubevirt/pull/1287)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix duplicate interface name.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1317)
<!-- Reviewable:end -->
