### PR TITLE
Change the skip function for multus genie and sriov.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -47,8 +47,8 @@ if [[ $TARGET =~ openshift-.* ]]; then
   fi
 elif [[ $TARGET =~ .*-1.10.4-.* ]]; then
   export KUBEVIRT_PROVIDER="k8s-1.10.4"
-elif [[ $TARGET =~ .*-multus-1.11.1-.* ]]; then
-  export KUBEVIRT_PROVIDER="k8s-multus-1.11.1"
+elif [[ $TARGET =~ .*-multus-1.12.2-.* ]]; then
+  export KUBEVIRT_PROVIDER="k8s-multus-1.12.2"
 elif [[ $TARGET =~ .*-genie-1.11.1-.* ]]; then
   export KUBEVIRT_PROVIDER="k8s-genie-1.11.1"
 else

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1955,21 +1955,21 @@ func SkipIfNoRhelImage(virtClient kubecli.KubevirtClient) {
 }
 
 func SkipIfNoSriovDevicePlugin(virtClient kubecli.KubevirtClient) {
-	_, err := virtClient.ExtensionsV1beta1().DaemonSets(KubeVirtInstallNamespace).Get("kube-sriov-device-plugin-amd64", metav1.GetOptions{})
+	_, err := virtClient.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Get("kube-sriov-device-plugin-amd64", metav1.GetOptions{})
 	if err != nil {
 		Skip("Skip srio tests that required sriov device plugin")
 	}
 }
 
 func SkipIfNoMultusProvider(virtClient kubecli.KubevirtClient) {
-	_, err := virtClient.ExtensionsV1beta1().DaemonSets(KubeVirtInstallNamespace).Get("kube-multus-ds-amd64", metav1.GetOptions{})
+	_, err := virtClient.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Get("kube-multus-ds-amd64", metav1.GetOptions{})
 	if err != nil {
 		Skip("Skip multus tests that required multus cni plugin")
 	}
 }
 
 func SkipIfNoGenieProvider(virtClient kubecli.KubevirtClient) {
-	_, err := virtClient.ExtensionsV1beta1().DaemonSets("kube-system").Get("genie-plugin", metav1.GetOptions{})
+	_, err := virtClient.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Get("genie-plugin", metav1.GetOptions{})
 	if err != nil {
 		Skip("Skip genie tests that required genie cni plugin")
 	}

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -150,7 +150,7 @@ var _ = Describe("Networking", func() {
 			var cmdCheck, addrShow, addr string
 
 			if destination == "InboundVMIWithCustomMacAddress" {
-				tests.SkipIfOpenShift("Custom MAC addresses on pod networks are not suppored")
+				tests.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
 			}
 
 			// assuming pod network is of standard MTU = 1500 (minus 50 bytes for vxlan overhead)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Check that the daemonsets exist on the kube-system namespace.

We change the `KubeVirtInstallNamespace` from kube-system to `kubevirt` and now the check functions for

```
SkipIfNoMultusProvider
SkipIfNoSriovDevicePlugin
```
are skipped

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Tests are not running the multus tests now.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1854)
<!-- Reviewable:end -->
