### PR TITLE
VMIRS server side printing

### DIFF
--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -7,6 +7,23 @@ metadata:
     kubevirt.io: ""
   name: virtualmachineinstancereplicasets.kubevirt.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Number of desired VirtualMachineInstances
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Number of managed and not final or deleted VirtualMachineInstances
+    name: Current
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Number of managed VirtualMachineInstances which are ready to receive
+      traffic
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: kubevirt.io
   names:
     kind: VirtualMachineInstanceReplicaSet

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -163,6 +163,7 @@ var _ = Describe("VirtualMachineInstanceReplicaSet", func() {
 	})
 
 	It("should return the correct data when using server-side printing", func() {
+		tests.SkipIfVersionBelow("server-side printing is only enabled by default from 1.11 on", "1.11")
 		newRS := newReplicaSet()
 		doScale(newRS.ObjectMeta.Name, 2)
 

--- a/tools/crd-generator/crd-generator.go
+++ b/tools/crd-generator/crd-generator.go
@@ -104,6 +104,15 @@ func generateReplicaSetCrd() {
 			Kind:       v1.VirtualMachineInstanceReplicaSetGroupVersionKind.Kind,
 			ShortNames: []string{"vmirs", "vmirss"},
 		},
+		AdditionalPrinterColumns: []extensionsv1.CustomResourceColumnDefinition{
+			{Name: "Desired", Type: "integer", JSONPath: ".spec.replicas",
+				Description: "Number of desired VirtualMachineInstances"},
+			{Name: "Current", Type: "integer", JSONPath: ".status.replicas",
+				Description: "Number of managed and not final or deleted VirtualMachineInstances"},
+			{Name: "Ready", Type: "integer", JSONPath: ".status.readyReplicas",
+				Description: "Number of managed VirtualMachineInstances which are ready to receive traffic"},
+			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
+		},
 	}
 
 	crdutils.MarshallCrd(crd, "yaml")


### PR DESCRIPTION
**What this PR does / why we need it**:

Use server-side printing for VMIR to make it easier for users to see in which state the VMIRS is.
Added columns are "Desired", "Current", "Ready" and "Age". They have similar meaning like the similar lookin output for the k8s replicaset.

An example:

```
NAME                    DESIRED   CURRENT   READY     AGE
vmi-replicaset-cirros   3         3         2         29s
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Use server-side printing when for VirtualMachineInstanceReplicaSet when using "kubectl get vmirs"
```