### PR TITLE
Remove references to OVM

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -763,7 +763,7 @@ type VirtualMachineCondition struct {
 type VirtualMachineConditionType string
 
 const (
-	// VirtualMachineFailure is added in a offline virtual machine when its vmi
+	// VirtualMachineFailure is added in a virtual machine when its vmi
 	// fails to be created due to insufficient quota, limit ranges, pod security policy, node selectors,
 	// etc. or deleted due to kubelet being down or finalizers are failing.
 	VirtualMachineFailure VirtualMachineConditionType = "Failure"

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -97,7 +97,7 @@ type VMIPresetInterface interface {
 }
 
 // VirtualMachineInterface provides convenience methods to work with
-// offline virtual machines inside the cluster
+// virtual machines inside the cluster
 type VirtualMachineInterface interface {
 	Get(name string, options *k8smetav1.GetOptions) (*v1.VirtualMachine, error)
 	List(opts *k8smetav1.ListOptions) (*v1.VirtualMachineList, error)

--- a/pkg/kubecli/kubevirt_test_utils.go
+++ b/pkg/kubecli/kubevirt_test_utils.go
@@ -36,8 +36,8 @@ func NewMinimalVM(name string) *v1.VirtualMachine {
 	return &v1.VirtualMachine{TypeMeta: k8smetav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "VirtualMachine"}, ObjectMeta: k8smetav1.ObjectMeta{Name: name}}
 }
 
-func NewVMList(ovms ...v1.VirtualMachine) *v1.VirtualMachineList {
-	return &v1.VirtualMachineList{TypeMeta: k8smetav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "VirtualMachineList"}, Items: ovms}
+func NewVMList(vms ...v1.VirtualMachine) *v1.VirtualMachineList {
+	return &v1.VirtualMachineList{TypeMeta: k8smetav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "VirtualMachineList"}, Items: vms}
 }
 
 func NewVirtualMachineInstanceReplicaSetList(rss ...v1.VirtualMachineInstanceReplicaSet) *v1.VirtualMachineInstanceReplicaSetList {

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -44,50 +44,50 @@ type vm struct {
 }
 
 // Create new VirtualMachine in the cluster to specified namespace
-func (o *vm) Create(offlinevm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
-	newOvmi := &v1.VirtualMachine{}
+func (o *vm) Create(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
+	newVm := &v1.VirtualMachine{}
 	err := o.restClient.Post().
 		Resource(o.resource).
 		Namespace(o.namespace).
-		Body(offlinevm).
+		Body(vm).
 		Do().
-		Into(newOvmi)
+		Into(newVm)
 
-	newOvmi.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+	newVm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 
-	return newOvmi, err
+	return newVm, err
 }
 
 // Get the OfflineVirtual machine from the cluster by its name and namespace
 func (o *vm) Get(name string, options *k8smetav1.GetOptions) (*v1.VirtualMachine, error) {
-	newOvm := &v1.VirtualMachine{}
+	newVm := &v1.VirtualMachine{}
 	err := o.restClient.Get().
 		Resource(o.resource).
 		Namespace(o.namespace).
 		Name(name).
 		VersionedParams(options, scheme.ParameterCodec).
 		Do().
-		Into(newOvm)
+		Into(newVm)
 
-	newOvm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+	newVm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 
-	return newOvm, err
+	return newVm, err
 }
 
 // Update the VirtualMachine instance in the cluster in given namespace
-func (o *vm) Update(offlinevm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
-	updatedOvmi := &v1.VirtualMachine{}
+func (o *vm) Update(vm *v1.VirtualMachine) (*v1.VirtualMachine, error) {
+	updatedVm := &v1.VirtualMachine{}
 	err := o.restClient.Put().
 		Resource(o.resource).
 		Namespace(o.namespace).
-		Name(offlinevm.Name).
-		Body(offlinevm).
+		Name(vm.Name).
+		Body(vm).
 		Do().
-		Into(updatedOvmi)
+		Into(updatedVm)
 
-	updatedOvmi.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
+	updatedVm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 
-	return updatedOvmi, err
+	return updatedVm, err
 }
 
 // Delete the defined VirtualMachine in the cluster in defined namespace
@@ -105,19 +105,19 @@ func (o *vm) Delete(name string, options *k8smetav1.DeleteOptions) error {
 
 // List all VirtualMachines in given namespace
 func (o *vm) List(options *k8smetav1.ListOptions) (*v1.VirtualMachineList, error) {
-	newOvmList := &v1.VirtualMachineList{}
+	newVmList := &v1.VirtualMachineList{}
 	err := o.restClient.Get().
 		Resource(o.resource).
 		Namespace(o.namespace).
 		VersionedParams(options, scheme.ParameterCodec).
 		Do().
-		Into(newOvmList)
+		Into(newVmList)
 
-	for _, vm := range newOvmList.Items {
+	for _, vm := range newVmList.Items {
 		vm.SetGroupVersionKind(v1.VirtualMachineGroupVersionKind)
 	}
 
-	return newOvmList, err
+	return newVmList, err
 }
 
 func (v *vm) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachine, err error) {

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -41,7 +41,7 @@ var timeout int
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "console (vmi)",
-		Short:   "Connect to a console of a virtual machine.",
+		Short:   "Connect to a console of a VMI.",
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -147,10 +147,10 @@ func (o *Command) RunE(cmd *cobra.Command, args []string) error {
 		// remove unwanted labels
 		delete(serviceSelector, "kubevirt.io/nodeName")
 	case "vm", "vms", "virtualmachine", "virtualmachines":
-		// get the offline VM
+		// get the VM
 		vm, err := virtClient.VirtualMachine(namespace).Get(vmName, &options)
 		if err != nil {
-			return fmt.Errorf("error fetching OfflineVirtual: %v", err)
+			return fmt.Errorf("error fetching Virtual Machine: %v", err)
 		}
 		serviceSelector = vm.Spec.Template.ObjectMeta.Labels
 	case "vmirs", "vmirss", "virtualmachineinstancereplicaset", "virtualmachineinstancereplicasets":

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -40,7 +40,7 @@ var namespace string
 func NewExposeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "expose TYPE NAME",
-		Short: "Expose a virtual machine as a new service.",
+		Short: "Expose a VMI, VM, or VMIRS as a new service.",
 		Long: `Looks up a virtual machine instance, virtual machine or virtual machine instance replica set by name and use its selector as the selector for a new service on the specified port.
 A virtual machine instance replica set will be exposed as a service only if its selector is convertible to a selector that service supports, i.e. when the selector contains only the matchLabels component.
 Note that if no port is specified via --port and the exposed resource has multiple ports, all will be re-used by the new service. 

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -26,9 +26,9 @@ var _ = Describe("Expose", func() {
 	const vmName = "my-vm"
 	const vmNoLabelName = "vm-no-label"
 	const unknownVM = "unknown-vm"
-	vm := v1.NewMinimalVMI(vmName)
+	vmi := v1.NewMinimalVMI(vmName)
 	vmNoLabel := v1.NewMinimalVMI(vmNoLabelName)
-	ovm := kubecli.NewMinimalVM(vmName)
+	vm := kubecli.NewMinimalVM(vmName)
 	vmrs := kubecli.NewMinimalVirtualMachineInstanceReplicaSet(vmName)
 
 	tests.BeforeAll(func() {
@@ -38,27 +38,27 @@ var _ = Describe("Expose", func() {
 		kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
 		kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
 		// create mock interfaces
-		vmInterface := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
-		ovmInterface := kubecli.NewMockVirtualMachineInterface(ctrl)
+		vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+		vmInterface := kubecli.NewMockVirtualMachineInterface(ctrl)
 		vmrsInterface := kubecli.NewMockReplicaSetInterface(ctrl)
 		kubeclient := fake.NewSimpleClientset()
 		// set up mock client behavior
-		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmInterface).AnyTimes()
-		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(ovmInterface).AnyTimes()
+		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).AnyTimes()
+		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().ReplicaSet(k8smetav1.NamespaceDefault).Return(vmrsInterface).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeclient.CoreV1()).AnyTimes()
-		// set labels on vm, ovm and vmrs
-		vm.ObjectMeta.Labels = map[string]string{"key": "value"}
+		// set labels on vm, vm and vmrs
+		vmi.ObjectMeta.Labels = map[string]string{"key": "value"}
 		vmNoLabel.ObjectMeta.Labels = map[string]string{}
-		ovm.Spec = v1.VirtualMachineSpec{Template: &v1.VirtualMachineInstanceTemplateSpec{ObjectMeta: vm.ObjectMeta}}
-		vmrs.Spec = v1.VirtualMachineInstanceReplicaSetSpec{Selector: &k8smetav1.LabelSelector{MatchLabels: vm.ObjectMeta.Labels}}
+		vm.Spec = v1.VirtualMachineSpec{Template: &v1.VirtualMachineInstanceTemplateSpec{ObjectMeta: vmi.ObjectMeta}}
+		vmrs.Spec = v1.VirtualMachineInstanceReplicaSetSpec{Selector: &k8smetav1.LabelSelector{MatchLabels: vmi.ObjectMeta.Labels}}
 		// set up mock interface behavior
-		vmInterface.EXPECT().Get(vm.Name, gomock.Any()).Return(vm, nil).AnyTimes()
-		vmInterface.EXPECT().Get(vmNoLabel.Name, gomock.Any()).Return(vmNoLabel, nil).AnyTimes()
-		vmInterface.EXPECT().Get(unknownVM, gomock.Any()).Return(nil, errors.New("unknonw VM")).AnyTimes()
-		ovmInterface.EXPECT().Get(vm.Name, gomock.Any()).Return(ovm, nil).AnyTimes()
-		ovmInterface.EXPECT().Get(unknownVM, gomock.Any()).Return(nil, errors.New("unknonw OVM")).AnyTimes()
-		vmrsInterface.EXPECT().Get(vm.Name, gomock.Any()).Return(vmrs, nil).AnyTimes()
+		vmiInterface.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmi, nil).AnyTimes()
+		vmiInterface.EXPECT().Get(vmNoLabel.Name, gomock.Any()).Return(vmNoLabel, nil).AnyTimes()
+		vmiInterface.EXPECT().Get(unknownVM, gomock.Any()).Return(nil, errors.New("unknown VM")).AnyTimes()
+		vmInterface.EXPECT().Get(vmi.Name, gomock.Any()).Return(vm, nil).AnyTimes()
+		vmInterface.EXPECT().Get(unknownVM, gomock.Any()).Return(nil, errors.New("unknown VM")).AnyTimes()
+		vmrsInterface.EXPECT().Get(vmi.Name, gomock.Any()).Return(vmrs, nil).AnyTimes()
 		vmrsInterface.EXPECT().Get(unknownVM, gomock.Any()).Return(nil, errors.New("unknonw VMRS")).AnyTimes()
 
 		// Make sure that all unexpected calls to kubeClient will fail
@@ -174,14 +174,14 @@ var _ = Describe("Expose", func() {
 				Expect(cmd()).To(BeNil())
 			})
 		})
-		Context("With cluster-ip on an ovm", func() {
+		Context("With cluster-ip on an vm", func() {
 			It("should succeed", func() {
 				err := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", vmName, "--name", "my-service",
 					"--port", "9999")
 				Expect(err()).To(BeNil())
 			})
 		})
-		Context("With cluster-ip on an unknown ovm", func() {
+		Context("With cluster-ip on an unknown vm", func() {
 			It("should fail", func() {
 				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", unknownVM, "--name", "my-service",
 					"--port", "9999")

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -39,8 +39,8 @@ const (
 
 func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "start (vmi)",
-		Short:   "Start a virtual machine which is managed by an offline virtual machine.",
+		Use:     "start (vm)",
+		Short:   "Start a VirtualMachine.",
 		Example: usage(COMMAND_START),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -54,8 +54,8 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	return &cobra.Command{
-		Use:     "stop (vmi)",
-		Short:   "Stop a virtual machine which is managed by an offline virtual machine.",
+		Use:     "stop (vm)",
+		Short:   "Stop a VirtualMachine.",
 		Example: usage(COMMAND_STOP),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/virtctl/vm/vm_suite_test.go
+++ b/pkg/virtctl/vm/vm_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOfflinevm(t *testing.T) {
+func TestVm(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "vm Suite")
 }

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -43,7 +43,7 @@ const FLAG = "vnc"
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "vnc (vmi)",
-		Short:   "Open a vnc connection to a virtual machine.",
+		Short:   "Open a vnc connection to a VMI.",
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Offline Virtual Machines were replaced by Virtual Machines. We have a few lingering references to ovms that this pr cleans up.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
