### PR TITLE
Save VMI UUID under map for future use on cleanup stage

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -415,6 +415,12 @@ func NewVMIReferenceFromNameWithNS(namespace string, name string) *VirtualMachin
 	return vmi
 }
 
+func NewVMIReferenceWithUUID(namespace string, name string, uuid types.UID) *VirtualMachineInstance {
+	vmi := NewVMIReferenceFromNameWithNS(namespace, name)
+	vmi.UID = uuid
+	return vmi
+}
+
 type VMISelector struct {
 	// Name of the VirtualMachineInstance to migrate
 	Name string `json:"name" valid:"required"`

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -610,6 +610,16 @@ func NewMinimalDomain(name string) *Domain {
 	return NewMinimalDomainWithNS(kubev1.NamespaceDefault, name)
 }
 
+func NewMinimalDomainWithUUID(name string, uuid types.UID) *Domain {
+	domain := NewMinimalDomainWithNS(kubev1.NamespaceDefault, name)
+	domain.Spec.Metadata = Metadata{
+		KubeVirt: KubeVirtMetadata{
+			UID: uuid,
+		},
+	}
+	return domain
+}
+
 func NewMinimalDomainWithNS(namespace string, name string) *Domain {
 	domain := NewDomainReferenceFromName(namespace, name)
 	domain.Spec = *NewMinimalDomainSpec(namespace + "_" + name)

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -49,6 +49,7 @@ func WatchdogFileRemove(baseDir string, vmi *v1.VirtualMachineInstance) error {
 
 	file := WatchdogFileFromNamespaceName(baseDir, namespace, domain)
 
+	log.Log.V(3).Infof("Remove watchdog file %s", file)
 	return diskutils.RemoveFile(file)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On the cleanup stage, VMI already does not have UUID, that prevented to remove socket file under `/var/run/kubevirt/sockets`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1448 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
