### PR TITLE
Automatically fill in requests / limits for resourceNames listed in multus network annotations

### DIFF
--- a/cluster/examples/vmi-sriov.yaml
+++ b/cluster/examples/vmi-sriov.yaml
@@ -25,10 +25,7 @@ spec:
     machine:
       type: ""
     resources:
-      limits:
-        intel.com/sriov: "1"
       requests:
-        intel.com/sriov: "1"
         memory: 1024M
   networks:
   - name: default

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -167,6 +167,30 @@ func CPUModelLabelFromCPUModel(vmi *v1.VirtualMachineInstance) (label string, er
 	return
 }
 
+// Request a resource by name. This function bumps the number of resources,
+// both its limits and requests attributes.
+//
+// If we were operating with a regular resource (CPU, memory, network
+// bandwidth), we would need to take care of QoS. For example,
+// https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
+// explains that when Limits are set but Requests are not then scheduler
+// assumes that Requests are the same as Limits for a particular resource.
+//
+// But this function is not called for this standard resources but for
+// resources managed by device plugins. The device plugin design document says
+// the following on the matter:
+// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md#end-user-story
+//
+// ```
+// Devices can be selected using the same process as for OIRs in the pod spec.
+// Devices have no impact on QOS. However, for the alpha, we expect the request
+// to have limits == requests.
+// ```
+//
+// Which suggests that, for resources managed by device plugins, 1) limits
+// should be equal to requests; and 2) QoS rules do not apply.
+//
+// Hence we don't copy Limits value to Requests if the latter is missing.
 func requestResource(resources *k8sv1.ResourceRequirements, resourceName string) {
 	name := k8sv1.ResourceName(resourceName)
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1400,6 +1400,35 @@ var _ = Describe("getNamespaceAndNetworkName", func() {
 	})
 })
 
+var _ = Describe("requestResource", func() {
+	It("should register resource in limits and requests", func() {
+		resources := kubev1.ResourceRequirements{}
+		resources.Requests = make(kubev1.ResourceList)
+		resources.Limits = make(kubev1.ResourceList)
+
+		resource := "intel.com/sriov"
+		resourceName := kubev1.ResourceName(resource)
+
+		for i := int64(1); i <= 5; i++ {
+			requestResource(&resources, resource)
+
+			val, ok := resources.Limits[resourceName]
+			Expect(ok).To(BeTrue())
+
+			valInt, isInt := val.AsInt64()
+			Expect(isInt).To(BeTrue())
+			Expect(valInt).To(Equal(i))
+
+			val, ok = resources.Requests[resourceName]
+			Expect(ok).To(BeTrue())
+
+			valInt, isInt = val.AsInt64()
+			Expect(isInt).To(BeTrue())
+			Expect(valInt).To(Equal(i))
+		}
+	})
+})
+
 func True() *bool {
 	b := true
 	return &b

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -226,13 +226,6 @@ var _ = Describe("Multus Networking", func() {
 			vmiOne.Spec.Domain.Devices.Interfaces = append(vmiOne.Spec.Domain.Devices.Interfaces, iface)
 			vmiOne.Spec.Networks = append(vmiOne.Spec.Networks, network)
 
-			// mutating hook is not integrated yet so fill in limits / requests to allocate intel devices
-			vmiOne.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-			for resource, value := range map[k8sv1.ResourceName]resource.Quantity{k8sv1.ResourceName("intel.com/sriov"): resource.MustParse("1")} {
-				vmiOne.Spec.Domain.Resources.Limits[resource] = value
-				vmiOne.Spec.Domain.Resources.Requests[resource] = value
-			}
-
 			// fedora requires some more memory to boot without kernel panics
 			vmiOne.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
 
@@ -289,13 +282,6 @@ var _ = Describe("Multus Networking", func() {
 				network := v1.Network{Name: name, NetworkSource: v1.NetworkSource{Multus: &v1.CniNetwork{NetworkName: name}}}
 				vmiOne.Spec.Domain.Devices.Interfaces = append(vmiOne.Spec.Domain.Devices.Interfaces, iface)
 				vmiOne.Spec.Networks = append(vmiOne.Spec.Networks, network)
-			}
-
-			// mutating hook is not integrated yet so fill in limits / requests to allocate intel devices
-			vmiOne.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-			for resource, value := range map[k8sv1.ResourceName]resource.Quantity{k8sv1.ResourceName("intel.com/sriov"): resource.MustParse("2")} {
-				vmiOne.Spec.Domain.Resources.Limits[resource] = value
-				vmiOne.Spec.Domain.Resources.Requests[resource] = value
 			}
 
 			// fedora requires some more memory to boot without kernel panics

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -349,8 +349,6 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vm := getBaseVMI(VmiSRIOV)
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
-	vm.Spec.Domain.Resources.Requests["intel.com/sriov"] = resource.MustParse("1")
-	vm.Spec.Domain.Resources.Limits = k8sv1.ResourceList{"intel.com/sriov": resource.MustParse("1")}
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.CniNetwork{NetworkName: "sriov-net"}}}}
 	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: this is a temporary workaround that removes the need to explicitly list SR-IOV device requests / limits when a VMI is attached to a SR-IOV network that already lists intel.com/sriov resourceName in its annotations. (The same mechanism can be leveraged by other plugins, for example, bridge-cni or ovs-cni.) This is a temporary solution because in the future Multus team is going to ship a mutating webhook that will serve the same need, at which point we'll drop our implementation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Automatically fill in resources.limits and resources.requests for SR-IOV network attachments.
```
