### PR TITLE
Use UID for Virtual Machine instace as the identifier 

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -296,7 +296,7 @@ func main() {
 	// Clients can use this service to tell virt-launcher
 	// to start/stop virtual machines
 	options := cmdserver.NewServerOptions(*useEmulation)
-	socketPath := cmdclient.SocketFromNamespaceName(*virtShareDir, *namespace, *name)
+	socketPath := cmdclient.SocketFromUID(*virtShareDir, *uid)
 	startCmdServer(socketPath, domainManager, stopChan, options)
 
 	watchdogFile := watchdog.WatchdogFileFromNamespaceName(*virtShareDir,

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -322,13 +322,13 @@ const (
 	// This label marks resources that belong to KubeVirt. An optional value
 	// may indicate which specific KubeVirt component a resource belongs to.
 	AppLabel string = "kubevirt.io"
-	// This label is used to match virtual machine instances represented as
-	// libvirt XML domains with their pods. Among other things, the label is
+	// This annotation is used to match virtual machine instances represented as
+	// libvirt XML domains with their pods. Among other things, the annotation is
 	// used to detect virtual machines with dead pods. Used on Pod.
-	DomainLabel string = "kubevirt.io/domain"
-	// This annotation is used to match virtual machine instance IDs with pods.
+	DomainAnnotation string = "kubevirt.io/domain"
+	// This label is used to match virtual machine instance IDs with pods.
 	// Similar to kubevirt.io/domain. Used on Pod.
-	CreatedByAnnotation string = "kubevirt.io/created-by"
+	CreatedByLabel string = "kubevirt.io/created-by"
 	// This annotation defines which KubeVirt component owns the resource. Used
 	// on Pod.
 	OwnedByAnnotation string = "kubevirt.io/owned-by"

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -150,9 +150,9 @@ func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, re
 	app.requestHandler(request, response, vmi, cmd)
 }
 
-func (app *SubresourceAPIApp) findPod(namespace string, name string) (string, error) {
+func (app *SubresourceAPIApp) findPod(namespace string, uid string) (string, error) {
 	fieldSelector := fields.ParseSelectorOrDie("status.phase==" + string(k8sv1.PodRunning))
-	labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel+"=virt-launcher,"+v1.DomainLabel+" in (%s)", name))
+	labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel + "=virt-launcher," + v1.CreatedByLabel + "=" + uid))
 	if err != nil {
 		return "", err
 	}
@@ -188,7 +188,7 @@ func (app *SubresourceAPIApp) remoteExecInfo(vmi *v1.VirtualMachineInstance) (st
 		return podName, http.StatusBadRequest, goerror.New(fmt.Sprintf("Unable to connect to VirtualMachineInstance because phase is %s instead of %s", vmi.Status.Phase, v1.Running))
 	}
 
-	podName, err := app.findPod(vmi.Namespace, vmi.Name)
+	podName, err := app.findPod(vmi.Namespace, string(vmi.UID))
 	if err != nil {
 		return podName, http.StatusBadRequest, fmt.Errorf("unable to find matching pod for remote execution: %v", err)
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -329,7 +329,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		podLabels[k] = v
 	}
 	podLabels[v1.AppLabel] = "virt-launcher"
-	podLabels[v1.DomainLabel] = domain
+	podLabels[v1.CreatedByLabel] = string(vmi.UID)
 
 	containers = append(containers, container)
 
