### PR TITLE
Merge pull request #1414 from rmohr/memory-overcommit-v2

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3821,6 +3821,10 @@
    "v1.Memory": {
     "description": "Memory allow specifying the VirtualMachineInstance memory features",
     "properties": {
+     "guest": {
+      "description": "Guest allows to specifying the amount of memory which is visible inside the Guest OS.\nThe Guest must lie between Requests and Limits from the resources section.\nDefaults to the requested memory in the resources section if not specified.\n+ optional",
+      "type": "string"
+     },
      "hugepages": {
       "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.\n+optional",
       "$ref": "#/definitions/v1.Hugepages"

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -189,6 +189,7 @@ spec:
                           - type
                         memory:
                           properties:
+                            guest: {}
                             hugepages:
                               properties:
                                 pageSize:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -182,6 +182,7 @@ spec:
                   - type
                 memory:
                   properties:
+                    guest: {}
                     hugepages:
                       properties:
                         pageSize:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -177,6 +177,7 @@ spec:
                   - type
                 memory:
                   properties:
+                    guest: {}
                     hugepages:
                       properties:
                         pageSize:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -193,6 +193,7 @@ spec:
                           - type
                         memory:
                           properties:
+                            guest: {}
                             hugepages:
                               properties:
                                 pageSize:

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -22,6 +22,7 @@ package v1
 
 import (
 	core_v1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -957,6 +958,15 @@ func (in *Memory) DeepCopyInto(out *Memory) {
 		} else {
 			*out = new(Hugepages)
 			**out = **in
+		}
+	}
+	if in.Guest != nil {
+		in, out := &in.Guest, &out.Guest
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(resource.Quantity)
+			**out = (*in).DeepCopy()
 		}
 	}
 	return

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -874,11 +874,17 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Hugepages"),
 							},
 						},
+						"guest": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Guest allows to specifying the amount of memory which is visible inside the Guest OS. The Guest must lie between Requests and Limits from the resources section. Defaults to the requested memory in the resources section if not specified.",
+								Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+							},
+						},
 					},
 				},
 			},
 			Dependencies: []string{
-				"kubevirt.io/kubevirt/pkg/api/v1.Hugepages"},
+				"k8s.io/apimachinery/pkg/api/resource.Quantity", "kubevirt.io/kubevirt/pkg/api/v1.Hugepages"},
 		},
 		"kubevirt.io/kubevirt/pkg/api/v1.Network": {
 			Schema: spec.Schema{

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -116,6 +116,11 @@ type Memory struct {
 	// Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.
 	// +optional
 	Hugepages *Hugepages `json:"hugepages,omitempty"`
+	// Guest allows to specifying the amount of memory which is visible inside the Guest OS.
+	// The Guest must lie between Requests and Limits from the resources section.
+	// Defaults to the requested memory in the resources section if not specified.
+	// + optional
+	Guest *resource.Quantity `json:"guest,omitempty"`
 }
 
 // Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -44,6 +44,7 @@ func (Memory) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":          "Memory allow specifying the VirtualMachineInstance memory features",
 		"hugepages": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.\n+optional",
+		"guest":     "Guest allows to specifying the amount of memory which is visible inside the Guest OS.\nThe Guest must lie between Requests and Limits from the resources section.\nDefaults to the requested memory in the resources section if not specified.\n+ optional",
 	}
 }
 

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -509,6 +509,59 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
+		It("should reject smaller guest memory than requested memory", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			guestMemory := resource.MustParse("1Mi")
+
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}
+			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
+		})
+		It("should reject bigger guest memory than the memory limit", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			guestMemory := resource.MustParse("128Mi")
+
+			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}
+			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
+		})
+		It("should allow guest memory which is between requests and limits", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			guestMemory := resource.MustParse("100Mi")
+
+			vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("128Mi"),
+			}
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}
+			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(causes).To(BeEmpty())
+		})
+		It("should allow setting guest memory when no limit is set", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			guestMemory := resource.MustParse("100Mi")
+
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}
+			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(causes).To(BeEmpty())
+		})
 		It("should reject not divisable by hugepages.size requests.memory", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -375,8 +375,15 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		}
 	}
 
+	// Take memory from the requested memory
 	if v, ok := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]; ok {
 		if domain.Spec.Memory, err = QuantityToByte(v); err != nil {
+			return err
+		}
+	}
+	// In case that guest memory is explicitly set, override it
+	if vmi.Spec.Domain.Memory != nil && vmi.Spec.Domain.Memory.Guest != nil {
+		if domain.Spec.Memory, err = QuantityToByte(*vmi.Spec.Domain.Memory.Guest); err != nil {
 			return err
 		}
 	}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -140,63 +140,6 @@ var _ = Describe("Configurations", func() {
 
 		})
 
-		Context("with namespace memory limits", func() {
-			var vmi *v1.VirtualMachineInstance
-			It("should failed to schedule the pod, copy limits to vm spec", func() {
-				// create a namespace default limit
-				limitRangeObj := kubev1.LimitRange{
-
-					ObjectMeta: metav1.ObjectMeta{Name: "abc1", Namespace: tests.NamespaceTestDefault},
-					Spec: kubev1.LimitRangeSpec{
-						Limits: []kubev1.LimitRangeItem{
-							{
-								Type: kubev1.LimitTypeContainer,
-								Default: kubev1.ResourceList{
-									kubev1.ResourceMemory: resource.MustParse("32Mi"),
-								},
-							},
-						},
-					},
-				}
-				_, err := virtClient.Core().LimitRanges(tests.NamespaceTestDefault).Create(&limitRangeObj)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Starting a VirtualMachineInstance")
-				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
-				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
-				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				var vmiCondition v1.VirtualMachineInstanceCondition
-				Eventually(func() bool {
-					vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					if len(vmi.Status.Conditions) > 0 {
-						for _, cond := range vmi.Status.Conditions {
-							if cond.Type == v1.VirtualMachineInstanceSynchronized && cond.Status == kubev1.ConditionFalse {
-								vmiCondition = vmi.Status.Conditions[0]
-								return true
-							}
-						}
-					}
-					return false
-				}, 30*time.Second, time.Second).Should(BeTrue())
-				Expect(vmiCondition.Message).To(ContainSubstring("must be less than or equal to memory limit"))
-				Expect(vmiCondition.Reason).To(Equal("FailedCreate"))
-				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(vmi.Spec.Domain.Resources.Limits.Memory().IsZero()).ShouldNot(BeTrue())
-				err = virtClient.Core().LimitRanges(tests.NamespaceTestDefault).Delete(limitRangeObj.Name, &metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-			})
-		})
-
 		Context("with hugepages", func() {
 			var hugepagesVmi *v1.VirtualMachineInstance
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow separating guest memory from resource request

(cherry picked from commit 1628128e6fda45d06b9eb22fbd2689c652ba3017)
Signed-off-by: Roman Mohr <rmohr@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow real memory overcommit on a node by adding a field spec.domain.memory.guest, which sets the visible memory for the guest and which can be higher than the amount of memory than requested from the k8s scheduler.
```
