### PR TITLE
Deprecating CreatedByLabel in favor of OwnerReferences

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -362,6 +362,7 @@ const (
 	MigrationJobNameAnnotation string = "kubevirt.io/migrationJobName"
 	// This label is used to match virtual machine instance IDs with pods.
 	// Similar to kubevirt.io/domain. Used on Pod.
+	// Deprecated: would be replaced by a Controller Reference in a future release.
 	CreatedByLabel string = "kubevirt.io/created-by"
 	// This label is used to indicate that this pod is the target of a migration job.
 	MigrationJobLabel string = "kubevirt.io/migrationJobUID"

--- a/pkg/controller/controller_ref.go
+++ b/pkg/controller/controller_ref.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The KubeVirt Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
+)
+
+// GetControllerOf returns the controllerRef if controllee has a controller,
+// otherwise returns nil.
+func GetControllerOf(pod *k8sv1.Pod) *metav1.OwnerReference {
+	controllerRef := metav1.GetControllerOf(pod)
+	if controllerRef != nil {
+		return controllerRef
+	}
+	// We may find pods that are only using CreatedByLabel and not set with an OwnerReference
+	if createdBy := pod.Labels[virtv1.CreatedByLabel]; len(createdBy) > 0 {
+		name := pod.Annotations[virtv1.DomainAnnotation]
+		uid := types.UID(createdBy)
+		vmi := virtv1.NewVMI(name, uid)
+		return metav1.NewControllerRef(vmi, virtv1.VirtualMachineInstanceGroupVersionKind)
+	}
+	return nil
+}
+
+func IsControlledBy(pod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance) bool {
+	if controllerRef := GetControllerOf(pod); controllerRef != nil {
+		return controllerRef.UID == vmi.UID
+	}
+	return false
+}

--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -37,19 +37,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/log"
 )
 
