### PR TITLE
Switch to httpGet on virt-api readinessProbe

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -92,29 +92,6 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha2/healthz": {
-    "get": {
-     "consumes": [
-      "application/json"
-     ],
-     "produces": [
-      "application/json"
-     ],
-     "summary": "Health endpoint",
-     "operationId": "checkHealth",
-     "responses": {
-      "200": {
-       "description": "OK"
-      },
-      "500": {
-       "description": "Unhealthy"
-      },
-      "default": {
-       "description": "OK"
-      }
-     }
-    }
-   },
    "/apis/kubevirt.io/v1alpha2/namespaces/{namespace}/virtualmachineinstancemigrations": {
     "get": {
      "produces": [
@@ -3683,6 +3660,29 @@
        "schema": {
         "$ref": "#/definitions/v1.APIResourceList"
        }
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1alpha2/healthz": {
+    "get": {
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "summary": "Health endpoint",
+     "operationId": "checkHealth",
+     "responses": {
+      "200": {
+       "description": "OK"
+      },
+      "500": {
+       "description": "Unhealthy"
+      },
+      "default": {
+       "description": "OK"
       }
      }
     }

--- a/manifests/dev/virt-api.yaml.in
+++ b/manifests/dev/virt-api.yaml.in
@@ -55,9 +55,11 @@ spec:
               name: "metrics"
               protocol: "TCP"
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              scheme: HTTPS
               port: 8443
-            initialDelaySeconds: 5
-            periodSeconds: 10
+              path: /apis/subresources.kubevirt.io/v1alpha2/healthz
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
       securityContext:
         runAsNonRoot: true

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -470,10 +470,12 @@ spec:
               name: "metrics"
               protocol: "TCP"
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              scheme: HTTPS
               port: 8443
-            initialDelaySeconds: 5
-            periodSeconds: 10
+              path: /apis/subresources.kubevirt.io/v1alpha2/healthz
+            initialDelaySeconds: 15
+            timeoutSeconds: 10
       securityContext:
         runAsNonRoot: true
 ---

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -185,7 +185,7 @@ func (a *authorizor) generateAccessReview(req *restful.Request) (*authorization.
 	return r, nil
 }
 
-func isInfoEndpoint(req *restful.Request) bool {
+func isInfoOrHealthEndpoint(req *restful.Request) bool {
 
 	httpRequest := req.Request
 	if httpRequest == nil || httpRequest.URL == nil {
@@ -195,7 +195,7 @@ func isInfoEndpoint(req *restful.Request) bool {
 	// /apis/subresources.kubevirt.io/v1alpha2/namespaces/default/virtualmachineinstances/testvmi/console
 	// The /apis/<group>/<version> part of the urls should be accessible without needing authorization
 	pathSplit := strings.Split(httpRequest.URL.Path, "/")
-	if len(pathSplit) <= 4 || (len(pathSplit) > 4 && pathSplit[4] == "version") {
+	if len(pathSplit) <= 4 || (len(pathSplit) > 4 && (pathSplit[4] == "version" || pathSplit[4] == "healthz")) {
 		return true
 	}
 
@@ -217,7 +217,7 @@ func (a *authorizor) Authorize(req *restful.Request) (bool, string, error) {
 	// Endpoints related to getting information about
 	// what apis our server provides are authorized to
 	// all users.
-	if isInfoEndpoint(req) {
+	if isInfoOrHealthEndpoint(req) {
 		return true, "", nil
 	}
 

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -154,6 +154,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			table.Entry("apis", "/apis"),
 			table.Entry("group", "/apis/subresources.kubevirt.io"),
 			table.Entry("version", "/apis/subresources.kubevirt.io/version"),
+			table.Entry("healthz", "/apis/subresources.kubevirt.io/healthz"),
 		)
 
 		table.DescribeTable("should reject all users for unknown endpoint paths", func(path string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Use a httpGet probe instead of tcpSocket on virt-api readiness checks. This improves the readinessProbe and removes irritating log lines like

```
{"component":"virt-api","level":"info","msg":"http: TLS handshake error from 169.254.255.254:65240: EOF\n","pos":"server.go:2923","timestamp":"2018-12-10T21:18:28.204775Z"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1832

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use httpGet instead of tcpSocket for virt-api readiness probe
```
