### PR TITLE
[POC] Hotplug disk

### DIFF
--- a/cluster/examples/hotplug-disk.yaml
+++ b/cluster/examples/hotplug-disk.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hotplug-disk
+  namespace: default
+spec:
+  containers:
+  - command:
+    - /share_disk.sh
+    - /var/run/kubevirt-private/vmi-disks/pvcvolume/disk.img
+    - /var/run/kubevirt/plug_device/nbd_disk.sock
+    #- sleep
+    #- "10000"
+    image: registry:5000/kubevirt/hotplug-disk:devel
+    imagePullPolicy: Always
+    securityContext:
+      privileged: true
+    name: busybox
+    volumeMounts:
+    - mountPath: /var/run/kubevirt
+      name: virt-share-dir
+    - mountPath: /var/run/kubevirt-private/vmi-disks/pvcvolume
+      name: pvcvolume
+  volumes:
+  - hostPath:
+      path: /var/run/kubevirt
+      type: ""
+    name: virt-share-dir
+  - name: pvcvolume
+    persistentVolumeClaim:
+      claimName: disk-alpine
+  dnsPolicy: ClusterFirst
+  hostNetwork: true
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  serviceAccount: default
+  serviceAccountName: default

--- a/cmd/hotplug-disk/Dockerfile
+++ b/cmd/hotplug-disk/Dockerfile
@@ -1,0 +1,10 @@
+FROM fedora:28
+
+RUN yum -y install \
+  qemu \
+  && dnf -y clean all && \
+  test $(id -u qemu) = 107 # make sure that the qemu user really is 107
+
+COPY share_disk.sh /
+
+ENTRYPOINT [ "/share_disk.sh" ]

--- a/cmd/hotplug-disk/share_disk.sh
+++ b/cmd/hotplug-disk/share_disk.sh
@@ -10,22 +10,27 @@ fi
 
 NBD_SOURCE=$1
 SOCKET_PATH=$2
+TMP_SOCKET_PATH="$(dirname $SOCKET_PATH)/.$(basename $SOCKET_PATH)"
 
-qemu-nbd $READ_ONLY -t -f raw -k "$SOCKET_PATH" $NBD_SOURCE &
+qemu-nbd $READ_ONLY -f raw -k "$TMP_SOCKET_PATH" $NBD_SOURCE &
 NBD_PID=$!
 
-# FIXME: this is a race condition. virt-launcher might already
-# be trying to attach the disk to the domain
-# unfortunately we can't assume NBD_SOURCE is readable unless root
 if [ "x$READ_ONLY" != "x-r" ] ; then
     RETRY_LIMIT=100
     RETRIES=0
     DONE=0
     while [ "$DONE" -eq "0" ] ; do
-        chown qemu:qemu "$SOCKET_PATH" && DONE=1 || RETRIES=$(($RETRIES + 1))
-        [ $RETRIES -gt $RETRY_LIMIT ] && fail "timed out waiting for socket"
+        chown qemu:qemu "$TMP_SOCKET_PATH" && DONE=1 || RETRIES=$(($RETRIES + 1))
+        [ $RETRIES -gt $RETRY_LIMIT ] && false "timed out waiting for socket"
         sleep 0.1
     done
+else
+    DONE=1
+fi
+
+if [ "$DONE" -eq "1" ] ; then
+    mv "$TMP_SOCKET_PATH" "$SOCKET_PATH"
 fi
 
 tail --pid="$NBD_PID" -f /dev/null
+rm -f "$TMP_SOCKET_PATH" "$SOCKET_PATH"

--- a/cmd/hotplug-disk/share_disk.sh
+++ b/cmd/hotplug-disk/share_disk.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -ex
+
+READ_ONLY=""
+if [ "$1" == "-r" ]; then
+    READ_ONLY="-r"
+    shift
+fi
+
+NBD_SOURCE=$1
+SOCKET_PATH=$2
+
+qemu-nbd $READ_ONLY -t -f raw -k "$SOCKET_PATH" $NBD_SOURCE &
+NBD_PID=$!
+
+# FIXME: this is a race condition. virt-launcher might already
+# be trying to attach the disk to the domain
+# unfortunately we can't assume NBD_SOURCE is readable unless root
+if [ "x$READ_ONLY" != "x-r" ] ; then
+    RETRY_LIMIT=100
+    RETRIES=0
+    DONE=0
+    while [ "$DONE" -eq "0" ] ; do
+        chown qemu:qemu "$SOCKET_PATH" && DONE=1 || RETRIES=$(($RETRIES + 1))
+        [ $RETRIES -gt $RETRY_LIMIT ] && fail "timed out waiting for socket"
+        sleep 0.1
+    done
+fi
+
+tail --pid="$NBD_PID" -f /dev/null

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -367,7 +367,9 @@ func main() {
 	domainConn := createLibvirtConnection()
 	defer domainConn.Close()
 
-	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn, *virtShareDir)
+	// FIXME: this needs to be moved outside of /var/run/kubevirt,
+	// (shared with host, but not other pods), and configurable
+	domainManager, err := virtwrap.NewLibvirtDomainManager(domainConn, *virtShareDir, "/var/run/kubevirt/plug_device")
 	if err != nil {
 		panic(err)
 	}
