### PR TITLE
Fix unsafe reference to CPU cores

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -334,7 +334,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		if resources.Limits == nil {
 			resources.Limits = make(k8sv1.ResourceList)
 		}
-		cores := vmi.Spec.Domain.CPU.Cores
+		cores := uint32(0)
+		if vmi.Spec.Domain.CPU != nil {
+			cores = vmi.Spec.Domain.CPU.Cores
+		}
 		if cores != 0 {
 			resources.Limits[k8sv1.ResourceCPU] = *resource.NewQuantity(int64(cores), resource.BinarySI)
 		} else {


### PR DESCRIPTION
Signed-off-by: Stu Gott <sgott@redhat.com>

Fixes a reference to CPU.Cores that assumed CPU was non-nil.

```release-note
NONE
```
