### PR TITLE
Set mac learning off on pod ifaces

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -55,6 +55,7 @@ type NetworkHandler interface {
 	LinkSetDown(link netlink.Link) error
 	LinkSetUp(link netlink.Link) error
 	LinkAdd(link netlink.Link) error
+	LinkSetLearningOff(link netlink.Link) error
 	ParseAddr(s string) (*netlink.Addr, error)
 	SetRandomMac(iface string) (net.HardwareAddr, error)
 	GetMacDetails(iface string) (net.HardwareAddr, error)
@@ -85,6 +86,9 @@ func (h *NetworkUtilsHandler) LinkSetUp(link netlink.Link) error {
 }
 func (h *NetworkUtilsHandler) LinkAdd(link netlink.Link) error {
 	return netlink.LinkAdd(link)
+}
+func (h *NetworkUtilsHandler) LinkSetLearningOff(link netlink.Link) error {
+	return netlink.LinkSetLearning(link, false)
 }
 func (h *NetworkUtilsHandler) ParseAddr(s string) (*netlink.Addr, error) {
 	return netlink.ParseAddr(s)

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -114,6 +114,16 @@ func (_mr *_MockNetworkHandlerRecorder) LinkAdd(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkAdd", arg0)
 }
 
+func (_m *MockNetworkHandler) LinkSetLearningOff(link netlink.Link) error {
+	ret := _m.ctrl.Call(_m, "LinkSetLearningOff", link)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) LinkSetLearningOff(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetLearningOff", arg0)
+}
+
 func (_m *MockNetworkHandler) ParseAddr(s string) (*netlink.Addr, error) {
 	ret := _m.ctrl.Call(_m, "ParseAddr", s)
 	ret0, _ := ret[0].(*netlink.Addr)

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -222,6 +222,12 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces() error {
 		return err
 	}
 
+	err = Handler.LinkSetLearningOff(b.podNicLink)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to disable mac learning for interface: %s", b.podInterfaceName)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkSetDown(dummy).Return(nil)
 		mockNetwork.EXPECT().SetRandomMac(podInterface).Return(updateFakeMac, nil)
 		mockNetwork.EXPECT().LinkSetUp(dummy).Return(nil)
+		mockNetwork.EXPECT().LinkSetLearningOff(dummy).Return(nil)
 		mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
 		mockNetwork.EXPECT().LinkByName(api.DefaultBridgeName).Return(bridgeTest, nil)
 		mockNetwork.EXPECT().LinkSetUp(bridgeTest).Return(nil)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -119,15 +119,10 @@ var _ = Describe("Networking", func() {
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string, prompt string) {
-		err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
-			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: prompt},
-			&expect.BSnd{S: "cat /sys/class/net/eth0/brport/learning\n"},
-			&expect.BExp{R: expectedValue},
-		}, 15)
-		Expect(err).ToNot(HaveOccurred())
-	}
+	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
+        output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0/brport/learning"})
+        Expect(output).To(Equal(expectedValue))
+    }
 
 	Describe("Multiple virtual machines connectivity", func() {
 		tests.BeforeAll(func() {
@@ -575,7 +570,7 @@ var _ = Describe("Networking", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitUntilVMIReady(learningDisabledVMI, tests.LoggedInAlpineExpecter)
-			checkLearningState(learningDisabledVMI, "0", "localhost:~#")
+			checkLearningState(learningDisabledVMI, "0")
 		})
 	})
 })

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Networking", func() {
 
 	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
 		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0/brport/learning"})
-		Expect(output).To(Equal(expectedValue))
+		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
 	}
 
 	Describe("Multiple virtual machines connectivity", func() {
@@ -565,7 +565,7 @@ var _ = Describe("Networking", func() {
 
 		It("should disable learning on pod iface", func() {
 			By("checking learning flag")
-			learningDisabledVMI := tests.NewRandomVMI()
+			learningDisabledVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskAlpine), "#!/bin/bash\necho 'hello'\n")
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(learningDisabledVMI)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -120,9 +120,9 @@ var _ = Describe("Networking", func() {
 	}
 
 	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
-        output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0/brport/learning"})
-        Expect(output).To(Equal(expectedValue))
-    }
+		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0/brport/learning"})
+		Expect(output).To(Equal(expectedValue))
+	}
 
 	Describe("Multiple virtual machines connectivity", func() {
 		tests.BeforeAll(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This resolves the intermittent arp learning issues.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1501 

**Special notes for your reviewer**:
The behavior observed in this issue has been puzzling and through several test iterations on our kubernetes cluster mac learning set to off has resolved all vmi cases seen to error previously.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
