### PR TITLE
Add VMI UID to watchdog and graceful trigger files names

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -299,14 +299,18 @@ func main() {
 	socketPath := cmdclient.SocketFromUID(*virtShareDir, *uid)
 	startCmdServer(socketPath, domainManager, stopChan, options)
 
-	watchdogFile := watchdog.WatchdogFileFromNamespaceName(*virtShareDir,
+	watchdogFile := watchdog.WatchdogFileFromNamespaceNameUID(*virtShareDir,
 		*namespace,
-		*name)
+		*name,
+		*uid,
+	)
 	startWatchdogTicker(watchdogFile, *watchdogInterval, stopChan)
 
-	gracefulShutdownTriggerFile := virtlauncher.GracefulShutdownTriggerFromNamespaceName(*virtShareDir,
+	gracefulShutdownTriggerFile := virtlauncher.GracefulShutdownTriggerFromNamespaceNameUID(*virtShareDir,
 		*namespace,
-		*name)
+		*name,
+		*uid,
+	)
 	err = virtlauncher.GracefulShutdownTriggerClear(gracefulShutdownTriggerFile)
 	if err != nil {
 		log.Log.Reason(err).Errorf("Error clearing shutdown trigger file %s.", gracefulShutdownTriggerFile)

--- a/pkg/inotify-informer/inotify_test.go
+++ b/pkg/inotify-informer/inotify_test.go
@@ -72,8 +72,8 @@ var _ = Describe("Inotify", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// create two files
-			Expect(os.Create(tmpDir + "/" + "default_testvmi")).ToNot(BeNil())
-			Expect(os.Create(tmpDir + "/" + "default1_testvmi1")).ToNot(BeNil())
+			Expect(os.Create(tmpDir + "/" + "default_testvmi_123-123-123-123")).ToNot(BeNil())
+			Expect(os.Create(tmpDir + "/" + "default1_testvmi1_123-123-123-123")).ToNot(BeNil())
 
 			queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 			informer = cache.NewSharedIndexInformer(
@@ -99,7 +99,7 @@ var _ = Describe("Inotify", func() {
 		It("should detect multiple creations and deletions", func() {
 			num := 5
 			key := "default2/test.vmi2"
-			fileName := tmpDir + "/" + "default2_test.vmi2"
+			fileName := tmpDir + "/" + "default2_test.vmi2_123-123-123-123"
 
 			for i := 0; i < num; i++ {
 				Expect(os.Create(fileName)).ToNot(BeNil())

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -51,6 +51,8 @@ var _ = Describe("Domain informer", func() {
 	var ctrl *gomock.Controller
 	var domainManager *virtwrap.MockDomainManager
 
+	uid := "123-123-123-123"
+
 	BeforeEach(func() {
 		stopChan = make(chan struct{})
 
@@ -149,7 +151,7 @@ var _ = Describe("Domain informer", func() {
 				watchdogTimeout:          1,
 			}
 
-			watchdogFile := watchdog.WatchdogFileFromNamespaceName(shareDir, "default", "test")
+			watchdogFile := watchdog.WatchdogFileFromNamespaceNameUID(shareDir, "default", "test", uid)
 			os.MkdirAll(filepath.Dir(watchdogFile), 0755)
 			watchdog.WatchdogFileUpdate(watchdogFile)
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -316,9 +316,9 @@ func (d *VirtualMachineController) execute(key string) error {
 		return err
 	}
 
-	log.Log.V(3).Infof("Processing vmi %v, existing: %v\n", vmi.Name, vmiExists)
+	log.Log.V(3).Infof("Processing vmi %v, existing: %v", vmi.Name, vmiExists)
 	if vmiExists {
-		log.Log.V(3).Infof("vmi is in phase: %v\n", vmi.Status.Phase)
+		log.Log.V(3).Infof("vmi is in phase: %v", vmi.Status.Phase)
 	}
 
 	domain, domainExists, err := d.getDomainFromCache(key)
@@ -336,9 +336,9 @@ func (d *VirtualMachineController) execute(key string) error {
 		return nil
 	}
 
-	log.Log.V(3).Infof("Domain: existing: %v\n", domainExists)
+	log.Log.V(3).Infof("Domain: existing: %v", domainExists)
 	if domainExists {
-		log.Log.V(3).Infof("Domain status: %v, reason: %v\n", domain.Status.Status, domain.Status.Reason)
+		log.Log.V(3).Infof("Domain status: %v, reason: %v", domain.Status.Status, domain.Status.Reason)
 	}
 
 	domainAlive := domainExists &&
@@ -495,6 +495,7 @@ func (d *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineIns
 	client.Close()
 	delete(d.launcherClients, sockFile)
 
+	log.Log.V(3).Object(vmi).Infof("Remove socket file %s", sockFile)
 	os.RemoveAll(sockFile)
 }
 

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -110,7 +110,12 @@ var _ = Describe("VirtLauncher", func() {
 
 	BeforeEach(func() {
 		InitializeSharedDirectories(tmpDir)
-		triggerFile := GracefulShutdownTriggerFromNamespaceName(tmpDir, "fakenamespace", "fakedomain")
+		triggerFile := GracefulShutdownTriggerFromNamespaceNameUID(
+			tmpDir,
+			"fakenamespace",
+			"fakedomain",
+			"123-123-123-123",
+		)
 		shutdownCallback := func(pid int) {
 			syscall.Kill(pid, syscall.SIGTERM)
 		}
@@ -199,7 +204,12 @@ var _ = Describe("VirtLauncher", func() {
 
 				time.Sleep(time.Second)
 
-				exists, err := hasGracefulShutdownTrigger(tmpDir, "fakenamespace", "fakedomain")
+				exists, err := hasGracefulShutdownTrigger(
+					tmpDir,
+					"fakenamespace",
+					"fakedomain",
+					"123-123-123-123",
+				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(exists).To(Equal(false))
 
@@ -207,7 +217,12 @@ var _ = Describe("VirtLauncher", func() {
 
 				time.Sleep(time.Second)
 
-				exists, err = hasGracefulShutdownTrigger(tmpDir, "fakenamespace", "fakedomain")
+				exists, err = hasGracefulShutdownTrigger(
+					tmpDir,
+					"fakenamespace",
+					"fakedomain",
+					"123-123-123-123",
+				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(exists).To(Equal(true))
 			})

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -610,11 +610,11 @@ func NewMinimalDomain(name string) *Domain {
 	return NewMinimalDomainWithNS(kubev1.NamespaceDefault, name)
 }
 
-func NewMinimalDomainWithUUID(name string, uuid types.UID) *Domain {
-	domain := NewMinimalDomainWithNS(kubev1.NamespaceDefault, name)
+func NewMinimalDomainWithUUID(namespace string, name string, uid string) *Domain {
+	domain := NewMinimalDomainWithNS(namespace, name)
 	domain.Spec.Metadata = Metadata{
 		KubeVirt: KubeVirtMetadata{
-			UID: uuid,
+			UID: types.UID(uid),
 		},
 	}
 	return domain

--- a/pkg/watchdog/watchdog_test.go
+++ b/pkg/watchdog/watchdog_test.go
@@ -27,6 +27,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/precond"
 )
@@ -51,7 +53,7 @@ var _ = Describe("Watchdog", func() {
 
 		It("should detect expired watchdog files", func() {
 
-			fileName := tmpWatchdogDir + "/default_expiredvmi"
+			fileName := tmpWatchdogDir + "/default_expiredvmi_123-123-123-123"
 			Expect(os.Create(fileName)).ToNot(BeNil())
 
 			domains, err := GetExpiredDomains(1, tmpVirtShareDir)
@@ -71,12 +73,13 @@ var _ = Describe("Watchdog", func() {
 		})
 
 		It("should successfully remove watchdog file", func() {
-
+			uid := "123-123-123-123"
 			vmi := v1.NewMinimalVMI("tvmi")
+			vmi.UID = types.UID("123-123-123-123")
 			namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
 			domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
 
-			fileName := WatchdogFileFromNamespaceName(tmpVirtShareDir, namespace, domain)
+			fileName := WatchdogFileFromNamespaceNameUID(tmpVirtShareDir, namespace, domain, uid)
 			Expect(os.Create(fileName)).ToNot(BeNil())
 			domains, err := GetExpiredDomains(1, tmpVirtShareDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -129,8 +132,8 @@ var _ = Describe("Watchdog", func() {
 			dir := WatchdogFileDirectory(tmpVirtShareDir)
 			Expect(dir).To(Equal(tmpVirtShareDir + "/watchdog-files"))
 
-			dir = WatchdogFileFromNamespaceName(tmpVirtShareDir, "tnamespace", "tvmi")
-			Expect(dir).To(Equal(tmpVirtShareDir + "/watchdog-files/tnamespace_tvmi"))
+			dir = WatchdogFileFromNamespaceNameUID(tmpVirtShareDir, "tnamespace", "tvmi", "123-123-123-123")
+			Expect(dir).To(Equal(tmpVirtShareDir + "/watchdog-files/tnamespace_tvmi_123-123-123-123"))
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Will create a unique name for VMI watchdog and graceful shutdown trigger files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1460 

**Special notes for your reviewer**:
I prefer to replace namespace and name only by UUID, but I blocked by logic under `getVMIFromCache` method, need to check with @davidvossel or @rmohr if we can to avoid it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
