### PR TITLE
Merge pull request #1353 from slintes/k8s1.11

### DIFF
--- a/automation/check-patch.k8s-1.11.0-dev.mounts
+++ b/automation/check-patch.k8s-1.11.0-dev.mounts
@@ -1,0 +1,1 @@
+check-patch.mounts

--- a/automation/check-patch.k8s-1.11.0-dev.packages
+++ b/automation/check-patch.k8s-1.11.0-dev.packages
@@ -1,0 +1,1 @@
+check-patch.packages.el7

--- a/automation/check-patch.k8s-1.11.0-dev.sh
+++ b/automation/check-patch.k8s-1.11.0-dev.sh
@@ -1,0 +1,1 @@
+check-patch.sh

--- a/automation/check-patch.k8s-1.11.0-release.mounts
+++ b/automation/check-patch.k8s-1.11.0-release.mounts
@@ -1,0 +1,1 @@
+check-patch.mounts

--- a/automation/check-patch.k8s-1.11.0-release.packages
+++ b/automation/check-patch.k8s-1.11.0-release.packages
@@ -1,0 +1,1 @@
+check-patch.packages.el7

--- a/automation/check-patch.k8s-1.11.0-release.sh
+++ b/automation/check-patch.k8s-1.11.0-release.sh
@@ -1,0 +1,1 @@
+check-patch.sh

--- a/automation/check-patch.yaml
+++ b/automation/check-patch.yaml
@@ -1,2 +1,0 @@
-runtime_requirements:
-  support_nesting_level: 2

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -2,7 +2,7 @@ unset binaries docker_images docker_prefix docker_tag manifest_templates \
     master_ip network_provider kubeconfig manifest_docker_prefix namespace
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
-KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.3}
+KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.4}
 
 source ${KUBEVIRT_PATH}hack/config-default.sh source ${KUBEVIRT_PATH}hack/config-${KUBEVIRT_PROVIDER}.sh
 

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,8 +1,11 @@
 ---
 sub-stages:
   - k8s-1.10.4-release
+  - k8s-1.11.0-dev
+  - k8s-1.11.0-release
   - openshift-3.10-release
   - openshift-3.10-crio-release
+  - windows2016-release
 runtime_requirements:
   support_nesting_level: 2
   isolation_level: container

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -135,24 +135,21 @@ var _ = Describe("User Access", func() {
 				By(fmt.Sprintf("verifying VIEW sa for verb %s", verb))
 				expectedRes, _ := viewVerbs[verb]
 				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, view)
-				result, err := tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
-				Expect(err).ToNot(HaveOccurred())
+				result, _ := tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// EDIT
 				By(fmt.Sprintf("verifying EDIT sa for verb %s", verb))
 				expectedRes, _ = editVerbs[verb]
 				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, edit)
-				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
-				Expect(err).ToNot(HaveOccurred())
+				result, _ = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// ADMIN
 				By(fmt.Sprintf("verifying ADMIN sa for verb %s", verb))
 				expectedRes, _ = adminVerbs[verb]
 				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, admin)
-				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
-				Expect(err).ToNot(HaveOccurred())
+				result, _ = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// DEFAULT - the default should always return 'no' for ever verb.
@@ -160,8 +157,7 @@ var _ = Describe("User Access", func() {
 				By(fmt.Sprintf("verifying DEFAULT sa for verb %s", verb))
 				expectedRes = "no"
 				as = fmt.Sprintf("system:serviceaccount:%s:default", namespace)
-				result, err = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
-				Expect(err).ToNot(HaveOccurred())
+				result, _ = tests.RunKubectlCommand("auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 			}
 		},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -99,6 +99,8 @@ const (
 	NamespaceTestAlternative = "kubevirt-test-alternative"
 )
 
+const LocalStorageClass = "local"
+
 var testNamespaces = []string{NamespaceTestDefault, NamespaceTestAlternative}
 
 type startType string
@@ -345,6 +347,8 @@ func newPVC(os string, size string) *k8sv1.PersistentVolumeClaim {
 	PanicOnError(err)
 
 	name := fmt.Sprintf("disk-%s", os)
+	storageClass := LocalStorageClass
+
 	return &k8sv1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: k8sv1.PersistentVolumeClaimSpec{
@@ -359,6 +363,7 @@ func newPVC(os string, size string) *k8sv1.PersistentVolumeClaim {
 					"kubevirt.io/test": os,
 				},
 			},
+			StorageClassName: &storageClass,
 		},
 	}
 }
@@ -371,7 +376,6 @@ func CreateHostPathPv(os string, hostPath string) {
 	PanicOnError(err)
 
 	name := fmt.Sprintf("%s-disk-for-tests", os)
-	hostPathType := k8sv1.HostPathDirectoryOrCreate
 	pv := &k8sv1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -386,11 +390,11 @@ func CreateHostPathPv(os string, hostPath string) {
 			},
 			PersistentVolumeReclaimPolicy: k8sv1.PersistentVolumeReclaimRetain,
 			PersistentVolumeSource: k8sv1.PersistentVolumeSource{
-				HostPath: &k8sv1.HostPathVolumeSource{
+				Local: &k8sv1.LocalVolumeSource{
 					Path: hostPath,
-					Type: &hostPathType,
 				},
 			},
+			StorageClassName: LocalStorageClass,
 		},
 	}
 


### PR DESCRIPTION
Added k8s 1.11.0 provider

(cherry picked from commit d4fa4c5e175d530305701a25fa192e503c3e0bad)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add k8s-1.11 provider to the CI
```
