### PR TITLE
add support for CPU sockets and threads

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4019,6 +4019,14 @@
      "model": {
       "description": "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nIt is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nFor more information see https://libvirt.org/formatdomain.html#elementsCPU.\nDefaults to host-model.\n+optional",
       "type": "string"
+     },
+     "sockets": {
+      "description": "Sockets specifies the number of sockets inside the vmi.\nMust be a value greater or equal 1.",
+      "type": "integer"
+     },
+     "threads": {
+      "description": "Threads specifies the number of threads inside the vmi.\nMust be a value greater or equal 1.",
+      "type": "integer"
      }
     }
    },

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -158,6 +158,20 @@ func schema_kubevirt_pkg_api_v1_CPU(ref common.ReferenceCallback) common.OpenAPI
 							Format:      "int64",
 						},
 					},
+					"sockets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Sockets specifies the number of sockets inside the vmi. Must be a value greater or equal 1.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"threads": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Threads specifies the number of threads inside the vmi. Must be a value greater or equal 1.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"model": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml. It is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node and \"host-model\" to get CPU closest to the node one. For more information see https://libvirt.org/formatdomain.html#elementsCPU. Defaults to host-model.",

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -162,6 +162,12 @@ type CPU struct {
 	// Cores specifies the number of cores inside the vmi.
 	// Must be a value greater or equal 1.
 	Cores uint32 `json:"cores,omitempty"`
+	// Sockets specifies the number of sockets inside the vmi.
+	// Must be a value greater or equal 1.
+	Sockets uint32 `json:"sockets,omitempty"`
+	// Threads specifies the number of threads inside the vmi.
+	// Must be a value greater or equal 1.
+	Threads uint32 `json:"threads,omitempty"`
 	// Model specifies the CPU model inside the VMI.
 	// List of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.
 	// It is possible to specify special cases like "host-passthrough" to get the same CPU as the node

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -69,6 +69,8 @@ func (CPU) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                      "CPU allows specifying the CPU topology.",
 		"cores":                 "Cores specifies the number of cores inside the vmi.\nMust be a value greater or equal 1.",
+		"sockets":               "Sockets specifies the number of sockets inside the vmi.\nMust be a value greater or equal 1.",
+		"threads":               "Threads specifies the number of threads inside the vmi.\nMust be a value greater or equal 1.",
 		"model":                 "Model specifies the CPU model inside the VMI.\nList of available models https://github.com/libvirt/libvirt/blob/master/src/cpu/cpu_map.xml.\nIt is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node\nand \"host-model\" to get CPU closest to the node one.\nFor more information see https://libvirt.org/formatdomain.html#elementsCPU.\nDefaults to host-model.\n+optional",
 		"dedicatedCpuPlacement": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node\nwith enough dedicated pCPUs and pin the vCPUs to it.\n+optional",
 	}

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -51,6 +51,8 @@ var exampleJSON = `{
       },
       "cpu": {
         "cores": 3,
+        "sockets": 1,
+        "threads": 1,
         "model": "Conroe",
         "dedicatedCpuPlacement": true
       },
@@ -333,8 +335,10 @@ var _ = Describe("Schema", func() {
 			UUID: "28a42a60-44ef-4428-9c10-1a6aee94627f",
 		}
 		exampleVMI.Spec.Domain.CPU = &CPU{
-			Cores: 3,
-			Model: "Conroe",
+			Cores:   3,
+			Sockets: 1,
+			Threads: 1,
+			Model:   "Conroe",
 			DedicatedCPUPlacement: true,
 		}
 		exampleVMI.Spec.Networks = []Network{

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -22,6 +22,8 @@ package hardware
 import (
 	"strconv"
 	"strings"
+
+	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 )
 
 const CPUSET_PATH = "/sys/fs/cgroup/cpuset/cpuset.cpus"
@@ -55,4 +57,25 @@ func ParseCPUSetLine(cpusetLine string) (cpusList []int, err error) {
 		}
 	}
 	return
+}
+
+//GetNumberOfVCPUs returns number of vCPUs
+//It counts sockets*cores*threads
+func GetNumberOfVCPUs(cpuSpec *v1.CPU) int64 {
+	vCPUs := cpuSpec.Cores
+	if cpuSpec.Sockets != 0 {
+		if vCPUs == 0 {
+			vCPUs = cpuSpec.Sockets
+		} else {
+			vCPUs *= cpuSpec.Sockets
+		}
+	}
+	if cpuSpec.Threads != 0 {
+		if vCPUs == 0 {
+			vCPUs = cpuSpec.Threads
+		} else {
+			vCPUs *= cpuSpec.Threads
+		}
+	}
+	return int64(vCPUs)
 }

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -22,6 +22,8 @@ package hardware
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 )
 
 var _ = Describe("Hardware utils test", func() {
@@ -34,6 +36,50 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(lst)).To(Equal(7))
 			Expect(lst).To(Equal(expectedList))
+		})
+	})
+
+	Context("count vCPUs", func() {
+		It("shoud count vCPUs correctly", func() {
+			vCPUs := GetNumberOfVCPUs(&v1.CPU{
+				Sockets: 2,
+				Cores:   2,
+				Threads: 2,
+			})
+			Expect(vCPUs).To(Equal(int64(8)), "Expect vCPUs")
+
+			vCPUs = GetNumberOfVCPUs(&v1.CPU{
+				Sockets: 2,
+			})
+			Expect(vCPUs).To(Equal(int64(2)), "Expect vCPUs")
+
+			vCPUs = GetNumberOfVCPUs(&v1.CPU{
+				Cores: 2,
+			})
+			Expect(vCPUs).To(Equal(int64(2)), "Expect vCPUs")
+
+			vCPUs = GetNumberOfVCPUs(&v1.CPU{
+				Threads: 2,
+			})
+			Expect(vCPUs).To(Equal(int64(2)), "Expect vCPUs")
+
+			vCPUs = GetNumberOfVCPUs(&v1.CPU{
+				Sockets: 2,
+				Threads: 2,
+			})
+			Expect(vCPUs).To(Equal(int64(4)), "Expect vCPUs")
+
+			vCPUs = GetNumberOfVCPUs(&v1.CPU{
+				Sockets: 2,
+				Cores:   2,
+			})
+			Expect(vCPUs).To(Equal(int64(4)), "Expect vCPUs")
+
+			vCPUs = GetNumberOfVCPUs(&v1.CPU{
+				Cores:   2,
+				Threads: 2,
+			})
+			Expect(vCPUs).To(Equal(int64(4)), "Expect vCPUs")
 		})
 	})
 })

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/precond"
 	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/pkg/virt-config"
@@ -530,12 +531,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		// schedule only on nodes with a running cpu manager
 		nodeSelector[v1.CPUManager] = "true"
 
-		cores := uint32(0)
-		if vmi.Spec.Domain.CPU != nil {
-			cores = vmi.Spec.Domain.CPU.Cores
-		}
-		if cores != 0 {
-			resources.Limits[k8sv1.ResourceCPU] = *resource.NewQuantity(int64(cores), resource.BinarySI)
+		vcpus := hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU)
+
+		if vcpus != 0 {
+			resources.Limits[k8sv1.ResourceCPU] = *resource.NewQuantity(vcpus, resource.BinarySI)
 		} else {
 			if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
 				resources.Requests[k8sv1.ResourceCPU] = cpuLimit

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -150,6 +150,8 @@ var _ = Describe("Converter", func() {
 					VendorID:   &v1.FeatureVendorID{Enabled: &_false, VendorID: "myvendor"},
 				},
 			}
+			vmi.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
+			vmi.Spec.Domain.Resources.Requests = make(k8sv1.ResourceList)
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
 					Name:       "mydisk",
@@ -516,7 +518,10 @@ var _ = Describe("Converter", func() {
       <vendor_id state="off" value="myvendor"></vendor_id>
     </hyperv>
   </features>
-  <cpu mode="host-model"></cpu>
+  <cpu mode="host-model">
+    <topology sockets="1" cores="1" threads="1"></topology>
+  </cpu>
+  <vcpu placement="static">1</vcpu>
   <iothreads>3</iothreads>
 </domain>`, domainType)
 
