### PR TITLE
Ensure that clusters have enough CPU cores to run multi-core tests

### DIFF
--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -29,7 +29,7 @@ function _registry_volume() {
 }
 
 function _add_common_params() {
-    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory 4096M --cpu 4 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
+    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory 4096M --cpu 5 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
     if [[ $TARGET =~ windows.* ]]; then
         params="--memory 8192M --nfs-data $WINDOWS_NFS_DIR $params"
     elif [[ $TARGET =~ openshift.* ]]; then

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -843,7 +843,7 @@ var _ = Describe("Configurations", func() {
 				output, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					readyPod,
-					readyPod.Spec.Containers[0].Name,
+					"compute",
 					[]string{"cat", hw_utils.CPUSET_PATH},
 				)
 				log.Log.Infof("%v", output)

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -20,17 +20,17 @@
 package tests_test
 
 import (
+	"encoding/xml"
 	"flag"
-	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+
 	"kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -53,27 +53,10 @@ var _ = Describe("IOThreads", func() {
 			policy := v1.IOThreadsPolicyShared
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
 
-			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
-			listOptions := metav1.ListOptions{}
-
-			Eventually(func() int {
-				podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
-				Expect(err).ToNot(HaveOccurred())
-				return len(podList.Items)
-			}, 75, 0.5).Should(Equal(1))
-
-			Eventually(func() error {
-				podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
-				Expect(err).ToNot(HaveOccurred())
-				for _, item := range podList.Items {
-					if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
-						return nil
-					}
-				}
-				return fmt.Errorf("Associated pod for VirtualMachineInstance '%s' not found", vmi.Name)
-			}, 75, 0.5).Should(Succeed())
+			tests.WaitForSuccessfulVMIStart(vmi)
 
 			getOptions := metav1.GetOptions{}
 			var newVMI *v1.VirtualMachineInstance
@@ -81,15 +64,13 @@ var _ = Describe("IOThreads", func() {
 			newVMI, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &getOptions)
 			Expect(err).ToNot(HaveOccurred())
 
-			domain := &api.Domain{}
-			context := &api.ConverterContext{
-				VirtualMachine: newVMI,
-				UseEmulation:   true,
-			}
-			api.Convert_v1_VirtualMachine_To_api_Domain(newVMI, domain, context)
+			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			Expect(err).ToNot(HaveOccurred())
+			domSpec := &api.DomainSpec{}
+			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
 
 			expectedIOThreads := 1
-			Expect(int(domain.Spec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
+			Expect(int(domSpec.IOThreads.IOThreads)).To(Equal(expectedIOThreads))
 
 			Expect(len(newVMI.Spec.Domain.Devices.Disks)).To(Equal(1))
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Under certain circumstances our test-infra consumed more than 1.0 cpu cores
which could make nodes non-fit for our cpu core tests. Increasing from 4
to 5 cpu cores to give the infrastrucure 2.0 cores.

Makes it possible to run the mult-core tests under more reliable conditions in the 1.11.1-multus clusters:

```
Configurations VirtualMachineInstance definition with 3 CPU cores should map cores to virtio net queues
Configurations VirtualMachineInstance definition with 3 CPU cores should map cores to virtio block queues
```

Further fixes

```
[Fail] IOThreads IOThreads Policies [It] Should honor shared ioThreadsPolicy 
/root/go/src/kubevirt.io/kubevirt/tests/vmi_iothreads_test.go:65
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1690

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
