### PR TITLE
Expose libvirtd logs to kubectl logs

### DIFF
--- a/cmd/virt-launcher/libvirtd.sh
+++ b/cmd/virt-launcher/libvirtd.sh
@@ -53,4 +53,7 @@ if [ -d "/dev/hugepages" ]; then
     echo 'hugetlbfs_mount = "/dev/hugepages"' >>/etc/libvirt/qemu.conf
 fi
 
+# Log to stderr
+echo "log_outputs = \"1:stderr\"" >> /etc/libvirt/libvirtd.conf
+
 /usr/sbin/libvirtd

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/xml"
 	"fmt"
+	"os"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -145,6 +146,10 @@ func StartLibvirt(stopChan chan struct{}) {
 		for {
 			exitChan := make(chan struct{})
 			cmd := exec.Command("/usr/share/kubevirt/virt-launcher/libvirtd.sh")
+
+			// libvirtd logs to stderr (see configuration in libvirtd.sh)
+			// connect libvirt's stderr to our own stdout in order to see the logs in the container logs
+			cmd.Stderr = os.Stdout
 
 			err := cmd.Start()
 			if err != nil {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -96,6 +96,23 @@ var _ = Describe("VMIlifecycle", func() {
 				Should(ContainSubstring("Found PID for"))
 		})
 
+		It("should log libvirtd logs", func() {
+			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).To(BeNil())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Getting virt-launcher logs")
+			logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
+			Eventually(logs,
+				11*time.Second,
+				500*time.Millisecond).
+				Should(ContainSubstring("info : libvirt version: "))
+			Eventually(logs,
+				2*time.Second,
+				500*time.Millisecond).
+				Should(ContainSubstring("info : hostname: " + vmi.Name))
+		})
+
 		It("should reject POST if schema is invalid", func() {
 			jsonBytes, err := json.Marshal(vmi)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose libvirtd logs to `kubectl logs` by
- Configure libvirtd to log to stderr
- Redirect libvirtd's stderr to virt-launchers stdout

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1310

**Special notes for your reviewer**:

**Release note**:
```release-note
Expose libvirtd logs to kubectl logs
```
