### PR TITLE
Add regression test for creating a VMI with name longer than 63 characters

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -954,6 +954,14 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 	return NewRandomVMIWithNS(NamespaceTestDefault)
 }
 
+func NewRandomLongNameVMI() *v1.VirtualMachineInstance {
+	vmi := v1.NewMinimalVMIWithNS(NamespaceTestDefault, "testvmi"+rand.String(63))
+
+	t := defaultTestGracePeriod
+	vmi.Spec.TerminationGracePeriodSeconds = &t
+	return vmi
+}
+
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi"+rand.String(48))
 
@@ -1016,6 +1024,14 @@ func NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(containerImage string, u
 
 func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
+
+	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
+	return vmi
+}
+
+func NewRandomLongNameVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
+	vmi := NewRandomLongNameVMI()
 
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -954,14 +954,6 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 	return NewRandomVMIWithNS(NamespaceTestDefault)
 }
 
-func NewRandomLongNameVMI() *v1.VirtualMachineInstance {
-	vmi := v1.NewMinimalVMIWithNS(NamespaceTestDefault, "testvmi"+rand.String(63))
-
-	t := defaultTestGracePeriod
-	vmi.Spec.TerminationGracePeriodSeconds = &t
-	return vmi
-}
-
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi"+rand.String(48))
 
@@ -1024,14 +1016,6 @@ func NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(containerImage string, u
 
 func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
-
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
-	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
-	return vmi
-}
-
-func NewRandomLongNameVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
-	vmi := NewRandomLongNameVMI()
 
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -191,6 +191,10 @@ var _ = Describe("VMIlifecycle", func() {
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
 				Expect(vmi.IsReady()).To(BeTrue(), "VirtualMachineInstance %q is not ready: %v", vmi.Name, vmi.Status.Phase)
+				By("Obtaining serial console")
+				expecter, err := tests.LoggedInAlpineExpecter(vmi)
+				Expect(err).ToNot(HaveOccurred(), "VirtualMachineInstance %q console is not accessible: %v", vmi.Name, err)
+				expecter.Close()
 			})
 		})
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -39,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
@@ -178,19 +179,21 @@ var _ = Describe("VMIlifecycle", func() {
 
 		Context("when name is longer than 63 characters", func() {
 			BeforeEach(func() {
-				vmi = tests.NewRandomLongNameVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
-				Expect(len(vmi.Name)).To(BeNumerically(">", 63), "VirtualMachineInstance %q name is not longer than 63 characters", vmi.Name)
+				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskAlpine))
+				vmi.Name = "testvmi" + rand.String(63)
 			})
 			It("should start it", func() {
 				By("Creating a VirtualMachineInstance with a long name")
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred(), "cannot create VirtualMachineInstance %q: %v", vmi.Name, err)
 				Expect(len(vmi.Name)).To(BeNumerically(">", 63), "VirtualMachineInstance %q name is not longer than 63 characters", vmi.Name)
+
 				By("Waiting until it starts")
 				tests.WaitForSuccessfulVMIStart(vmi)
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
 				Expect(vmi.IsReady()).To(BeTrue(), "VirtualMachineInstance %q is not ready: %v", vmi.Name, vmi.Status.Phase)
+
 				By("Obtaining serial console")
 				expecter, err := tests.LoggedInAlpineExpecter(vmi)
 				Expect(err).ToNot(HaveOccurred(), "VirtualMachineInstance %q console is not accessible: %v", vmi.Name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
I added a test to `tests/vmi_lifecycle_test.go` to capture eventual regressions of the issue #1222 that had been fixed by PR #1320.

**Release note**:
```release-note
NONE
```
