### PR TITLE
Add possibility to use CPU passthrough for VM's

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3354,7 +3354,7 @@
       "type": "integer"
      },
      "model": {
-      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
+      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"passthrough\" to get the same CPU as the node.\n+optional",
       "type": "string"
      }
     }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3354,7 +3354,7 @@
       "type": "integer"
      },
      "model": {
-      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"passthrough\" to get the same CPU as the node.\n+optional",
+      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nYou can find more information under https://libvirt.org/formatdomain.html#elementsCPU.\nDefaults to host-model.\n+optional",
       "type": "string"
      }
     }

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -71,7 +71,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"model": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml. You also can specify special cases like \"passthrough\" to get the same CPU as the node.",
+								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml. You also can specify special cases like \"host-passthrough\" to get the same CPU as the node and \"host-model\" to get CPU closest to the node one. You can find more information under https://libvirt.org/formatdomain.html#elementsCPU. Defaults to host-model.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -71,7 +71,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"model": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.",
+								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml. You also can specify special cases like \"passthrough\" to get the same CPU as the node.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -125,7 +125,10 @@ type CPU struct {
 	Cores uint32 `json:"cores,omitempty"`
 	// Model specifies the CPU model inside the VMI.
 	// List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.
-	// You also can specify special cases like "passthrough" to get the same CPU as the node.
+	// You also can specify special cases like "host-passthrough" to get the same CPU as the node
+	// and "host-model" to get CPU closest to the node one.
+	// You can find more information under https://libvirt.org/formatdomain.html#elementsCPU.
+	// Defaults to host-model.
 	// +optional
 	Model string `json:"model,omitempty"`
 }

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -125,6 +125,7 @@ type CPU struct {
 	Cores uint32 `json:"cores,omitempty"`
 	// Model specifies the CPU model inside the VMI.
 	// List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.
+	// You also can specify special cases like "passthrough" to get the same CPU as the node.
 	// +optional
 	Model string `json:"model,omitempty"`
 }

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -48,7 +48,7 @@ func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":      "CPU allows specifying the CPU topology.",
 		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
-		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
+		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"passthrough\" to get the same CPU as the node.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -48,7 +48,7 @@ func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":      "CPU allows specifying the CPU topology.",
 		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
