### PR TITLE
[RFC][POC] Add collectd node agent to export VMI metrics

### DIFF
--- a/manifests/cluster-monitoring-collectd-config.yaml
+++ b/manifests/cluster-monitoring-collectd-config.yaml
@@ -1,0 +1,22 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: collectd-config
+  namespace: kube-system
+data:
+  node-collectd.conf: |-
+    LoadPlugin syslog
+    <Plugin syslog>
+       LogLevel info
+    </Plugin>
+    LoadPlugin write_prometheus
+    <Plugin "write_prometheus">
+      Port "9090"
+    </Plugin>
+    LoadPlugin unixsock
+    <Plugin unixsock>
+      SocketFile "/var/run/collectd.sock"
+      SocketPerms "0700"
+      DeleteSocket true
+    </Plugin>
+

--- a/manifests/cluster-monitoring-collectd-node-agent.yaml
+++ b/manifests/cluster-monitoring-collectd-node-agent.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: collectd-node-agent
+  namespace: kube-system
+  labels:
+    app: collectd-node-agent
+spec:
+  template:
+    metadata:
+      labels:
+        name: collectd-node-agent
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      serviceAccountName: kubevirt-privileged
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        node-role.kubernetes.io/infra: "true"
+      containers:
+      - name: collectd
+        ports:
+        - containerPort: 9091
+          protocol: TCP
+        image: fromanirh/collectd:0.3.5
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: collectd-config
+          mountPath: /etc/collectd
+      volumes:
+      - name: collectd-config
+        configMap:
+          name: collectd-config
+          items:
+          - key: node-collectd.conf
+            path: collectd.conf
+


### PR DESCRIPTION
In order to monitor, troubleshoot and tune VMs, we would like
to expose detailed metrics about how the VM instance is behaving.
We are concerned about the infrastructure here, so the infrastructure
processes running inside the virt-launcher pod.
For example, we want to assess the overhead of the aformenentioned
infrastructure, allowing to have answers to queries like

- how much memory is libvirtd taking?
- is that memory growing?
- how much memory QEMU takes?
- is libvirtd leaking threads?

This patch provide the initial support to report those metrics.

Signed-off-by: Francesco Romani <fromani@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR is a POC implementation to expose VMI detailed metrics

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/1594

**Special notes for your reviewer**:
Still pending:
- polishing: need to review permissions and reduce even more the privileges needed, if possible
- ServiceMonitor integration, still WIP

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add detailed VMI metric reporting, for tuning and troubleshooting.
```
