### PR TITLE
Add virtio-win registry disk

### DIFF
--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,6 +1,6 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virtctl cmd/fake-qemu-process cmd/virt-api cmd/subresource-access-test cmd/example-hook-sidecar"
 docker_images_cacheable="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api images/disks-images-provider images/vm-killer cmd/subresource-access-test images/winrmcli cmd/example-hook-sidecar images/cdi-http-import-server cmd/container-disk-v1alpha"
-docker_images_container_disks="images/cirros-container-disk-demo images/fedora-cloud-container-disk-demo images/alpine-container-disk-demo"
+docker_images_container_disks="images/cirros-container-disk-demo images/fedora-cloud-container-disk-demo images/alpine-container-disk-demo images/virtio-container-disk"
 docker_images="${docker_images_cacheable} ${docker_images_container_disks}"
 docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}

--- a/images/virtio-container-disk/Dockerfile
+++ b/images/virtio-container-disk/Dockerfile
@@ -1,0 +1,34 @@
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+FROM fedora:28 as builder
+
+RUN curl https://fedorapeople.org/groups/virt/virtio-win/virtio-win.repo -o /etc/yum.repos.d/virtio-win.repo \
+&& dnf install -y virtio-win && mkdir -p /disk 
+
+# the virtio-win package is shipped with version number, move it to standardized location
+# with standardized name, docker copy does not follow links
+RUN cp -L /usr/share/virtio-win/virtio-win.iso /disk/virtio-win.iso
+
+
+FROM kubevirt/registry-disk-v1alpha 
+
+LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
+
+WORKDIR /disk
+COPY --from=builder /disk/virtio-win.iso ./virtio-win.iso


### PR DESCRIPTION
**What this PR does / why we need it**:
Package virtio win drivers as a registry disk
to provide easy distribution for kubevirt users

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add virtio win registry disk
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1720)
<!-- Reviewable:end -->
