### PR TITLE
Set reporting style for STDCI to plain HTML

### DIFF
--- a/stdci.yaml
+++ b/stdci.yaml
@@ -9,3 +9,5 @@ sub-stages:
 runtime_requirements:
   support_nesting_level: 2
   isolation_level: container
+reporting:
+  style: stdci


### PR DESCRIPTION
Make the links posted on tested PRs point to a static HTML file that
loads much faster then Blue Ocean.
