### PR TITLE
Dropping OwnedByAnnotation from VMIs

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -366,9 +366,6 @@ const (
 	CreatedByLabel string = "kubevirt.io/created-by"
 	// This label is used to indicate that this pod is the target of a migration job.
 	MigrationJobLabel string = "kubevirt.io/migrationJobUID"
-	// This annotation defines which KubeVirt component owns the resource. Used
-	// on Pod.
-	OwnedByAnnotation string = "kubevirt.io/owned-by"
 	// This label describes which cluster node runs the virtual machine
 	// instance. Needed because with CRDs we can't use field selectors. Used on
 	// VirtualMachineInstance.

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -599,8 +599,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	hostName := dns.SanitizeHostname(vmi)
 
 	annotationsList := map[string]string{
-		v1.DomainAnnotation:  domain,
-		v1.OwnedByAnnotation: "virt-controller",
+		v1.DomainAnnotation: domain,
 	}
 
 	cniNetworks, cniAnnotation := getCniInterfaceList(vmi)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -71,8 +71,7 @@ var _ = Describe("Template", func() {
 					v1.CreatedByLabel: "1234",
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
-					v1.DomainAnnotation:  "testvmi",
-					v1.OwnedByAnnotation: "virt-controller",
+					v1.DomainAnnotation: "testvmi",
 				}))
 				Expect(pod.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{{
 					APIVersion:         v1.VirtualMachineInstanceGroupVersionKind.GroupVersion().String(),

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -68,7 +68,6 @@ var _ = Describe("Migration watcher", func() {
 		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			update, ok := action.(testing.CreateAction)
 			Expect(ok).To(BeTrue())
-			Expect(update.GetObject().(*k8sv1.Pod).Annotations[v1.OwnedByAnnotation]).To(Equal("virt-controller"))
 			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.CreatedByLabel]).To(Equal(string(uid)))
 			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.MigrationJobLabel]).To(Equal(string(migrationUid)))
 			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.MigrationJobLabel]).To(Equal(string(migrationUid)))
@@ -557,7 +556,6 @@ func newTargetPodForVirtualMachine(vmi *v1.VirtualMachineInstance, migration *v1
 			},
 			Annotations: map[string]string{
 				v1.DomainAnnotation:           vmi.Name,
-				v1.OwnedByAnnotation:          "virt-controller",
 				v1.MigrationJobNameAnnotation: migration.Name,
 			},
 		},

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -330,7 +330,6 @@ func createDataVolumeManifest(dataVolume *cdiv1.DataVolume, vm *virtv1.VirtualMa
 	annotations := map[string]string{}
 
 	labels[virtv1.CreatedByLabel] = string(vm.UID)
-	annotations[virtv1.OwnedByAnnotation] = "virt-controller"
 
 	for k, v := range dataVolume.Labels {
 		annotations[k] = v

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -93,7 +93,6 @@ var _ = Describe("VirtualMachine", func() {
 				*idx++
 				dataVolume := update.GetObject().(*cdiv1.DataVolume)
 				Expect(dataVolume.ObjectMeta.OwnerReferences[0].UID).To(Equal(uid))
-				Expect(dataVolume.Annotations[v1.OwnedByAnnotation]).To(Equal("virt-controller"))
 				return true, update.GetObject(), nil
 			})
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removing OwnedByAnnotation from VMIs.

**Special notes for your reviewer**:
This PR complements the alignments with Kubernetes that are introduced by PRs #1641 and #1665. This time we target  the `OwnedByAnnotation`  ([see Roman's suggestion](https://github.com/kubevirt/kubevirt/pull/1435#issuecomment-419808273)). 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
