### PR TITLE
[WIP] Registry Disk Mount Propagation (no copy mode)

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4335,6 +4335,10 @@
      "image"
     ],
     "properties": {
+     "allowMountPropagation": {
+      "description": "AllowMountPropagation toggles whether or not the registry disk container is allowed to bind mount the disk to the compute pod instead of making a full copy.",
+      "type": "boolean"
+     },
      "image": {
       "description": "Image is the name of the image with the embedded disk.",
       "type": "string"

--- a/cluster/examples/vmi-fedora-mount-propagation.yaml
+++ b/cluster/examples/vmi-fedora-mount-propagation.yaml
@@ -1,0 +1,37 @@
+apiVersion: kubevirt.io/v1alpha2
+kind: VirtualMachineInstance
+metadata:
+  creationTimestamp: null
+  labels:
+    special: vmi-fedora-mount-propagation
+  name: vmi-fedora-mount-propagation
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: registrydisk
+        volumeName: registryvolume
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+        volumeName: cloudinitvolume
+    machine:
+      type: ""
+    resources:
+      requests:
+        memory: 1024M
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - name: registryvolume
+    registryDisk:
+      allowMountPropagation: true
+      image: registry:5000/kubevirt/fedora-cloud-registry-disk-demo:devel
+  - cloudInitNoCloud:
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
+    name: cloudinitvolume
+status: {}

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -171,6 +171,7 @@ func startWatchdogTicker(watchdogFile string, watchdogInterval time.Duration, st
 
 func initializeDirs(virtShareDir string,
 	ephemeralDiskDir string,
+	registryDiskDir string,
 	uid string) {
 
 	err := virtlauncher.InitializeSharedDirectories(virtShareDir)
@@ -188,7 +189,7 @@ func initializeDirs(virtShareDir string,
 		panic(err)
 	}
 
-	err = registrydisk.SetLocalDirectory(ephemeralDiskDir + "/registry-disk-data")
+	err = registrydisk.SetLocalDirectory(registryDiskDir)
 	if err != nil {
 		panic(err)
 	}
@@ -265,6 +266,7 @@ func main() {
 	qemuTimeout := flag.Duration("qemu-timeout", defaultStartTimeout, "Amount of time to wait for qemu")
 	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
 	ephemeralDiskDir := flag.String("ephemeral-disk-dir", "/var/run/libvirt/kubevirt-ephemeral-disk", "Base directory for ephemeral disk data")
+	registryDiskDir := flag.String("registry-disk-dir", "/var/run/kubevirt-registry-disk", "Base directory for registry disk host share mount")
 	name := flag.String("name", "", "Name of the VirtualMachineInstance")
 	uid := flag.String("uid", "", "UID of the VirtualMachineInstance")
 	namespace := flag.String("namespace", "", "Namespace of the VirtualMachineInstance")
@@ -302,7 +304,7 @@ func main() {
 	vm := v1.NewVMIReferenceFromNameWithNS(*namespace, *name)
 
 	// Initialize local and shared directories
-	initializeDirs(*virtShareDir, *ephemeralDiskDir, *uid)
+	initializeDirs(*virtShareDir, *ephemeralDiskDir, *registryDiskDir, *uid)
 
 	// Start libvirtd, virtlogd, and establish libvirt connection
 	stopChan := make(chan struct{})

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -305,6 +305,8 @@ spec:
                           persistentVolumeClaim: {}
                           registryDisk:
                             properties:
+                              allowMountPropagation:
+                                type: boolean
                               image:
                                 type: string
                               imagePullSecret:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -295,6 +295,8 @@ spec:
                   persistentVolumeClaim: {}
                   registryDisk:
                     properties:
+                      allowMountPropagation:
+                        type: boolean
                       image:
                         type: string
                       imagePullSecret:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -306,6 +306,8 @@ spec:
                           persistentVolumeClaim: {}
                           registryDisk:
                             properties:
+                              allowMountPropagation:
+                                type: boolean
                               image:
                                 type: string
                               imagePullSecret:

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1405,6 +1405,13 @@ func schema_kubevirt_pkg_api_v1_RegistryDiskSource(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
+					"allowMountPropagation": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AllowMountPropagation toggles whether or not the registry disk container is allowed to bind mount the disk to the compute pod instead of making a full copy.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"image"},
 			},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -396,6 +396,8 @@ type RegistryDiskSource struct {
 	Image string `json:"image"`
 	// ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
+	// AllowMountPropagation toggles whether or not the registry disk container is allowed to bind mount the disk to the compute pod instead of making a full copy.
+	AllowMountPropagation bool `json:"allowMountPropagation,omitempty"`
 }
 
 // Exactly one of its members must be set.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -194,9 +194,10 @@ func (EmptyDiskSource) SwaggerDoc() map[string]string {
 
 func (RegistryDiskSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":                "Represents a docker image with an embedded disk.",
-		"image":           "Image is the name of the image with the embedded disk.",
-		"imagePullSecret": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
+		"":                      "Represents a docker image with an embedded disk.",
+		"image":                 "Image is the name of the image with the embedded disk.",
+		"imagePullSecret":       "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
+		"allowMountPropagation": "AllowMountPropagation toggles whether or not the registry disk container is allowed to bind mount the disk to the compute pod instead of making a full copy.",
 	}
 }
 

--- a/pkg/registry-disk/registry-disk_test.go
+++ b/pkg/registry-disk/registry-disk_test.go
@@ -43,7 +43,7 @@ var _ = Describe("RegistryDisk", func() {
 		appendRegistryDisk(vmi, "r0")
 
 		// create a fake disk file
-		volumeMountDir := generateVMIBaseDir(vmi)
+		volumeMountDir := GetVMIBaseDir(vmi)
 		err = os.MkdirAll(volumeMountDir+"/disk_r0", 0750)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -88,7 +88,7 @@ var _ = Describe("RegistryDisk", func() {
 				vmi := v1.NewMinimalVMI("fake-vmi")
 				appendRegistryDisk(vmi, "r1")
 				appendRegistryDisk(vmi, "r0")
-				containers := GenerateContainers(vmi, "libvirt-runtime", "/var/run/libvirt")
+				containers := GenerateContainers(vmi, "some-vol")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(containers)).To(Equal(2))

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -128,6 +128,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		Name:      "libvirt-runtime",
 		MountPath: "/var/run/libvirt",
 	})
+	volumesMounts = append(volumesMounts, k8sv1.VolumeMount{
+		Name:      "registry-disk-share",
+		MountPath: registrydisk.GetVMIBaseDir(vmi),
+	})
 	for _, volume := range vmi.Spec.Volumes {
 		volumeMount := k8sv1.VolumeMount{
 			Name:      volume.Name,
@@ -424,13 +428,21 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		Resources: resources,
 		Ports:     ports,
 	}
-	containers := registrydisk.GenerateContainers(vmi, "libvirt-runtime", "/var/run/libvirt")
+	containers := registrydisk.GenerateContainers(vmi, "registry-disk-share")
 
 	volumes = append(volumes, k8sv1.Volume{
 		Name: "virt-share-dir",
 		VolumeSource: k8sv1.VolumeSource{
 			HostPath: &k8sv1.HostPathVolumeSource{
 				Path: t.virtShareDir,
+			},
+		},
+	})
+	volumes = append(volumes, k8sv1.Volume{
+		Name: "registry-disk-share",
+		VolumeSource: k8sv1.VolumeSource{
+			HostPath: &k8sv1.HostPathVolumeSource{
+				Path: registrydisk.GetVMIBaseDir(vmi),
 			},
 		},
 	})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -128,9 +128,11 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		Name:      "libvirt-runtime",
 		MountPath: "/var/run/libvirt",
 	})
+	propMode := k8sv1.MountPropagationHostToContainer
 	volumesMounts = append(volumesMounts, k8sv1.VolumeMount{
-		Name:      "registry-disk-share",
-		MountPath: registrydisk.GetVMIBaseDir(vmi),
+		Name:             "registry-disk-share",
+		MountPath:        registrydisk.GetVMIBaseDir(vmi),
+		MountPropagation: &propMode,
 	})
 	for _, volume := range vmi.Spec.Volumes {
 		volumeMount := k8sv1.VolumeMount{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -486,12 +486,12 @@ var _ = Describe("Template", func() {
 				Expect(hugepagesRequest.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
 				Expect(hugepagesLimit.ToDec().ScaledValue(resource.Mega)).To(Equal(int64(64)))
 
-				Expect(len(pod.Spec.Volumes)).To(Equal(3))
+				Expect(len(pod.Spec.Volumes)).To(Equal(4))
 				Expect(pod.Spec.Volumes[0].EmptyDir).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].EmptyDir.Medium).To(Equal(kubev1.StorageMediumHugePages))
 
-				Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(3))
-				Expect(pod.Spec.Containers[0].VolumeMounts[2].MountPath).To(Equal("/dev/hugepages"))
+				Expect(len(pod.Spec.Containers[0].VolumeMounts)).To(Equal(4))
+				Expect(pod.Spec.Containers[0].VolumeMounts[3].MountPath).To(Equal("/dev/hugepages"))
 			},
 				table.Entry("hugepages-2Mi", "2Mi"),
 				table.Entry("hugepages-1Gi", "1Gi"),
@@ -519,7 +519,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
-				Expect(len(pod.Spec.Volumes)).To(Equal(3))
+				Expect(len(pod.Spec.Volumes)).To(Equal(4))
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].PersistentVolumeClaim.ClaimName).To(Equal("nfs-pvc"))
 			})
@@ -784,7 +784,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
-				Expect(len(pod.Spec.Volumes)).To(Equal(3))
+				Expect(len(pod.Spec.Volumes)).To(Equal(4))
 				Expect(pod.Spec.Volumes[0].ConfigMap).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].ConfigMap.LocalObjectReference.Name).To(Equal("test-configmap"))
 			})
