### PR TITLE
virtctl console wait until the virtual machine is in running state

### DIFF
--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -684,15 +684,15 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) Patch(arg0, arg1, arg2 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) SerialConsole(name string) (StreamInterface, error) {
-	ret := _m.ctrl.Call(_m, "SerialConsole", name)
+func (_m *MockVirtualMachineInstanceInterface) SerialConsole(name string, timeout int) (StreamInterface, error) {
+	ret := _m.ctrl.Call(_m, "SerialConsole", name, timeout)
 	ret0, _ := ret[0].(StreamInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) SerialConsole(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SerialConsole", arg0)
+func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) SerialConsole(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SerialConsole", arg0, arg1)
 }
 
 func (_m *MockVirtualMachineInstanceInterface) VNC(name string) (StreamInterface, error) {

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -4,6 +4,8 @@
 package kubecli
 
 import (
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -684,7 +686,7 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) Patch(arg0, arg1, arg2 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) SerialConsole(name string, timeout int) (StreamInterface, error) {
+func (_m *MockVirtualMachineInstanceInterface) SerialConsole(name string, timeout time.Duration) (StreamInterface, error) {
 	ret := _m.ctrl.Call(_m, "SerialConsole", name, timeout)
 	ret0, _ := ret[0].(StreamInterface)
 	ret1, _ := ret[1].(error)

--- a/pkg/kubecli/kubecli.go
+++ b/pkg/kubecli/kubecli.go
@@ -1,4 +1,4 @@
-/*
+	/*
  * This file is part of the KubeVirt project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/kubecli/kubecli.go
+++ b/pkg/kubecli/kubecli.go
@@ -1,4 +1,4 @@
-	/*
+/*
  * This file is part of the KubeVirt project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -74,7 +74,7 @@ type VirtualMachineInstanceInterface interface {
 	Update(*v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstance, err error)
-	SerialConsole(name string) (StreamInterface, error)
+	SerialConsole(name string, timeout int) (StreamInterface, error)
 	VNC(name string) (StreamInterface, error)
 }
 

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -27,6 +27,7 @@ package kubecli
 
 import (
 	"io"
+	"time"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -74,7 +75,7 @@ type VirtualMachineInstanceInterface interface {
 	Update(*v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstance, err error)
-	SerialConsole(name string, timeout int) (StreamInterface, error)
+	SerialConsole(name string, timeout time.Duration) (StreamInterface, error)
 	VNC(name string) (StreamInterface, error)
 }
 

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"time"
 
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -97,7 +98,7 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 	signal.Notify(waitInterrupt, os.Interrupt)
 
 	go func() {
-		con, err := virtCli.VirtualMachineInstance(namespace).SerialConsole(vmi, timeout)
+		con, err := virtCli.VirtualMachineInstance(namespace).SerialConsole(vmi, time.Duration(timeout)*time.Minute)
 		runningChan <- err
 
 		if err != nil {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -98,6 +98,15 @@ var _ = Describe("Console", func() {
 					Expect(err).ToNot(HaveOccurred())
 				}
 			}, 220)
+			It("should wait until the virtual machine is in running state and return a stream interface", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
+
+				By("Creating a new VirtualMachineInstance")
+				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
+
+				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name)
+				Expect(err).ToNot(HaveOccurred())
+			}, 220)
 		})
 	})
 })

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -47,7 +47,6 @@ var _ = Describe("Console", func() {
 
 		By("Creating a new VirtualMachineInstance")
 		Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
-		tests.WaitForSuccessfulVMIStart(vmi)
 
 		By("Expecting the VirtualMachineInstance console")
 		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
@@ -88,7 +87,6 @@ var _ = Describe("Console", func() {
 
 				By("Creating a new VirtualMachineInstance")
 				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
-				tests.WaitForSuccessfulVMIStart(vmi)
 
 				for i := 0; i < 5; i++ {
 					By("Checking that the console output equals to expected one")

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Console", func() {
 			}, 220)
 			It("should fail waiting for the virtual machine instance to be running", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
-				vmi.Spec.Affinity = &v1.Affinity{
+				vmi.Spec.Affinity = &k8sv1.Affinity{
 					NodeAffinity: &k8sv1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
 							NodeSelectorTerms: []k8sv1.NodeSelectorTerm{

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Console", func() {
 		Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
 
 		By("Expecting the VirtualMachineInstance console")
-		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		defer expecter.Close()
 
@@ -105,7 +105,7 @@ var _ = Describe("Console", func() {
 				By("Creating a new VirtualMachineInstance")
 				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
 
-				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, 2)
+				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, 30*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			}, 220)
 			It("should fail waiting for the virtual machine instance to be running", func() {
@@ -127,8 +127,33 @@ var _ = Describe("Console", func() {
 				By("Creating a new VirtualMachineInstance")
 				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
 
-				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, 1)
+				_, err := virtClient.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, 30*time.Second)
 				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
+			}, 180)
+			It("should fail waiting for the expecter", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
+				vmi.Spec.Affinity = &k8sv1.Affinity{
+					NodeAffinity: &k8sv1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+							NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+								{
+									MatchExpressions: []k8sv1.NodeSelectorRequirement{
+										{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{"notexist"}},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				By("Creating a new VirtualMachineInstance")
+				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
+
+				By("Expecting the VirtualMachineInstance console")
+				_, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
 			}, 180)
 		})
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1130,7 +1130,7 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	expecterReader, expecterWriter := io.Pipe()
 	resCh := make(chan error)
 	go func() {
-		con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name)
+		con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, int(timeout))
 		if err != nil {
 			resCh <- err
 			return

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
@@ -1132,20 +1131,9 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	resCh := make(chan error)
 	go func() {
 		con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name)
-		for err != nil {
-			if asyncSubresourceError, ok := err.(*kubecli.AsyncSubresourceError); ok {
-				if asyncSubresourceError.GetStatusCode() == http.StatusBadRequest {
-					// Sleep to prevent denial of service on the api server
-					time.Sleep(500 * time.Millisecond)
-					con, err = virtCli.VirtualMachineInstance(vmi.ObjectMeta.Namespace).SerialConsole(vmi.Name)
-				} else {
-					resCh <- asyncSubresourceError
-					return
-				}
-			} else {
-				resCh <- err
-				return
-			}
+		if err != nil {
+			resCh <- err
+			return
 		}
 
 		resCh <- con.Stream(kubecli.StreamOptions{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1129,13 +1129,15 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	vmiReader, vmiWriter := io.Pipe()
 	expecterReader, expecterWriter := io.Pipe()
 	resCh := make(chan error)
-	go func() {
-		con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, int(timeout))
-		if err != nil {
-			resCh <- err
-			return
-		}
 
+	startTime := time.Now()
+	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, timeout)
+	if err != nil {
+		return nil, nil, err
+	}
+	timeout = timeout - time.Now().Sub(startTime)
+
+	go func() {
 		resCh <- con.Stream(kubecli.StreamOptions{
 			In:  vmiReader,
 			Out: expecterWriter,
@@ -1179,7 +1181,7 @@ func RegistryDiskFor(name RegistryDisk) string {
 func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
virtctl console wait until the virtual machine is in running state

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1001 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl console wait until the virtual machine is in running state
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1323)
<!-- Reviewable:end -->
