### PR TITLE
Handle failed domain metadata queries to let live-migration proceed

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -272,7 +272,7 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 	}
 
 	// Update migration progress if domain reports anything in the migration metadata.
-	if domain != nil && domain.Spec.Metadata.KubeVirt.Migration != nil && vmi.Status.MigrationState != nil {
+	if domain != nil && domain.Spec.Metadata.KubeVirt.Migration != nil && vmi.Status.MigrationState != nil && d.isMigrationSource(vmi) {
 		migrationMetadata := domain.Spec.Metadata.KubeVirt.Migration
 		if migrationMetadata.UID == vmi.Status.MigrationState.MigrationUID {
 

--- a/pkg/virt-launcher/virtwrap/errors/errors.go
+++ b/pkg/virt-launcher/virtwrap/errors/errors.go
@@ -39,6 +39,11 @@ func IsNotFound(err error) bool {
 	return checkError(err, libvirt.ERR_NO_DOMAIN)
 }
 
+// IsInvalidOperation detects libvirt's VIR_ERR_OPERATION_INVALID. It accepts both error and libvirt.Error (as returned by GetLastError function).
+func IsInvalidOperation(err error) bool {
+	return checkError(err, libvirt.ERR_OPERATION_INVALID)
+}
+
 // IsOk detects libvirt's ERR_OK. It accepts both error and libvirt.Error (as returned by GetLastError function).
 func IsOk(err error) bool {
 	return checkError(err, libvirt.ERR_OK)

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -110,15 +110,21 @@ func GetDomainSpecWithRuntimeInfo(status libvirt.DomainState, dom cli.VirDomain)
 	// get libvirt xml with runtime status
 	activeSpec, err := GetDomainSpecWithFlags(dom, 0)
 	if err != nil {
+		log.Log.Reason(err).Error("failed to get domain spec")
 		return nil, err
 	}
 
 	metadataXML, err := dom.GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG)
+	if err != nil {
+		log.Log.Reason(err).Error("failed to get domain metadata")
+		return activeSpec, err
+	}
 
 	metadata := &api.KubeVirtMetadata{}
 	err = xml.Unmarshal([]byte(metadataXML), metadata)
 	if err != nil {
-		return nil, err
+		log.Log.Reason(err).Error("failed to unmarshal domain metadata")
+		return activeSpec, err
 	}
 
 	activeSpec.Metadata.KubeVirt = *metadata

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Migrations", func() {
 		return uid
 	}
 
-	PDescribe("Starting a VirtualMachineInstance ", func() {
+	Describe("Starting a VirtualMachineInstance ", func() {
 		Context("with an Alpine read only disk", func() {
 			It("should be successfully migrated multiple times", func() {
 


### PR DESCRIPTION
**What this PR does / why we need it**:
While live migration proceeds, querying the migrating domain metadata is not allowed.
This PR handles any failed domain metadata queries to allow the migration to proceed.

**Which issue(s) this PR fixes**
Fixes #1699 

**Release note**:

-->
```release-note
NONE
```
