### PR TITLE
Allow separating guest memory from resource request

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3961,6 +3961,10 @@
    "v1.Memory": {
     "description": "Memory allows specifying the VirtualMachineInstance memory features.",
     "properties": {
+     "guest": {
+      "description": "Guest allows to specifying the amount of memory which is visible inside the Guest OS.\nThe Guest must lie between Requests and Limits from the resources section.\nDefaults to the requested memory in the resources section if not specified.\n+ optional",
+      "type": "string"
+     },
      "hugepages": {
       "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.\n+optional",
       "$ref": "#/definitions/v1.Hugepages"

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -204,6 +204,7 @@ spec:
                           - type
                         memory:
                           properties:
+                            guest: {}
                             hugepages:
                               properties:
                                 pageSize:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -197,6 +197,7 @@ spec:
                   - type
                 memory:
                   properties:
+                    guest: {}
                     hugepages:
                       properties:
                         pageSize:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -196,6 +196,7 @@ spec:
                   - type
                 memory:
                   properties:
+                    guest: {}
                     hugepages:
                       properties:
                         pageSize:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -208,6 +208,7 @@ spec:
                           - type
                         memory:
                           properties:
+                            guest: {}
                             hugepages:
                               properties:
                                 pageSize:

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -22,6 +22,7 @@ package v1
 
 import (
 	core_v1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -1008,6 +1009,15 @@ func (in *Memory) DeepCopyInto(out *Memory) {
 		} else {
 			*out = new(Hugepages)
 			**out = **in
+		}
+	}
+	if in.Guest != nil {
+		in, out := &in.Guest, &out.Guest
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(resource.Quantity)
+			**out = (*in).DeepCopy()
 		}
 	}
 	return

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -955,11 +955,17 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Hugepages"),
 							},
 						},
+						"guest": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Guest allows to specifying the amount of memory which is visible inside the Guest OS. The Guest must lie between Requests and Limits from the resources section. Defaults to the requested memory in the resources section if not specified.",
+								Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+							},
+						},
 					},
 				},
 			},
 			Dependencies: []string{
-				"kubevirt.io/kubevirt/pkg/api/v1.Hugepages"},
+				"k8s.io/apimachinery/pkg/api/resource.Quantity", "kubevirt.io/kubevirt/pkg/api/v1.Hugepages"},
 		},
 		"kubevirt.io/kubevirt/pkg/api/v1.Network": {
 			Schema: spec.Schema{

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -144,6 +144,11 @@ type Memory struct {
 	// Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.
 	// +optional
 	Hugepages *Hugepages `json:"hugepages,omitempty"`
+	// Guest allows to specifying the amount of memory which is visible inside the Guest OS.
+	// The Guest must lie between Requests and Limits from the resources section.
+	// Defaults to the requested memory in the resources section if not specified.
+	// + optional
+	Guest *resource.Quantity `json:"guest,omitempty"`
 }
 
 // Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -57,6 +57,7 @@ func (Memory) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":          "Memory allows specifying the VirtualMachineInstance memory features.",
 		"hugepages": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.\n+optional",
+		"guest":     "Guest allows to specifying the amount of memory which is visible inside the Guest OS.\nThe Guest must lie between Requests and Limits from the resources section.\nDefaults to the requested memory in the resources section if not specified.\n+ optional",
 	}
 }
 

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -427,6 +427,16 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		})
 	}
 
+	if spec.Domain.Memory != nil && spec.Domain.Memory.Hugepages != nil && spec.Domain.Memory.Guest != nil {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("'%s' and '%s' must not be set at the same time",
+				field.Child("domain", "memory", "guest").String(),
+				field.Child("domain", "memory", "hugepages", "size").String()),
+			Field: field.Child("domain", "resources", "requests", "memory").String(),
+		})
+	}
+
 	// Validate hugepages
 	if spec.Domain.Memory != nil && spec.Domain.Memory.Hugepages != nil {
 		hugepagesSize, err := resource.ParseQuantity(spec.Domain.Memory.Hugepages.PageSize)
@@ -465,6 +475,36 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					Field: field.Child("domain", "resources", "requests", "memory").String(),
 				})
 			}
