### PR TITLE
[skip ci] Fixed error message formatting

### DIFF
--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -122,8 +122,7 @@ func (c *VirtLauncherClient) genericSendCmd(args *Args, cmd string) (*Reply, err
 		msg := fmt.Sprintf("unknown error encountered sending command %s: %s", cmd, err.Error())
 		return reply, fmt.Errorf(msg)
 	} else if reply.Success != true {
-		msg := fmt.Sprintf("server error. command %s failed: %s", cmd, reply.Message)
-		return reply, fmt.Errorf(msg)
+		return reply, fmt.Errorf("server error. command %s failed: %q", cmd, reply.Message)
 	}
 	return reply, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When the msg contained a percent sign, it was wrongly formatted.

**Special notes for your reviewer**:
see https://github.com/kubevirt/kubevirt/pull/1727#discussion_r235679801

**Release note**:
```release-note
NONE
```
