### PR TITLE
Allow creating VMIs with minimal guest overhead to achieve a higher VMI density per node

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4360,6 +4360,10 @@
        "$ref": "#/definitions/resource.Quantity"
       }
      },
+     "overcommitGuestOverhead": {
+      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the requested memory limits. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
+      "type": "boolean"
+     },
      "requests": {
       "description": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
       "type": "object",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3440,6 +3440,10 @@
    "v1.DeletionPropagation": {},
    "v1.Devices": {
     "properties": {
+     "autoattachGraphicsDevice": {
+      "description": "Wheater to attach the default graphics device or not.\nVNC will not be available if set to false. Defaults to true.",
+      "type": "boolean"
+     },
      "autoattachPodInterface": {
       "description": "Whether to attach a pod network interface. Defaults to true.",
       "type": "boolean"

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -212,6 +212,8 @@ spec:
                           properties:
                             limits:
                               type: object
+                            overcommitGuestOverhead:
+                              type: boolean
                             requests:
                               type: object
                       required:

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -54,6 +54,8 @@ spec:
                               type: string
                         devices:
                           properties:
+                            autoattachGraphicsDevice:
+                              type: boolean
                             autoattachPodInterface:
                               type: boolean
                             disks:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -47,6 +47,8 @@ spec:
                       type: string
                 devices:
                   properties:
+                    autoattachGraphicsDevice:
+                      type: boolean
                     autoattachPodInterface:
                       type: boolean
                     disks:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -205,6 +205,8 @@ spec:
                   properties:
                     limits:
                       type: object
+                    overcommitGuestOverhead:
+                      type: boolean
                     requests:
                       type: object
               required:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -46,6 +46,8 @@ spec:
                       type: string
                 devices:
                   properties:
+                    autoattachGraphicsDevice:
+                      type: boolean
                     autoattachPodInterface:
                       type: boolean
                     disks:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -204,6 +204,8 @@ spec:
                   properties:
                     limits:
                       type: object
+                    overcommitGuestOverhead:
+                      type: boolean
                     requests:
                       type: object
             selector: {}

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -216,6 +216,8 @@ spec:
                           properties:
                             limits:
                               type: object
+                            overcommitGuestOverhead:
+                              type: boolean
                             requests:
                               type: object
                       required:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -58,6 +58,8 @@ spec:
                               type: string
                         devices:
                           properties:
+                            autoattachGraphicsDevice:
+                              type: boolean
                             autoattachPodInterface:
                               type: boolean
                             disks:

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -212,6 +212,15 @@ func (in *Devices) DeepCopyInto(out *Devices) {
 			**out = **in
 		}
 	}
+	if in.AutoattachGraphicsDevice != nil {
+		in, out := &in.AutoattachGraphicsDevice, &out.AutoattachGraphicsDevice
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1158,6 +1158,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"overcommitGuestOverhead": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the requested memory limits. This can lead to crashes if all memory is in use on a node. Defaults to false.",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -220,6 +220,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"autoattachGraphicsDevice": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Wheater to attach the default graphics device or not. VNC will not be available if set to false. Defaults to true.",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -176,6 +176,9 @@ type Devices struct {
 	Interfaces []Interface `json:"interfaces,omitempty"`
 	// Whether to attach a pod network interface. Defaults to true.
 	AutoattachPodInterface *bool `json:"autoattachPodInterface,omitempty"`
+	// Wheater to attach the default graphics device or not.
+	// VNC will not be available if set to false. Defaults to true.
+	AutoattachGraphicsDevice *bool `json:"autoattachGraphicsDevice,omitempty"`
 }
 
 // ---

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -114,6 +114,10 @@ type ResourceRequirements struct {
 	// Valid resource keys are "memory" and "cpu".
 	// +optional
 	Limits v1.ResourceList `json:"limits,omitempty"`
+	// Don't ask the scheduler to take the guest-management overhead into account. Instead
+	// put the overhead only into the requested memory limits. This can lead to crashes if
+	// all memory is in use on a node. Defaults to false.
+	OvercommitGuestOverhead bool `json:"overcommitGuestOverhead,omitempty"`
 }
 
 // CPU allows specifying the CPU topology.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -39,8 +39,9 @@ func (DomainPresetSpec) SwaggerDoc() map[string]string {
 
 func (ResourceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"requests": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
-		"limits":   "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"requests":                "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"limits":                  "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the requested memory limits. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -80,10 +80,11 @@ func (Firmware) SwaggerDoc() map[string]string {
 
 func (Devices) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"disks":                  "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
-		"watchdog":               "Watchdog describes a watchdog device which can be added to the vmi.",
-		"interfaces":             "Interfaces describe network interfaces which are added to the vm.",
-		"autoattachPodInterface": "Whether to attach a pod network interface. Defaults to true.",
+		"disks":                    "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
+		"watchdog":                 "Watchdog describes a watchdog device which can be added to the vmi.",
+		"interfaces":               "Interfaces describe network interfaces which are added to the vm.",
+		"autoattachPodInterface":   "Whether to attach a pod network interface. Defaults to true.",
+		"autoattachGraphicsDevice": "Wheater to attach the default graphics device or not.\nVNC will not be available if set to false. Defaults to true.",
 	}
 }
 

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -47,12 +47,9 @@ type SubresourceAPIApp struct {
 	VirtCli kubecli.KubevirtClient
 }
 
-func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response *restful.Response, cmd []string) {
+func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response *restful.Response, vmi *v1.VirtualMachineInstance, cmd []string) {
 
-	vmiName := request.PathParameter("name")
-	namespace := request.PathParameter("namespace")
-
-	podName, httpStatusCode, err := app.remoteExecInfo(vmiName, namespace)
+	podName, httpStatusCode, err := app.remoteExecInfo(vmi)
 	if err != nil {
 		log.Log.Reason(err).Error("Failed to gather remote exec info for subresource request.")
 		response.WriteError(httpStatusCode, err)
@@ -84,7 +81,7 @@ func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response 
 	httpResponseChan := make(chan int)
 	copyErr := make(chan error)
 	go func() {
-		httpCode, err := remoteExecHelper(podName, namespace, cmd, inReader, outWriter)
+		httpCode, err := remoteExecHelper(podName, vmi.Namespace, cmd, inReader, outWriter)
 		log.Log.Errorf("%v", err)
 		httpResponseChan <- httpCode
 	}()
@@ -117,18 +114,39 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 
 	vmiName := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
-
 	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-%s", namespace, vmiName, "vnc")}
-	app.requestHandler(request, response, cmd)
+
+	vmi, code, err := app.fetchVirtualMachineInstance(vmiName, namespace)
+	if err != nil {
+		log.Log.Reason(err).Error("Failed to gather remote exec info for subresource request.")
+		response.WriteError(code, err)
+		return
+	}
+
+	// If there are no graphics devices present, we can't proceed
+	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice != nil && *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == false {
+		err := fmt.Errorf("No graphics devices are present.")
+		log.Log.Reason(err).Error("Can't establish VNC connection.")
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+
+	app.requestHandler(request, response, vmi, cmd)
 }
 
 func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, response *restful.Response) {
 	vmiName := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
-
 	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-%s", namespace, vmiName, "serial0")}
 
-	app.requestHandler(request, response, cmd)
+	vmi, code, err := app.fetchVirtualMachineInstance(vmiName, namespace)
+	if err != nil {
+		log.Log.Reason(err).Error("Failed to gather remote exec info for subresource request.")
+		response.WriteError(code, err)
+		return
+	}
+
+	app.requestHandler(request, response, vmi, cmd)
 }
 
 func (app *SubresourceAPIApp) findPod(namespace string, name string) (string, error) {
@@ -150,22 +168,26 @@ func (app *SubresourceAPIApp) findPod(namespace string, name string) (string, er
 	return podList.Items[0].ObjectMeta.Name, nil
 }
 
-func (app *SubresourceAPIApp) remoteExecInfo(name string, namespace string) (string, int, error) {
-	podName := ""
+func (app *SubresourceAPIApp) fetchVirtualMachineInstance(name string, namespace string) (*v1.VirtualMachineInstance, int, error) {
 
 	vmi, err := app.VirtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return "", http.StatusNotFound, goerror.New(fmt.Sprintf("VirtualMachineInstance %s in namespace %s not found.", name, namespace))
+			return nil, http.StatusNotFound, goerror.New(fmt.Sprintf("VirtualMachineInstance %s in namespace %s not found.", name, namespace))
 		}
-		return podName, http.StatusInternalServerError, err
+		return nil, http.StatusInternalServerError, err
 	}
+	return vmi, 0, nil
+}
+
+func (app *SubresourceAPIApp) remoteExecInfo(vmi *v1.VirtualMachineInstance) (string, int, error) {
+	podName := ""
 
 	if vmi.IsRunning() == false {
 		return podName, http.StatusBadRequest, goerror.New(fmt.Sprintf("Unable to connect to VirtualMachineInstance because phase is %s instead of %s", vmi.Status.Phase, v1.Running))
 	}
 
-	podName, err = app.findPod(namespace, name)
+	podName, err := app.findPod(vmi.Namespace, vmi.Name)
 	if err != nil {
 		return podName, http.StatusBadRequest, fmt.Errorf("unable to find matching pod for remote execution: %v", err)
 	}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -68,16 +68,12 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, podList),
 				),
 			)
 
-			podName, httpStatusCode, err := app.remoteExecInfo("testvmi", "default")
+			podName, httpStatusCode, err := app.remoteExecInfo(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(podName).To(Equal("madeup-name"))
@@ -90,14 +86,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi.Status.Phase = v1.Succeeded
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
 
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
-				),
-			)
-
-			_, httpStatusCode, err := app.remoteExecInfo("testvmi", "default")
+			_, httpStatusCode, err := app.remoteExecInfo(vmi)
 
 			Expect(err).To(HaveOccurred())
 			Expect(httpStatusCode).To(Equal(http.StatusBadRequest))
