### PR TITLE
Don't use tty in remote exec

### DIFF
--- a/cmd/virt-launcher/sock-connector
+++ b/cmd/virt-launcher/sock-connector
@@ -29,5 +29,4 @@ if ! [ -S "$SOCKET" ]; then
 	exit 1
 fi
 
-stty -echo
-socat unix-connect:/$SOCKET stdio,cfmakeraw
+socat unix-connect:/$SOCKET stdio

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -48,7 +48,36 @@ type SubresourceAPIApp struct {
 	VirtCli kubecli.KubevirtClient
 }
 
-func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response *restful.Response, vmi *v1.VirtualMachineInstance, cmd []string) {
+type requestType struct {
+	socketName string
+}
+
+var CONSOLE = requestType{socketName: "serial0"}
+var VNC = requestType{socketName: "vnc"}
+
+func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response *restful.Response, requestType requestType) {
+
+	vmiName := request.PathParameter("name")
+	namespace := request.PathParameter("namespace")
+
+	vmi, code, err := app.fetchVirtualMachineInstance(vmiName, namespace)
+	if err != nil {
+		log.Log.Reason(err).Error("Failed to gather remote exec info for subresource request.")
+		response.WriteError(code, err)
+		return
+	}
+
+	if requestType == VNC {
+		// If there are no graphics devices present, we can't proceed
+		if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice != nil && *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == false {
+			err := fmt.Errorf("No graphics devices are present.")
+			log.Log.Reason(err).Error("Can't establish VNC connection.")
+			response.WriteError(http.StatusBadRequest, err)
+			return
+		}
+	}
+
+	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/virt-%s", vmi.GetUID(), requestType.socketName)}
 
 	podName, httpStatusCode, err := app.remoteExecInfo(vmi)
 	if err != nil {
@@ -83,7 +112,7 @@ func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response 
 	httpResponseChan := make(chan int)
 	copyErr := make(chan error)
 	go func() {
-		httpCode, err := remoteExecHelper(podName, vmi.Namespace, cmd, inReader, outWriter)
+		httpCode, err := remoteExecHelper(podName, vmi.Namespace, cmd, inReader, outWriter, requestType)
 		log.Log.Errorf("%v", err)
 		httpResponseChan <- httpCode
 	}()
@@ -113,43 +142,11 @@ func (app *SubresourceAPIApp) requestHandler(request *restful.Request, response 
 }
 
 func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, response *restful.Response) {
-
-	vmiName := request.PathParameter("name")
-	namespace := request.PathParameter("namespace")
-
-	vmi, code, err := app.fetchVirtualMachineInstance(vmiName, namespace)
-	if err != nil {
-		log.Log.Reason(err).Error("Failed to gather remote exec info for subresource request.")
-		response.WriteError(code, err)
-		return
-	}
-
-	// If there are no graphics devices present, we can't proceed
-	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice != nil && *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == false {
-		err := fmt.Errorf("No graphics devices are present.")
-		log.Log.Reason(err).Error("Can't establish VNC connection.")
-		response.WriteError(http.StatusBadRequest, err)
-		return
-	}
-
-	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/virt-%s", vmi.GetUID(), "vnc")}
-
-	app.requestHandler(request, response, vmi, cmd)
+	app.requestHandler(request, response, VNC)
 }
 
 func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, response *restful.Response) {
-	vmiName := request.PathParameter("name")
-	namespace := request.PathParameter("namespace")
-
-	vmi, code, err := app.fetchVirtualMachineInstance(vmiName, namespace)
-	if err != nil {
-		log.Log.Reason(err).Error("Failed to gather remote exec info for subresource request.")
-		response.WriteError(code, err)
-		return
-	}
-
-	cmd := []string{"/usr/share/kubevirt/virt-launcher/sock-connector", fmt.Sprintf("/var/run/kubevirt-private/%s/virt-%s", vmi.GetUID(), "serial0")}
-	app.requestHandler(request, response, vmi, cmd)
+	app.requestHandler(request, response, CONSOLE)
 }
 
 func (app *SubresourceAPIApp) findPod(namespace string, uid string) (string, error) {
@@ -198,7 +195,7 @@ func (app *SubresourceAPIApp) remoteExecInfo(vmi *v1.VirtualMachineInstance) (st
 	return podName, http.StatusOK, nil
 }
 
-func remoteExecHelper(podName string, namespace string, cmd []string, in io.Reader, out io.Writer) (int, error) {
+func remoteExecHelper(podName string, namespace string, cmd []string, in io.Reader, out io.Writer, requestType requestType) (int, error) {
 
 	config, err := kubecli.GetConfig()
 	if err != nil {
@@ -222,13 +219,15 @@ func remoteExecHelper(podName string, namespace string, cmd []string, in io.Read
 		SubResource("exec").
 		Param("container", containerName)
 
+	tty := requestType == CONSOLE
+
 	req = req.VersionedParams(&k8sv1.PodExecOptions{
 		Container: containerName,
 		Command:   cmd,
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,
-		TTY:       false,
+		TTY:       tty,
 	}, scheme.ParameterCodec)
 
 	// execute request

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -228,7 +228,7 @@ func remoteExecHelper(podName string, namespace string, cmd []string, in io.Read
 		Stdin:     true,
 		Stdout:    true,
 		Stderr:    true,
-		TTY:       true,
+		TTY:       false,
 	}, scheme.ParameterCodec)
 
 	// execute request

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"flag"
 	"io"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -99,7 +98,7 @@ var _ = Describe("VNC", func() {
 						log.Log.Info("zero bytes read from vnc socket.")
 						return
 					}
-					readStop <- strings.TrimSpace(string(buf[0:n]))
+					readStop <- string(buf[0:n])
 				}()
 
 				response := ""
@@ -116,7 +115,7 @@ var _ = Describe("VNC", func() {
 				// This verifies that the test is able to establish a connection with VNC and
 				// communicate.
 				By("Checking the response from VNC server")
-				Expect(response).To(Equal("RFB 003.008"))
+				Expect(response).To(Equal("RFB 003.008\n"))
 				Expect(err).To(BeNil())
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

virtctl vnc didn't work with CRI-O, because the remote exec command in
virt-api converted LFs into CR + LF, which broke the VNC network protocol.
The root cause for this is that this seems to be a default behaviour
of tty, see https://github.com/moby/moby/issues/8513#issuecomment-216191236.
The solution is to not use tty, we don't need it.
(Still unclear why this only happened with CRI-O)

**Release note**:
```release-note
Fixed virtctl vnc for Openshift CRI-O
```
