### PR TITLE
[WIP] Using k8s workload controllers to manage virtual machines

### DIFF
--- a/manifests/dev/rbac.authorization.k8s.yaml.in
+++ b/manifests/dev/rbac.authorization.k8s.yaml.in
@@ -116,6 +116,14 @@ rules:
   - apiGroups:
       - ''
     resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
       - configmaps
     resourceNames:
       - extension-apiserver-authentication
@@ -140,6 +148,7 @@ rules:
       - list
       - watch
       - delete
+      - create
   - apiGroups:
       - ''
     resources:

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -393,6 +393,10 @@ const (
 	// if a particular node is alive and hence should be available for new
 	// virtual machine instance scheduling. Used on Node.
 	VirtHandlerHeartbeat string = "kubevirt.io/heartbeat"
+	// References a VM that a pod should be constructed to look like
+	VirtualMachineWorkloadRef string = "kubevirt.io/vm-workload-ref"
+	// Indicates the VMI is controlled by the pod and a workload controller
+	K8sWorkloadControlled string = "kubevirt.io/k8s-workload-controlled"
 
 	VirtualMachineInstanceFinalizer string = "foregroundDeleteVirtualMachine"
 	CPUManager                      string = "cpumanager"

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -80,6 +80,10 @@ type Informers struct {
 	VMIPresetInformer       cache.SharedIndexInformer
 	NamespaceLimitsInformer cache.SharedIndexInformer
 	VMIInformer             cache.SharedIndexInformer
+	VMInformer              cache.SharedIndexInformer
+	ConfigMapInformer       cache.SharedIndexInformer
+	PVCInformer             cache.SharedIndexInformer
+	KubeClient              kubecli.KubevirtClient
 }
 
 func GetInformers() *Informers {
@@ -107,9 +111,13 @@ func newInformers() *Informers {
 	}
 	kubeInformerFactory := controller.NewKubeInformerFactory(kubeClient.RestClient(), kubeClient, namespace)
 	return &Informers{
+		VMInformer:              kubeInformerFactory.VirtualMachine(),
 		VMIInformer:             kubeInformerFactory.VMI(),
 		VMIPresetInformer:       kubeInformerFactory.VirtualMachinePreset(),
 		NamespaceLimitsInformer: kubeInformerFactory.LimitRanges(),
+		ConfigMapInformer:       kubeInformerFactory.ConfigMap(),
+		PVCInformer:             kubeInformerFactory.PersistentVolumeClaim(),
+		KubeClient:              kubeClient,
 	}
 }
 

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -32,7 +34,8 @@ func IsControlledBy(obj Object, owner Object) bool {
 // GetControllerOf returns a pointer to a copy of the controllerRef if controllee has a controller
 func GetControllerOf(controllee Object) *OwnerReference {
 	for _, ref := range controllee.GetOwnerReferences() {
-		if ref.Controller != nil && *ref.Controller {
+		// looking for kubevirt controller references only here
+		if strings.Contains(ref.APIVersion, "kubevirt.io") {
 			return &ref
 		}
 	}


### PR DESCRIPTION
**This is a prototype just for discussion right now.**



This pr allows us to manage virtual machines directly with k8s controllers.

**Example.**
1. User posts a vm spec.
```
apiVersion: kubevirt.io/v1alpha2
kind: VirtualMachine
metadata:
  labels:
    kubevirt.io/vm: my-vm
  name: my-vm
spec:
  running: false
  template:
    metadata:
      labels:
        kubevirt.io/vm: my-vm
    spec:
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: containerdisk
            volumeName: registryvolume
        resources:
          requests:
            memory: 64M
      volumes:
      - containerDisk:
          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
        name: registryvolume

```
2. User posts a Deployment referencing the VM in the *kubevirt.io/vm-workload-ref* annotation.

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: my-deployment
  labels:
    kubevirt.io: "my-deployment"
spec:
  replicas: 2
  template:
    metadata:
      annotations:
        kubevirt.io/vm-workload-ref: my-vm
      labels:
        kubevirt.io: "my-deployment"
    spec:
      containers:
        - name: fake
          image: fake
```

As the deployment controller spins up new pods, we have a mutation webhook that injects the virt-launcher containers into the pods and generates a unique VMI for each pod.  With this method, the pods the deployment manages are running the virtual machine processes directly.  The resulting VMI objects only exist to facilitate the start/stop flow. VMI objects created in this way automatically delete themselves when their corresponding Pod is deleted. 

```
[dvossel@localhost kubevirt]$ kubectl get pods
NAME                             READY     STATUS    RESTARTS   AGE
my-deployment-8486cdd665-kwkw7   2/2       Running   0          15s
my-deployment-8486cdd665-z8jnp   2/2       Running   0          14s
[dvossel@localhost kubevirt]$ kubectl get vmi
NAME                                 AGE
vmi-my-deployment-8486cdd665-9wpt6   18s
vmi-my-deployment-8486cdd665-qwmp6   19s
```

**Release note**:
```release-note
NONE
```
