### PR TITLE
VMs lifecycle tests: fix assumption for compute nodes

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1988,6 +1988,12 @@ func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.Res
 	return nil
 }
 
+func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
+	nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: "kubevirt.io/schedulable=true"})
+	Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
+	return nodes
+}
+
 // SkipIfVersionBelow will skip tests if it runs on an environment with k8s version below specified
 func SkipIfVersionBelow(message string, expectedVersion string) {
 	virtClient, err := kubecli.GetKubevirtClient()

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -598,9 +598,8 @@ var _ = Describe("VMIlifecycle", func() {
 		Context("with non default namespace", func() {
 			table.DescribeTable("should log libvirt start and stop lifecycle events of the domain", func(namespace string) {
 
-				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should list nodes")
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some node")
+				nodes := tests.GetAllSchedulableNodes(virtClient)
+				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
 
 				By("Creating a VirtualMachineInstance with different namespace")
@@ -866,12 +865,10 @@ var _ = Describe("VMIlifecycle", func() {
 			})
 
 			It("Should provide KVM via plugin framework", func() {
-				listOptions := metav1.ListOptions{}
-				nodeList, err := virtClient.CoreV1().Nodes().List(listOptions)
-				Expect(err).ToNot(HaveOccurred(), "Should list nodes")
+				nodeList := tests.GetAllSchedulableNodes(virtClient)
 
 				if len(nodeList.Items) == 0 {
-					Skip("Unable to inspect nodes in cluster")
+					Skip("There are no compute nodes in cluster")
 				}
 				node := nodeList.Items[0]
 
@@ -1008,9 +1005,8 @@ var _ = Describe("VMIlifecycle", func() {
 		})
 		Context("with grace period greater than 0", func() {
 			It("should run graceful shutdown", func() {
-				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should list nodes")
-				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some node")
+				nodes := tests.GetAllSchedulableNodes(virtClient)
+				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
 
 				virtHandlerPod, err := kubecli.NewVirtHandlerClient(virtClient).ForNode(node).Pod()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Some test requires to work with compute node - these are counting with
fact that all nodes are compute, which is wrong assumption.

Signed-off-by: Lukas Bednar <lbednar@redhat.com>

```release-note
NONE
```