### PR TITLE
Revert "Update k8s providers for 1.10 and 1.11"

### DIFF
--- a/cluster/k8s-1.10.4/provider.sh
+++ b/cluster/k8s-1.10.4/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.10.4@sha256:486064eddea289b17e150e6600fefc89dab9164d5cba07153c02888a35fed4f1"
+image="k8s-1.10.4@sha256:09ac918cc16f13a5d0af51d4c98e3e25cbf4f97b7b32fe18ec61b32f04ca1009"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-1.11.0/provider.sh
+++ b/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:2e8b82787e4c65bc7cf25ddd7bea30d9e203009c620cf637291b87ed617edd79"
+image="k8s-1.11.0@sha256:6c1caf5559eb02a144bf606de37eb0194c06ace4d77ad4561459f3bde876151c"
 
 source cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
I shouldn't have hit "merge" on this PR without an official ack. I'm going to leave this up for a few days for visibility in case there was an objection.

If anyone had a reason not to update the provider hash to the latest builds for k8s 1.10 and 1.11, feel free to merge this.  Otherwise I'll close the PR sometime next week. 