### PR TITLE
Clarify the README for the external provisioner

### DIFF
--- a/cluster/external/README.md
+++ b/cluster/external/README.md
@@ -24,6 +24,13 @@ make cluster-build
 ## Installing Kubevirt artifacts on the cluster
 
 ```bash
+make cluster-deploy
+```
+
+## Or do the build and deploy in one step
+
+```bash
 make cluster-sync
+```
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Readme describes running cluster-build then cluster-sync, but that's
sort of silly; cluster-sync includes running cluster-build.

Clarify in the document that cluster-sync can do both, or you can use
cluster-deploy.

**Release note**:
```release-note
NONE
```