-// GetControllerOf returns the controllerRef if controllee has a controller,
-// otherwise returns nil.
-func GetControllerOf(controllee metav1.Object) *metav1.OwnerReference {
-	ownerRefs := controllee.GetOwnerReferences()
-	for i := range ownerRefs {
-		owner := &ownerRefs[i]
-		if owner.Controller != nil && *owner.Controller == true {
-			return owner
-		}
-	}
-	return nil
-}
-
 type BaseControllerRefManager struct {
 	Controller metav1.Object
 	Selector   labels.Selector
@@ -84,7 +71,7 @@ func (m *BaseControllerRefManager) CanAdopt() error {
 //
 // No reconciliation will be attempted if the controller is being deleted.
 func (m *BaseControllerRefManager) ClaimObject(obj metav1.Object, match func(metav1.Object) bool, adopt, release func(metav1.Object) error) (bool, error) {
-	controllerRef := GetControllerOf(obj)
+	controllerRef := metav1.GetControllerOf(obj)
 	if controllerRef != nil {
 		if controllerRef.UID != m.Controller.GetUID() {
 			// Owned by someone else. Ignore.

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/precond"
-	"kubevirt.io/kubevirt/pkg/registry-disk"
+	registrydisk "kubevirt.io/kubevirt/pkg/registry-disk"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/util/types"
@@ -546,20 +546,14 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	}
 
 	// TODO use constants for podLabels
-	trueVar := true
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "virt-launcher-" + domain + "-",
 			Labels:       podLabels,
 			Annotations:  annotationsList,
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         v1.VirtualMachineInstanceGroupVersionKind.GroupVersion().String(),
-				Kind:               v1.VirtualMachineInstanceGroupVersionKind.Kind,
-				Name:               vmi.Name,
-				UID:                vmi.UID,
-				Controller:         &trueVar,
-				BlockOwnerDeletion: &trueVar,
-			}},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(vmi, v1.VirtualMachineInstanceGroupVersionKind),
+			},
 		},
 		Spec: k8sv1.PodSpec{
 			Hostname:  hostName,

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -296,7 +296,7 @@ func filterStuckVirtualMachinesWithoutPods(vmis []*virtv1.VirtualMachineInstance
 	return filtered
 }
 
-func isControlledByVMI(controllerRef *metav1.OwnerReference) {
+func isControlledByVMI(controllerRef *metav1.OwnerReference) bool {
 	return controllerRef != nil && controllerRef.Kind == virtv1.VirtualMachineInstanceGroupVersionKind.Kind
 }
 

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -387,6 +387,7 @@ func NewHealthyPodForVirtualMachine(podName string, vmi *virtv1.VirtualMachineIn
 			Namespace: k8sv1.NamespaceDefault,
 			Labels: map[string]string{
 				virtv1.CreatedByLabel: string(vmi.UID),
+				virtv1.AppLabel:       "virt-launcher",
 			},
 		},
 		Spec: k8sv1.PodSpec{NodeName: vmi.Status.NodeName},

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -435,7 +435,7 @@ func (c *VMIReplicaSet) addVirtualMachine(obj interface{}) {
 	}
 
 	// If it has a ControllerRef, that's all that matters.
-	if controllerRef := controller.GetControllerOf(vmi); controllerRef != nil {
+	if controllerRef := v1.GetControllerOf(vmi); controllerRef != nil {
 		rs := c.resolveControllerRef(vmi.Namespace, controllerRef)
 		if rs == nil {
 			return
@@ -491,8 +491,8 @@ func (c *VMIReplicaSet) updateVirtualMachine(old, cur interface{}) {
 		return
 	}
 
-	curControllerRef := controller.GetControllerOf(curVMI)
-	oldControllerRef := controller.GetControllerOf(oldVMI)
+	curControllerRef := v1.GetControllerOf(curVMI)
+	oldControllerRef := v1.GetControllerOf(oldVMI)
 	controllerRefChanged := !reflect.DeepEqual(curControllerRef, oldControllerRef)
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
@@ -550,7 +550,7 @@ func (c *VMIReplicaSet) deleteVirtualMachine(obj interface{}) {
 		}
 	}
 
-	controllerRef := controller.GetControllerOf(vmi)
+	controllerRef := v1.GetControllerOf(vmi)
 	if controllerRef == nil {
 		// No controller should care about orphans being deleted.
 		return

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -641,7 +641,7 @@ func (c *VMController) addVirtualMachine(obj interface{}) {
 	}
 
 	// If it has a ControllerRef, that's all that matters.
-	if controllerRef := controller.GetControllerOf(vmi); controllerRef != nil {
+	if controllerRef := v1.GetControllerOf(vmi); controllerRef != nil {
 		log.Log.Object(vmi).V(4).Info("Looking for VirtualMachineInstance Ref")
 		vm := c.resolveControllerRef(vmi.Namespace, controllerRef)
 		if vm == nil {
@@ -700,8 +700,8 @@ func (c *VMController) updateVirtualMachine(old, cur interface{}) {
 		return
 	}
 
-	curControllerRef := controller.GetControllerOf(curVMI)
-	oldControllerRef := controller.GetControllerOf(oldVMI)
+	curControllerRef := v1.GetControllerOf(curVMI)
+	oldControllerRef := v1.GetControllerOf(oldVMI)
 	controllerRefChanged := !reflect.DeepEqual(curControllerRef, oldControllerRef)
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
@@ -759,7 +759,7 @@ func (c *VMController) deleteVirtualMachine(obj interface{}) {
 		}
 	}
 
-	controllerRef := controller.GetControllerOf(vmi)
+	controllerRef := v1.GetControllerOf(vmi)
 	if controllerRef == nil {
 		// No controller should care about orphans being deleted.
 		return
@@ -782,7 +782,7 @@ func (c *VMController) addDataVolume(obj interface{}) {
 		c.deleteDataVolume(dataVolume)
 		return
 	}
-	controllerRef := controller.GetControllerOf(dataVolume)
+	controllerRef := v1.GetControllerOf(dataVolume)
 	if controllerRef == nil {
 		return
 	}
@@ -822,8 +822,8 @@ func (c *VMController) updateDataVolume(old, cur interface{}) {
 		}
 		return
 	}
-	curControllerRef := controller.GetControllerOf(curDataVolume)
-	oldControllerRef := controller.GetControllerOf(oldDataVolume)
+	curControllerRef := v1.GetControllerOf(curDataVolume)
+	oldControllerRef := v1.GetControllerOf(oldDataVolume)
 	controllerRefChanged := !reflect.DeepEqual(curControllerRef, oldControllerRef)
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
@@ -860,7 +860,7 @@ func (c *VMController) deleteDataVolume(obj interface{}) {
 			return
 		}
 	}
-	controllerRef := controller.GetControllerOf(dataVolume)
+	controllerRef := v1.GetControllerOf(dataVolume)
 	if controllerRef == nil {
 		// No controller should care about orphans being deleted.
 		return

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -341,15 +341,9 @@ func createDataVolumeManifest(dataVolume *cdiv1.DataVolume, vm *virtv1.VirtualMa
 	newDataVolume.ObjectMeta.Labels = labels
 	newDataVolume.ObjectMeta.Annotations = annotations
 
-	tr := true
-	newDataVolume.ObjectMeta.OwnerReferences = []v1.OwnerReference{{
-		APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-		Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
-		Name:               vm.Name,
-		UID:                vm.UID,
-		Controller:         &tr,
-		BlockOwnerDeletion: &tr,
-	}}
+	newDataVolume.ObjectMeta.OwnerReferences = []v1.OwnerReference{
+		*v1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind),
+	}
 	return newDataVolume
 }
 
@@ -535,17 +529,11 @@ func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.Virtual
 
 	setupStableFirmwareUUID(vm, vmi)
 
-	t := true
 	// TODO check if vmi labels exist, and when make sure that they match. For now just override them
 	vmi.ObjectMeta.Labels = vm.Spec.Template.ObjectMeta.Labels
-	vmi.ObjectMeta.OwnerReferences = []v1.OwnerReference{{
-		APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
-		Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
-		Name:               vm.ObjectMeta.Name,
-		UID:                vm.ObjectMeta.UID,
-		Controller:         &t,
-		BlockOwnerDeletion: &t,
-	}}
+	vmi.ObjectMeta.OwnerReferences = []v1.OwnerReference{
+		*v1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind),
+	}
 
 	return vmi
 }

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -921,14 +921,3 @@ func (c *VMIController) getControllerOf(pod *k8sv1.Pod) *v1.OwnerReference {
 		BlockOwnerDeletion: &t,
 	}
 }
-
-func (c *VMIController) getControllerOfDataVolume(dataVolume *cdiv1.DataVolume) *v1.OwnerReference {
-	t := true
-	return &v1.OwnerReference{
-		Kind:               virtv1.VirtualMachineInstanceGroupVersionKind.Kind,
-		Name:               dataVolume.Annotations[virtv1.DomainAnnotation],
-		UID:                types.UID(dataVolume.Annotations[virtv1.CreatedByLabel]),
-		Controller:         &t,
-		BlockOwnerDeletion: &t,
-	}
-}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -912,12 +912,8 @@ func (c *VMIController) checkHandOverExpectation(pod *k8sv1.Pod, vmi *virtv1.Vir
 }
 
 func (c *VMIController) getControllerOf(pod *k8sv1.Pod) *v1.OwnerReference {
-	t := true
-	return &v1.OwnerReference{
-		Kind:               virtv1.VirtualMachineInstanceGroupVersionKind.Kind,
-		Name:               pod.Annotations[virtv1.DomainAnnotation],
-		UID:                types.UID(pod.Labels[virtv1.CreatedByLabel]),
-		Controller:         &t,
-		BlockOwnerDeletion: &t,
-	}
+	name := pod.Annotations[virtv1.DomainAnnotation]
+	uid := types.UID(pod.Labels[virtv1.CreatedByLabel])
+	vmi := virtv1.NewVMI(name, uid)
+	return v1.NewControllerRef(vmi, virtv1.VirtualMachineInstanceGroupVersionKind)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We wish to replace CreatedByLabel, that virt-launcher is set with, with the a controller reference.
Unfortunately, we cannot do it right now due to backward compatibility issue (we might find running VMIs that are not set with a controller in their OwnerReferences).
This PR does the following:
1. Replace our implementations of GetControllerOf and IsControlledBy with those in Kubernetes.
2. Encapsulates the retrieval of the controller of virt-launcher in a way that it would be clear that it overrides that in Kubernetes. We first try to use the Kubernetes way and fall back to the existing logic that relies  on CreatedByLabel.
3. Deprecates CreatedByLabel (using a comment).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1369

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
