### PR TITLE
Kubevirt namespace

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -144,7 +144,7 @@ if [ -n "${JOB_NAME}" ]; then
 namespace=${NAMESPACE}
 EOF
 else
-  export NAMESPACE="${NAMESPACE:-kube-system}"
+  export NAMESPACE="${NAMESPACE:-kubevirt}"
 fi
 
 
@@ -179,8 +179,8 @@ kubectl get nodes
 make cluster-sync
 
 # OpenShift is running important containers under default namespace
-namespaces=(kube-system default)
-if [[ $NAMESPACE != "kube-system" ]]; then
+namespaces=(kubevirt default)
+if [[ $NAMESPACE != "kubevirt" ]]; then
   namespaces+=($NAMESPACE)
 fi
 

--- a/cluster/examples/vm-alpine-datavolume.yaml
+++ b/cluster/examples/vm-alpine-datavolume.yaml
@@ -20,7 +20,7 @@ spec:
         storageClassName: local
       source:
         http:
-          url: http://cdi-http-import-server.kube-system/images/alpine.iso
+          url: http://cdi-http-import-server.kubevirt/images/alpine.iso
     status: {}
   running: false
   template:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,8 +169,8 @@ Finally start a VMI called `vmi-ephemeral`:
     # You can actually use kubelet.sh to introspect the cluster in general
     ./cluster/kubectl.sh get pods
 
-    # To check the running kubevirt services you need to introspect the `kube-system` namespace:
-    ./cluster/kubectl.sh -n kube-system get pods
+    # To check the running kubevirt services you need to introspect the `kubevirt` namespace:
+    ./cluster/kubectl.sh -n kubevirt get pods
 ```
 
 This will start a VMI on master or one of the running nodes with a macvtap and a
@@ -182,7 +182,7 @@ tap networking device attached.
 $ ./cluster/kubectl.sh create -f cluster/examples/vmi-ephemeral.yaml
 vm "vmi-ephemeral" created
 
-$ ./cluster/kubectl.sh -n kube-system get pods
+$ ./cluster/kubectl.sh -n kubevirt get pods
 NAME                              READY     STATUS    RESTARTS   AGE
 virt-api                          1/1       Running   1          10h
 virt-controller                   1/1       Running   1          10h

--- a/docs/software-emulation.md
+++ b/docs/software-emulation.md
@@ -18,19 +18,19 @@ If `useEmulation` is enabled,
 # Configuration
 
 Enabling software emulation is a cluster-wide setting, and is activated using a
-ConfigMap in the `kube-system` namespace. It can be enabled with the following
+ConfigMap in the `kubevirt` namespace. It can be enabled with the following
 command:
 
 ```bash
-cluster/kubectl.sh --namespace kube-system create configmap kubevirt-config \
+cluster/kubectl.sh --namespace kubevirt create configmap kubevirt-config \
     --from-literal debug.useEmulation=true
 ```
 
-If the `kube-system/kubevirt-config` ConfigMap already exists, the above entry
+If the `kubevirt/kubevirt-config` ConfigMap already exists, the above entry
 can be added using:
 
 ```bash
