### PR TITLE
Include 'git describe' result in all virt-* containers

### DIFF
--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -26,5 +26,6 @@ WORKDIR /home/virt-api
 USER 1001
 
 COPY virt-api /usr/bin/virt-api
+COPY .version /.version
 
 ENTRYPOINT [ "/usr/bin/virt-api" ]

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -25,5 +25,6 @@ RUN useradd -u 1001 --create-home -s /bin/bash virt-controller
 WORKDIR /home/virt-controller
 USER 1001
 COPY virt-controller /usr/bin/virt-controller
+COPY .version /.version
 
 ENTRYPOINT [ "/usr/bin/virt-controller" ]

--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -21,5 +21,6 @@ FROM fedora:28
 MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
 
 COPY virt-handler /usr/bin/virt-handler
+COPY .version /.version
 
 ENTRYPOINT [ "/usr/bin/virt-handler" ]

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -32,6 +32,7 @@ RUN dnf -y install \
 
 COPY virt-launcher /usr/bin/virt-launcher
 COPY kubevirt-sudo /etc/sudoers.d/kubevirt
+COPY .version /.version
 
 # Allow qemu to bind privileged ports
 RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/qemu-system-x86_64

--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -21,6 +21,7 @@ set -e
 
 source hack/common.sh
 source hack/config.sh
+source hack/version.sh
 
 if [ -z "$1" ]; then
     target="build"
@@ -40,6 +41,8 @@ for arg in $args; do
     if [ "${target}" = "build" ]; then
         (
             cd ${CMD_OUT_DIR}/${BIN_NAME}/
+            kubevirt::version::get_version_vars
+            echo "$KUBEVIRT_GIT_VERSION" >.version
             docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${job_prefix} --label ${BIN_NAME} .
         )
     elif [ "${target}" = "push" ]; then


### PR DESCRIPTION
This helps with determining which exact git tree was used to build
containers.

Just do: docker exec -it <...> cat /gitinfo

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: simplifies determination of git hash used to build an image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: maybe the name of the file inside container should be different from `/gitinfo` (perhaps `/.gitinfo`?)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
