### PR TITLE
Improve event logging granularity

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -33,6 +33,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/go-kit/kit/log"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -221,6 +222,24 @@ func (l FilteredLogger) Object(obj LoggableObject) *FilteredLogger {
 	logParams = append(logParams, "name", name)
 	logParams = append(logParams, "kind", kind)
 	logParams = append(logParams, "uid", uid)
+
+	l.With(logParams...)
+	return &l
+}
+
+func (l FilteredLogger) ObjectRef(obj *v1.ObjectReference) *FilteredLogger {
+
+	if obj == nil {
+		return &l
+	}
+
+	logParams := make([]interface{}, 0)
+	if obj.Namespace != "" {
+		logParams = append(logParams, "namespace", obj.Namespace)
+	}
+	logParams = append(logParams, "name", obj.Name)
+	logParams = append(logParams, "kind", obj.Kind)
+	logParams = append(logParams, "uid", obj.UID)
 
 	l.With(logParams...)
 	return &l

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -29,6 +29,8 @@ import (
 
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8sv1 "k8s.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 
@@ -273,6 +275,31 @@ func TestObject(t *testing.T) {
 	log.SetLogLevel(INFO)
 	vm := v1.VirtualMachineInstance{ObjectMeta: v12.ObjectMeta{Namespace: "test"}}
 	log.Object(&vm).Log("test", "message")
+	logEntry := logParams[0].([]interface{})
+	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
+	assert(t, logEntry[1].(string) == logLevelNames[INFO], "Logged line was not of level INFO")
+	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
+	assert(t, logEntry[4].(string) == "pos", "Logged line was not pos")
+	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
+	assert(t, logEntry[7].(string) == "test", "Component was not logged")
+	assert(t, logEntry[8].(string) == "namespace", "Logged line did not contain object namespace")
+	assert(t, logEntry[10].(string) == "name", "Logged line did not contain object name")
+	assert(t, logEntry[12].(string) == "kind", "Logged line did not contain object kind")
+	assert(t, logEntry[14].(string) == "uid", "Logged line did not contain UUID")
+	tearDown()
+}
+
+func TestObjectRef(t *testing.T) {
+	setUp()
+	log := MakeLogger(MockLogger{})
+	log.SetLogLevel(INFO)
+	vmRef := &k8sv1.ObjectReference{
+		Kind:      "test",
+		Name:      "test",
+		Namespace: "test",
+		UID:       "test",
+	}
+	log.ObjectRef(vmRef).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
 	assert(t, logEntry[1].(string) == logLevelNames[INFO], "Logged line was not of level INFO")

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -290,6 +290,7 @@ var _ = Describe("VMIlifecycle", func() {
 				err = pkillAllLaunchers(virtClient, nodeName)
 				Expect(err).To(BeNil())
 
+				By("Waiting for the vm to be stopped")
 				tests.NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(tests.WarningEvent, v1.Stopped)
 
 				By("Checking that VirtualMachineInstance has 'Failed' phase")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In order to make it easier to track down issues when we see unwanted
events in our tests, better log which entity was responsible for
triggering the event and not just log the event message itself.

```release-note
NONE
```
