### PR TITLE
Use CRD to represent custom resource instead of TPR in arch doc

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,8 +46,7 @@ required state.
 This same mechanism is used by KubeVirt. Thus KubeVirt delivers three things
 to provide the new functionality:
 
-1. Additional types - so called 3rd party resources - are added to the
-   Kubernetes API
+1. Additional types - so called [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRD) - are added to the Kubernetes API
 2. Additional controllers for cluster wide logic associated with this new types
 3. Additional daemons for node specific logic associated with new types
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For ThirdPartyResource (TPR) has been entirely deprecated since Kubernetes v1.8, replace it with CustomResourceDefinition (CRD) with the link to the official page.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: imjoey <majunjiev@gmail.com>
