### PR TITLE
Allow running ci in containers

### DIFF
--- a/stdci.yaml
+++ b/stdci.yaml
@@ -7,3 +7,4 @@ sub-stages:
   - windows2016-release
 runtime_requirements:
   support_nesting_level: 2
+  isolation_level: container


### PR DESCRIPTION
In order to increase the capacity of our bare-metal machines, we now can
run builds and tests in containers on top of bare-metal slaves. This
PR 'switches on' this configuration.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Increase the capacity of bare-metal slaves we have

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
