### PR TITLE
Simplify the template_test logic

### DIFF
--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -59,123 +59,86 @@ var _ = Describe("Templates", func() {
 
 	Describe("Launching VMI from VM Template", func() {
 
-		assertGeneratedVMJson := func() func() {
-			return func() {
-				By("Generating VM JSON from the Template via oc-process command")
-				_, err := runOcProcessCommand(templateJsonFile, templateParams, vmJsonFile)
+		assertGeneratedVMJson := func() {
+			By("Generating VM JSON from the Template via oc-process command")
+			_, err := runOcProcessCommand(templateJsonFile, templateParams, vmJsonFile)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, vmJsonFile).To(BeAnExistingFile())
+		}
+
+		assertCreatedVM := func() {
+			By("Creating VM via oc-create command")
+			out, err := runOcCreateCommand(vmJsonFile)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" created\n", templateParams.Name)
+			ExpectWithOffset(1, out).To(Equal(message))
+
+			By("Checking if the VM exists via oc-get command.")
+			EventuallyWithOffset(1, func() bool {
+				out, err := runOcGetCommand("vms")
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				ExpectWithOffset(1, vmJsonFile).To(BeAnExistingFile())
-			}
+				return strings.Contains(out, templateParams.Name)
+			}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VM to apppear")
 		}
 
-		assertCreatedVM := func() func() {
-			return func() {
-				By("Creating VM via oc-create command")
-				out, err := runOcCreateCommand(vmJsonFile)
+		assertDeletedVM := func() {
+			By("Deleting the VM via oc-delete command")
+			out, err := runOcDeleteCommand(templateParams.Name)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" deleted\n", templateParams.Name)
+			ExpectWithOffset(1, out).To(Equal(message))
+
+			By("Checking if the VM does not exist anymore via oc-get command.")
+			EventuallyWithOffset(1, func() bool {
+				out, err := runOcGetCommand("vms")
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" created\n", templateParams.Name)
-				ExpectWithOffset(1, out).To(Equal(message))
-
-				By("Checking if the VM exists via oc-get command.")
-				EventuallyWithOffset(1, func() bool {
-					out, err := runOcGetCommand("vms")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return strings.Contains(out, templateParams.Name)
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VM to apppear")
-			}
+				return out == "No resources found.\n"
+			}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VM to disappear")
 		}
 
-		assertDeletedVM := func() func() {
-			return func() {
-				By("Deleting the VM via oc-delete command")
-				out, err := runOcDeleteCommand(templateParams.Name)
+		assertLaunchedVMI := func() {
+			By("Launching VMI via oc-patch command")
+			out, err := runOcPatchCommand(templateParams.Name, "{\"spec\":{\"running\":true}}")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", templateParams.Name)
+			ExpectWithOffset(1, out).To(Equal(message))
+
+			By("Checking if the VMI does exist via oc-get command")
+			EventuallyWithOffset(1, func() bool {
+				out, err := runOcGetCommand("vmis")
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" deleted\n", templateParams.Name)
-				ExpectWithOffset(1, out).To(Equal(message))
-
-				By("Checking if the VM does not exist anymore via oc-get command.")
-				EventuallyWithOffset(1, func() bool {
-					out, err := runOcGetCommand("vms")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return out == "No resources found.\n"
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VM to disappear")
-			}
+				return strings.Contains(out, templateParams.Name)
+			}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to appear")
 		}
 
-		assertLaunchedVMI := func() func() {
-			return func() {
-				By("Launching VMI via oc-patch command")
-				out, err := runOcPatchCommand(templateParams.Name, "{\"spec\":{\"running\":true}}")
+		assertTerminatedVMI := func() {
+			By("Terminating the VMI via oc-patch command")
+			out, err := runOcPatchCommand(templateParams.Name, "{\"spec\":{\"running\":false}}")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", templateParams.Name)
+			ExpectWithOffset(1, out).To(Equal(message))
+
+			By("Checking if the VMI does not exist anymore via oc-get command")
+			EventuallyWithOffset(1, func() bool {
+				out, err := runOcGetCommand("vmis")
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", templateParams.Name)
-				ExpectWithOffset(1, out).To(Equal(message))
-
-				By("Checking if the VMI does exist via oc-get command")
-				EventuallyWithOffset(1, func() bool {
-					out, err := runOcGetCommand("vmis")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return strings.Contains(out, templateParams.Name)
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to appear")
-			}
+				return out == "No resources found.\n"
+			}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to disappear")
 		}
 
-		assertTerminatedVMI := func() func() {
-			return func() {
-				By("Terminating the VMI via oc-patch command")
-				out, err := runOcPatchCommand(templateParams.Name, "{\"spec\":{\"running\":false}}")
+		assertRemovedFile := func(file string) {
+			if _, err := os.Stat(file); !os.IsNotExist(err) {
+				err := os.Remove(file)
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", templateParams.Name)
-				ExpectWithOffset(1, out).To(Equal(message))
-
-				By("Checking if the VMI does not exist anymore via oc-get command")
-				EventuallyWithOffset(1, func() bool {
-					out, err := runOcGetCommand("vmis")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return out == "No resources found.\n"
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to disappear")
 			}
-		}
-
-		assertRemovedFile := func(file string) func() {
-			return func() {
-				if _, err := os.Stat(file); !os.IsNotExist(err) {
-					err := os.Remove(file)
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				}
-				ExpectWithOffset(1, file).NotTo(BeAnExistingFile())
-			}
-		}
-
-		testGivenTemplate := func() {
-			It("should succeed to generate a VM JSON file using oc-process command", assertGeneratedVMJson())
-
-			Context("with given VM JSON from the Template", func() {
-				JustBeforeEach(assertGeneratedVMJson())
-				AfterEach(assertDeletedVM())
-
-				It("should succeed to create a VM using oc-create command", assertCreatedVM())
-
-				Context("with given VM from the VM JSON", func() {
-					JustBeforeEach(assertCreatedVM())
-
-					It("should succeed to launch a VMI using oc-patch command", assertLaunchedVMI())
-
-					Context("with given VMI from the VM", func() {
-						JustBeforeEach(assertLaunchedVMI())
-
-						It("should succeed to terminate the VMI using oc-patch command", assertTerminatedVMI())
-					})
-				})
-			})
+			ExpectWithOffset(1, file).NotTo(BeAnExistingFile())
 		}
 
 		BeforeEach(func() {
-			templateParams = TemplateParams{
-				Name:     "testvm",
-				CpuCores: "2",
-			}
+			templateParams = TemplateParams{Name: "testvm", CpuCores: "2"}
 			vmJsonFile = fmt.Sprintf("%s.json", templateParams.Name)
 			Expect(vmJsonFile).NotTo(BeAnExistingFile())
+
 		})
 
 		JustBeforeEach(func() {
@@ -186,8 +149,9 @@ var _ = Describe("Templates", func() {
 		})
 
 		AfterEach(func() {
-			assertRemovedFile(vmJsonFile)()
-			assertRemovedFile(templateJsonFile)()
+			assertDeletedVM()
+			assertRemovedFile(vmJsonFile)
+			assertRemovedFile(templateJsonFile)
 		})
 
 		Context("with given Fedora Template", func() {
@@ -201,8 +165,12 @@ var _ = Describe("Templates", func() {
 					UserData:    "#cloud-config\npassword: fedora\nchpasswd: { expire: False }",
 				})
 			})
-
-			testGivenTemplate()
+			It("create VM, Launch VMI and Terminate VMI", func() {
+				assertGeneratedVMJson()
+				assertCreatedVM()
+				assertLaunchedVMI()
+				assertTerminatedVMI()
+			})
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Shiyang Wang <shiywang@redhat.com>

quoting ginkgo doc here: https://onsi.github.io/ginkgo/#separating-creation-and-configuration-justbeforeeach

> You can have multiple JustBeforeEaches at different levels of nesting. Ginkgo will first run all the BeforeEaches from the outside in, then it will run the JustBeforeEaches from the outside in. While powerful, this can lead to confusing test suites – so use nested JustBeforeEaches judiciously.

> Some parting words: JustBeforeEach is a powerful tool that can be easily abused. Use it well.


reduce unnecessary nested logic make code more readable for others.


```release-note
NONE
```
