### PR TITLE
Fix manifest rbac

### DIFF
--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -138,6 +138,9 @@ rules:
       - ''
     resources:
       - pods
+      - configmaps
+      - endpoints
+      - limitranges
     verbs:
       - get
       - list
@@ -145,6 +148,20 @@ rules:
       - delete
       - update
       - create
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - update
+      - create
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/finalizers
+    verbs:
+      - update
   - apiGroups:
       - ''
     resources:
@@ -157,16 +174,9 @@ rules:
   - apiGroups:
       - kubevirt.io
     resources:
-      - virtualmachineinstances
-      - virtualmachineinstancereplicasets
+      - '*'
     verbs:
-      - get
-      - list
-      - watch
-      - delete
-      - update
-      - create
-      - deletecollection
+      - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -194,22 +204,6 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: kubevirt-controller
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: kubevirt-controller
-    namespace: {{.Namespace}}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: kubevirt-controller-cluster-admin
-  namespace: {{.Namespace}}
-  labels:
-    kubevirt.io: ""
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -166,6 +166,15 @@ rules:
       - ''
     resources:
       - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
       - persistentvolumeclaims
     verbs:
       - get

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -222,6 +222,9 @@ rules:
       - ''
     resources:
       - pods
+      - configmaps
+      - endpoints
+      - limitranges
     verbs:
       - get
       - list
@@ -229,6 +232,20 @@ rules:
       - delete
       - update
       - create
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - update
+      - create
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/finalizers
+    verbs:
+      - update
   - apiGroups:
       - ''
     resources:
@@ -241,18 +258,9 @@ rules:
   - apiGroups:
       - kubevirt.io
     resources:
-      - virtualmachineinstances
-      - virtualmachineinstancereplicasets
-      - virtualmachineinstancepresets
-      - virtualmachines
+      - '*'
     verbs:
-      - get
-      - list
-      - watch
-      - delete
-      - update
-      - create
-      - deletecollection
+      - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -280,22 +288,6 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: kubevirt-controller
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-  - kind: ServiceAccount
-    name: kubevirt-controller
-    namespace: {{.Namespace}}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: kubevirt-controller-cluster-admin
-  namespace: {{.Namespace}}
-  labels:
-    kubevirt.io: ""
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -174,6 +174,14 @@ metadata:
     kubevirt.io: ""
 rules:
   - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - apiregistration.k8s.io
     resources:
       - apiservices
@@ -386,7 +394,7 @@ spec:
       labels:
         kubevirt.io: virt-api
     spec:
-      serviceAccountName: kubevirt-controller
+      serviceAccountName: kubevirt-apiserver
       containers:
         - name: virt-api
           image: {{.DockerPrefix}}/virt-api:{{.DockerTag}}

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -243,13 +243,16 @@ rules:
   - apiGroups:
       - ''
     resources:
-      - pods/finalizers
+      - nodes
     verbs:
+      - get
+      - list
+      - watch
       - update
+      - patch
   - apiGroups:
       - ''
     resources:
-      - nodes
       - persistentvolumeclaims
     verbs:
       - get


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

KubeVirt's RBAC roles are incorrectly generated for virt-controller and virt-api.

Virt-api in the release manifest was using the wrong service account. It worked because that service account had full cluster privileges, which we don't want.

Virt-controller was also given full cluster privileges, which made all the targeted RBAC Roles/ClusterRoles we've been making useless.

Both virt-api and virt-controller now use targeted RBAC Roles/ClusterRoles that only expose the exact privileges required to run each component. 

**Release note**:
```release-note
NONE
```
