### PR TITLE
Fix parsing of custom emulated machines

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -34,10 +34,11 @@ import (
 )
 
 const (
-	configMapName         = "kubevirt-config"
-	featureGateEnvVar     = "FEATURE_GATES"
-	FeatureGatesKey       = "feature-gates"
-	emulatedMachineEnvVar = "VIRT_EMULATED_MACHINES"
+	configMapName          = "kubevirt-config"
+	featureGateEnvVar      = "FEATURE_GATES"
+	FeatureGatesKey        = "feature-gates"
+	emulatedMachinesEnvVar = "VIRT_EMULATED_MACHINES"
+	emulatedMachinesKey    = "emulated-machines"
 )
 
 // We cannot rely on automatic invocation of 'init' method because this initialization
@@ -47,8 +48,8 @@ func Init() {
 	if val, ok := cfgMap.Data[FeatureGatesKey]; ok {
 		os.Setenv(featureGateEnvVar, val)
 	}
-	if val, ok := cfgMap.Data["emulated-machines"]; ok {
-		os.Setenv(emulatedMachineEnvVar, val)
+	if val, ok := cfgMap.Data[emulatedMachinesKey]; ok {
+		os.Setenv(emulatedMachinesEnvVar, val)
 	}
 }
 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -19,6 +19,11 @@
 
 package virtconfig
 
+/*
+ This module is intended for determining whether an optional feature is enabled or not at the system-level.
+ Note that the virtconfig package needs to be initialized before using this (see config-map.Init)
+*/
+
 import (
 	"os"
 	"strings"

--- a/pkg/virt-config/virt-properties.go
+++ b/pkg/virt-config/virt-properties.go
@@ -22,6 +22,7 @@ package virtconfig
 /*
  This module is intended for retrieving virt related properties that might
  be overridden by kubevirt-config configmap.
+ Note that the virtconfig package needs to be initialized before using this (see config-map.Init)
 */
 
 import (

--- a/pkg/virt-config/virt-properties.go
+++ b/pkg/virt-config/virt-properties.go
@@ -31,7 +31,7 @@ import (
 )
 
 func SupportedEmulatedMachines() []string {
-	config := os.Getenv(emulatedMachineEnvVar)
+	config := os.Getenv(emulatedMachinesEnvVar)
 	if len(config) == 0 {
 		return []string{"q35*", "pc-q35*"}
 	}

--- a/pkg/virt-config/virt-properties.go
+++ b/pkg/virt-config/virt-properties.go
@@ -35,5 +35,9 @@ func SupportedEmulatedMachines() []string {
 		return []string{"q35*", "pc-q35*"}
 	}
 
-	return strings.Split(config, ",")
+	vals := strings.Split(config, ",")
+	for i := range vals {
+		vals[i] = strings.TrimSpace(vals[i])
+	}
+	return vals
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We now limit kubevirt to Q35 by default but enable overriding it for testing and debugging purposes. This can be done by setting custom `emulated-machines`  within `kubevirt-config` as a comma-separated list. However, users would typically introduce spaces between the values in this list (e.g., "a, b, c") and those space are not treated correctly by the current code. Those spaces will now by trimmed during parsing.

**Special notes for your reviewer**:
This PR also contains some minor cleanups as separate commits.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
