### PR TITLE
DiskSecret: either have Usage or UUID, not both

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -307,8 +307,8 @@ type DiskAuth struct {
 }
 
 type DiskSecret struct {
-	Type  string `xml:"type,attr"`
-	Usage string `xml:"usage,attr"`
+	Type  string `xml:"type,attr,omitempty"`
+	Usage string `xml:"usage,attr,omitempty"`
 }
 
 type ReadOnly struct{}


### PR DESCRIPTION
While deserializing DiskSecrets as part of virt-wrapper/api, libvirt only accepts 
either Usage or UUID but not both. Not even "" (empty)

Signed-off-by: Alexander Gallego <gallego.alexx@gmail.com>