### PR TITLE
Schedule VMs on nodes which support the requested CPU model

### DIFF
--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -28,8 +28,10 @@ import (
 type IOThreadsPolicy string
 
 const (
-	IOThreadsPolicyShared IOThreadsPolicy = "shared"
-	IOThreadsPolicyAuto   IOThreadsPolicy = "auto"
+	IOThreadsPolicyShared  IOThreadsPolicy = "shared"
+	IOThreadsPolicyAuto    IOThreadsPolicy = "auto"
+	CPUModeHostPassthrough                 = "host-passthrough"
+	CPUModeHostModel                       = "host-model"
 )
 
 //go:generate swagger-doc

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -21,7 +21,6 @@ package virtconfig
 
 import (
 	"os"
-	"strings"
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -37,6 +36,7 @@ import (
 const (
 	configMapName         = "kubevirt-config"
 	featureGateEnvVar     = "FEATURE_GATES"
+	FeatureGatesKey       = "feature-gates"
 	emulatedMachineEnvVar = "VIRT_EMULATED_MACHINES"
 )
 
@@ -44,7 +44,7 @@ const (
 // code assumes a cluster is available to pull the configmap from
 func Init() {
 	cfgMap := getConfigMap()
-	if val, ok := cfgMap.Data["feature-gates"]; ok {
+	if val, ok := cfgMap.Data[FeatureGatesKey]; ok {
 		os.Setenv(featureGateEnvVar, val)
 	}
 	if val, ok := cfgMap.Data["emulated-machines"]; ok {
@@ -86,8 +86,4 @@ func getConfigMap() *k8sv1.ConfigMap {
 	}
 
 	return cfgMap
-}
-
-func CPUNodeDiscoveryEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), CPUNodeDiscoveryGate)
 }

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -21,6 +21,7 @@ package virtconfig
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -85,4 +86,8 @@ func getConfigMap() *k8sv1.ConfigMap {
 	}
 
 	return cfgMap
+}
+
+func CPUNodeDiscoveryEnabled() bool {
+	return strings.Contains(os.Getenv(featureGateEnvVar), CPUNodeDiscoveryGate)
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	dataVolumesGate   = "DataVolumes"
-	cpuManager        = "CPUManager"
-	liveMigrationGate = "LiveMigration"
-	SRIOVGate         = "SRIOV"
+	dataVolumesGate      = "DataVolumes"
+	cpuManager           = "CPUManager"
+	liveMigrationGate    = "LiveMigration"
+	SRIOVGate            = "SRIOV"
+	CPUNodeDiscoveryGate = "CPUNodeDiscovery"
 )
 
 func DataVolumesEnabled() bool {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -618,9 +618,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	}
 	if featuregates.CPUNodeDiscoveryEnabled() {
-		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" &&
-			vmi.Spec.Domain.CPU.Model != "host-model" && vmi.Spec.Domain.CPU.Model != "host-passthrough" {
-			nodeSelector[NFD_CPU_FAMILY_PREFIX+vmi.Spec.Domain.CPU.Model] = "true"
+		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" {
+			if vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+				nodeSelector[NFD_CPU_FAMILY_PREFIX+vmi.Spec.Domain.CPU.Model] = "true"
+			}
 		}
 	}
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -62,7 +62,7 @@ const CAP_SYS_NICE = "SYS_NICE"
 const LibvirtStartupDelay = 10
 //This is a perfix for node feature discovery, used in a NodeSelector on the pod
 //to match a VirtualMachineInstance CPU model(Family) to nodes that support this model.
-const NFD_CPU_FAMILY_PREFIX = "feature.node.kubernetes.io/nfd-cpu-family-"
+const NFD_CPU_FAMILY_PREFIX = "feature.node.kubernetes.io/cpu-family-"
 
 const MULTUS_RESOURCE_NAME_ANNOTATION = "k8s.v1.cni.cncf.io/resourceName"
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -618,7 +618,8 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	}
 	if featuregates.CPUNodeDiscoveryEnabled() {
-		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" {
+		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" &&
+			vmi.Spec.Domain.CPU.Model != "host-model" && vmi.Spec.Domain.CPU.Model != "host-passthrough" {
 			nodeSelector[NFD_CPU_FAMILY_PREFIX+vmi.Spec.Domain.CPU.Model] = "true"
 		}
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -62,7 +62,7 @@ const CAP_SYS_NICE = "SYS_NICE"
 const LibvirtStartupDelay = 10
 //This is a perfix for node feature discovery, used in a NodeSelector on the pod
 //to match a VirtualMachineInstance CPU model(Family) to nodes that support this model.
-const NFD_CPU_FAMILY_PREFIX = "feature.node.kubernetes.io/cpu-family-"
+const NFD_CPU_FAMILY_PREFIX = "feature.node.kubernetes.io/cpu-model-"
 
 const MULTUS_RESOURCE_NAME_ANNOTATION = "k8s.v1.cni.cncf.io/resourceName"
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -262,7 +262,7 @@ var _ = Describe("Template", func() {
 					Spec: v1.VirtualMachineInstanceSpec{
 						Domain: v1.DomainSpec{
 							CPU: &v1.CPU{
-								Model: "Conore",
+								Model: "Conroe",
 							},
 						},
 					},
@@ -270,7 +270,7 @@ var _ = Describe("Template", func() {
 
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_CPU_FAMILY_PREFIX+"Conore", "true"))
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_CPU_FAMILY_PREFIX+"Conroe", "true"))
 			})
 
 			It("should add default cpu/memory resources to the sidecar container if cpu pinning was requested", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -21,7 +21,6 @@ package services
 
 import (
 	"errors"
-	"os"
 	"strconv"
 	"testing"
 
@@ -39,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/feature-gates"
 	"kubevirt.io/kubevirt/pkg/hooks"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
@@ -252,7 +252,15 @@ var _ = Describe("Template", func() {
 
 			It("should add node selector for node discovery feature to template", func() {
 
-				os.Setenv("FEATURE_GATES", "CPUNodeDiscovery")
+				cfgMap := kubev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceKubevirt,
+						Name:      "kubevirt-config",
+					},
+					Data: map[string]string{featuregates.FEATURE_GATES_KEY: featuregates.CPUNodeDiscoveryGate},
+				}
+				cmCache.Add(&cfgMap)
+
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -46,9 +46,7 @@ import (
 )
 
 const (
-	CPUModeHostPassthrough = "host-passthrough"
-	CPUModeHostModel       = "host-model"
-	defaultIOThread        = uint(1)
+	defaultIOThread = uint(1)
 )
 
 type ConverterContext struct {
@@ -782,7 +780,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 
 		// Set VM CPU model and vendor
 		if vmi.Spec.Domain.CPU.Model != "" {
-			if vmi.Spec.Domain.CPU.Model == CPUModeHostModel || vmi.Spec.Domain.CPU.Model == CPUModeHostPassthrough {
+			if vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostPassthrough {
 				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
 			} else {
 				domain.Spec.CPU.Mode = "custom"
@@ -792,7 +790,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	}
 
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		domain.Spec.CPU.Mode = CPUModeHostModel
+		domain.Spec.CPU.Mode = v1.CPUModeHostModel
 	}
 
 	// Adjust guest vcpu config. Currenty will handle vCPUs to pCPUs pinning

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -578,8 +578,8 @@ var _ = Describe("Converter", func() {
 
 			Expect(domainSpec.CPU.Mode).To(Equal(model))
 		},
-			table.Entry(CPUModeHostPassthrough, CPUModeHostPassthrough),
-			table.Entry(CPUModeHostModel, CPUModeHostModel),
+			table.Entry(v1.CPUModeHostPassthrough, v1.CPUModeHostPassthrough),
+			table.Entry(v1.CPUModeHostModel, v1.CPUModeHostModel),
 		)
 
 		Context("when CPU spec defined and model not", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -60,10 +60,10 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/feature-gates"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
+	"kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virtctl"
 	vmsgen "kubevirt.io/kubevirt/tools/vms-generator/utils"
@@ -2617,7 +2617,7 @@ func HasCDI() bool {
 	options := metav1.GetOptions{}
 	cfgMap, err := virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Get("kubevirt-config", options)
 	if err == nil {
-		val, ok := cfgMap.Data[featuregates.FEATURE_GATES_KEY]
+		val, ok := cfgMap.Data[virtconfig.FeatureGatesKey]
 		if !ok {
 			return hasCDI
 		}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -60,6 +60,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/feature-gates"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
@@ -2616,7 +2617,7 @@ func HasCDI() bool {
 	options := metav1.GetOptions{}
 	cfgMap, err := virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Get("kubevirt-config", options)
 	if err == nil {
-		val, ok := cfgMap.Data["feature-gates"]
+		val, ok := cfgMap.Data[featuregates.FEATURE_GATES_KEY]
 		if !ok {
 			return hasCDI
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The goal is to set a nodeSelector on the pod that virt-controller creates for vmis, which selects only nodes for scheduling that provide the CPU model set on the VM.
The CPU model is taken from the VirtualMachine spec and should match the CPU family label on nodes.
The CPU family labels on nodes will be created using a [node feature discovery](https://github.com/kubernetes-incubator/node-feature-discovery) plugin.

This feature is disabled by default and can be enabled using the feature-gate : "CPUNodeDiscovery" 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Handles #1247 

**Special notes for your reviewer**:
The final format of the label is not determined yet (also depends on [Plugin mechanism for customer-specific labels](https://github.com/kubernetes-incubator/node-feature-discovery/issues/144))
Currently its in the form of:
feature.node.kubernetes.io/cpu-model-\<cpu family\> = "true" 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
To enable scheduling virtual machines on nodes by matching cpu model on the virtual machine spec
and cpu model labels on nodes (generated and added to node using node feature discovery plugin) :  
Enable the feature gate CPUNodeDiscovery - add it to the kubevirt-config ConfigMap.
The feature is disabled by default.   

```