@@ -114,16 +103,12 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, podList),
 				),
 			)
 
-			_, httpStatusCode, err := app.remoteExecInfo("testvmi", "default")
+			_, httpStatusCode, err := app.remoteExecInfo(vmi)
 
 			Expect(err).To(HaveOccurred())
 			Expect(httpStatusCode).To(Equal(http.StatusBadRequest))

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -443,7 +443,9 @@ func getMemoryOverhead(domain v1.DomainSpec) *resource.Quantity {
 	overhead.Add(resource.MustParse("8Mi"))
 
 	// Add video RAM overhead
-	overhead.Add(resource.MustParse("16Mi"))
+	if domain.Devices.AutoattachGraphicsDevice == nil || *domain.Devices.AutoattachGraphicsDevice == true {
+		overhead.Add(resource.MustParse("16Mi"))
+	}
 
 	return overhead
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -198,7 +198,9 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	} else {
 		// Add overhead memory
 		memoryRequest := resources.Requests[k8sv1.ResourceMemory]
-		memoryRequest.Add(*memoryOverhead)
+		if !vmi.Spec.Domain.Resources.OvercommitGuestOverhead {
+			memoryRequest.Add(*memoryOverhead)
+		}
 		resources.Requests[k8sv1.ResourceMemory] = memoryRequest
 
 		if memoryLimit, ok := resources.Limits[k8sv1.ResourceMemory]; ok {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -315,6 +315,40 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			})
