### PR TITLE
virt-preview is missing the repo file

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -2,8 +2,7 @@ FROM fedora:28
 
 ENV LIBVIRT_VERSION 4.2.0
 
-RUN curl --output /etc/yum.repos.d/fedora-virt-preview.repo \
-      https://fedorapeople.org/groups/virt/virt-preview/fedora-virt-preview.repo
+COPY fedora-virt-preview.repo /etc/yum.repos.d/fedora-virt-preview.repo
 
 RUN dnf -y install libvirt-devel-${LIBVIRT_VERSION} make git mercurial sudo gcc findutils gradle rsync-daemon rsync qemu-img protobuf-compiler && \
     dnf -y clean all

--- a/hack/docker-builder/fedora-virt-preview.repo
+++ b/hack/docker-builder/fedora-virt-preview.repo
@@ -1,0 +1,24 @@
+# Fedora Virt preview repository
+# Details: https://fedoraproject.org/wiki/Virtualization_Preview_Repository
+
+[fedora-virt-preview]
+name=Virtualization packages from Rawhide built for latest Fedora
+baseurl=http://fedorapeople.org/groups/virt/virt-preview/fedora-$releasever/$basearch
+enabled=1
+skip_if_unavailable=1
+gpgcheck=0
+
+[fedora-virt-preview-debuginfo]
+name=Fedora $releasever - $basearch - Debug
+name=Virtualization packages from Rawhide built for latest Fedora - Debug
+baseurl=http://fedorapeople.org/groups/virt/virt-preview/fedora-$releasever/debuginfo
+enabled=0
+skip_if_unavailable=1
+gpgcheck=0
+
+[fedora-virt-preview-source]
+name=Virtualization packages from Rawhide built for latest Fedora - Source
+baseurl=http://fedorapeople.org/groups/virt/virt-preview/fedora-$releasever/SRPMS
+enabled=0
+skip_if_unavailable=1
+gpgcheck=0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Work around virt-preview repo until the missing file is back, to make CI work.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
