### PR TITLE
Introduce an optional subprotocol for browser websocket connections

### DIFF
--- a/pkg/kubecli/vmi.go
+++ b/pkg/kubecli/vmi.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/util/subresources"
 )
 
 const (
@@ -178,6 +179,7 @@ func roundTripperFromConfig(config *rest.Config, callback RoundTripCallback) (ht
 		TLSClientConfig: tlsConfig,
 		WriteBufferSize: WebsocketMessageBufferSize,
 		ReadBufferSize:  WebsocketMessageBufferSize,
+		Subprotocols:    []string{subresources.PlainStreamProtocolName},
 	}
 
 	// Create a roundtripper which will pass in the final underlying websocket connection to a callback

--- a/pkg/util/subresources/constants.go
+++ b/pkg/util/subresources/constants.go
@@ -1,0 +1,25 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 The KubeVirt Authors
+ *
+ */
+
+package subresources
+
+// PlainStreamProtocolName is a subprotocol which indicates a plain websocket stream.
+// Mostly useful for browser connections which need to use the websocket subprotocol
+// field to pass credentials. As a consequence they need to get a subprotocol back.
+const PlainStreamProtocolName = "plain.kubevirt.io"

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util/subresources"
 )
 
 type SubresourceAPIApp struct {
@@ -62,6 +63,7 @@ func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response 
 		CheckOrigin: func(_ *http.Request) bool {
 			return true
 		},
+		Subprotocols: []string{subresources.PlainStreamProtocolName},
 	}
 
 	clientSocket, err := upgrader.Upgrade(response.ResponseWriter, request.Request, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

Browsers need to use subprotocols to pass credentials to kubernetes to
open websocket connections. Kubernetes will remove the authentication
subprotocol from the protocols. In order to let the browser continue the
handshake, the server needs to return another subprotocol. The
subprotocol is named "plain.kubevirt.io" and is an alias for a plain
websocket connection.

A valid connection attempt from the browser may look like this:
```
Sec-WebSocket-Protocol: base64url.bearer.authorization.k8s.io.bXl0b2tlbg, plain.kubevirt.io
```
The server will then respond with
```
Sec-WebSocket-Protocol: plain.kubevirt.io
```
If no subprotocols are given, the connection is upgraded regardless, for
backward compatibility.

**Release note**:

```release-note
To allow browsers to connect to KubeVirt websocket subresources, the "plain.kubevirt.io" subprotocol is introduced.
```
