### PR TITLE
[release-0.8] goimports works now better, fix imports

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -22,7 +22,6 @@ package main
 import (
 	"fmt"
 	"os"
-
 	"time"
 
 	flag "github.com/spf13/pflag"

--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -22,10 +22,9 @@ package main
 import (
 	"os"
 
-	"kubevirt.io/kubevirt/pkg/virtctl"
-
-	// Import to initialize client auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"kubevirt.io/kubevirt/pkg/virtctl" // Import to initialize client auth plugins.
 )
 
 func main() {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -42,9 +42,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	"kubevirt.io/kubevirt/pkg/precond"
-
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
+	"kubevirt.io/kubevirt/pkg/precond"
 )
 
 // GroupName is the group name use in this package

--- a/pkg/api/v1/v1_suite_test.go
+++ b/pkg/api/v1/v1_suite_test.go
@@ -20,10 +20,10 @@
 package v1
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestV1(t *testing.T) {

--- a/pkg/cloud-init/cloudinit_suite_test.go
+++ b/pkg/cloud-init/cloudinit_suite_test.go
@@ -20,10 +20,10 @@
 package cloudinit
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestCloudInit(t *testing.T) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,8 +20,10 @@
 package controller
 
 import (
+	"fmt"
 	"runtime/debug"
 
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,14 +32,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"fmt"
-
-	k8sv1 "k8s.io/api/core/v1"
-
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 const (

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -31,11 +31,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 // GetControllerOf returns the controllerRef if controllee has a controller,

--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -19,9 +19,8 @@ package controller
 
 import (
 	"reflect"
-	"testing"
-
 	"sync"
+	"testing"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,10 +1,10 @@
 package controller_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestController(t *testing.T) {

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -24,16 +24,14 @@ import (
 	"sync"
 	"time"
 
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-
-	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	cdiv1informers "kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions"
-
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"

--- a/pkg/emptydisk/emptydisk_test.go
+++ b/pkg/emptydisk/emptydisk_test.go
@@ -3,12 +3,11 @@ package emptydisk
 import (
 	"io/ioutil"
 	"os"
+	"path"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"path"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )

--- a/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
@@ -20,10 +20,10 @@
 package ephemeraldisk
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestRegistryDisk(t *testing.T) {

--- a/pkg/ephemeral-disk/ephemeral-disk_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_test.go
@@ -28,7 +28,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/pkg/feature-gates/feature-gates.go
+++ b/pkg/feature-gates/feature-gates.go
@@ -26,10 +26,9 @@ import (
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 )

--- a/pkg/inotify-informer/inotify_suite_test.go
+++ b/pkg/inotify-informer/inotify_suite_test.go
@@ -20,10 +20,10 @@
 package inotifyinformer
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestInotifyInformer(t *testing.T) {

--- a/pkg/kubecli/kubecli.go
+++ b/pkg/kubecli/kubecli.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -33,9 +34,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	cdiclient "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
-
-	"github.com/spf13/pflag"
-
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/kubecli/kubecli_suite_test.go
+++ b/pkg/kubecli/kubecli_suite_test.go
@@ -20,10 +20,10 @@
 package kubecli_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestKubecli(t *testing.T) {

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	cdiclient "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned"
-
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
 

--- a/pkg/kubecli/replicaset_test.go
+++ b/pkg/kubecli/replicaset_test.go
@@ -26,10 +26,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	k8sv1 "k8s.io/api/core/v1"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
-
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 

--- a/pkg/kubecli/version_test.go
+++ b/pkg/kubecli/version_test.go
@@ -20,16 +20,14 @@
 package kubecli
 
 import (
-	"net/http"
-
 	"fmt"
+	"net/http"
 	"runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/version"

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -21,10 +21,9 @@ package kubecli
 
 import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-
-	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )

--- a/pkg/kubecli/vm_test.go
+++ b/pkg/kubecli/vm_test.go
@@ -26,10 +26,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	k8sv1 "k8s.io/api/core/v1"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
-
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/pkg/kubecli/vmi.go
+++ b/pkg/kubecli/vmi.go
@@ -28,13 +28,11 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-
-	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/util/subresources"

--- a/pkg/kubecli/vmi_test.go
+++ b/pkg/kubecli/vmi_test.go
@@ -29,10 +29,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	k8sv1 "k8s.io/api/core/v1"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
-
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/pkg/kubecli/vmpreset.go
+++ b/pkg/kubecli/vmpreset.go
@@ -21,10 +21,9 @@ package kubecli
 
 import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-
-	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -30,9 +30,8 @@ import (
 	"sync"
 	"time"
 
-	flag "github.com/spf13/pflag"
-
 	"github.com/go-kit/kit/log"
+	flag "github.com/spf13/pflag"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"

--- a/pkg/log/log_suite_test.go
+++ b/pkg/log/log_suite_test.go
@@ -1,10 +1,10 @@
 package log_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestLogging(t *testing.T) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -27,9 +27,8 @@ import (
 	"strings"
 	"testing"
 
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k8sv1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -20,16 +20,14 @@
 package middleware
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"runtime/debug"
 
 	"github.com/go-kit/kit/endpoint"
-	"golang.org/x/net/context"
-
-	"encoding/json"
-
 	gklog "github.com/go-kit/kit/log"
+	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 

--- a/pkg/middleware/middleware_suite_test.go
+++ b/pkg/middleware/middleware_suite_test.go
@@ -20,10 +20,10 @@
 package middleware
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestEndpoints(t *testing.T) {

--- a/pkg/registry-disk/registry-disk_suite_test.go
+++ b/pkg/registry-disk/registry-disk_suite_test.go
@@ -20,10 +20,10 @@
 package registrydisk
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestRegistryDisk(t *testing.T) {

--- a/pkg/rest/endpoints/builder.go
+++ b/pkg/rest/endpoints/builder.go
@@ -20,13 +20,11 @@
 package endpoints
 
 import (
-	"golang.org/x/net/context"
-
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
-
+	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/precond"

--- a/pkg/rest/endpoints/decoders.go
+++ b/pkg/rest/endpoints/decoders.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -35,8 +36,6 @@ import (
 	gokithttp "github.com/go-kit/kit/transport/http"
 	"golang.org/x/net/context"
 	"k8s.io/apimachinery/pkg/types"
-
-	"io"
 
 	"kubevirt.io/kubevirt/pkg/middleware"
 	"kubevirt.io/kubevirt/pkg/rest"

--- a/pkg/rest/endpoints/delete_test.go
+++ b/pkg/rest/endpoints/delete_test.go
@@ -20,16 +20,14 @@
 package endpoints
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"net/http"
-
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 
 	"github.com/emicklei/go-restful"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
 
 	"kubevirt.io/kubevirt/pkg/rest"

--- a/pkg/rest/endpoints/endpoints_suite_test.go
+++ b/pkg/rest/endpoints/endpoints_suite_test.go
@@ -20,10 +20,10 @@
 package endpoints
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestEndpoints(t *testing.T) {

--- a/pkg/rest/endpoints/get_test.go
+++ b/pkg/rest/endpoints/get_test.go
@@ -20,21 +20,18 @@
 package endpoints
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	ini "gopkg.in/ini.v1"
-
-	"net/http"
-
-	kithttp "github.com/go-kit/kit/transport/http"
-
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"
+	kithttp "github.com/go-kit/kit/transport/http"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
+	ini "gopkg.in/ini.v1"
 
 	"kubevirt.io/kubevirt/pkg/rest"
 )

--- a/pkg/rest/endpoints/post_test.go
+++ b/pkg/rest/endpoints/post_test.go
@@ -20,19 +20,17 @@
 package endpoints
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"net/http"
-
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
 
 	"kubevirt.io/kubevirt/pkg/rest"

--- a/pkg/rest/endpoints/put_test.go
+++ b/pkg/rest/endpoints/put_test.go
@@ -20,20 +20,18 @@
 package endpoints
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"net/http"
-
 	"bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 
 	"github.com/emicklei/go-restful"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"golang.org/x/net/context"
 	"gopkg.in/yaml.v2"
 

--- a/pkg/testutils/matchers.go
+++ b/pkg/testutils/matchers.go
@@ -23,15 +23,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/ghodss/yaml"
+	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
-
-	"strings"
-
-	"github.com/onsi/gomega"
 	"k8s.io/client-go/tools/record"
 
 	rest2 "kubevirt.io/kubevirt/pkg/rest"

--- a/pkg/testutils/mock_queue.go
+++ b/pkg/testutils/mock_queue.go
@@ -3,17 +3,15 @@ package testutils
 import (
 	"sync"
 
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/util/workqueue"
 
-	k8sv1 "k8s.io/api/core/v1"
-
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 /*

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -34,7 +34,6 @@ import (
 	openapispec "github.com/go-openapi/spec"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/net/context"
-
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	k8sv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/emicklei/go-restful"
-
 	authorization "k8s.io/api/authorization/v1beta1"
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1beta1"
 	restclient "k8s.io/client-go/rest"

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
 

--- a/pkg/virt-api/rest/kubeproxy_test.go
+++ b/pkg/virt-api/rest/kubeproxy_test.go
@@ -20,13 +20,12 @@
 package rest_test
 
 import (
-	"flag"
-	"net/http"
-	"net/http/httptest"
-
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 
 	"github.com/emicklei/go-restful"
 	"github.com/ghodss/yaml"

--- a/pkg/virt-api/rest/rest_suite_test.go
+++ b/pkg/virt-api/rest/rest_suite_test.go
@@ -20,10 +20,10 @@
 package rest_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestRest(t *testing.T) {

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/emicklei/go-restful"
 	"github.com/gorilla/websocket"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/virt-api/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook.go
@@ -29,15 +29,13 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	v1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-
-	"k8s.io/apimachinery/pkg/labels"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/feature-gates"

--- a/pkg/virt-api/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/validating-webhook/validating-webhook_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
 	v1beta1 "k8s.io/api/admission/v1beta1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -37,9 +36,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
-	v1 "kubevirt.io/kubevirt/pkg/api/v1"
-
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
+	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 )
 
 var _ = Describe("Validating Webhook", func() {

--- a/pkg/virt-api/virt-api_suite_test.go
+++ b/pkg/virt-api/virt-api_suite_test.go
@@ -20,10 +20,10 @@
 package virt_api
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestVirtApi(t *testing.T) {

--- a/pkg/virt-controller/services/services_suite_test.go
+++ b/pkg/virt-controller/services/services_suite_test.go
@@ -20,10 +20,10 @@
 package services_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestServices(t *testing.T) {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -23,8 +23,6 @@ import (
 	"testing"
 	"time"
 
-	. "kubevirt.io/kubevirt/pkg/virt-controller/services"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -38,6 +36,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/log"
+	. "kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
 var _ = Describe("Template", func() {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"kubevirt.io/kubevirt/pkg/controller"
+	featuregates "kubevirt.io/kubevirt/pkg/feature-gates"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/registry-disk"
@@ -47,8 +48,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/leaderelectionconfig"
 	"kubevirt.io/kubevirt/pkg/virt-controller/rest"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
-
-	featuregates "kubevirt.io/kubevirt/pkg/feature-gates"
 )
 
 const (

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -20,15 +20,14 @@
 package watch
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 
 	"github.com/emicklei/go-restful"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/pkg/rest"
 )

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -3,6 +3,7 @@ package watch
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -14,8 +15,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-
-	"strings"
 
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -2,6 +2,7 @@ package watch
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -19,8 +20,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
-
-	"fmt"
 
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/pkg/virt-controller/watch/preset.go
+++ b/pkg/virt-controller/watch/preset.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
-
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"

--- a/pkg/virt-controller/watch/preset_test.go
+++ b/pkg/virt-controller/watch/preset_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -20,23 +20,18 @@
 package watch
 
 import (
+	"fmt"
+	"reflect"
+	"sync"
 	"time"
 
+	k8score "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-
-	"sync"
-
-	k8score "k8s.io/api/core/v1"
-
-	"fmt"
-
-	"reflect"
 
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -20,12 +20,15 @@
 package watch
 
 import (
+	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
 
 	"github.com/pborman/uuid"
-
+	k8score "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,20 +36,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	k8score "k8s.io/api/core/v1"
-
-	"fmt"
-
-	"reflect"
-
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 // TODO remove the dataVolume deletion retry logic once CDI fixes this issue.

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -5,11 +5,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pborman/uuid"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,12 +18,10 @@ import (
 	"k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
-
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	cdifake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
-
 	"kubevirt.io/kubevirt/pkg/api/v1"
+	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -20,29 +20,25 @@
 package watch
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	"fmt"
-	"reflect"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
-
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 // Reasons for vmi events

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -20,33 +20,28 @@
 package watch
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/client-go/tools/cache"
-
-	k8sv1 "k8s.io/api/core/v1"
+	"fmt"
 
 	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
-	"fmt"
-
-	"github.com/onsi/ginkgo/extensions/table"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/testing"
-
-	"k8s.io/apimachinery/pkg/types"
-
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	//cdifake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
 )
 

--- a/pkg/virt-controller/watch/watch_suite_test.go
+++ b/pkg/virt-controller/watch/watch_suite_test.go
@@ -20,10 +20,10 @@
 package watch
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestWatch(t *testing.T) {

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -29,11 +29,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/rpc"
-	"path/filepath"
-
 	"net"
+	"net/rpc"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/pkg/virt-handler/virt_handler_suite_test.go
+++ b/pkg/virt-handler/virt_handler_suite_test.go
@@ -20,10 +20,10 @@
 package virthandler
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestVirtHandler(t *testing.T) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -20,6 +20,7 @@
 package virthandler
 
 import (
+	"encoding/json"
 	goerror "errors"
 	"fmt"
 	"os"
@@ -28,16 +29,12 @@ import (
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"encoding/json"
-
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/cloud-init"

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -28,15 +28,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
-
-	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/fake"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -31,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/watch"
 
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"

--- a/pkg/virt-launcher/virtwrap/api/api_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/api/api_suite_test.go
@@ -1,10 +1,10 @@
 package api_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestApi(t *testing.T) {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -28,12 +28,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"strconv"
-	"strings"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/cloud-init"

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -21,19 +21,16 @@ package api
 
 import (
 	"encoding/xml"
+	"fmt"
 	"net"
+	"os"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"github.com/onsi/ginkgo/extensions/table"
-
+	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"fmt"
-	"os"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -24,14 +24,12 @@ package api
 
 import (
 	"encoding/xml"
+	"fmt"
 
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/pkg/virt-launcher/virtwrap/cli/cli_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/cli/cli_suite_test.go
@@ -1,10 +1,10 @@
 package cli_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestCli(t *testing.T) {

--- a/pkg/virt-launcher/virtwrap/cli/libvirt_test.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt_test.go
@@ -20,11 +20,11 @@
 package cli
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"fmt"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Libvirt Suite", func() {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 
 	"github.com/libvirt/libvirt-go"
-
 	k8sv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -28,13 +28,12 @@ import (
 	"net"
 	"os"
 
+	lmf "github.com/subgraph/libmacouflage"
 	"github.com/vishvananda/netlink"
 
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network/dhcp"
-
-	lmf "github.com/subgraph/libmacouflage"
 )
 
 type VIF struct {

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -31,8 +32,6 @@ import (
 	dhcp "github.com/krolaw/dhcp4"
 	dhcpConn "github.com/krolaw/dhcp4/conn"
 	"github.com/vishvananda/netlink"
-
-	"os"
 
 	"kubevirt.io/kubevirt/pkg/log"
 )

--- a/pkg/virt-launcher/virtwrap/virtwrap_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/virtwrap_suite_test.go
@@ -1,10 +1,10 @@
 package virtwrap_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestVirtwrap(t *testing.T) {

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -26,10 +26,8 @@ import (
 	"os/signal"
 	"time"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/spf13/cobra"
-
+	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -6,18 +6,15 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
-
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/testing"
-
 	"kubevirt.io/kubevirt/tests"
 )
 

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -1,13 +1,12 @@
 package virtctl
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	"flag"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/spf13/cobra"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"

--- a/pkg/watchdog/watchdog_suite_test.go
+++ b/pkg/watchdog/watchdog_suite_test.go
@@ -20,10 +20,10 @@
 package watchdog
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestWatchdog(t *testing.T) {

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -26,12 +26,11 @@ import (
 	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"
-
-	k8sv1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Console", func() {

--- a/tests/controller_leader_election_test.go
+++ b/tests/controller_leader_election_test.go
@@ -27,7 +27,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -25,13 +25,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"k8s.io/apimachinery/pkg/runtime"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -21,22 +21,17 @@ package tests_test
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"strings"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/onsi/ginkgo/extensions/table"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/json"
-
 	"time"
 
-	"fmt"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -25,7 +25,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -20,15 +20,13 @@
 package tests_test
 
 import (
-	. "github.com/onsi/ginkgo"
-
-	. "github.com/onsi/gomega"
-
 	"testing"
 
-	"kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
 func TestTests(t *testing.T) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -40,7 +40,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
-
 	k8sv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,17 +47,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	k8sversion "k8s.io/apimachinery/pkg/version"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 
-	"k8s.io/apimachinery/pkg/types"
-
-	"k8s.io/apimachinery/pkg/labels"
-
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
@@ -66,8 +63,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virtctl"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 var KubeVirtVersionTag = "latest"

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -21,12 +21,11 @@ package tests_test
 
 import (
 	"flag"
+	"fmt"
+	"runtime"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"fmt"
-	"runtime"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/tests"

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -24,18 +24,15 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	v13 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"time"
 
 	"github.com/google/goexpect"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v13 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/google/goexpect"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -21,15 +21,12 @@ package tests_test
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
+	"github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/google/goexpect"
-
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -21,22 +21,17 @@ package tests_test
 
 import (
 	"flag"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"github.com/google/goexpect"
-
-	"fmt"
-	"strconv"
-
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 	v12 "k8s.io/api/core/v1"
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/onsi/ginkgo/extensions/table"
-
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"

--- a/tests/vmi_userdata_test.go
+++ b/tests/vmi_userdata_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pborman/uuid"
-
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -28,7 +28,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -21,20 +21,16 @@ package tests_test
 
 import (
 	"flag"
+	"fmt"
 	"io"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
+	"net/http"
 	"time"
 
-	"net/http"
-
 	"github.com/gorilla/websocket"
+	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
-
-	"fmt"
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -29,7 +29,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tools/crd-generator/crd-generator.go
+++ b/tools/crd-generator/crd-generator.go
@@ -25,7 +25,6 @@ import (
 
 	crdutils "github.com/ant31/crd-validation/pkg"
 	"github.com/go-openapi/spec"
-
 	extensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	common "k8s.io/kube-openapi/pkg/common"

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -27,22 +28,17 @@ import (
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
-
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	"encoding/json"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-api/validating-webhook"
-
-	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

Backprot of #1617 for 0.8 releases. A new version of goimports better sorts our dependencies. Fixes travis builds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
