### PR TITLE
Set docker build to quiet if automated build

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -15,7 +15,7 @@ TEMPFILE=".rsynctemp"
 
 # Reduce verbosity if an automated build
 BUILD_QUIET=
-if [ -n "$JOB_NAME" -o -n "$TRAVIS_BUILD_ID" ];then
+if [ -n "$JOB_NAME" -o -n "$TRAVIS_BUILD_ID" ]; then
     BUILD_QUIET="-q"
 fi
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -13,8 +13,14 @@ SYNC_VENDOR=${SYNC_VENDOR:-false}
 
 TEMPFILE=".rsynctemp"
 
+# Reduce verbosity if an automated build
+BUILD_QUIET=
+if [ -n "$JOB_NAME" -o -n "$TRAVIS_BUILD_ID" ];then
+    BUILD_QUIET="-q"
+fi
+
 # Build the build container
-(cd ${DOCKER_DIR} && docker build . -t ${BUILDER})
+(cd ${DOCKER_DIR} && docker build . ${BUILD_QUIET} -t ${BUILDER})
 
 # Create the persistent docker volume
 if [ -z "$(docker volume list | grep ${BUILDER})" ]; then


### PR DESCRIPTION
Automated is defined as having either of the environment variables
JOB_NAME or TRAVIS_BUILD_ID set.

Signed-off-by: Ben Warren <bawarren@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As requested by @rmohr, this turns on 'quiet' mode when building the build docker container, but only if being run in an automated build environment, either Jenkins or Travis.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
N/A
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
