### PR TITLE
Report mac addresses in vmi status interfaces section

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5527,6 +5527,10 @@
      "mac": {
       "description": "Hardware address of a Virtual Machine interface",
       "type": "string"
+     },
+     "name": {
+      "description": "Name of the interface, corresponds to name of the network assigned to the interface",
+      "type": "string"
      }
     }
    },

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1998,6 +1998,13 @@ func schema_kubevirt_pkg_api_v1_VirtualMachineInstanceNetworkInterface(ref commo
 							Format:      "",
 						},
 					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the interface, corresponds to name of the network assigned to the interface",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -293,6 +293,9 @@ type VirtualMachineInstanceNetworkInterface struct {
 	IP string `json:"ipAddress,omitempty"`
 	// Hardware address of a Virtual Machine interface
 	MAC string `json:"mac,omitempty"`
+	// Name of the interface, corresponds to name of the network assigned to the interface
+	// TODO: remove omitempty, when api breaking changes are allowed
+	Name string `json:"name,omitempty"`
 }
 
 type VirtualMachineInstanceMigrationState struct {

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -51,6 +51,7 @@ func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"ipAddress": "IP address of a Virtual Machine interface",
 		"mac":       "Hardware address of a Virtual Machine interface",
+		"name":      "Name of the interface, corresponds to name of the network assigned to the interface",
 	}
 }
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -310,11 +310,15 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			if isPodOwnedByHandler(pod) {
 				// vmi is still owned by the controller but pod is already handed over,
 				// so let's hand over the vmi too
-				vmiCopy.Status.Interfaces = []virtv1.VirtualMachineInstanceNetworkInterface{
-					{
-						IP: pod.Status.PodIP,
-					},
+				interfaces := make([]virtv1.VirtualMachineInstanceNetworkInterface, 0)
+				for _, network := range vmi.Spec.Networks {
+					if network.NetworkSource.Pod != nil {
+						ifc := virtv1.VirtualMachineInstanceNetworkInterface{Name: network.Name, IP: pod.Status.PodIP}
+						interfaces = append(interfaces, ifc)
+					}
 				}
+				vmiCopy.Status.Interfaces = interfaces
+
 				vmiCopy.Status.Phase = virtv1.Scheduled
 				if vmiCopy.Labels == nil {
 					vmiCopy.Labels = map[string]string{}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -824,6 +824,72 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			table.Entry("and in failed state", k8sv1.PodFailed),
 		)
 	})
+
+	Context("When VirtualMachineInstance is connected to a network", func() {
+		It("should report the status of this network", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = v1.Scheduling
+			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
+
+			addVirtualMachine(vmi)
+			podFeeder.Add(pod)
+
+			networkName := "test net"
+			podIp := "1.1.1.1"
+			pod.Annotations[v1.OwnedByAnnotation] = "virt-handler"
+			pod.Status.PodIP = podIp
+			vmi.Spec.Networks = []v1.Network{
+				v1.Network{
+					Name: networkName,
+					NetworkSource: v1.NetworkSource{
+						Pod: &v1.PodNetwork{
+							VMNetworkCIDR: "1.1.1.1",
+						},
+					},
+				},
+			}
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Interfaces)).To(Equal(1))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].Name).To(Equal(networkName))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IP).To(Equal(podIp))
+			}).Return(vmi, nil)
+			controller.Execute()
+		})
+
+		It("should only report the pod network in status", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = v1.Scheduling
+			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
+
+			addVirtualMachine(vmi)
+			podFeeder.Add(pod)
+
+			networkName := "test net"
+			pod.Annotations[v1.OwnedByAnnotation] = "virt-handler"
+			vmi.Spec.Networks = []v1.Network{
+				v1.Network{
+					Name: networkName,
+					NetworkSource: v1.NetworkSource{
+						Pod: &v1.PodNetwork{
+							VMNetworkCIDR: "1.1.1.1",
+						},
+					},
+				},
+				v1.Network{
+					Name: networkName,
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.CniNetwork{
+							NetworkName: "multus",
+						},
+					},
+				},
+			}
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Interfaces)).To(Equal(1))
+			}).Return(vmi, nil)
+			controller.Execute()
+		})
+	})
 })
 
 func NewPendingVirtualMachine(name string) *v1.VirtualMachineInstance {


### PR DESCRIPTION
Report mac addresses in vmi status interfaces section
Preserve the ip address given to eth0 by dhcp
The patch recognizes the 'primary' interface (with ip set by our dhcp code) by it's name "k6t-eth0"

```release-note
VMI status is updated with a list of all network interfaces added to the vmi.
Initially each interface consists of the interface name, and the IP for the pod interface.
After the vmi is started and additional data is received from libvirt, the interfaces in the
vmi status are populated with mac addresses.
```