### PR TITLE
[WIP] registryDisk: Permitusing it as an iSCSI target (again)

### DIFF
--- a/cmd/registry-disk-v1alpha/README.as-iscsi.md
+++ b/cmd/registry-disk-v1alpha/README.as-iscsi.md
@@ -1,0 +1,74 @@
+The registrydisk can be used ina  different context as well:
+It can be used in a standalone pod to expose the disk it carries as an iSCSI target.
+
+Two things you need:
+1. A pod to run the iSCSI target and a servcie exporting it
+2. A PV and PVC to make it usable on the clutser
+
+Creating the pod and service:
+
+```
+$ kubectl create -f - <<<EOY
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-iscsi-target
+  labels:
+    app: my-iscsi-target
+spec:
+  containers:
+  - name: my-iscsi-target
+    image: kubevirt/cirros-registry-disk-demo:latest
+    env:
+    - name: AS_ISCSI
+      value: yes
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-iscsi-target
+spec:
+  selector:
+    app: my-iscsi-target
+  ports:
+  - protocol: TCP
+    port: 3260
+    targetPort: 3260
+EOY
+```
+
+Creating a PV and PVC pointing to it:
+
+```
+$ kubectl create -f - <<<EOY
+apiVersion: "v1"
+kind: "PersistentVolume"
+metadata:
+  name: my-iscsi-lun
+spec:
+  capacity:
+    storage: "10G"
+  accessModes:
+    - "ReadWriteMany"
+  claimRef:
+    namespace: default
+    name: my-iscsi-lun-claim
+  volumeMode: block
+  iscsi:
+    targetPortal: my-iscsi-target.svc:3260
+    iqn: iqn.2018-01.io.kubevirt:wrapper
+    lun: 1
+    readOnly: false
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: my-iscsi-lun
+spec:
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "10G"
+EOY
+```

--- a/cmd/registry-disk-v1alpha/entry-point.sh
+++ b/cmd/registry-disk-v1alpha/entry-point.sh
@@ -54,6 +54,11 @@ fi
 echo "copied $IMAGE_PATH to $COPY_PATH.${IMAGE_EXTENSION}"
 
 touch /tmp/healthy
-while [ -f "${COPY_PATH}.${IMAGE_EXTENSION}" ]; do
-	sleep 5
-done
+if [ -n "$AS_ISCSI" ];
+then
+	bash expose-as-iscsi.sh "${COPY_PATH}.${IMAGE_EXTENSION}"
+else
+	while [ -f "${COPY_PATH}.${IMAGE_EXTENSION}" ]; do
+		sleep 5
+	done
+fi

--- a/cmd/registry-disk-v1alpha/expose-as-iscsi.sh
+++ b/cmd/registry-disk-v1alpha/expose-as-iscsi.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/bash
+
+IMAGE_PATH="$1"
+
+if [ ! -f "$IMAGE_PATH" ]; then
+	echo "vm image '$IMAGE_PATH' not found"
+	exit 1
+fi
+
+# USING 'set -e' error detection for everything below this point.
+set -e
+
+PORT=${PORT:-3260}
+WWN=${WWN:-iqn.2018-01.io.kubevirt:wrapper}
+LUNID=1
+
+echo "Starting tgtd at port $PORT"
+tgtd -f --iscsi portal="0.0.0.0:${PORT}" &
+sleep 5
+
+echo "Adding target and exposing it"
+tgtadm --lld iscsi --mode target --op new --tid=1 --targetname $WWN
+tgtadm --lld iscsi --mode target --op bind --tid=1 -I ALL
+
+if [ -n "$PASSWORD" ]; then
+	echo "Adding authentication for user $USERNAME"
+	tgtadm --lld iscsi --op new --mode account --user $USERNAME --password $PASSWORD
+	tgtadm --lld iscsi --op bind --mode account --tid=1 --user $USERNAME
+fi
+
+echo "Adding volume file as LUN"
+tgtadm --lld iscsi --mode logicalunit --op new --tid=1 --lun=$LUNID -b $IMAGE_PATH
+tgtadm --lld iscsi --mode logicalunit --op update --tid=1 --lun=$LUNID --params thin_provisioning=1
+
+echo "Start monitoring"
+touch previous_state
+while true ; do
+	tgtadm --lld iscsi --mode target --op show > current_state
+	diff -q previous_state current_state || ( date ; cat current_state ; )
+	mv -f current_state previous_state
+	sleep 5
+done


### PR DESCRIPTION
This change allows a user to use the registryDisk container standalone,
to export the disk it carries as an iSCSI target.

The primary use-case is to use the registryDisk in iSCSI mode in order
to support shared storage live migration intesting.

```release-note
Allow to use registryDisks as iSCSI targets
```


Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>