### PR TITLE
[WIP] Make registry disk containers init containers on the VMI pod.

### DIFF
--- a/cmd/registry-disk-v1alpha/entry-point.sh
+++ b/cmd/registry-disk-v1alpha/entry-point.sh
@@ -53,6 +53,10 @@ else
 fi
 echo "copied $IMAGE_PATH to $COPY_PATH.${IMAGE_EXTENSION}"
 
+if [ "$EXIT_AFTER_COPY" = "true" ]; then
+	exit 0
+fi
+
 touch /tmp/healthy
 while [ -f "${COPY_PATH}.${IMAGE_EXTENSION}" ]; do
 	sleep 5

--- a/pkg/registry-disk/registry-disk.go
+++ b/pkg/registry-disk/registry-disk.go
@@ -98,12 +98,6 @@ func SetFilePermissions(vmi *v1.VirtualMachineInstance) error {
 func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, podVolumeMountDir string) []kubev1.Container {
 	var containers []kubev1.Container
 
-	initialDelaySeconds := 2
-	timeoutSeconds := 5
-	periodSeconds := 5
-	successThreshold := 2
-	failureThreshold := 5
-
 	// Make VirtualMachineInstance Image Wrapper Containers
 	for _, volume := range vmi.Spec.Volumes {
 		if volume.RegistryDisk != nil {
@@ -122,29 +116,16 @@ func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, po
 						Name:  "COPY_PATH",
 						Value: volumeMountDir + "/" + filePrefix,
 					},
+					{
+						Name:  "EXIT_AFTER_COPY",
+						Value: "true",
+					},
 				},
 				VolumeMounts: []kubev1.VolumeMount{
 					{
 						Name:      podVolumeName,
 						MountPath: podVolumeMountDir,
 					},
-				},
-				// The readiness probes ensure the volume coversion and copy finished
-				// before the container is marked as "Ready: True"
-				ReadinessProbe: &kubev1.Probe{
-					Handler: kubev1.Handler{
-						Exec: &kubev1.ExecAction{
-							Command: []string{
-								"cat",
-								"/tmp/healthy",
-							},
-						},
-					},
-					InitialDelaySeconds: int32(initialDelaySeconds),
-					PeriodSeconds:       int32(periodSeconds),
-					TimeoutSeconds:      int32(timeoutSeconds),
-					SuccessThreshold:    int32(successThreshold),
-					FailureThreshold:    int32(failureThreshold),
 				},
 			})
 		}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -111,6 +111,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	var privileged bool = false
 	var volumesMounts []k8sv1.VolumeMount
 	var imagePullSecrets []k8sv1.LocalObjectReference
+	var containers []k8sv1.Container
 
 	gracePeriodSeconds := v1.DefaultGracePeriodSeconds
 	if vmi.Spec.TerminationGracePeriodSeconds != nil {
@@ -339,7 +340,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		Ports:     ports,
 	}
 
-	containers := registrydisk.GenerateContainers(vmi, "libvirt-runtime", "/var/run/libvirt")
+	initContainers := registrydisk.GenerateContainers(vmi, "libvirt-runtime", "/var/run/libvirt")
 
 	volumes = append(volumes, k8sv1.Volume{
 		Name: "virt-share-dir",
@@ -411,6 +412,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,
 			RestartPolicy:                 k8sv1.RestartPolicyNever,
 			Containers:                    containers,
+			InitContainers:                initContainers,
 			NodeSelector:                  nodeSelector,
 			Volumes:                       volumes,
 			ImagePullSecrets:              imagePullSecrets,


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

**What this PR does / why we need it**:

RegistryDisk (RD) containers exist to provide a disk image stored within a container to a VM. 

The current behavior for a RD is to convert the disk to RAW format and copy the disk to a shared emptyDir{} which provides the qemu process access to the disk. This is heavy weight and wastes resources as it requires multiple copies of the disk to exist on a single node.

To make this process more efficient, we planned to utilize MountPropagation to allow the disk's file to be shared between both the compute and RD containers in a Pod. The RD containers would be read only, and the compute container would make backing volumes for each RD containers's disk.

However, after attempting to use MountPropagation, I came to the realization that bidirectional mount propagation requires the pod to be privileged, which is something we really don't want. 

If we determine that there's not a reasonable way to share the RD directly with the compute container without requiring a copy to occur, we should consider the work I've done in this PR to transition RDs to init containers. This helps us more accurately set the resource requests/limits for the pod as discussed [here](https://github.com/kubevirt/kubevirt/pull/1381#discussion_r214616202) for PR #1381 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
