### PR TITLE
Updated CI images for fixing test issues with ssh.sh

### DIFF
--- a/cluster/k8s-1.10.4/provider.sh
+++ b/cluster/k8s-1.10.4/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.10.4@sha256:9341db6774ccc7d81a2fe90417fcced02867d7109e7c21a12dc6791b2746cccc"
+image="k8s-1.10.4@sha256:b60a61ca03a1a6c504481020709a04f65e4dd9c929a8bcad18821c5f80d1b2b6"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-1.11.0/provider.sh
+++ b/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:b407bce5ab0c4fce5cd58e78d84eca086e2a0ac28f5672b89c3ae75a40b14418"
+image="k8s-1.11.0@sha256:3412f158ecad53543c9b0aa8468db84dd043f01832a66f0db90327b7dc36a8e8"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/k8s-multus-1.11.1/provider.sh
+++ b/cluster/k8s-multus-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.11.1@sha256:47ea6a0bef30846c72f194d4899ca1e2fd6b15061e928734610c6255f73fe56b"
+image="k8s-multus-1.11.1@sha256:f37109a50354d7f34ba71a85bcfe0bc6c62897b9dded28e8dfd819598d5cde43"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/cluster/os-3.10.0-crio/provider.sh
+++ b/cluster/os-3.10.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-crio@sha256:88b64f9efc17281427aba67b3499831c03a28990f2f5fc4a540472f98e64cfb4"
+image="os-3.10.0-crio@sha256:56debd7bc2ce87dd616ebc30f06971e388b6983c0cda8646a7563e1dafadb69b"

--- a/cluster/os-3.10.0-multus/provider.sh
+++ b/cluster/os-3.10.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.10.0/provider.sh
 
-image="os-3.10.0-multus@sha256:fa6d763af28634417200ee35e095cc56d8ad4039e58f70c3a04a59d498011ec5"
+image="os-3.10.0-multus@sha256:7d43b9fe2135b5b218ded4817e17f3766931e2ca007748566217806d5683cfbb"

--- a/cluster/os-3.10.0/provider.sh
+++ b/cluster/os-3.10.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.10.0@sha256:45e0b2797134c147da5f3cba1ca768340ef6da1f7d52978c81b6813421833501"
+image="os-3.10.0@sha256:cc418c0c837d8e6c9a31a063762d9e4c8bfc70a1fcca10823b11c6d8a7ae2394"
 
 source cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update CI images, fixes test issues with ssh.sh (not found, permission denied)
See https://github.com/kubevirt/kubevirtci/issues/46
 
**Release note**:
```release-note
NONE
```
