### PR TITLE
Updated registry disk docs to build off of the proper image.

### DIFF
--- a/docs/container-register-disks.md
+++ b/docs/container-register-disks.md
@@ -62,7 +62,7 @@ device consumable by libvirt.
 Example:
 ```
 cat << END > Dockerfile
-FROM kubevirt.io:disk
+FROM kubevirt/registry-disk-v1alpha
 ADD fedora25.qcow2 /disk
 END
 docker build -t vmdisks/fedora25:latest .


### PR DESCRIPTION
Signed-off-by: Dylan Redding <dzr0001@gmail.com>

**What this PR does / why we need it**:
Updates documentation on building a container registry disk. The example attempts to build off an image that is not available.

**Release note**:

```release-note
Updates documentation on building a container registry disk.
```
