### PR TITLE
Backport of #1516 to release-0.8

### DIFF
--- a/cmd/virt-launcher/sock-connector
+++ b/cmd/virt-launcher/sock-connector
@@ -29,5 +29,4 @@ if ! [ -S "$SOCKET" ]; then
 	exit 1
 fi
 
-stty -echo
-socat unix-connect:/$SOCKET stdio,cfmakeraw
+socat unix-connect:/$SOCKET stdio

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"flag"
 	"io"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -99,7 +98,7 @@ var _ = Describe("VNC", func() {
 						log.Log.Info("zero bytes read from vnc socket.")
 						return
 					}
-					readStop <- strings.TrimSpace(string(buf[0:n]))
+					readStop <- string(buf[0:n])
 				}()
 
 				response := ""
@@ -116,7 +115,7 @@ var _ = Describe("VNC", func() {
 				// This verifies that the test is able to establish a connection with VNC and
 				// communicate.
 				By("Checking the response from VNC server")
-				Expect(response).To(Equal("RFB 003.008"))
+				Expect(response).To(Equal("RFB 003.008\n"))
 				Expect(err).To(BeNil())
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of https://github.com/kubevirt/kubevirt/pull/1516 to branch `release-0.8`

**Release note**:
```release-note
Fixed virtctl vnc for Openshift CRI-O
```
