### PR TITLE
Ensure that transitive builds work with kubevirt after glog shadowing was introduced

### DIFF
--- a/cmd/fake-qemu-process/fake-qemu.go
+++ b/cmd/fake-qemu-process/fake-qemu.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -31,13 +30,12 @@ import (
 )
 
 func main() {
-	uuid := flag.String("uuid", "", "some fake arg")
+	uuid := pflag.String("uuid", "", "some fake arg")
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt,
 		syscall.SIGTERM,
 	)
 
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 	fmt.Printf("Started fake qemu process with uuid %s\n", *uuid)
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -99,7 +99,7 @@ func (app *virtHandlerApp) Run() {
 	}
 
 	logger := log.Log
-	logger.V(1).Level(glog.INFO).Log("hostname", app.HostOverride)
+	logger.V(1).Level(log.INFO).Log("hostname", app.HostOverride)
 
 	// Create event recorder
 	virtCli, err := kubecli.GetKubevirtClient()

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -20,7 +20,7 @@
 package main
 
 import (
-	"flag"
+	goflag "flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -303,23 +303,23 @@ func waitForFinalNotify(deleteNotificationSent chan watch.Event,
 }
 
 func main() {
-	qemuTimeout := flag.Duration("qemu-timeout", defaultStartTimeout, "Amount of time to wait for qemu")
-	virtShareDir := flag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
-	ephemeralDiskDir := flag.String("ephemeral-disk-dir", "/var/run/kubevirt-ephemeral-disks", "Base directory for ephemeral disk data")
-	name := flag.String("name", "", "Name of the VirtualMachineInstance")
-	uid := flag.String("uid", "", "UID of the VirtualMachineInstance")
-	namespace := flag.String("namespace", "", "Namespace of the VirtualMachineInstance")
-	watchdogInterval := flag.Duration("watchdog-update-interval", defaultWatchdogInterval, "Interval at which watchdog file should be updated")
-	readinessFile := flag.String("readiness-file", "/tmp/health", "Pod looks for this file to determine when virt-launcher is initialized")
-	gracePeriodSeconds := flag.Int("grace-period-seconds", 30, "Grace period to observe before sending SIGTERM to vm process")
-	useEmulation := flag.Bool("use-emulation", false, "Use software emulation")
-	hookSidecars := flag.Uint("hook-sidecars", 0, "Number of requested hook sidecars, virt-launcher will wait for all of them to become available")
-	noFork := flag.Bool("no-fork", false, "Fork and let virt-launcher watch itself to react to crashes if set to false")
+	qemuTimeout := pflag.Duration("qemu-timeout", defaultStartTimeout, "Amount of time to wait for qemu")
+	virtShareDir := pflag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
+	ephemeralDiskDir := pflag.String("ephemeral-disk-dir", "/var/run/kubevirt-ephemeral-disks", "Base directory for ephemeral disk data")
+	name := pflag.String("name", "", "Name of the VirtualMachineInstance")
+	uid := pflag.String("uid", "", "UID of the VirtualMachineInstance")
+	namespace := pflag.String("namespace", "", "Namespace of the VirtualMachineInstance")
+	watchdogInterval := pflag.Duration("watchdog-update-interval", defaultWatchdogInterval, "Interval at which watchdog file should be updated")
+	readinessFile := pflag.String("readiness-file", "/tmp/health", "Pod looks for this file to determine when virt-launcher is initialized")
+	gracePeriodSeconds := pflag.Int("grace-period-seconds", 30, "Grace period to observe before sending SIGTERM to vm process")
+	useEmulation := pflag.Bool("use-emulation", false, "Use software emulation")
+	hookSidecars := pflag.Uint("hook-sidecars", 0, "Number of requested hook sidecars, virt-launcher will wait for all of them to become available")
+	noFork := pflag.Bool("no-fork", false, "Fork and let virt-launcher watch itself to react to crashes if set to false")
 
 	// set new default verbosity, was set to 0 by glog
-	flag.Set("v", "2")
+	goflag.Set("v", "2")
 
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
 	pflag.Parse()
 
 	log.InitializeLogging("virt-launcher")

--- a/hack/dep-prune.sh
+++ b/hack/dep-prune.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
 for file in $(find vendor/ -name "*_test.go"); do rm ${file}; done
+rm -rf vendor/github.com/golang/glog
+mkdir -p vendor/github.com/golang/
+ln -s ../../../pkg/staging/glog/ vendor/github.com/golang/glog

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"runtime/debug"
 
-	"github.com/golang/glog"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -71,7 +70,7 @@ func NewListWatchFromClient(c cache.Getter, resource string, namespace string, f
 
 func HandlePanic() {
 	if r := recover(); r != nil {
-		log.Log.Level(glog.FATAL).Log("stacktrace", debug.Stack(), "msg", r)
+		log.Log.Level(log.FATAL).Log("stacktrace", debug.Stack(), "msg", r)
 	}
 }
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang/glog"
 	k8sv1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -96,7 +95,7 @@ func TestBadLevel(t *testing.T) {
 func TestGoodLevel(t *testing.T) {
 	setUp()
 	l := Logger("test")
-	error := l.SetLogLevel(glog.INFO)
+	error := l.SetLogLevel(INFO)
 	assert(t, error == nil, "Unable to set log level")
 	tearDown()
 }
@@ -118,14 +117,14 @@ func TestComponent(t *testing.T) {
 func TestInfoCutoff(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.WARNING)
-	assert(t, log.filterLevel == glog.WARNING, "Unable to set log level")
+	log.SetLogLevel(WARNING)
+	assert(t, log.filterLevel == WARNING, "Unable to set log level")
 
-	log = log.Level(glog.INFO)
+	log = log.Level(INFO)
 	log.Log("This is an info message")
 	assert(t, !logCalled, "Info log entry should not have been recorded")
 
-	log = log.Level(glog.WARNING)
+	log = log.Level(WARNING)
 	log.Log("This is a warning message")
 	assert(t, logCalled, "Warning log entry should have been recorded")
 	tearDown()
@@ -181,13 +180,13 @@ func TestCachedLoggers(t *testing.T) {
 	log.SetLogger(logger)
 
 	// set a value on this log class
-	log.SetLogLevel(glog.ERROR)
+	log.SetLogLevel(ERROR)
 	// obtain a new filtered logger and prove it reflects that same log level
 
 	log2 := Logger("test")
 
-	assert(t, log.filterLevel == glog.ERROR, "Log object was not correctly filtered")
-	assert(t, log2.filterLevel == glog.ERROR, "Log object was not cached")
+	assert(t, log.filterLevel == ERROR, "Log object was not correctly filtered")
+	assert(t, log2.filterLevel == ERROR, "Log object was not cached")
 	tearDown()
 }
 
@@ -195,10 +194,10 @@ func TestWarningCutoff(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
 
-	log.Level(glog.WARNING).Log("message", "test warning message")
+	log.Level(WARNING).Log("message", "test warning message")
 	assert(t, logCalled, "Warning level message should have been recorded")
 
-	log.Level(glog.ERROR).Log("error", "test error message")
+	log.Level(ERROR).Log("error", "test error message")
 	assert(t, logCalled, "Error level message should have been recorded")
 	tearDown()
 }
@@ -207,20 +206,20 @@ func TestLogConcurrency(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
 	// create a new log object from the previous one.
-	log2 := log.Level(glog.WARNING)
+	log2 := log.Level(WARNING)
 	assert(t, log.currentLogLevel != log2.currentLogLevel, "log and log2 should not have the same log level")
-	assert(t, log.currentLogLevel == glog.INFO, "Calling Warning() did not create a new log object")
+	assert(t, log.currentLogLevel == INFO, "Calling Warning() did not create a new log object")
 	tearDown()
 }
 
 func TestInfoMessage(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
-	log.Level(glog.INFO).Log("test", "message")
+	log.SetLogLevel(INFO)
+	log.Level(INFO).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.INFO], "Logged line was not glog.INFO level")
+	assert(t, logEntry[1].(string) == LogLevelNames[INFO], "Logged line was not infoLevel level")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
 	assert(t, logEntry[7].(string) == "test", "Component was not logged")
@@ -230,11 +229,11 @@ func TestInfoMessage(t *testing.T) {
 func TestWarningMessage(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.WARNING)
-	log.Level(glog.WARNING).Log("test", "message")
+	log.SetLogLevel(WARNING)
+	log.Level(WARNING).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.WARNING], "Logged line was not glog.WARNING level")
+	assert(t, logEntry[1].(string) == LogLevelNames[WARNING], "Logged line was not warningLevel level")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
 	assert(t, logEntry[7].(string) == "test", "Component was not logged")
@@ -244,11 +243,11 @@ func TestWarningMessage(t *testing.T) {
 func TestErrorMessage(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.ERROR)
-	log.Level(glog.ERROR).Log("test", "message")
+	log.SetLogLevel(ERROR)
+	log.Level(ERROR).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.ERROR], "Logged line was not glog.ERROR level")
+	assert(t, logEntry[1].(string) == LogLevelNames[ERROR], "Logged line was not errorLevel level")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
 	assert(t, logEntry[7].(string) == "test", "Component was not logged")
@@ -258,11 +257,11 @@ func TestErrorMessage(t *testing.T) {
 func TestCriticalMessage(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.FATAL)
-	log.Level(glog.FATAL).Log("test", "message")
+	log.SetLogLevel(FATAL)
+	log.Level(FATAL).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.FATAL], "Logged line was not glog.FATAL level")
+	assert(t, logEntry[1].(string) == LogLevelNames[FATAL], "Logged line was not fatalLevel level")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
 	assert(t, logEntry[7].(string) == "test", "Component was not logged")
