### PR TITLE
libvirt: DiskSecret - add supported UUID field

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -316,8 +316,9 @@ type DiskAuth struct {
 }
 
 type DiskSecret struct {
-	Type  string `xml:"type,attr,omitempty"`
+	Type  string `xml:"type,attr"`
 	Usage string `xml:"usage,attr,omitempty"`
+	UUID  string `xml:"uuid,attr,omitempty"`
 }
 
 type ReadOnly struct{}


### PR DESCRIPTION
From libvirt docs:
The encryption tag can currently contain a sequence of secret tags,
each with mandatory attributes type and either uuid or usage (since 2.1.0).

The type is required. UUID or Usage is optional, only one must
be set.

Ref: https://libvirt.org/formatstorageencryption.html
Signed-off-by: Alexander Gallego <gallego.alexx@gmail.com>
Signed-off-by: Jason Baron <jbaron@akamai.com>


```release-note
NONE

```
