### PR TITLE
Merge pull request #1364 from rmohr/memory-overcommit

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3361,6 +3361,10 @@
    "v1.DeletionPropagation": {},
    "v1.Devices": {
     "properties": {
+     "autoattachGraphicsDevice": {
+      "description": "Wheater to attach the default graphics device or not.\nVNC will not be available if set to false. Defaults to true.",
+      "type": "boolean"
+     },
      "disks": {
       "description": "Disks describes disks, cdroms, floppy and luns which are connected to the vmi",
       "type": "array",
@@ -4174,6 +4178,10 @@
      "limits": {
       "description": "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
       "type": "object"
+     },
+     "overcommitGuestOverhead": {
+      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the requested memory limits. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
+      "type": "boolean"
      },
      "requests": {
       "description": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -58,6 +58,8 @@ spec:
                               type: string
                         devices:
                           properties:
+                            autoattachGraphicsDevice:
+                              type: boolean
                             disks:
                               items:
                                 properties:
@@ -192,6 +194,8 @@ spec:
                           properties:
                             limits:
                               type: object
+                            overcommitGuestOverhead:
+                              type: boolean
                             requests:
                               type: object
                       required:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -51,6 +51,8 @@ spec:
                       type: string
                 devices:
                   properties:
+                    autoattachGraphicsDevice:
+                      type: boolean
                     disks:
                       items:
                         properties:
@@ -185,6 +187,8 @@ spec:
                   properties:
                     limits:
                       type: object
+                    overcommitGuestOverhead:
+                      type: boolean
                     requests:
                       type: object
               required:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -46,6 +46,8 @@ spec:
                       type: string
                 devices:
                   properties:
+                    autoattachGraphicsDevice:
+                      type: boolean
                     disks:
                       items:
                         properties:
@@ -180,6 +182,8 @@ spec:
                   properties:
                     limits:
                       type: object
+                    overcommitGuestOverhead:
+                      type: boolean
                     requests:
                       type: object
               required:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -62,6 +62,8 @@ spec:
                               type: string
                         devices:
                           properties:
+                            autoattachGraphicsDevice:
+                              type: boolean
                             disks:
                               items:
                                 properties:
@@ -196,6 +198,8 @@ spec:
                           properties:
                             limits:
                               type: object
+                            overcommitGuestOverhead:
+                              type: boolean
                             requests:
                               type: object
                       required:

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -246,6 +246,15 @@ func (in *Devices) DeepCopyInto(out *Devices) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AutoattachGraphicsDevice != nil {
+		in, out := &in.AutoattachGraphicsDevice, &out.AutoattachGraphicsDevice
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -242,6 +242,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								},
 							},
 						},
+						"autoattachGraphicsDevice": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Wheater to attach the default graphics device or not. VNC will not be available if set to false. Defaults to true.",
+								Type:        []string{"boolean"},
+								Format:      "",
+							},
+						},
 					},
 				},
 			},
@@ -1021,6 +1028,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 										},
 									},
 								},
+							},
+						},
+						"overcommitGuestOverhead": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the requested memory limits. This can lead to crashes if all memory is in use on a node. Defaults to false.",
+								Type:        []string{"boolean"},
+								Format:      "",
 							},
 						},
 					},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -86,6 +86,10 @@ type ResourceRequirements struct {
 	// Valid resource keys are "memory" and "cpu".
 	// +optional
 	Limits v1.ResourceList `json:"limits,omitempty"`
+	// Don't ask the scheduler to take the guest-management overhead into account. Instead
+	// put the overhead only into the requested memory limits. This can lead to crashes if
+	// all memory is in use on a node. Defaults to false.
+	OvercommitGuestOverhead bool `json:"overcommitGuestOverhead,omitempty"`
 }
 
 // CPU allow specifying the CPU topology
@@ -146,6 +150,9 @@ type Devices struct {
 	Watchdog *Watchdog `json:"watchdog,omitempty"`
 	// Interfaces describe network interfaces which are added to the vm
 	Interfaces []Interface `json:"interfaces,omitempty"`
+	// Wheater to attach the default graphics device or not.
+	// VNC will not be available if set to false. Defaults to true.
+	AutoattachGraphicsDevice *bool `json:"autoattachGraphicsDevice,omitempty"`
 }
 
 // ---

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -26,8 +26,9 @@ func (DomainSpec) SwaggerDoc() map[string]string {
 
 func (ResourceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"requests": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
-		"limits":   "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"requests":                "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"limits":                  "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the requested memory limits. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
 	}
 }
 
