### PR TITLE
Update cluster images for enabling BlockVolume feature gate

### DIFF
--- a/cluster/k8s-1.10.4/provider.sh
+++ b/cluster/k8s-1.10.4/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.10.4@sha256:e697f59d5b3b09130a8854b08417959eb70197fcc1b47cf64fe83c5164f00cfa"
+image="k8s-1.10.4@sha256:9341db6774ccc7d81a2fe90417fcced02867d7109e7c21a12dc6791b2746cccc"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-1.11.0/provider.sh
+++ b/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:de5606811adba4945e01d07ee77b5c1a7cddeed5412b020219dadb8fb96d77be"
+image="k8s-1.11.0@sha256:b407bce5ab0c4fce5cd58e78d84eca086e2a0ac28f5672b89c3ae75a40b14418"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-multus-1.11.1/provider.sh
+++ b/cluster/k8s-multus-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.11.1@sha256:ce7b961a449e20cf0628fba4deb90a8f399271659a0dd98eecdd249ec6c9d4b0"
+image="k8s-multus-1.11.1@sha256:47ea6a0bef30846c72f194d4899ca1e2fd6b15061e928734610c6255f73fe56b"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/os-3.10.0-crio/provider.sh
+++ b/cluster/os-3.10.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-crio@sha256:cbcf274bc7414db321719ce346a0d6ccb26c27479defd0b65d51954a08e91681"
+image="os-3.10.0-crio@sha256:88b64f9efc17281427aba67b3499831c03a28990f2f5fc4a540472f98e64cfb4"

--- a/cluster/os-3.10.0-crio/provider.sh
+++ b/cluster/os-3.10.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-crio@sha256:63e2f80caef0328960f3f72860ed19c59e4070cb6e9815a4c7f6051cd243f501"
+image="os-3.10.0-crio@sha256:cbcf274bc7414db321719ce346a0d6ccb26c27479defd0b65d51954a08e91681"

--- a/cluster/os-3.10.0-multus/provider.sh
+++ b/cluster/os-3.10.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-multus@sha256:6250657e259b5d12ee76a7413b4b7545853e8d9ac5cb0c30f50e28ffcd759a87"
+image="os-3.10.0-multus@sha256:fa6d763af28634417200ee35e095cc56d8ad4039e58f70c3a04a59d498011ec5"

--- a/cluster/os-3.10.0-multus/provider.sh
+++ b/cluster/os-3.10.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-multus@sha256:410d8efbbaf6b84139e130aae1f7e127327e672167304dc4b9ec4a95261446a4"
+image="os-3.10.0-multus@sha256:6250657e259b5d12ee76a7413b4b7545853e8d9ac5cb0c30f50e28ffcd759a87"

--- a/cluster/os-3.10.0/provider.sh
+++ b/cluster/os-3.10.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.10.0@sha256:a94fa5a213405147879bd4498c48a2deee0e5d0db4ece2482494b70d1e9c92b7"
+image="os-3.10.0@sha256:45e0b2797134c147da5f3cba1ca768340ef6da1f7d52978c81b6813421833501"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/os-3.10.0/provider.sh
+++ b/cluster/os-3.10.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.10.0@sha256:faa467495207af8faa9214b1bf8adabf6161fab7f4da11b63efa41610a3ff0ab"
+image="os-3.10.0@sha256:a94fa5a213405147879bd4498c48a2deee0e5d0db4ece2482494b70d1e9c92b7"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -28,4 +28,4 @@ if [[ ${TARGET} == openshift* ]]; then
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 120m ${FUNC_TEST_ARGS}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -tag=${docker_tag} -prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 180m ${FUNC_TEST_ARGS}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update cluster images for enabling BlockVolume feature gate
 
**Special notes for your reviewer**:
See https://github.com/kubevirt/kubevirtci/pull/42
Let's see if all clusters still work

**Release note**:
```release-note
NONE
```