@@ -355,8 +355,8 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			GenerateName: "virt-launcher-" + domain + "-",
 			Labels:       podLabels,
 			Annotations: map[string]string{
-				v1.CreatedByAnnotation: string(vmi.UID),
-				v1.OwnedByAnnotation:   "virt-controller",
+				v1.DomainAnnotation:  domain,
+				v1.OwnedByAnnotation: "virt-controller",
 			},
 		},
 		Spec: k8sv1.PodSpec{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -58,12 +58,12 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers)).To(Equal(2))
 				Expect(pod.Spec.Containers[0].Image).To(Equal("kubevirt/virt-launcher"))
 				Expect(pod.ObjectMeta.Labels).To(Equal(map[string]string{
-					v1.AppLabel:    "virt-launcher",
-					v1.DomainLabel: "testvmi",
+					v1.AppLabel:       "virt-launcher",
+					v1.CreatedByLabel: "1234",
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
-					v1.CreatedByAnnotation: "1234",
-					v1.OwnedByAnnotation:   "virt-controller",
+					v1.DomainAnnotation:  "testvmi",
+					v1.OwnedByAnnotation: "virt-controller",
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvmi-"))
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
@@ -105,8 +105,8 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers)).To(Equal(2))
 				Expect(pod.Spec.Containers[0].Image).To(Equal("kubevirt/virt-launcher"))
 				Expect(pod.ObjectMeta.Labels).To(Equal(map[string]string{
-					v1.AppLabel:    "virt-launcher",
-					v1.DomainLabel: "testvmi",
+					v1.AppLabel:       "virt-launcher",
+					v1.CreatedByLabel: "1234",
 				}))
 				Expect(pod.ObjectMeta.GenerateName).To(Equal("virt-launcher-testvmi-"))
 				Expect(pod.Spec.NodeSelector).To(Equal(map[string]string{
@@ -232,10 +232,10 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Labels).To(Equal(
 					map[string]string{
-						"key1":         "val1",
-						"key2":         "val2",
-						v1.AppLabel:    "virt-launcher",
-						v1.DomainLabel: "testvmi",
+						"key1":            "val1",
+						"key2":            "val2",
+						v1.AppLabel:       "virt-launcher",
+						v1.CreatedByLabel: "1234",
 					},
 				))
 			})

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -126,7 +127,7 @@ var _ = Describe("Node controller with", func() {
 			By("filtering out vmis which have a pod")
 			Expect(vmis).ToNot(ContainElement(vmiWithPod))
 
-			By("keeping vmis which are running und have no pod in their namespace")
+			By("keeping vmis which are running and have no pod in their namespace")
 			Expect(vmis).To(ContainElement(vmiWithoutPod))
 			Expect(vmis).To(ContainElement(vmiWithPodInDifferentNamespace))
 		})
@@ -339,7 +340,7 @@ func nowAsJSONWithOffset(offset time.Duration) string {
 
 func NewRunningVirtualMachine(vmiName string, node *k8sv1.Node) *virtv1.VirtualMachineInstance {
 	vmi := virtv1.NewMinimalVMI(vmiName)
-	vmi.UID = "1234"
+	vmi.UID = types.UID(uuid.NewRandom().String())
 	vmi.Status.Phase = virtv1.Running
 	vmi.Status.NodeName = node.Name
 	addInitializedAnnotation(vmi)
@@ -355,7 +356,7 @@ func NewHealthyPodForVirtualMachine(podName string, vmi *virtv1.VirtualMachineIn
 			Name:      podName,
 			Namespace: k8sv1.NamespaceDefault,
 			Labels: map[string]string{
-				virtv1.DomainLabel: vmi.Name,
+				virtv1.CreatedByLabel: string(vmi.UID),
 			},
 		},
 		Spec: k8sv1.PodSpec{NodeName: vmi.Status.NodeName}}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -560,13 +560,13 @@ func (c *VMIController) listPodsFromNamespace(namespace string) ([]*k8sv1.Pod, e
 }
 
 func (c *VMIController) filterMatchingPods(vmi *virtv1.VirtualMachineInstance, pods []*k8sv1.Pod) ([]*k8sv1.Pod, error) {
-	selector, err := v1.LabelSelectorAsSelector(&v1.LabelSelector{MatchLabels: map[string]string{virtv1.DomainLabel: vmi.Name, virtv1.AppLabel: "virt-launcher"}})
+	selector, err := v1.LabelSelectorAsSelector(&v1.LabelSelector{MatchLabels: map[string]string{virtv1.CreatedByLabel: string(vmi.UID), virtv1.AppLabel: "virt-launcher"}})
 	if err != nil {
 		return nil, err
 	}
 	matchingPods := []*k8sv1.Pod{}
 	for _, pod := range pods {
-		if selector.Matches(labels.Set(pod.ObjectMeta.Labels)) && pod.Annotations[virtv1.CreatedByAnnotation] == string(vmi.UID) {
+		if selector.Matches(labels.Set(pod.ObjectMeta.Labels)) {
 			matchingPods = append(matchingPods, pod)
 		}
 	}
@@ -592,8 +592,8 @@ func (c *VMIController) getControllerOf(pod *k8sv1.Pod) *v1.OwnerReference {
 	t := true
 	return &v1.OwnerReference{
 		Kind:               virtv1.VirtualMachineInstanceGroupVersionKind.Kind,
-		Name:               pod.Labels[virtv1.DomainLabel],
-		UID:                types.UID(pod.Annotations[virtv1.CreatedByAnnotation]),
+		Name:               pod.Annotations[virtv1.DomainAnnotation],
+		UID:                types.UID(pod.Labels[virtv1.CreatedByLabel]),
 		Controller:         &t,
 		BlockOwnerDeletion: &t,
 	}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -71,7 +71,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			update, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
 			Expect(update.GetObject().(*k8sv1.Pod).Annotations[v1.OwnedByAnnotation]).To(Equal("virt-controller"))
-			Expect(update.GetObject().(*k8sv1.Pod).Annotations[v1.CreatedByAnnotation]).To(Equal(string(uid)))
+			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.CreatedByLabel]).To(Equal(string(uid)))
 			return true, update.GetObject(), nil
 		})
 	}
