### PR TITLE
Generalize dockerization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 export GO15VENDOREXPERIMENT := 1
 
-all:
-	hack/dockerized "./hack/check.sh && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT} && ./hack/build-copy-artifacts.sh ${WHAT} && DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build-manifests.sh"
+all: build manifests
 
 generate:
 	hack/dockerized "./hack/generate.sh"
@@ -10,13 +9,13 @@ apidocs:
 	hack/dockerized "./hack/generate.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1 html"
 
 client-python:
-	hack/dockerized "./hack/generate.sh && TRAVIS_TAG=${TRAVIS_TAG} ./hack/gen-client-python/generate.sh"
+	hack/dockerized -e travis_env "./hack/generate.sh && ./hack/gen-client-python/generate.sh"
 
 build:
-	hack/dockerized "./hack/check.sh && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
+	hack/dockerized -e build_env "./hack/check.sh && ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
 
 goveralls:
-	SYNC_OUT=false hack/dockerized "./hack/check.sh && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized -e travis_env "./hack/check.sh && ./hack/goveralls.sh"
 
 test:
 	SYNC_OUT=false hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"
@@ -54,7 +53,7 @@ verify-build:
 	hack/verify-build.sh
 
 manifests:
-	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/build-manifests.sh"
+	hack/dockerized -e manifest_env ./hack/build-manifests.sh
 
 .release-functest:
 	make functest > .release-functest 2>&1

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -34,7 +34,7 @@ fi
 #If run on jenkins, let us create isolated environments based on the job and
 # the executor number
 provider_prefix=${JOB_NAME:-${KUBEVIRT_PROVIDER}}${EXECUTOR_NUMBER}
-job_prefix=${JOB_NAME:-kubevirt}${EXECUTOR_NUMBER}
+job_prefix=${JOB_NAME:-${CONTAINER_BASE:-kubevirt}}${EXECUTOR_NUMBER}
 
 # Populate an environment variable with the version info needed.
 # It should be used for everything which needs a version when building (not generating)

--- a/hack/docker-builder/build_env
+++ b/hack/docker-builder/build_env
@@ -1,0 +1,4 @@
+# Environment variables to pass in to the container
+# If no value is specified, Docker will evaluate them at run-time based on its environment
+KUBEVIRT_VERSION
+KUBEVIRT_PROVIDER

--- a/hack/docker-builder/manifest_env
+++ b/hack/docker-builder/manifest_env
@@ -1,0 +1,6 @@
+# Environment variables to pass in to the container
+# If no value is specified, Docker will evaluate them at run-time based on its environment
+KUBEVIRT_PROVIDER
+IMAGE_PULL_POLICY
+DOCKER_PREFIX
+DOCKER_TAG

--- a/hack/docker-builder/travis_env
+++ b/hack/docker-builder/travis_env
@@ -1,0 +1,6 @@
+# Environment variables to pass in to the container
+# If no value is specified, Docker will evaluate them at run-time based on its environment
+TRAVIS_TAG
+TRAVIS_JOB_ID
+TRAVIS_PULL_REQUEST
+TRAVIS_BRANCH

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -14,9 +14,9 @@ while getopts "c:e:i:" opt; do
     c)
         CONTAINER_BASE=$OPTARG
         ;;
-    # Allow specifying an environment variable file for runtime in the container
+    # Allow specifying one or more environment variable files for runtime in the container
     e)
-        ENV_FILE=$OPTARG
+        ENV_FILE="$ENV_FILE $OPTARG"
         ;;
     # Allow specifying a template for building the container
     i)
@@ -51,12 +51,14 @@ fi
 # Build up arguments for passing environment data to containers
 ENV_ARG=
 if [ -n "$ENV_FILE" ]; then
