### PR TITLE
Add unit tests to subresource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ coverage:
 	hack/dockerized "./hack/check.sh && ./hack/coverage.sh ${WHAT}"
 
 goveralls:
-	SYNC_OUT=false hack/dockerized "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/check.sh && ./hack/coverage.sh && ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/check.sh && ./hack/goveralls.sh"
 
 test:
 	SYNC_OUT=false hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,11 @@ client-python:
 build:
 	hack/dockerized "./hack/check.sh && KUBEVIRT_VERSION=${KUBEVIRT_VERSION} ./hack/build-go.sh install ${WHAT}" && ./hack/build-copy-artifacts.sh ${WHAT}
 
+coverage:
+	hack/dockerized "./hack/check.sh && ./hack/coverage.sh ${WHAT}"
+
 goveralls:
-	SYNC_OUT=false hack/dockerized "./hack/check.sh && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/check.sh && ./hack/coverage.sh && ./hack/goveralls.sh"
 
 test:
 	SYNC_OUT=false hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ coverage:
 	hack/dockerized "./hack/check.sh && ./hack/coverage.sh ${WHAT}"
 
 goveralls:
-	SYNC_OUT=false hack/dockerized "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/check.sh && ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "./hack/check.sh && TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
 
 test:
 	SYNC_OUT=false hack/dockerized "./hack/check.sh && ./hack/build-go.sh test ${WHAT}"

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+path=${1:-./pkg/...}
+
+go test -cover -v -coverprofile=.coverprofile $(go list ${path})

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-./hacks/coverage.sh
+./hack/coverage.sh
 goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 set -e
+
 ./hack/coverage.sh
 goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 set -e
