### PR TITLE
Fix wrong demo-content.yaml

### DIFF
--- a/manifests/release/demo-content.yaml.in
+++ b/manifests/release/demo-content.yaml.in
@@ -3,10 +3,10 @@ apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstancePreset
 metadata:
   name: windows-server-2012r2
+spec:
   selector:
     matchLabels:
       kubevirt.io/os: win2k12r2
-spec:
   domain:
     cpu:
       cores: 2
@@ -31,3 +31,4 @@ spec:
         rtc:
           tickPolicy: catchup
         hyperv: {}
+    devices: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the wrong demo-content.yaml in manifests.
The `VirtualMachineInstancePreset` have to have the `selector` placed in the `domain` section.
This version of kubevirt also requires the `devices` to be present. The fix is done in the simplest possible way. Add empty devices. This way the patch omits unnecessary code changes, which could potentially lead to additional issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1614322

**Special notes for your reviewer**:
This patch is done in the most possible non-destructive way to introduce as little changes as possible.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
Signed-off-by: Petr Kotas <petr.kotas@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1473)
<!-- Reviewable:end -->
