### PR TITLE
[WIP] Fix virtClient initialization

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -38,10 +38,12 @@ var _ = Describe("Console", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/controller_leader_election_test.go
+++ b/tests/controller_leader_election_test.go
@@ -43,10 +43,12 @@ import (
 var _ = Describe("LeaderElection", func() {
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -37,10 +37,12 @@ import (
 var _ = Describe("DataVolume Integration", func() {
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 		if !tests.HasCDI() {
 			Skip("Skip DataVolume tests when CDI is not present")

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -54,8 +54,14 @@ var _ = Describe("Expose", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+	})
+
 	const testPort = 1500
 
 	Context("Expose service on a VM", func() {

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -43,12 +43,17 @@ var _ = Describe("Networkpolicy", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	var vmia *v1.VirtualMachineInstance
 	var vmib *v1.VirtualMachineInstance
 	var vmic *v1.VirtualMachineInstance
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+	})
 
 	tests.BeforeAll(func() {
 		tests.SkipIfUseFlannel(virtClient)

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -42,10 +42,12 @@ var _ = Describe("RegistryDisk", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -47,10 +47,12 @@ var _ = Describe("VirtualMachineInstanceReplicaSet", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -46,10 +46,12 @@ type VMICreationFunc func(string) *v1.VirtualMachineInstance
 var _ = Describe("Storage", func() {
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -38,10 +38,12 @@ var _ = Describe("Subresource Api", func() {
 
 	flag.Parse()
 
-	virtCli, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtCli kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtCli, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -49,10 +49,12 @@ var _ = Describe("VirtualMachine", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -45,10 +45,12 @@ var _ = Describe("Configurations", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -41,13 +41,18 @@ var _ = Describe("HookSidecars", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
+	})
+
+	JustBeforeEach(func() {
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 		vmi.ObjectMeta.Annotations = map[string]string{
 			"hooks.kubevirt.io/hookSidecars":              fmt.Sprintf(`[{"image": "%s/%s:%s", "imagePullPolicy": "IfNotPresent"}]`, tests.KubeVirtRepoPrefix, hookSidecarImage, tests.KubeVirtVersionTag),

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -70,15 +70,20 @@ var _ = Describe("VMIlifecycle", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	var vmi *v1.VirtualMachineInstance
 
 	var useEmulation *bool
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
+	})
+
+	JustBeforeEach(func() {
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 	})
 

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -38,8 +38,8 @@ var _ = Describe("Health Monitoring", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	launchVMI := func(vmi *v1.VirtualMachineInstance) {
 		By("Starting a VirtualMachineInstance")
@@ -50,6 +50,8 @@ var _ = Describe("Health Monitoring", func() {
 	}
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -42,12 +42,20 @@ var _ = Describe("Multus Networking", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
+
 	var detachedVMI *v1.VirtualMachineInstance
 
 	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.SkipIfNoMultusProvider(virtClient)
+	})
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vmi_userdata_test.go
+++ b/tests/vmi_userdata_test.go
@@ -49,8 +49,8 @@ var _ = Describe("CloudInit UserData", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	LaunchVMI := func(vmi *v1.VirtualMachineInstance) {
 		By("Starting a VirtualMachineInstance")
@@ -76,6 +76,8 @@ var _ = Describe("CloudInit UserData", func() {
 	}
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -35,13 +35,18 @@ import (
 var _ = Describe("VMIDefaults", func() {
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
+	})
+
+	JustBeforeEach(func() {
 		// create VMI with missing disk target
 		vmi = tests.NewRandomVMI()
 		vmi.Spec = v1.VirtualMachineInstanceSpec{

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -42,8 +42,8 @@ import (
 var _ = Describe("VMIPreset", func() {
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	var vmi *v1.VirtualMachineInstance
 	var memoryPreset *v1.VirtualMachineInstancePreset
@@ -59,7 +59,12 @@ var _ = Describe("VMIPreset", func() {
 	cores := 7
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
+	})
+
+	JustBeforeEach(func() {
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
 		vmi.Labels = map[string]string{flavorKey: memoryFlavor}
 

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -48,8 +48,12 @@ var _ = Describe("VNC", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
+	var virtClient kubecli.KubevirtClient
+	var err error
+
+	virtClient, err = kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
+
 	var vmi *v1.VirtualMachineInstance
 
 	Describe("A new VirtualMachineInstance", func() {

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -57,8 +57,8 @@ const (
 var _ = Describe("Windows VirtualMachineInstance", func() {
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	var windowsVMI *v1.VirtualMachineInstance
 
@@ -119,11 +119,18 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 	}
 
 	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.SkipIfNoWindowsImage(virtClient)
 	})
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 		tests.BeforeTestCleanup()
+	})
+
+	JustBeforeEach(func() {
 		windowsVMI = tests.NewRandomVMI()
 		windowsVMI.Spec = windowsVMISpec
 		tests.AddExplicitPodNetworkInterface(windowsVMI)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes the timouts by reseting virtclient connection by creating new client for each test.

Still WIP, here just to see how the CI reacts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1510)
<!-- Reviewable:end -->
