### PR TITLE
dockerfile: Update maintainer instruction with label

### DIFF
--- a/cmd/example-hook-sidecar/Dockerfile
+++ b/cmd/example-hook-sidecar/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:27
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 COPY example-hook-sidecar /example-hook-sidecar
 

--- a/cmd/registry-disk-v1alpha/Dockerfile
+++ b/cmd/registry-disk-v1alpha/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM debian:sid
 
-MAINTAINER "David Vossel" \<dvossel@redhat.com\>
+LABEL maintainer="David Vossel <dvossel@redhat.com>"
 ENV container docker
 
 RUN apt-get update && apt-get install -y \

--- a/cmd/subresource-access-test/Dockerfile
+++ b/cmd/subresource-access-test/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
 RUN useradd -u 1001 --create-home -s /bin/bash virtctl

--- a/cmd/virt-api/Dockerfile
+++ b/cmd/virt-api/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
 RUN useradd -u 1001 --create-home -s /bin/bash virt-api

--- a/cmd/virt-controller/Dockerfile
+++ b/cmd/virt-controller/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Create non-root user
 RUN useradd -u 1001 --create-home -s /bin/bash virt-controller

--- a/cmd/virt-handler/Dockerfile
+++ b/cmd/virt-handler/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 COPY virt-handler /usr/bin/virt-handler
 COPY .version /.version

--- a/cmd/virt-launcher/Dockerfile
+++ b/cmd/virt-launcher/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM kubevirt/libvirt:4.2.0
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 RUN dnf -y install \
   socat \

--- a/images/alpine-registry-disk-demo/Dockerfile
+++ b/images/alpine-registry-disk-demo/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM kubevirt/registry-disk-v1alpha
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Add alpine image
 RUN curl http://dl-cdn.alpinelinux.org/alpine/v3.7/releases/x86_64/alpine-virt-3.7.0-x86_64.iso > /disk/alpine.iso

--- a/images/cdi-http-import-server/Dockerfile
+++ b/images/cdi-http-import-server/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:27
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 ENV container docker
 
 RUN dnf install -y nginx \

--- a/images/cirros-registry-disk-demo/Dockerfile
+++ b/images/cirros-registry-disk-demo/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM kubevirt/registry-disk-v1alpha
 
-MAINTAINER "David Vossel" \<dvossel@redhat.com\>
+LABEL maintainer="David Vossel <dvossel@redhat.com>"
 
 # Add cirros
 RUN curl https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img > /disk/cirros.img

--- a/images/disks-images-provider/Dockerfile
+++ b/images/disks-images-provider/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 ENV container docker
 
 # Prepare all images

--- a/images/fedora-cloud-registry-disk-demo/Dockerfile
+++ b/images/fedora-cloud-registry-disk-demo/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM kubevirt/registry-disk-v1alpha
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Add fedora cloud disk image
 RUN curl -g -L https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2 > /disk/fedora.qcow2

--- a/images/vm-killer/Dockerfile
+++ b/images/vm-killer/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 ENV container docker
 
 RUN dnf -y install procps-ng nmap-ncat \

--- a/images/winrmcli/Dockerfile
+++ b/images/winrmcli/Dockerfile
@@ -18,7 +18,7 @@
 
 FROM fedora:28
 
-MAINTAINER "The KubeVirt Project" <kubevirt-dev@googlegroups.com>
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 ENV container docker
 
 RUN dnf -y install make git gcc && dnf -y clean all


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
According to [1], the `MAINTAINER` instruction has been deprecated. The new `LABEL maintainer="xxx"` is recommended and it could be easily revealed via `docker inspect` command.

[1]: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
