### PR TITLE
add boot order to network interface for 0.6

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3392,7 +3392,7 @@
     ],
     "properties": {
      "bootOrder": {
-      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices.\nLower values take precedence.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
+      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
       "type": "integer",
       "format": "integer"
      },
@@ -3706,6 +3706,11 @@
      "name"
     ],
     "properties": {
+     "bootOrder": {
+      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach interface or disk that has a boot order must have a unique value.\nInterfaces without a boot order are not tried.\n+optional",
+      "type": "integer",
+      "format": "integer"
+     },
      "bridge": {
       "$ref": "#/definitions/v1.InterfaceBridge"
      },

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -103,6 +103,9 @@ spec:
                             interfaces:
                               items:
                                 properties:
+                                  bootOrder:
+                                    format: int32
+                                    type: integer
                                   bridge: {}
                                   name:
                                     type: string

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -96,6 +96,9 @@ spec:
                     interfaces:
                       items:
                         properties:
+                          bootOrder:
+                            format: int32
+                            type: integer
                           bridge: {}
                           name:
                             type: string

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -91,6 +91,9 @@ spec:
                     interfaces:
                       items:
                         properties:
+                          bootOrder:
+                            format: int32
+                            type: integer
                           bridge: {}
                           name:
                             type: string

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -107,6 +107,9 @@ spec:
                             interfaces:
                               items:
                                 properties:
+                                  bootOrder:
+                                    format: int32
+                                    type: integer
                                   bridge: {}
                                   name:
                                     type: string

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -827,6 +827,15 @@ func (in *I6300ESBWatchdog) DeepCopy() *I6300ESBWatchdog {
 func (in *Interface) DeepCopyInto(out *Interface) {
 	*out = *in
 	in.InterfaceBindingMethod.DeepCopyInto(&out.InterfaceBindingMethod)
+	if in.BootOrder != nil {
+		in, out := &in.BootOrder, &out.BootOrder
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(uint)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -299,7 +299,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"bootOrder": {
 							SchemaProps: spec.SchemaProps{
-								Description: "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Disks without a boot order are not tried if a disk with a boot order exists.",
+								Description: "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.",
 								Type:        []string{"integer"},
 								Format:      "int32",
 							},
@@ -767,6 +767,13 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						"bridge": {
 							SchemaProps: spec.SchemaProps{
 								Ref: ref("kubevirt.io/kubevirt/pkg/api/v1.InterfaceBridge"),
+							},
+						},
+						"bootOrder": {
+							SchemaProps: spec.SchemaProps{
+								Description: "BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each interface or disk that has a boot order must have a unique value. Interfaces without a boot order are not tried.",
+								Type:        []string{"integer"},
+								Format:      "int32",
 							},
 						},
 					},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -168,6 +168,7 @@ type Disk struct {
 	DiskDevice `json:",inline"`
 	// BootOrder is an integer value > 0, used to determine ordering of boot devices.
 	// Lower values take precedence.
+	// Each disk or interface that has a boot order must have a unique value.
 	// Disks without a boot order are not tried if a disk with a boot order exists.
 	// +optional
 	BootOrder *uint `json:"bootOrder,omitempty"`
@@ -655,6 +656,12 @@ type Interface struct {
 	// BindingMethod specifies the method which will be used to connect the interface to the guest
 	// Defaults to Bridge
 	InterfaceBindingMethod `json:",inline"`
+	// BootOrder is an integer value > 0, used to determine ordering of boot devices.
+	// Lower values take precedence.
+	// Each interface or disk that has a boot order must have a unique value.
+	// Interfaces without a boot order are not tried.
+	// +optional
+	BootOrder *uint `json:"bootOrder,omitempty"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -79,7 +79,7 @@ func (Disk) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"name":       "Name is the device name",
 		"volumeName": "Name of the volume which is referenced\nMust match the Name of a Volume.",
-		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
+		"bootOrder":  "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 	}
 }
 
@@ -302,7 +302,8 @@ func (I6300ESBWatchdog) SwaggerDoc() map[string]string {
 
 func (Interface) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"name": "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
+		"name":      "Logical name of the interface as well as a reference to the associated networks\nMust match the Name of a Network",
+		"bootOrder": "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach interface or disk that has a boot order must have a unique value.\nInterfaces without a boot order are not tried.\n+optional",
 	}
 }
 

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -182,7 +182,7 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
 				Message: fmt.Sprintf("%s must have a boot order > 0, if supplied", field.Index(idx).String()),
-				Field:   field.Index(idx).Child("bootorder").String(),
+				Field:   field.Index(idx).Child("bootOrder").String(),
 			})
 		}
 	}
@@ -438,6 +438,9 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		volumeNameMap[volume.Name] = &volume
 	}
 
+	// used to validate uniqueness of boot orders among disks and interfaces
+	bootOrderMap := make(map[uint]bool)
+
 	// Validate disks and VolumeNames match up correctly
 	for idx, disk := range spec.Domain.Devices.Disks {
 		var matchingVolume *v1.Volume
@@ -472,6 +475,19 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 				Field:   field.Child("domain", "devices", "disks").Index(idx).Child("lun").String(),
 			})
 		}
+
+		// verify that there are no duplicate boot orders
+		if disk.BootOrder != nil {
+			order := *disk.BootOrder
+			if bootOrderMap[order] {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("Boot order for %s already set for a different device.", field.Child("domain", "devices", "disks").Index(idx).Child("bootOrder").String()),
+					Field:   field.Child("domain", "devices", "disks").Index(idx).Child("bootOrder").String(),
+				})
+			}
+			bootOrderMap[order] = true
+		}
 	}
 
 	if len(spec.Networks) > 0 && len(spec.Domain.Devices.Interfaces) > 0 {
@@ -499,6 +515,28 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					Message: fmt.Sprintf("only a %s network source can be selected.", field.Child("domain", "devices", "networks").Index(0).Child("pod").String()),
 					Field:   field.Child("domain", "devices", "networks").Index(0).Child("pod").String(),
 				})
+			}
+
+			if iface.BootOrder != nil {
+				order := *iface.BootOrder
+				// Verify boot order is greater than 0, if provided
+				if order < 1 {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: fmt.Sprintf("%s must have a boot order > 0, if supplied", field.Index(idx).String()),
+						Field:   field.Index(idx).Child("bootOrder").String(),
+					})
+				} else {
+					// verify that there are no duplicate boot orders
+					if bootOrderMap[order] {
+						causes = append(causes, metav1.StatusCause{
+							Type:    metav1.CauseTypeFieldValueInvalid,
+							Message: fmt.Sprintf("Boot order for %s already set for a different device.", field.Child("domain", "devices", "interfaces").Index(idx).Child("bootOrder").String()),
+							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("bootOrder").String(),
+						})
+					}
+					bootOrderMap[order] = true
+				}
 			}
 		}
 	}

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -874,7 +874,7 @@ var _ = Describe("Validating Webhook", func() {
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
 			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake[0].bootorder"))
+			Expect(causes[0].Field).To(Equal("fake[0].bootOrder"))
 		})
 	})
 })
@@ -937,6 +937,104 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		spec.Networks = []v1.Network{net1, net2}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1, iface2}
 		Expect(getNumberOfPodInterfaces(spec)).To(Equal(2))
+	})
+	It("should work when boot order is given to interfaces", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet",
+		}
+		order := uint(1)
+		iface := v1.Interface{Name: net.Name, BootOrder: &order}
+		spec.Networks = []v1.Network{net}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(causes).To(HaveLen(0))
+	})
+	It("should fail when invalid boot order is given to interface", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet",
+		}
+		order := uint(0)
+		iface := v1.Interface{Name: net.Name, BootOrder: &order}
+		spec.Networks = []v1.Network{net}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(Equal("fake[0].bootOrder"))
+	})
+	It("should work when different boot orders are given to devices", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet",
+		}
+		order1 := uint(7)
+		iface := v1.Interface{Name: net.Name, BootOrder: &order1}
+		spec.Networks = []v1.Network{net}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
+		order2 := uint(77)
+		disk := v1.Disk{
+			Name:       "testdisk",
+			VolumeName: "testvolume",
+			BootOrder:  &order2,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{},
+			},
+		}
+		spec.Domain.Devices.Disks = []v1.Disk{disk}
+		volume := v1.Volume{
+			Name: "testvolume",
+			VolumeSource: v1.VolumeSource{
+				RegistryDisk: &v1.RegistryDiskSource{},
+			},
+		}
+
+		spec.Volumes = []v1.Volume{volume}
+		spec.Domain.Devices.Disks = []v1.Disk{disk}
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(causes).To(HaveLen(0))
+	})
+	It("should fail when same boot order is given to more than one device", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		net := v1.Network{
+			NetworkSource: v1.NetworkSource{
+				Pod: &v1.PodNetwork{},
+			},
+			Name: "testnet",
+		}
+		order := uint(7)
+		iface := v1.Interface{Name: net.Name, BootOrder: &order}
+		spec.Networks = []v1.Network{net}
+		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
+		disk := v1.Disk{
+			Name:       "testdisk",
+			VolumeName: "testvolume",
+			BootOrder:  &order,
+			DiskDevice: v1.DiskDevice{
+				Disk: &v1.DiskTarget{},
+			},
+		}
+		spec.Domain.Devices.Disks = []v1.Disk{disk}
+		volume := v1.Volume{
+			Name: "testvolume",
+			VolumeSource: v1.VolumeSource{
+				RegistryDisk: &v1.RegistryDiskSource{},
+			},
+		}
+		spec.Volumes = []v1.Volume{volume}
+
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(ContainSubstring("bootOrder"))
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -538,6 +538,11 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		return nil, fmt.Errorf("failed to find network %s", name)
 	}
 
+	networks := map[string]*v1.Network{}
+	for _, network := range vmi.Spec.Networks {
+		networks[network.Name] = network.DeepCopy()
+	}
+
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		net, err := findNetwork(vmi.Spec.Networks, iface.Name)
 		if err != nil {
@@ -559,6 +564,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			Alias: &Alias{
 				Name: iface.Name,
 			},
+		}
+		if iface.BootOrder != nil {
+			domainIface.BootOrder = &BootOrder{Order: *iface.BootOrder}
 		}
 		domain.Spec.Devices.Interfaces = append(domain.Spec.Devices.Interfaces, domainIface)
 	}

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -575,6 +575,30 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Networks = append(vmi.Spec.Networks, *net)
 			Expect(Convert_v1_VirtualMachine_To_api_Domain(vmi, &Domain{}, c)).ToNot(Succeed())
 		})
+
+		It("should allow setting boot order", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			name1 := "Name1"
+			name2 := "Name2"
+			iface1 := v1.DefaultNetworkInterface()
+			iface2 := v1.DefaultNetworkInterface()
+			net1 := v1.DefaultPodNetwork()
+			net2 := v1.DefaultPodNetwork()
+			iface1.Name = name1
+			iface2.Name = name2
+			bootOrder := uint(1)
+			iface1.BootOrder = &bootOrder
+			net1.Name = name1
+			net2.Name = name2
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*iface1, *iface2}
+			vmi.Spec.Networks = []v1.Network{*net1, *net2}
+			domain := vmiToDomain(vmi, c)
+			Expect(domain).ToNot(Equal(nil))
+			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(2))
+			Expect(domain.Spec.Devices.Interfaces[0].BootOrder).NotTo(BeNil())
+			Expect(domain.Spec.Devices.Interfaces[0].BootOrder.Order).To(Equal(uint(bootOrder)))
+			Expect(domain.Spec.Devices.Interfaces[1].BootOrder).To(BeNil())
+		})
 	})
 
 	Context("graphics and video device", func() {


### PR DESCRIPTION
(cherry picked from commit af75d4882003eea472b5c6fc9501b4f797e933e2)

**What this PR does / why we need it**:
Backport of #1411. With this patch and L2 network plugin, we make it possible to boot VM from PXE.

**Special notes for your reviewer**:
Not sure whether we want to merge this. Is it possible to use it with default Kubernetes network?