### PR TITLE
add additional fields to kubectl get vm/vmi

### DIFF
--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -7,6 +7,17 @@ metadata:
     kubevirt.io: ""
   name: virtualmachines.kubevirt.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .spec.running
+    name: Running
+    type: boolean
+  - JSONPath: .spec.volumes[0].name
+    description: Primary Volume
+    name: Volume
+    type: string
   group: kubevirt.io
   names:
     kind: VirtualMachine

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -7,6 +7,19 @@ metadata:
     kubevirt.io: ""
   name: virtualmachineinstances.kubevirt.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
+  - JSONPath: .status.interfaces[0].ipAddress
+    name: IP
+    type: string
+  - JSONPath: .status.nodeName
+    name: NodeName
+    type: string
   group: kubevirt.io
   names:
     kind: VirtualMachineInstance

--- a/tools/crd-generator/crd-generator.go
+++ b/tools/crd-generator/crd-generator.go
@@ -59,6 +59,11 @@ func generateVirtualMachineCrd() {
 			Kind:       v1.VirtualMachineGroupVersionKind.Kind,
 			ShortNames: []string{"vm", "vms"},
 		},
+		AdditionalPrinterColumns: []extensionsv1.CustomResourceColumnDefinition{
+			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+			{Name: "Running", Type: "boolean", JSONPath: ".spec.running"},
+			{Name: "Volume", Description: "Primary Volume", Type: "string", JSONPath: ".spec.volumes[0].name"},
+		},
 	}
 
 	crdutils.MarshallCrd(crd, "yaml")
@@ -138,6 +143,12 @@ func generateVirtualMachineInstanceCrd() {
 			Singular:   "virtualmachineinstance",
 			Kind:       v1.VirtualMachineInstanceGroupVersionKind.Kind,
 			ShortNames: []string{"vmi", "vmis"},
+		},
+		AdditionalPrinterColumns: []extensionsv1.CustomResourceColumnDefinition{
+			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+			{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
+			{Name: "IP", Type: "string", JSONPath: ".status.interfaces[0].ipAddress"},
+			{Name: "NodeName", Type: "string", JSONPath: ".status.nodeName"},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- add fields running and primary volume to kubectl get vm
- add fields phase, ip and node name to kubectl get vmi

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
kubectl get vms is enhanced so that default output contains additional running and primary volume 
fields
NAME      AGE       RUNNING   VOLUME
windows   3d        true
xx        3d        true

kubectl get vmis is enhanced so that default output contains additional phase, ip and nodeName

NAME      AGE       PHASE     IP            NODENAME
magic1    3d        Running   10.130.0.13   node01.default
magic2    3d        Running   10.130.0.14   node01.default
windows   3d        Running   10.129.0.19   node02.default
xx        3d        Running   10.129.0.17   node02.default



```
