### PR TITLE
fix cleanup of crd objects during make cluster-deploy

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -59,7 +59,6 @@ for i in ${namespaces[@]}; do
     _kubectl -n ${i} delete clusterroles -l 'kubevirt.io'
     _kubectl -n ${i} delete serviceaccounts -l 'kubevirt.io'
     _kubectl -n ${i} delete configmaps -l 'kubevirt.io'
-    _kubectl -n ${i} delete crd -l 'kubevirt.io'
 done
 
 # delete all traces of CDI


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

make cluster-deploy fails with this error.

```
error: the server doesn't have a resource type "crd"
Makefile:75: recipe for target 'cluster-clean' failed
```

There's a bug in kubectl that results in the 'crd' short name not working at times. To get around this we've always used the full name 'customeresourcedefinition' during the deprovision script (cluster/clean.sh). 

The short name showed up recently again and is causing the same problems that we had in the past. We don't even need this line because we clean up CRDs using the full name a few lines above the one I've removed. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
