### PR TITLE
Run the network pod tests only on the compute container

### DIFF
--- a/cmd/container-disk-v1alpha/Dockerfile
+++ b/cmd/container-disk-v1alpha/Dockerfile
@@ -22,8 +22,7 @@ LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 ENV container docker
 
-# TODO: iproute should be removed when tests no longer rely on it
-RUN yum install -y bzip2 qemu-img iproute && dnf clean all && mkdir -p /disk
+RUN yum install -y bzip2 qemu-img && dnf clean all && mkdir -p /disk
 
 ADD entry-point.sh /
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Networking", func() {
 			output, err := tests.ExecuteCommandOnPod(
 				virtClient,
 				vmiPod,
-				vmiPod.Spec.Containers[0].Name, // TODO: Be more explicit in the way we run commands on specific containers.
+				"compute",
 				[]string{"ip", "address", "show", "k6t-eth0"},
 			)
 			log.Log.Infof("%v", output)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Run the network pod tests only on the compute container
**What this PR does / why we need it**:
Fix the network tests

related to https://github.com/kubevirt/kubevirt/pull/1797


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1799)
<!-- Reviewable:end -->
