### PR TITLE
add boot order to network interface

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3475,7 +3475,7 @@
     ],
     "properties": {
      "bootOrder": {
-      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices.\nLower values take precedence.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
+      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
       "type": "integer",
       "format": "integer"
      },
@@ -3829,9 +3829,10 @@
      "name"
     ],
     "properties": {
-     "bootorder": {
-      "description": "Boot order for this interface.\nany number larger than zero gives the order in which this interface will be used\nfor bootting among all other devices (interfaces and disks)",
-      "type": "string"
+     "bootOrder": {
+      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach interface or disk that has a boot order must have a unique value.\nInterfaces without a boot order are not tried.\n+optional",
+      "type": "integer",
+      "format": "integer"
      },
      "bridge": {
       "$ref": "#/definitions/v1.InterfaceBridge"

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3829,6 +3829,10 @@
      "name"
     ],
     "properties": {
+     "bootorder": {
+      "description": "Boot order for this interface.\nany number larger than zero gives the order in which this interface will be used\nfor bootting among all other devices (interfaces and disks)",
+      "type": "string"
+     },
      "bridge": {
       "$ref": "#/definitions/v1.InterfaceBridge"
      },

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -103,6 +103,8 @@ spec:
                             interfaces:
                               items:
                                 properties:
+                                  bootorder:
+                                    type: string
                                   bridge: {}
                                   macAddress:
                                     type: string

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -103,8 +103,9 @@ spec:
                             interfaces:
                               items:
                                 properties:
-                                  bootorder:
-                                    type: string
+                                  bootOrder:
+                                    format: int32
+                                    type: integer
                                   bridge: {}
                                   macAddress:
                                     type: string

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -96,8 +96,9 @@ spec:
                     interfaces:
                       items:
                         properties:
-                          bootorder:
-                            type: string
+                          bootOrder:
+                            format: int32
+                            type: integer
                           bridge: {}
                           macAddress:
                             type: string

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -96,6 +96,8 @@ spec:
                     interfaces:
                       items:
                         properties:
+                          bootorder:
+                            type: string
                           bridge: {}
                           macAddress:
                             type: string

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -95,6 +95,8 @@ spec:
                     interfaces:
                       items:
                         properties:
+                          bootorder:
+                            type: string
                           bridge: {}
                           macAddress:
                             type: string

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -95,8 +95,9 @@ spec:
                     interfaces:
                       items:
                         properties:
-                          bootorder:
-                            type: string
+                          bootOrder:
+                            format: int32
+                            type: integer
                           bridge: {}
                           macAddress:
                             type: string

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -107,8 +107,9 @@ spec:
                             interfaces:
                               items:
                                 properties:
-                                  bootorder:
-                                    type: string
+                                  bootOrder:
+                                    format: int32
+                                    type: integer
                                   bridge: {}
                                   macAddress:
                                     type: string

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -107,6 +107,8 @@ spec:
                             interfaces:
                               items:
                                 properties:
+                                  bootorder:
+                                    type: string
                                   bridge: {}
                                   macAddress:
                                     type: string

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -862,6 +862,15 @@ func (in *Interface) DeepCopyInto(out *Interface) {
 		*out = make([]Port, len(*in))
 		copy(*out, *in)
 	}
+	if in.BootOrder != nil {
+		in, out := &in.BootOrder, &out.BootOrder
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(uint)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -277,7 +277,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"bootOrder": {
 							SchemaProps: spec.SchemaProps{
-								Description: "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Disks without a boot order are not tried if a disk with a boot order exists.",
+								Description: "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.",
 								Type:        []string{"integer"},
 								Format:      "int32",
 							},
@@ -844,11 +844,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
-						"bootorder": {
+						"bootOrder": {
 							SchemaProps: spec.SchemaProps{
-								Description: "Boot order for this interface. any number larger than zero gives the order in which this interface will be used for bootting among all other devices (interfaces and disks)",
-								Type:        []string{"string"},
-								Format:      "",
+								Description: "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each interface or disk that has a boot order must have a unique value. Interfaces without a boot order are not tried.",
+								Type:        []string{"integer"},
+								Format:      "int32",
 							},
 						},
 					},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -844,6 +844,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format:      "",
 							},
 						},
+						"bootorder": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Boot order for this interface. any number larger than zero gives the order in which this interface will be used for bootting among all other devices (interfaces and disks)",
+								Type:        []string{"string"},
+								Format:      "",
+							},
+						},
 					},
 					Required: []string{"name"},
 				},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -198,6 +198,7 @@ type Disk struct {
 	DiskDevice `json:",inline"`
 	// BootOrder is an integer value > 0, used to determine ordering of boot devices.
 	// Lower values take precedence.
+	// Each disk or interface that has a boot order must have a unique value.
 	// Disks without a boot order are not tried if a disk with a boot order exists.
 	// +optional
 	BootOrder *uint `json:"bootOrder,omitempty"`
@@ -697,10 +698,12 @@ type Interface struct {
 	Ports []Port `json:"ports,omitempty"`
 	// Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.
 	MacAddress string `json:"macAddress,omitempty"`
-	// Boot order for this interface.
-	// any number larger than zero gives the order in which this interface will be used
-	// for bootting among all other devices (interfaces and disks)
-	BootOrder string `json:"bootorder,omitempty"`
+	// BootOrder is an integer value > 0, used to determine ordering of boot devices.
+	// Lower values take precedence.
+	// Each interface or disk that has a boot order must have a unique value.
+	// Interfaces without a boot order are not tried.
+	// +optional
+	BootOrder *uint `json:"bootOrder,omitempty"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -697,6 +697,10 @@ type Interface struct {
 	Ports []Port `json:"ports,omitempty"`
 	// Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.
 	MacAddress string `json:"macAddress,omitempty"`
+	// Boot order for this interface.
+	// any number larger than zero gives the order in which this interface will be used
+	// for bootting among all other devices (interfaces and disks)
+	BootOrder string `json:"bootorder,omitempty"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -321,6 +321,7 @@ func (Interface) SwaggerDoc() map[string]string {
 		"model":      "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
 		"ports":      "List of ports to be forwarded to the virtual machine.",
 		"macAddress": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
+		"bootorder":  "Boot order for this interface.\nany number larger than zero gives the order in which this interface will be used\nfor bootting among all other devices (interfaces and disks)",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -93,7 +93,7 @@ func (Disk) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name":       "Name is the device name",
 		"volumeName": "Name of the volume which is referenced.\nMust match the Name of a Volume.",
-		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
+		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":     "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 	}
 }
@@ -321,7 +321,7 @@ func (Interface) SwaggerDoc() map[string]string {
 		"model":      "Interface model.\nOne of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio.\nDefaults to virtio.",
 		"ports":      "List of ports to be forwarded to the virtual machine.",
 		"macAddress": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
-		"bootorder":  "Boot order for this interface.\nany number larger than zero gives the order in which this interface will be used\nfor bootting among all other devices (interfaces and disks)",
+		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach interface or disk that has a boot order must have a unique value.\nInterfaces without a boot order are not tried.\n+optional",
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -543,6 +543,15 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		return "virtio"
 	}
 
+	getBootOrder := func(iface *v1.Interface, network *v1.Network) *BootOrder {
+		// TODO: should take network into account deciding whether boot order is suported
+		order, err := strconv.ParseUint(iface.BootOrder, 10, 0)
+		if err != nil || order < 1 {
+			return nil
+		}
+		return &BootOrder{Order: uint(order)}
+	}
+
 	networks := map[string]*v1.Network{}
 	for _, network := range vmi.Spec.Networks {
 		networks[network.Name] = network.DeepCopy()
@@ -572,6 +581,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				Alias: &Alias{
 					Name: iface.Name,
 				},
+				BootOrder: getBootOrder(&iface, net),
 			}
 			domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, domainIface)
 		} else if iface.Slirp != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -543,15 +543,6 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		return "virtio"
 	}
 
