### PR TITLE
stdci: set path to junit results to be collected by jenkins

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -29,6 +29,7 @@
 set -ex
 
 export WORKSPACE="${WORKSPACE:-$PWD}"
+readonly ARTIFACTS_PATH="$WORKSPACE/exported-artifacts"
 
 if [[ $TARGET =~ openshift-.* ]]; then
   if [[ $TARGET =~ .*-crio-.* ]]; then
@@ -61,7 +62,7 @@ wait_for_windows_lock() {
   exit 1
 }
 
-release_windows_lock() {      
+release_windows_lock() {
   if [[ -e "$WINDOWS_LOCK_PATH" ]]; then
       rm -f "$WINDOWS_LOCK_PATH"
       echo "Released lock: $WINDOWS_LOCK_PATH"
@@ -152,7 +153,9 @@ done
 
 kubectl version
 
-ginko_params="--ginkgo.noColor --junit-output=$WORKSPACE/junit.xml"
+mkdir -p "$ARTIFACTS_PATH"
+
+ginko_params="--ginkgo.noColor --junit-output=$ARTIFACTS_PATH/tests.junit.xml"
 
 # Prepare PV for windows testing
 if [[ $TARGET =~ windows.* ]]; then


### PR DESCRIPTION
STDCI Jenkins job is configured to match junit results
as exported-artifacts/*.junit.xml .

Signed-off-by: Lukas Bednar <lbednar@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR enables junit reporting for the CI system. This will allow the CI system to generate history and information about the functional tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
