### PR TITLE
Allow static networking in cloudinit metadata

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -794,6 +794,14 @@ type Interface struct {
 	// If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10
 	// +optional
 	PciAddress string `json:"pciAddress,omitempty"`
+	// Boot Protocol of a Virtual Machine interface
+	BootProto string `json:"bootProto,omitempty"`
+	// Ip of a Virtual Machine interface
+	Ip string `json:"ip,omitempty"`
+	// Netmask of a Virtual Machine interface
+	Netmask string `json:"netmask,omitempty"`
+	// Gateway of a Virtual Machine interface
+	Gateway string `json:"gateway,omitempty"`
 }
 
 // Represents the method which will be used to connect the interface to the guest.

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -45,7 +45,7 @@ var _ = Describe("CloudInit", func() {
 		panic(err)
 	}
 	isoCreationFunc := func(isoOutFile string, inFiles []string) error {
-		if isoOutFile == "noCloud" && len(inFiles) != 2 {
+		if isoOutFile == "noCloud" && len(inFiles) != 3 {
 			return errors.New("unexpected number of files for noCloud")
 		}
 
@@ -111,10 +111,11 @@ var _ = Describe("CloudInit", func() {
 				namespace := "fake-namespace"
 				domain := "fake-domain"
 				userData := "fake\nuser\ndata\n"
+				vmi := v1.NewMinimalVMI(domain)
 				cloudInitData := &v1.CloudInitNoCloudSource{
 					UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
 				}
-				err := GenerateLocalData(domain, domain, namespace, cloudInitData)
+				err := GenerateLocalData(vmi, domain, namespace, cloudInitData)
 				Expect(err).To(HaveOccurred())
 				Expect(timedOut).To(Equal(true))
 			})
@@ -168,7 +169,8 @@ var _ = Describe("CloudInit", func() {
 			verifyCloudInitIso := func(dataSource *v1.CloudInitNoCloudSource) {
 				namespace := "fake-namespace"
 				domain := "fake-domain"
-				err := GenerateLocalData(domain, domain, namespace, dataSource)
+				vmi := v1.NewMinimalVMI(domain)
+				err := GenerateLocalData(vmi, domain, namespace, dataSource)
 				Expect(err).ToNot(HaveOccurred())
 
 				// verify iso is created

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -314,7 +314,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 	if cloudInitData != nil {
 		hostname := dns.SanitizeHostname(vmi)
 
-		err := cloudinit.GenerateLocalData(vmi.Name, hostname, vmi.Namespace, cloudInitData)
+		err := cloudinit.GenerateLocalData(vmi, hostname, vmi.Namespace, cloudInitData)
 		if err != nil {
 			return domain, err
 		}


### PR DESCRIPTION
```release-note
Allow static networking in cloudinit metadata
```

We parse the interface section of a vm and if ip, address and gateway are set, populate this so that the static networking configuration is injected through cloudinit.
a sample interface section looks like this

```
interfaces:
  - name: default
     bridge: {}
     ip: 192.168.122.4
     netmask: 255.255.255.0
     gateway: 192.168.122.1
```