### PR TITLE
Deploy test infrastructure before other components

### DIFF
--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -34,6 +34,9 @@ metadata:
   name: ${namespace}
 EOF
 
+# Deploy infra for testing first
+_kubectl create -f ${MANIFESTS_OUT_DIR}/testing -R $i
+
 # Deploy the right manifests for the right target
 if [[ -z $TARGET ]] || [[ $TARGET =~ .*-dev ]]; then
     _kubectl create -f ${MANIFESTS_OUT_DIR}/dev -R $i
@@ -45,9 +48,6 @@ elif [[ $TARGET =~ .*-release ]] || [[ $TARGET =~ windows.* ]]; then
         _kubectl create -f $manifest
     done
 fi
-
-# Deploy additional infra for testing
-_kubectl create -f ${MANIFESTS_OUT_DIR}/testing -R $i
 
 if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]]; then
     _kubectl adm policy add-scc-to-user privileged -z kubevirt-controller -n ${namespace}

--- a/pkg/feature-gates/feature-gates.go
+++ b/pkg/feature-gates/feature-gates.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
+	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/util"
 )
 
@@ -40,6 +41,7 @@ const (
 	cpuManager        = "CPUManager"
 	liveMigrationGate = "LiveMigration"
 	SRIOVGate         = "SRIOV"
+	configMapName     = "kubevirt-config"
 )
 
 func ParseFeatureGatesFromConfigMap() {
@@ -56,10 +58,12 @@ func ParseFeatureGatesFromConfigMap() {
 			return false, err
 		}
 
-		cfgMap, curErr = virtClient.CoreV1().ConfigMaps(namespace).Get("kubevirt-config", metav1.GetOptions{})
+		cfgMap, curErr = virtClient.CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
 
 		if curErr != nil {
 			if errors.IsNotFound(curErr) {
+				logger := log.DefaultLogger()
+				logger.Infof("%s ConfigMap does not exist. Using defaults.", configMapName)
 				// ignore if config map does not exist
 				return true, nil
 			}


### PR DESCRIPTION
Fixes a race condition in the dev environment where kubevirt-config
is deployed after virt-api.

```release-note
NONE
```
