### PR TITLE
Stabilize test where virt-handler should recover after crash

### DIFF
--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -493,8 +493,7 @@ var _ = Describe("Storage", func() {
 
 				By("Checking events")
 				objectEventWatcher := tests.NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(120) * time.Second)
-				event := objectEventWatcher.WaitFor(tests.WarningEvent, v1.SyncFailed.String())
-				Expect(event).ToNot(BeNil())
+				objectEventWatcher.WaitFor(tests.WarningEvent, v1.SyncFailed.String())
 
 			})
 
@@ -510,9 +509,7 @@ var _ = Describe("Storage", func() {
 				By("Checking events")
 				objectEventWatcher := tests.NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(30) * time.Second)
 				objectEventWatcher.FailOnWarnings()
-				event := objectEventWatcher.WaitFor(tests.EventType(hostdisk.EventTypeToleratedSmallPV), hostdisk.EventReasonToleratedSmallPV)
-				Expect(event).ToNot(BeNil())
-
+				objectEventWatcher.WaitFor(tests.EventType(hostdisk.EventTypeToleratedSmallPV), hostdisk.EventReasonToleratedSmallPV)
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Stabilize 

```
VMIlifecycle Creating a VirtualMachineInstance when virt-handler crashes should recover and continue management
```
test.

It was necessary to wait longer for the events to come because there are many uncertainties when the pod gets killed. Especially: How fast it gets killed and restarted and what it will then exactly see.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
