### PR TITLE
[WIP] Added custom dhcp options to vmi interface spec.

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -768,6 +768,15 @@ type Interface struct {
 	// If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10
 	// +optional
 	PciAddress string `json:"pciAddress,omitempty"`
+	// Custom DHCP options that may be needed.
+	// +optional
+	DHCPOptions []DHCPOption `json:"dhcpOptions,omitempty"`
+}
+
+// +k8s:openapi-gen=true
+type DHCPOption struct {
+	OptionCode  byte   `json:"optionCode"`
+	OptionValue string `json:"optionValue"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -723,6 +723,13 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			},
 		}
 
+		for _, customDHCPOption := range iface.DHCPOptions {
+			domainIface.DHCPOptions = append(domainIface.DHCPOptions, DHCPOption{
+				OptionCode:  customDHCPOption.OptionCode,
+				OptionValue: customDHCPOption.OptionValue,
+			})
+		}
+
 		// Add a pciAddress if specifed
 		if iface.PciAddress != "" {
 			dbsfFields, err := util.ParsePciAddress(iface.PciAddress)

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -406,6 +406,12 @@ type Interface struct {
 	LinkState           *LinkState       `xml:"link,omitempty"`
 	FilterRef           *FilterRef       `xml:"filterref,omitempty"`
 	Alias               *Alias           `xml:"alias,omitempty"`
+	DHCPOptions         []DHCPOption     `xml:"dhcpOptions,omitempty"`
+}
+
+type DHCPOption struct {
+	OptionCode  byte   `xml:"optionCode"`
+	OptionValue string `xml:"optionValue"`
 }
 
 type LinkState struct {

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -58,7 +58,7 @@ type NetworkHandler interface {
 	ParseAddr(s string) (*netlink.Addr, error)
 	SetRandomMac(iface string) (net.HardwareAddr, error)
 	GetMacDetails(iface string) (net.HardwareAddr, error)
-	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string)
+	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions []api.DHCPOption)
 }
 
 type NetworkUtilsHandler struct{}
@@ -128,7 +128,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 	return currentMac, nil
 }
 
-func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string) {
+func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions []api.DHCPOption) {
 	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
 	nameservers, searchDomains, err := api.GetResolvConfDetailsFromPod()
 	if err != nil {
@@ -150,6 +150,7 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr *netlink.Addr, brid
 			nic.Routes,
 			searchDomains,
 			nic.Mtu,
+			dhcpOptions,
 		); err != nil {
 			log.Log.Errorf("failed to run DHCP: %v", err)
 			panic(err)

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -35,6 +35,7 @@ import (
 	"os"
 
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 const (
@@ -57,7 +58,8 @@ func SingleClientDHCPServer(
 	dnsIPs [][]byte,
 	routes *[]netlink.Route,
 	searchDomains []string,
-	mtu uint16) error {
+	mtu uint16,
+	customDHCPOptions []api.DHCPOption) error {
 
 	log.Log.Info("Starting SingleClientDHCPServer")
 
@@ -90,6 +92,12 @@ func SingleClientDHCPServer(
 		return fmt.Errorf("reading the pods hostname failed: %v", err)
 	}
 	dhcpOptions[dhcp.OptionHostName] = []byte(hostname)
+
+	for _, customDHCPOption := range customDHCPOptions {
+		log.Log.Infof("Setting dhcp option %s to %s", customDHCPOption.OptionCode, customDHCPOption.OptionValue)
+		optionCode := dhcp.OptionCode(customDHCPOption.OptionCode)
+		dhcpOptions[optionCode] = []byte(customDHCPOption.OptionValue)
+	}
 
 	handler := &DHCPHandler{
 		clientIP:      clientIP,

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -8,6 +8,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	netlink "github.com/vishvananda/netlink"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 // Mock of NetworkHandler interface
@@ -147,10 +149,10 @@ func (_mr *_MockNetworkHandlerRecorder) GetMacDetails(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMacDetails", arg0)
 }
 
-func (_m *MockNetworkHandler) StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string) {
-	_m.ctrl.Call(_m, "StartDHCP", nic, serverAddr, bridgeInterfaceName)
+func (_m *MockNetworkHandler) StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, customDHCPOptions []api.DHCPOption) {
+	_m.ctrl.Call(_m, "StartDHCP", nic, serverAddr, bridgeInterfaceName, customDHCPOptions)
 }
 
-func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2)
+func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2, arg3)
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -227,8 +227,10 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces() error {
 
 func (b *BridgePodInterface) startDHCPServer() {
 	// Start DHCP Server
+	dhcpOptions := b.domain.Spec.Devices.Interfaces[b.podInterfaceNum].DHCPOptions
+
 	fakeServerAddr, _ := netlink.ParseAddr(fmt.Sprintf(bridgeFakeIP, b.podInterfaceNum))
-	Handler.StartDHCP(b.vif, fakeServerAddr, b.bridgeInterfaceName)
+	Handler.StartDHCP(b.vif, fakeServerAddr, b.bridgeInterfaceName, dhcpOptions)
 }
 
 func (b *BridgePodInterface) decorateConfig() error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -108,7 +108,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkSetUp(bridgeTest).Return(nil)
 		mockNetwork.EXPECT().ParseAddr(fmt.Sprintf(bridgeFakeIP, 0)).Return(bridgeAddr, nil)
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
-		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName)
+		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName, nil)
 
 		err := SetupPodNetwork(vm, domain)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds custom DHCP options to interface config to set options that might be needed. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1579

**Special notes for your reviewer**:

This PR still needs:

- Documentation
- Tests
- Checks to make sure important options set by kubevirt aren't being overriden
- Example?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
