### PR TITLE
Fix console expecter in tests

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -38,19 +38,13 @@ var _ = Describe("Console", func() {
 
 	flag.Parse()
 
-	var virtClient kubecli.KubevirtClient
-	var err error
-
+	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
 	})
 
-	JustBeforeEach(func() {
-		By("Opening new virtClient")
-		virtClient, err = kubecli.GetKubevirtClient()
-	})
 
 	RunVMIAndWaitForStart := func(vmi *v1.VirtualMachineInstance) {
 		By("Creating a new VirtualMachineInstance")

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -45,7 +45,6 @@ var _ = Describe("Console", func() {
 		tests.BeforeTestCleanup()
 	})
 
-
 	RunVMIAndWaitForStart := func(vmi *v1.VirtualMachineInstance) {
 		By("Creating a new VirtualMachineInstance")
 		Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())

--- a/tests/vmi_userdata_test.go
+++ b/tests/vmi_userdata_test.go
@@ -87,6 +87,7 @@ var _ = Describe("CloudInit UserData", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), userData)
 				LaunchVMI(vmi)
 				VerifyUserDataVMI(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: expectedUserData},
 				}, time.Second*120)
 			})
@@ -144,6 +145,7 @@ var _ = Describe("CloudInit UserData", func() {
 
 				By("executing a user-data script")
 				VerifyUserDataVMI(vmi, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: expectedUserData},
 				}, time.Second*120)
 
@@ -197,6 +199,7 @@ var _ = Describe("CloudInit UserData", func() {
 			}
 			LaunchVMI(vmi)
 			VerifyUserDataVMI(vmi, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: expectedUserData},
 			}, time.Second*120)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes the expecter behaviour. By adding the `\n` as the first command it makes sure that the expecter is receiving properly.



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This patch fixes CI issues.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1503)
<!-- Reviewable:end -->
