### PR TITLE
Tests: wait for VMI start to be sure that compute container exists

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -686,23 +686,13 @@ var _ = Describe("VMIlifecycle", func() {
 			})
 
 			It("should enable emulation in virt-launcher", func() {
-				err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()
-				Expect(err).To(BeNil(), "Should post VMI successfully")
+				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
 
-				listOptions := metav1.ListOptions{}
-				var pod k8sv1.Pod
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Eventually(func() error {
-					podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should list pods")
-					for _, item := range podList.Items {
-						if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
-							pod = item
-							return nil
-						}
-					}
-					return fmt.Errorf("Associated pod for VirtualMachineInstance '%s' not found", vmi.Name)
-				}, 75, 2).Should(Succeed(), "Should find the right VMI pod")
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+				Expect(pod).NotTo(BeNil())
 
 				emulationFlagFound := false
 				computeContainerFound := false
@@ -767,23 +757,13 @@ var _ = Describe("VMIlifecycle", func() {
 			})
 
 			It("should request a TUN device but not KVM", func() {
-				err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()
-				Expect(err).To(BeNil(), "Should post VMI")
+				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
 
-				listOptions := metav1.ListOptions{}
-				var pod k8sv1.Pod
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Eventually(func() error {
-					podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should list pods")
-					for _, item := range podList.Items {
-						if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
-							pod = item
-							return nil
-						}
-					}
-					return fmt.Errorf("Associated pod for VM '%s' not found", vmi.Name)
-				}, 75, 0.5).Should(Succeed(), "Should find VMI pod")
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+				Expect(pod).NotTo(BeNil())
 
 				computeContainerFound := false
 				for _, container := range pod.Spec.Containers {
@@ -815,23 +795,13 @@ var _ = Describe("VMIlifecycle", func() {
 			})
 
 			It("should request a KVM and TUN device", func() {
-				err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()
-				Expect(err).To(BeNil(), "Should post VMI")
+				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
 
-				listOptions := metav1.ListOptions{}
-				var pod k8sv1.Pod
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Eventually(func() error {
-					podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
-					Expect(err).ToNot(HaveOccurred(), "Should list pods")
-					for _, item := range podList.Items {
-						if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
-							pod = item
-							return nil
-						}
-					}
-					return fmt.Errorf("Associated pod for VM '%s' not found", vmi.Name)
-				}, 75, 0.5).Should(Succeed(), "Should find the VMI pod")
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+				Expect(pod).NotTo(BeNil())
 
 				computeContainerFound := false
 				for _, container := range pod.Spec.Containers {
@@ -850,23 +820,13 @@ var _ = Describe("VMIlifecycle", func() {
 			})
 
 			It("should not enable emulation in virt-launcher", func() {
-				err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()
-				Expect(err).To(BeNil(), "Should post VMI")
+				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
 
-				listOptions := metav1.ListOptions{}
-				var pod k8sv1.Pod
+				tests.WaitForSuccessfulVMIStart(vmi)
 
-				Eventually(func() error {
-					podList, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(listOptions)
-					Expect(err).ToNot(HaveOccurred())
-					for _, item := range podList.Items {
-						if strings.HasPrefix(item.Name, vmi.ObjectMeta.GenerateName) {
-							pod = item
-							return nil
-						}
-					}
-					return fmt.Errorf("Associated pod for VM '%s' not found", vmi.Name)
-				}, 75, 0.5).Should(Succeed(), "Should find VMI pod")
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+				Expect(pod).NotTo(BeNil())
 
 				emulationFlagFound := false
 				computeContainerFound := false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Tests waited for the virt-launcher pod, but possible situation when the pod already exists but still does not have `compute` container.
Now it will wait for VMI successful start, and just after it will check for `compute` container.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1703 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