-    FULL_ENV_FILE=${DOCKER_DIR}/${ENV_FILE}
-    if [ ! -f $FULL_ENV_FILE ]; then
-        echo "Environment file $FULL_ENV_FILE not found"
-        exit 1
-    fi
-    ENV_ARG="--env-file=$FULL_ENV_FILE"
+    for e in $ENV_FILE; do
+        FULL_ENV_FILE=${DOCKER_DIR}/$e
+        if [ ! -f $FULL_ENV_FILE ]; then
+            echo "Environment file $FULL_ENV_FILE not found"
+            exit 1
+        fi
+        ENV_ARG="$ENV_ARG --env-file=$FULL_ENV_FILE"
+    done
 fi
 
 # Build the build container

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -1,9 +1,38 @@
 #!/bin/bash
 set -e
 
+usage() {
+    echo "Usage: $(basename $0) [ -c container name] [ -e environment ] [ -i docker image template ]"
+    exit 1
+}
+
+DOCKER_IMG=docker-builder
+ENV_FILE=
+while getopts "c:e:i:" opt; do
+    case $opt in
+    # Allow specifying a named container
+    c)
+        CONTAINER_BASE=$OPTARG
+        ;;
+    # Allow specifying an environment variable file for runtime in the container
+    e)
+        ENV_FILE=$OPTARG
+        ;;
+    # Allow specifying a template for building the container
+    i)
+        DOCKER_IMG=$OPTARG
+        ;;
+    *)
+        usage
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+# Fill in the environment
 source $(dirname "$0")/common.sh
 
-DOCKER_DIR=${KUBEVIRT_DIR}/hack/docker-builder
+DOCKER_DIR=${KUBEVIRT_DIR}/hack/$DOCKER_IMG
 
 SYNC_OUT=${SYNC_OUT:-true}
 
@@ -17,6 +46,17 @@ TEMPFILE=".rsynctemp"
 BUILD_QUIET=
 if [ -n "$JOB_NAME" -o -n "$TRAVIS_BUILD_ID" ]; then
     BUILD_QUIET="-q"
+fi
+
+# Build up arguments for passing environment data to containers
+ENV_ARG=
+if [ -n "$ENV_FILE" ]; then
+    FULL_ENV_FILE=${DOCKER_DIR}/${ENV_FILE}
+    if [ ! -f $FULL_ENV_FILE ]; then
+        echo "Environment file $FULL_ENV_FILE not found"
+        exit 1
+    fi
+    ENV_ARG="--env-file=$FULL_ENV_FILE"
 fi
 
 # Build the build container
@@ -74,7 +114,8 @@ _rsync --delete --exclude 'cluster/**/.kubectl' --exclude 'cluster/**/.oc' --exc
 
 # Run the command
 test -t 1 && USE_TTY="-it"
-docker run --rm -v "${BUILDER}:/root:rw,z" --security-opt label:disable ${USE_TTY} -w "/root/go/src/kubevirt.io/kubevirt" ${BUILDER} "$@"
+
+docker run --rm -v "${BUILDER}:/root:rw,z" $ENV_ARG --security-opt label:disable ${USE_TTY} -w "/root/go/src/kubevirt.io/kubevirt" ${BUILDER} "$@"
 
 # Copy the whole kubevirt data out to get generated sources and formatting changes
 _rsync --exclude '.glide*' --exclude 'cluster/**/.kubectl' --exclude 'cluster/**/.oc' --exclude 'cluster/**/.kubeconfig' --exclude "_out" --exclude "vendor" --exclude ".vagrant" --exclude ".git" "rsync://root@127.0.0.1:${RSYNCD_PORT}/build" ${KUBEVIRT_DIR}/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This generalizes the "dockerize" script and associated plumbing
to allow different containers for different purposes.  As a proof
of concept, the manifest generation is performed in a simple Python
container, since that's all that it really needs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

**Special notes for your reviewer**:
Environment variables for each container are specified in a per-
container file.  This is related to the work in PR #1311, where I tried a couple of ways to get environment variables into the container.

Note that this also obviates all the specification of environment variables in the root Makefile

The existing rsync synchronization stuff is retained for now, although
it's probably not necessary for this particular container (a simple bind
mount would probably suffice for the output).
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
@rmohr 