### PR TITLE
Pin goimports to release 1.11 branch

### DIFF
--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -18,7 +18,10 @@ RUN \
     source /etc/profile.d/gimme.sh && \
     go get github.com/mattn/goveralls && \
     go get -u github.com/Masterminds/glide && \
-    go get -u golang.org/x/tools/cmd/goimports && \
+    go get -d golang.org/x/tools/cmd/goimports && \
+    cd /go/src/golang.org/x/tools/cmd/goimports && \
+    git checkout release-branch.go1.11 && \
+    go install && \
     git clone https://github.com/mvdan/sh.git $GOPATH/src/mvdan.cc/sh && \
     cd /go/src/mvdan.cc/sh/cmd/shfmt && \
     git checkout v2.5.0 && \


### PR DESCRIPTION
Running against master means we are prone to breakage if changes to
rules land there.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