@@ -421,9 +423,7 @@ func main() {
 	markReady(*readinessFile)
 
 	go func() {
-		deviceMap := map[string]string{}
-		deviceMap["foo"] = "bar"
-		hotplug.WatchPluggableDisks(domainManager, "/var/run/kubevirt/plug_device", deviceMap, stopChan)
+		hotplug.WatchHotplugDomains(domainManager, "/var/run/kubevirt/plug_device", stopChan)
 	}()
 
 	domain := waitForDomainUUID(*qemuTimeout, events, signalStopChan, domainManager)

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,5 +1,5 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virtctl cmd/fake-qemu-process cmd/virt-api cmd/subresource-access-test cmd/example-hook-sidecar"
-docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api images/disks-images-provider images/vm-killer cmd/registry-disk-v1alpha images/cirros-registry-disk-demo images/fedora-cloud-registry-disk-demo images/alpine-registry-disk-demo cmd/subresource-access-test images/winrmcli cmd/example-hook-sidecar images/cdi-http-import-server"
+docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api images/disks-images-provider images/vm-killer cmd/registry-disk-v1alpha images/cirros-registry-disk-demo images/fedora-cloud-registry-disk-demo images/alpine-registry-disk-demo cmd/subresource-access-test images/winrmcli cmd/example-hook-sidecar images/cdi-http-import-server cmd/hotplug-disk"
 docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2

--- a/hotplug-disk.yaml
+++ b/hotplug-disk.yaml
@@ -8,22 +8,20 @@ spec:
   - command:
     - /share_disk.sh
     - /var/run/kubevirt-private/vmi-disks/pvcvolume/disk.img
-    - /var/run/kubevirt/plug_device/default_vmi-ephemeral/nbd_disk.sock
-    #- sleep
-    #- "10000"
+    - /var/run/kubevirt-hotplug/disk/nbd_disk.sock
     image: registry:5000/kubevirt/hotplug-disk:devel
     imagePullPolicy: Always
     securityContext:
       privileged: true
     name: busybox
     volumeMounts:
-    - mountPath: /var/run/kubevirt
+    - mountPath: /var/run/kubevirt-hotplug
       name: virt-share-dir
     - mountPath: /var/run/kubevirt-private/vmi-disks/pvcvolume
       name: pvcvolume
   volumes:
   - hostPath:
-      path: /var/run/kubevirt
+      path: /var/run/kubevirt-hotplug/default/vmi-ephemeral
       type: ""
     name: virt-share-dir
   - name: pvcvolume

--- a/hotplug-disk.yaml
+++ b/hotplug-disk.yaml
@@ -8,7 +8,7 @@ spec:
   - command:
     - /share_disk.sh
     - /var/run/kubevirt-private/vmi-disks/pvcvolume/disk.img
-    - /var/run/kubevirt/plug_device/nbd_disk.sock
+    - /var/run/kubevirt/plug_device/default_vmi-ephemeral/nbd_disk.sock
     #- sleep
     #- "10000"
     image: registry:5000/kubevirt/hotplug-disk:devel

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -53,7 +53,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Status.Phase = v1.Running
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
-			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", configCache, pvcCache)
+			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", "whatever", configCache, pvcCache)
 
 			pod, err := templateService.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Template", func() {
 	svc := NewTemplateService("kubevirt/virt-launcher",
 		"/var/run/kubevirt",
 		"/var/run/kubevirt-ephemeral-disks",
+		"/var/run/kubevirt-hotplug",
 		"pull-secret-1",
 		configCache,
 		pvcCache)

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -64,6 +64,8 @@ const (
 
 	ephemeralDiskDir = virtShareDir + "-ephemeral-disks"
 
+	hotplugDir = "/var/run/kubevirt-hotplug"
+
 	controllerThreads = 3
 )
 
@@ -107,6 +109,7 @@ type VirtControllerApp struct {
 	imagePullSecret   string
 	virtShareDir      string
 	ephemeralDiskDir  string
+	hotplugDir        string
 	readyChan         chan bool
 	kubevirtNamespace string
 }
@@ -271,6 +274,7 @@ func (vca *VirtControllerApp) initCommon() {
 	vca.templateService = services.NewTemplateService(vca.launcherImage,
 		vca.virtShareDir,
 		vca.ephemeralDiskDir,
+		vca.hotplugDir,
 		vca.imagePullSecret,
 		vca.configMapCache,
 		vca.persistentVolumeClaimCache)
@@ -334,4 +338,7 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", ephemeralDiskDir,
 		"Base directory for ephemeral disk data")
+
+	flag.StringVar(&vca.hotplugDir, "hotplug-dir", hotplugDir,
+		"Base directory for hotplug device data")
 }

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Migration watcher", func() {
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 
 		controller = NewMigrationController(
-			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore()),
+			services.NewTemplateService("a", "b", "c", "d", "e", configMapInformer.GetStore(), pvcInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			migrationInformer,

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -163,7 +163,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		configMapInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		controller = NewVMIController(
-			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore()),
+			services.NewTemplateService("a", "b", "c", "d", "e", configMapInformer.GetStore(), pvcInformer.GetStore()),
 			vmiInformer,
 			podInformer,
 			recorder,

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -165,6 +165,19 @@ func InitializeSharedDirectories(baseDir string) error {
 	return nil
 }
 
+func InitializeHotplugDirectories(baseDir string) error {
+	socketPath := filepath.Join(baseDir, "plug_device")
+	err := os.MkdirAll(socketPath, 0755)
+	if err != nil {
+		return err
+	}
+	err = diskutils.SetFileOwnership("qemu", socketPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func NewProcessMonitor(cmdlineMatchStr string,
 	gracefulShutdownTriggerFile string,
 	gracePeriod int,

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -166,7 +166,7 @@ func InitializeSharedDirectories(baseDir string) error {
 }
 
 func InitializeHotplugDirectories(baseDir string) error {
-	socketPath := filepath.Join(baseDir, "plug_device")
+	socketPath := filepath.Join(baseDir, "disk")
 	err := os.MkdirAll(socketPath, 0755)
 	if err != nil {
 		return err

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -182,11 +182,11 @@ func makeDeviceName(bus string, devicePerBus map[string]int) string {
 		log.Log.Errorf("Unrecognized bus '%s'", bus)
 		return ""
 	}
-	return formatDeviceName(prefix, index)
+	return FormatDeviceName(prefix, index)
 }
 
 // port of http://elixir.free-electrons.com/linux/v4.15/source/drivers/scsi/sd.c#L3211
-func formatDeviceName(prefix string, index int) string {
+func FormatDeviceName(prefix string, index int) string {
 	base := int('z' - 'a' + 1)
 	name := ""
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -57,7 +57,6 @@ type ConverterContext struct {
 	VirtualMachine *v1.VirtualMachineInstance
 	CPUSet         []int
 	IsBlockPVC     map[string]bool
-	DevicePerBus   map[string]int
 }
 
 func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk, devicePerBus map[string]int, numQueues *uint) error {
@@ -631,10 +630,11 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		}
 	}
 
+	devicePerBus := make(map[string]int)
 	for _, disk := range vmi.Spec.Domain.Devices.Disks {
 		newDisk := Disk{}
 
-		err := Convert_v1_Disk_To_api_Disk(&disk, &newDisk, c.DevicePerBus, numQueues)
+		err := Convert_v1_Disk_To_api_Disk(&disk, &newDisk, devicePerBus, numQueues)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -57,6 +57,7 @@ type ConverterContext struct {
 	VirtualMachine *v1.VirtualMachineInstance
 	CPUSet         []int
 	IsBlockPVC     map[string]bool
+	DevicePerBus   map[string]int
 }
 
 func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk, devicePerBus map[string]int, numQueues *uint) error {
@@ -630,11 +631,10 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		}
 	}
 
-	devicePerBus := make(map[string]int)
 	for _, disk := range vmi.Spec.Domain.Devices.Disks {
 		newDisk := Disk{}
 
-		err := Convert_v1_Disk_To_api_Disk(&disk, &newDisk, devicePerBus, numQueues)
+		err := Convert_v1_Disk_To_api_Disk(&disk, &newDisk, c.DevicePerBus, numQueues)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -605,13 +605,6 @@ func (in *ConverterContext) DeepCopyInto(out *ConverterContext) {
 			(*out)[key] = val
 		}
 	}
-	if in.DevicePerBus != nil {
-		in, out := &in.DevicePerBus, &out.DevicePerBus
-		*out = make(map[string]int, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -605,6 +605,13 @@ func (in *ConverterContext) DeepCopyInto(out *ConverterContext) {
 			(*out)[key] = val
 		}
 	}
+	if in.DevicePerBus != nil {
+		in, out := &in.DevicePerBus, &out.DevicePerBus
+		*out = make(map[string]int, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -355,8 +355,10 @@ type DiskDriver struct {
 }
 
 type DiskSourceHost struct {
-	Name string `xml:"name,attr"`
-	Port string `xml:"port,attr,omitempty"`
+	Name      string `xml:"name,attr"`
+	Port      string `xml:"port,attr,omitempty"`
+	Transport string `xml:"transport,attr,omitempty"`
+	Socket    string `xml:"socket,attr,omitempty"`
 }
 
 type BackingStore struct {

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -6,6 +6,8 @@ package cli
 import (
 	gomock "github.com/golang/mock/gomock"
 	libvirt_go "github.com/libvirt/libvirt-go"
+
+	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 // Mock of Connection interface
@@ -92,6 +94,26 @@ func (_m *MockConnection) NewStream(flags libvirt_go.StreamFlags) (Stream, error
 
 func (_mr *_MockConnectionRecorder) NewStream(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewStream", arg0)
+}
+
+func (_m *MockConnection) AttachDisk(dom VirDomain, disk *api.Disk) error {
+	ret := _m.ctrl.Call(_m, "AttachDisk", dom, disk)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockConnectionRecorder) AttachDisk(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachDisk", arg0, arg1)
+}
+
+func (_m *MockConnection) DetachDisk(dom VirDomain, disk *api.Disk) error {
+	ret := _m.ctrl.Call(_m, "DetachDisk", dom, disk)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockConnectionRecorder) DetachDisk(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachDisk", arg0, arg1)
 }
 
 // Mock of Stream interface

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -168,16 +168,13 @@ func (l *LibvirtConnection) _attachDetachDisk(dom VirDomain, disk *api.Disk, att
 		return err
 	}
 
-	// FIXME: the xml encoder doesn't know to lower-case the <Disk/> tag
+	// FIXME: the xml encoder doesn't know to cat the <Disk/> tag to lower-case
 	// and libvirt is case sensitive/rejects it. Is there a way to cleanly
 	// hint to xml.Marshal what to do here?
 	byteData[1] = 'd'
 	byteData[len(byteData)-5] = 'd'
 
 	data := string(byteData)
-
-	//data = strings.Replace(data, "<Disk>", "<disk>", 1)
-	//data = strings.Replace(data, "</Disk>", "</disk>", 1)
 
 	log.Log.Infof("XML data being sent to libvirt:\n\n\n%s\n\n\n", data)
 
@@ -198,7 +195,7 @@ func (l *LibvirtConnection) _attachDetachDisk(dom VirDomain, disk *api.Disk, att
 			return err
 		}
 		if domName == thisName {
-			if attach {
+			if attach == true {
 				err = thisDom.AttachDevice(data)
 			} else {
 				err = thisDom.DetachDevice(data)

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -102,3 +102,23 @@ func (_m *MockDomainManager) PrepareMigrationTarget(_param0 *v1.VirtualMachineIn
 func (_mr *_MockDomainManagerRecorder) PrepareMigrationTarget(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrepareMigrationTarget", arg0, arg1)
 }
+
+func (_m *MockDomainManager) AttachDisk(_param0 *api.Disk) error {
+	ret := _m.ctrl.Call(_m, "AttachDisk", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) AttachDisk(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachDisk", arg0)
+}
+
+func (_m *MockDomainManager) DetachDisk(_param0 *api.Disk) error {
+	ret := _m.ctrl.Call(_m, "DetachDisk", _param0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) DetachDisk(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachDisk", arg0)
+}

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -103,22 +103,22 @@ func (_mr *_MockDomainManagerRecorder) PrepareMigrationTarget(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrepareMigrationTarget", arg0, arg1)
 }
 
-func (_m *MockDomainManager) AttachDisk(_param0 *api.Disk) error {
-	ret := _m.ctrl.Call(_m, "AttachDisk", _param0)
+func (_m *MockDomainManager) AttachDisk(_param0 string, _param1 *api.Disk) error {
+	ret := _m.ctrl.Call(_m, "AttachDisk", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockDomainManagerRecorder) AttachDisk(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachDisk", arg0)
+func (_mr *_MockDomainManagerRecorder) AttachDisk(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AttachDisk", arg0, arg1)
 }
 
-func (_m *MockDomainManager) DetachDisk(_param0 *api.Disk) error {
-	ret := _m.ctrl.Call(_m, "DetachDisk", _param0)
+func (_m *MockDomainManager) DetachDisk(_param0 string, _param1 *api.Disk) error {
+	ret := _m.ctrl.Call(_m, "DetachDisk", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockDomainManagerRecorder) DetachDisk(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachDisk", arg0)
+func (_mr *_MockDomainManagerRecorder) DetachDisk(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachDisk", arg0, arg1)
 }

--- a/pkg/virt-launcher/virtwrap/hotplug/disk_hotplug.go
+++ b/pkg/virt-launcher/virtwrap/hotplug/disk_hotplug.go
@@ -1,0 +1,159 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package hotplug
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/fsnotify/fsnotify"
+
+	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const VIRTIO_DEVICE_PREFIX = "vd"
+const VIRTIO_BUS_TYPE = "virtio"
+
+func isPathWriteable(path string) bool {
+	return unix.Access(path, unix.W_OK) == nil
+}
+
+func allocateNextDevice(target string, deviceMap map[string]string) string {
+	// FormatDeviceName is zero-indexed to the length is already a one-up
+	idx := len(deviceMap)
+	node := api.FormatDeviceName(VIRTIO_DEVICE_PREFIX, idx)
+	deviceMap[target] = node
+	return node
+}
+
+func addHotpluggedDisk(domainManager virtwrap.DomainManager, nbdDiskPath string, deviceMap map[string]string) error {
+	/*virshCmd, err := exec.LookPath("virsh")
+	if err != nil {
+		log.Log.Reason(err).Error("virsh not found in $PATH")
+	}*/
+
+	deviceNode := allocateNextDevice(nbdDiskPath, deviceMap)
+	disk := &api.Disk{
+		Type:   "network",
+		Device: "disk",
+		Driver: &api.DiskDriver{
+			Name: "qemu",
+			Type: "raw",
+		},
+		Source: api.DiskSource{
+			Protocol: "nbd",
+			Host: &api.DiskSourceHost{
+				Transport: "unix",
+				Socket:    nbdDiskPath,
+			},
+		},
+		Target: api.DiskTarget{
+			Device: deviceNode,
+			Bus:    VIRTIO_BUS_TYPE,
+		},
+	}
+
+	if !isPathWriteable(nbdDiskPath) {
+		disk.ReadOnly = &api.ReadOnly{}
+	}
+
+	/*
+		data, err := xml.Marshal(disk)
+		if err != nil {
+			log.Log.Reason(err).Error("Unable to marshal disk data")
+			return err
+		}*/
+
+	// FIXME: so there's an issue here. golang reponds so fast that the
+	// socket isn't completely ready before trying to add the disk
+	// a blind sleep is not a great way to fix this.
+	time.Sleep(3 * time.Second)
+
+	// FIXME: how can we know which domain to attach to?
+	err := domainManager.AttachDisk(disk)
+	if err != nil {
+		log.Log.Reason(err).Error("Unable to attach disk to domain")
+		return err
+	}
+
+	/*domainName := "default_vmi-ephemeral"
+
+	f, err := ioutil.TempFile("", fmt.Sprintf("disk-%s-", deviceNode))
+	fn := f.Name()
+	f.Write([]byte(data))
+	f.Close()
+
+	cmd := exec.Command(virshCmd, "attach-device", domainName, fn)
+	err = cmd.Run()
+	if err != nil {
+		log.Log.Reason(err).Error("Unable to attach disk")
+		return err
+	}*/
+
+	return nil
+}
+
+func delHotpluggedDisk(domainManager virtwrap.DomainManager, nbdDiskPath string, deviceMap map[string]string) error {
+	//FIXME implement
+	return nil
+}
+
+// FIXME: in order to be able to remove pluggable disks already present
+// at VMI start, the NBD socket directory should contain a stub for each.
+// fsnotify watcher can't observe what's not there.
+func WatchPluggableDisks(domainManager virtwrap.DomainManager, baseDir string, deviceMap map[string]string, stop chan struct{}) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(baseDir)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Error attempting to watch path: %s", baseDir)
+		return err
+	}
+
+	for {
+		select {
+		case event := <-watcher.Events:
+			target := event.Name
+			if event.Op == fsnotify.Create {
+				err = addHotpluggedDisk(domainManager, target, deviceMap)
+				if err != nil {
+					log.Log.Reason(err).Errorf("Unable to add NBD disk: %s", target)
+					return err
+				}
+			} else if event.Op == fsnotify.Remove {
+				err = delHotpluggedDisk(domainManager, target, deviceMap)
+				if err != nil {
+					log.Log.Reason(err).Errorf("Unable to add NBD disk: %s", target)
+					return err
+				}
+			}
+		case <-stop:
+			return fmt.Errorf("shutting down pluggable disk watcher")
+		}
+	}
+}

--- a/pkg/virt-launcher/virtwrap/hotplug/disk_hotplug.go
+++ b/pkg/virt-launcher/virtwrap/hotplug/disk_hotplug.go
@@ -21,7 +21,9 @@ package hotplug
 
 import (
 	"fmt"
-	"time"
+	"io/ioutil"
+	"path"
+	"strings"
 
 	"golang.org/x/sys/unix"
 
@@ -40,19 +42,14 @@ func isPathWriteable(path string) bool {
 }
 
 func allocateNextDevice(target string, deviceMap map[string]string) string {
-	// FormatDeviceName is zero-indexed to the length is already a one-up
+	// FormatDeviceName is zero-indexed so the length is already a one-up
 	idx := len(deviceMap)
 	node := api.FormatDeviceName(VIRTIO_DEVICE_PREFIX, idx)
 	deviceMap[target] = node
 	return node
 }
 
-func addHotpluggedDisk(domainManager virtwrap.DomainManager, nbdDiskPath string, deviceMap map[string]string) error {
-	/*virshCmd, err := exec.LookPath("virsh")
-	if err != nil {
-		log.Log.Reason(err).Error("virsh not found in $PATH")
-	}*/
-
+func addHotpluggedDisk(domainManager virtwrap.DomainManager, domName string, nbdDiskPath string, deviceMap map[string]string) error {
 	deviceNode := allocateNextDevice(nbdDiskPath, deviceMap)
 	disk := &api.Disk{
 		Type:   "network",
@@ -78,51 +75,52 @@ func addHotpluggedDisk(domainManager virtwrap.DomainManager, nbdDiskPath string,
 		disk.ReadOnly = &api.ReadOnly{}
 	}
 
-	/*
-		data, err := xml.Marshal(disk)
-		if err != nil {
-			log.Log.Reason(err).Error("Unable to marshal disk data")
-			return err
-		}*/
-
-	// FIXME: so there's an issue here. golang reponds so fast that the
-	// socket isn't completely ready before trying to add the disk
-	// a blind sleep is not a great way to fix this.
-	time.Sleep(3 * time.Second)
-
-	// FIXME: how can we know which domain to attach to?
-	err := domainManager.AttachDisk(disk)
+	err := domainManager.AttachDisk(domName, disk)
 	if err != nil {
 		log.Log.Reason(err).Error("Unable to attach disk to domain")
 		return err
 	}
 
-	/*domainName := "default_vmi-ephemeral"
+	return nil
+}
 
-	f, err := ioutil.TempFile("", fmt.Sprintf("disk-%s-", deviceNode))
-	fn := f.Name()
-	f.Write([]byte(data))
-	f.Close()
+func delHotpluggedDisk(domainManager virtwrap.DomainManager, domName string, nbdDiskPath string, deviceMap map[string]string) error {
+	deviceNode := allocateNextDevice(nbdDiskPath, deviceMap)
+	disk := &api.Disk{
+		Type:   "network",
+		Device: "disk",
+		Driver: &api.DiskDriver{
+			Name: "qemu",
+			Type: "raw",
+		},
+		Source: api.DiskSource{
+			Protocol: "nbd",
+			Host: &api.DiskSourceHost{
+				Transport: "unix",
+				Socket:    nbdDiskPath,
+			},
+		},
+		Target: api.DiskTarget{
+			Device: deviceNode,
+			Bus:    VIRTIO_BUS_TYPE,
+		},
+	}
 
-	cmd := exec.Command(virshCmd, "attach-device", domainName, fn)
-	err = cmd.Run()
+	if !isPathWriteable(nbdDiskPath) {
+		disk.ReadOnly = &api.ReadOnly{}
+	}
+
+	err := domainManager.DetachDisk(domName, disk)
 	if err != nil {
-		log.Log.Reason(err).Error("Unable to attach disk")
+		log.Log.Reason(err).Error("Unable to attach disk to domain")
 		return err
-	}*/
+	}
 
 	return nil
 }
 
-func delHotpluggedDisk(domainManager virtwrap.DomainManager, nbdDiskPath string, deviceMap map[string]string) error {
-	//FIXME implement
-	return nil
-}
-
-// FIXME: in order to be able to remove pluggable disks already present
-// at VMI start, the NBD socket directory should contain a stub for each.
-// fsnotify watcher can't observe what's not there.
-func WatchPluggableDisks(domainManager virtwrap.DomainManager, baseDir string, deviceMap map[string]string, stop chan struct{}) error {
+// Watches for domains and monitors each for hotplug events
+func WatchHotplugDomains(domainManager virtwrap.DomainManager, baseDir string, stop chan struct{}) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err
@@ -131,7 +129,58 @@ func WatchPluggableDisks(domainManager virtwrap.DomainManager, baseDir string, d
 
 	err = watcher.Add(baseDir)
 	if err != nil {
-		log.Log.Reason(err).Errorf("Error attempting to watch path: %s", baseDir)
+		log.Log.Reason(err).Errorf("Error attempting to watch base path: %s", baseDir)
+		return err
+	}
+
+	stopChanPerDomain := make(map[string]chan struct{})
+
+	for {
+		select {
+		case event := <-watcher.Events:
+			target := event.Name
+			domName := path.Base(target)
+			// ignore prefixes starting with "."
+			if !strings.HasPrefix(domName, ".") {
+				if event.Op == fsnotify.Create {
+					deviceMap := map[string]string{}
+					stopChanPerDomain[domName] = make(chan struct{})
+					fileList, err := ioutil.ReadDir(target)
+					if err != nil {
+						return err
+					}
+					for idx, _ := range fileList {
+						// These are just placeholders for now.
+						deviceMap[fmt.Sprintf("dev_%d", idx)] = ""
+					}
+					WatchPluggableDisks(domainManager, domName, target, deviceMap, stopChanPerDomain[domName])
+				} else if event.Op == fsnotify.Remove {
+					close(stopChanPerDomain[domName])
+					delete(stopChanPerDomain, domName)
+				}
+			}
+		case <-stop:
+			for _, stopChan := range stopChanPerDomain {
+				close(stopChan)
+			}
+			return fmt.Errorf("shutting down pluggable disk watcher")
+		}
+	}
+
+	//
+
+}
+
+func WatchPluggableDisks(domainManager virtwrap.DomainManager, domName string, hotplugDir string, deviceMap map[string]string, stop chan struct{}) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(hotplugDir)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Error attempting to watch domain hotplug path: %s", hotplugDir)
 		return err
 	}
 
@@ -139,17 +188,20 @@ func WatchPluggableDisks(domainManager virtwrap.DomainManager, baseDir string, d
 		select {
 		case event := <-watcher.Events:
 			target := event.Name
-			if event.Op == fsnotify.Create {
-				err = addHotpluggedDisk(domainManager, target, deviceMap)
-				if err != nil {
-					log.Log.Reason(err).Errorf("Unable to add NBD disk: %s", target)
-					return err
-				}
-			} else if event.Op == fsnotify.Remove {
-				err = delHotpluggedDisk(domainManager, target, deviceMap)
-				if err != nil {
-					log.Log.Reason(err).Errorf("Unable to add NBD disk: %s", target)
-					return err
+			basePath := path.Base(target)
+			if !strings.HasPrefix(basePath, ".") {
+				if event.Op == fsnotify.Create {
+					err = addHotpluggedDisk(domainManager, domName, target, deviceMap)
+					if err != nil {
+						log.Log.Reason(err).Errorf("Unable to add NBD disk: %s", target)
+						return err
+					}
+				} else if event.Op == fsnotify.Remove {
+					err = delHotpluggedDisk(domainManager, domName, target, deviceMap)
+					if err != nil {
+						log.Log.Reason(err).Errorf("Unable to add NBD disk: %s", target)
+						return err
+					}
 				}
 			}
 		case <-stop:

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -62,6 +62,8 @@ type DomainManager interface {
 	ListAllDomains() ([]*api.Domain, error)
 	MigrateVMI(*v1.VirtualMachineInstance) error
 	PrepareMigrationTarget(*v1.VirtualMachineInstance, bool) error
+	AttachDisk(*api.Disk) error
+	DetachDisk(*api.Disk) error
 }
 
 type LibvirtDomainManager struct {
@@ -676,4 +678,26 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 	}
 
 	return list, nil
+}
+
+func (l *LibvirtDomainManager) AttachDisk(disk *api.Disk) error {
+	// FIXME: this is completely the wrong approach. we should *know* which domain
+	// to attach to. Perhaps pass in VMI?
+	domList, err := l.virConn.ListAllDomains(libvirt.CONNECT_LIST_DOMAINS_ACTIVE | libvirt.CONNECT_LIST_DOMAINS_INACTIVE)
+	if err != nil {
+		return err
+	}
+	domain := domList[0]
+	return l.virConn.AttachDisk(domain, disk)
+}
+
+func (l *LibvirtDomainManager) DetachDisk(disk *api.Disk) error {
+	// FIXME: this is completely the wrong approach. we should *know* which domain
+	// to attach to. Perhaps pass in VMI?
+	domList, err := l.virConn.ListAllDomains(libvirt.CONNECT_LIST_DOMAINS_ACTIVE | libvirt.CONNECT_LIST_DOMAINS_INACTIVE)
+	if err != nil {
+		return err
+	}
+	domain := domList[0]
+	return l.virConn.DetachDisk(domain, disk)
 }

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -22,8 +22,6 @@ package virtwrap
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/golang/mock/gomock"
 	"github.com/libvirt/libvirt-go"
@@ -43,7 +41,6 @@ var _ = Describe("Manager", func() {
 	var mockConn *cli.MockConnection
 	var mockDomain *cli.MockVirDomain
 	var ctrl *gomock.Controller
-	var workDir string
 	testVmName := "testvmi"
 	testNamespace := "testnamespace"
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
@@ -55,12 +52,7 @@ var _ = Describe("Manager", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockConn = cli.NewMockConnection(ctrl)
 		mockDomain = cli.NewMockVirDomain(ctrl)
-		workDir, err = ioutil.TempDir("", "kubevirt-test-XXXXXX")
 		Expect(err).ToNot(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		os.RemoveAll(workDir)
 	})
 
 	expectIsolationDetectionForVMI := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {
@@ -91,7 +83,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-			manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 			newspec, err := manager.SyncVMI(vmi, true)
 			Expect(err).To(BeNil())
 			Expect(newspec).ToNot(BeNil())
@@ -106,7 +98,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-			manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 			newspec, err := manager.SyncVMI(vmi, true)
 			Expect(err).To(BeNil())
 			Expect(newspec).ToNot(BeNil())
@@ -124,7 +116,7 @@ var _ = Describe("Manager", func() {
 				mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 				mockDomain.EXPECT().Create().Return(nil)
 				mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-				manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+				manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 				newspec, err := manager.SyncVMI(vmi, true)
 				Expect(err).To(BeNil())
 				Expect(newspec).ToNot(BeNil())
@@ -145,7 +137,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, 1, nil)
 			mockDomain.EXPECT().Resume().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(xml), nil)
-			manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 			newspec, err := manager.SyncVMI(vmi, true)
 			Expect(err).To(BeNil())
 			Expect(newspec).ToNot(BeNil())
@@ -158,7 +150,7 @@ var _ = Describe("Manager", func() {
 			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 
-			manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 			err := manager.PrepareMigrationTarget(vmi, true)
 			Expect(err).To(BeNil())
 		})
@@ -178,7 +170,7 @@ var _ = Describe("Manager", func() {
 				UID: vmi.Status.MigrationState.MigrationUID,
 			}
 
-			manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
@@ -201,7 +193,7 @@ var _ = Describe("Manager", func() {
 				mockDomain.EXPECT().Free()
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().Undefine().Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+				manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 				err := manager.DeleteVMI(newVMI(testNamespace, testVmName))
 				Expect(err).To(BeNil())
 			},
@@ -215,7 +207,7 @@ var _ = Describe("Manager", func() {
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
 				mockDomain.EXPECT().DestroyFlags(libvirt.DOMAIN_DESTROY_GRACEFUL).Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+				manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 				err := manager.KillVMI(newVMI(testNamespace, testVmName))
 				Expect(err).To(BeNil())
 			},
@@ -240,7 +232,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_INACTIVE)).Return(string(x), nil)
 			mockConn.EXPECT().ListAllDomains(gomock.Eq(libvirt.CONNECT_LIST_DOMAINS_ACTIVE|libvirt.CONNECT_LIST_DOMAINS_INACTIVE)).Return([]cli.VirDomain{mockDomain}, nil)
 
-			manager, _ := NewLibvirtDomainManager(mockConn, "fake", workDir)
+			manager, _ := NewLibvirtDomainManager(mockConn, "fake")
 			doms, err := manager.ListAllDomains()
 
 			Expect(len(doms)).To(Equal(1))


### PR DESCRIPTION
POC implementation of disk hotplugging in KubeVirt. This implementation uses Network Block Devices from a complementary pod to make dynamically introduced disks available to already-running VMI's.

**Release note**:
```release-note
Disk hotplugging on the virtoio bus is now implemented through Network Block Devices.
```
