### PR TITLE
Allow setting vNIC pci address

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3849,6 +3849,10 @@
       "description": "Logical name of the interface as well as a reference to the associated networks.\nMust match the Name of a Network.",
       "type": "string"
      },
+     "pciAddress": {
+      "description": "If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10\n+optional",
+      "type": "string"
+     },
      "ports": {
       "description": "List of ports to be forwarded to the virtual machine.",
       "type": "array",

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -113,6 +113,8 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  pciAddress:
+                                    type: string
                                   ports:
                                     items:
                                       properties:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -106,6 +106,8 @@ spec:
                             type: string
                           name:
                             type: string
+                          pciAddress:
+                            type: string
                           ports:
                             items:
                               properties:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -105,6 +105,8 @@ spec:
                             type: string
                           name:
                             type: string
+                          pciAddress:
+                            type: string
                           ports:
                             items:
                               properties:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -117,6 +117,8 @@ spec:
                                     type: string
                                   name:
                                     type: string
+                                  pciAddress:
+                                    type: string
                                   ports:
                                     items:
                                       properties:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -851,6 +851,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "int32",
 							},
 						},
+						"pciAddress": {
+							SchemaProps: spec.SchemaProps{
+								Description: "If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"name"},
 				},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -709,6 +709,9 @@ type Interface struct {
 	// Interfaces without a boot order are not tried.
 	// +optional
 	BootOrder *uint `json:"bootOrder,omitempty"`
+	// If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10
+	// +optional
+	PciAddress string `json:"pciAddress,omitempty"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -323,6 +323,7 @@ func (Interface) SwaggerDoc() map[string]string {
 		"ports":      "List of ports to be forwarded to the virtual machine.",
 		"macAddress": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
 		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach interface or disk that has a boot order must have a unique value.\nInterfaces without a boot order are not tried.\n+optional",
+		"pciAddress": "If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10\n+optional",
 	}
 }
 

--- a/pkg/util/hw_helper.go
+++ b/pkg/util/hw_helper.go
@@ -26,6 +26,7 @@ import (
 
 const PCI_ADDRESS_PATTERN = `^([\da-fA-F]{4}):([\da-fA-F]{2}):([\da-fA-F]{2}).([0-7]{1})$`
 
+// ParsePciAddress returns an array of PCI DBSF fields (domain, bus, slot, function)
 func ParsePciAddress(pciAddress string) ([]string, error) {
 	pciAddrRegx, err := regexp.Compile(PCI_ADDRESS_PATTERN)
 	if err != nil {

--- a/pkg/util/hw_helper.go
+++ b/pkg/util/hw_helper.go
@@ -35,5 +35,5 @@ func ParsePciAddress(pciAddress string) ([]string, error) {
 	if len(res) == 0 {
 		return nil, fmt.Errorf("failed to parse pci address %s", pciAddress)
 	}
-	return res, nil
+	return res[1:], nil
 }

--- a/pkg/util/hw_helper.go
+++ b/pkg/util/hw_helper.go
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package util
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const PCI_ADDRESS_PATTERN = `^([\da-fA-F]{4}):([\da-fA-F]{2}):([\da-fA-F]{2}).([0-7]{1})$`
+
+func ParsePciAddress(pciAddress string) ([]string, error) {
+	pciAddrRegx, err := regexp.Compile(PCI_ADDRESS_PATTERN)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile pci address pattern, %v", err)
+	}
+	res := pciAddrRegx.FindStringSubmatch(pciAddress)
+	if len(res) == 0 {
+		return nil, fmt.Errorf("failed to parse pci address %s", pciAddress)
+	}
+	return res, nil
+}

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -41,6 +41,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -744,6 +745,17 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 						})
 					}
 					bootOrderMap[order] = true
+				}
+			}
+			// verify that the specified pci address is valid
+			if iface.PciAddress != "" {
+				_, err := util.ParsePciAddress(iface.PciAddress)
+				if err != nil {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: fmt.Sprintf("interface %s has malformed PCI address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.PciAddress),
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("pciAddress").String(),
+					})
 				}
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -42,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/registry-disk"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -572,6 +573,21 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			Alias: &Alias{
 				Name: iface.Name,
 			},
+		}
+
+		// Add a pciAddress if specifed
+		if iface.PciAddress != "" {
+			dbsfFields, err := util.ParsePciAddress(iface.PciAddress)
+			if err != nil {
+				return err
+			}
+			domainIface.Address = &Address{
+				Type:     "pci",
+				Domain:   "0x" + dbsfFields[0],
+				Bus:      "0x" + dbsfFields[1],
+				Slot:     "0x" + dbsfFields[2],
+				Function: "0x" + dbsfFields[3],
+			}
 		}
 
 		if iface.Bridge != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -510,6 +510,20 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("e1000"))
 		})
 
+		It("should set nic pci address when specified", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:81:01.0"
+			test_address := Address{
+				Type:     "pci",
+				Domain:   "0x0000",
+				Bus:      "0x81",
+				Slot:     "0x01",
+				Function: "0x0",
+			}
+			domain := vmiToDomain(vmi, c)
+			Expect(*domain.Spec.Devices.Interfaces[0].Address).To(Equal(test_address))
+		})
+
 		It("should calculate memory in bytes", func() {
 			By("specifying memory 64M")
 			m64, _ := resource.ParseQuantity("64M")


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow users to specify an optional PCI address for network interfaces.
This is particularly needed for users who are concerned with PCI addresses stability and would like to set their own.

**Which issue(s) this PR fixes** :
Related #1325

**Special notes for your reviewer**:

**Release note**:
```
Allow users or higher level applications to set a specific PCI address for guest interfaces to maintain stability.

```