+		}
+	}
+	// Validate hugepages
+	if spec.Domain.Memory != nil && spec.Domain.Memory.Guest != nil {
+		requests := spec.Domain.Resources.Requests.Memory().Value()
+		limits := spec.Domain.Resources.Limits.Memory().Value()
+		guest := spec.Domain.Memory.Guest.Value()
+		if requests > guest {
+			causes = append(causes, metav1.StatusCause{
+				Type: metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%s '%s' must be equal to or larger than the requested memory %s '%s'",
+					field.Child("domain", "memory", "guest").String(),
+					spec.Domain.Memory.Guest,
+					field.Child("domain", "resources", "requests", "memory").String(),
+					spec.Domain.Resources.Requests.Memory(),
+				),
+				Field: field.Child("domain", "memory", "guest").String(),
+			})
+		}
+		if limits < guest && limits != 0 {
+			causes = append(causes, metav1.StatusCause{
+				Type: metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%s '%s' must be equal to or less than the memory limit %s '%s'",
+					field.Child("domain", "memory", "guest").String(),
+					spec.Domain.Memory.Guest,
+					field.Child("domain", "resources", "limits", "memory").String(),
+					spec.Domain.Resources.Limits.Memory(),
+				),
+				Field: field.Child("domain", "memory", "guest").String(),
+			})
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -382,8 +382,15 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		}
 	}
 
+	// Take memory from the requested memory
 	if v, ok := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]; ok {
 		if domain.Spec.Memory, err = QuantityToByte(v); err != nil {
+			return err
+		}
+	}
+	// In case that guest memory is explicitly set, override it
+	if vmi.Spec.Domain.Memory != nil && vmi.Spec.Domain.Memory.Guest != nil {
+		if domain.Spec.Memory, err = QuantityToByte(*vmi.Spec.Domain.Memory.Guest); err != nil {
 			return err
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -565,6 +565,20 @@ var _ = Describe("Converter", func() {
 			Expect(domainSpec.Memory.Value).To(Equal(uint64(8388608)))
 			Expect(domainSpec.Memory.Unit).To(Equal("B"))
 		})
+
+		It("should use guest memory instead of requested memory if present", func() {
+			guestMemory := resource.MustParse("123Mi")
+			vmi.Spec.Domain.Memory = &v1.Memory{
+				Guest: &guestMemory,
+			}
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+
+			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+			Expect(domainSpec.Memory.Value).To(Equal(uint64(128974848)))
+			Expect(domainSpec.Memory.Unit).To(Equal("B"))
+		})
+
 	})
 	Context("Network convert", func() {
 		var vmi *v1.VirtualMachineInstance


### PR DESCRIPTION
**What this PR does / why we need it**:

To allow real memory overcommit for VMIs, it is necessary to allow giving VMIs more memory than we actually request from the KubeVirt scheduler. Alongside `spec.domain.resources.memory.requests`, which requests reserved memory from the scheduler, `spec.domain.memory.guest` can contain a differen value for the guest.

In case a VMI with `100M` wants to overcommit 10%, it can set `spec.domain.resources.memory.requests` to `90M` and `spec.domain.memory.guest` to `100M`: 

```yaml
apiVersion: kubevirt.io/v1alpha2
kind: VirtualMachineInstance
metadata:
  name: vmi-ephemeral
spec:
  domain:
      memory:
        guest: 90M
    devices:
      disks:
      - disk:
          bus: virtio
        name: registrydisk
        volumeName: registryvolume
    machine:
      type: ""
    resources:
      requests:
        memory: 100M
  terminationGracePeriodSeconds: 0
  volumes:
  - name: registryvolume
    registryDisk:
      image: registry:5000/kubevirt/cirros-registry-disk-demo:devel
```

Soft-eviction and Hard-eviction rules from the kubelet will apply as configured on the node to these VMIs.


In case that a k8s cluster with kubevirt is run, mostly just for the purpose to run Virtual Machines, it is possible to reconfigure the cluster to use `swap`.

```release-note
Allow real memory overcommit on a node by adding a field spec.domain.memory.guest, which sets the visible memory for the guest and which can be higher than the amount of memory than requested from the k8s scheduler.
```
