### PR TITLE
Start caching infrastructure and base containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ dist: trusty
 services:
 - docker
 
-env:
-- BUILDER_NAME="kubevirt/${TRAVIS_JOB_ID}builder"
-
 install:
  - git reset --hard
 
 script:
+- export KUBEVIRT_UPDATE_CACHE_FROM="${TRAVIS_BRANCH}"
+- export KUBEVIRT_CACHE_FROM="${TRAVIS_BRANCH}"
+- if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then make pull-cache; fi # only use the cache in PRs, rebuild otherwise
 - make generate
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
@@ -31,6 +31,12 @@ deploy:
   skip_cleanup: true
   on:
     branch: master
+- provider: script
+  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && KUBEVIRT_UPDATE_CACHE_FROM="${TRAVIS_BRANCH}" make push-cache
+  skip_cleanup: true
+  on:
+    tags: false
+    all_branches: true
 - provider: script
   script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && make publish DOCKER_TAG=$TRAVIS_TAG
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ docker: build
 push: docker
 	hack/build-docker.sh push ${WHAT}
 
+push-cache:
+	hack/build-docker.sh push-cache ${WHAT}
+
+pull-cache:
+	hack/build-docker.sh pull-cache ${WHAT}
+
 publish: docker verify-build
 	hack/build-docker.sh push ${WHAT}
 

--- a/automation/check-patch.environment.yaml
+++ b/automation/check-patch.environment.yaml
@@ -1,0 +1,4 @@
+---
+- name: 'ghprbTargetBranch'
+  valueFrom:
+    runtimeEnv: 'ghprbTargetBranch'

--- a/automation/check-patch.k8s-1.10.4-release.environment.yaml
+++ b/automation/check-patch.k8s-1.10.4-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.k8s-1.11.0-dev.environment.yaml
+++ b/automation/check-patch.k8s-1.11.0-dev.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.k8s-1.11.0-release.environment.yaml
+++ b/automation/check-patch.k8s-1.11.0-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.k8s-genie-1.11.1-release.environment.yaml
+++ b/automation/check-patch.k8s-genie-1.11.1-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.k8s-multus-1.11.1-release.environment.yaml
+++ b/automation/check-patch.k8s-multus-1.11.1-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.openshift-3.10-multus-release.environment.yaml
+++ b/automation/check-patch.openshift-3.10-multus-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.openshift-3.11-crio-release.environment.yaml
+++ b/automation/check-patch.openshift-3.11-crio-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.openshift-3.11-release.environment.yaml
+++ b/automation/check-patch.openshift-3.11-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/check-patch.windows2016-release.environment.yaml
+++ b/automation/check-patch.windows2016-release.environment.yaml
@@ -1,0 +1,1 @@
+check-patch.environment.yaml

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -146,6 +146,13 @@ fi
 # Make sure that the VM is properly shut down on exit
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM SIGSTOP
 
+
+# Check if we are on a pull request in jenkins.
+export KUBEVIRT_CACHE_FROM=${ghprbTargetBranch}
+if [ -n ${KUBEVIRT_CACHE_FROM} ]; then
+    make pull-cache
+fi
+
 make cluster-down
 make cluster-up
 

--- a/hack/build-docker.sh
+++ b/hack/build-docker.sh
@@ -36,16 +36,49 @@ else
 fi
 
 for arg in $args; do
+    BUILDER_EXTRA_ARGS=""
     BIN_NAME=$(basename $arg)
     if [ "${target}" = "build" ]; then
         (
+            if [ -n "$KUBEVIRT_CACHE_FROM" ]; then
+                BUILDER_EXTRA_ARGS="${BUILDER_EXTRA_ARGS} --cache-from kubevirt/${BIN_NAME}:${KUBEVIRT_CACHE_FROM}"
+            fi
+            if [ -n "$KUBEVIRT_UPDATE_CACHE_FROM" ]; then
+                BUILDER_EXTRA_ARGS="${BUILDER_EXTRA_ARGS} -t kubevirt/${BIN_NAME}:${KUBEVIRT_UPDATE_CACHE_FROM}"
+            fi
             cd ${CMD_OUT_DIR}/${BIN_NAME}/
-            docker $target -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${job_prefix} --label ${BIN_NAME} .
+            docker build -t ${docker_prefix}/${BIN_NAME}:${docker_tag} --label ${job_prefix} --label ${BIN_NAME} ${BUILDER_EXTRA_ARGS} .
         )
     elif [ "${target}" = "push" ]; then
         (
             cd ${CMD_OUT_DIR}/${BIN_NAME}/
-            docker $target ${docker_prefix}/${BIN_NAME}:${docker_tag}
+            docker push ${docker_prefix}/${BIN_NAME}:${docker_tag}
         )
     fi
 done
