### PR TITLE
Add feature gate for SR-IOV interface type

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -192,7 +192,24 @@ Finally, create a new SR-IOV network CRD that will use SR-IOV device plugin to a
 
 # Install kubevirt services
 
-This step is not specific to SR-IOV.
+The SR-IOV feature is gated, so you would need to enable the `SRIOV` gate
+feature using `kubevirt-config` map before deploying Kubevirt. For example,
+
+```
+cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubevirt-config
+  namespace: kube-system
+  labels:
+    kubevirt.io: ""
+data:
+  feature-gates: "SRIOV"
+```
+
+After that, you are ready to deploy Kubevirt. As you can see, this particular
+step is not specific to SR-IOV.
 
 ```
 make cluster-sync

--- a/pkg/feature-gates/feature-gates.go
+++ b/pkg/feature-gates/feature-gates.go
@@ -39,6 +39,7 @@ const (
 	dataVolumesGate   = "DataVolumes"
 	cpuManager        = "CPUManager"
 	liveMigrationGate = "LiveMigration"
+	SRIOVGate         = "SRIOV"
 )
 
 func ParseFeatureGatesFromConfigMap() {
@@ -90,4 +91,8 @@ func CPUManagerEnabled() bool {
 
 func LiveMigrationEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), liveMigrationGate)
+}
+
+func SRIOVEnabled() bool {
+	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
 }

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -870,6 +870,14 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 				})
 			}
 
+			if iface.SRIOV != nil && !featuregates.SRIOVEnabled() {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("SRIOV feature gate is not enabled in kubevirt-config"),
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+				})
+			}
+
 			// Check if the interface name is unique
 			if _, networkAlreadyUsed := networkInterfaceMap[iface.Name]; networkAlreadyUsed {
 				causes = append(causes, metav1.StatusCause{

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Parse()
 
 	// Required to validate DataVolume usage
-	os.Setenv("FEATURE_GATES", "DataVolumes,LiveMigration")
+	os.Setenv("FEATURE_GATES", "DataVolumes,LiveMigration,SRIOV")
 
 	var vms = map[string]*v1.VirtualMachine{
 		utils.VmCirros:           utils.GetVMCirros(),


### PR DESCRIPTION
The feature is still in development, lacks proper CI, at times relies on
unreleased / unmerged patches in dependency components (device plugin, multus,
CNI), and runs launcher containers in privileged mode. We would like to make it
disabled by default while we complete the feature.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add SRIOV feature gate (disabled by default)
```