@@ -288,7 +288,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				update, ok := action.(testing.CreateAction)
 				Expect(ok).To(BeTrue())
 				Expect(update.GetObject().(*k8sv1.Pod).Annotations[v1.OwnedByAnnotation]).To(Equal("virt-controller"))
-				Expect(update.GetObject().(*k8sv1.Pod).Annotations[v1.CreatedByAnnotation]).To(Equal(string(vmi.UID)))
+				Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.CreatedByLabel]).To(Equal(string(vmi.UID)))
 				return true, update.GetObject(), nil
 			})
 
@@ -627,12 +627,12 @@ func NewPodForVirtualMachine(vmi *v1.VirtualMachineInstance, phase k8sv1.PodPhas
 			Name:      "test",
 			Namespace: vmi.Namespace,
 			Labels: map[string]string{
-				v1.AppLabel:    "virt-launcher",
-				v1.DomainLabel: vmi.Name,
+				v1.AppLabel:       "virt-launcher",
+				v1.CreatedByLabel: string(vmi.UID),
 			},
 			Annotations: map[string]string{
-				v1.CreatedByAnnotation: string(vmi.UID),
-				v1.OwnedByAnnotation:   "virt-controller",
+				v1.DomainAnnotation:  vmi.Name,
+				v1.OwnedByAnnotation: "virt-controller",
 			},
 		},
 		Status: k8sv1.PodStatus{

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -26,13 +26,11 @@ package cmdclient
 */
 
 import (
-	goerror "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/rpc"
 	"path/filepath"
-	"strings"
 
 	"net"
 	"os"
@@ -95,21 +93,9 @@ func SocketsDirectory(baseDir string) string {
 	return filepath.Join(baseDir, "sockets")
 }
 
-func SocketFromNamespaceName(baseDir string, namespace string, name string) string {
-	sockFile := namespace + "_" + name + "_sock"
+func SocketFromUID(baseDir string, uid string) string {
+	sockFile := uid + "_sock"
 	return filepath.Join(SocketsDirectory(baseDir), sockFile)
-}
-
-func DomainFromSocketPath(socketPath string) (*api.Domain, error) {
-	splitName := strings.SplitN(filepath.Base(socketPath), "_", 3)
-	if len(splitName) != 3 {
-		return nil, goerror.New(fmt.Sprintf("malformed domain socket %s", socketPath))
-	}
-	namespace := splitName[0]
-	name := splitName[1]
-	domain := api.NewDomainReferenceFromName(namespace, name)
-
-	return domain, nil
 }
 
 func GetClient(socketPath string) (LauncherClient, error) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -475,9 +475,7 @@ func (d *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineIns
 	d.launcherClientLock.Lock()
 	defer d.launcherClientLock.Unlock()
 
-	namespace := vmi.ObjectMeta.Namespace
-	name := vmi.ObjectMeta.Name
-	sockFile := cmdclient.SocketFromNamespaceName(d.virtShareDir, namespace, name)
+	sockFile := cmdclient.SocketFromUID(d.virtShareDir, string(vmi.GetUID()))
 
 	client, ok := d.launcherClients[sockFile]
 	if ok == false {
@@ -506,9 +504,7 @@ func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInsta
 	d.launcherClientLock.Lock()
 	defer d.launcherClientLock.Unlock()
 
-	namespace := vmi.ObjectMeta.Namespace
-	name := vmi.ObjectMeta.Name
-	sockFile := cmdclient.SocketFromNamespaceName(d.virtShareDir, namespace, name)
+	sockFile := cmdclient.SocketFromUID(d.virtShareDir, string(vmi.GetUID()))
 
 	client, ok := d.launcherClients[sockFile]
 	if ok {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -108,7 +108,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		)
 
 		client = cmdclient.NewMockLauncherClient(ctrl)
-		sockFile := cmdclient.SocketFromNamespaceName(shareDir, "default", "testvmi")
+		sockFile := cmdclient.SocketFromUID(shareDir, "")
 		controller.addLauncherClient(client, sockFile)
 
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -646,6 +646,16 @@ func DeletePV(os string) {
 	}
 }
 
+func GetRunningPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace string) *k8sv1.Pod {
+	virtCli, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	vmi, err = virtCli.VirtualMachineInstance(namespace).Get(vmi.Name, &metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
+	return GetRunningPodByLabel(string(vmi.GetUID()), v1.CreatedByLabel, namespace)
+}
+
 func GetRunningPodByLabel(label string, labelType string, namespace string) *k8sv1.Pod {
 	virtCli, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
@@ -779,7 +789,7 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 }
 
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
-	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi"+rand.String(5))
+	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi"+rand.String(63))
 
 	t := defaultTestGracePeriod
 	vmi.Spec.TerminationGracePeriodSeconds = &t
@@ -1488,10 +1498,16 @@ func NotDeleted(vmis *v1.VirtualMachineInstanceList) (notDeleted []v1.VirtualMac
 }
 
 func UnfinishedVMIPodSelector(vmi *v1.VirtualMachineInstance) metav1.ListOptions {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+
 	fieldSelector := fields.ParseSelectorOrDie(
 		"status.phase!=" + string(k8sv1.PodFailed) +
 			",status.phase!=" + string(k8sv1.PodSucceeded))
-	labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel+"=virt-launcher,"+v1.DomainLabel+" in (%s)", vmi.GetName()))
+	labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel + "=virt-launcher," + v1.CreatedByLabel + "=" + string(vmi.GetUID())))
 	if err != nil {
 		panic(err)
 	}

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -40,6 +40,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virtctl/vm"
 	"kubevirt.io/kubevirt/tests"
 )
