### PR TITLE
Multus webhook support

### DIFF
--- a/cluster/examples/vmi-sriov.yaml
+++ b/cluster/examples/vmi-sriov.yaml
@@ -25,10 +25,7 @@ spec:
     machine:
       type: ""
     resources:
-      limits:
-        intel.com/sriov: "1"
       requests:
-        intel.com/sriov: "1"
         memory: 1024M
   networks:
   - name: default

--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -190,6 +190,19 @@ $ go get -u -d github.com/intel/sriov-cni/
 $ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-cni/images/sriov-cni-daemonset.yaml
 ```
 
+Deploy Multus webhook. The webhook is not merged upstream yet, so we need to
+fetch the code from an open pull request.
+
+```
+$ cd $GOPATH/src/github.com/intel/multus-cni/
+$ git fetch origin pull/186/head:webhook
+$ git checkout webhook
+$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/deployment/webhook/rbac.yaml
+$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/deployment/webhook/install.yaml
+$ # change image to quay.io/booxter/multus-webhook:latest
+$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/deployment/webhook/server.yaml
+```
+
 Finally, create a new SR-IOV network CRD that will use SR-IOV device plugin to allocate devices.
 
 ```

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -702,6 +702,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "virt-launcher-" + domain + "-",
 			Labels:       podLabels,
+			Namespace:    namespace,
 			Annotations:  annotationsList,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(vmi, v1.VirtualMachineInstanceGroupVersionKind),

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -226,13 +226,6 @@ var _ = Describe("Multus Networking", func() {
 			vmiOne.Spec.Domain.Devices.Interfaces = append(vmiOne.Spec.Domain.Devices.Interfaces, iface)
 			vmiOne.Spec.Networks = append(vmiOne.Spec.Networks, network)
 
-			// mutating hook is not integrated yet so fill in limits / requests to allocate intel devices
-			vmiOne.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-			for resource, value := range map[k8sv1.ResourceName]resource.Quantity{k8sv1.ResourceName("intel.com/sriov"): resource.MustParse("1")} {
-				vmiOne.Spec.Domain.Resources.Limits[resource] = value
-				vmiOne.Spec.Domain.Resources.Requests[resource] = value
-			}
-
 			// fedora requires some more memory to boot without kernel panics
 			vmiOne.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
 
@@ -289,13 +282,6 @@ var _ = Describe("Multus Networking", func() {
 				network := v1.Network{Name: name, NetworkSource: v1.NetworkSource{Multus: &v1.CniNetwork{NetworkName: name}}}
 				vmiOne.Spec.Domain.Devices.Interfaces = append(vmiOne.Spec.Domain.Devices.Interfaces, iface)
 				vmiOne.Spec.Networks = append(vmiOne.Spec.Networks, network)
-			}
-
-			// mutating hook is not integrated yet so fill in limits / requests to allocate intel devices
-			vmiOne.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-			for resource, value := range map[k8sv1.ResourceName]resource.Quantity{k8sv1.ResourceName("intel.com/sriov"): resource.MustParse("2")} {
-				vmiOne.Spec.Domain.Resources.Limits[resource] = value
-				vmiOne.Spec.Domain.Resources.Requests[resource] = value
 			}
 
 			// fedora requires some more memory to boot without kernel panics

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -333,8 +333,6 @@ func GetVMISlirp() *v1.VirtualMachineInstance {
 func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vm := getBaseVMI(VmiSRIOV)
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
-	vm.Spec.Domain.Resources.Requests["intel.com/sriov"] = resource.MustParse("1")
-	vm.Spec.Domain.Resources.Limits = k8sv1.ResourceList{"intel.com/sriov": resource.MustParse("1")}
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.CniNetwork{NetworkName: "sriov-net"}}}}
 	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: this adopts kubevirt to support new multus mutating webhook

TODO: add functional test for sriov network crd from different namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: this is work in progress, building on top of another PR for sriov support. Posted to start discussion and better visualisation of what's required to make it work in kubevirt context.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adopt multus mutating webhook for resource requests, which removes the need to explicitly request device plugin resources in VMI spec
```