+
+if [ $# -eq 0 ]; then
+    args=$docker_images_cacheable
+else
+    args=$@
+fi
+
+if [ "${target}" = "push-cache" ]; then
+    docker push kubevirt/builder-cache:${KUBEVIRT_UPDATE_CACHE_FROM}
+    if [ -n "$KUBEVIRT_UPDATE_CACHE_FROM" ]; then
+        for arg in $args; do
+            BIN_NAME=$(basename $arg)
+            docker push kubevirt/${BIN_NAME}:${KUBEVIRT_UPDATE_CACHE_FROM}
+        done
+    fi
+fi
+
+if [ "${target}" = "pull-cache" ]; then
+    docker pull kubevirt/builder-cache:${KUBEVIRT_CACHE_FROM}
+    if [ -n "$KUBEVIRT_CACHE_FROM" ]; then
+        for arg in $args; do
+            BIN_NAME=$(basename $arg)
+            docker pull kubevirt/${BIN_NAME}:${KUBEVIRT_CACHE_FROM} || true
+        done
+    fi
+fi

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -23,6 +23,12 @@ KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.10.4}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
 
+# If set to the name of a branch, the builds will try to use an image of the form kubevirt/{name}:{branche}
+# as cache source (--cache-from)
+KUBEVIRT_CACHE_FROM=${KUBEVIRT_CACHE_FROM}
+# Push images in the form kubevirt/{name}:{branche} to update the build cache for this branch
+KUBEVIRT_UPDATE_CACHE_FROM=${KUBEVIRT_UPDATE_CACHE_FROM}
+
 # Use this environment variable to set a custom pkgdir path
 # Useful for cross-compilation where the default -pkdir for cross-builds may not be writable
 #KUBEVIRT_GO_BASE_PKGDIR="${GOPATH}/crossbuild-cache-root/"

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -1,5 +1,7 @@
 binaries="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virtctl cmd/fake-qemu-process cmd/virt-api cmd/subresource-access-test cmd/example-hook-sidecar"
-docker_images="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api images/disks-images-provider images/vm-killer cmd/container-disk-v1alpha images/cirros-container-disk-demo images/fedora-cloud-container-disk-demo images/alpine-container-disk-demo cmd/subresource-access-test images/winrmcli cmd/example-hook-sidecar images/cdi-http-import-server"
+docker_images_cacheable="cmd/virt-controller cmd/virt-launcher cmd/virt-handler cmd/virt-api images/disks-images-provider images/vm-killer cmd/subresource-access-test images/winrmcli cmd/example-hook-sidecar images/cdi-http-import-server cmd/container-disk-v1alpha"
+docker_images_container_disks="images/cirros-container-disk-demo images/fedora-cloud-container-disk-demo images/alpine-container-disk-demo"
+docker_images="${docker_images_cacheable} ${docker_images_container_disks}"
 docker_prefix=${DOCKER_PREFIX:-kubevirt}
 docker_tag=${DOCKER_TAG:-latest}
 master_ip=192.168.200.2

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -13,8 +13,6 @@ RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimm
 
 ENV GOPATH="/go" GOBIN="/usr/bin"
 
-ADD rsyncd.conf /etc/rsyncd.conf
-
 RUN \
     mkdir -p /go && \
     source /etc/profile.d/gimme.sh && \
@@ -49,6 +47,8 @@ RUN \
 
 RUN pip install j2cli
 
-ADD entrypoint.sh /entrypoint.sh
-
 ENTRYPOINT [ "/entrypoint.sh" ]
+
+ADD rsyncd.conf /etc/rsyncd.conf
+
+ADD entrypoint.sh /entrypoint.sh

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -14,13 +14,17 @@ SYNC_VENDOR=${SYNC_VENDOR:-false}
 TEMPFILE=".rsynctemp"
 
 # Reduce verbosity if an automated build
-BUILD_QUIET=
-if [ -n "$JOB_NAME" -o -n "$TRAVIS_BUILD_ID" ]; then
-    BUILD_QUIET="-q"
+BUILDER_EXTRA_ARGS=""
+if [ -n "${KUBEVIRT_CACHE_FROM}" ]; then
+    BUILDER_EXTRA_ARGS="${BUILDER_EXTRA_ARGS} --cache-from kubevirt/builder-cache:${KUBEVIRT_CACHE_FROM}"
+fi
+
+if [ -n "${KUBEVIRT_UPDATE_CACHE_FROM}" ]; then
+    BUILDER_EXTRA_ARGS="${BUILDER_EXTRA_ARGS} -t kubevirt/builder-cache:${KUBEVIRT_UPDATE_CACHE_FROM}"
 fi
 
 # Build the build container
-(cd ${DOCKER_DIR} && docker build . ${BUILD_QUIET} -t ${BUILDER})
+(cd ${DOCKER_DIR} && docker build . ${BUILDER_EXTRA_ARGS} -t ${BUILDER})
 
 # Create the persistent docker volume
 if [ -z "$(docker volume list | grep ${BUILDER})" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Use travis for building and publishing cache-containers on every branch. The branch caches are built and updated on every merged PR or on cron runs, but not on tag runs.

These cached containers can then be used in stdci and have the following benefits: 
 * stdci should have to build the build-container and base containers very seldom which reduces build times for more than half an hour.
 * It will eliminate package manager download errors or other transient errors when pulling external dependencies to build the containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

What this does not do right now:

 * Caching registry disks. Only the registry-disk base is cached but the actual images will continue to be downloaded in stdci.

**Release note**:

```release-note
NONE
```
