### PR TITLE
Wait in virt-api for cache sync before reporting it as ready

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -39,6 +39,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/cert/triple"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -952,9 +953,10 @@ func (app *virtAPIApp) Run() {
 
 	stopChan := make(chan struct{}, 1)
 	defer close(stopChan)
-	go webhookInformers.VMIInformer.Run(stopChan)
 	go webhookInformers.VMIPresetInformer.Run(stopChan)
 	go webhookInformers.NamespaceLimitsInformer.Run(stopChan)
+
+	cache.WaitForCacheSync(stopChan, webhookInformers.NamespaceLimitsInformer.HasSynced, webhookInformers.NamespaceLimitsInformer.HasSynced)
 
 	// Verify/create webhook endpoint.
 	err = app.createWebhook()

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -40,7 +40,6 @@ var webhookInformers *Informers
 var once sync.Once
 
 type Informers struct {
-	VMIInformer             cache.SharedIndexInformer
 	VMIPresetInformer       cache.SharedIndexInformer
 	NamespaceLimitsInformer cache.SharedIndexInformer
 }
@@ -67,7 +66,6 @@ func newInformers() *Informers {
 	kubeInformerFactory := controller.NewKubeInformerFactory(kubeClient.RestClient(), kubeClient)
 	kubeInformerFactory.VMI()
 	return &Informers{
-		VMIInformer:             kubeInformerFactory.VMI(),
 		VMIPresetInformer:       kubeInformerFactory.VirtualMachinePreset(),
 		NamespaceLimitsInformer: kubeInformerFactory.LimitRanges(),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

virt-api should have an almost consistent view of the cluster-state
before it starts listening for connections and therefore marking intself
as ready. Otherwise we may see weird inconsistencies on bigger clusters where virt-api may need some time to do an initial sync.

Further remove all traces of the no longer used VMIInformer in virt-api.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
