### PR TITLE
Increase the default number of cpus on test nodes

### DIFF
--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -29,7 +29,7 @@ function _registry_volume() {
 }
 
 function _add_common_params() {
-    local params="--nodes ${KUBEVIRT_NUM_NODES} --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
+    local params="--nodes ${KUBEVIRT_NUM_NODES} --cpu 4 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
     if [[ -d $NFS_WINDOWS_DIR ]] && [[ $TARGET =~ windows.* ]]; then
         params="--memory 8192M --nfs-data $NFS_WINDOWS_DIR $params"
     fi


### PR DESCRIPTION
Signed-off-by: Vladik Romanovsky <vromanso@redhat.com>

**What this PR does / why we need it**:
This simply increases the default amount of CPUs we create on a test node.
It's needed in order to run CPU related functional tests, specifically for cpu pinning.

**Release note**:
```release-note
Node
```