-
-go test -cover -v -coverprofile=.coverprofile $(go list ./pkg/...)
+./hacks/coverage.sh
 goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -283,7 +283,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/api/v1/namespaces/default/pods/madeup-name/exec"),
 					func(w http.ResponseWriter, r *http.Request) {
-						// TODO: Just testing code we should use real SPDY stuff
 						upgrader := spdy.NewResponseUpgrader()
 						upgrader.UpgradeResponse(w, r,
 							func(stream httpstream.Stream, replySent <-chan struct{}) error {

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -20,12 +20,20 @@
 package rest
 
 import (
+	"flag"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 
+	"github.com/emicklei/go-restful"
+	"github.com/gorilla/websocket"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/cache"
 
@@ -37,6 +45,10 @@ import (
 
 var _ = Describe("VirtualMachineInstance Subresources", func() {
 	var server *ghttp.Server
+	var backend *ghttp.Server
+	var request *restful.Request
+	var response *restful.Response
+	var wsURL string
 
 	log.Log.SetIOWriter(GinkgoWriter)
 
@@ -45,7 +57,26 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 	app := SubresourceAPIApp{}
 	BeforeEach(func() {
 		server = ghttp.NewServer()
+		backend = ghttp.NewServer()
+		flag.Set("kubeconfig", "")
+		flag.Set("master", server.URL())
 		app.VirtCli, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+
+		request = restful.NewRequest(&http.Request{})
+		response = restful.NewResponse(httptest.NewRecorder())
+		wsURL = "ws" + strings.TrimPrefix(backend.URL(), "http")
+
+		// To emulate rest server
+		backend.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/"),
+				func(w http.ResponseWriter, r *http.Request) {
+					request.Request = r
+					response.ResponseWriter = w
+					app.VNCRequestHandler(request, response)
+				},
+			),
+		)
 	})
 
 	Context("Subresource api", func() {
@@ -114,9 +145,202 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			Expect(httpStatusCode).To(Equal(http.StatusBadRequest))
 			close(done)
 		}, 5)
+
+		It("should fail with no 'name' path param", func(done Done) {
+
+			app.VNCRequestHandler(request, response)
+			Expect(response.Error()).To(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusInternalServerError))
+			close(done)
+		}, 5)
+
+		It("should fail with no 'namespace' path param", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+
+			app.VNCRequestHandler(request, response)
+			Expect(response.Error()).To(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusInternalServerError))
+			close(done)
+		}, 5)
+
+		It("should fail if vmi is not found", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+			request.PathParameters()["namespace"] = "default"
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
+					ghttp.RespondWithJSONEncoded(http.StatusNotFound, nil),
+				),
+			)
+
+			app.VNCRequestHandler(request, response)
+			Expect(response.Error()).To(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusNotFound))
+			close(done)
+		}, 5)
+
+		It("should fail with internal at fetching vmi errors", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+			request.PathParameters()["namespace"] = "default"
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
+					ghttp.RespondWithJSONEncoded(http.StatusServiceUnavailable, nil),
+				),
+			)
+
+			app.VNCRequestHandler(request, response)
+			Expect(response.Error()).To(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusInternalServerError))
+			close(done)
+		}, 5)
+
+		It("should fail with no graphics device at VNC connections", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+			request.PathParameters()["namespace"] = "default"
+
+			flag := false
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Status.Phase = v1.Running
+			vmi.ObjectMeta.SetUID(uuid.NewUUID())
+			vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &flag
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
+				),
+			)
+			app.VNCRequestHandler(request, response)
+			Expect(response.Error()).To(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusBadRequest))
+			close(done)
+		}, 5)
+
+		It("should fail with no graphics device at VNC connections", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+			request.PathParameters()["namespace"] = "default"
+
+			flag := false
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Status.Phase = v1.Running
+			vmi.ObjectMeta.SetUID(uuid.NewUUID())
+			vmi.Spec.Domain.Devices.AutoattachGraphicsDevice = &flag
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
+				),
+			)
+
+			app.VNCRequestHandler(request, response)
+			Expect(response.Error()).To(HaveOccurred())
+			Expect(response.StatusCode()).To(Equal(http.StatusBadRequest))
+			close(done)
+		}, 5)
+
+		It("Should pass client websocket io to server SPDY io", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+			request.PathParameters()["namespace"] = "default"
+
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Status.Phase = v1.Running
+			vmi.ObjectMeta.SetUID(uuid.NewUUID())
+
+			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", configCache, pvcCache)
+
+			pod, err := templateService.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			pod.ObjectMeta.Name = "madeup-name"
+
+			pod.Spec.NodeName = "mynode"
+			pod.Status.Phase = k8sv1.PodRunning
+
+			podList := k8sv1.PodList{}
+			podList.Items = []k8sv1.Pod{}
+			podList.Items = append(podList.Items, *pod)
+
+			newStreamChannel := make(chan httpstream.Stream)
+
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/api/v1/namespaces/default/pods"),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, podList),
+				),
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/api/v1/namespaces/default/pods/madeup-name/exec"),
+					func(w http.ResponseWriter, r *http.Request) {
+						// TODO: Just testing code we should use real SPDY stuff
+						upgrader := spdy.NewResponseUpgrader()
+						upgrader.UpgradeResponse(w, r,
+							func(stream httpstream.Stream, replySent <-chan struct{}) error {
+								newStreamChannel <- stream
+								return nil
+							})
+					},
+				),
+			)
+
+			ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusSwitchingProtocols))
+
+			streamType := func(stream httpstream.Stream) string {
+				return stream.Headers().Get("streamType")
+			}
+
+			// Receive accepted stream
+			// FIXME: It's no good to depend on order, implementation
+			// can change
+			streamError := <-newStreamChannel
+			Expect(streamType(streamError)).To(Equal("error"))
+			streamStdin := <-newStreamChannel
+			Expect(streamType(streamStdin)).To(Equal("stdin"))
+			streamStdout := <-newStreamChannel
+			Expect(streamType(streamStdout)).To(Equal("stdout"))
+			streamStderror := <-newStreamChannel
+			Expect(streamType(streamStderror)).To(Equal("stderr"))
+
+			expected := []byte("Hello")
+			err = ws.WriteMessage(websocket.BinaryMessage, expected)
+			Expect(err).NotTo(HaveOccurred())
+
+			obtained := make([]byte, len(expected))
+			_, err = io.ReadFull(streamStdin, obtained)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obtained).To(Equal(expected))
+
+			expected = []byte("World")
+			_, err = streamStdout.Write(expected)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, obtained, err = ws.ReadMessage()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obtained).To(Equal(expected))
+
+			// TODO: Check error streams
+			defer ws.Close()
+			close(done)
+
+		}, 5)
+
 	})
 
 	AfterEach(func() {
 		server.Close()
+		backend.Close()
 	})
 })


### PR DESCRIPTION
Now it exercises websockets and SPDY stuff

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It increases unit test coverage, increasing virt-api/rest to 51.3%, covers part of #1063.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:
Missing stuff:
- SPDY upgrade failure
- test 'error' and 'stderror' SPDY streams.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unit test coverage increased
```
