### PR TITLE
remove registry reference from local provider manifests

### DIFF
--- a/cluster/local/provider.sh
+++ b/cluster/local/provider.sh
@@ -40,7 +40,9 @@ EOF
 }
 
 function build() {
-    make manifests docker
+    ${KUBEVIRT_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG}
+    KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-manifests.sh"
+    make docker
 }
 
 function _kubectl() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removed the registry reference from a local provider manifests

```release-note
NONE
```
