### PR TITLE
Merge pull request #1345 from cynepco3hahue/cpu_host_passthrough

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3275,7 +3275,7 @@
       "type": "integer"
      },
      "model": {
-      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
+      "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nYou can find more information under https://libvirt.org/formatdomain.html#elementsCPU.\nDefaults to host-model.\n+optional",
       "type": "string"
      }
     }

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -100,7 +100,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"model": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.",
+								Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml. You also can specify special cases like \"host-passthrough\" to get the same CPU as the node and \"host-model\" to get CPU closest to the node one. You can find more information under https://libvirt.org/formatdomain.html#elementsCPU. Defaults to host-model.",
 								Type:        []string{"string"},
 								Format:      "",
 							},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -97,6 +97,10 @@ type CPU struct {
 	Cores uint32 `json:"cores,omitempty"`
 	// Model specifies the CPU model inside the VMI.
 	// List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.
+	// You also can specify special cases like "host-passthrough" to get the same CPU as the node
+	// and "host-model" to get CPU closest to the node one.
+	// You can find more information under https://libvirt.org/formatdomain.html#elementsCPU.
+	// Defaults to host-model.
 	// +optional
 	Model string `json:"model,omitempty"`
 }

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -35,7 +35,7 @@ func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":      "CPU allow specifying the CPU topology",
 		"cores": "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
-		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\n+optional",
+		"model": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nYou also can specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nYou can find more information under https://libvirt.org/formatdomain.html#elementsCPU.\nDefaults to host-model.\n+optional",
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -38,6 +38,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/registry-disk"
 )
 
+const (
+	CPUModeHostPassthrough = "host-passthrough"
+	CPUModeHostModel       = "host-model"
+)
+
 type ConverterContext struct {
 	AllowEmulation bool
 	Secrets        map[string]*k8sv1.Secret
@@ -454,13 +459,17 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 
 		// Set VM CPU model and vendor
 		if vmi.Spec.Domain.CPU.Model != "" {
-			domain.Spec.CPU.Mode = "custom"
-			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+			if vmi.Spec.Domain.CPU.Model == CPUModeHostModel || vmi.Spec.Domain.CPU.Model == CPUModeHostPassthrough {
+				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
+			} else {
+				domain.Spec.CPU.Mode = "custom"
+				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+			}
 		}
 	}
 
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		domain.Spec.CPU.Mode = "host-model"
+		domain.Spec.CPU.Mode = CPUModeHostModel
 	}
 
 	// Add mandatory console device

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/onsi/ginkgo/extensions/table"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -462,6 +464,20 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.VCPU.Placement).To(Equal("static"))
 			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
 		})
+
+		table.DescribeTable("should convert CPU model", func(model string) {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores: 3,
+				Model: model,
+			}
+			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+			Expect(domainSpec.CPU.Mode).To(Equal(model))
+		},
+			table.Entry(CPUModeHostPassthrough, CPUModeHostPassthrough),
+			table.Entry(CPUModeHostModel, CPUModeHostModel),
+		)
 
 		Context("when CPU spec defined and model not", func() {
 			It("should set host-model CPU mode", func() {


### PR DESCRIPTION
Add possibility to use CPU passthrough for VM's

(cherry picked from commit e29d57e262a762be6b476008f6ac3eb2698aff0d)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add possibility to pass-through host CPU model to a VM
```
