### PR TITLE
Do not skip windows tests when windows PV is bounded

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1338,7 +1338,7 @@ func BeforeAll(fn func()) {
 
 func SkipIfNoWindowsImage(virtClient kubecli.KubevirtClient) {
 	windowsPv, err := virtClient.CoreV1().PersistentVolumes().Get(DiskWindows, metav1.GetOptions{})
-	if err != nil || (windowsPv.Status.Phase != k8sv1.VolumeAvailable && windowsPv.Status.Phase != k8sv1.VolumeReleased) {
+	if err != nil || windowsPv.Status.Phase == k8sv1.VolumePending || windowsPv.Status.Phase == k8sv1.VolumeFailed {
 		Skip(fmt.Sprintf("Skip Windows tests that requires PVC %s", DiskWindows))
 	} else if windowsPv.Status.Phase == k8sv1.VolumeReleased {
 		windowsPv.Spec.ClaimRef = nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
I checked the latest windows test runs and I can see that all tests skipped because windows PV is bounded, I do not sure how it passed before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>