### PR TITLE
Add default value for oc/virtctl/kubectl

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -71,19 +71,17 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
-var KubeVirtVersionTag = "latest"
-var KubeVirtRepoPrefix = "kubevirt"
-var KubeVirtKubectlPath = ""
-var KubeVirtOcPath = ""
-var KubeVirtVirtctlPath = ""
-var KubeVirtInstallNamespace = "kube-system"
+var KubeVirtVersionTag string
+var KubeVirtRepoPrefix string
+var KubeVirtInstallNamespace string
+var KubeVirtKubectlPath, KubeVirtOcPath, KubeVirtVirtctlPath string
 
 func init() {
 	flag.StringVar(&KubeVirtVersionTag, "tag", "latest", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtRepoPrefix, "prefix", "kubevirt", "Set the repository prefix for all images")
-	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "", "Set path to kubectl binary")
-	flag.StringVar(&KubeVirtOcPath, "oc-path", "", "Set path to oc binary")
-	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "", "Set path to virtctl binary")
+	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "/usr/bin/kubectl", "Set path to kubectl binary")
+	flag.StringVar(&KubeVirtOcPath, "oc-path", "/usr/bin/oc", "Set path to oc binary")
+	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "/usr/bin/virtctl", "Set path to virtctl binary")
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "kube-system", "Set the namespace KubeVirt is installed in")
 }
 


### PR DESCRIPTION
Signed-off-by: Guohua Ouyang <gouyang@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Set default value for these binaries so our tests won't be failed if not specify them. Convenient for run tests manually.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