-		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"passthrough\" to get the same CPU as the node.\n+optional",
+		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nYou can find more information under https://libvirt.org/formatdomain.html#elementsCPU.\nDefaults to host-model.\n+optional",
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -44,6 +44,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
+const (
+	CPUModeHostPassthrough = "host-passthrough"
+	CPUModeHostModel       = "host-model"
+)
+
 type ConverterContext struct {
 	UseEmulation   bool
 	Secrets        map[string]*k8sv1.Secret
@@ -461,8 +466,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 
 		// Set VM CPU model and vendor
 		if vmi.Spec.Domain.CPU.Model != "" {
-			if vmi.Spec.Domain.CPU.Model == "passthrough" {
-				domain.Spec.CPU.Mode = "host-passthrough"
+			if vmi.Spec.Domain.CPU.Model == CPUModeHostModel || vmi.Spec.Domain.CPU.Model == CPUModeHostPassthrough {
+				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
 			} else {
 				domain.Spec.CPU.Mode = "custom"
 				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
@@ -471,7 +476,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	}
 
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		domain.Spec.CPU.Mode = "host-model"
+		domain.Spec.CPU.Mode = CPUModeHostModel
 	}
 
 	// Add mandatory console device

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -461,8 +461,12 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 
 		// Set VM CPU model and vendor
 		if vmi.Spec.Domain.CPU.Model != "" {
-			domain.Spec.CPU.Mode = "custom"
-			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+			if vmi.Spec.Domain.CPU.Model == "passthrough" {
+				domain.Spec.CPU.Mode = "host-passthrough"
+			} else {
+				domain.Spec.CPU.Mode = "custom"
+				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+			}
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/onsi/ginkgo/extensions/table"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -464,16 +466,19 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
 		})
 
-		It("should convert CPU model passthrough", func() {
+		table.DescribeTable("should convert CPU model", func(model string) {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.CPU = &v1.CPU{
 				Cores: 3,
-				Model: "passthrough",
+				Model: model,
 			}
 			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
 
-			Expect(domainSpec.CPU.Mode).To(Equal("host-passthrough"))
-		})
+			Expect(domainSpec.CPU.Mode).To(Equal(model))
+		},
+			table.Entry(CPUModeHostPassthrough, CPUModeHostPassthrough),
+			table.Entry(CPUModeHostModel, CPUModeHostModel),
+		)
 
 		Context("when CPU spec defined and model not", func() {
 			It("should set host-model CPU mode", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -464,6 +464,17 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
 		})
 
+		It("should convert CPU model passthrough", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores: 3,
+				Model: "passthrough",
+			}
+			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+			Expect(domainSpec.CPU.Mode).To(Equal("host-passthrough"))
+		})
+
 		Context("when CPU spec defined and model not", func() {
 			It("should set host-model CPU mode", func() {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1527,13 +1527,11 @@ func SkipIfVersionBelow(message string, expectedVersion string) {
 	}
 }
 
-// GetNodeLibvirtCapabilities returns node libvirt capabilities
-func GetNodeLibvirtCapabilities(nodeName string) string {
+// StartVmOnNode will start a VMI on the specified node
+func StartVmOnNode(vmi *v1.VirtualMachineInstance, nodeName string) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 
-	// Create a virt-launcher pod, that can fetch virsh capabilities
-	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(RegistryDiskFor(RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
 	vmi.Spec.Affinity = &k8sv1.Affinity{
 		NodeAffinity: &k8sv1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
@@ -1551,6 +1549,12 @@ func GetNodeLibvirtCapabilities(nodeName string) string {
 	_, err = virtClient.VirtualMachineInstance(NamespaceTestDefault).Create(vmi)
 	Expect(err).ToNot(HaveOccurred())
 	WaitForSuccessfulVMIStart(vmi)
+}
+
+// RunCommandOnVmiPod will run specified command on the virt-launcher pod
+func RunCommandOnVmiPod(vmi *v1.VirtualMachineInstance, command []string) string {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
 
 	pods, err := virtClient.CoreV1().Pods(NamespaceTestDefault).List(UnfinishedVMIPodSelector(vmi))
 	Expect(err).ToNot(HaveOccurred())
@@ -1561,11 +1565,28 @@ func GetNodeLibvirtCapabilities(nodeName string) string {
 		virtClient,
 		&vmiPod,
 		"compute",
-		[]string{"virsh", "-r", "capabilities"},
+		command,
 	)
 	Expect(err).ToNot(HaveOccurred())
 
 	return output
+}
+
+// GetNodeLibvirtCapabilities returns node libvirt capabilities
+func GetNodeLibvirtCapabilities(nodeName string) string {
+	// Create a virt-launcher pod, that can fetch virsh capabilities
+	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(RegistryDiskFor(RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+	StartVmOnNode(vmi, nodeName)
+
+	return RunCommandOnVmiPod(vmi, []string{"virsh", "-r", "capabilities"})
+}
+
+// GetNodeCPUInfo returns output of lscpu on the pod that runs on the specified node
+func GetNodeCPUInfo(nodeName string) string {
+	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(RegistryDiskFor(RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+	StartVmOnNode(vmi, nodeName)
+
+	return RunCommandOnVmiPod(vmi, []string{"lscpu"})
 }
 
 // KubevirtFailHandler call ginkgo.Fail with printing the additional information

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Configurations", func() {
 		Context("when CPU model equals to passthrough", func() {
 			It("should report exactly the same model as node CPU", func() {
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
-					Model: "passthrough",
+					Model: "host-passthrough",
 				}
 
 				By("Starting a VirtualMachineInstance")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -236,11 +236,13 @@ var _ = Describe("Configurations", func() {
 	})
 
 	Context("with CPU spec", func() {
-		cpuRegexp := regexp.MustCompile(`<model>(\w+)\-*\w*</model>`)
-		vendorRegexp := regexp.MustCompile(`<vendor>(\w+)</vendor>`)
+		libvirtCPUModelRegexp := regexp.MustCompile(`<model>(\w+)\-*\w*</model>`)
+		libvirtCPUVendorRegexp := regexp.MustCompile(`<vendor>(\w+)</vendor>`)
+		cpuModelNameRegexp := regexp.MustCompile(`Model name:\s*([\s\w\-@\.\(\)]+)`)
 
-		var cpuModel string
-		var cpuVendor string
+		var libvirtCpuModel string
+		var libvirtCpuVendor string
+		var cpuModelName string
 		var cpuVmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
@@ -250,13 +252,18 @@ var _ = Describe("Configurations", func() {
 
 			virshCaps := tests.GetNodeLibvirtCapabilities(nodes.Items[0].Name)
 
-			model := cpuRegexp.FindStringSubmatch(virshCaps)
+			model := libvirtCPUModelRegexp.FindStringSubmatch(virshCaps)
 			Expect(len(model)).To(Equal(2))
-			cpuModel = model[1]
+			libvirtCpuModel = model[1]
 
-			vendor := vendorRegexp.FindStringSubmatch(virshCaps)
+			vendor := libvirtCPUVendorRegexp.FindStringSubmatch(virshCaps)
 			Expect(len(vendor)).To(Equal(2))
-			cpuVendor = vendor[1]
+			libvirtCpuVendor = vendor[1]
+
+			cpuInfo := tests.GetNodeCPUInfo(nodes.Items[0].Name)
+			modelName := cpuModelNameRegexp.FindStringSubmatch(cpuInfo)
+			Expect(len(modelName)).To(Equal(2))
+			cpuModelName = modelName[1]
 
 			cpuVmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			cpuVmi.Spec.Affinity = &kubev1.Affinity{
@@ -277,7 +284,7 @@ var _ = Describe("Configurations", func() {
 		Context("when CPU model defined", func() {
 			It("should report defined CPU model", func() {
 				vmiModel := "Conroe"
-				if cpuVendor == "AMD" {
+				if libvirtCpuVendor == "AMD" {
 					vmiModel = "Opteron_G1"
 				}
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
@@ -302,6 +309,30 @@ var _ = Describe("Configurations", func() {
 			})
 		})
 
+		Context("when CPU model equals to passthrough", func() {
+			It("should report exactly the same model as node CPU", func() {
+				cpuVmi.Spec.Domain.CPU = &v1.CPU{
+					Model: "passthrough",
+				}
+
+				By("Starting a VirtualMachineInstance")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(cpuVmi)
+
+				By("Expecting the VirtualMachineInstance console")
+				expecter, err := tests.LoggedInCirrosExpecter(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				By("Checking the CPU model under the guest OS")
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", cpuModelName)},
+					&expect.BExp{R: "model name"},
+				}, 10*time.Second)
+			})
+		})
+
 		Context("when CPU model not defined", func() {
 			It("should report CPU model from libvirt capabilities", func() {
 				By("Starting a VirtualMachineInstance")
@@ -316,7 +347,7 @@ var _ = Describe("Configurations", func() {
 
 				By("Checking the CPU model under the guest OS")
 				_, err = expecter.ExpectBatch([]expect.Batcher{
-					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", cpuModel)},
+					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", libvirtCpuModel)},
 					&expect.BExp{R: "model name"},
 				}, 10*time.Second)
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
You can specify `passthrough` as the CPU model and it will
automatically passthrough CPU model from the node to the VM.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1340 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add the possibility to pass-through the node CPU to the VM
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>