+
+			table.DescribeTable("should check autoattachGraphicsDevicse", func(autoAttach *bool, memory int) {
+
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+
+							CPU: &v1.CPU{Cores: 3},
+							Resources: v1.ResourceRequirements{
+								Requests: kubev1.ResourceList{
+									kubev1.ResourceCPU:    resource.MustParse("1m"),
+									kubev1.ResourceMemory: resource.MustParse("64M"),
+								},
+							},
+						},
+					},
+				}
+				vmi.Spec.Domain.Devices = v1.Devices{
+					AutoattachGraphicsDevice: autoAttach,
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
+			},
+				table.Entry("and consider graphics overhead if it is not set", nil, 179),
+				table.Entry("and consider graphics overhead if it is set to true", True(), 179),
+				table.Entry("and not consider graphics overhead if it is set to false", False(), 162),
+			)
 		})
 
 		Context("with hugepages constraints", func() {
@@ -629,4 +663,14 @@ func MakeFakeConfigMapWatcher(configMaps []kubev1.ConfigMap) *cache.ListWatch {
 		},
 	}
 	return cmListWatch
+}
+
+func True() *bool {
+	b := true
+	return &b
+}
+
+func False() *bool {
+	b := false
+	return &b
 }

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -505,15 +505,27 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		},
 	}
 
