### PR TITLE
Set option 15 for windows machines on DHCP requests

### DIFF
--- a/pkg/util/net/dns/dns_suite_test.go
+++ b/pkg/util/net/dns/dns_suite_test.go
@@ -1,0 +1,13 @@
+package dns_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestDns(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dns Suite")
+}

--- a/pkg/util/net/dns/resolveconf.go
+++ b/pkg/util/net/dns/resolveconf.go
@@ -1,0 +1,73 @@
+package dns
+
+import (
+	"bufio"
+	"net"
+	"regexp"
+	"strings"
+)
+
+const (
+	domainSearchPrefix  = "search"
+	nameserverPrefix    = "nameserver"
+	defaultDNS          = "8.8.8.8"
+	defaultSearchDomain = "cluster.local"
+)
+
+func ParseNameservers(content string) ([][]byte, error) {
+	var nameservers [][]byte
+
+	re, err := regexp.Compile("([0-9]{1,3}.?){4}")
+	if err != nil {
+		return nameservers, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, nameserverPrefix) {
+			nameserver := re.FindString(line)
+			if nameserver != "" {
+				nameservers = append(nameservers, net.ParseIP(nameserver).To4())
+			}
+		}
+	}
+
+	if err = scanner.Err(); err != nil {
+		return nameservers, err
+	}
+
+	// apply a default DNS if none found from pod
+	if len(nameservers) == 0 {
+		nameservers = append(nameservers, net.ParseIP(defaultDNS).To4())
+	}
+
+	return nameservers, nil
+}
+
+func ParseSearchDomains(content string) ([]string, error) {
+	var searchDomains []string
+
+	scanner := bufio.NewScanner(strings.NewReader(content))
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, domainSearchPrefix) {
+			doms := strings.Fields(strings.TrimPrefix(line, domainSearchPrefix))
+			for _, dom := range doms {
+				searchDomains = append(searchDomains, dom)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	if len(searchDomains) == 0 {
+		searchDomains = append(searchDomains, defaultSearchDomain)
+	}
+
+	return searchDomains, nil
+}

--- a/pkg/util/net/dns/resolveconf_test.go
+++ b/pkg/util/net/dns/resolveconf_test.go
@@ -1,0 +1,73 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Resolveconf", func() {
+	Context("Function ParseNameservers()", func() {
+		It("should return a byte array of nameservers", func() {
+			ns1, ns2 := []uint8{8, 8, 8, 8}, []uint8{8, 8, 4, 4}
+			resolvConf := "nameserver 8.8.8.8\nnameserver 8.8.4.4\n"
+			nameservers, err := ParseNameservers(resolvConf)
+			Expect(nameservers).To(Equal([][]uint8{ns1, ns2}))
+			Expect(err).To(BeNil())
+		})
+
+		It("should ignore non-nameserver lines and malformed nameserver lines", func() {
+			ns1, ns2 := []uint8{8, 8, 8, 8}, []uint8{8, 8, 4, 4}
+			resolvConf := "search example.com\nnameserver 8.8.8.8\nnameserver 8.8.4.4\nnameserver mynameserver\n"
+			nameservers, err := ParseNameservers(resolvConf)
+			Expect(nameservers).To(Equal([][]uint8{ns1, ns2}))
+			Expect(err).To(BeNil())
+		})
+
+		It("should return a default nameserver if none is parsed", func() {
+			nameservers, err := ParseNameservers("")
+			expectedDNS := net.ParseIP(defaultDNS).To4()
+			Expect(nameservers).To(Equal([][]uint8{expectedDNS}))
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Function ParseSearchDomains()", func() {
+		It("should return a string of search domains", func() {
+			resolvConf := "search cluster.local svc.cluster.local example.com\nnameserver 8.8.8.8\n"
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
+			Expect(err).To(BeNil())
+		})
+
+		It("should handle multi-line search domains", func() {
+			resolvConf := "search cluster.local\nsearch svc.cluster.local example.com\nnameserver 8.8.8.8\n"
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
+			Expect(err).To(BeNil())
+		})
+
+		It("should clean up extra whitespace between search domains", func() {
+			resolvConf := "search cluster.local\tsvc.cluster.local    example.com\nnameserver 8.8.8.8\n"
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
+			Expect(err).To(BeNil())
+		})
+
+		It("should handle non-presence of search domains by returning default search domain", func() {
+			resolvConf := fmt.Sprintf("nameserver %s\n", defaultDNS)
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{defaultSearchDomain}))
+			Expect(err).To(BeNil())
+		})
+
+		It("should allow partial search domains", func() {
+			resolvConf := "search local\nnameserver 8.8.8.8\n"
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{"local"}))
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -20,17 +20,17 @@
 package api
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 
 	"strconv"
 	"strings"
@@ -949,12 +949,12 @@ func GetResolvConfDetailsFromPod() ([][]byte, []string, error) {
 		return nil, nil, err
 	}
 
-	nameservers, err := ParseNameservers(string(b))
+	nameservers, err := dns.ParseNameservers(string(b))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	searchDomains, err := ParseSearchDomains(string(b))
+	searchDomains, err := dns.ParseSearchDomains(string(b))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -963,62 +963,4 @@ func GetResolvConfDetailsFromPod() ([][]byte, []string, error) {
 	log.Log.Reason(err).Infof("Found search domains in %s: %s", resolvConf, strings.Join(searchDomains, " "))
 
 	return nameservers, searchDomains, err
-}
-
-func ParseNameservers(content string) ([][]byte, error) {
-	var nameservers [][]byte
-
-	re, err := regexp.Compile("([0-9]{1,3}.?){4}")
-	if err != nil {
-		return nameservers, err
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(content))
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, nameserverPrefix) {
-			nameserver := re.FindString(line)
-			if nameserver != "" {
-				nameservers = append(nameservers, net.ParseIP(nameserver).To4())
-			}
-		}
-	}
-
-	if err = scanner.Err(); err != nil {
-		return nameservers, err
-	}
-
-	// apply a default DNS if none found from pod
-	if len(nameservers) == 0 {
-		nameservers = append(nameservers, net.ParseIP(defaultDNS).To4())
-	}
-
-	return nameservers, nil
-}
-
-func ParseSearchDomains(content string) ([]string, error) {
-	var searchDomains []string
-
-	scanner := bufio.NewScanner(strings.NewReader(content))
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, domainSearchPrefix) {
-			doms := strings.Fields(strings.TrimPrefix(line, domainSearchPrefix))
-			for _, dom := range doms {
-				searchDomains = append(searchDomains, dom)
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	if len(searchDomains) == 0 {
-		searchDomains = append(searchDomains, defaultSearchDomain)
-	}
-
-	return searchDomains, nil
 }

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -21,7 +21,6 @@ package api
 
 import (
 	"encoding/xml"
-	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -825,67 +824,6 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].BootOrder).NotTo(BeNil())
 			Expect(domain.Spec.Devices.Interfaces[0].BootOrder.Order).To(Equal(uint(bootOrder)))
 			Expect(domain.Spec.Devices.Interfaces[1].BootOrder).To(BeNil())
-		})
-	})
-	Context("Function ParseNameservers()", func() {
-		It("should return a byte array of nameservers", func() {
-			ns1, ns2 := []uint8{8, 8, 8, 8}, []uint8{8, 8, 4, 4}
-			resolvConf := "nameserver 8.8.8.8\nnameserver 8.8.4.4\n"
-			nameservers, err := ParseNameservers(resolvConf)
-			Expect(nameservers).To(Equal([][]uint8{ns1, ns2}))
-			Expect(err).To(BeNil())
-		})
-
-		It("should ignore non-nameserver lines and malformed nameserver lines", func() {
-			ns1, ns2 := []uint8{8, 8, 8, 8}, []uint8{8, 8, 4, 4}
-			resolvConf := "search example.com\nnameserver 8.8.8.8\nnameserver 8.8.4.4\nnameserver mynameserver\n"
-			nameservers, err := ParseNameservers(resolvConf)
-			Expect(nameservers).To(Equal([][]uint8{ns1, ns2}))
-			Expect(err).To(BeNil())
-		})
-
-		It("should return a default nameserver if none is parsed", func() {
-			nameservers, err := ParseNameservers("")
-			expectedDNS := net.ParseIP(defaultDNS).To4()
-			Expect(nameservers).To(Equal([][]uint8{expectedDNS}))
-			Expect(err).To(BeNil())
-		})
-	})
-
-	Context("Function ParseSearchDomains()", func() {
-		It("should return a string of search domains", func() {
-			resolvConf := "search cluster.local svc.cluster.local example.com\nnameserver 8.8.8.8\n"
-			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
-			Expect(err).To(BeNil())
-		})
-
-		It("should handle multi-line search domains", func() {
-			resolvConf := "search cluster.local\nsearch svc.cluster.local example.com\nnameserver 8.8.8.8\n"
-			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
-			Expect(err).To(BeNil())
-		})
-
-		It("should clean up extra whitespace between search domains", func() {
-			resolvConf := "search cluster.local\tsvc.cluster.local    example.com\nnameserver 8.8.8.8\n"
-			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
-			Expect(err).To(BeNil())
-		})
-
-		It("should handle non-presence of search domains by returning default search domain", func() {
-			resolvConf := fmt.Sprintf("nameserver %s\n", defaultDNS)
-			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{defaultSearchDomain}))
-			Expect(err).To(BeNil())
-		})
-
-		It("should allow partial search domains", func() {
-			resolvConf := "search local\nnameserver 8.8.8.8\n"
-			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"local"}))
-			Expect(err).To(BeNil())
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -1,14 +1,10 @@
 package api
 
 const (
-	defaultDNS          = "8.8.8.8"
-	resolvConf          = "/etc/resolv.conf"
-	defaultSearchDomain = "cluster.local"
-	domainSearchPrefix  = "search"
-	nameserverPrefix    = "nameserver"
-	DefaultProtocol     = "TCP"
-	DefaultVMCIDR       = "10.0.2.0/24"
-	DefaultBridgeName   = "k6t-eth0"
+	resolvConf        = "/etc/resolv.conf"
+	DefaultProtocol   = "TCP"
+	DefaultVMCIDR     = "10.0.2.0/24"
+	DefaultBridgeName = "k6t-eth0"
 )
 
 func SetDefaults_Devices(devices *Devices) {

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
@@ -22,6 +22,7 @@ package dhcp
 import (
 	"net"
 
+	"github.com/krolaw/dhcp4"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
@@ -129,6 +130,20 @@ var _ = Describe("DHCP", func() {
 		})
 	})
 
