### PR TITLE
add mac support to host bridge

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -587,6 +587,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 					Name: iface.Name,
 				},
 			}
+			if iface.MacAddress != "" {
+				domainIface.MAC = &MAC{MAC: iface.MacAddress}
+			}
 		}
 
 		if domainIface != nil {

--- a/tests/vmi_bridge_test.go
+++ b/tests/vmi_bridge_test.go
@@ -49,12 +49,12 @@ var _ = FDescribe("Bridge", func() {
 
 	var nodeWithBridges *k8sv1.Node
 
-	createBridgeVMI := func(networkName1 string, networkName2 string) *v1.VirtualMachineInstance {
+	createBridgeVMI := func(networkName string, bridgeName string) *v1.VirtualMachineInstance {
 		vmi := tests.NewRandomVMIWithBridgeNetworkEphemeralDiskAndUserdata(
 			tests.RegistryDiskFor(tests.RegistryDiskCirros),
 			"#!/bin/bash\necho 'hello'\n",
-			networkName1,
-			networkName2,
+			networkName,
+			bridgeName,
 		)
 		vmi.Spec.Affinity = &v1.Affinity{
 			NodeAffinity: &k8sv1.NodeAffinity{
@@ -134,6 +134,8 @@ var _ = FDescribe("Bridge", func() {
 		const macAddress = "de:ad:00:00:be:af"
 		tests.BeforeAll(func() {
 			vmi = createBridgeVMI(networkName, networkName)
+			Expect(vmi.Spec.Domain.Devices.Interfaces).To(HaveLen(2))
+			vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = macAddress
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 120)


### PR DESCRIPTION
hostBridge static mac support was lost during back merge to 0.6
also MAC address tests were incorrect

```release-note
NONE
```
