### PR TITLE
Fix Vm controller orphan logic

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -293,19 +293,9 @@ func (c *VMController) orphan(cm *controller.VirtualMachineControllerRefManager,
 		return nil
 	}
 
-	errChan := make(chan error, 1)
-
-	go func(vmi *virtv1.VirtualMachineInstance) {
-		err := cm.ReleaseVirtualMachine(vmi)
-		if err != nil {
-			errChan <- err
-		}
-	}(vmi)
-
-	select {
-	case err := <-errChan:
+	err := cm.ReleaseVirtualMachine(vmi)
+	if err != nil {
 		return err
-	default:
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

While the VM controller is spawning goroutines to orphan a single VMI. This logic was something pulled from the VMIRS controller, which has to act on a large number of VMIs at once in parallel. The VM controller works on a single VMI, so there's no work to be done in parallel using goroutines here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
