### PR TITLE
Feature make virtctl a kubectl plugin

### DIFF
--- a/pkg/kubecli/install.go
+++ b/pkg/kubecli/install.go
@@ -77,7 +77,7 @@ func InstallVirtPlugin(cmd *cobra.Command) error {
 		return err
 	}
 
-	plugin := makePluginConfiguration(cmd)
+	plugin := MakePluginConfiguration(cmd)
 
 	err = writePluginYaml(plugin)
 	if err != nil {
@@ -109,7 +109,7 @@ func getPluginFolder() error {
 	return fmt.Errorf("Fail to find kubernetes plugin folder")
 }
 
-func makePluginConfiguration(cmd *cobra.Command) *Plugin {
+func MakePluginConfiguration(cmd *cobra.Command) *Plugin {
 	tree := make(Plugins, 0)
 	for _, command := range cmd.Commands() {
 		if command.Name() != "install" && command.Name() != "options" {

--- a/pkg/kubecli/install.go
+++ b/pkg/kubecli/install.go
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ * Copyright 2018 The Kubernetes Authors.
+ *
+ */
+
+package kubecli
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Plugin holds everything needed to register a
+// plugin as a command. Usually comes from a descriptor file.
+type Plugin struct {
+	Name      string  `json:"name"`
+	ShortDesc string  `json:"shortDesc"`
+	LongDesc  string  `json:"longDesc,omitempty"`
+	Example   string  `json:"example,omitempty"`
+	Command   string  `json:"command"`
+	Flags     []Flag  `json:"flags,omitempty"`
+	Tree      Plugins `json:"tree,omitempty"`
+}
+
+// Source holds the location of a given plugin in the filesystem.
+type Source struct {
+	Dir            string `json:"-"`
+	DescriptorName string `json:"-"`
+}
+
+// Plugins is a list of plugins.
+type Plugins []*Plugin
+
+// Flag describes a single flag supported by a given plugin.
+type Flag struct {
+	Name      string `json:"name"`
+	Shorthand string `json:"shorthand,omitempty"`
+	Desc      string `json:"desc"`
+	DefValue  string `json:"defValue,omitempty"`
+}
+
+func MakePluginConfiguration(cmd *cobra.Command) *Plugin {
+	tree := make(Plugins, 0)
+	for _, command := range cmd.Commands() {
+		flags := make([]Flag, 0)
+
+		checkFlags := func(f *pflag.Flag) {
+			flags = append(flags, Flag{Name: f.Name})
+		}
+		command.Flags().VisitAll(checkFlags)
+		tree = append(tree, &Plugin{Name: command.Name(), ShortDesc: command.Short, Command: command.Name(), Flags: flags})
+	}
+
+	plugin := &Plugin{Name: "virt", ShortDesc: "kubevirt command plugin", Command: "./virtctl", Tree: tree}
+
+	return plugin
+}
+
+func WritePluginYaml(plugin *Plugin) error {
+	return nil
+}
+
+func CopyVirtctlFile() error {
+	return nil
+}

--- a/pkg/kubecli/install.go
+++ b/pkg/kubecli/install.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * Copyright 2018 Red Hat, Inc.
- * Copyright 2018 The Kubernetes Authors.
  *
  */
 

--- a/pkg/kubecli/install.go
+++ b/pkg/kubecli/install.go
@@ -68,15 +68,13 @@ func InstallVirtPlugin(cmd *cobra.Command) error {
 	}
 
 	// Create virt folder
-	err = os.MkdirAll(kubectlPluginPath, os.ModePerm)
-	if err != nil {
+	if err := os.MkdirAll(kubectlPluginPath, os.ModePerm); err != nil {
 		return err
 	}
 
 	plugin := MakePluginConfiguration(kubectlPluginPath, cmd)
 
-	err = writePluginYaml(kubectlPluginPath, plugin)
-	if err != nil {
+	if err := writePluginYaml(kubectlPluginPath, plugin); err != nil {
 		return err
 	}
 

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -72,6 +72,11 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	value := os.Getenv("KUBECTL_PLUGINS_CURRENT_NAMESPACE")
+	if value != "" {
+		namespace = value
+	}
+
 	vmi := args[0]
 
 	virtCli, err := kubecli.GetKubevirtClientFromClientConfig(c.clientConfig)

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -72,8 +72,7 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	value := os.Getenv("KUBECTL_PLUGINS_CURRENT_NAMESPACE")
-	if value != "" {
+	if value, ok := os.LookupEnv("KUBECTL_PLUGINS_CURRENT_NAMESPACE"); ok {
 		namespace = value
 	}
 

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -26,6 +26,8 @@ import (
 	"os/signal"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/util"
+
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/client-go/tools/clientcmd"
@@ -43,6 +45,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			c := Console{clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -21,7 +21,10 @@ package expose
 
 import (
 	"fmt"
+	"os"
 	"strings"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/util"
 
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
@@ -71,6 +74,7 @@ virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplica
 		Example: usage(),
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			c := Command{command: COMMAND_EXPOSE, clientConfig: clientConfig}
 			return c.RunE(cmd, args)
 		},
@@ -143,6 +147,10 @@ func (o *Command) RunE(cmd *cobra.Command, args []string) error {
 	namespace, _, err := o.clientConfig.Namespace()
 	if err != nil {
 		return err
+	}
+
+	if value, ok := os.LookupEnv("KUBECTL_PLUGINS_CURRENT_NAMESPACE"); ok {
+		namespace = value
 	}
 
 	// get the client

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package expose
 
 import (

--- a/pkg/virtctl/expose/expose_suite_test.go
+++ b/pkg/virtctl/expose/expose_suite_test.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package expose_test
 
 import (

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package expose_test
 
 import (

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -27,6 +27,8 @@ import (
 	"os"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/util"
+
 	"github.com/spf13/cobra"
 	pb "gopkg.in/cheggaaa/pb.v1"
 	v1 "k8s.io/api/core/v1"
@@ -95,6 +97,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			v := command{clientConfig: clientConfig}
 			return v.run(cmd, args)
 		},

--- a/pkg/virtctl/install/install.go
+++ b/pkg/virtctl/install/install.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * Copyright 2018 Red Hat, Inc.
- * Copyright 2018 The Kubernetes Authors.
  *
  */
 

--- a/pkg/virtctl/install/install.go
+++ b/pkg/virtctl/install/install.go
@@ -1,0 +1,42 @@
+package install
+
+import (
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/templates"
+)
+
+func InstallCommand(rootCommand *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "install",
+		Short:   "Install virtctl as a kubectl plugin",
+		Example: usage(),
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			i := Install{rootCommand: rootCommand}
+			return i.Run(cmd, args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func usage() string {
+	usage := "# Install virtctl as a kubectl plugin \n"
+	usage += "virtctl install"
+	return usage
+}
+
+type Install struct {
+	rootCommand *cobra.Command
+}
+
+func (I *Install) Run(cmd *cobra.Command, args []string) error {
+	pluginConfig := clientcmdapi.
+
+	for _, command := range I.rootCommand.Commands() {
+
+	}
+	return nil
+}

--- a/pkg/virtctl/install/install.go
+++ b/pkg/virtctl/install/install.go
@@ -52,13 +52,5 @@ type Install struct {
 }
 
 func (I *Install) Run(cmd *cobra.Command, args []string) error {
-	plugin := kubecli.MakePluginConfiguration(I.rootCommand)
-	err := kubecli.WritePluginYaml(plugin)
-	if err != nil {
-		return err
-	}
-
-	err := kubecli.CopyVirtctlFile()
-	
-	return err
+	return kubecli.InstallVirtPlugin(I.rootCommand)
 }

--- a/pkg/virtctl/install/install.go
+++ b/pkg/virtctl/install/install.go
@@ -1,9 +1,28 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017, 2018 Red Hat, Inc.
+ *
+ */
+
 package install
 
 import (
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 
+	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
@@ -33,10 +52,13 @@ type Install struct {
 }
 
 func (I *Install) Run(cmd *cobra.Command, args []string) error {
-	pluginConfig := clientcmdapi.
-
-	for _, command := range I.rootCommand.Commands() {
-
+	plugin := kubecli.MakePluginConfiguration(I.rootCommand)
+	err := kubecli.WritePluginYaml(plugin)
+	if err != nil {
+		return err
 	}
-	return nil
+
+	err := kubecli.CopyVirtctlFile()
+	
+	return err
 }

--- a/pkg/virtctl/install/install.go
+++ b/pkg/virtctl/install/install.go
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017, 2018 Red Hat, Inc.
+ * Copyright 2018 Red Hat, Inc.
+ * Copyright 2018 The Kubernetes Authors.
  *
  */
 

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ * Copyright 2018 The Kubernetes Authors.
+ *
+ */
+
 package virtctl
 
 import (

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * Copyright 2018 Red Hat, Inc.
- * Copyright 2018 The Kubernetes Authors.
  *
  */
 

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -12,6 +12,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 	"kubevirt.io/kubevirt/pkg/virtctl/imageupload"
+	"kubevirt.io/kubevirt/pkg/virtctl/install"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 	"kubevirt.io/kubevirt/pkg/virtctl/version"
 	"kubevirt.io/kubevirt/pkg/virtctl/vm"
@@ -50,6 +51,7 @@ func NewVirtctlCommand() *cobra.Command {
 		expose.NewExposeCommand(clientConfig),
 		version.VersionCommand(clientConfig),
 		imageupload.NewImageUploadCommand(clientConfig),
+		install.InstallCommand(rootCmd),
 		optionsCmd,
 	)
 	return rootCmd

--- a/pkg/virtctl/root_suite_test.go
+++ b/pkg/virtctl/root_suite_test.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * Copyright 2018 Red Hat, Inc.
- * Copyright 2018 The Kubernetes Authors.
  *
  */
 package virtctl

--- a/pkg/virtctl/root_suite_test.go
+++ b/pkg/virtctl/root_suite_test.go
@@ -26,7 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOfflinevm(t *testing.T) {
+func TestRoot(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "root Suite")
 }

--- a/pkg/virtctl/root_suite_test.go
+++ b/pkg/virtctl/root_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ * Copyright 2018 The Kubernetes Authors.
+ *
+ */
+package virtctl
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOfflinevm(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "root Suite")
+}

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -21,6 +21,8 @@
 package virtctl
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -129,13 +131,15 @@ tree:
 var _ = Describe("Kubevirt Root Client", func() {
 	var command *cobra.Command
 	var plugin *kubecli.Plugin
+	workDir, err := ioutil.TempDir("", "kubevirt-test")
+	Expect(err).ToNot(HaveOccurred())
 
 	BeforeEach(func() {
 		command = NewVirtctlCommand()
-		plugin = kubecli.MakePluginConfiguration(command)
+		plugin = kubecli.MakePluginConfiguration(workDir, command)
 	})
 
-	Context("With example yaml check install command", func() {
+	FContext("With example yaml check install command", func() {
 		It("Marshal struct into yaml", func() {
 			yamlData, err := yaml.Marshal(plugin)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -22,6 +22,7 @@ package virtctl
 
 import (
 	"io/ioutil"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -44,7 +45,11 @@ tree:
   longdesc: ""
   example: ""
   command: ./virtctl console
-  flags: []
+  flags:
+  - name: timeout
+    shorthand: ""
+    desc: The number of minutes to wait for the virtual machine instance to be ready.
+    defvalue: "5"
   tree: []
 - name: expose
   shortdesc: Expose a virtual machine as a new service.
@@ -92,7 +97,7 @@ tree:
     shorthand: ""
     desc: Name or number for the port on the VM that the service should direct traffic
       to. Optional.
-    defvalue: "0"
+    defvalue: ""
   - name: type
     shorthand: ""
     desc: 'Type for this service: ClusterIP, NodePort, or LoadBalancer.'
@@ -131,15 +136,19 @@ tree:
 var _ = Describe("Kubevirt Root Client", func() {
 	var command *cobra.Command
 	var plugin *kubecli.Plugin
-	workDir, err := ioutil.TempDir("", "kubevirt-test")
-	Expect(err).ToNot(HaveOccurred())
+	var workDir string
 
 	BeforeEach(func() {
+		workDir, err := ioutil.TempDir("", "kubevirt-test")
+		Expect(err).ToNot(HaveOccurred())
 		command = NewVirtctlCommand()
 		plugin = kubecli.MakePluginConfiguration(workDir, command)
 	})
 
-	FContext("With example yaml check install command", func() {
+	AfterEach(func() {
+		os.RemoveAll(workDir)
+	})
+	Context("With example yaml check install command", func() {
 		It("Marshal struct into yaml", func() {
 			yamlData, err := yaml.Marshal(plugin)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -1,0 +1,145 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ * Copyright 2018 The Kubernetes Authors.
+ *
+ */
+
+package virtctl
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+
+	"kubevirt.io/kubevirt/pkg/kubecli"
+)
+
+var exampleYaml = `name: virt
+shortdesc: kubevirt command plugin
+longdesc: ""
+example: ""
+command: ./virtctl
+flags: []
+tree:
+- name: console
+  shortdesc: Connect to a console of a virtual machine.
+  longdesc: ""
+  example: ""
+  command: ./virtctl console
+  flags: []
+  tree: []
+- name: expose
+  shortdesc: Expose a virtual machine as a new service.
+  longdesc: ""
+  example: ""
+  command: ./virtctl expose
+  flags:
+  - name: cluster-ip
+    shorthand: ""
+    desc: ClusterIP to be assigned to the service. Leave empty to auto-allocate, or
+      set to 'None' to create a headless service.
+    defvalue: ""
+  - name: external-ip
+    shorthand: ""
+    desc: Additional external IP address (not managed by the cluster) to accept for
+      the service. If this IP is routed to a node, the service can be accessed by
+      this IP in addition to its generated service IP. Optional.
+    defvalue: ""
+  - name: load-balancer-ip
+    shorthand: ""
+    desc: IP to assign to the Load Balancer. If empty, an ephemeral IP will be created
+      and used.
+    defvalue: ""
+  - name: name
+    shorthand: ""
+    desc: Name of the service created for the exposure of the VM
+    defvalue: ""
+  - name: node-port
+    shorthand: ""
+    desc: Port used to expose the service on each node in a cluster.
+    defvalue: "0"
+  - name: port
+    shorthand: ""
+    desc: The port that the service should serve on
+    defvalue: "0"
+  - name: port-name
+    shorthand: ""
+    desc: Name of the port. Optional.
+    defvalue: ""
+  - name: protocol
+    shorthand: ""
+    desc: The network protocol for the service to be created.
+    defvalue: TCP
+  - name: target-port
+    shorthand: ""
+    desc: Name or number for the port on the VM that the service should direct traffic
+      to. Optional.
+    defvalue: "0"
+  - name: type
+    shorthand: ""
+    desc: 'Type for this service: ClusterIP, NodePort, or LoadBalancer.'
+    defvalue: ClusterIP
+  tree: []
+- name: start
+  shortdesc: Start a virtual machine instance which is managed by a virtual machine.
+  longdesc: ""
+  example: ""
+  command: ./virtctl start
+  flags: []
+  tree: []
+- name: stop
+  shortdesc: Stop a virtual machine instace which is managed by a virtual machine.
+  longdesc: ""
+  example: ""
+  command: ./virtctl stop
+  flags: []
+  tree: []
+- name: version
+  shortdesc: Print the client and server version information
+  longdesc: ""
+  example: ""
+  command: ./virtctl version
+  flags: []
+  tree: []
+- name: vnc
+  shortdesc: Open a vnc connection to a virtual machine.
+  longdesc: ""
+  example: ""
+  command: ./virtctl vnc
+  flags: []
+  tree: []
+`
+
+var _ = Describe("Kubevirt Root Client", func() {
+	var command *cobra.Command
+	var plugin *kubecli.Plugin
+
+	BeforeEach(func() {
+		command = NewVirtctlCommand()
+		plugin = kubecli.MakePluginConfiguration(command)
+	})
+
+	Context("With example yaml check install command", func() {
+		It("Marshal struct into yaml", func() {
+			yamlData, err := yaml.Marshal(plugin)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exampleYaml).To(Equal(string(yamlData)))
+		})
+	})
+})

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -41,7 +41,7 @@ command: ./virtctl
 flags: []
 tree:
 - name: console
-  shortdesc: Connect to a console of a virtual machine.
+  shortdesc: Connect to a console of a virtual machine instance.
   longdesc: ""
   example: ""
   command: ./virtctl console
@@ -52,7 +52,8 @@ tree:
     defvalue: "5"
   tree: []
 - name: expose
-  shortdesc: Expose a virtual machine as a new service.
+  shortdesc: Expose a virtual machine instance, virtual machine, or virtual machine
+    instance replica set as a new service.
   longdesc: ""
   example: ""
   command: ./virtctl expose
@@ -111,7 +112,7 @@ tree:
   flags: []
   tree: []
 - name: stop
-  shortdesc: Stop a virtual machine instace which is managed by a virtual machine.
+  shortdesc: Stop a virtual machine instance which is managed by a virtual machine.
   longdesc: ""
   example: ""
   command: ./virtctl stop
@@ -125,7 +126,7 @@ tree:
   flags: []
   tree: []
 - name: vnc
-  shortdesc: Open a vnc connection to a virtual machine.
+  shortdesc: Open a vnc connection to a virtual machine instance.
   longdesc: ""
   example: ""
   command: ./virtctl vnc

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -75,7 +75,7 @@ tree:
     defvalue: ""
   - name: name
     shorthand: ""
-    desc: Name of the service created for the exposure of the VM
+    desc: Name of the service created for the exposure of the VM.
     defvalue: ""
   - name: node-port
     shorthand: ""
@@ -83,7 +83,7 @@ tree:
     defvalue: "0"
   - name: port
     shorthand: ""
-    desc: The port that the service should serve on
+    desc: The port that the service should serve on.
     defvalue: "0"
   - name: port-name
     shorthand: ""
@@ -103,22 +103,72 @@ tree:
     desc: 'Type for this service: ClusterIP, NodePort, or LoadBalancer.'
     defvalue: ClusterIP
   tree: []
+- name: image-upload
+  shortdesc: Upload a VM image to a PersistentVolumeClaim.
+  longdesc: ""
+  example: ""
+  command: ./virtctl image-upload
+  flags:
+  - name: access-mode
+    shorthand: ""
+    desc: The access mode for the PVC.
+    defvalue: ReadWriteOnce
+  - name: image-path
+    shorthand: ""
+    desc: Path to the local VM image.
+    defvalue: ""
+  - name: insecure
+    shorthand: ""
+    desc: Allow insecure server connections when using HTTPS.
+    defvalue: "false"
+  - name: no-create
+    shorthand: ""
+    desc: Don't attempt to create a new PVC.
+    defvalue: "false"
+  - name: pvc-name
+    shorthand: ""
+    desc: The destination PVC.
+    defvalue: ""
+  - name: pvc-size
+    shorthand: ""
+    desc: The size of the PVC to create (ex. 10Gi, 500Mi).
+    defvalue: ""
+  - name: storage-class
+    shorthand: ""
+    desc: The storage class for the PVC.
+    defvalue: ""
+  - name: uploadproxy-url
+    shorthand: ""
+    desc: The URL of the cdi-upload proxy service.
+    defvalue: ""
+  - name: wait-secs
+    shorthand: ""
+    desc: Seconds to wait for upload pod to start.
+    defvalue: "60"
+  tree: []
+- name: restart
+  shortdesc: Restart a virtual machine.
+  longdesc: ""
+  example: ""
+  command: ./virtctl restart
+  flags: []
+  tree: []
 - name: start
-  shortdesc: Start a virtual machine instance which is managed by a virtual machine.
+  shortdesc: Start a virtual machine.
   longdesc: ""
   example: ""
   command: ./virtctl start
   flags: []
   tree: []
 - name: stop
-  shortdesc: Stop a virtual machine instance which is managed by a virtual machine.
+  shortdesc: Stop a virtual machine.
   longdesc: ""
   example: ""
   command: ./virtctl stop
   flags: []
   tree: []
 - name: version
-  shortdesc: Print the client and server version information
+  shortdesc: Print the client and server version information.
   longdesc: ""
   example: ""
   command: ./virtctl version

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  *
  * Copyright 2018 Red Hat, Inc.
- * Copyright 2018 The Kubernetes Authors.
  *
  */
 
@@ -28,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 )
@@ -123,7 +122,11 @@ tree:
   longdesc: ""
   example: ""
   command: ./virtctl version
-  flags: []
+  flags:
+  - name: client
+    shorthand: ""
+    desc: Client version only (no server required).
+    defvalue: "false"
   tree: []
 - name: vnc
   shortdesc: Open a vnc connection to a virtual machine instance.

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package templates
 
 // UsageTemplate returns the usage template for all subcommands

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -39,3 +39,12 @@ func OptionsUsageTemplate() string {
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 `
 }
+
+func InstallPluginTemplate() string {
+	return `name: "virt"
+  shortDesc: "virt controls virtual machine related operations on your kubernetes cluster."
+  command: "./virtctl"
+  tree:
+  
+  `
+}

--- a/pkg/virtctl/util/util.go
+++ b/pkg/virtctl/util/util.go
@@ -1,0 +1,39 @@
+package util
+
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package flags implements command-line flag parsing.
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// FlagToEnv converts flag string to upper-case environment variable key string.
+func FlagToEnv(prefix, name string) string {
+	return prefix + "_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
+}
+
+func LoadEnvVariables(cmd *cobra.Command) {
+	cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		env := FlagToEnv("KUBECTL_PLUGINS_LOCAL_FLAG", flag.Name)
+		if value, ok := os.LookupEnv(env); ok {
+			flag.Value.Set(value)
+		}
+	})
+}

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -22,6 +22,8 @@ package version
 import (
 	"fmt"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/util"
+
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -39,6 +41,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			v := Version{clientConfig: clientConfig}
 			return v.Run(cmd, args)
 		},
@@ -66,6 +69,9 @@ func (v *Version) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+
+		test, _ := v.clientConfig.ClientConfig()
+		fmt.Printf("%s\n", test.Host)
 
 		serverInfo, err := virCli.ServerVersion().Get()
 		if err != nil {

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package version
 
 import (

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -21,8 +21,10 @@ package vm
 
 import (
 	"fmt"
-	"strings"
 	"os"
+	"strings"
+
+	"kubevirt.io/kubevirt/pkg/virtctl/util"
 
 	"github.com/spf13/cobra"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +48,7 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(COMMAND_START),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			c := Command{command: COMMAND_START, clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},
@@ -61,6 +64,7 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(COMMAND_STOP),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},
@@ -76,6 +80,7 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(COMMAND_RESTART),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -108,8 +108,7 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	value := os.Getenv("KUBECTL_PLUGINS_CURRENT_NAMESPACE")
-	if value != "" {
+	if value, ok := os.LookupEnv("KUBECTL_PLUGINS_CURRENT_NAMESPACE"); ok {
 		namespace = value
 	}
 

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -22,6 +22,7 @@ package vm
 import (
 	"fmt"
 	"strings"
+	"os"
 
 	"github.com/spf13/cobra"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,6 +106,11 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 	namespace, _, err := o.clientConfig.Namespace()
 	if err != nil {
 		return err
+	}
+
+	value := os.Getenv("KUBECTL_PLUGINS_CURRENT_NAMESPACE")
+	if value != "" {
+		namespace = value
 	}
 
 	virtClient, err := kubecli.GetKubevirtClientFromClientConfig(o.clientConfig)

--- a/pkg/virtctl/vm/vm_suite_test.go
+++ b/pkg/virtctl/vm/vm_suite_test.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package vm_test
 
 import (

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
 package vm_test
 
 import (

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -30,6 +30,8 @@ import (
 	"runtime"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/virtctl/util"
+
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -65,6 +67,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			util.LoadEnvVariables(cmd)
 			c := VNC{clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -83,6 +83,11 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	value := os.Getenv("KUBECTL_PLUGINS_CURRENT_NAMESPACE")
+	if value != "" {
+		namespace = value
+	}
+
 	vmi := args[0]
 
 	virtCli, err := kubecli.GetKubevirtClientFromClientConfig(o.clientConfig)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -83,8 +83,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	value := os.Getenv("KUBECTL_PLUGINS_CURRENT_NAMESPACE")
-	if value != "" {
+	if value, ok := os.LookupEnv("KUBECTL_PLUGINS_CURRENT_NAMESPACE"); ok {
 		namespace = value
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the install command into our virtctl cli.
The command creates the plugin yaml and copy the virctl binary to the kubectl plugin folder.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #912 

**Special notes for your reviewer**:
This PR is in wip. I will add unit tests and functional tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
make virtctl a kubectl plugin
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1361)
<!-- Reviewable:end -->
