### PR TITLE
require sriovnic for multus lane

### DIFF
--- a/stdci.yaml
+++ b/stdci.yaml
@@ -6,7 +6,11 @@ sub-stages:
       timeout: 4h
   - k8s-1.11.0-release:
       timeout: 4h
-  - k8s-multus-1.11.1-release
+  - k8s-multus-1.11.1-release:
+      runtime_requirements:
+        sriovnic: true
+        support_nesting_level: 2
+        isolation_level: container
   - k8s-genie-1.11.1-release
   - openshift-3.11-release:
       timeout: 4h


### PR DESCRIPTION
this should not be merged, as it serializes all PRs on what is currently only a single nic on a single host.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We need to see how we test our sriov support. This PR makes sure that the sriov test is run on a supporting host. It is way too crude as it is.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/hold
Can you think about a smarter way to run our sriov test on sriov-enabled hardware? this PR runs a whole deployment on a single host, instead of a single relevant test.
@booxter I expect the the PR to fail on not finding any PF on its filesystem, but let us see.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
