### PR TITLE
Consolidate virtctl commands

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -40,7 +40,7 @@ var timeout int
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "console (vmi)",
+		Use:     "console (VMI)",
 		Short:   "Connect to a console of a virtual machine instance.",
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -39,7 +39,7 @@ var namespace string
 // generate a new "expose" command
 func NewExposeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "expose TYPE NAME",
+		Use:   "expose (TYPE NAME)",
 		Short: "Expose a virtual machine instance, virtual machine, or virtual machine instance replica set as a new service.",
 		Long: `Looks up a virtual machine instance, virtual machine or virtual machine instance replica set by name and use its selector as the selector for a new service on the specified port.
 A virtual machine instance replica set will be exposed as a service only if its selector is convertible to a selector that service supports, i.e. when the selector contains only the matchLabels component.
@@ -58,12 +58,12 @@ virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplica
 	}
 
 	// flags for the "expose" command
-	cmd.Flags().StringVar(&serviceName, "name", "", "Name of the service created for the exposure of the VM")
+	cmd.Flags().StringVar(&serviceName, "name", "", "Name of the service created for the exposure of the VM.")
 	cmd.MarkFlagRequired("name")
 	cmd.Flags().StringVar(&clusterIP, "cluster-ip", "", "ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service.")
 	cmd.Flags().StringVar(&externalIP, "external-ip", "", "Additional external IP address (not managed by the cluster) to accept for the service. If this IP is routed to a node, the service can be accessed by this IP in addition to its generated service IP. Optional.")
 	cmd.Flags().StringVar(&loadBalancerIP, "load-balancer-ip", "", "IP to assign to the Load Balancer. If empty, an ephemeral IP will be created and used.")
-	cmd.Flags().Int32Var(&port, "port", 0, "The port that the service should serve on")
+	cmd.Flags().Int32Var(&port, "port", 0, "The port that the service should serve on.")
 	cmd.MarkFlagRequired("port")
 	cmd.Flags().StringVar(&strProtocol, "protocol", "TCP", "The network protocol for the service to be created.")
 	cmd.Flags().StringVar(&strTargetPort, "target-port", "", "Name or number for the port on the VM that the service should direct traffic to. Optional.")

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -17,7 +17,7 @@ var clientOnly bool
 func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
-		Short:   "Print the client and server version information",
+		Short:   "Print the client and server version information.",
 		Example: usage(),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -31,7 +31,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 }
 
 func usage() string {
-	usage := "  # Print the client and server versions for the current context \n"
+	usage := "  # Print the client and server versions for the current context:\n"
 	usage += "  virtctl version"
 	return usage
 }
@@ -54,7 +54,7 @@ func (v *Version) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		fmt.Printf("Server Version: %s\n", fmt.Sprintf("%#v", serverInfo))
+		fmt.Printf("Server Version: %s\n", fmt.Sprintf("%#v", *serverInfo))
 	}
 
 	return nil

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -40,8 +40,8 @@ const (
 
 func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "start vm",
-		Short:   "Start a VirtualMachine.",
+		Use:     "start (VM)",
+		Short:   "Start a virtual machine.",
 		Example: usage(COMMAND_START),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,8 +55,8 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "stop vm",
-		Short:   "Stop a VirtualMachine.",
+		Use:     "stop (VM)",
+		Short:   "Stop a virtual machine.",
 		Example: usage(COMMAND_STOP),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -78,7 +78,7 @@ func NewCommand(command string) *Command {
 }
 
 func usage(cmd string) string {
-	usage := fmt.Sprintf("  # %s a VirtualMachine called 'myvm':\n", strings.Title(cmd))
+	usage := fmt.Sprintf("  # %s a virtual machine called 'myvm':\n", strings.Title(cmd))
 	usage += fmt.Sprintf("  virtctl %s myvm", cmd)
 	return usage
 }
@@ -125,7 +125,7 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 		if running {
 			stateMsg = "running"
 		}
-		return fmt.Errorf("Error: VirtualMachine '%s' is already %s", vmiName, stateMsg)
+		return fmt.Errorf("Error: VirtualMachineInstance '%s' is already %s", vmiName, stateMsg)
 	}
 
 	cmd.Printf("VM %s was scheduled to %s\n", vmiName, o.command)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -42,7 +42,7 @@ const FLAG = "vnc"
 
 func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "vnc vmi",
+		Use:     "vnc (VMI)",
 		Short:   "Open a vnc connection to a virtual machine instance.",
 		Example: usage(),
 		Args:    cobra.ExactArgs(1),
@@ -190,7 +190,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 }
 
 func usage() string {
-	usage := "  # Connect to testvmi via remote-viewer:\n"
+	usage := "  # Connect to 'testvmi' via remote-viewer:\n"
 	usage += "  virtctl vnc testvmi"
 	return usage
 }


### PR DESCRIPTION
  * remove '&' from serverInfo
  * add dots in the end of sentences
  * add '()' for each NAME and TYPE
  * use 'virtual machine' instead of 'VirtualMachine'

Signed-off-by: Guohua Ouyang <gouyang@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhanced virtctl command's usage and help
```
