### PR TITLE
Fix cpu pinning

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -622,9 +622,7 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability 
 		res = append(res, CAP_NET_ADMIN)
 	}
 	// add a CAP_SYS_NICE capability to allow setting cpu affinity
-	if vmi.IsCPUDedicated() {
-		res = append(res, CAP_SYS_NICE)
-	}
+	res = append(res, CAP_SYS_NICE)
 	return res
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CAP_SYS_NICE to all vm pods to allow libvirt to call `sched_setaffinity()`
Libvirt always calls this method each time it executes the qemu process and normally doesn't require the SYS_NICE capability. However, after starting a VM with cpu pinning, starting each next VM will require the process to have the capability to start qemu.

**Which issue(s) this PR fixes**
Fixes #1622 

```release-note
"NONE"
```
