### PR TITLE
Extend FailHandler to print VMI's

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1691,6 +1691,17 @@ func KubevirtFailHandler(message string, callerSkip ...int) {
 				fmt.Printf(string(logsRaw))
 			}
 		}
+
+		vmis, err := virtClient.VirtualMachineInstance(ns).List(&metav1.ListOptions{})
+		if err != nil {
+			fmt.Println(err)
+			Fail(message, callerSkip...)
+			return
+		}
+
+		for _, vmi := range vmis.Items {
+			fmt.Printf("%v\n", vmi)
+		}
 	}
 	Fail(message, callerSkip...)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
VMI object can include useful information, like conditions and VMI state, I prefer to have this information for debug purpose.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
