### PR TITLE
VMI configuration test: add retrying to make sure LimitRange cached

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -84,6 +84,9 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&VirtualMachine{},
 		&VirtualMachineList{},
 	)
+	scheme.AddKnownTypes(metav1.Unversioned,
+		&metav1.Status{},
+	)
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
VMI creation often succeeds just after the request to set LimitRange when it's not yet cached in virt-api side. Retrying 5 times ~~with its interval set to 1 second~~ should be enough. (c.f. https://github.com/kubevirt/kubevirt/pull/1567#issuecomment-426186191)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Tested on my local cluster.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