+	Context("function getDomainName", func() {
+		It("should return the longest search domain entry", func() {
+			searchDomains := []string{
+				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
+				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				"t4lanpt7z4ix58nvxl4d.com",
+				"14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+			}
+			domain := getDomainName(searchDomains)
+			Expect(domain).To(Equal("14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com"))
+		})
+	})
+
 	Context("function isValidSearchDomain(domain string) bool", func() {
 		createBytes := func(size int) []byte {
 			b := make([]byte, size)
@@ -180,6 +195,22 @@ var _ = Describe("DHCP", func() {
 
 		It("should accept a partial search domain", func() {
 			Expect(isValidSearchDomain("local")).To(BeTrue())
+		})
+	})
+
+	Context("Options returned by prepareDHCPOptions", func() {
+		It("should contain the domain name option", func() {
+			searchDomains := []string{
+				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
+				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				"t4lanpt7z4ix58nvxl4d.com",
+				"14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+			}
+			ip := net.ParseIP("192.168.2.1")
+			options, err := prepareDHCPOptions(ip.DefaultMask(), ip, nil, nil, searchDomains, 1500, "myhost")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(options[dhcp4.OptionDomainName]).To(Equal([]byte("14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com")))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to allow service-name DNS resolution not only via the FQDN, it
is necessary to put the VMI into a domain. This domain equals to the
search domain entry of the namespace the VMI runs in.

As a consequence, services in the namespace of the VMI can be resolved

 * via the FQDN: `myservice.mynamespace.svc.cluster.local`
 * relative to the namespaces: `myservice`

Headless services can also be accessed

 * via the FQDN: `myservice.mydomain.mynamespace.svc.cluster.local`
 * relative to the namespace: `myservice.mydomain`

Before only FQDN was possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to https://github.com/kubevirt/user-guide/issues/126 and #906 

**Special notes for your reviewer**:

**Release note**:

```release-note
Allows Windows VMIs DNS resolution of services without FQDN in their own namespace
```