@@ -813,7 +813,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.Volumes).ToNot(BeEmpty())
-				Expect(len(pod.Spec.Volumes)).To(Equal(3))
+				Expect(len(pod.Spec.Volumes)).To(Equal(4))
 				Expect(pod.Spec.Volumes[0].Secret).ToNot(BeNil())
 				Expect(pod.Spec.Volumes[0].Secret.SecretName).To(Equal("test-secret"))
 			})

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -66,6 +66,8 @@ const (
 
 	ephemeralDiskDir = "/var/run/libvirt/kubevirt-ephemeral-disk"
 
+	registryDiskDir = "/var/run/kubevirt-registry-disk"
+
 	controllerThreads = 3
 )
 
@@ -103,6 +105,7 @@ type VirtControllerApp struct {
 	imagePullSecret  string
 	virtShareDir     string
 	ephemeralDiskDir string
+	registryDiskDir  string
 	readyChan        chan bool
 }
 
@@ -252,7 +255,7 @@ func (vca *VirtControllerApp) getNewRecorder(namespace string, componentName str
 func (vca *VirtControllerApp) initCommon() {
 	var err error
 
-	registrydisk.SetLocalDirectory(vca.ephemeralDiskDir + "/registry-disk-data")
+	registrydisk.SetLocalDirectory(vca.registryDiskDir)
 	if err != nil {
 		golog.Fatal(err)
 	}
@@ -315,4 +318,8 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", ephemeralDiskDir,
 		"Base directory for ephemeral disk data")
+
+	flag.StringVar(&vca.registryDiskDir, "registry-disk-dir", registryDiskDir,
+		"Base directory for registry disk host share mount")
+
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -50,6 +50,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/precond"
+	"kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/pkg/virt-launcher"
@@ -511,6 +512,8 @@ func (d *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstan
 	if err != nil {
 		return err
 	}
+
+	os.RemoveAll(registrydisk.GetVMIBaseDir(vmi))
 
 	d.closeLauncherClient(vmi)
 	return nil

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -53,18 +53,19 @@ func main() {
 	}
 
 	var vmis = map[string]*v1.VirtualMachineInstance{
-		utils.VmiEphemeral:         utils.GetVMIEphemeral(),
-		utils.VmiFlavorSmall:       utils.GetVMIFlavorSmall(),
-		utils.VmiSata:              utils.GetVMISata(),
-		utils.VmiFedora:            utils.GetVMIEphemeralFedora(),
-		utils.VmiNoCloud:           utils.GetVMINoCloud(),
-		utils.VmiPVC:               utils.GetVMIPvc(),
-		utils.VmiWindows:           utils.GetVMIWindows(),
-		utils.VmiSlirp:             utils.GetVMISlirp(),
-		utils.VmiWithHookSidecar:   utils.GetVMIWithHookSidecar(),
-		utils.VmiMultusPtp:         utils.GetVMIMultusPtp(),
-		utils.VmiMultusMultipleNet: utils.GetVMIMultusMultipleNet(),
-		utils.VmiHostDisk:          utils.GetVMIHostDisk(),
+		utils.VmiEphemeral:              utils.GetVMIEphemeral(),
+		utils.VmiFlavorSmall:            utils.GetVMIFlavorSmall(),
+		utils.VmiSata:                   utils.GetVMISata(),
+		utils.VmiFedora:                 utils.GetVMIEphemeralFedora(),
+		utils.VmiFedoraMountPropagation: utils.GetVMIEphemeralFedoraMountPropagation(),
+		utils.VmiNoCloud:                utils.GetVMINoCloud(),
+		utils.VmiPVC:                    utils.GetVMIPvc(),
+		utils.VmiWindows:                utils.GetVMIWindows(),
+		utils.VmiSlirp:                  utils.GetVMISlirp(),
+		utils.VmiWithHookSidecar:        utils.GetVMIWithHookSidecar(),
+		utils.VmiMultusPtp:              utils.GetVMIMultusPtp(),
+		utils.VmiMultusMultipleNet:      utils.GetVMIMultusMultipleNet(),
+		utils.VmiHostDisk:               utils.GetVMIHostDisk(),
 	}
 
 	var vmireplicasets = map[string]*v1.VirtualMachineInstanceReplicaSet{


### PR DESCRIPTION

**What this PR does / why we need it**:

This is an enhancement to RegistryDisks that allows the registry disk to be used without requiring a copy to be made. With the 'allowMountPropagation" feature, registry disks will bind mount the disk in the container to a shared host mount on the local node. The VMI will then access that file on the host mount share and use it as the disk. 

While we can achieve this feature without requiring privileged mode for the VMI's compute container, the registry disk container does need privileged mode in order to perform the mount propagation. This is the main point that needs discussion here before merger. 

## Future Usage

If we take in this feature, it provides a path that will allow us to be much more efficient with the usage of registry disks.  For example, with mount propagation we can use read only RegistryDisks and create local backing volumes for each VMI. This means that only a single copy of the registry disk will exist per a local node, and only a backing volume will be required per a VMI.

To take this even a step further, we could place the backing volume on a PVC and use the registry disk just for the root disk. This would essentially let us have persistent VM's using registry disks.  The base "golden" image would be delivered as a registry disk, and only the backing volume would need to be on a PVC. 


**Release note**:

```release-note
Registry Disk usage of Mount Propagation for no copy mode. 
```
