### PR TITLE
Backport of #1668 to release-0.9

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -613,9 +613,7 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability 
 		res = append(res, CAP_NET_ADMIN)
 	}
 	// add a CAP_SYS_NICE capability to allow setting cpu affinity
-	if vmi.IsCPUDedicated() {
-		res = append(res, CAP_SYS_NICE)
-	}
+	res = append(res, CAP_SYS_NICE)
 	return res
 }
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -864,6 +864,37 @@ var _ = Describe("Configurations", func() {
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
 			})
+			It("should start a vm with no cpu pinning after a vm with cpu pinning on same node", func() {
+				Vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.RegistryDiskFor(tests.RegistryDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				cpuVmi.Spec.Domain.CPU = &v1.CPU{
+					DedicatedCPUPlacement: true,
+				}
+				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceCPU:    resource.MustParse("2"),
+						kubev1.ResourceMemory: resource.MustParse("64M"),
+					},
+				}
+				Vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceCPU: resource.MustParse("1"),
+					},
+				}
+				Vmi.Spec.NodeSelector = map[string]string{v1.CPUManager: "true"}
+
+				By("Starting a VirtualMachineInstance with dedicated cpus")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
+				Expect(err).ToNot(HaveOccurred())
+				node := tests.WaitForSuccessfulVMIStart(cpuVmi)
+				Expect(node).To(ContainSubstring("node02"))
+
+				By("Starting a VirtualMachineInstance without dedicated cpus")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(Vmi)
+				Expect(err).ToNot(HaveOccurred())
+				node1 := tests.WaitForSuccessfulVMIStart(Vmi)
+				Expect(node1).To(ContainSubstring("node02"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of #1668 to branch `release-0.9`

**Release note**:
```release-note
Allows running VMs with pinned/non-pinned CPUs on the same node, by adding a SYS_NICE capability to all containers 
```
