### PR TITLE
Report failed migrations correctly

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -176,7 +176,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 	}
 
 	migrationMetadata := domainSpec.Metadata.KubeVirt.Migration
-	if migrationMetadata != nil {
+	if migrationMetadata == nil {
 		// nothing to report if migration metadata is empty
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: David Vossel <davidvossel@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Because of a simple logic error, migration failure results are not getting reported correctly. Instead of getting the detailed error related to why the migration failed, we instead were getting a generic error related to the target pod eventually timing out.

With this fix, we now immediately report the detailed error related to the failure. 

**Release note**:
```release-note
Fixes issue with reporting failed live migrations. 
```
