### PR TITLE
Improve preStart hook by taking unconditionally all xml modifications

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -124,7 +124,7 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 		UID:            vmi.Status.MigrationState.MigrationUID,
 		StartTimestamp: &now,
 	}
-	_, err = util.SetDomainSpec(l.virConn, vmi, *domainSpec)
+	_, err = l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return false, err
 	}
@@ -191,7 +191,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 	}
 	domainSpec.Metadata.KubeVirt.Migration.EndTimestamp = &now
 
-	_, err = util.SetDomainSpec(l.virConn, vmi, *domainSpec)
+	_, err = l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 	podCPUSet, err := util.GetPodCPUSet()
 	if err != nil {
 		logger.Reason(err).Error("failed to read pod cpuset.")
-		return err
+		return fmt.Errorf("failed to read pod cpuset: %v", err)
 	}
 
 	// Map the VirtualMachineInstance to the Domain
@@ -288,11 +288,21 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		CPUSet:         podCPUSet,
 	}
 	if err := api.Convert_v1_VirtualMachine_To_api_Domain(vmi, domain, c); err != nil {
-		logger.Error("Conversion failed.")
-		return err
+		return fmt.Errorf("conversion failed: %v", err)
 	}
 
-	_, err = l.preStartHook(vmi, domain)
+	dom, err := l.preStartHook(vmi, domain)
+	if err != nil {
+		return fmt.Errorf("pre-start pod-setup failed: %v", err)
+	}
+	// TODO this should probably a OnPrepareMigration hook or something.
+	// Right now we need to call OnDefineDomain, so that additional setup, which might be done
+	// by the hook can also be done for the new target pod
+	hooksManager := hooks.GetManager()
+	_, err = hooksManager.OnDefineDomain(&dom.Spec, vmi)
+	if err != nil {
+		return fmt.Errorf("executing custom preStart hooks failed: %v", err)
+	}
 	return nil
 }
 
@@ -370,13 +380,6 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 			return domain, err
 		}
 	}
-
-	hooksManager := hooks.GetManager()
-	domainSpec, err := hooksManager.OnDefineDomain(&domain.Spec, vmi)
-	if err != nil {
-		return domain, err
-	}
-	domain.Spec = *domainSpec
 
 	return domain, err
 }
@@ -457,7 +460,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 				logger.Reason(err).Error("pre start setup for VirtualMachineInstance failed.")
 				return nil, err
 			}
-			dom, err = util.SetDomainSpec(l.virConn, vmi, domain.Spec)
+			dom, err = l.setDomainSpecWithHooks(vmi, &domain.Spec)
 			if err != nil {
 				return nil, err
 			}
@@ -477,7 +480,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 	// To make sure, that we set the right qemu wrapper arguments,
 	// we update the domain XML whenever a VirtualMachineInstance was already defined but not running
 	if !newDomain && cli.IsDown(domState) {
-		dom, err = util.SetDomainSpec(l.virConn, vmi, domain.Spec)
+		dom, err = l.setDomainSpecWithHooks(vmi, &domain.Spec)
 		if err != nil {
 			return nil, err
 		}
@@ -596,7 +599,7 @@ func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance)
 
 			now := metav1.Now()
 			domSpec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp = &now
-			_, err = util.SetDomainSpec(l.virConn, vmi, *domSpec)
+			_, err = l.setDomainSpecWithHooks(vmi, domSpec)
 			if err != nil {
 				log.Log.Object(vmi).Reason(err).Error("Unable to update grace period start time on domain xml")
 				return err
@@ -707,4 +710,14 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 	}
 
 	return list, nil
+}
+
+func (l *LibvirtDomainManager) setDomainSpecWithHooks(vmi *v1.VirtualMachineInstance, spec *api.DomainSpec) (cli.VirDomain, error) {
+
+	hooksManager := hooks.GetManager()
+	domainSpec, err := hooksManager.OnDefineDomain(spec, vmi)
+	if err != nil {
+		return nil, err
+	}
+	return util.SetDomainSpecStr(l.virConn, vmi, domainSpec)
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -323,7 +323,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 	// ensure registry disk files have correct ownership privileges
 	err := containerdisk.SetFilePermissions(vmi)
 	if err != nil {
-		return domain, err
+		return domain, fmt.Errorf("setting registry-disk file permissions failed: %v", err)
 	}
 
 	// generate cloud-init data
@@ -333,14 +333,14 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 
 		err := cloudinit.GenerateLocalData(vmi.Name, hostname, vmi.Namespace, cloudInitData)
 		if err != nil {
-			return domain, err
+			return domain, fmt.Errorf("generating local cloud-init data failed: %v", err)
 		}
 	}
 
 	// setup networking
 	err = network.SetupPodNetwork(vmi, domain)
 	if err != nil {
-		return domain, err
+		return domain, fmt.Errorf("preparing the pod network failed: %v", err)
 	}
 
 	// create disks images on the cluster lever
@@ -348,13 +348,13 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 	hostDiskCreator := hostdisk.NewHostDiskCreator(l.notifier, l.lessPVCSpaceToleration)
 	err = hostDiskCreator.Create(vmi)
 	if err != nil {
-		return domain, err
+		return domain, fmt.Errorf("preparing host-disks failed: %v", err)
 	}
 
 	// Create images for volumes that are marked ephemeral.
 	err = ephemeraldisk.CreateEphemeralImages(vmi)
 	if err != nil {
-		return domain, err
+		return domain, fmt.Errorf("preparing ephemeral images failed: %v", err)
 	}
 	// create empty disks if they exist
 	if err := emptydisk.CreateTemporaryDisks(vmi); err != nil {

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -89,14 +89,9 @@ func ConvReason(status libvirt.DomainState, reason int) api.StateChangeReason {
 	}
 }
 
-func SetDomainSpec(virConn cli.Connection, vmi *v1.VirtualMachineInstance, wantedSpec api.DomainSpec) (cli.VirDomain, error) {
-	xmlStr, err := xml.Marshal(&wantedSpec)
-	if err != nil {
-		log.Log.Object(vmi).Reason(err).Error("Generating the domain XML failed.")
-		return nil, err
-	}
-	log.Log.Object(vmi).V(3).With("xml", string(xmlStr)).Info("Domain XML generated.")
-	dom, err := virConn.DomainDefineXML(string(xmlStr))
+func SetDomainSpecStr(virConn cli.Connection, vmi *v1.VirtualMachineInstance, wantedSpec string) (cli.VirDomain, error) {
+	log.Log.Object(vmi).V(3).With("xml", wantedSpec).Info("Domain XML generated.")
+	dom, err := virConn.DomainDefineXML(wantedSpec)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Defining the VirtualMachineInstance failed.")
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to ensure that we forward arbitrary Domain XML modifications, don't deserialize the modified domain xml again when we receive it from the preStart hook.

Since e.g. the metadata can under some conditions change, and we
persist the whole domain xml with the change, we need to call the
prestart hook also in these scenarios.

The prestart hooks needed to be written in an idempotent way because they are executed
*at-least-once*. It should therefore not introduce problems with existing prestart hooks.
In the future we should not write kubevirt specific metadata. We can directly persist it in memory of virt-launcher.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Take all modifcations to the domain xml in the preStart hook into account
```
