### PR TITLE
Make sure the kubevirt namespace exists

### DIFF
--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -1,3 +1,9 @@
+# Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{.Namespace}}
+---
 # Monitoring
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The kubevirt components moved from the kube-system namespace to the kubevirt namespace.
Because the kubevirt namespace doesn't exist by default, creating the cluster using commands like

```
kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/${RELEASE}/kubevirt.yaml
``` 

would break.

This PR fixes that by making sure `kubevirt.yaml` automatically creates the kubevirt namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
