### PR TITLE
Check qcow2 before converting it to raw to prohibit DOS #1318

### DIFF
--- a/cmd/container-disk-v1alpha/entry-point.sh
+++ b/cmd/container-disk-v1alpha/entry-point.sh
@@ -40,6 +40,26 @@ IMAGE_EXTENSION=$(echo $IMAGE_PATH | sed  -n -e 's/^.*\.\(.*\)$/\1/p')
 mkdir -p $COPY_PATH
 echo $IMAGE_NAME | grep -q -e "raw" -e "qcow2"
 if [ $? -ne 0 ]; then
+	output=$(/usr/bin/qemu-img info $IMAGE_PATH --output=json)
+	if [ $? -ne 0 ]; then
+        echo "qemu-img info returned error"
+        exit 1
+    fi
+
+    IFS=","
+    echo $output | while read -r LINE; do
+    #it is not a valid image if its format is not qcow2.
+    if [ `echo $LINE | awk '$1 == "\"format\":" {print $1 }'` ]  && [ `echo $LINE | awk '$2 != "\"qcow2\"" {print $2 }'` ] ; then
+        echo "Invalid format for image $IMAGE_PATH"
+        exit 1
+    fi
+    #it is not a valid image if it has backing-filename
+    if [ `echo $LINE | awk '$1 == "\"backing-filename\":" {print $1 }'` ]; then
+        echo "Image $IMAGE_PATH is invalid because it has a backing file"
+        exit 1
+    fi
+    done
+
 	IMAGE_EXTENSION="raw"
 	/usr/bin/qemu-img convert $IMAGE_PATH ${COPY_PATH}.${IMAGE_EXTENSION}
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR is to a fix for 'Check qcow2 before converting it to raw to prohibit DOS #1318'
Right now, there is no image validation before it is converted to raw format (to be used by kubevirt).
This patch adds this validation by runing 'qemu-img info' to check that the image is in the right format (qcow2) and that it does not include backing file, before we convert it to raw format.

**Which issue(s) this PR fixes** :
Fixes #1318

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