@@ -517,7 +518,7 @@ func NewRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.V
 			Running: running,
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: v12.ObjectMeta{
-					Labels:    map[string]string{"name": name},
+					Labels:    map[string]string{"name": dns.SanitizeHostname(vmi)},
 					Name:      name,
 					Namespace: namespace,
 				},

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Configurations", func() {
 				By("Checking the requested amount of memory allocated for a guest")
 				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("64M"))
 
-				readyPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
+				readyPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
 				var computeContainer *kubev1.Container
 				for _, container := range readyPod.Spec.Containers {
 					println(container.Name)

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -127,8 +127,8 @@ func getVmDomainXml(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstan
 
 func getVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
-	domain := vmi.GetObjectMeta().GetName()
-	labelSelector := fmt.Sprintf("kubevirt.io/domain in (%s)", domain)
+	uid := vmi.GetObjectMeta().GetUID()
+	labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
 
 	pods, err := virtCli.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: labelSelector})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -416,7 +416,7 @@ var _ = Describe("VMIlifecycle", func() {
 
 				// Delete vmi pod
 				pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(metav1.ListOptions{
-					LabelSelector: v1.DomainLabel + " = " + vmi.Name,
+					LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pods.Items).To(HaveLen(1))
@@ -1071,9 +1071,9 @@ func renderPkillAllJob(processName string) *k8sv1.Pod {
 
 func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	namespace := vmi.GetObjectMeta().GetNamespace()
-	domain := vmi.GetObjectMeta().GetName()
+	uid := vmi.GetObjectMeta().GetUID()
 
-	labelSelector := fmt.Sprintf("kubevirt.io/domain in (%s)", domain)
+	labelSelector := fmt.Sprintf(v1.CreatedByLabel + "=" + string(uid))
 
 	pods, err := virtCli.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: labelSelector})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Networking", func() {
 		}
 
 		By("checking br1 MTU inside the pod")
-		vmiPod := tests.GetRunningPodByLabel(outboundVMI.Name, v1.DomainLabel, tests.NamespaceTestDefault)
+		vmiPod := tests.GetRunningPodByVirtualMachineInstance(outboundVMI, tests.NamespaceTestDefault)
 		output, err := tests.ExecuteCommandOnPod(
 			virtClient,
 			vmiPod,

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Slirp", func() {
 	table.DescribeTable("should be able to", func(vmiRef **v1.VirtualMachineInstance) {
 		By("have containerPort in the pod manifest")
 		vmi := *vmiRef
-		vmiPod := tests.GetRunningPodByLabel(vmi.Name, v1.DomainLabel, tests.NamespaceTestDefault)
+		vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
 		for _, containerSpec := range vmiPod.Spec.Containers {
 			if containerSpec.Name == "compute" {
 				container = containerSpec

--- a/tests/vmi_userdata_test.go
+++ b/tests/vmi_userdata_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
 
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -152,7 +154,7 @@ var _ = Describe("CloudInit UserData", func() {
 
 				res, err := expecter.ExpectBatch([]expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
-					&expect.BExp{R: vmi.Name},
+					&expect.BExp{R: dns.SanitizeHostname(vmi)},
 				}, time.Second*10)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -170,7 +172,7 @@ var _ = Describe("CloudInit UserData", func() {
 				}
 				idx = i
 
-				secretID := fmt.Sprintf("%s-test-secret", vmi.Name)
+				secretID := fmt.Sprintf("%s-test-secret", uuid.NewRandom().String())
 				spec := volume.CloudInitNoCloud
 				spec.UserDataSecretRef = &kubev1.LocalObjectReference{Name: secretID}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Change Virtual Machine Instance Identifier from VM name to VM UID.
Now instead of using the VM name in a label that acts as an identifier, the VM uid will be kept in a label and the vm name (domain) will be kept under an annotation : 
```
	CreatedByLabel       string = "kubevirt.io/created-by"
	DomainAnnotation     string = "kubevirt.io/domain"
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #1222, fixes #1223  

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