@@ -272,12 +271,12 @@ func TestCriticalMessage(t *testing.T) {
 func TestObject(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	vm := v1.VirtualMachineInstance{ObjectMeta: v12.ObjectMeta{Namespace: "test"}}
 	log.Object(&vm).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.INFO], "Logged line was not of level glog.INFO")
+	assert(t, logEntry[1].(string) == LogLevelNames[INFO], "Logged line was not of level infoLevel")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[4].(string) == "pos", "Logged line was not pos")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
@@ -292,7 +291,7 @@ func TestObject(t *testing.T) {
 func TestObjectRef(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	vmRef := &k8sv1.ObjectReference{
 		Kind:      "test",
 		Name:      "test",
@@ -302,7 +301,7 @@ func TestObjectRef(t *testing.T) {
 	log.ObjectRef(vmRef).Log("test", "message")
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.INFO], "Logged line was not of level glog.INFO")
+	assert(t, logEntry[1].(string) == LogLevelNames[INFO], "Logged line was not of level infoLevel")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[4].(string) == "pos", "Logged line was not pos")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
@@ -317,9 +316,9 @@ func TestObjectRef(t *testing.T) {
 func TestError(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	err := errors.New("Test error")
-	log.Level(glog.ERROR).Log(err)
+	log.Level(ERROR).Log(err)
 	assert(t, logCalled, "Error was not logged via .Log()")
 
 	logCalled = false
@@ -340,13 +339,13 @@ func TestError(t *testing.T) {
 func TestMultipleLevels(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	// change levels more than once
-	log.Level(glog.WARNING).Level(glog.INFO).Level(glog.WARNING).msg("test")
+	log.Level(WARNING).Level(INFO).Level(WARNING).msg("test")
 
 	logEntry := logParams[0].([]interface{})
 	assert(t, logEntry[0].(string) == "level", "Logged line did not have level entry")
-	assert(t, logEntry[1].(string) == glog.LogLevelNames[glog.WARNING], "Logged line was not of level glog.WARNING")
+	assert(t, logEntry[1].(string) == LogLevelNames[WARNING], "Logged line was not of level warningLevel")
 	assert(t, logEntry[2].(string) == "timestamp", "Logged line is not expected format")
 	assert(t, logEntry[4].(string) == "pos", "Logged line was not pos")
 	assert(t, logEntry[6].(string) == "component", "Logged line is not expected format")
@@ -359,7 +358,7 @@ func TestMultipleLevels(t *testing.T) {
 func TestLogVerbosity(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	log.SetVerbosityLevel(2)
 	log.V(2).Log("msg", "test")
 
@@ -372,7 +371,7 @@ func TestLogVerbosity(t *testing.T) {
 func TestMsgVerbosity(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	log.SetVerbosityLevel(2)
 	log.V(2).msg("test")
 
@@ -384,7 +383,7 @@ func TestMsgVerbosity(t *testing.T) {
 func TestMsgfVerbosity(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})
-	log.SetLogLevel(glog.INFO)
+	log.SetLogLevel(INFO)
 	log.SetVerbosityLevel(2)
 	log.V(2).msgf("%s", "test")
 

--- a/pkg/rest/filter/filter.go
+++ b/pkg/rest/filter/filter.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/emicklei/go-restful"
-	"github.com/golang/glog"
 
 	"kubevirt.io/kubevirt/pkg/log"
 )
@@ -37,7 +36,7 @@ func RequestLoggingFilter() restful.FilterFunction {
 			}
 		}
 		chain.ProcessFilter(req, resp)
-		log.Log.Level(glog.INFO).
+		log.Log.Level(log.INFO).
 			With("remoteAddress", strings.Split(req.Request.RemoteAddr, ":")[0]).
 			With("username", username).
 			With("method", req.Request.Method).

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -47,7 +47,9 @@ func (service *ServiceListen) Address() string {
 }
 
 func (service *ServiceListen) InitFlags() {
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("kubeconfig"))
+	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("master"))
 }
 
 func (service *ServiceListen) AddCommonFlags() {

--- a/pkg/virt-controller/leaderelectionconfig/config.go
+++ b/pkg/virt-controller/leaderelectionconfig/config.go
@@ -20,9 +20,9 @@
 package leaderelectionconfig
 
 import (
-	"flag"
 	"time"
 
+	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
 )
@@ -46,20 +46,20 @@ func DefaultLeaderElectionConfiguration() Configuration {
 
 // BindFlags binds the common LeaderElectionCLIConfig flags
 func BindFlags(l *Configuration) {
-	flag.DurationVar(&l.LeaseDuration.Duration, "leader-elect-lease-duration", l.LeaseDuration.Duration, ""+
+	pflag.DurationVar(&l.LeaseDuration.Duration, "leader-elect-lease-duration", l.LeaseDuration.Duration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
 		"slot. This is effectively the maximum duration that a leader can be stopped "+
 		"before it is replaced by another candidate. This is only applicable if leader "+
 		"election is enabled.")
-	flag.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
+	pflag.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
 		"The interval between attempts by the acting master to renew a leadership slot "+
 		"before it stops leading. This must be less than or equal to the lease duration. "+
 		"This is only applicable if leader election is enabled.")
-	flag.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
+	pflag.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
 		"The duration the clients should wait between attempting acquisition and renewal "+
 		"of a leadership. This is only applicable if leader election is enabled.")
-	flag.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
+	pflag.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
 		"The type of resource object that is used for locking during "+
 		"leader election. Supported options are `endpoints` (default) and `configmap`.")
 }

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -116,11 +116,11 @@ func Execute() {
 	var err error
 	var app VirtControllerApp = VirtControllerApp{}
 
-	featuregates.ParseFeatureGatesFromConfigMap()
-
 	app.LeaderElection = leaderelectionconfig.DefaultLeaderElectionConfiguration()
 
 	service.Setup(&app)
+
+	featuregates.ParseFeatureGatesFromConfigMap()
 
 	app.readyChan = make(chan bool, 1)
 
@@ -198,7 +198,7 @@ func (vca *VirtControllerApp) Run() {
 	defer close(stop)
 	go func() {
 		httpLogger := logger.With("service", "http")
-		httpLogger.Level(glog.INFO).Log("action", "listening", "interface", vca.BindAddress, "port", vca.Port)
+		httpLogger.Level(log.INFO).Log("action", "listening", "interface", vca.BindAddress, "port", vca.Port)
 		http.Handle("/metrics", promhttp.Handler())
 		if err := http.ListenAndServeTLS(vca.Address(), certStore.CurrentPath(), certStore.CurrentPath(), nil); err != nil {
 			golog.Fatal(err)

--- a/pkg/virt-handler/migration-proxy/migration_proxy_suite_test.go
+++ b/pkg/virt-handler/migration-proxy/migration_proxy_suite_test.go
@@ -5,9 +5,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/log"
 )
 
 func TestMigrationProxy(t *testing.T) {
 	RegisterFailHandler(Fail)
+	log.Log.SetIOWriter(GinkgoWriter)
 	RunSpecs(t, "MigrationProxy Suite")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that our glog package only exposes what the original glog package exposes. This way, if kubevirt is vendored, the other project can pull in the original glog package and does not even notice that we shadow it. The long term solution is to synchronize our public APIs into a separate repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1612 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
