### PR TITLE
Adopted build system to hosts without /bin/bash

### DIFF
--- a/cluster/build.sh
+++ b/cluster/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/cluster/down.sh
+++ b/cluster/down.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source hack/common.sh
 source cluster/$KUBEVIRT_PROVIDER/provider.sh

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/cluster/k8s-1.10.4/provider.sh
+++ b/cluster/k8s-1.10.4/provider.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/cluster/k8s-1.11.0/provider.sh
+++ b/cluster/k8s-1.11.0/provider.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/cluster/k8s-1.9.3/provider.sh
+++ b/cluster/k8s-1.9.3/provider.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/cluster/local/provider.sh
+++ b/cluster/local/provider.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function _cert_dir() {
     echo $GOPATH/src/kubevirt.io/kubevirt/cluster/local/certs

--- a/cluster/os-3.10.0/provider.sh
+++ b/cluster/os-3.10.0/provider.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/cluster/os-3.9.0-crio/provider.sh
+++ b/cluster/os-3.9.0-crio/provider.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source hack/common.sh
 source cluster/$KUBEVIRT_PROVIDER/provider.sh

--- a/cluster/virtctl.sh
+++ b/cluster/virtctl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/bootstrap-ginkgo.sh
+++ b/hack/bootstrap-ginkgo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/build-copy-artifacts.sh
+++ b/hack/build-copy-artifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/build-func-tests.sh
+++ b/hack/build-func-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 source hack/common.sh

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KUBEVIRT_DIR="$(
     cd "$(dirname "$BASH_SOURCE[0]")/../"

--- a/hack/dep-prune.sh
+++ b/hack/dep-prune.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 for file in $(find vendor/ -name "*_test.go"); do rm ${file}; done

--- a/hack/docker-builder/entrypoint.sh
+++ b/hack/docker-builder/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 source $(dirname "$0")/common.sh

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # gen-swagger-docs.sh $API_VERSION $OUTPUT_FORMAT
 # API_VERSION=v1

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 go test -cover -v -coverprofile=.coverprofile $(go list ./pkg/...)

--- a/hack/release-announce.sh
+++ b/hack/release-announce.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/usr/bin/env bash
 
 underline() {
     echo "$2"

--- a/hack/verify-build.sh
+++ b/hack/verify-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014 The Kubernetes Authors.
 #


### PR DESCRIPTION
Some linux hosts don't keep their bash binary under /bin but in other
places. One example of such a host is nixos that keeps it somewhere
under /nix/store.

Instead of assuming the location of the binary, use /usr/bin/env to
determine it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
