### PR TITLE
Handle the (unlikely) event of spoofed MAC address being same

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -37,6 +37,8 @@ import (
 	lmf "github.com/subgraph/libmacouflage"
 )
 
+const randomMacGenerationAttempts = 10
+
 type VIF struct {
 	Name    string
 	IP      netlink.Addr
@@ -103,7 +105,7 @@ func (h *NetworkUtilsHandler) GetMacDetails(iface string) (net.HardwareAddr, err
 	return currentMac, nil
 }
 
-// SetRandomMac changes the MAC address for a agiven interface to a randomly generated, preserving the vendor prefix
+// SetRandomMac changes the MAC address for a given interface to a randomly generated, preserving the vendor prefix
 func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, error) {
 	var mac net.HardwareAddr
 
@@ -112,18 +114,28 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 		return nil, err
 	}
 
-	changed, err := lmf.SpoofMacSameVendor(iface, false)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to spoof MAC for an interface: %s", iface)
-		return nil, err
-	}
+	changed := false
 
-	if changed {
-		mac, err = Handler.GetMacDetails(iface)
+	for i := 0; i < randomMacGenerationAttempts; i++ {
+		changed, err = lmf.SpoofMacSameVendor(iface, false)
 		if err != nil {
+			log.Log.Reason(err).Errorf("failed to spoof MAC for an interface: %s", iface)
 			return nil, err
 		}
-		log.Log.Reason(err).Errorf("updated MAC for interface: %s - %s", iface, mac)
+
+		if changed {
+			mac, err = Handler.GetMacDetails(iface)
+			if err != nil {
+				return nil, err
+			}
+			log.Log.Reason(err).Errorf("updated MAC for interface: %s - %s", iface, mac)
+			break
+		}
+	}
+	if !changed {
+		err := fmt.Errorf("failed to spoof MAC for an interface %s after %d attempts", iface, randomMacGenerationAttempts)
+		log.Log.Reason(err)
+		return nil, err
 	}
 	return currentMac, nil
 }


### PR DESCRIPTION
When we spoof a MAC address, we keep the first 3 octets the same (to keep the
vendor) but randomize the last 3 octets. We never guard against the (unlikely,
1 in 256^3 chance) event of the new address to be the same as permanent. This
may result in pod interface and the bridge carrying the same MAC address as the
VMI, which will break traffic flow.

This patch makes us try 10 times if the MAC address is for some reason returned
the same, and gracefully fail if we are so unlucky that we hit the jackpot of
256^(3*10). Perhaps at this point we should also buy a lottery ticket after
returning the error, but I will leave this for a follow-up patch... ;)

Related to bug 1501

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: closing a tiny unlikely gap in podinterface MAC spoofing logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**: this is more of a theoretical excercise, we haven't seen this in the wild. The patch is just a result of code inspection.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
