### PR TITLE
Tidy up virtctl command usage and help

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -60,9 +60,9 @@ type Console struct {
 }
 
 func usage() string {
-	usage := `# Connect to the console on VirtualMachineInstance 'myvmi':
+	usage := `  # Connect to the console on VirtualMachineInstance 'myvmi':
   virtctl console myvmi
-# Configure one minute timeout (default 5 minutes)
+  # Configure one minute timeout (default 5 minutes)
   virtctl console --timeout=1 myvmi`
 
 	return usage

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -31,8 +31,8 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func usage() string {
-	usage := "# Print the client and server versions for the current context \n"
-	usage += "virtctl version"
+	usage := "  # Print the client and server versions for the current context \n"
+	usage += "  virtctl version"
 	return usage
 }
 

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -21,6 +21,7 @@ package vm
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,8 +40,8 @@ const (
 
 func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "start (vm)",
-		Short:   "Start a virtual machine.",
+		Use:     "start vm",
+		Short:   "Start a VirtualMachine.",
 		Example: usage(COMMAND_START),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -53,8 +54,8 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
-	return &cobra.Command{
-		Use:     "stop (vm)",
+	cmd := &cobra.Command{
+		Use:     "stop vm",
 		Short:   "Stop a VirtualMachine.",
 		Example: usage(COMMAND_STOP),
 		Args:    cobra.ExactArgs(1),
@@ -63,6 +64,8 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 			return c.Run(cmd, args)
 		},
 	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
 }
 
 type Command struct {
@@ -75,8 +78,8 @@ func NewCommand(command string) *Command {
 }
 
 func usage(cmd string) string {
-	usage := "#Start a virtual machine called 'myvmi':\n"
-	usage += fmt.Sprintf("virtctl %s myvmi", cmd)
+	usage := fmt.Sprintf("  # %s a VirtualMachine called 'myvm':\n", strings.Title(cmd))
+	usage += fmt.Sprintf("  virtctl %s myvm", cmd)
 	return usage
 }
 
@@ -122,7 +125,7 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 		if running {
 			stateMsg = "running"
 		}
-		return fmt.Errorf("Error: VirtualMachineInstance '%s' is already %s", vmiName, stateMsg)
+		return fmt.Errorf("Error: VirtualMachine '%s' is already %s", vmiName, stateMsg)
 	}
 
 	cmd.Printf("VM %s was scheduled to %s\n", vmiName, o.command)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -42,7 +42,7 @@ const FLAG = "vnc"
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "vnc (vmi)",
+		Use:     "vnc vmi",
 		Short:   "Open a vnc connection to a virtual machine instance.",
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),
@@ -190,7 +190,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 }
 
 func usage() string {
-	usage := "# Connect to testvmi via remote-viewer:\n"
-	usage += "./virtctl vnc testvmi"
+	usage := "  # Connect to testvmi via remote-viewer:\n"
+	usage += "  virtctl vnc testvmi"
 	return usage
 }


### PR DESCRIPTION
Signed-off-by: Guohua Ouyang <gouyang@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tidy up virtctl command usage and help.
```
