### PR TITLE
Fix libvirt log collection test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -40,6 +40,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
@@ -110,7 +111,7 @@ var _ = Describe("VMIlifecycle", func() {
 			Eventually(logs,
 				2*time.Second,
 				500*time.Millisecond).
-				Should(ContainSubstring("info : hostname: " + vmi.Name))
+				Should(ContainSubstring("info : hostname: " + dns.SanitizeHostname(vmi)))
 		})
 
 		It("should reject POST if schema is invalid", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

If the VMI name is too long the name will be truncated and not
completely used for the host name of the pod.

In such a case the string match for the hostname of the libvirt logs fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
