### PR TITLE
api: return empty array in resources for subresources endpoint

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -269,6 +269,7 @@ func (app *virtAPIApp) composeSubresources(ctx context.Context) {
 			list.Kind = "APIResourceList"
 			list.GroupVersion = v1.SubresourceGroupVersion.Group + "/" + v1.SubresourceGroupVersion.Version
 			list.APIVersion = v1.SubresourceGroupVersion.Version
+			list.APIResources = []metav1.APIResource{}
 
 			response.WriteAsJson(list)
 		}).


### PR DESCRIPTION
Dynamic client is complaining about null value in resources. This
PR fixes this issue by returning empty array.

Fixes: https://github.com/kubevirt/kubevirt/issues/1500

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>