### PR TITLE
Use git clone to fetch shfmt intead of go get

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -19,9 +19,10 @@ RUN \
     go get github.com/mattn/goveralls && \
     go get -u github.com/Masterminds/glide && \
     go get golang.org/x/tools/cmd/goimports && \
-    go get -u mvdan.cc/sh/cmd/shfmt && \
+    git clone https://github.com/mvdan/sh.git $GOPATH/src/mvdan.cc/sh && \
     cd /go/src/mvdan.cc/sh/cmd/shfmt && \
-    git checkout v2.3.0 && \
+    git checkout v2.5.0 && \
+    go get mvdan.cc/sh/cmd/shfmt && \
     go install && \
     go get -u github.com/golang/mock/gomock && \
     go get -u github.com/rmohr/mock/mockgen && \


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There is an import issue on latest shfmt master branch which prevents
downloading shfmt  via `go get`. Clone shfmt instead of using `go get`.

Issue is reported here: https://github.com/mvdan/sh/issues/267

Fixes failing travis builds because the dockerized builder can't be built.

```release-note
NONE
```
