### PR TITLE
fixed shebang and path

### DIFF
--- a/cluster/cli.sh
+++ b/cluster/cli.sh
@@ -1,7 +1,8 @@
-source $(dirname "$0")/../hack/common.sh
+#!/bin/bash
+set -e
 
+source hack/common.sh
 test -t 1 && USE_TTY="-it"
-
 source ${KUBEVIRT_DIR}/cluster/$KUBEVIRT_PROVIDER/provider.sh
 source hack/config.sh
 


### PR DESCRIPTION
Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->


**What this PR does / why we need it**:
`make cli` reports to unable to find source as `path` was not. 
- Added shebang to fix this.
- made inline with other scripts in cluster/*.sh

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
