### PR TITLE
Fix some launcher flows

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher"
 	notifyclient "kubevirt.io/kubevirt/pkg/virt-launcher/notify-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	virtcli "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
@@ -207,29 +208,22 @@ func initializeDirs(virtShareDir string,
 	}
 }
 
-func waitForDomainUUID(timeout time.Duration, domainManager virtwrap.DomainManager) string {
-	start := time.Now()
+func waitForDomainUUID(timeout time.Duration, events chan watch.Event, stop chan struct{}) *api.Domain {
+	ticker := time.NewTicker(timeout).C
 
-	for time.Since(start) < timeout {
-		time.Sleep(time.Second)
-		list, err := domainManager.ListAllDomains()
-		if err != nil {
-			log.Log.Reason(err).Error("failed to retrieve domains from libvirt")
-			continue
-		}
-
-		if len(list) == 0 {
-			continue
-		}
-
-		domain := list[0]
-		if domain.Spec.UUID != "" {
+	select {
+	case <-ticker:
+		panic(fmt.Errorf("timed out waiting for domain to be defined"))
+	case e := <-events:
+		if e.Object != nil {
+			domain := e.Object.(*api.Domain)
 			log.Log.Infof("Detected domain with UUID %s", domain.Spec.UUID)
-			return domain.Spec.UUID
+			return domain
 		}
+	case <-stop:
+		return nil
 	}
-
-	panic(fmt.Errorf("timed out waiting for domain to be defined"))
+	return nil
 }
 
 func waitForFinalNotify(deleteNotificationSent chan watch.Event,
@@ -246,7 +240,7 @@ func waitForFinalNotify(deleteNotificationSent chan watch.Event,
 	log.Log.Info("Waiting on final notifications to be sent to virt-handler.")
 
 	// We don't want to block here forever. If the delete does not occur, that could mean
-	// something is wrong with libvirt. In this situation, wirt-handler will detect that
+	// something is wrong with libvirt. In this situation, virt-handler will detect that
 	// the domain went away eventually, however the exit status will be unknown.
 	timeout := time.After(30 * time.Second)
 	select {
@@ -350,30 +344,46 @@ func main() {
 			syscall.Kill(pid, syscall.SIGTERM)
 		}
 	}
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	)
 
-	deleteNotificationSent := make(chan watch.Event, 10)
+	signalStopChan := make(chan struct{})
+	go func() {
+		s := <-c
+		log.Log.Infof("Received signal %s", s.String())
+		close(signalStopChan)
+	}()
+
+	events := make(chan watch.Event, 10)
 	// Send domain notifications to virt-handler
-	startDomainEventMonitoring(*virtShareDir, domainConn, deleteNotificationSent)
+	startDomainEventMonitoring(*virtShareDir, domainConn, events)
 
 	// Marking Ready allows the container's readiness check to pass.
 	// This informs virt-controller that virt-launcher is ready to handle
 	// managing virtual machines.
 	markReady(*readinessFile)
 
-	domainUUID := waitForDomainUUID(*qemuTimeout, domainManager)
-	mon := virtlauncher.NewProcessMonitor(domainUUID,
-		gracefulShutdownTriggerFile,
-		*gracePeriodSeconds,
-		shutdownCallback)
+	domain := waitForDomainUUID(*qemuTimeout, events, signalStopChan)
+	if domain != nil {
+		mon := virtlauncher.NewProcessMonitor(domain.Spec.UUID,
+			gracefulShutdownTriggerFile,
+			*gracePeriodSeconds,
+			shutdownCallback)
 
-	// This is a wait loop that monitors the qemu pid. When the pid
-	// exits, the wait loop breaks.
-	mon.RunForever(*qemuTimeout)
+		// This is a wait loop that monitors the qemu pid. When the pid
+		// exits, the wait loop breaks.
+		mon.RunForever(*qemuTimeout, signalStopChan)
+	}
 
 	// Now that the pid has exited, we wait for the final delete notification to be
 	// sent back to virt-handler. This delete notification contains the reason the
 	// domain exited.
-	waitForFinalNotify(deleteNotificationSent, domainManager, vm)
+	waitForFinalNotify(events, domainManager, vm)
 
 	log.Log.Info("Exiting...")
 }

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -51,7 +51,7 @@ type monitor struct {
 }
 
 type ProcessMonitor interface {
-	RunForever(startTimeout time.Duration, stopChan chan struct{})
+	RunForever(startTimeout time.Duration, signalStopChan chan struct{})
 }
 
 func GracefulShutdownTriggerDir(baseDir string) string {
@@ -240,7 +240,7 @@ func (mon *monitor) refresh() {
 	return
 }
 
-func (mon *monitor) monitorLoop(startTimeout time.Duration, stopChan chan struct{}) {
+func (mon *monitor) monitorLoop(startTimeout time.Duration, signalStopChan chan struct{}) {
 	// random value, no real rationale
 	rate := 1 * time.Second
 
@@ -260,8 +260,7 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, stopChan chan struct
 		select {
 		case <-ticker.C:
 			mon.refresh()
-		case <-stopChan:
-
+		case <-signalStopChan:
 			if mon.gracePeriodStartTime != 0 {
 				continue
 			}
@@ -277,9 +276,9 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, stopChan chan struct
 	ticker.Stop()
 }
 
-func (mon *monitor) RunForever(startTimeout time.Duration, stopChan chan struct{}) {
+func (mon *monitor) RunForever(startTimeout time.Duration, signalStopChan chan struct{}) {
 
-	mon.monitorLoop(startTimeout, stopChan)
+	mon.monitorLoop(startTimeout, signalStopChan)
 }
 
 func readProcCmdline(pathname string) ([]string, error) {

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -23,19 +23,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/precond"
-	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	watchdog "kubevirt.io/kubevirt/pkg/watchdog"
+	"kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	"kubevirt.io/kubevirt/pkg/watchdog"
 )
 
 type OnShutdownCallback func(pid int)
@@ -53,7 +51,7 @@ type monitor struct {
 }
 
 type ProcessMonitor interface {
-	RunForever(startTimeout time.Duration)
+	RunForever(startTimeout time.Duration, stopChan chan struct{})
 }
 
 func GracefulShutdownTriggerDir(baseDir string) string {
@@ -242,7 +240,7 @@ func (mon *monitor) refresh() {
 	return
 }
 
-func (mon *monitor) monitorLoop(startTimeout time.Duration, signalChan chan os.Signal) {
+func (mon *monitor) monitorLoop(startTimeout time.Duration, stopChan chan struct{}) {
 	// random value, no real rationale
 	rate := 1 * time.Second
 
@@ -262,8 +260,7 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, signalChan chan os.S
 		select {
 		case <-ticker.C:
 			mon.refresh()
-		case s := <-signalChan:
-			log.Log.Infof("Received signal %d.", s)
+		case <-stopChan:
 
 			if mon.gracePeriodStartTime != 0 {
 				continue
@@ -280,16 +277,9 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, signalChan chan os.S
 	ticker.Stop()
 }
 
-func (mon *monitor) RunForever(startTimeout time.Duration) {
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
+func (mon *monitor) RunForever(startTimeout time.Duration, stopChan chan struct{}) {
 
-	mon.monitorLoop(startTimeout, c)
+	mon.monitorLoop(startTimeout, stopChan)
 }
 
 func readProcCmdline(pathname string) ([]string, error) {

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -75,7 +75,7 @@ func newWatchEventError(err error) watch.Event {
 	return watch.Event{Type: watch.Error, Object: &metav1.Status{Status: metav1.StatusFailure, Message: err.Error()}}
 }
 
-func libvirtEventCallback(d cli.VirDomain, event *libvirt.DomainEventLifecycle, client *DomainEventClient, deleteNotificationSent chan watch.Event) {
+func libvirtEventCallback(d cli.VirDomain, event *libvirt.DomainEventLifecycle, client *DomainEventClient, events chan watch.Event) {
 
 	// check for reconnects, and emit an error to force a resync
 	if event == nil {
@@ -121,10 +121,12 @@ func libvirtEventCallback(d cli.VirDomain, event *libvirt.DomainEventLifecycle, 
 	case api.ReasonNonExistent:
 		event := watch.Event{Type: watch.Deleted, Object: domain}
 		client.SendDomainEvent(event)
-		deleteNotificationSent <- event
+		events <- event
 	default:
 		if event.Event == libvirt.DOMAIN_EVENT_DEFINED && libvirt.DomainEventDefinedDetailType(event.Detail) == libvirt.DOMAIN_EVENT_DEFINED_ADDED {
-			client.SendDomainEvent(watch.Event{Type: watch.Added, Object: domain})
+			event := watch.Event{Type: watch.Added, Object: domain}
+			client.SendDomainEvent(event)
+			events <- event
 		} else {
 			client.SendDomainEvent(watch.Event{Type: watch.Modified, Object: domain})
 		}

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/libvirt/libvirt-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"kubevirt.io/kubevirt/pkg/log"
@@ -75,48 +76,53 @@ func newWatchEventError(err error) watch.Event {
 	return watch.Event{Type: watch.Error, Object: &metav1.Status{Status: metav1.StatusFailure, Message: err.Error()}}
 }
 
-func libvirtEventCallback(d cli.VirDomain, event *libvirt.DomainEventLifecycle, client *DomainEventClient, events chan watch.Event) {
+func libvirtEventCallback(c cli.Connection, domain *api.Domain, event *libvirt.DomainEventLifecycle, client *DomainEventClient, events chan watch.Event) {
 
 	// check for reconnects, and emit an error to force a resync
 	if event == nil {
 		client.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect")))
 		return
 	}
-
-	domain, err := util.NewDomain(d)
-	if err != nil {
-		log.Log.Reason(err).Error("Could not create the Domain.")
-		client.SendDomainEvent(newWatchEventError(err))
-		return
-	}
-
-	// No matter which event, try to fetch the domain xml
-	// and the state. If we get a IsNotFound error, that
-	// means that the VirtualMachineInstance was removed.
-	spec, err := util.GetDomainSpec(d)
+	d, err := c.LookupDomainByName(util.DomainFromNamespaceName(domain.ObjectMeta.Namespace, domain.ObjectMeta.Name))
 	if err != nil {
 		if !domainerrors.IsNotFound(err) {
-			log.Log.Reason(err).Error("Could not fetch the Domain specification.")
-			client.SendDomainEvent(newWatchEventError(err))
-			return
-		}
-	} else {
-		domain.Spec = *spec
-		domain.ObjectMeta.UID = spec.Metadata.KubeVirt.UID
-	}
-	status, reason, err := d.GetState()
-	if err != nil {
-		if !domainerrors.IsNotFound(err) {
-			log.Log.Reason(err).Error("Could not fetch the Domain state.")
+			log.Log.Reason(err).Error("Could not fetch the Domain.")
 			client.SendDomainEvent(newWatchEventError(err))
 			return
 		}
 		domain.SetState(api.NoState, api.ReasonNonExistent)
 	} else {
-		domain.SetState(util.ConvState(status), util.ConvReason(status, reason))
+		defer d.Free()
+
+		// No matter which event, try to fetch the domain xml
+		// and the state. If we get a IsNotFound error, that
+		// means that the VirtualMachineInstance was removed.
+		status, reason, err := d.GetState()
+		if err != nil {
+			if !domainerrors.IsNotFound(err) {
+				log.Log.Reason(err).Error("Could not fetch the Domain state.")
+				client.SendDomainEvent(newWatchEventError(err))
+				return
+			}
+			domain.SetState(api.NoState, api.ReasonNonExistent)
+		} else {
+			domain.SetState(util.ConvState(status), util.ConvReason(status, reason))
+		}
+		spec, err := util.GetDomainSpec(status, d)
+		if err != nil {
+			if !domainerrors.IsNotFound(err) {
+				log.Log.Reason(err).Error("Could not fetch the Domain specification.")
+				client.SendDomainEvent(newWatchEventError(err))
+				return
+			}
+		} else {
+			domain.Spec = *spec
+			domain.ObjectMeta.UID = spec.Metadata.KubeVirt.UID
+		}
+
+		log.Log.Infof("kubevirt domain status: %v (%v):%v (%v)", domain.Status.Status, status, domain.Status.Reason, reason)
 	}
 
-	log.Log.Infof("domain status: %v:%v", status, reason)
 	switch domain.Status.Reason {
 	case api.ReasonNonExistent:
 		event := watch.Event{Type: watch.Deleted, Object: domain}
@@ -133,18 +139,40 @@ func libvirtEventCallback(d cli.VirDomain, event *libvirt.DomainEventLifecycle, 
 	}
 }
 
-func StartNotifier(virtShareDir string, domainConn cli.Connection, deleteNotificationSent chan watch.Event) error {
+func StartNotifier(virtShareDir string, domainConn cli.Connection, deleteNotificationSent chan watch.Event, vmiUID types.UID) error {
+	type LibvirtEvent struct {
+		Domain string
+		Event  *libvirt.DomainEventLifecycle
+	}
+
+	eventChan := make(chan LibvirtEvent, 10)
+
+	// Run the event process logic in a separate go-routine to not block libvirt
+	go func() {
+		for event := range eventChan {
+			// TODO don't make a client every single time
+			client, err := NewDomainEventClient(virtShareDir)
+			if err != nil {
+				log.Log.Reason(err).Error("Unable to create domain event notify client")
+				continue
+			}
+
+			libvirtEventCallback(domainConn, util.NewDomainFromName(event.Domain, vmiUID), event.Event, client, deleteNotificationSent)
+			log.Log.Info("processed event")
+		}
+	}()
+
 	entrypointCallback := func(c *libvirt.Connect, d *libvirt.Domain, event *libvirt.DomainEventLifecycle) {
 		log.Log.Infof("Libvirt event %d with reason %d received", event.Event, event.Detail)
-		// TODO don't make a client every single time
-		client, err := NewDomainEventClient(virtShareDir)
+		name, err := d.GetName()
 		if err != nil {
-			log.Log.Reason(err).Error("Unable to create domain event notify client")
-			return
+			log.Log.Reason(err).Info("Could not determine name of libvirt domain in event callback.")
 		}
-
-		libvirtEventCallback(d, event, client, deleteNotificationSent)
-		log.Log.Info("processed event")
+		select {
+		case eventChan <- LibvirtEvent{Event: event, Domain: name}:
+		default:
+			log.Log.Infof("Libvirt event channel is full, dropping event.")
+		}
 	}
 	err := domainConn.DomainEventLifecycleRegister(entrypointCallback)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -165,11 +165,13 @@ var _ = Describe("Manager", func() {
 	table.DescribeTable("on successful list all domains",
 		func(state libvirt.DomainState, kubevirtState api.LifeCycle, libvirtReason int, kubevirtReason api.StateChangeReason) {
 
-			mockDomain.EXPECT().GetState().Return(state, libvirtReason, nil)
+			mockDomain.EXPECT().GetState().Return(state, libvirtReason, nil).AnyTimes()
 			mockDomain.EXPECT().GetName().Return("test", nil)
 			x, err := xml.Marshal(api.NewMinimalDomainSpec("test"))
 			Expect(err).To(BeNil())
-			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(x), nil)
+			if !cli.IsDown(state) {
+				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(x), nil)
+			}
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_INACTIVE)).Return(string(x), nil)
 			mockConn.EXPECT().ListAllDomains(gomock.Eq(libvirt.CONNECT_LIST_DOMAINS_ACTIVE|libvirt.CONNECT_LIST_DOMAINS_INACTIVE)).Return([]cli.VirDomain{mockDomain}, nil)
 

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -13,6 +13,8 @@ import (
 	"github.com/libvirt/libvirt-go"
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -102,15 +104,22 @@ func SetDomainSpec(virConn cli.Connection, vmi *v1.VirtualMachineInstance, wante
 	return dom, nil
 }
 
-func GetDomainSpec(dom cli.VirDomain) (*api.DomainSpec, error) {
-	spec, err := GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_MIGRATABLE)
+func GetDomainSpec(status libvirt.DomainState, dom cli.VirDomain) (*api.DomainSpec, error) {
+
+	var spec *api.DomainSpec
+	inactiveSpec, err := GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_INACTIVE)
 	if err != nil {
 		return nil, err
 	}
 
-	inactiveSpec, err := GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_INACTIVE)
-	if err != nil {
-		return nil, err
+	spec = inactiveSpec
+	// libvirt (the whole server) sometimes block indefinitely if a guest-shutdown was performed
+	// and we immediately ask it after the successful shutdown for a migratable xml.
+	if !cli.IsDown(status) {
+		spec, err = GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_MIGRATABLE)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if !reflect.DeepEqual(spec.Metadata, inactiveSpec.Metadata) {
@@ -119,7 +128,6 @@ func GetDomainSpec(dom cli.VirDomain) (*api.DomainSpec, error) {
 		metadata := &inactiveSpec.Metadata
 		metadata.DeepCopyInto(&spec.Metadata)
 	}
-
 	return spec, nil
 }
 
@@ -225,8 +233,11 @@ func SplitVMINamespaceKey(domainName string) (namespace, name string) {
 // VMINamespaceKeyFunc constructs the domain name with a namespace prefix i.g.
 // namespace_name.
 func VMINamespaceKeyFunc(vmi *v1.VirtualMachineInstance) string {
-	domName := fmt.Sprintf("%s_%s", vmi.GetObjectMeta().GetNamespace(), vmi.GetObjectMeta().GetName())
-	return domName
+	return DomainFromNamespaceName(vmi.Namespace, vmi.Name)
+}
+
+func DomainFromNamespaceName(namespace, name string) string {
+	return fmt.Sprintf("%s_%s", namespace, name)
 }
 
 func NewDomain(dom cli.VirDomain) (*api.Domain, error) {
@@ -240,6 +251,15 @@ func NewDomain(dom cli.VirDomain) (*api.Domain, error) {
 	domain := api.NewDomainReferenceFromName(namespace, name)
 	domain.GetObjectMeta().SetUID(domain.Spec.Metadata.KubeVirt.UID)
 	return domain, nil
+}
+
+func NewDomainFromName(name string, vmiUID types.UID) *api.Domain {
+	namespace, name := SplitVMINamespaceKey(name)
+
+	domain := api.NewDomainReferenceFromName(namespace, name)
+	domain.Spec.Metadata.KubeVirt.UID = vmiUID
+	domain.GetObjectMeta().SetUID(domain.Spec.Metadata.KubeVirt.UID)
+	return domain
 }
 
 func SetupLibvirt() error {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1034,7 +1034,8 @@ var _ = Describe("VMIlifecycle", func() {
 				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
 				By("Deleting the VirtualMachineInstance")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed())
-				tests.NewObjectEventWatcher(obj).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(tests.NormalEvent, v1.Deleted)
+				event := tests.NewObjectEventWatcher(obj).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(tests.NormalEvent, v1.Deleted)
+				Expect(event).ToNot(BeNil())
 
 				// Check if the graceful shutdown was logged
 				By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix some possible sync errors. All of them are non-fatal for kubevirt itself but lead to a lot of unpredictabilities for our tests which causes a lot of additional random test errors. Also if the system is healthy it should act as predictable as possible, even if it is eventually consistent.

Fixes:    
* Fetching migratable XML from libvirt blocks sometimes if
  domain performed a guest shutdown
* the libvirt client could have block if the client is used in the libvirt
  event callback.
* If the VMI does a guest shutdown, don't accidently restart the VMI.
* Don't hot-loop on graceful shutdown (passing -1 to queue.AddAfter is equivalent to an immediate requeue)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Extracts some fixes from #1404 

**Release note**:

```release-note
NONE
```
