### PR TITLE
Remove "/kubevirt" from manifest_docker_prefix

### DIFF
--- a/cluster/external/provider.sh
+++ b/cluster/external/provider.sh
@@ -8,7 +8,7 @@ function prepare_config() {
     cat >hack/config-provider-external.sh <<EOF
 docker_tag=devel
 docker_prefix=${DOCKER_PREFIX}
-manifest_docker_prefix=${DOCKER_PREFIX}/kubevirt
+manifest_docker_prefix=${DOCKER_PREFIX}
 image_pull_policy=${IMAGE_PULL_POLICY:-Always}
 EOF
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
It appears that the external provider.sh script is adding an additional
string to the manifest_docker_prefix ("/kubevirt").  The result is that
the image specified in the built manifests is of the form
"$DOCKER_PREFIX/kubevirt/virt-api", however images were pushed to
"$DOCKER_PREFIX/virt-api" so the image pull fails when you try to
deploy.

This change just removes the extra string that was added.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1558

**Special notes for your reviewer**:


```release-note
NONE
```
