### PR TITLE
docs: Fix kubectl command showing virt-launcher pod

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -182,11 +182,8 @@ tap networking device attached.
 $ ./cluster/kubectl.sh create -f cluster/examples/vmi-ephemeral.yaml
 vm "vmi-ephemeral" created
 
-$ ./cluster/kubectl.sh -n kubevirt get pods
+$ ./cluster/kubectl.sh get pods
 NAME                              READY     STATUS    RESTARTS   AGE
-virt-api                          1/1       Running   1          10h
-virt-controller                   1/1       Running   1          10h
-virt-handler-z90mp                1/1       Running   1          10h
 virt-launcher-vmi-ephemeral9q7es  1/1       Running   0          10s
 
 $ ./cluster/kubectl.sh get vmis


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The example in getting_started.md is not correct. The virt-launcher pod appears in the "default" namespace and not "kubevirt".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
