### PR TITLE
Move VMI to failed state if compute container is terminated

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -315,7 +315,16 @@ func isPodReady(pod *k8sv1.Pod) bool {
 }
 
 func isPodDownOrGoingDown(pod *k8sv1.Pod) bool {
-	return podIsDown(pod) || pod.DeletionTimestamp != nil
+	return podIsDown(pod) || isComputeContainerDown(pod) || pod.DeletionTimestamp != nil
+}
+
+func isComputeContainerDown(pod *k8sv1.Pod) bool {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name == "compute" {
+			return containerStatus.State.Terminated != nil
+		}
+	}
+	return false
 }
 
 func podIsDown(pod *k8sv1.Pod) bool {


### PR DESCRIPTION

**What this PR does / why we need it**:

In case the compute pod terminates with exit code `0` before the pod was handed over to
virt-handler, the vmi got stuck forever inscheduled state and did not
move to failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1388

```release-note
Fix a rare condition where the VMI can get stuck if parts of the launcher pods terminate with exit  ode `0` very early during the VMI scheduling.
```
