### PR TITLE
presets: allow to sort by annotations

### DIFF
--- a/docs/vm-presets.md
+++ b/docs/vm-presets.md
@@ -108,6 +108,23 @@ metadata:
   ...
 ```
 
+Priority
+------------------------
+Presets are applied sequentially to `VirtualMachineInstance`s, in a not-specified order.
+Optionally, presets may be annotated with a `priority` value. The value must be a non-negative
+integer. The `priority` value is used to sort the presets when applying them.
+Presets will be applied in decreasing priority order; if two presets have the same priority,
+they will be applied in an unspecified order.
+If priority is not specified, the default value is zero, the minimum possible priority.
+
+```yaml
+kind: VirtualMachineInstancePreset
+metadata:
+  name: example-preset
+  annotations:
+    virtualmachineinstancepresets.admission.kubevirt.io/priority: "10"
+  ...
+```
 
 Examples
 =============================

--- a/pkg/virt-controller/watch/preset_test.go
+++ b/pkg/virt-controller/watch/preset_test.go
@@ -579,7 +579,6 @@ var _ = Describe("VirtualMachineInstance Initializer", func() {
 	})
 
 	Context("Sorting by priority", func() {
-		var vmi v1.VirtualMachineInstance
 		var preset1 v1.VirtualMachineInstancePreset
 		var preset2 v1.VirtualMachineInstancePreset
 		var preset3 v1.VirtualMachineInstancePreset
@@ -587,11 +586,7 @@ var _ = Describe("VirtualMachineInstance Initializer", func() {
 		m64, _ := resource.ParseQuantity("64M")
 		m128, _ := resource.ParseQuantity("128M")
 
-		var recorder FakeRecorder
-
 		BeforeEach(func() {
-			vmi = v1.VirtualMachineInstance{ObjectMeta: k8smetav1.ObjectMeta{Name: "test-vmi"}}
-
 			preset1 = v1.VirtualMachineInstancePreset{
 				ObjectMeta: k8smetav1.ObjectMeta{
 					Name:        "memory-64",
@@ -632,7 +627,6 @@ var _ = Describe("VirtualMachineInstance Initializer", func() {
 					},
 				},
 			}
-			recorder = NewFakeRecorder()
 		})
 
 		It("should not change the order without annotations", func() {

--- a/pkg/virt-controller/watch/preset_test.go
+++ b/pkg/virt-controller/watch/preset_test.go
@@ -578,6 +578,82 @@ var _ = Describe("VirtualMachineInstance Initializer", func() {
 		})
 	})
 
+	Context("Sorting by priority", func() {
+		var vmi v1.VirtualMachineInstance
+		var preset1 v1.VirtualMachineInstancePreset
+		var preset2 v1.VirtualMachineInstancePreset
+		var preset3 v1.VirtualMachineInstancePreset
+
+		m64, _ := resource.ParseQuantity("64M")
+		m128, _ := resource.ParseQuantity("128M")
+
+		var recorder FakeRecorder
+
+		BeforeEach(func() {
+			vmi = v1.VirtualMachineInstance{ObjectMeta: k8smetav1.ObjectMeta{Name: "test-vmi"}}
+
+			preset1 = v1.VirtualMachineInstancePreset{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Name:        "memory-64",
+					Annotations: make(map[string]string),
+				},
+				Spec: v1.VirtualMachineInstancePresetSpec{
+					Selector: k8smetav1.LabelSelector{MatchLabels: map[string]string{"kubevirt.io/m64": "memory-64"}},
+					Domain: &v1.DomainPresetSpec{
+						Resources: v1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{"memory": m64},
+						},
+					},
+				},
+			}
+			preset2 = v1.VirtualMachineInstancePreset{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Name:        "memory-128",
+					Annotations: make(map[string]string),
+				},
+				Spec: v1.VirtualMachineInstancePresetSpec{
+					Selector: k8smetav1.LabelSelector{MatchLabels: map[string]string{"kubevirt.io/m128": "memory-128"}},
+					Domain: &v1.DomainPresetSpec{
+						Resources: v1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{"memory": m128},
+						},
+					},
+				},
+			}
+			preset3 = v1.VirtualMachineInstancePreset{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Name:        "cpu-4",
+					Annotations: make(map[string]string),
+				},
+				Spec: v1.VirtualMachineInstancePresetSpec{
+					Selector: k8smetav1.LabelSelector{MatchLabels: map[string]string{"kubevirt.io/cpu": "cpu-4"}},
+					Domain: &v1.DomainPresetSpec{
+						CPU: &v1.CPU{Cores: 4},
+					},
+				},
+			}
+			recorder = NewFakeRecorder()
+		})
+
+		It("should not change the order without annotations", func() {
+			presets := []v1.VirtualMachineInstancePreset{preset1, preset2, preset3}
+			sortPresets(presets)
+			Expect(presets[0].Name).To(Equal("memory-64"))
+			Expect(presets[1].Name).To(Equal("memory-128"))
+			Expect(presets[2].Name).To(Equal("cpu-4"))
+		})
+
+		It("should enforce priorities", func() {
+			presets := []v1.VirtualMachineInstancePreset{preset1, preset2, preset3}
+			preset1.Annotations[priorityMarking] = "1"
+			preset2.Annotations[priorityMarking] = "9"
+			sortPresets(presets)
+			Expect(presets[0].Name).To(Equal("memory-128"))
+			Expect(presets[1].Name).To(Equal("memory-64"))
+			Expect(presets[2].Name).To(Equal("cpu-4"))
+		})
+	})
+
 	Context("Apply Presets", func() {
 		var vmi v1.VirtualMachineInstance
 		var preset v1.VirtualMachineInstancePreset


### PR DESCRIPTION
**What this PR does / why we need it**:
We would like to let the operator have control on the order of which
the presets are applied. To do so, we introduce an optional "priority"
annotation, that can be used to enforce the order.

No change is expected, thus the order of application is not specified,
when no annotations are used.

**Special notes for your reviewer**:
Partially addresses https://github.com/kubevirt/kubevirt/issues/1375

**Release note**:
```release-note
Allow to annotate presets with a priority, so the operator can control the order on which the presets are applied to VirtualMachineInstances.
```
