### PR TITLE
consolidate kubectl/oc/virtctl RunCommand() into one

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -40,7 +40,7 @@ var _ = Describe("User Access", func() {
 
 	Describe("With default kubevirt service accounts", func() {
 		table.DescribeTable("should verify permissions are correct for view, edit, and admin", func(resource string) {
-			tests.SkipIfNoKubectl()
+			tests.SkipIfNoCmd("kubectl")
 
 			view := tests.ViewServiceAccountName
 			edit := tests.EditServiceAccountName
@@ -98,21 +98,21 @@ var _ = Describe("User Access", func() {
 				By(fmt.Sprintf("verifying VIEW sa for verb %s", verb))
 				expectedRes, _ := viewVerbs[verb]
 				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, view)
-				result, _ := tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				result, _ := tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// EDIT
 				By(fmt.Sprintf("verifying EDIT sa for verb %s", verb))
 				expectedRes, _ = editVerbs[verb]
 				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, edit)
-				result, _ = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				result, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// ADMIN
 				By(fmt.Sprintf("verifying ADMIN sa for verb %s", verb))
 				expectedRes, _ = adminVerbs[verb]
 				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, admin)
-				result, _ = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				result, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// DEFAULT - the default should always return 'no' for ever verb.
@@ -120,7 +120,7 @@ var _ = Describe("User Access", func() {
 				By(fmt.Sprintf("verifying DEFAULT sa for verb %s", verb))
 				expectedRes = "no"
 				as = fmt.Sprintf("system:serviceaccount:%s:default", namespace)
-				result, _ = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
+				result, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 			}
 		},

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Templates", func() {
 	)
 
 	BeforeEach(func() {
-		tests.SkipIfNoOc()
+		tests.SkipIfNoCmd("oc")
 		tests.BeforeTestCleanup()
 	})
 
@@ -224,7 +224,7 @@ type TemplateParams struct {
 func runOcProcessCommand(templateJsonFile string, templateParams TemplateParams, vmJsonFile string) (string, error) {
 	templateParamArgs := []string{"-p", "NAME=" + templateParams.Name, "-p", "CPU_CORES=" + templateParams.CpuCores}
 	args := append([]string{"process", "-f", templateJsonFile}, templateParamArgs...)
-	out, err := tests.RunOcCommand(args...)
+	out, err := tests.RunCommand("oc", args...)
 	if err != nil {
 		return out, err
 	}
@@ -236,22 +236,22 @@ func runOcProcessCommand(templateJsonFile string, templateParams TemplateParams,
 }
 
 func runOcCreateCommand(vmJsonFile string) (string, error) {
-	out, err := tests.RunOcCommand("create", "-f", vmJsonFile)
+	out, err := tests.RunCommand("oc", "create", "-f", vmJsonFile)
 	return out, err
 }
 
 func runOcPatchCommand(vmName string, patch string) (string, error) {
-	out, err := tests.RunOcCommand("patch", "virtualmachine", vmName, "--type", "merge", "-p", patch)
+	out, err := tests.RunCommand("oc", "patch", "virtualmachine", vmName, "--type", "merge", "-p", patch)
 	return out, err
 }
 
 func runOcDeleteCommand(vmName string) (string, error) {
-	out, err := tests.RunOcCommand("delete", "vm", vmName)
+	out, err := tests.RunCommand("oc", "delete", "vm", vmName)
 	return out, err
 }
 
 func runOcGetCommand(resourceType string) (string, error) {
-	out, err := tests.RunOcCommand("get", resourceType)
+	out, err := tests.RunCommand("oc", "get", resourceType)
 	return out, err
 }
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -82,7 +82,7 @@ var _ = Describe("HookSidecars", func() {
 
 			It("should update domain XML with SM BIOS properties", func() {
 				By("Reading domain XML using virsh")
-				tests.SkipIfNoKubectl()
+				tests.SkipIfNoCmd("kubectl")
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				tests.WaitForSuccessfulVMIStart(vmi)
 				domainXml := getVmDomainXml(virtClient, vmi)
@@ -115,11 +115,11 @@ func getHookSidecarLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 func getVmDomainXml(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	podName := getVmPodName(virtCli, vmi)
 
-	vmNameListRaw, err := tests.RunKubectlCommand("exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "list", "--name")
+	vmNameListRaw, err := tests.RunCommand("kubectl", "exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "list", "--name")
 	Expect(err).ToNot(HaveOccurred())
 
 	vmName := strings.Split(vmNameListRaw, "\n")[0]
-	vmDomainXML, err := tests.RunKubectlCommand("exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "dumpxml", vmName)
+	vmDomainXML, err := tests.RunCommand("kubectl", "exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "dumpxml", vmName)
 	Expect(err).ToNot(HaveOccurred())
 
 	return vmDomainXML

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 	Context("with kubectl command", func() {
 		var yamlFile string
 		BeforeEach(func() {
-			tests.SkipIfNoKubectl()
+			tests.SkipIfNoCmd("kubectl")
 			yamlFile, err = tests.GenerateVMIJson(windowsVMI)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -241,7 +241,7 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 
 		It("should succeed to start a vmi", func() {
 			By("Starting the vmi via kubectl command")
-			_, err = tests.RunKubectlCommand("create", "-f", yamlFile)
+			_, err = tests.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 120)
@@ -249,13 +249,13 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 
 		It("should succeed to stop a vmi", func() {
 			By("Starting the vmi via kubectl command")
-			_, err = tests.RunKubectlCommand("create", "-f", yamlFile)
+			_, err = tests.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 120)
 
 			By("Deleting the vmi via kubectl command")
-			_, err = tests.RunKubectlCommand("delete", "-f", yamlFile)
+			_, err = tests.RunCommand("kubectl", "delete", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the vmi does not exist anymore")


### PR DESCRIPTION
Signed-off-by: Shiyang Wang <shiywang@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
make downstream kubevirt-ansible more easy to consume the lib.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
