### PR TITLE
add variable for setting memory size for node

### DIFF
--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -29,11 +29,11 @@ function _registry_volume() {
 }
 
 function _add_common_params() {
-    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory 4096M --cpu 5 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
+    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 5 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
     if [[ $TARGET =~ windows.* ]]; then
-        params="--memory 8192M --nfs-data $WINDOWS_NFS_DIR $params"
+        params=" --nfs-data $WINDOWS_NFS_DIR $params"
     elif [[ $TARGET =~ openshift.* ]]; then
-        params="--memory 4096M --nfs-data $RHEL_NFS_DIR $params"
+        params=" --nfs-data $RHEL_NFS_DIR $params"
     fi
     echo $params
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,15 @@ export KUBEVIRT_NUM_NODES=2 # schedulable master + one additional node
 make cluster-up
 ```
 
+You can use the `KUBEVIRT_MEMORY_SIZE` environment 
+variable to increase memory size per node. Normally you don't need it, 
+because default node memory size is set.
+
+```bash
+export KUBEVIRT_MEMORY_SIZE=8192M # node has 8GB memory size
+make cluster-up
+```
+
 You could also run some build steps individually:
 
 ```bash

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -21,6 +21,7 @@ function build_func_tests() {
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.4}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
+KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
 
 # Use this environment variable to set a custom pkgdir path
 # Useful for cross-compilation where the default -pkdir for cross-builds may not be writable


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds possibility to set memory size when node is created by setting special env variable
**Which issue(s) this PR fixes** 
Fixes #1677

**Special notes for your reviewer**:

**Release note**:
```release-note
added new env variable for setting node memory size
```