### PR TITLE
Fix the example of listing pods in the getting-started doc

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,12 +173,12 @@ tap networking device attached.
 $ ./cluster/kubectl.sh create -f cluster/examples/vmi-ephemeral.yaml
 vm "vmi-ephemeral" created
 
-$ ./cluster/kubectl.sh get pods
+$ ./cluster/kubectl.sh -n kube-system get pods
 NAME                              READY     STATUS    RESTARTS   AGE
 virt-api                          1/1       Running   1          10h
 virt-controller                   1/1       Running   1          10h
 virt-handler-z90mp                1/1       Running   1          10h
-virt-launcher-vmi-ephemeral9q7es   1/1       Running   0          10s
+virt-launcher-vmi-ephemeral9q7es  1/1       Running   0          10s
 
 $ ./cluster/kubectl.sh get vmis
 NAME           LABELS                        DATA


### PR DESCRIPTION
Inspect pods within the kube-system namespace to get virt-api,
virt-controller, etc. Also, fix the layout of the output.

Signed-off-by: Arik Hadas <ahadas@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
