### PR TITLE
Moved .version generation to build-go.sh

### DIFF
--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -21,7 +21,6 @@ set -e
 
 source hack/common.sh
 source hack/config.sh
-source hack/version.sh
 
 if [ -z "$1" ]; then
     target="build"
@@ -41,8 +40,6 @@ for arg in $args; do
     if [ "${target}" = "build" ]; then
         (
             cd ${CMD_OUT_DIR}/${BIN_NAME}/
-            kubevirt::version::get_version_vars
-            echo "$KUBEVIRT_GIT_VERSION" >.version
             docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${job_prefix} --label ${BIN_NAME} .
         )
     elif [ "${target}" = "push" ]; then

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -92,6 +92,9 @@ for arg in $args; do
             GOOS=linux GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
 
+            kubevirt::version::get_version_vars
+            echo "$KUBEVIRT_GIT_VERSION" >${CMD_OUT_DIR}/${BIN_NAME}/.version
+
             # build virtctl also for darwin and windows
             if [ "${BIN_NAME}" = "virtctl" ]; then
                 GOOS=darwin GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)


### PR DESCRIPTION
This way, other Dockerfiles may copy the file without calling to docker-build.sh (helpful for downstream builds of CNV that, as it turned out, don't call to docker-build.sh but to build-go.sh only).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: this is to allow Dockerfiles for CNV container builds call to build-go.sh and get the version file generated for them. (Alternatively, CNV could generate the file themselves but that somewhat leaks details from upstream into downstream).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
