### PR TITLE
configure the cloud-init disks as read-only

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -320,6 +320,7 @@ func Convert_v1_CloudInitNoCloudSource_To_api_Disk(source *v1.CloudInitNoCloudSo
 	disk.Source.File = fmt.Sprintf("%s/%s", cloudinit.GetDomainBasePath(c.VirtualMachine.Name, c.VirtualMachine.Namespace), cloudinit.NoCloudFile)
 	disk.Type = "file"
 	disk.Driver.Type = "raw"
+	disk.ReadOnly = toApiReadOnly(true)
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -402,12 +402,14 @@ var _ = Describe("Converter", func() {
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="virtio" dev="vdb"></target>
       <driver name="qemu" type="raw" iothread="3"></driver>
+      <readonly></readonly>
       <alias name="ua-mydisk1"></alias>
     </disk>
     <disk device="cdrom" type="file">
       <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
       <target bus="sata" dev="sda" tray="closed"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
+      <readonly></readonly>
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1384,6 +1384,12 @@ func AddUserData(vmi *v1.VirtualMachineInstance, name string, userData string) {
 	})
 }
 
+func NewRandomVMIWithPVCAndUserdata(claimName string, userData string) *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithPVC(claimName)
+	AddUserData(vmi, "disk1", userData)
+	return vmi
+}
+
 func NewRandomVMIWithPVC(claimName string) *v1.VirtualMachineInstance {
 
 	vmi := NewRandomVMI()


### PR DESCRIPTION
**What this PR does / why we need it**:
The `CloudInit` disk is being created during the virt-launcher start. 
When VMI is being live migrated, this disk will be re-created on the destination side. Therefore, it should be skipped during migration. Currently, `cloud-init` is being presented as regular file type disks and affects live migration in numerous ways. 

This PR configures the `cloud-init` disk as `ReadOnly`, effectively skipping the disk during live migration.

Fixes #
#1865 

**Release note**:
```release-note
Cloud-Init disk will be configured as read-only and will not be copied during live migration
```
