### PR TITLE
Test attributes for user access tests

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -30,7 +30,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("User Access", func() {
+var _ = Describe("[rfe_id:500, crit:high, vendor:cnv-qe@redhat.com, level:component]User Access", func() {
 
 	flag.Parse()
 
@@ -124,10 +124,10 @@ var _ = Describe("User Access", func() {
 				Expect(result).To(ContainSubstring(expectedRes))
 			}
 		},
-			table.Entry("given a vmi", "virtualmachineinstances"),
-			table.Entry("given an vm", "virtualmachines"),
-			table.Entry("given a vmi preset", "virtualmachineinstancepresets"),
-			table.Entry("given a vmi replica set", "virtualmachineinstancereplicasets"),
+			table.Entry("[test_id:526]given a vmi", "virtualmachineinstances"),
+			table.Entry("[test_id:527]given an vm", "virtualmachines"),
+			table.Entry("[test_id:528]given a vmi preset", "virtualmachineinstancepresets"),
+			table.Entry("[test_id:529, crit:low]given a vmi replica set", "virtualmachineinstancereplicasets"),
 		)
 	})
 })

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -30,7 +30,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[rfe_id:500, crit:high, vendor:cnv-qe@redhat.com, level:component]User Access", func() {
+var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:component]User Access", func() {
 
 	flag.Parse()
 
@@ -127,7 +127,7 @@ var _ = Describe("[rfe_id:500, crit:high, vendor:cnv-qe@redhat.com, level:compon
 			table.Entry("[test_id:526]given a vmi", "virtualmachineinstances"),
 			table.Entry("[test_id:527]given an vm", "virtualmachines"),
 			table.Entry("[test_id:528]given a vmi preset", "virtualmachineinstancepresets"),
-			table.Entry("[test_id:529, crit:low]given a vmi replica set", "virtualmachineinstancereplicasets"),
+			table.Entry("[test_id:529][crit:low]given a vmi replica set", "virtualmachineinstancereplicasets"),
 		)
 	})
 })


### PR DESCRIPTION

**What this PR does / why we need it**:
Changed all test levels in api_validation_test to focus (FDescribe, FContext, FIt)
added rfe id, test id, criticality etc

based on issue
https://github.com/kubevirt/containerized-data-importer/issues/359

**Special notes for your reviewer**:
This is an example on how i plan to change the tests, so we will be able to auto create them in Polarion from the code.
There are 2 steps to it:
first, we create the tests without test ids (if they are new tests)
after running the script which creates the tests in Polarion (kubevirt/qe-tools/polarion-generator), each one gets its own ID,
and we can than add the test ids to the test code (this will allow reporting & changing the test in the future).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