@@ -67,9 +68,10 @@ func (Firmware) SwaggerDoc() map[string]string {
 
 func (Devices) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"disks":      "Disks describes disks, cdroms, floppy and luns which are connected to the vmi",
-		"watchdog":   "Watchdog describes a watchdog device which can be added to the vmi",
-		"interfaces": "Interfaces describe network interfaces which are added to the vm",
+		"disks":                    "Disks describes disks, cdroms, floppy and luns which are connected to the vmi",
+		"watchdog":                 "Watchdog describes a watchdog device which can be added to the vmi",
+		"interfaces":               "Interfaces describe network interfaces which are added to the vm",
+		"autoattachGraphicsDevice": "Wheater to attach the default graphics device or not.\nVNC will not be available if set to false. Defaults to true.",
 	}
 }
 

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -68,16 +68,12 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, podList),
 				),
 			)
 
-			podName, httpStatusCode, err := app.remoteExecInfo("testvmi", "default")
+			podName, httpStatusCode, err := app.remoteExecInfo(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(podName).To(Equal("madeup-name"))
@@ -90,14 +86,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi.Status.Phase = v1.Succeeded
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
 
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
-				),
-			)
-
-			_, httpStatusCode, err := app.remoteExecInfo("testvmi", "default")
+			_, httpStatusCode, err := app.remoteExecInfo(vmi)
 
 			Expect(err).To(HaveOccurred())
 			Expect(httpStatusCode).To(Equal(http.StatusBadRequest))
@@ -114,16 +103,12 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, podList),
 				),
 			)
 
-			_, httpStatusCode, err := app.remoteExecInfo("testvmi", "default")
+			_, httpStatusCode, err := app.remoteExecInfo(vmi)
 
 			Expect(err).To(HaveOccurred())
 			Expect(httpStatusCode).To(Equal(http.StatusBadRequest))

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -195,7 +195,9 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	} else {
 		// Add overhead memory
 		memoryRequest := resources.Requests[k8sv1.ResourceMemory]
-		memoryRequest.Add(*memoryOverhead)
+		if !vmi.Spec.Domain.Resources.OvercommitGuestOverhead {
+			memoryRequest.Add(*memoryOverhead)
+		}
 		resources.Requests[k8sv1.ResourceMemory] = memoryRequest
 
 		if memoryLimit, ok := resources.Limits[k8sv1.ResourceMemory]; ok {
@@ -379,7 +381,9 @@ func getMemoryOverhead(domain v1.DomainSpec) *resource.Quantity {
 	overhead.Add(resource.MustParse("8Mi"))
 
 	// Add video RAM overhead
-	overhead.Add(resource.MustParse("16Mi"))
+	if domain.Devices.AutoattachGraphicsDevice == nil || *domain.Devices.AutoattachGraphicsDevice == true {
+		overhead.Add(resource.MustParse("16Mi"))
+	}
 
 	return overhead
 }

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -498,15 +498,27 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		},
 	}
 
-	// Add mandatory vnc device
-	domain.Spec.Devices.Graphics = []Graphics{
-		{
-			Listen: &GraphicsListen{
-				Type:   "socket",
-				Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-vnc", vmi.ObjectMeta.Namespace, vmi.ObjectMeta.Name),
+	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == nil || *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == true {
+		var heads uint = 1
+		var vram uint = 16384
+		domain.Spec.Devices.Video = []Video{
+			{
+				Model: VideoModel{
+					Type:  "vga",
+					Heads: &heads,
+					VRam:  &vram,
+				},
 			},
-			Type: "vnc",
-		},
+		}
+		domain.Spec.Devices.Graphics = []Graphics{
+			{
+				Listen: &GraphicsListen{
+					Type:   "socket",
+					Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/%s/virt-vnc", vmi.ObjectMeta.Namespace, vmi.ObjectMeta.Name),
+				},
+				Type: "vnc",
+			},
+		}
 	}
 
 	// Add mandatory interface

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -576,6 +576,42 @@ var _ = Describe("Converter", func() {
 			Expect(Convert_v1_VirtualMachine_To_api_Domain(vmi, &Domain{}, c)).ToNot(Succeed())
 		})
 	})
