### PR TITLE
pkg/virt-api: Remove redundant codes

### DIFF
--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -106,7 +106,6 @@ func newInformers() *Informers {
 		glog.Fatalf("Error searching for namespace: %v", err)
 	}
 	kubeInformerFactory := controller.NewKubeInformerFactory(kubeClient.RestClient(), kubeClient, namespace)
-	kubeInformerFactory.VMI()
 	return &Informers{
 		VMIInformer:             kubeInformerFactory.VMI(),
 		VMIPresetInformer:       kubeInformerFactory.VirtualMachinePreset(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
IMHO, the function call `kubeInformerFactory.VMI()` here seems to not do anything meaningful. The idempotent factory method, which is to get the informer for watching `VMI` objects,  neither warms up the cache nor does any preparations. If I'm wrong or missing anything, please correct me. Thanks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