-	// Add mandatory vnc device
-	domain.Spec.Devices.Graphics = []Graphics{
-		{
-			Listen: &GraphicsListen{
-				Type:   "socket",
-				Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-vnc", vmi.ObjectMeta.Namespace, vmi.ObjectMeta.Name),
+	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == nil || *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == true {
+		var heads uint = 1
+		var vram uint = 16384
+		domain.Spec.Devices.Video = []Video{
+			{
+				Model: VideoModel{
+					Type:  "vga",
+					Heads: &heads,
+					VRam:  &vram,
+				},
 			},
-			Type: "vnc",
-		},
+		}
+		domain.Spec.Devices.Graphics = []Graphics{
+			{
+				Listen: &GraphicsListen{
+					Type:   "socket",
+					Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-vnc", vmi.ObjectMeta.Namespace, vmi.ObjectMeta.Name),
+				},
+				Type: "vnc",
+			},
+		}
 	}
 
 	getInterfaceType := func(iface *v1.Interface) string {

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -11,23 +11,6 @@ const (
 	DefaultBridgeName   = "br1"
 )
 
-func SetDefaults_Devices(devices *Devices) {
-	// Use vga as video device, since it is better than cirrus
-	// and does not require guest drivers
-	var heads uint = 1
-	var vram uint = 16384
-	devices.Video = []Video{
-		{
-			Model: VideoModel{
-				Type:  "vga",
-				Heads: &heads,
-				VRam:  &vram,
-			},
-		},
-	}
-
-}
-
 func SetDefaults_OSType(ostype *OSType) {
 	ostype.OS = "hvm"
 

--- a/pkg/virt-launcher/virtwrap/api/zz_generated.defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/zz_generated.defaults.go
@@ -39,7 +39,6 @@ func SetObjectDefaults_Domain(in *Domain) {
 	if in.Spec.SysInfo != nil {
 		SetDefaults_SysInfo(in.Spec.SysInfo)
 	}
-	SetDefaults_Devices(&in.Spec.Devices)
 }
 
 func SetObjectDefaults_DomainList(in *DomainList) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows configuring VMs with a small guest overhead. That involves two changes:

1. Headless VMIs (no video ram overhead, but also no VNC)
2. Allow overcommiting for the per-guest overhead.

Ad 1.) Allow headless VirtualMachineInstances:

 * Add autoattachGraphicsDevice with default to true
 * If set to false, don't consider video ram in vm overhead
 * If set to false, don't allow VNC connections to the vm

Ad 2.) Allow overcommiting guest overhead

 * Add overcommitGuestOverhead to the API
 * Let it default to false to keep the current behaviour
 * If set, only add the guest overhead to memory limits (if present)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1305

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
