### PR TITLE
Always put default route last to ensure it can be applied

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
@@ -56,7 +56,7 @@ var _ = Describe("DHCP", func() {
 		})
 
 		It("should build OpenShift routes correctly", func() {
-			expected := []byte{0, 10, 129, 0, 1, 14, 10, 128, 0, 0, 0, 0, 4, 224, 0, 0, 0, 0}
+			expected := []byte{14, 10, 128, 0, 0, 0, 0, 4, 224, 0, 0, 0, 0, 0, 10, 129, 0, 1}
 			gatewayRoute := netlink.Route{Gw: net.IPv4(10, 129, 0, 1)}
 			staticRoute1 := netlink.Route{
 				Dst: &net.IPNet{
@@ -76,7 +76,7 @@ var _ = Describe("DHCP", func() {
 		})
 
 		It("should build Calico routes correctly", func() {
-			expected := []byte{0, 169, 254, 1, 1, 32, 169, 254, 1, 1, 0, 0, 0, 0}
+			expected := []byte{32, 169, 254, 1, 1, 0, 0, 0, 0, 0, 169, 254, 1, 1}
 			gatewayRoute := netlink.Route{Gw: net.IPv4(169, 254, 1, 1)}
 			staticRoute1 := netlink.Route{
 				Dst: &net.IPNet{


### PR DESCRIPTION
**What this PR does / why we need it**:

Sorts routes in `dhcp.go` and puts the default route last, this fixes an issue with calico where the default route can not get applied because there is no route to its gateway yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1434

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where calico routes were not properly passed down to the VM
```