-cluster/kubectl.sh --namespace kube-system edit configmap kubevirt-config
+cluster/kubectl.sh --namespace kubevirt edit configmap kubevirt-config
 ```
 
 In this case, add the `debug.useEmulation: "true"` setting to `data`:
@@ -40,7 +40,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-config
-  namespace: kube-system
+  namespace: kubevirt
 data:
   debug.useEmulation: "true"
 

--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -207,7 +207,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-config
-  namespace: kube-system
+  namespace: kubevirt
   labels:
     kubevirt.io: ""
 data:

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -42,6 +42,7 @@ for arg in $args; do
 
     ${KUBEVIRT_DIR}/tools/manifest-templator/manifest-templator \
         --namespace=${namespace} \
+        --cdi-namespace=${cdi_namespace} \
         --docker-prefix=${manifest_docker_prefix} \
         --docker-tag=${docker_tag} \
         --image-pull-policy=${image_pull_policy} \
@@ -50,6 +51,7 @@ for arg in $args; do
 
     ${KUBEVIRT_DIR}/tools/manifest-templator/manifest-templator \
         --namespace="{{ namespace }}" \
+        --cdi-namespace="{{ cdi_namespace }}" \
         --docker-prefix="{{ docker_prefix }}" \
         --docker-tag="{{ docker_tag }}" \
         --image-pull-policy="{{ image_pull_policy }}" \
@@ -63,6 +65,7 @@ find ${MANIFEST_TEMPLATES_OUT_DIR}/ -type f -exec sed -i {} -e '${/^$/d;}' \;
 
 # make sure that template manifests align with release manifests
 export namespace=${namespace}
+export cdi_namespace=${cdi_namespace}
 export docker_tag=${docker_tag}
 export docker_prefix=${manifest_docker_prefix}
 export image_pull_policy=${image_pull_policy}
@@ -81,4 +84,7 @@ for file in $(find ${MANIFEST_TEMPLATES_OUT_DIR}/ -type f); do
 done
 
 # If diff fails then we have an issue
-diff -r ${MANIFESTS_OUT_DIR} ${TMP_DIR}/${MANIFEST_TEMPLATES_OUT_DIR}
+diff -ru ${MANIFESTS_OUT_DIR} ${TMP_DIR}/${MANIFEST_TEMPLATES_OUT_DIR} || (
+    echo "Error: Generated manifests don't match"
+    false
+)

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -7,4 +7,5 @@ docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel
 namespace=kubevirt
+cdi_namespace=kube-system
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -6,5 +6,5 @@ docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2
 network_provider=flannel
-namespace=kube-system
+namespace=kubevirt
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}

--- a/manifests/testing/cdi-v1.3.0.yaml.in
+++ b/manifests/testing/cdi-v1.3.0.yaml.in
@@ -2,7 +2,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: cdi-sa
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: ""
 ---
@@ -47,7 +47,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cdi-sa
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: ""
 roleRef:
@@ -57,13 +57,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cdi-sa
-    namespace: {{.Namespace}}
+    namespace: {{.CDINamespace}}
 ---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-deployment
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: ""
     app: containerized-data-importer
@@ -117,7 +117,7 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: cdi-apiserver
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: ""
 ---
@@ -125,7 +125,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: cdi-apiserver
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: ""
 roleRef:
@@ -135,13 +135,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cdi-apiserver
-    namespace: {{.Namespace}}
+    namespace: {{.CDINamespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: cdi-apiserver
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: ""
 rules:
@@ -173,7 +173,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cdi-apiserver
-    namespace: {{.Namespace}}
+    namespace: {{.CDINamespace}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -212,13 +212,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cdi-apiserver
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: cdi-api
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: "cdi-api"
 spec:
@@ -233,7 +233,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-api
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: "cdi-api"
 spec:
@@ -257,7 +257,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cdi-uploadproxy
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: "cdi-uploadproxy"
 spec:
@@ -272,7 +272,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: cdi-uploadproxy
-  namespace: {{.Namespace}}
+  namespace: {{.CDINamespace}}
   labels:
     cdi.kubevirt.io: "cdi-uploadproxy"
 spec:

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -35,7 +35,7 @@ var _ = Describe("ImageUpload", func() {
 		It("Should succeed", func() {
 			By("Setting up port forwarding")
 			portMapping := fmt.Sprintf("%d:%d", localUploadProxyPort, uploadProxyPort)
-			_, kubectlCmd, err := tests.CreateCommandWithNS(tests.KubeVirtInstallNamespace, "kubectl", "port-forward", uploadProxyService, portMapping)
+			_, kubectlCmd, err := tests.CreateCommandWithNS(tests.ContainerizedDataImporterNamespace, "kubectl", "port-forward", uploadProxyService, portMapping)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = kubectlCmd.Start()

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -48,7 +48,7 @@ import (
 
 const (
 	diskSerial        = "FB-fb_18030C10002032"
-	namespaceKubevirt = "kube-system"
+	namespaceKubevirt = "kubevirt"
 )
 
 type VMICreationFunc func(string) *v1.VirtualMachineInstance

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -70,6 +70,7 @@ import (
 
 var KubeVirtVersionTag = "latest"
 var KubeVirtRepoPrefix = "kubevirt"
+var ContainerizedDataImporterNamespace = "kube-system"
 var KubeVirtKubectlPath = ""
 var KubeVirtOcPath = ""
 var KubeVirtVirtctlPath = ""
@@ -78,6 +79,7 @@ var KubeVirtInstallNamespace string
 func init() {
 	flag.StringVar(&KubeVirtVersionTag, "tag", "latest", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtRepoPrefix, "prefix", "kubevirt", "Set the repository prefix for all images")
+	flag.StringVar(&ContainerizedDataImporterNamespace, "cdi-namespace", "kube-system", "Set the repository prefix for CDI components")
 	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "", "Set path to kubectl binary")
 	flag.StringVar(&KubeVirtOcPath, "oc-path", "", "Set path to oc binary")
 	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "", "Set path to virtctl binary")
@@ -94,8 +96,8 @@ const (
 )
 
 const (
-	AlpineHttpUrl     = "http://cdi-http-import-server.kube-system/images/alpine.iso"
-	GuestAgentHttpUrl = "http://cdi-http-import-server.kube-system/qemu-ga"
+	AlpineHttpUrl     = "http://cdi-http-import-server.kubevirt/images/alpine.iso"
+	GuestAgentHttpUrl = "http://cdi-http-import-server.kubevirt/qemu-ga"
 )
 
 const (

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -29,6 +29,7 @@ import (
 
 type templateData struct {
 	Namespace          string
+	CDINamespace       string
 	DockerTag          string
 	DockerPrefix       string
 	ImagePullPolicy    string
@@ -37,6 +38,7 @@ type templateData struct {
 
 func main() {
 	namespace := flag.String("namespace", "", "")
+	cdiNamespace := flag.String("cdi-namespace", "", "")
 	dockerPrefix := flag.String("docker-prefix", "", "")
 	dockerTag := flag.String("docker-tag", "", "")
 	imagePullPolicy := flag.String("image-pull-policy", "IfNotPresent", "")
@@ -46,6 +48,7 @@ func main() {
 
 	data := templateData{
 		Namespace:          *namespace,
+		CDINamespace:       *cdiNamespace,
 		DockerTag:          *dockerTag,
 		DockerPrefix:       *dockerPrefix,
 		ImagePullPolicy:    *imagePullPolicy,

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -696,7 +696,7 @@ func GetVMDataVolume() *v1.VirtualMachine {
 		Spec: cdiv1.DataVolumeSpec{
 			Source: cdiv1.DataVolumeSource{
 				HTTP: &cdiv1.DataVolumeSourceHTTP{
-					URL: "http://cdi-http-import-server.kube-system/images/alpine.iso",
+					URL: "http://cdi-http-import-server.kubevirt/images/alpine.iso",
 				},
 			},
 			PVC: &k8sv1.PersistentVolumeClaimSpec{


### PR DESCRIPTION
Switch default namespace to 'kubevirt'

```release-note
Default namespace for KubeVirt components is now kubevirt
```