+
+	Context("graphics and video device", func() {
+
+		table.DescribeTable("should check autoattachGraphicsDevicse", func(autoAttach *bool, devices int) {
+
+			vmi := v1.VirtualMachineInstance{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name:      "testvmi",
+					Namespace: "default",
+					UID:       "1234",
+				},
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						CPU: &v1.CPU{Cores: 3},
+						Resources: v1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								k8sv1.ResourceCPU:    resource.MustParse("1m"),
+								k8sv1.ResourceMemory: resource.MustParse("64M"),
+							},
+						},
+					},
+				},
+			}
+			vmi.Spec.Domain.Devices = v1.Devices{
+				AutoattachGraphicsDevice: autoAttach,
+			}
+			domain := vmiToDomain(&vmi, &ConverterContext{AllowEmulation: true})
+			Expect(domain.Spec.Devices.Video).To(HaveLen(devices))
+			Expect(domain.Spec.Devices.Graphics).To(HaveLen(devices))
+
+		},
+			table.Entry("and add the graphics and video device if it is not set", nil, 1),
+			table.Entry("and add the graphics and video device if it is set to true", True(), 1),
+			table.Entry("and not add the graphics and video device if it is set to false", False(), 0),
+		)
+	})
 })
 
 func diskToDiskXML(disk *v1.Disk) string {
@@ -612,4 +648,14 @@ func xmlToDomainSpec(data string) *DomainSpec {
 
 func vmiToDomainXMLToDomainSpec(vmi *v1.VirtualMachineInstance, c *ConverterContext) *DomainSpec {
 	return xmlToDomainSpec(vmiToDomainXML(vmi, c))
+}
+
+func True() *bool {
+	b := true
+	return &b
+}
+
+func False() *bool {
+	b := false
+	return &b
 }

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -2,23 +2,6 @@ package api
 
 const DefaultBridgeName = "br1"
 
-func SetDefaults_Devices(devices *Devices) {
-	// Use vga as video device, since it is better than cirrus
-	// and does not require guest drivers
-	var heads uint = 1
-	var vram uint = 16384
-	devices.Video = []Video{
-		{
-			Model: VideoModel{
-				Type:  "vga",
-				Heads: &heads,
-				VRam:  &vram,
-			},
-		},
-	}
-
-}
-
 func SetDefaults_OSType(ostype *OSType) {
 	ostype.OS = "hvm"
 

--- a/pkg/virt-launcher/virtwrap/api/zz_generated.defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/zz_generated.defaults.go
@@ -39,7 +39,6 @@ func SetObjectDefaults_Domain(in *Domain) {
 	if in.Spec.SysInfo != nil {
 		SetDefaults_SysInfo(in.Spec.SysInfo)
 	}
-	SetDefaults_Devices(&in.Spec.Devices)
 }
 
 func SetObjectDefaults_DomainList(in *DomainList) {


### PR DESCRIPTION
Allow creating VMIs with minimal guest overhead to achieve a higher VMI density per node

(cherry picked from commit f59c0f83b85d140f8beda1530f60c4dd70eb3519)
Signed-off-by: Roman Mohr <rmohr@redhat.com>

**What this PR does / why we need it**:

This PR allows configuring VMs with a small guest overhead. That involves two changes:

1. Headless VMIs (no video ram overhead, but also no VNC)
2. Allow overcommiting for the per-guest overhead.

Ad 1.) Allow headless VirtualMachineInstances:

 * Add autoattachGraphicsDevice with default to true
 * If set to false, don't consider video ram in vm overhead
 * If set to false, don't allow VNC connections to the vm

Ad 2.) Allow overcommiting guest overhead

 * Add overcommitGuestOverhead to the API
 * Let it default to false to keep the current behaviour
 * If set, only add the guest overhead to memory limits (if present)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1305

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Add a field "autoattachGraphicsDevice" to the API to let users create headless VMIs
* Add a field "overcommitGuestOverhead" to the API to only allocate from k8s as much memory which the VM can see
```