### PR TITLE
Initialize kubevirt client only once

### DIFF
--- a/pkg/kubecli/kubecli.go
+++ b/pkg/kubecli/kubecli.go
@@ -23,6 +23,7 @@ package kubecli
 import (
 	"flag"
 	"os"
+	"sync"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,6 +44,9 @@ var (
 	kubeconfig string
 	master     string
 )
+
+var virtclient KubevirtClient
+var once sync.Once
 
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
@@ -210,7 +214,11 @@ func GetKubevirtClientFromFlags(master string, kubeconfig string) (KubevirtClien
 }
 
 func GetKubevirtClient() (KubevirtClient, error) {
-	return GetKubevirtClientFromFlags(master, kubeconfig)
+	var err error
+	once.Do(func() {
+		virtclient, err = GetKubevirtClientFromFlags(master, kubeconfig)
+	})
+	return virtclient, err
 }
 
 func GetKubevirtSubresourceClient() (KubevirtClient, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It should reduce logs noise from `Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
