### PR TITLE
docs: make it clear kubevirt-ansible is recommended for sriov

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -83,6 +83,13 @@ Now you are ready to set up your cluster.
 You can use your preferred mechanism to deploy your kubernetes cluster as long
 as you deploy on bare metal.
 
+Current recommendation is to use ```kubevirt-ansible``` to deploy the cluster.
+Ansible playbooks will also deploy all the relevant SR-IOV components
+for you. See [here](https://github.com/kubevirt/kubevirt-ansible/).
+
+You may still want to deploy software using `local` provider if you'd like to
+deploy from Kubevirt sources though.
+
 In the following example, we configure the cluster using `local` provider which
 is part of kubevirt/kubevirt repo. Please consult cluster/local/README.md for
 general information on setting up a host using the `local` provider.


### PR DESCRIPTION
Now that kubevirt-ansible automatically deploys all the relevant
SR-IOV components on cluster, we should recommend using it unless one
has a legit reason not to (for example, to deploy kubevirt from
sources).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
