### PR TITLE
Improve reaction speed if virt-handler is unresponsive

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4928,6 +4928,10 @@
      "phase": {
       "description": "Phase is the status of the VirtualMachineInstance in kubernetes world. It is not the VirtualMachineInstance status, but partially correlates to it.",
       "type": "string"
+     },
+     "reason": {
+      "description": "A brief CamelCase message indicating details about why the VMI is in this state. e.g. 'NodeUnresponsive'\n+optional",
+      "type": "string"
      }
     }
    },

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -343,4 +343,6 @@ spec:
               type: string
             phase:
               type: string
+            reason:
+              type: string
   version: v1alpha2

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -2243,6 +2243,13 @@ func schema_kubevirt_pkg_api_v1_VirtualMachineInstanceStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A brief CamelCase message indicating details about why the VMI is in this state. e.g. 'NodeUnresponsive'",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions are specific points in VirtualMachineInstance's pod runtime.",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -162,6 +162,9 @@ type VirtualMachineInstanceSpec struct {
 type VirtualMachineInstanceStatus struct {
 	// NodeName is the name where the VirtualMachineInstance is currently running.
 	NodeName string `json:"nodeName,omitempty"`
+	// A brief CamelCase message indicating details about why the VMI is in this state. e.g. 'NodeUnresponsive'
+	// +optional
+	Reason string `json:"reason,omitempty"`
 	// Conditions are specific points in VirtualMachineInstance's pod runtime.
 	Conditions []VirtualMachineInstanceCondition `json:"conditions,omitempty"`
 	// Phase is the status of the VirtualMachineInstance in kubernetes world. It is not the VirtualMachineInstance status, but partially correlates to it.

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -35,6 +35,7 @@ func (VirtualMachineInstanceStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":           "VirtualMachineInstanceStatus represents information about the status of a VirtualMachineInstance. Status may trail the actual\nstate of a system.",
 		"nodeName":   "NodeName is the name where the VirtualMachineInstance is currently running.",
+		"reason":     "A brief CamelCase message indicating details about why the VMI is in this state. e.g. 'NodeUnresponsive'\n+optional",
 		"conditions": "Conditions are specific points in VirtualMachineInstance's pod runtime.",
 		"phase":      "Phase is the status of the VirtualMachineInstance in kubernetes world. It is not the VirtualMachineInstance status, but partially correlates to it.",
 		"interfaces": "Interfaces represent the details of available network interfaces.",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -258,7 +258,8 @@ func (vca *VirtControllerApp) initCommon() {
 	}
 	vca.templateService = services.NewTemplateService(vca.launcherImage, vca.virtShareDir, vca.imagePullSecret, vca.configMapCache)
 	vca.vmiController = NewVMIController(vca.templateService, vca.vmiInformer, vca.podInformer, vca.vmiRecorder, vca.clientSet, vca.configMapInformer, vca.dataVolumeInformer)
-	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, nil)
+	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "node-controller")
+	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, recorder)
 }
 
 func (vca *VirtControllerApp) initReplicaSet() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/google/goexpect"
 
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -452,7 +454,10 @@ var _ = Describe("VMIlifecycle", func() {
 					failedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get vmi successfully")
 					return failedVMI.Status.Phase
-				}, 180*time.Second, 1*time.Second).Should(Equal(v1.Failed), "VMI should be failed")
+				}, 180*time.Second, 1*time.Second).Should(Equal(v1.Failed))
+				failedVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(failedVMI.Status.Reason).To(Equal(watch.NodeUnresponsiveReason))
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

* If virt-handler is unresponsive and pods are already in a final
  state, let the node controller immediately move the VMIs to failed
  state.
* Send events when node gets marked as unhealthy and send events for each
  VMI which gets moved to failed.
* Add an API field `status.reason`, similar to the one on pods and set it to `NodeUnresponsive` to indicate why the VMI was moved to Failed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1077 

**Special notes for your reviewer**:

**Release note**:

```release-note
Add the field status.reason which indicates the reason why the cluster may unexpectedly have stopped VMIs and improve the reaction speed of the node controller, in case virt-handler becomes unresponsive.
```
