### PR TITLE
Collect cdi logs during functional test failures

### DIFF
--- a/manifests/testing/cdi-v1.1.1.yaml.in
+++ b/manifests/testing/cdi-v1.1.1.yaml.in
@@ -68,6 +68,7 @@ spec:
     metadata:
       labels:
         app: containerized-data-importer
+        cdi.kubevirt.io: ""
     spec:
       serviceAccountName: cdi-sa
       containers:

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2103,7 +2103,7 @@ func KubevirtFailHandler(message string, callerSkip ...int) {
 
 	for _, ns := range []string{metav1.NamespaceSystem, NamespaceTestDefault} {
 		// Get KubeVirt specific pods information
-		pods, err := virtClient.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: "kubevirt.io"})
+		pods, err := virtClient.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: "kubevirt.io,cdi.kubevirt.io"})
 		if err != nil {
 			fmt.Println(err)
 			Fail(message, callerSkip...)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2102,15 +2102,26 @@ func KubevirtFailHandler(message string, callerSkip ...int) {
 	}
 
 	for _, ns := range []string{metav1.NamespaceSystem, NamespaceTestDefault} {
+		pods := []k8sv1.Pod{}
 		// Get KubeVirt specific pods information
-		pods, err := virtClient.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: "kubevirt.io,cdi.kubevirt.io"})
+		kubevirtPods, err := virtClient.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: "kubevirt.io"})
 		if err != nil {
 			fmt.Println(err)
 			Fail(message, callerSkip...)
 			return
 		}
+		pods = append(pods, kubevirtPods.Items...)
 
-		for _, pod := range pods.Items {
+		// Get CDI specific pods information
+		cdiPods, err := virtClient.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: "cdi.kubevirt.io"})
+		if err != nil {
+			fmt.Println(err)
+			Fail(message, callerSkip...)
+			return
+		}
+		pods = append(pods, cdiPods.Items...)
+
+		for _, pod := range pods {
 			fmt.Printf("\nPod name: %s\t Pod phase: %s\n\n", pod.Name, pod.Status.Phase)
 			var tailLines int64 = 15
 			var containerName = ""


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Lets us gain visibility into cdi controller logs when functional tests fail. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
