### PR TITLE
make sure clean script deletes CDI stuff

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -39,7 +39,7 @@ _kubectl delete pods -n ${namespace} -l="kubevirt.io=libvirt" --force --grace-pe
 _kubectl delete pods -n ${namespace} -l="kubevirt.io=virt-handler" --force --grace-period 0 2>/dev/null || :
 
 # Delete all traces of kubevirt
-namespaces=(default ${namespace})
+namespaces=(default ${namespace} ${cdi_namespace})
 for i in ${namespaces[@]}; do
     _kubectl -n ${i} delete apiservices -l 'kubevirt.io'
     _kubectl -n ${i} delete deployment -l 'kubevirt.io'
@@ -68,7 +68,10 @@ for i in ${namespaces[@]}; do
     _kubectl -n ${i} delete apiservices -l 'cdi.kubevirt.io'
     _kubectl -n ${i} delete validatingwebhookconfiguration -l 'cdi.kubevirt.io'
     _kubectl -n ${i} delete secrets -l 'cdi.kubevirt.io'
+    _kubectl -n ${i} delete configmaps -l 'cdi.kubevirt.io'
+    _kubectl -n ${i} delete pv -l 'cdi.kubevirt.io'
     _kubectl -n ${i} delete pvc -l 'cdi.kubevirt.io'
+    _kubectl -n ${i} delete ds -l 'cdi.kubevirt.io'
     _kubectl -n ${i} delete customresourcedefinitions -l 'cdi.kubevirt.io'
     _kubectl -n ${i} delete pods -l 'cdi.kubevirt.io'
     _kubectl -n ${i} delete clusterrolebinding -l 'cdi.kubevirt.io'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

"make cluster-sync make cluster-sync" fails because clean scrip did not delete CDI stuff.  This is regression cased by kubevirt namespace change.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
