### PR TITLE
Add http to scheme of image-upload if not there

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -171,7 +172,12 @@ func (c *command) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
+	u, err := url.Parse(uploadProxyURL)
+	if err != nil {
+		return err
+	} else if u.Scheme == "" {
+		uploadProxyURL = fmt.Sprintf("http://%s", uploadProxyURL)
+	}
 	fmt.Printf("Uploading data to %s\n", uploadProxyURL)
 
 	err = uploadData(uploadProxyURL, token, file, insecure)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
automatically adds http to image uploader proxy url if not present
```
