### PR TITLE
Skip custom MAC address test on OpenShift

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -158,6 +158,10 @@ var _ = Describe("Networking", func() {
 	table.DescribeTable("should be able to reach", func(destination string) {
 		var cmdCheck, addrShow, addr string
 
+		if destination == "InboundVMIWithCustomMacAddress" {
+			tests.SkipIfOpenShift("Custom MAC addresses on pod networks are not suppored")
+		}
+
 		// assuming pod network is of standard MTU = 1500 (minus 50 bytes for vxlan overhead)
 		expectedMtu := 1450
 		ipHeaderSize := 28 // IPv4 specific


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Disable the custom mac on pod network test for openshift since it does not work there. Finding a solution is tracked in #1282.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #1282

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
