### PR TITLE
Support disconnected instances

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3440,6 +3440,10 @@
    "v1.DeletionPropagation": {},
    "v1.Devices": {
     "properties": {
+     "autoattachPodInterface": {
+      "description": "Whether to attach a pod network interface. Defaults to true.",
+      "type": "boolean"
+     },
      "disks": {
       "description": "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
       "type": "array",

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -58,6 +58,8 @@ spec:
                               type: string
                         devices:
                           properties:
+                            autoattachPodInterface:
+                              type: boolean
                             disks:
                               items:
                                 properties:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -51,6 +51,8 @@ spec:
                       type: string
                 devices:
                   properties:
+                    autoattachPodInterface:
+                      type: boolean
                     disks:
                       items:
                         properties:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -46,6 +46,8 @@ spec:
                       type: string
                 devices:
                   properties:
+                    autoattachPodInterface:
+                      type: boolean
                     disks:
                       items:
                         properties:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -62,6 +62,8 @@ spec:
                               type: string
                         devices:
                           properties:
+                            autoattachPodInterface:
+                              type: boolean
                             disks:
                               items:
                                 properties:

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -246,6 +246,15 @@ func (in *Devices) DeepCopyInto(out *Devices) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AutoattachPodInterface != nil {
+		in, out := &in.AutoattachPodInterface, &out.AutoattachPodInterface
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -153,6 +153,11 @@ func setDefaults_DiskFromMachineType(obj *VirtualMachineInstance) {
 }
 
 func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
+	autoAttach := obj.Spec.Domain.Devices.AutoattachPodInterface
+	if autoAttach != nil && *autoAttach == false {
+		return
+	}
+
 	// Override only when nothing is specified
 	if len(obj.Spec.Networks) == 0 {
 		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultNetworkInterface()}

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -272,4 +272,26 @@ var _ = Describe("Function SetDefaults_NetworkInterface()", func() {
 		Expect(vmi.Spec.Networks[0].Name).To(Equal("testnet"))
 		Expect(vmi.Spec.Networks[0].Pod).To(BeNil())
 	})
+
+	It("should not append pod interface if it's explicitly disabled", func() {
+		autoAttach := false
+		vmi := &VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
+
+		SetDefaults_NetworkInterface(vmi)
+		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(0))
+		Expect(len(vmi.Spec.Networks)).To(Equal(0))
+	})
+
+	It("should append pod interface if auto attach is true", func() {
+		autoAttach := true
+		vmi := &VirtualMachineInstance{}
+		vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
+		SetDefaults_NetworkInterface(vmi)
+		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).To(Equal(1))
+		Expect(vmi.Spec.Domain.Devices.Interfaces[0].Name).To(Equal("default"))
+		Expect(vmi.Spec.Networks[0].Name).To(Equal("default"))
+		Expect(vmi.Spec.Networks[0].Pod).ToNot(BeNil())
+	})
+
 })

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -242,6 +242,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"autoattachPodInterface": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Whether to attach a pod network interface. Defaults to true.",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -170,6 +170,8 @@ type Devices struct {
 	Watchdog *Watchdog `json:"watchdog,omitempty"`
 	// Interfaces describe network interfaces which are added to the vm.
 	Interfaces []Interface `json:"interfaces,omitempty"`
+	// Whether to attach a pod network interface. Defaults to true.
+	AutoattachPodInterface *bool `json:"autoattachPodInterface,omitempty"`
 }
 
 // ---

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -80,9 +80,10 @@ func (Firmware) SwaggerDoc() map[string]string {
 
 func (Devices) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"disks":      "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
-		"watchdog":   "Watchdog describes a watchdog device which can be added to the vmi.",
-		"interfaces": "Interfaces describe network interfaces which are added to the vm.",
+		"disks":                  "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
+		"watchdog":               "Watchdog describes a watchdog device which can be added to the vmi.",
+		"interfaces":             "Interfaces describe network interfaces which are added to the vm.",
+		"autoattachPodInterface": "Whether to attach a pod network interface. Defaults to true.",
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -50,10 +50,6 @@ func SetupNetworkInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain) 
 		networks[network.Name] = network.DeepCopy()
 	}
 
-	if len(networks) == 0 {
-		return fmt.Errorf("no networks were specified on a vm spec")
-	}
-
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 
 		network, ok := networks[iface.Name]

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -55,5 +55,12 @@ var _ = Describe("Network", func() {
 			err := SetupNetworkInterfaces(vm, domain)
 			Expect(err).To(BeNil())
 		})
+
+		It("should accept empty network list", func() {
+			vmi := newVMI("testnamespace", "testVmName")
+			domain := &api.Domain{}
+			err := SetupNetworkInterfaces(vmi, domain)
+			Expect(err).To(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: adds support for network isolated instances.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #1067.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for autoAttachPodInterface field in devices section to disable automatic attacment of a pod network interface to an instance.
```
