### PR TITLE
fix virtctl image-upload tests

### DIFF
--- a/manifests/testing/cdi-v1.3.0.yaml.in
+++ b/manifests/testing/cdi-v1.3.0.yaml.in
@@ -119,7 +119,7 @@ metadata:
   name: cdi-apiserver
   namespace: {{.Namespace}}
   labels:
-    kubevirt.io: ""
+    cdi.kubevirt.io: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -127,7 +127,7 @@ metadata:
   name: cdi-apiserver
   namespace: {{.Namespace}}
   labels:
-    kubevirt.io: ""
+    cdi.kubevirt.io: ""
 roleRef:
   kind: Role
   name: cdi-apiserver
@@ -143,7 +143,7 @@ metadata:
   name: cdi-apiserver
   namespace: {{.Namespace}}
   labels:
-    kubevirt.io: ""
+    cdi.kubevirt.io: ""
 rules:
   - apiGroups:
       - ''
@@ -165,7 +165,7 @@ kind: ClusterRoleBinding
 metadata:
   name: cdi-apiserver
   labels:
-    kubevirt.io: ""
+    cdi.kubevirt.io: ""
 roleRef:
   kind: ClusterRole
   name: cdi-apiserver
@@ -180,7 +180,7 @@ kind: ClusterRole
 metadata:
   name: cdi-apiserver
   labels:
-    kubevirt.io: ""
+    cdi.kubevirt.io: ""
 rules:
   - apiGroups:
       - apiregistration.k8s.io
@@ -204,7 +204,7 @@ kind: ClusterRoleBinding
 metadata:
   name: cdi-apiserver-auth-delegator
   labels:
-    kubevirt.io: ""
+    cdi.kubevirt.io: ""
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/testing/local-block-storage.yaml.in
+++ b/manifests/testing/local-block-storage.yaml.in
@@ -21,7 +21,7 @@ spec:
           values:
           - node01
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: local
+  storageClassName: local-block
   volumeMode: Block
 ---
 apiVersion: v1
@@ -37,7 +37,7 @@ spec:
     requests:
       storage: 1Gi
   volumeMode: Block
-  storageClassName: local
+  storageClassName: local-block
   selector:
     matchLabels:
       blockstorage: "cirros"

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -57,6 +57,7 @@ var _ = Describe("ImageUpload", func() {
 				"--pvc-size", pvcSize,
 				"--uploadproxy-url", fmt.Sprintf("https://127.0.0.1:%d", localUploadProxyPort),
 				"--wait-secs", "30",
+				"--storage-class", "local",
 				"--insecure")
 			err = virtctlCmd()
 			if err != nil {

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Storage", func() {
 			BeforeEach(func() {
 				// Setup second PVC to use in this context
 				tests.CreateHostPathPv(tests.CustomHostPath, tests.HostPathCustom)
-				tests.CreatePVC(tests.CustomHostPath, "1Gi")
+				tests.CreateHostPathPVC(tests.CustomHostPath, "1Gi")
 			}, 120)
 
 			AfterEach(func() {
@@ -397,7 +397,7 @@ var _ = Describe("Storage", func() {
 			BeforeEach(func() {
 				for _, pvc := range pvcs {
 					tests.CreateHostPathPv(pvc, filepath.Join(tests.HostPathBase, pvc))
-					tests.CreatePVC(pvc, "1G")
+					tests.CreateHostPathPVC(pvc, "1G")
 				}
 			}, 120)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Often the virtctl image upload functional times out.  The system gets in a weird state.  The upload pvc is waiting for a pod and the pod is waiting for a pvc.  Deadlock occurs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1679 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
