### PR TITLE
Update k8s providers for 1.10 and 1.11

### DIFF
--- a/cluster/k8s-1.10.4/provider.sh
+++ b/cluster/k8s-1.10.4/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.10.4@sha256:09ac918cc16f13a5d0af51d4c98e3e25cbf4f97b7b32fe18ec61b32f04ca1009"
+image="k8s-1.10.4@sha256:486064eddea289b17e150e6600fefc89dab9164d5cba07153c02888a35fed4f1"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-1.11.0/provider.sh
+++ b/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:6c1caf5559eb02a144bf606de37eb0194c06ace4d77ad4561459f3bde876151c"
+image="k8s-1.11.0@sha256:2e8b82787e4c65bc7cf25ddd7bea30d9e203009c620cf637291b87ed617edd79"
 
 source cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The latest k8s providers provide the ability to use local storage. I'm going to need this soon for DataVolume integration. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