-	getBootOrder := func(iface *v1.Interface, network *v1.Network) *BootOrder {
-		// TODO: should take network into account deciding whether boot order is suported
-		order, err := strconv.ParseUint(iface.BootOrder, 10, 0)
-		if err != nil || order < 1 {
-			return nil
-		}
-		return &BootOrder{Order: uint(order)}
-	}
-
 	networks := map[string]*v1.Network{}
 	for _, network := range vmi.Spec.Networks {
 		networks[network.Name] = network.DeepCopy()
@@ -581,7 +572,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				Alias: &Alias{
 					Name: iface.Name,
 				},
-				BootOrder: getBootOrder(&iface, net),
+			}
+			if iface.BootOrder != nil {
+				domainIface.BootOrder = &BootOrder{Order: *iface.BootOrder}
 			}
 			domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, domainIface)
 		} else if iface.Slirp != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -34,7 +34,6 @@ import (
 
 	"fmt"
 	"os"
-	"strconv"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
@@ -696,10 +695,8 @@ var _ = Describe("Converter", func() {
 			net2 := v1.DefaultPodNetwork()
 			iface1.Name = name1
 			iface2.Name = name2
-			bootOrder := 1
-			invalidOrder := 0
-			iface1.BootOrder = strconv.Itoa(bootOrder)
-			iface2.BootOrder = strconv.Itoa(invalidOrder)
+			bootOrder := uint(1)
+			iface1.BootOrder = &bootOrder
 			net1.Name = name1
 			net2.Name = name2
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*iface1, *iface2}


### PR DESCRIPTION
This PR add boot order to network interfaces

Doing integration test id dependent with exposing L2 network.

```release-note
It will be now possible to boot the virtual machine from one of its network interfaces. 
To achieve that, a numeric boot order value will have to be provided to the interface with following format:
interfaces:
    - bridge: {}
      bootOrder: 2
These values used to determine ordering of boot devices.
Lower values take precedence.
Each interface or disk that has a boot order must have a unique value.
Interfaces without a boot order are not tried.
The network connected to the interface must support booting (e.g. run PXE server there). 
This is not yet supported by the networks available for the virtual machine (the "pod" network).
```
