### PR TITLE
Rate limit vmi sync errors

### DIFF
--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -230,7 +230,7 @@ func (c *VMIReplicaSet) execute(key string) error {
 		logger.Reason(err).Error("Updating the replicaset status failed.")
 	}
 
-	return err
+	return scaleErr
 }
 
 // orphan removes the owner reference of all VMIs which are owned by the controller instance.

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -254,7 +254,17 @@ func (c *VMIController) execute(key string) error {
 	if needsSync {
 		syncErr = c.sync(vmi, pods, dataVolumes)
 	}
-	return c.updateStatus(vmi, pods, dataVolumes, syncErr)
+	err = c.updateStatus(vmi, pods, dataVolumes, syncErr)
+	if err != nil {
+		return err
+	}
+
+	if syncErr != nil {
+		return syncErr
+	}
+
+	return nil
+
 }
 
 func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pods []*k8sv1.Pod, dataVolumes []*cdiv1.DataVolume, syncErr syncError) error {


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The vmi controller doesn't appear to be rate limiting vmi's when sync errors occur. This patch ensures the vmi controller rate limits errors correctly. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
