### PR TITLE
Update documentation link to the http://kubevirt.io/docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Example:
 
 Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).
 
-See our user documentation at [docs.kubevirt.io](http://docs.kubevirt.io/).
+See our user documentation at [kubevirt.io/docs](http://kubevirt.io/docs/).
 
 # To start developing KubeVirt
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR replaces URL pointing to the deprecated [User Guide](http://kubevirt.io/user-guide/) with the one pointing to the new [KubeVirt documentation](http://kubevirt.io/docs/). The [KubeVirt documentation](http://kubevirt.io/docs/) that is part of the new [KubeVirt Web site](http://kubevirt.io) had been already reconciled. It is convenient to adjust the user documentation URL since the legacy [User Guide](http://kubevirt.io/user-guide/) is about to be deprecated.

**Special notes for your reviewer**:

The PR closely relates to the kubevirt/kubevirt.github.io#88  If the `docs.kubevirt.io` subdomain was redirected to the [new documentation](http://kubevirt.io/docs/) this change would not be required.

**Release note**:

```release-note
NONE
```