@@ -551,36 +556,131 @@ var _ = Describe("Converter", func() {
 			Expect(vmiToDomainXMLToDomainSpec(vmi, c).Type).To(Equal(domainType))
 		})
 
-		It("should convert CPU cores and model", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores: 3,
-				Model: "Conroe",
-			}
-			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+		Context("when CPU spec defined", func() {
+			It("should convert CPU cores and model", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Cores:   3,
+					Sockets: 2,
+					Threads: 2,
+					Model:   "Conroe",
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
 
-			Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(3)))
-			Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(1)))
-			Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)))
-			Expect(domainSpec.CPU.Mode).To(Equal("custom"))
-			Expect(domainSpec.CPU.Model).To(Equal("Conroe"))
-			Expect(domainSpec.VCPU.Placement).To(Equal("static"))
-			Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)))
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(3)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(2)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(2)), "Expect threads")
+				Expect(domainSpec.CPU.Mode).To(Equal("custom"), "Expect cpu mode")
+				Expect(domainSpec.CPU.Model).To(Equal("Conroe"), "Expect cpu model")
+				Expect(domainSpec.VCPU.Placement).To(Equal("static"), "Expect vcpu placement")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(12)), "Expect vcpus")
+			})
+
+			It("should convert CPU cores", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Cores: 3,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(3)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(1)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should convert CPU sockets", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Sockets: 3,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should convert CPU threads", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Threads: 3,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(1)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(3)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should convert CPU requests to sockets", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = nil
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2200m")
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should convert CPU limits to sockets", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = nil
+				vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("2.3")
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should prefer CPU spec instead of CPU requests", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Sockets: 3,
+				}
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("400m")
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should prefer CPU spec instead of CPU limits", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Sockets: 3,
+				}
+				vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("400m")
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			table.DescribeTable("should convert CPU model", func(model string) {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Cores: 3,
+					Model: model,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Mode).To(Equal(model), "Expect mode")
+			},
+				table.Entry(v1.CPUModeHostPassthrough, v1.CPUModeHostPassthrough),
+				table.Entry(v1.CPUModeHostModel, v1.CPUModeHostModel),
+			)
 		})
