### PR TITLE
Ensure CRDs create/update is rejected when webhook is unavailable

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -547,9 +547,12 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 		}
 	}
 
+	failurePolicy := admissionregistrationv1beta1.Fail
+
 	webHooks := []admissionregistrationv1beta1.Webhook{
 		{
-			Name: "virtualmachineinstances-create-validator.kubevirt.io",
+			Name:          "virtualmachineinstances-create-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Create,
@@ -570,7 +573,8 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			},
 		},
 		{
-			Name: "virtualmachineinstances-update-validator.kubevirt.io",
+			Name:          "virtualmachineinstances-update-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Update,
@@ -591,7 +595,8 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			},
 		},
 		{
-			Name: "virtualmachine-validator.kubevirt.io",
+			Name:          "virtualmachine-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Create,
@@ -613,7 +618,8 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			},
 		},
 		{
-			Name: "virtualmachinereplicaset-validator.kubevirt.io",
+			Name:          "virtualmachinereplicaset-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Create,
@@ -635,7 +641,8 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			},
 		},
 		{
-			Name: "virtualmachinepreset-validator.kubevirt.io",
+			Name:          "virtualmachinepreset-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Create,
@@ -657,7 +664,8 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			},
 		},
 		{
-			Name: "migration-create-validator.kubevirt.io",
+			Name:          "migration-create-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Create,
@@ -678,7 +686,8 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			},
 		},
 		{
-			Name: "migration-update-validator.kubevirt.io",
+			Name:          "migration-update-validator.kubevirt.io",
+			FailurePolicy: &failurePolicy,
 			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
 				Operations: []admissionregistrationv1beta1.OperationType{
 					admissionregistrationv1beta1.Update,


### PR DESCRIPTION


**What this PR does / why we need it**:

The default failure policy for webhooks is to ignore failures when the webhook is unavailable. This can lead to situations where invalid CRD objects are posted to the cluster. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 1618

**Special notes for your reviewer**:

**Release note**:

```release-note
Ensures CRDs are rejected when webhook is unavailable. 
```
