### PR TITLE
Move kubevirt to the kubevirt namespace by default

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -123,7 +123,7 @@ if [ -n "${JOB_NAME}" ]; then
 namespace=${NAMESPACE}
 EOF
 else
-  export NAMESPACE="${NAMESPACE:-kube-system}"
+  export NAMESPACE="${NAMESPACE:-kubevirt}"
 fi
 
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,8 +160,8 @@ Finally start a VMI called `vmi-ephemeral`:
     # You can actually use kubelet.sh to introspect the cluster in general
     ./cluster/kubectl.sh get pods
 
-    # To check the running kubevirt services you need to introspect the `kube-system` namespace:
-    ./cluster/kubectl.sh -n kube-system get pods
+    # To check the running kubevirt services you need to introspect the `kubevirt` namespace:
+    ./cluster/kubectl.sh -n kubevirt get pods
 ```
 
 This will start a VMI on master or one of the running nodes with a macvtap and a
@@ -173,7 +173,7 @@ tap networking device attached.
 $ ./cluster/kubectl.sh create -f cluster/examples/vmi-ephemeral.yaml
 vm "vmi-ephemeral" created
 
-$ ./cluster/kubectl.sh -n kube-system get pods
+$ ./cluster/kubectl.sh -n kubevirt get pods
 NAME                              READY     STATUS    RESTARTS   AGE
 virt-api                          1/1       Running   1          10h
 virt-controller                   1/1       Running   1          10h

--- a/docs/software-emulation.md
+++ b/docs/software-emulation.md
@@ -18,19 +18,19 @@ If `useEmulation` is enabled,
 # Configuration
 
 Enabling software emulation is a cluster-wide setting, and is activated using a
-ConfigMap in the `kube-system` namespace. It can be enabled with the following
+ConfigMap in the `kubevirt` namespace. It can be enabled with the following
 command:
 
 ```bash
-cluster/kubectl.sh --namespace kube-system create configmap kubevirt-config \
+cluster/kubectl.sh --namespace kubevirt create configmap kubevirt-config \
     --from-literal debug.useEmulation=true
 ```
 
-If the `kube-system/kubevirt-config` ConfigMap already exists, the above entry
+If the `kubevirt/kubevirt-config` ConfigMap already exists, the above entry
 can be added using:
 
 ```bash
-cluster/kubectl.sh --namespace kube-system edit configmap kubevirt-config
+cluster/kubectl.sh --namespace kubevirt edit configmap kubevirt-config
 ```
 
 In this case, add the `debug.useEmulation: "true"` setting to `data`:
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-config
-  namespace: kube-system
+  namespace: kubevirt
 data:
   debug.useEmulation: "true"
 

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -4,5 +4,5 @@ docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel
-namespace=kube-system
+namespace=kubevirt
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the default installation namespace from `kube-system` to `kubevirt`. Creating the namespace itself is not part of the release-manifests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1553, #1581, #1491

**Special notes for your reviewer**:

Three questions remain:

 * should we include the `kubevirt` namespace yaml in our release manifests or should the user create the namespace?
 * should we run locally for engineers in a fixed namespace different than `kubevirt`?
 * should we switch by default to `kubevirt` or stick to `kube-system` and basically just ensure that kubevirt works if installed in random namespaces?



**Release note**:

```release-note
Change the default installation namespace to "kubevirt". The namespace creation itself is not included in the manifests.
```

/hold