### PR TITLE
Don't deploy test infra if using external provider

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -47,7 +47,12 @@ elif [[ $TARGET =~ .*-release ]] || [[ $TARGET =~ windows.* ]]; then
 fi
 
 # Deploy additional infra for testing
-_kubectl create -f ${MANIFESTS_OUT_DIR}/testing -R $i
+# In the case of external providers we don't control all of the various requriements here
+# rather than try and call them all out and check let's just explicitly skip deployment
+# we'll provide a new varialbe to over ride this for folks that know what they're doing
+if [[ "$KUBEVIRT_PROVIDER" != "external" ]] || [[ "$KUBEVIRT_DEPLOY_TESTS_TO_EXTERNAL_PROVIDER" == true ]]; then
+    _kubectl create -f ${MANIFESTS_OUT_DIR}/testing -R $i
+fi
 
 if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]]; then
     _kubectl adm policy add-scc-to-user privileged -z kubevirt-controller -n ${namespace}

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -3,6 +3,12 @@ unset binaries docker_images docker_prefix docker_tag manifest_templates \
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
 
+# We don't have any control over the infrastructure avaialbe on an external provider.  In some cases
+# like using hack/local-cluster-up.sh we can get everything we need here, but in others lik GKE we may
+# not be able to add things depending on our config.  So, by default we'll skip trying to deploy the tests
+# for external providers, but provide this override for folks that know what they're doing
+KUBEVIRT_DEPLOY_TESTS_TO_EXTERNAL_PROVIDER=${KUBEVIRT_DEPLOY_TESTS_TO_EXTERNAL_PROVIDER:-false}
+
 source ${KUBEVIRT_PATH}hack/config-default.sh source ${KUBEVIRT_PATH}hack/config-${KUBEVIRT_PROVIDER}.sh
 
 # Allow different providers to override default config values


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch modifies cluster/deploy.sh to NOT attempt deploying test
infra when using an external KubeVirt Provider.

Since we don't have control over the target Cluster in this case there's
a high probability that it won't have all of the expected configuration
settings and avaialble resources we expect for our tests.  Rather than
just running it and having it fail for various reasons, this patch will
skip that portion of the deployment for external providers.

In the case of a user that knows what they're doing and has everything
he/she needs on their cluster, they can override this behavior with an
enviornment variable.

`KUBEVIRT_DEPLOY_TESTS_TO_EXTERNAL_PROVIDER=true` will override the
provider check and attempt to deploy the additional test infra.



**Which issue(s) this PR fixes** 
Fixes #1644 

**Special notes for your reviewer**:

**Release note**:

```release-note
Modifies make cluster-sync to skip deploying test infra when using an external provider.  To override this user must export KUBEVIRT_DEPLOY_TESTS_TO_EXTERNAL_PROVIDER=true

```
