### PR TITLE
Set mac address on libvirt domain for VMs #1850

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -988,6 +988,10 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				if iface.BootOrder != nil {
 					domainIface.BootOrder = &BootOrder{Order: *iface.BootOrder}
 				}
+
+				if iface.MacAddress != "" {
+					domainIface.MAC = &MAC{MAC: iface.MacAddress}
+				}
 			} else if iface.Slirp != nil {
 				domainIface.Type = "user"
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -978,6 +978,21 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].Source.Bridge).To(Equal("k6t-eth0"))
 			Expect(domain.Spec.Devices.Interfaces[1].Source.Bridge).To(Equal("k6t-net1"))
 		})
+
+		It("should set the mac address if it is set in configuration", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+
+			iface := v1.DefaultNetworkInterface()
+			iface.MacAddress = "11:22:33:44:55:66"
+
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*iface}
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+
+			domain := vmiToDomain(vmi, c)
+			Expect(domain).ToNot(Equal(nil))
+			Expect(domain.Spec.Devices.Interfaces).To(HaveLen(1))
+			Expect(domain.Spec.Devices.Interfaces[0].MAC.MAC).To(Equal("11:22:33:44:55:66"))
+		})
 	})
 
 	Context("graphics and video device", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR ensures that the mac address of the VM matches what is defined in kubevirt so that DHCP works correctly.

Before:

```
Starting network...
udhcpc (v1.23.2) started
Sending discover...
Sending discover...
Sending discover...
Usage: /sbin/cirros-dhcpc <up|down>
No lease, failing
WARN: /etc/rc3.d/S40-network failed
```

After:

```
Starting network...
udhcpc (v1.23.2) started
Sending discover...
Sending select for 10.42.0.129...
Lease of 10.42.0.129 obtained, lease time 86313600
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1850 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix mac address assignment in VMs.
```
