### PR TITLE
Fix ptp cni plugin test and added tests for ovs cni plugin.

### DIFF
--- a/cluster/k8s-multus-1.11.1/provider.sh
+++ b/cluster/k8s-multus-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.11.1@sha256:f37109a50354d7f34ba71a85bcfe0bc6c62897b9dded28e8dfd819598d5cde43"
+image="k8s-multus-1.11.1@sha256:5d57cacc0d845b7ee20722e3481a1e9525336dd3ee8ac479037bce531d48c9f8"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-multus-1.11.1/provider.sh
+++ b/cluster/k8s-multus-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.11.1@sha256:5d57cacc0d845b7ee20722e3481a1e9525336dd3ee8ac479037bce531d48c9f8"
+image="k8s-multus-1.11.1@sha256:b5f1fa6125f1ad0057284fac433b9f9f0abad3a27214784552d84b6265be20d1"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/os-3.10.0-multus/provider.sh
+++ b/cluster/os-3.10.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-multus@sha256:7d43b9fe2135b5b218ded4817e17f3766931e2ca007748566217806d5683cfbb"
+image="os-3.10.0-multus@sha256:d831f538a99a214560b7e95f9de7235a4ebfdfb24997c15080b1e38fa5528ad2"

--- a/cluster/os-3.10.0-multus/provider.sh
+++ b/cluster/os-3.10.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-multus@sha256:d831f538a99a214560b7e95f9de7235a4ebfdfb24997c15080b1e38fa5528ad2"
+image="os-3.10.0-multus@sha256:dfeaa7c1f7c264f953e44c93b50bb76c9bb58b0df8bb94dcaa108db254f87eb3"

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -41,7 +43,11 @@ var _ = Describe("Multus Networking", func() {
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
+	nodes, err := virtClient.CoreV1().Nodes().List(v13.ListOptions{})
+	tests.PanicOnError(err)
 	var detachedVMI *v1.VirtualMachineInstance
+	var vmiOne *v1.VirtualMachineInstance
+	var vmiTwo *v1.VirtualMachineInstance
 
 	tests.BeforeAll(func() {
 		tests.SkipIfNoMultusProvider(virtClient)
@@ -75,16 +81,7 @@ var _ = Describe("Multus Networking", func() {
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReadyWithNamespace("default", detachedVMI, tests.LoggedInCirrosExpecter)
 
-			cmdCheck := fmt.Sprintf("ping %s -c 1 -w 5\n", "10.1.1.1")
-			err = tests.CheckForTextExpecter(detachedVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "\\$ "},
-				&expect.BSnd{S: cmdCheck},
-				&expect.BExp{R: "\\$ "},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
-			}, 180)
-			Expect(err).ToNot(HaveOccurred())
+			pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
 		})
 
 		It("should create a virtual machine with two interfaces", func() {
@@ -109,6 +106,154 @@ var _ = Describe("Multus Networking", func() {
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReadyWithNamespace("default", detachedVMI, tests.LoggedInCirrosExpecter)
 
+			cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
+			err = tests.CheckForTextExpecter(detachedVMI, []expect.Batcher{
+				&expect.BSnd{S: "\n"},
+				&expect.BExp{R: "\\$ "},
+				&expect.BSnd{S: cmdCheck},
+				&expect.BExp{R: "\\$ "},
+				&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l"},
+				&expect.BExp{R: "1"},
+			}, 15)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking virtual machine instance as two interfaces")
+			checkInterface(detachedVMI, "eth0", "\\$ ")
+			checkInterface(detachedVMI, "eth1", "\\$ ")
+
+			pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
+		})
+	})
+
+	Context("VirtualMachineInstance with ovs-cni plugin interface", func() {
+		nodeAffinity := &k8sv1.Affinity{
+			NodeAffinity: &k8sv1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+					NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
+						{
+							MatchExpressions: []k8sv1.NodeSelectorRequirement{
+								{Key: "kubernetes.io/hostname", Operator: k8sv1.NodeSelectorOpIn, Values: []string{nodes.Items[0].Name}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		AfterEach(func() {
+			deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne, vmiTwo})
+		})
+
+		It("should create two virtual machines with one interface", func() {
+			By("checking virtual machine instance can ping the secondary virtual machine instance using ovs-cni plugin")
+			// The virtual machines needs to run on the default namespace because the network-attachment-definitions.k8s.cni.cncf.io are there
+			vmiOne = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskAlpine), "#!/bin/bash\n")
+			vmiOne.Namespace = "default"
+			vmiOne.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ovs", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+			vmiOne.Spec.Networks = []v1.Network{{Name: "ovs", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ovs-net-vlan100"}}}}
+			vmiOne.Spec.Affinity = nodeAffinity
+
+			vmiTwo = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskAlpine), "#!/bin/bash\n")
+			vmiTwo.Namespace = "default"
+			vmiTwo.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ovs", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+			vmiTwo.Spec.Networks = []v1.Network{{Name: "ovs", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ovs-net-vlan100"}}}}
+			vmiTwo.Spec.Affinity = nodeAffinity
+
+			_, err = virtClient.VirtualMachineInstance("default").Create(vmiOne)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = virtClient.VirtualMachineInstance("default").Create(vmiTwo)
+			Expect(err).ToNot(HaveOccurred())
+
+			tests.WaitUntilVMIReadyWithNamespace("default", vmiOne, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReadyWithNamespace("default", vmiTwo, tests.LoggedInAlpineExpecter)
+
+			configInterface(vmiOne, "eth0", "10.1.1.1/24", "localhost:~#")
+			By("checking virtual machine interface eth0 state")
+			checkInterface(vmiOne, "eth0", "localhost:~#")
+
+			configInterface(vmiTwo, "eth0", "10.1.1.2/24", "localhost:~#")
+			By("checking virtual machine interface eth0 state")
+			checkInterface(vmiTwo, "eth0", "localhost:~#")
+
+			By("ping between virtual machines")
+			pingVirtualMachine(vmiOne, "10.1.1.2", "localhost:~#")
+		})
+
+		It("should create two virtual machines with two interfaces", func() {
+			By("checking the first virtual machine instance can ping 10.1.1.2 using ovs-cni plugin")
+			// The virtual machines needs to run on the default namespace because the network-attachment-definitions.k8s.cni.cncf.io are there
+			vmiOne = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskAlpine), "#!/bin/bash\necho 'hello'\n")
+			vmiOne.Namespace = "default"
+			vmiOne.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+				{Name: "ovs", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+			vmiOne.Spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+				{Name: "ovs", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ovs-net-vlan100"}}}}
+			vmiOne.Spec.Affinity = nodeAffinity
+
+			vmiTwo = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskAlpine), "#!/bin/bash\necho 'hello'\n")
+			vmiTwo.Namespace = "default"
+			vmiTwo.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+				{Name: "ovs", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
+			vmiTwo.Spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+				{Name: "ovs", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ovs-net-vlan100"}}}}
+			vmiTwo.Spec.Affinity = nodeAffinity
+
+			_, err = virtClient.VirtualMachineInstance("default").Create(vmiOne)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = virtClient.VirtualMachineInstance("default").Create(vmiTwo)
+			Expect(err).ToNot(HaveOccurred())
+
+			tests.WaitUntilVMIReadyWithNamespace("default", vmiOne, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReadyWithNamespace("default", vmiTwo, tests.LoggedInAlpineExpecter)
+
+			configInterface(vmiOne, "eth1", "10.1.1.1/24", "localhost:~#")
+			By("checking virtual machine interface eth1 state")
+			checkInterface(vmiOne, "eth1", "localhost:~#")
+
+			configInterface(vmiTwo, "eth1", "10.1.1.2/24", "localhost:~#")
+			By("checking virtual machine interface eth1 state")
+			checkInterface(vmiTwo, "eth1", "localhost:~#")
+
+			By("ping between virtual machines")
+			pingVirtualMachine(vmiOne, "10.1.1.2", "localhost:~#")
+		})
+	})
+})
+
+func deleteVMIs(virtClient kubecli.KubevirtClient, vmis []*v1.VirtualMachineInstance) {
+	for _, deleteVMI := range vmis {
+		virtClient.VirtualMachineInstance("default").Delete(deleteVMI.Name, &v13.DeleteOptions{})
+		fmt.Printf("Waiting for vmi %s in default namespace to be removed, this can take a while ...\n", deleteVMI.Name)
+		EventuallyWithOffset(1, func() bool {
+			return errors.IsNotFound(virtClient.VirtualMachineInstance("default").Delete(deleteVMI.Name, nil))
+		}, 180*time.Second, 1*time.Second).
+			Should(BeTrue())
+	}
+}
+
+func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAddress, prompt string) {
+	cmdCheck := fmt.Sprintf("ip addr add %s dev %s\n", interfaceAddress, interfaceName)
+	err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: cmdCheck},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: "0"},
+	}, 15)
+	Expect(err).ToNot(HaveOccurred())
+
+	cmdCheck = fmt.Sprintf("ip link set %s up\n", interfaceName)
+	err = tests.CheckForTextExpecter(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: cmdCheck},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: "0"},
+	}, 15)
+	Expect(err).ToNot(HaveOccurred())
+}
 			By("checking virtual machine instance as two interfaces")
 			cmdCheck := fmt.Sprintf("ip link show %s\n", "eth0")
 			err = tests.CheckForTextExpecter(detachedVMI, []expect.Batcher{
@@ -121,16 +266,28 @@ var _ = Describe("Multus Networking", func() {
 			}, 180)
 			Expect(err).ToNot(HaveOccurred())
 
-			cmdCheck = fmt.Sprintf("ip link show %s\n", "eth1")
-			err = tests.CheckForTextExpecter(detachedVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "\\$ "},
-				&expect.BSnd{S: cmdCheck},
-				&expect.BExp{R: "\\$ "},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
-			}, 180)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-})
+func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string) {
+	cmdCheck := fmt.Sprintf("ip link show %s\n", interfaceName)
+	err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: cmdCheck},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: "0"},
+	}, 15)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
+	cmdCheck := fmt.Sprintf("ping %s -c 1 -w 5\n", ipAddr)
+	err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: cmdCheck},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: "0"},
+	}, 30)
+	Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Use a new k8s 1.11.1 with multus provider
- Fix the multus tests and also added more tests to check the ovs-cni plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1569 

**Release note**:

```release-note
Introduce new k8s 1.11.1 multus provider
Fix ptp cni plugin tests
Add ovs-cni plugin tests
```

