### PR TITLE
Fix CPU placement test

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1255,7 +1255,7 @@ var _ = Describe("Converter", func() {
 				},
 			}
 		})
-		It("assigns a set of cpus per iothread, if there are more vcpus that iothreads", func() {
+		It("assigns a set of cpus per iothread, if there are more vcpus than iothreads", func() {
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("16")
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			c := &ConverterContext{CPUSet: []int{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},


### PR DESCRIPTION
**What this PR does / why we need it**:

In case that no core count was set, but dedicated CPUs were requested
via the cpu resource, only one cpu was set inside the VMI, where it
should have been equal to the number of requested dedicated cpu cores.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
