### PR TITLE
Merge pull request #1651 from mfranczy/bugfix-disk-device-cache

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -100,7 +100,8 @@ func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk, devicePerBus m
 		}
 	}
 	disk.Driver = &DiskDriver{
-		Name: "qemu",
+		Name:  "qemu",
+		Cache: string(diskDevice.Cache),
 	}
 	if numQueues != nil {
 		disk.Driver.Queues = numQueues
@@ -113,48 +114,32 @@ func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk, devicePerBus m
 	return nil
 }
 
-func checkDirectIOFlag(path string, isBlockDev bool) bool {
-	fileExists := true
-
+func checkDirectIOFlag(path string) bool {
 	// check if fs where disk.img file is located or block device
 	// support direct i/o
 	f, err := os.OpenFile(path, syscall.O_RDONLY|syscall.O_DIRECT, 0)
 	defer f.Close()
-	if err != nil {
-		if fileExists = !os.IsNotExist(err); fileExists {
-			return false
-		}
-	}
-
-	if !fileExists && !isBlockDev {
-		path = path + ".directio_check"
-		f, err := os.OpenFile(path, syscall.O_CREAT|syscall.O_DIRECT, 755)
-		defer f.Close()
-		defer os.Remove(path)
-		if err != nil {
-			return false
-		}
+	if err != nil && !os.IsNotExist(err) {
+		return false
 	}
 	return true
 }
 
-func setDriverCacheMode(disk *Disk, mode v1.DriverCache) error {
+func SetDriverCacheMode(disk *Disk) error {
 	var path string
-	var blockDevice bool
 	supportDirectIO := true
+	mode := v1.DriverCache(disk.Driver.Cache)
 
 	if disk.Source.File != "" {
 		path = disk.Source.File
-		blockDevice = false
 	} else if disk.Source.Dev != "" {
 		path = disk.Source.Dev
-		blockDevice = true
 	} else {
 		return fmt.Errorf("Unable to set a driver cache mode, disk is neither a block device nor a file")
 	}
 
 	if mode == "" || mode == v1.CacheNone {
-		supportDirectIO = checkDirectIOFlag(path, blockDevice)
+		supportDirectIO = checkDirectIOFlag(path)
 		if !supportDirectIO {
 			log.Log.Infof("%s file system does not support direct I/O", path)
 		}
@@ -679,11 +664,6 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				currentAutoThread = (currentAutoThread % uint(autoThreads)) + 1
 			}
 			newDisk.Driver.IOThread = &ioThreadId
-		}
-
-		err = setDriverCacheMode(&newDisk, disk.Cache)
-		if err != nil {
-			return err
 		}
 
 		domain.Spec.Devices.Disks = append(domain.Spec.Devices.Disks, newDisk)

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Converter", func() {
 				{
 					Name:       "ephemeral_pvc",
 					VolumeName: "volume5",
+					Cache:      "none",
 				},
 				{
 					Name:       "secret_test",
@@ -228,6 +229,7 @@ var _ = Describe("Converter", func() {
 				{
 					Name:       "pvc_block_test",
 					VolumeName: "volume8",
+					Cache:      "writethrough",
 				},
 				{
 					Name:       "serviceaccount_test",
@@ -390,51 +392,51 @@ var _ = Describe("Converter", func() {
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/myvolume/disk.img"></source>
       <target bus="virtio" dev="vda"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="2"></driver>
+      <driver name="qemu" type="raw" iothread="2"></driver>
       <alias name="ua-mydisk"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="virtio" dev="vdb"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="3"></driver>
+      <driver name="qemu" type="raw" iothread="3"></driver>
       <alias name="ua-mydisk1"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="sata" dev="sda" tray="closed"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/volume1/disk.img"></source>
       <target bus="sata" dev="sdb" tray="open"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
     <disk device="floppy" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/volume2/disk.img"></source>
       <target bus="fdc" dev="fda" tray="closed"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-floppy_tray_unspecified"></alias>
     </disk>
     <disk device="floppy" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/volume3/disk.img"></source>
       <target bus="fdc" dev="fdb" tray="open"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <readonly></readonly>
       <alias name="ua-floppy_tray_open"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/vmi-disks/volume4/disk.img"></source>
       <target bus="sata" dev="sdc"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-should_default_to_disk"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/libvirt/kubevirt-ephemeral-disk/volume5/disk.qcow2"></source>
       <target bus="sata" dev="sdd"></target>
-      <driver cache="writethrough" name="qemu" type="qcow2" iothread="1"></driver>
+      <driver cache="none" name="qemu" type="qcow2" iothread="1"></driver>
       <alias name="ua-ephemeral_pvc"></alias>
       <backingStore type="file">
         <format type="raw"></format>
@@ -445,26 +447,26 @@ var _ = Describe("Converter", func() {
       <source file="/var/run/kubevirt-private/secret-disks/volume6.iso"></source>
       <target bus="sata" dev="sde"></target>
       <serial>D23YZ9W6WA5DJ487</serial>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-secret_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/config-map-disks/volume7.iso"></source>
       <target bus="sata" dev="sdf"></target>
       <serial>CVLY623300HK240D</serial>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-configmap_test"></alias>
     </disk>
     <disk device="disk" type="block">
       <source dev="/dev/volume8"></source>
       <target bus="sata" dev="sdg"></target>
-      <driver cache="none" name="qemu" type="raw" iothread="1"></driver>
+      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
       <target bus="sata" dev="sdh"></target>
-      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
     <serial type="unix">

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -355,6 +355,14 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		return domain, fmt.Errorf("creating service account disk failed: %v", err)
 	}
 
+	// set drivers cache mode
+	for i := range domain.Spec.Devices.Disks {
+		err := api.SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
+		if err != nil {
+			return domain, err
+		}
+	}
+
 	hooksManager := hooks.GetManager()
 	domainSpec, err := hooksManager.OnDefineDomain(&domain.Spec, vmi)
 	if err != nil {

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -440,7 +440,7 @@ var _ = Describe("Storage", func() {
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi := tests.NewRandomVMIWithPVC(pvName)
 				// Without userdata the hostname isn't set correctly and the login expecter fails...
-				tests.AddUserData(vmi, "#!/bin/bash\necho 'hello'\n")
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
 				tests.RunVMIAndExpectLaunch(vmi, false, 90)
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -20,6 +20,7 @@
 package tests_test
 
 import (
+	"encoding/xml"
 	"flag"
 	"fmt"
 	"regexp"
@@ -41,6 +42,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	hw_utils "kubevirt.io/kubevirt/pkg/util/hardware"
+	launcherApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -553,59 +555,75 @@ var _ = Describe("Configurations", func() {
 	})
 
 	Context("with driver cache settings", func() {
-		It("should set a default cache mode to 'none'", func() {
-			vmi := tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
+		blockPVName := "block-pv-" + rand.String(48)
+
+		BeforeEach(func() {
+			// create a new PV and PVC (PVs can't be reused)
+			tests.CreateBlockVolumePvAndPvc(blockPVName, "1Gi")
+		}, 60)
+
+		AfterEach(func() {
+			tests.DeletePvAndPvc(blockPVName)
+		}, 60)
+
+		It("should set appropriate cache modes", func() {
+			vmi := tests.NewRandomVMI()
+			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
+
+			By("adding disks to a VMI")
+			tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", tests.RegistryDiskFor(tests.RegistryDiskCirros))
+			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
+
+			tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", tests.RegistryDiskFor(tests.RegistryDiskCirros))
+			vmi.Spec.Domain.Devices.Disks[1].Cache = v1.CacheWriteThrough
+
+			tests.AddEphemeralDisk(vmi, "ephemeral-disk3", "virtio", tests.RegistryDiskFor(tests.RegistryDiskCirros))
+			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+			tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
+			tests.AddPVCDisk(vmi, "block-pvc", "virtio", blockPVName)
+			tests.AddHostDisk(vmi, "/run/kubevirt-private/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "hostdisk")
 			tests.RunVMIAndExpectLaunch(vmi, false, 60)
 
+			runningVMISpec := launcherApi.DomainSpec{}
 			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring("cache='none'"))
-		})
-
-		It("should set a writethrough cache for fs which does not support direct I/O", func() {
-			// tmpfs does not support direct I/O
-			vmi := tests.NewRandomVMIWithHostDisk("/run/kubevirt-private/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "")
-			tests.RunVMIAndExpectLaunch(vmi, false, 60)
-
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			err = xml.Unmarshal([]byte(domXml), &runningVMISpec)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring(fmt.Sprintf("cache='%s'", v1.CacheWriteThrough)))
-		})
 
-		table.DescribeTable("should set demanded cache mode", func(cache v1.DriverCache) {
-			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.RegistryDiskFor(tests.RegistryDiskCirros))
-			vmi.Spec.Domain.Devices.Disks[0].Cache = cache
-			tests.RunVMIAndExpectLaunch(vmi, false, 60)
+			disks := runningVMISpec.Devices.Disks
+			By("checking if number of attached disks is equal to real disks number")
+			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
 
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domXml).To(ContainSubstring(fmt.Sprintf("cache='%s'", cache)))
-		},
-			table.Entry(fmt.Sprintf("with a cache set to '%s'", v1.CacheNone), v1.CacheNone),
-			table.Entry(fmt.Sprintf("with a cache set to '%s'", v1.CacheWriteThrough), v1.CacheWriteThrough),
-		)
+			cacheNone := string(v1.CacheNone)
+			cacheWritethrough := string(v1.CacheWriteThrough)
 
-		Context("with a block device", func() {
-			pvName := "block-pv-" + rand.String(48)
+			By("checking if requested cache 'none' has been set")
+			Expect(disks[0].Alias.Name).To(Equal("ephemeral-disk1"))
+			Expect(disks[0].Driver.Cache).To(Equal(cacheNone))
 
-			BeforeEach(func() {
-				// create a new PV and PVC (PVs can't be reused)
-				tests.CreateBlockVolumePvAndPvc(pvName, "1Gi")
-			}, 60)
+			By("checking if requested cache 'writethrough' has been set")
+			Expect(disks[1].Alias.Name).To(Equal("ephemeral-disk2"))
+			Expect(disks[1].Driver.Cache).To(Equal(cacheWritethrough))
 
-			AfterEach(func() {
-				// create a new PV and PVC (PVs can't be reused)
-				tests.DeletePvAndPvc(pvName)
-			}, 60)
+			By("checking if default cache 'none' has been set to ephemeral disk")
+			Expect(disks[2].Alias.Name).To(Equal("ephemeral-disk3"))
+			Expect(disks[2].Driver.Cache).To(Equal(cacheNone))
 
-			It("should set a default cache mode to 'none'", func() {
-				vmi := tests.NewRandomVMIWithPVC(pvName)
-				tests.RunVMIAndExpectLaunch(vmi, false, 90)
+			By("checking if default cache 'none' has been set to cloud-init disk")
+			Expect(disks[3].Alias.Name).To(Equal("cloud-init"))
+			Expect(disks[3].Driver.Cache).To(Equal(cacheNone))
 
-				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(ContainSubstring("cache='none'"))
-			})
+			By("checking if default cache 'none' has been set to pvc disk")
+			Expect(disks[4].Alias.Name).To(Equal("hostpath-pvc"))
+			Expect(disks[4].Driver.Cache).To(Equal(cacheNone))
+
+			By("checking if default cache 'none' has been set to block pvc")
+			Expect(disks[5].Alias.Name).To(Equal("block-pvc"))
+			Expect(disks[5].Driver.Cache).To(Equal(cacheNone))
+
+			By("checking if default cache 'writethrough' has been set to fs which does not support direct I/O")
+			Expect(disks[6].Alias.Name).To(Equal("hostdisk"))
+			Expect(disks[6].Driver.Cache).To(Equal(cacheWritethrough))
 		})
 	})
 


### PR DESCRIPTION
Bugfix - disk device cache

(cherry picked from commit eb05f0949d55e8c7d084462329bcb7de02f783cc)
Signed-off-by: Marcin Franczyk <mfranczy@redhat.com>


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It moves function responsible for setting a driver cache mode to preStartHook,
because of that I have already prepared disk images and can easily check if fs supports direct I/O.
I don't have to create temporary files in disk location anymore, that was causing some problems if dir was not created yet (my bad).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VM high performance - add cache options
```
