### PR TITLE
basic VMI restart endpoint

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3774,6 +3774,35 @@
      }
     }
    },
+   "/apis/subresources.kubevirt.io/v1alpha2/namespaces/{namespace}/virtualmachines/{name}/restart": {
+    "get": {
+     "summary": "Restart a VM",
+     "operationId": "restart",
+     "parameters": [
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK"
+      }
+     }
+    }
+   },
    "/apis/subresources.kubevirt.io/v1alpha2/version": {
     "get": {
      "produces": [

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3775,7 +3775,7 @@
     }
    },
    "/apis/subresources.kubevirt.io/v1alpha2/namespaces/{namespace}/virtualmachines/{name}/restart": {
-    "get": {
+    "put": {
      "summary": "Restart a VM",
      "operationId": "restart",
      "parameters": [

--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -132,12 +132,14 @@ rules:
   - apiGroups:
       - kubevirt.io
     resources:
+      - virtualmachines
       - virtualmachineinstances
       - virtualmachineinstancemigrations
     verbs:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ''
     resources:
@@ -280,6 +282,7 @@ rules:
     resources:
       - virtualmachineinstances/console
       - virtualmachineinstances/vnc
+      - virtualmachines/restart
     verbs:
       - get
   - apiGroups:
@@ -312,6 +315,7 @@ rules:
     resources:
       - virtualmachineinstances/console
       - virtualmachineinstances/vnc
+      - virtualmachines/restart
     verbs:
       - get
   - apiGroups:

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -30,6 +30,7 @@ rules:
     resources:
       - virtualmachineinstances/console
       - virtualmachineinstances/vnc
+      - virtualmachines/restart
     verbs:
       - get
   - apiGroups:
@@ -62,6 +63,7 @@ rules:
     resources:
       - virtualmachineinstances/console
       - virtualmachineinstances/vnc
+      - virtualmachines/restart
     verbs:
       - get
   - apiGroups:
@@ -234,12 +236,14 @@ rules:
   - apiGroups:
       - kubevirt.io
     resources:
+      - virtualmachines
       - virtualmachineinstances
       - virtualmachineinstancemigrations
     verbs:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - ''
     resources:

--- a/pkg/kubecli/generated_mock_kubevirt.go
+++ b/pkg/kubecli/generated_mock_kubevirt.go
@@ -997,6 +997,16 @@ func (_mr *_MockVirtualMachineInterfaceRecorder) Patch(arg0, arg1, arg2 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
+func (_m *MockVirtualMachineInterface) Restart(name string) error {
+	ret := _m.ctrl.Call(_m, "Restart", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirtualMachineInterfaceRecorder) Restart(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Restart", arg0)
+}
+
 // Mock of VirtualMachineInstanceMigrationInterface interface
 type MockVirtualMachineInstanceMigrationInterface struct {
 	ctrl     *gomock.Controller

--- a/pkg/kubecli/kubevirt.go
+++ b/pkg/kubecli/kubevirt.go
@@ -112,6 +112,7 @@ type VirtualMachineInterface interface {
 	Update(*v1.VirtualMachine) (*v1.VirtualMachine, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachine, err error)
+	Restart(name string) error
 }
 
 type VirtualMachineInstanceMigrationInterface interface {

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -20,6 +20,8 @@
 package kubecli
 
 import (
+	"fmt"
+
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -27,6 +29,8 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/api/v1"
 )
+
+const vmSubresourceURL = "/apis/subresources.kubevirt.io/v1alpha2/namespaces/%s/virtualmachines/%s/%s"
 
 func (k *kubevirt) VirtualMachine(namespace string) VirtualMachineInterface {
 	return &vm{
@@ -130,4 +134,9 @@ func (v *vm) Patch(name string, pt types.PatchType, data []byte, subresources ..
 		Do().
 		Into(result)
 	return result, err
+}
+
+func (v *vm) Restart(name string) error {
+	uri := fmt.Sprintf(vmSubresourceURL, v.namespace, name, "restart")
+	return v.restClient.Get().RequestURI(uri).Do().Error()
 }

--- a/pkg/kubecli/vm.go
+++ b/pkg/kubecli/vm.go
@@ -138,5 +138,5 @@ func (v *vm) Patch(name string, pt types.PatchType, data []byte, subresources ..
 
 func (v *vm) Restart(name string) error {
 	uri := fmt.Sprintf(vmSubresourceURL, v.namespace, name, "restart")
-	return v.restClient.Get().RequestURI(uri).Do().Error()
+	return v.restClient.Put().RequestURI(uri).Do().Error()
 }

--- a/pkg/kubecli/vm_test.go
+++ b/pkg/kubecli/vm_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 
 	It("should restart a VirtualMachine", func() {
 		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", subVMIPath+"/restart"),
+			ghttp.VerifyRequest("PUT", subVMIPath+"/restart"),
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
 		err := client.VirtualMachine(k8sv1.NamespaceDefault).Restart("testvm")

--- a/pkg/kubecli/vm_test.go
+++ b/pkg/kubecli/vm_test.go
@@ -38,6 +38,8 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 	var client KubevirtClient
 	basePath := "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachines"
 	vmiPath := basePath + "/testvm"
+	subBasePath := "/apis/subresources.kubevirt.io/v1alpha2/namespaces/default/virtualmachines"
+	subVMIPath := subBasePath + "/testvm"
 
 	BeforeEach(func() {
 		var err error
@@ -154,6 +156,17 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 		))
 		err := client.VirtualMachine(k8sv1.NamespaceDefault).Delete("testvm", &k8smetav1.DeleteOptions{})
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should restart a VirtualMachine", func() {
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", subVMIPath+"/restart"),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
+		))
+		err := client.VirtualMachine(k8sv1.NamespaceDefault).Restart("testvm")
 
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -195,6 +195,7 @@ func (app *virtAPIApp) composeHealthEndpoint() {
 
 func (app *virtAPIApp) composeSubresources() {
 
+	subresourcesvmGVR := schema.GroupVersionResource{Group: v1.SubresourceGroupVersion.Group, Version: v1.SubresourceGroupVersion.Version, Resource: "virtualmachines"}
 	subresourcesvmiGVR := schema.GroupVersionResource{Group: v1.SubresourceGroupVersion.Group, Version: v1.SubresourceGroupVersion.Version, Resource: "virtualmachineinstances"}
 
 	subws := new(restful.WebService)
@@ -204,6 +205,12 @@ func (app *virtAPIApp) composeSubresources() {
 	subresourceApp := &rest.SubresourceAPIApp{
 		VirtCli: app.virtCli,
 	}
+
+	subws.Route(subws.GET(rest.ResourcePath(subresourcesvmGVR) + rest.SubResourcePath("restart")).
+		To(subresourceApp.RestartVMRequestHandler).
+		Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
+		Operation("restart").
+		Doc("Restart a VM"))
 
 	subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("console")).
 		To(subresourceApp.ConsoleRequestHandler).

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -206,7 +206,7 @@ func (app *virtAPIApp) composeSubresources() {
 		VirtCli: app.virtCli,
 	}
 
-	subws.Route(subws.GET(rest.ResourcePath(subresourcesvmGVR) + rest.SubResourcePath("restart")).
+	subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR) + rest.SubResourcePath("restart")).
 		To(subresourceApp.RestartVMRequestHandler).
 		Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 		Operation("restart").

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -150,7 +150,7 @@ func (a *authorizor) generateAccessReview(req *restful.Request) (*authorization.
 	subresource := pathSplit[8]
 	userExtras := a.getUserExtras(headers)
 
-	if resource != "virtualmachineinstances" {
+	if resource != "virtualmachineinstances" && resource != "virtualmachines" {
 		return nil, fmt.Errorf("unknown resource type %s", resource)
 	}
 

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -46,6 +46,7 @@ func NewVirtctlCommand() *cobra.Command {
 		vnc.NewCommand(clientConfig),
 		vm.NewStartCommand(clientConfig),
 		vm.NewStopCommand(clientConfig),
+		vm.NewRestartCommand(clientConfig),
 		expose.NewExposeCommand(clientConfig),
 		version.VersionCommand(clientConfig),
 		imageupload.NewImageUploadCommand(clientConfig),

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -33,8 +33,9 @@ import (
 )
 
 const (
-	COMMAND_START = "start"
-	COMMAND_STOP  = "stop"
+	COMMAND_START   = "start"
+	COMMAND_STOP    = "stop"
+	COMMAND_RESTART = "restart"
 )
 
 func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
@@ -60,6 +61,21 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
+			return c.Run(cmd, args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "restart (VM)",
+		Short:   "Restart a virtual machine.",
+		Example: usage(COMMAND_RESTART),
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},
 	}
@@ -102,29 +118,37 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Error fetching VirtualMachine: %v", err)
 	}
 
-	var running bool
-	if o.command == COMMAND_START {
-		running = true
-	} else if o.command == COMMAND_STOP {
-		running = false
-	}
+	switch o.command {
+	case COMMAND_STOP, COMMAND_START:
+		var running bool
+		if o.command == COMMAND_START {
+			running = true
+		} else if o.command == COMMAND_STOP {
+			running = false
+		}
 
-	if vm.Spec.Running != running {
-		bodyStr := fmt.Sprintf("{\"spec\":{\"running\":%t}}", running)
+		if vm.Spec.Running != running {
+			bodyStr := fmt.Sprintf("{\"spec\":{\"running\":%t}}", running)
 
-		_, err := virtClient.VirtualMachine(namespace).Patch(vm.Name, types.MergePatchType,
-			[]byte(bodyStr))
+			_, err := virtClient.VirtualMachine(namespace).Patch(vm.Name, types.MergePatchType,
+				[]byte(bodyStr))
 
+			if err != nil {
+				return fmt.Errorf("Error updating VirtualMachine: %v", err)
+			}
+
+		} else {
+			stateMsg := "stopped"
+			if running {
+				stateMsg = "running"
+			}
+			return fmt.Errorf("Error: VirtualMachineInstance '%s' is already %s", vmiName, stateMsg)
+		}
+	case COMMAND_RESTART:
+		err = virtClient.VirtualMachine(namespace).Restart(vmiName)
 		if err != nil {
-			return fmt.Errorf("Error updating VirtualMachine: %v", err)
+			return fmt.Errorf("Error restarting VirtualMachine %v", err)
 		}
-
-	} else {
-		stateMsg := "stopped"
-		if running {
-			stateMsg = "running"
-		}
-		return fmt.Errorf("Error: VirtualMachineInstance '%s' is already %s", vmiName, stateMsg)
 	}
 
 	cmd.Printf("VM %s was scheduled to %s\n", vmiName, o.command)

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -120,11 +120,9 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 
 	switch o.command {
 	case COMMAND_STOP, COMMAND_START:
-		var running bool
+		running := false
 		if o.command == COMMAND_START {
 			running = true
-		} else if o.command == COMMAND_STOP {
-			running = false
 		}
 
 		if vm.Spec.Running != running {

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -92,8 +92,7 @@ var _ = Describe("Subresource Api", func() {
 
 				Eventually(func() v1.VirtualMachineInstancePhase {
 					newVMI, err := virtCli.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					if vmi.UID == newVMI.UID {
+					if err != nil || vmi.UID == newVMI.UID {
 						return v1.VmPhaseUnset
 					}
 					return newVMI.Status.Phase


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It provides a basic VMI restart endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I still have to add tests, in progress.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
a new endpoint which is providing a VM restart functionality
```
