### PR TITLE
1.10.3 prodider doesn't exist anymore so make 1.10.4 default?

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -19,7 +19,7 @@ function build_func_tests() {
     mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
 }
 
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.11.0}
+KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.4}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 
 # Use this environment variable to set a custom pkgdir path

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -19,7 +19,7 @@ function build_func_tests() {
     mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
 }
 
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.3}
+KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.11.0}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 
 # Use this environment variable to set a custom pkgdir path

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -2,7 +2,6 @@ unset binaries docker_images docker_prefix docker_tag manifest_templates \
     master_ip network_provider kubeconfig manifest_docker_prefix namespace
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.4}
 
 source ${KUBEVIRT_PATH}hack/config-default.sh source ${KUBEVIRT_PATH}hack/config-${KUBEVIRT_PROVIDER}.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If KUBEVIRT_PROVIDER was not defined, `make cluster-up` failed.  1.10.3 was the default provider.  But it got removed when we added support for Kubernetes 1.11.0.

**Which issue(s) this PR fixes** 
Fixes #1353

