### PR TITLE
Extend and refactor template test

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -98,21 +98,21 @@ var _ = Describe("User Access", func() {
 				By(fmt.Sprintf("verifying VIEW sa for verb %s", verb))
 				expectedRes, _ := viewVerbs[verb]
 				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, view)
-				result, _ := tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
+				result, _, _ := tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// EDIT
 				By(fmt.Sprintf("verifying EDIT sa for verb %s", verb))
 				expectedRes, _ = editVerbs[verb]
 				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, edit)
-				result, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
+				result, _, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// ADMIN
 				By(fmt.Sprintf("verifying ADMIN sa for verb %s", verb))
 				expectedRes, _ = adminVerbs[verb]
 				as = fmt.Sprintf("system:serviceaccount:%s:%s", namespace, admin)
-				result, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
+				result, _, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 
 				// DEFAULT - the default should always return 'no' for ever verb.
@@ -120,7 +120,7 @@ var _ = Describe("User Access", func() {
 				By(fmt.Sprintf("verifying DEFAULT sa for verb %s", verb))
 				expectedRes = "no"
 				as = fmt.Sprintf("system:serviceaccount:%s:default", namespace)
-				result, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
+				result, _, _ = tests.RunCommand("kubectl", "auth", "can-i", "--as", as, verb, resource)
 				Expect(result).To(ContainSubstring(expectedRes))
 			}
 		},

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Templates", func() {
 		AfterEach(AssertTestCleanupSuccess())
 
 		Context("with Fedora Template", func() {
-			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTestTemplateFedora(), nil))
+			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTemplateFedora(), nil))
 
 			AssertTemplateTestSuccess()
 		})

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -22,17 +22,29 @@ package tests_test
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	vmsgen "kubevirt.io/kubevirt/tools/vms-generator/utils"
+)
+
+const (
+	defaultNamePrefix = "testvm-"
+	defaultCPUCores   = "2"
+	defaultMemory     = "2Gi"
 )
 
 var _ = Describe("Templates", func() {
@@ -42,201 +54,212 @@ var _ = Describe("Templates", func() {
 	tests.PanicOnError(err)
 
 	var (
-		template         *vmsgen.Template
-		parameters       templateParams
-		templateJsonFile string
-		vmJsonFile       string
+		templateParams map[string]string
+		templateFile   string
+		vmName         string
 	)
 
 	BeforeEach(func() {
 		tests.SkipIfNoCmd("oc")
 		tests.BeforeTestCleanup()
+		SetDefaultEventuallyTimeout(120 * time.Second)
+		SetDefaultEventuallyPollingInterval(2 * time.Second)
 	})
 
 	Describe("Creating VM from Template", func() {
 
-		assertGeneratedVMJson := func() func() {
+		AssertTestSetupSuccess := func() func() {
 			return func() {
-				By("Generating VM JSON from the Template via oc-process command")
-				_, _, err := runOcProcessCommand(templateJsonFile, parameters, vmJsonFile)
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				ExpectWithOffset(1, vmJsonFile).To(BeAnExistingFile())
-			}
-		}
-
-		assertCreatedVM := func() func() {
-			return func() {
-				By("Creating VM via oc-create command")
-				out, _, err := runOcCreateCommand(vmJsonFile)
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" created\n", parameters.name)
-				ExpectWithOffset(1, out).To(ContainSubstring(message))
-
-				By("Checking if the VM exists via oc-get command.")
-				EventuallyWithOffset(1, func() bool {
-					out, _, err := runOcGetCommand("vms")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return strings.Contains(out, parameters.name)
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VM to apppear")
-			}
-		}
-
-		assertDeletedVM := func() func() {
-			return func() {
-				By("Deleting the VM via oc-delete command")
-				out, _, err := runOcDeleteCommand(parameters.name)
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" deleted\n", parameters.name)
-				ExpectWithOffset(1, out).To(ContainSubstring(message))
-
-				By("Checking if the VM does not exist anymore via oc-get command.")
-				EventuallyWithOffset(1, func() bool {
-					out, _, err := runOcGetCommand("vms")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return out == "No resources found.\n"
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VM to disappear")
-			}
-		}
-
-		assertStartedVM := func() func() {
-			return func() {
-				By("Starting VM via oc-patch command")
-				out, _, err := runOcPatchCommand(parameters.name, "{\"spec\":{\"running\":true}}")
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", parameters.name)
-				ExpectWithOffset(1, out).To(ContainSubstring(message))
-
-				By("Checking if the VMI does exist via oc-get command")
-				EventuallyWithOffset(1, func() bool {
-					out, _, err := runOcGetCommand("vmis")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return strings.Contains(out, parameters.name)
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to appear")
-			}
-		}
-
-		assertStoppedVM := func() func() {
-			return func() {
-				By("Stopping the VM via oc-patch command")
-				out, _, err := runOcPatchCommand(parameters.name, "{\"spec\":{\"running\":false}}")
-				ExpectWithOffset(1, err).ToNot(HaveOccurred())
-				message := fmt.Sprintf("virtualmachine.kubevirt.io \"%s\" patched\n", parameters.name)
-				ExpectWithOffset(1, out).To(ContainSubstring(message))
-
-				By("Checking if the VMI does not exist anymore via oc-get command")
-				EventuallyWithOffset(1, func() bool {
-					out, _, err := runOcGetCommand("vmis")
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-					return out == "No resources found.\n"
-				}, time.Duration(60)*time.Second).Should(BeTrue(), "Timed out waiting for VMI to disappear")
-			}
-		}
-
-		assertRemovedFile := func(file string) func() {
-			return func() {
-				if _, err := os.Stat(file); !os.IsNotExist(err) {
-					err := os.Remove(file)
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+				templateParams = map[string]string{
+					"NAME":      defaultNamePrefix + rand.String(12),
+					"CPU_CORES": defaultCPUCores,
+					"MEMORY":    defaultMemory,
 				}
-				ExpectWithOffset(1, file).NotTo(BeAnExistingFile())
+				templateFile = ""
+				ExpectWithOffset(1, templateParams).To(HaveKeyWithValue("NAME", Not(BeEmpty())), "invalid NAME parameter: VirtualMachine name cannot be empty string")
+				ExpectWithOffset(1, templateParams).To(HaveKeyWithValue("CPU_CORES", MatchRegexp(`^[0-9]+$`)), "invalid CPU_CORES parameter: %q is not unsigned integer", templateParams["CPU_CORES"])
+				ExpectWithOffset(1, templateParams).To(HaveKeyWithValue("MEMORY", MatchRegexp(`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`)), "invalid MEMORY parameter: %q is not valid quantity", templateParams["MEMORY"])
+				vmName = templateParams["NAME"]
+				vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+				ExpectWithOffset(1, errors.IsNotFound(err) || vm.ObjectMeta.DeletionTimestamp != nil).To(BeTrue(), "invalid NAME parameter: VirtualMachine %q already exists", vmName)
 			}
 		}
 
-		testGivenTemplate := func() {
-			It("should succeed to generate a VM JSON file using oc-process command", assertGeneratedVMJson())
+		AssertTemplateSetupSuccess := func(template *vmsgen.Template, params map[string]string) func() {
+			return func() {
+				ExpectWithOffset(1, template).NotTo(BeNil(), "template object was not provided")
+				By("Creating the Template JSON file")
+				var err error
+				templateFile, err = tests.GenerateTemplateJson(template)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to write template JSON file: %v", err)
+				ExpectWithOffset(1, templateFile).To(BeAnExistingFile(), "template JSON file %q was not created", templateFile)
 
-			Context("with the given VM JSON", func() {
-				JustBeforeEach(assertGeneratedVMJson())
-				AfterEach(assertDeletedVM())
+				if params != nil {
+					By("Validating template parameters")
+					for param, value := range params {
+						switch param {
+						case "NAME":
+							ExpectWithOffset(1, value).NotTo(BeEmpty(), "invalid NAME parameter: VirtualMachine name cannot be empty string")
+							vmName = value
+							vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+							ExpectWithOffset(1, errors.IsNotFound(err) || vm.ObjectMeta.DeletionTimestamp != nil).To(BeTrue(), "invalid NAME parameter: VirtualMachine %q already exists", vmName)
+						case "CPU_CORES":
+							ExpectWithOffset(1, templateParams).To(HaveKeyWithValue("CPU_CORES", MatchRegexp(`^[0-9]+$`)), "invalid CPU_CORES parameter: %q is not unsigned integer", templateParams["CPU_CORES"])
+						case "MEMORY":
+							ExpectWithOffset(1, templateParams).To(HaveKeyWithValue("MEMORY", MatchRegexp(`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`)), "invalid MEMORY parameter: %q is not valid quantity", templateParams["MEMORY"])
+						}
+						templateParams[param] = value
+					}
+				}
+			}
+		}
 
-				It("should succeed to create a VM using oc-create command", assertCreatedVM())
+		AssertTestCleanupSuccess := func() func() {
+			return func() {
+				if vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{}); err == nil && vm.ObjectMeta.DeletionTimestamp == nil {
+					By("Deleting the VirtualMachine")
+					ExpectWithOffset(1, virtClient.VirtualMachine(tests.NamespaceTestDefault).Delete(vmName, &metav1.DeleteOptions{})).To(Succeed(), "failed to delete VirtualMachine %q: %v", vmName, err)
+					EventuallyWithOffset(1, func() bool {
+						obj, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+						return errors.IsNotFound(err) || obj.ObjectMeta.DeletionTimestamp != nil
+					}).Should(BeTrue(), "VirtualMachine %q still exists and the deletion timestamp was not set", vmName)
+				}
+				if templateFile != "" {
+					if _, err := os.Stat(templateFile); !os.IsNotExist(err) {
+						By("Deleting template JSON file")
+						ExpectWithOffset(1, os.RemoveAll(filepath.Dir(templateFile))).To(Succeed(), "failed to remove template JSON file %q: %v", templateFile, err)
+						ExpectWithOffset(1, templateFile).NotTo(BeAnExistingFile(), "template JSON file %q was not removed", templateFile)
+					}
+				}
+			}
+		}
 
-				Context("with the given created VM", func() {
-					JustBeforeEach(assertCreatedVM())
+		AssertVMCreationSuccess := func() func() {
+			return func() {
+				By("Creating VirtualMachine from Template via oc command")
+				ocProcessCommand := []string{"oc", "process", "-f", templateFile}
+				for param, value := range templateParams {
+					ocProcessCommand = append(ocProcessCommand, "-p", fmt.Sprintf("%s=%s", param, value))
+				}
+				out, stderr, err := tests.RunCommandPipe(ocProcessCommand, []string{"oc", "create", "-f", "-"})
+				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to create VirtualMachine %q via command \"%s | oc create -f -\": %s: %v", vmName, strings.Join(ocProcessCommand, " "), out+stderr, err)
+				ExpectWithOffset(1, out).To(MatchRegexp(`"?%s"? created\n`, vmName), "command \"%s | oc create -f -\" did not print expected message: %s", strings.Join(ocProcessCommand, " "), out+stderr)
+				By("Checking if the VirtualMachine exists")
+				EventuallyWithOffset(1, func() error {
+					_, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+					return err
+				}).Should(Succeed(), "VirtualMachine %q still does not exist", vmName)
+			}
+		}
 
-					It("should succeed to start the VM using oc-patch command", assertStartedVM())
+		AssertVMCreationFailure := func() func() {
+			return func() {
+				By("Creating VirtualMachine from Template via oc command")
+				ocProcessCommand := []string{"oc", "process", "-f", templateFile}
+				for param, value := range templateParams {
+					ocProcessCommand = append(ocProcessCommand, "-p", fmt.Sprintf("%s=%s", param, value))
+				}
+				out, stderr, err := tests.RunCommandPipe(ocProcessCommand, []string{"oc", "create", "-f", "-"})
+				ExpectWithOffset(1, err).To(HaveOccurred(), "creation of VirtualMachine %q via command \"%s | oc create -f -\" succeeded: %s: %v", vmName, strings.Join(ocProcessCommand, " "), out+stderr, err)
+			}
+		}
 
-					Context("with the given running VM", func() {
-						JustBeforeEach(assertStartedVM())
+		AssertVMDeletionSuccess := func() func() {
+			return func() {
+				By("Deleting the VirtualMachine via oc command")
+				out, stderr, err := tests.RunCommand("oc", "delete", "vm", vmName)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to delete VirtualMachine via command \"oc delete vm %s\": %s: %v", vmName, out+stderr, err)
+				ExpectWithOffset(1, out).To(MatchRegexp(`"?%s"? deleted\n`, vmName), "command \"oc delete vm %s\" did not print expected message: %s", vmName, out)
 
-						It("should succeed to stop the VM using oc-patch command", assertStoppedVM())
-					})
-				})
+				By("Checking if the VM does not exist anymore")
+				EventuallyWithOffset(1, func() bool {
+					vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+					return errors.IsNotFound(err) || vm.ObjectMeta.DeletionTimestamp != nil
+				}).Should(BeTrue(), "the VirtualMachine %q still exists and deletion timestamp was not set", vmName)
+			}
+		}
+
+		AssertVMDeletionFailure := func() func() {
+			return func() {
+				By("Deleting the VirtualMachine via oc command")
+				out, stderr, err := tests.RunCommand("oc", "delete", "vm", vmName)
+				ExpectWithOffset(1, err).To(HaveOccurred(), "failed to delete VirtualMachine via command \"oc delete vm %s\": %s: %v", vmName, out+stderr, err)
+			}
+		}
+
+		AssertVMStartSuccess := func(command string) func() {
+			return func() {
+				switch command {
+				case "oc":
+					By("Starting VirtualMachine via oc command")
+					patch := `{"spec":{"running":true}}`
+					out, stderr, err := tests.RunCommand("oc", "patch", "vm", vmName, "--type=merge", "-p", patch)
+					ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed schedule VirtualMachine %q start via command \"oc patch vm %s --type=merge -p '%s'\": %s: %v", vmName, vmName, patch, out+stderr, err)
+					ExpectWithOffset(1, out).To(MatchRegexp(`"?%s"? patched\n`, vmName), "command \"oc patch vm %s --type=merge -p '%s'\" did not print expected message: %s", vmName, patch, out+stderr)
+
+				case "virtctl":
+					By("Starting VirtualMachine via virtctl command")
+					out, stderr, err := tests.RunCommand("virtctl", "start", vmName)
+					ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to schedule VirtualMachine %q start via command \"virtctl start %s\": %s: %v", vmName, vmName, out+stderr, err)
+					ExpectWithOffset(1, out).To(ContainSubstring("%s was scheduled to start\n", vmName), "command \"virtctl start %s\" did not print expected message: %s", vmName, out+stderr)
+				}
+
+				By("Checking if the VirtualMachineInstance was created")
+				EventuallyWithOffset(1, func() error {
+					_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+					return err
+				}).Should(Succeed(), "the VirtualMachineInstance %q still does not exist", vmName)
+
+				By("Checking if the VirtualMachine has status ready")
+				EventuallyWithOffset(1, func() bool {
+					vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+					ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to fetch VirtualMachine %q: %v", vmName, err)
+					return vm.Status.Ready
+				}).Should(BeTrue(), "VirtualMachine %q still does not have status ready", vmName)
+
+				By("Checking if the VirtualMachineInstance specs match Template parameters")
+				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
+				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to fetch VirtualMachine %q: %v", vmName, err)
+				vmiCPUCores := vmi.Spec.Domain.CPU.Cores
+				templateParamCPUCores, err := strconv.ParseUint(templateParams["CPU_CORES"], 10, 32)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "cannot parse CPU_CORES parameter: value %q: %v", templateParams["CPU_CORES"], err)
+				ExpectWithOffset(1, vmiCPUCores).To(Equal(uint32(templateParamCPUCores)), "VirtualMachineInstance CPU cores (%d) does not match CPU_CORES parameter value: %s", vmiCPUCores, templateParams["CPU_CORES"])
+				vmiMemory := vmi.Spec.Domain.Resources.Requests["memory"]
+				templateParamMemory, err := resource.ParseQuantity(templateParams["MEMORY"])
+				ExpectWithOffset(1, err).ToNot(HaveOccurred(), "cannot parse MEMORY parameter: value %q: %v", templateParams["MEMORY"], err)
+				ExpectWithOffset(1, vmiMemory).To(Equal(templateParamMemory), "VirtualMachineInstance memory (%s) does not match MEMORY parameter value: %s", vmiMemory.String(), templateParams["MEMORY"])
+			}
+		}
+
+		AssertTemplateTestSuccess := func() {
+			It("should succeed to create VirtualMachine via oc command", AssertVMCreationSuccess())
+			It("should fail to delete VirtualMachine via oc command", AssertVMDeletionFailure())
+
+			When("the VirtualMachine was created", func() {
+				BeforeEach(AssertVMCreationSuccess())
+				It("should succeed to start the VirtualMachine via oc command", AssertVMStartSuccess("oc"))
+				It("should succeed to delete VirtualMachine via oc command", AssertVMDeletionSuccess())
+				It("should fail to create the same VirtualMachine via oc command", AssertVMCreationFailure())
 			})
 		}
 
-		BeforeEach(func() {
-			parameters = templateParams{
-				name:     "testvm",
-				cpuCores: "2",
-			}
-			vmJsonFile = fmt.Sprintf("%s.json", parameters.name)
-			Expect(vmJsonFile).NotTo(BeAnExistingFile())
+		BeforeEach(AssertTestSetupSuccess())
+
+		AfterEach(AssertTestCleanupSuccess())
+
+		Context("with Fedora Template", func() {
+			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTestTemplateFedora(), nil))
+
+			AssertTemplateTestSuccess()
 		})
 
-		JustBeforeEach(func() {
-			var err error
-			templateJsonFile, err = tests.GenerateTemplateJson(template)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(templateJsonFile).To(BeAnExistingFile())
-		})
-
-		AfterEach(func() {
-			assertRemovedFile(vmJsonFile)()
-			assertRemovedFile(templateJsonFile)()
-		})
-
-		Context("with given Fedora Template", func() {
-			BeforeEach(func() {
-				template = vmsgen.GetTestTemplateFedora()
-			})
-
-			testGivenTemplate()
-		})
-
-		Context("with given RHEL Template", func() {
+		Context("with RHEL Template", func() {
 			BeforeEach(func() {
 				tests.SkipIfNoRhelImage(virtClient)
-				template = vmsgen.GetTestTemplateRHEL7()
+				AssertTemplateSetupSuccess(vmsgen.GetTestTemplateRHEL7(), nil)()
 			})
 
-			testGivenTemplate()
+			AssertTemplateTestSuccess()
 		})
 	})
 })
-
-type templateParams struct {
-	name     string
-	cpuCores string
-	memory   string
-}
-
-func runOcProcessCommand(templateJsonFile string, parameters templateParams, vmJsonFile string) (string, string, error) {
-	parameterArgs := []string{"-p", "NAME=" + parameters.name, "-p", "CPU_CORES=" + parameters.cpuCores}
-	args := append([]string{"process", "-f", templateJsonFile}, parameterArgs...)
-	out, stderr, err := tests.RunCommand("oc", args...)
-	if err != nil {
-		return out, stderr, err
-	}
-	err = ioutil.WriteFile(vmJsonFile, []byte(out), 0644)
-	if err != nil {
-		return out, stderr, fmt.Errorf("failed to write json file %s", vmJsonFile)
-	}
-	return out, stderr, err
-}
-
-func runOcCreateCommand(vmJsonFile string) (string, string, error) {
-	return tests.RunCommand("oc", "create", "-f", vmJsonFile)
-}
-
-func runOcPatchCommand(vmName string, patch string) (string, string, error) {
-	return tests.RunCommand("oc", "patch", "virtualmachine", vmName, "--type", "merge", "-p", patch)
-}
-
-func runOcDeleteCommand(vmName string) (string, string, error) {
-	return tests.RunCommand("oc", "delete", "vm", vmName)
-}
-
-func runOcGetCommand(resourceType string) (string, string, error) {
-	return tests.RunCommand("oc", "get", resourceType)
-}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1847,6 +1847,107 @@ func RunCommandWithNS(namespace string, cmdName string, args ...string) (string,
 	return outputString, stderrString, nil
 }
 
+func RunCommandPipe(commands ...[]string) (string, string, error) {
+	return RunCommandPipeWithNS(NamespaceTestDefault, commands...)
+}
+
+func RunCommandPipeWithNS(namespace string, commands ...[]string) (string, string, error) {
+	commandPipeString := func() string {
+		commandStrings := []string{}
+		for _, command := range commands {
+			commandStrings = append(commandStrings, strings.Join(command, " "))
+		}
+		return strings.Join(commandStrings, " | ")
+	}
+
+	if len(commands) < 2 {
+		err := goerrors.New("requires at least two commands")
+		log.Log.Reason(err).With("command", commandPipeString()).Error("command pipe failed")
+		return "", "", fmt.Errorf("command pipe failed: %v", err)
+	}
+
+	for i, command := range commands {
+		cmdPath := ""
+		cmdName := strings.ToLower(command[0])
+		switch cmdName {
+		case "oc":
+			cmdPath = KubeVirtOcPath
+		case "kubectl":
+			cmdPath = KubeVirtKubectlPath
+		case "virtctl":
+			cmdPath = KubeVirtVirtctlPath
+		}
+		if cmdPath == "" {
+			err := fmt.Errorf("no %s binary specified", cmdName)
+			log.Log.Reason(err).With("command", commandPipeString()).Error("command pipe failed")
+			return "", "", fmt.Errorf("command pipe failed: %v", err)
+		}
+		commands[i][0] = cmdPath
+	}
+
+	kubeconfig := flag.Lookup("kubeconfig").Value
+	if kubeconfig == nil || kubeconfig.String() == "" {
+		err := goerrors.New("cannot find kubeconfig")
+		log.Log.Reason(err).With("command", commandPipeString()).Error("command pipe failed")
+		return "", "", fmt.Errorf("command pipe failed: %v", err)
+	}
+	kubeconfEnv := fmt.Sprintf("KUBECONFIG=%s", kubeconfig.String())
+
+	master := flag.Lookup("master").Value
+	cmds := make([]*exec.Cmd, len(commands))
+	for i := range cmds {
+		if master != nil && master.String() != "" {
+			commands[i] = append(commands[i], "--server", master.String())
+		}
+		if namespace != "" {
+			commands[i] = append(commands[i], "-n", namespace)
+		}
+		cmds[i] = exec.Command(commands[i][0], commands[i][1:]...)
+		cmds[i].Env = append(os.Environ(), kubeconfEnv)
+	}
+
+	var output, stderr bytes.Buffer
+	captureOutputBuffers := func() (string, string) {
+		trimNullChars := func(buf bytes.Buffer) string {
+			return string(bytes.Trim(buf.Bytes(), "\x00"))
+		}
+		return trimNullChars(output), trimNullChars(stderr)
+	}
+
+	last := len(cmds) - 1
+	for i, cmd := range cmds[:last] {
+		var err error
+		if cmds[i+1].Stdin, err = cmd.StdoutPipe(); err != nil {
+			cmdArgString := strings.Join(cmd.Args, " ")
+			log.Log.Reason(err).With("command", commandPipeString()).Errorf("command pipe failed: cannot attach stdout pipe to command %q", cmdArgString)
+			return "", "", fmt.Errorf("command pipe failed: cannot attach stdout pipe to command %q: %v", cmdArgString, err)
+		}
+		cmd.Stderr = &stderr
+	}
+	cmds[last].Stdout, cmds[last].Stderr = &output, &stderr
+
+	for _, cmd := range cmds {
+		if err := cmd.Start(); err != nil {
+			outputString, stderrString := captureOutputBuffers()
+			cmdArgString := strings.Join(cmd.Args, " ")
+			log.Log.Reason(err).With("command", commandPipeString(), "output", outputString, "stderr", stderrString).Errorf("command pipe failed: cannot start command %q", cmdArgString)
+			return outputString, stderrString, fmt.Errorf("command pipe failed: cannot start command %q: %v", cmdArgString, err)
+		}
+	}
+
+	for _, cmd := range cmds {
+		if err := cmd.Wait(); err != nil {
+			outputString, stderrString := captureOutputBuffers()
+			cmdArgString := strings.Join(cmd.Args, " ")
+			log.Log.Reason(err).With("command", commandPipeString(), "output", outputString, "stderr", stderrString).Errorf("command pipe failed: error while waiting for command %q", cmdArgString)
+			return outputString, stderrString, fmt.Errorf("command pipe failed: error while waiting for command %q: %v", cmdArgString, err)
+		}
+	}
+
+	outputString, stderrString := captureOutputBuffers()
+	return outputString, stderrString, nil
+}
+
 func GenerateVMIJson(vmi *v1.VirtualMachineInstance) (string, error) {
 	data, err := json.Marshal(vmi)
 	if err != nil {

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -115,11 +115,13 @@ func getHookSidecarLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 func getVmDomainXml(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {
 	podName := getVmPodName(virtCli, vmi)
 
-	vmNameListRaw, err := tests.RunCommand("kubectl", "exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "list", "--name")
+	// passing an empty namespace allows to position --namespace argument correctly
+	vmNameListRaw, _, err := tests.RunCommandWithNS("", "kubectl", "exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "list", "--name")
 	Expect(err).ToNot(HaveOccurred())
 
 	vmName := strings.Split(vmNameListRaw, "\n")[0]
-	vmDomainXML, err := tests.RunCommand("kubectl", "exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "dumpxml", vmName)
+	// passing an empty namespace allows to position --namespace argument correctly
+	vmDomainXML, _, err := tests.RunCommandWithNS("", "kubectl", "exec", "-ti", "--namespace", vmi.GetObjectMeta().GetNamespace(), podName, "--container", "compute", "--", "virsh", "dumpxml", vmName)
 	Expect(err).ToNot(HaveOccurred())
 
 	return vmDomainXML

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 
 		It("should succeed to start a vmi", func() {
 			By("Starting the vmi via kubectl command")
-			_, err = tests.RunCommand("kubectl", "create", "-f", yamlFile)
+			_, _, err = tests.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 120)
@@ -249,14 +249,14 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 
 		It("should succeed to stop a vmi", func() {
 			By("Starting the vmi via kubectl command")
-			_, err = tests.RunCommand("kubectl", "create", "-f", yamlFile)
+			_, _, err = tests.RunCommand("kubectl", "create", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitForSuccessfulVMIStartWithTimeout(windowsVMI, 120)
 
 			podSelector := tests.UnfinishedVMIPodSelector(windowsVMI)
 			By("Deleting the vmi via kubectl command")
-			_, err = tests.RunCommand("kubectl", "delete", "-f", yamlFile)
+			_, _, err = tests.RunCommand("kubectl", "delete", "-f", yamlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the vmi does not exist anymore")

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -468,16 +468,8 @@ func GetVMCirros() *v1.VirtualMachine {
 }
 
 func GetTemplateFedora() *Template {
-	return newTemplateFedoraWithDockerTag(DockerTag)
-}
-
-func GetTestTemplateFedora() *Template {
-	return newTemplateFedoraWithDockerTag("latest")
-}
-
-func newTemplateFedoraWithDockerTag(dockerTag string) *Template {
 	vm := getBaseVM("", map[string]string{"kubevirt-vm": "vm-${NAME}", "kubevirt.io/os": "fedora27"})
-	addRegistryDisk(&vm.Spec.Template.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, dockerTag), busVirtio)
+	addRegistryDisk(&vm.Spec.Template.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
 	addNoCloudDiskWitUserData(&vm.Spec.Template.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
 
 	template := getBaseTemplate(vm, "4096Mi", "4")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the following functionality:
- [x] Refactor and extend `tests.RunCommand()` function to be more verbose, to allow separate handling of `stdout` and `stderr`, and to confine the executed external command to clearly defined namespace.
- [x] Implement new function `test.RunCommandPipe()` function that allows executing a set of commands chained by stdout pipe. It follows the logic of the new `tests.RunCommand()`.
- [x] Extend and refactor `tests/template_test.go`, simplify code structure and add more test case to comply actual test plan, optimize test time, add the proper annotation to all Gomega matcher calls to simplify debugging.

We need to this PR to optimize test execution and to extend test coverage. This PR also sets the ground for future test automation. The Template test was also modified to be backward compatible with the older KubeVirt releases; thus it is recommendable to include this test into cherry-picked backports.

**Special notes for your reviewer**:
I provide a detailed description of the partial contributions in the corresponding commit messages. All commits were rebased on top of `master` branch.

**Release note**:
```release-note
NONE
```