### PR TITLE
Device order

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -131,7 +131,7 @@ func (c *DeviceController) Run(stop chan struct{}) error {
 	logger.Info("Starting device plugin controller")
 
 	for _, dev := range c.devicePlugins {
-		c.startDevicePlugin(dev, stop)
+		go c.startDevicePlugin(dev, stop)
 	}
 
 	<-stop

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -37,14 +37,14 @@ const (
 )
 
 type DeviceController struct {
-	devicePlugins []*GenericDevicePlugin
+	devicePlugins []GenericDevice
 	host          string
 	maxDevices    int
 }
 
 func NewDeviceController(host string, maxDevices int) *DeviceController {
 	return &DeviceController{
-		devicePlugins: []*GenericDevicePlugin{
+		devicePlugins: []GenericDevice{
 			NewGenericDevicePlugin(KVMName, KVMPath, maxDevices),
 			NewGenericDevicePlugin(TunName, TunPath, maxDevices),
 		},
@@ -105,24 +105,26 @@ func (c *DeviceController) waitForPath(target string, stop chan struct{}) error 
 	}
 }
 
-func (c *DeviceController) startDevicePlugin(dev *GenericDevicePlugin, stop chan struct{}) error {
+func (c *DeviceController) startDevicePlugin(dev GenericDevice, stop chan struct{}) error {
 	logger := log.DefaultLogger()
-	if !c.nodeHasDevice(dev.devicePath) {
-		logger.Infof("%s device not found. Waiting.", dev.deviceName)
-		err := c.waitForPath(dev.devicePath, stop)
+	devicePath := dev.GetDevicePath()
+	deviceName := dev.GetDeviceName()
+	if !c.nodeHasDevice(devicePath) {
+		logger.Infof("%s device not found. Waiting.", deviceName)
+		err := c.waitForPath(devicePath, stop)
 		if err != nil {
-			logger.Errorf("error waiting for %s device: %v", dev.deviceName, err)
+			logger.Errorf("error waiting for %s device: %v", deviceName, err)
 			return err
 		}
 	}
 
 	err := dev.Start(stop)
 	if err != nil {
-		logger.Errorf("Error starting %s device plugin: %v", dev.deviceName, err)
+		logger.Errorf("Error starting %s device plugin: %v", deviceName, err)
 		return err
 	}
 
-	logger.Infof("%s device plugin started", dev.deviceName)
+	logger.Infof("%s device plugin started", deviceName)
 	return nil
 }
 

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -12,6 +12,34 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+type FakePlugin struct {
+	started    chan struct{}
+	devicePath string
+	deviceName string
+}
+
+func (fp *FakePlugin) Start(stop chan struct{}) error {
+	//fp.started <- struct{}{}
+	close(fp.started)
+	return nil
+}
+
+func (fp *FakePlugin) GetDevicePath() string {
+	return fp.devicePath
+}
+
+func (fp *FakePlugin) GetDeviceName() string {
+	return fp.deviceName
+}
+
+func NewFakePlugin(name string, path string) *FakePlugin {
+	return &FakePlugin{
+		deviceName: name,
+		devicePath: path,
+		started:    make(chan struct{}),
+	}
+}
+
 var _ = Describe("Device Controller", func() {
 	var workDir string
 	var err error
@@ -19,20 +47,20 @@ var _ = Describe("Device Controller", func() {
 	var deviceController *DeviceController
 	var stop chan struct{}
 
+	BeforeEach(func() {
+		workDir, err = ioutil.TempDir("", "kubevirt-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		host = "master"
+		stop = make(chan struct{})
+	})
+
+	AfterEach(func() {
+		close(stop)
+		os.RemoveAll(workDir)
+	})
+
 	Context("Basic Tests", func() {
-		BeforeEach(func() {
-			workDir, err = ioutil.TempDir("", "kubevirt-test")
-			Expect(err).ToNot(HaveOccurred())
-
-			host = "master"
-			stop = make(chan struct{})
-		})
-
-		AfterEach(func() {
-			close(stop)
-			os.RemoveAll(workDir)
-		})
-
 		It("Should indicate if node has device", func() {
 			deviceController = NewDeviceController(host, 10)
 			devicePath := path.Join(workDir, "fake-device")
@@ -82,6 +110,77 @@ var _ = Describe("Device Controller", func() {
 
 			err = deviceController.waitForPath(devicePath, timeout)
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("Multiple Plugins", func() {
+		var devicePath1 string
+		var devicePath2 string
+
+		var plugin1 *FakePlugin
+		var plugin2 *FakePlugin
+
+		BeforeEach(func() {
+			// only create the second device.
+			devicePath1 = path.Join(workDir, "fake-device1")
+			devicePath2 = path.Join(workDir, "fake-device2")
+			os.Create(devicePath2)
+
+			plugin1 = NewFakePlugin("fake-device1", devicePath1)
+			plugin2 = NewFakePlugin("fake-device2", devicePath2)
+		})
+
+		It("Should not block on other plugins", func() {
+			deviceController = NewDeviceController(host, 10)
+			deviceController.devicePlugins = []GenericDevice{plugin1, plugin2}
+			go deviceController.Run(stop)
+
+			Expect(deviceController.nodeHasDevice(devicePath1)).To(BeFalse())
+			Expect(deviceController.nodeHasDevice(devicePath2)).To(BeTrue())
+
+			timeout := make(chan struct{})
+
+			go func() {
+				time.Sleep(1 * time.Second)
+				close(timeout)
+			}()
+
+			started := false
+			timedOut := false
+			select {
+			case <-plugin2.started:
+				started = true
+			case <-timeout:
+				timedOut = true
+			}
+
+			Expect(started).To(BeTrue(), "device plugin never started")
+			Expect(timedOut).To(BeFalse(), "device plugin should not have timed out")
+		})
+
+		It("Should block until ready", func() {
+			deviceController = NewDeviceController(host, 10)
+			deviceController.devicePlugins = []GenericDevice{plugin1, plugin2}
+			go deviceController.Run(stop)
+
+			timeout := make(chan struct{})
+
+			go func() {
+				time.Sleep(1 * time.Second)
+				close(timeout)
+			}()
+
+			started := false
+			timedOut := false
+			select {
+			case <-plugin1.started:
+				started = true
+			case <-timeout:
+				timedOut = true
+			}
+
+			Expect(started).To(BeFalse(), "device plugin should not have started")
+			Expect(timedOut).To(BeTrue(), "device plugin should have timed out")
 		})
 	})
 })

--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -41,6 +41,12 @@ const (
 	connectionTimeout = 5 * time.Second
 )
 
+type GenericDevice interface {
+	Start(chan struct{}) error
+	GetDevicePath() string
+	GetDeviceName() string
+}
+
 type GenericDevicePlugin struct {
 	counter    int
 	devs       []*pluginapi.Device
@@ -94,6 +100,14 @@ func connect(socketPath string, timeout time.Duration) (*grpc.ClientConn, error)
 	}
 
 	return c, nil
+}
+
+func (dpi *GenericDevicePlugin) GetDevicePath() string {
+	return dpi.devicePath
+}
+
+func (dpi *GenericDevicePlugin) GetDeviceName() string {
+	return dpi.deviceName
 }
 
 // Start starts the gRPC server of the device plugin


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes: https://github.com/kubevirt/kubevirt/issues/1346

Each device plugin is now started in a goroutine so that they are independent of each other.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: virt-handler would not start the tun device plugin on systems without kvm devices--regardless of whether or not emulation was requested.
```
