### PR TITLE
improve 'not enough space' error log

### DIFF
--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -88,7 +88,6 @@ func getPVCDiskImgPath(volumeName string) string {
 func CreateHostDisks(vmi *v1.VirtualMachineInstance) error {
 	for _, volume := range vmi.Spec.Volumes {
 		if hostDisk := volume.VolumeSource.HostDisk; hostDisk != nil && hostDisk.Type == v1.HostDiskExistsOrCreate && hostDisk.Path != "" {
-
 			if _, err := os.Stat(hostDisk.Path); os.IsNotExist(err) {
 				availableSpace, err := dirBytesAvailable(path.Dir(hostDisk.Path))
 				if err != nil {
@@ -96,7 +95,7 @@ func CreateHostDisks(vmi *v1.VirtualMachineInstance) error {
 				}
 				size, _ := hostDisk.Capacity.AsInt64()
 				if uint64(size) > availableSpace {
-					return fmt.Errorf("Unable to create %s with size %s - not enough space on the cluster", hostDisk.Path, hostDisk.Capacity.String())
+					return fmt.Errorf("Unable to create %s, not enough space, demanded size %d B is bigger than available space %d B", hostDisk.Path, uint64(size), availableSpace)
 				}
 				err = createSparseRaw(hostDisk.Path, size)
 				if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It provides a better error message when there is not enough space to create a disk image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