-
-		table.DescribeTable("should convert CPU model", func(model string) {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores: 3,
-				Model: model,
-			}
-			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
-
-			Expect(domainSpec.CPU.Mode).To(Equal(model))
-		},
-			table.Entry(v1.CPUModeHostPassthrough, v1.CPUModeHostPassthrough),
-			table.Entry(v1.CPUModeHostModel, v1.CPUModeHostModel),
-		)
 
 		Context("when CPU spec defined and model not", func() {
 			It("should set host-model CPU mode", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for CPU sockets and threads

The performance team identified an issue with how we define CPUs for VMs. They were getting significantly better performance when configuring virtual CPUs as sockets (vs. the current method of specifying cores) - https://bugzilla.redhat.com/show_bug.cgi?id=1653453. This PR allows user to specify socket and threads in vm. 
This patch changes the way how cores are calculated. Previously cpu topology had just 1 socket, 1 thread and n cores. Now cpu topology can have n cores, threads and sockets. If none of cores, threads and sockets are defined in `Spec.Domain.CPU`, virt-launcher looks into `Spec.Domain.Resources.Requests` and `Spec.Domain.Resources.Limits` for `k8sv1.ResourceCPU` and sets this value into sockets (because sockets have better performance than cores). Calculation of `vcpu` is changed to `sockets*cores*threads`.

@MarSik, @fromanirh, @yanirq, @petrkotas, @rmohr please review

**Release note**:
```release-note
Add support for CPU sockets and threads
```
