### PR TITLE
Add virctl wrapper

### DIFF
--- a/cmd/virtctl/virtctl.go
+++ b/cmd/virtctl/virtctl.go
@@ -20,7 +20,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -28,6 +30,9 @@ import (
 )
 
 func main() {
-	virtctl.Execute()
+	if err := virtctl.Execute(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, strings.TrimSpace(err.Error())+"\n")
+		os.Exit(1)
+	}
 	os.Exit(0)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,3 +20,15 @@ func GetNamespace() (string, error) {
 	}
 	return namespaceKubevirt, nil
 }
+
+func FileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	exists := false
+
+	if err == nil {
+		exists = true
+	} else if os.IsNotExist(err) {
+		err = nil
+	}
+	return exists, err
+}

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Expose", func() {
 		Context("With empty set of flags", func() {
 			It("should succeed", func() {
 				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE)
-				Expect(cmd).ToNot(BeNil())
+				Expect(cmd()).ToNot(BeNil())
 			})
 		})
 	})
@@ -92,10 +92,10 @@ var _ = Describe("Expose", func() {
 				kubecli.GetKubevirtClientFromClientConfig = kubecli.GetInvalidKubevirtClientFromClientConfig
 			})
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999")
 				// not executing the command
-				Expect(cmd).NotTo(BeNil())
+				Expect(cmd()).NotTo(BeNil())
 			})
 			AfterEach(func() {
 				// set back the value so that other tests won't fail on client
@@ -104,130 +104,130 @@ var _ = Describe("Expose", func() {
 		})
 		Context("With missing resource", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With missing port and missing pod network ports", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service")
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With missing port but existing pod network ports ", func() {
 			It("should succeed on vmis", func() {
 				addPodNetworkWithPorts(&vmi.Spec)
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service")
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service")
 				prependServicePortReactor(kubeclient)
 				Expect(cmd()).To(Succeed())
 			})
 			It("should succeed on vms", func() {
 				addPodNetworkWithPorts(&vm.Spec.Template.Spec)
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", vmName, "--name", "my-service")
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vm", vmName, "--name", "my-service")
 				prependServicePortReactor(kubeclient)
 				Expect(cmd()).To(Succeed())
 			})
 			It("should succeed on vmirs", func() {
 				addPodNetworkWithPorts(&vmrs.Spec.Template.Spec)
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", vmName, "--name", "my-service")
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", vmName, "--name", "my-service")
 				prependServicePortReactor(kubeclient)
 				Expect(cmd()).To(Succeed())
 			})
 		})
 		Context("With missing service name", func() {
 			It("should fail", func() {
-				err := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--port", "9999")
+				err := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--port", "9999")
 				Expect(err()).NotTo(BeNil())
 			})
 		})
 		Context("With invalid type", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999", "--type", "kaboom")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With a invalid protocol", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999", "--protocol", "http")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With unknown resource type", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "kaboom", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "kaboom", vmName, "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With unknown flag", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999", "--kaboom")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With cluster-ip on a vm", func() {
 			It("should succeed", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).To(BeNil())
 			})
 		})
 		Context("With cluster-ip on a vm that has no label", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmNoLabelName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmNoLabelName, "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With cluster-ip on an unknown vm", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", unknownVM, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", unknownVM, "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With node-port service on a vm", func() {
 			It("should succeed", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999", "--type", "NodePort")
 				Expect(cmd()).To(BeNil())
 			})
 		})
 		Context("With cluster-ip on an vm", func() {
 			It("should succeed", func() {
-				err := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", vmName, "--name", "my-service",
+				err := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vm", vmName, "--name", "my-service",
 					"--port", "9999")
 				Expect(err()).To(BeNil())
 			})
 		})
 		Context("With cluster-ip on an unknown vm", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", unknownVM, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vm", unknownVM, "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With cluster-ip on an vm replica set", func() {
 			It("should succeed", func() {
-				err := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", vmName, "--name", "my-service",
+				err := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", vmName, "--name", "my-service",
 					"--port", "9999")
 				Expect(err()).To(BeNil())
 			})
 		})
 		Context("With cluster-ip on an unknown vm replica set", func() {
 			It("should fail", func() {
-				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", unknownVM, "--name", "my-service",
+				cmd := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", unknownVM, "--name", "my-service",
 					"--port", "9999")
 				Expect(cmd()).NotTo(BeNil())
 			})
 		})
 		Context("With string target-port", func() {
 			It("should succeed", func() {
-				err := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+				err := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 					"--port", "9999", "--target-port", "http")
 				Expect(err()).To(BeNil())
 			})

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -206,7 +206,7 @@ var _ = Describe("ImageUpload", func() {
 	Context("Successful upload to PVC", func() {
 		It("PVC does not exist", func() {
 			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", pvcName, "--pvc-size", pvcSize,
+			cmd := tests.NewVirtctlCommand(commandName, "--pvc-name", pvcName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
 			Expect(createCalled).To(BeTrue())
@@ -215,7 +215,7 @@ var _ = Describe("ImageUpload", func() {
 
 		DescribeTable("PVC does exist", func(pvc *v1.PersistentVolumeClaim) {
 			testInit(http.StatusOK, pvc)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--no-create", "--pvc-name", pvcName,
+			cmd := tests.NewVirtctlCommand(commandName, "--no-create", "--pvc-name", pvcName,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
 			Expect(createCalled).To(BeFalse())
@@ -233,14 +233,14 @@ var _ = Describe("ImageUpload", func() {
 	Context("Upload fails", func() {
 		It("PVC already uploaded", func() {
 			testInit(http.StatusOK, pvcSpecWithUploadSucceeded())
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", pvcName, "--pvc-size", pvcSize,
+			cmd := tests.NewVirtctlCommand(commandName, "--pvc-name", pvcName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).NotTo(BeNil())
 		})
 
 		It("Upload fails", func() {
 			testInit(http.StatusInternalServerError)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", pvcName, "--pvc-size", pvcSize,
+			cmd := tests.NewVirtctlCommand(commandName, "--pvc-name", pvcName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).NotTo(BeNil())
 		})
@@ -248,7 +248,7 @@ var _ = Describe("ImageUpload", func() {
 		DescribeTable("Bad args", func(args []string) {
 			testInit(http.StatusOK)
 			args = append([]string{commandName}, args...)
-			cmd := tests.NewRepeatableVirtctlCommand(args...)
+			cmd := tests.NewVirtctlCommand(args...)
 			Expect(cmd()).NotTo(BeNil())
 		},
 			Entry("No args", []string{}),

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -1,14 +1,18 @@
 package virtctl
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virtctl/console"
 	"kubevirt.io/kubevirt/pkg/virtctl/expose"
 	"kubevirt.io/kubevirt/pkg/virtctl/imageupload"
@@ -55,10 +59,110 @@ func NewVirtctlCommand() *cobra.Command {
 	return rootCmd
 }
 
-func Execute() {
+func Execute(args []string) error {
 	log.InitializeLogging("virtctl")
-	if err := NewVirtctlCommand().Execute(); err != nil {
-		fmt.Println(strings.TrimSpace(err.Error()))
-		os.Exit(1)
+	// check whether there is a MIME config file
+	// if yes, then set up the args for commands and execute
+	// otherwise normal operation
+	confArgs, err := parseMime(args)
+	if err != nil {
+		return err
 	}
+
+	cmd := NewVirtctlCommand()
+
+	if confArgs != nil {
+		cmd.SetArgs(confArgs)
+	} else {
+		cmd.SetArgs(args)
+	}
+
+	if err := cmd.Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseMime(args []string) ([]string, error) {
+	var parsedArgs []string
+
+	for ind := 0; ind < len(args); ind++ {
+
+		filePath, err := checkForFile(args[ind])
+		if err == nil && filePath != "" {
+			data, err := ioutil.ReadFile(filePath)
+			if err != nil {
+				return nil, fmt.Errorf("Cannot read config file: %s", filePath)
+			}
+
+			mimeArgs, err := parseMimeConfig(string(data))
+			if err != nil {
+				return nil, err
+			}
+			for _, mimeArg := range mimeArgs {
+				parsedArgs = append(parsedArgs, mimeArg)
+			}
+
+			return parsedArgs, nil
+		} else if err != nil {
+			return nil, err
+		}
+
+		if args[ind] == "--kubeconfig" || args[ind] == "--server" {
+			parsedArgs = append(parsedArgs, args[ind], args[ind+1])
+			ind = ind + 1
+		}
+
+	}
+
+	return nil, nil
+}
+
+func checkForFile(arg string) (string, error) {
+	var err error
+	filePath := ""
+
+	if strings.HasSuffix(arg, ".vvv") {
+		exist, _ := util.FileExists(arg)
+		if exist {
+			filePath = arg
+		} else {
+			err = errors.New("File does not exist")
+		}
+	}
+
+	return filePath, err
+}
+
+func parseMimeConfig(data string) ([]string, error) {
+	// read only single line as expected
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	scanner.Scan()
+	line := scanner.Text()
+
+	tokens := strings.Split(line, " ")
+	if len(tokens) != 3 {
+		// invalid param line
+		return nil, fmt.Errorf("Invalid file format, 3 parameters required, %d received", len(tokens))
+	}
+
+	// first token have to be one of vnc|console
+	if tokens[0] != "vnc" && tokens[0] != "console" {
+		return nil, fmt.Errorf("Protocol have to be one of: vnc, console. Got: %s", tokens[0])
+	}
+
+	for _, token := range tokens {
+		matched, err := regexp.MatchString(`^[a-z\d\-_]+$`, token)
+		if err != nil {
+			return nil, fmt.Errorf("Cannot parse token: %s", token)
+		}
+		if !matched {
+			return nil, fmt.Errorf("Token containing illegal character: %s", token)
+		}
+	}
+
+	tokens[1] = "--namespace=" + tokens[1]
+
+	return tokens, nil
 }

--- a/pkg/virtctl/virtctl_suite_test.go
+++ b/pkg/virtctl/virtctl_suite_test.go
@@ -1,0 +1,13 @@
+package virtctl
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVirtctl(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Virtctl Suite")
+}

--- a/pkg/virtctl/virtctl_test.go
+++ b/pkg/virtctl/virtctl_test.go
@@ -1,0 +1,169 @@
+package virtctl
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("virctl command", func() {
+
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+	})
+
+	Context("with valid file path", func() {
+		tempConfig, err := ioutil.TempFile(os.TempDir(), "kubevirt-test.*.vvv")
+		if err != nil {
+			Fail("Cannot create the temporary file")
+		}
+		defer func() {
+			err := tempConfig.Close()
+			if err != nil {
+				Fail("Cannot close the file")
+			}
+		}()
+
+		data := []byte("vnc default test_vm_123")
+		_, err = tempConfig.Write(data)
+
+		osArgs := []string{tempConfig.Name()}
+
+		It("should mark valid file", func() {
+			filePath, err := checkForFile(tempConfig.Name())
+			Expect(err).To(BeNil(), "should be nil for existing file")
+			Expect(filePath).To(Equal(tempConfig.Name()), "marked file path should match")
+		})
+
+		It("should parse file properly", func() {
+			parsedArgs, err := parseMime(osArgs)
+
+			Expect(err).To(BeNil(), "should parse properly")
+			Expect(len(parsedArgs)).To(Equal(3), "parsed arguments should have len 3")
+			Expect(parsedArgs[0]).To(Equal("vnc"), "first argument should be")
+			Expect(parsedArgs[1]).To(Equal("--namespace=default"), "second argument should be")
+			Expect(parsedArgs[2]).To(Equal("test_vm_123"), "third argument should be")
+		})
+	})
+
+	Context("with invalid file path", func() {
+		validFilePath := "./does_not_exist.imaginary"
+
+		It("should mark invalid file", func() {
+			filePath, err := checkForFile(validFilePath)
+			Expect(err).To(BeNil(), "should do nothing")
+			Expect(filePath).To(Equal(""), "marked file path should match")
+		})
+	})
+
+	Context("with valid file read", func() {
+		simulatedFile := `vnc default my-vm`
+
+		It("should parse file properly", func() {
+			parsedArgs, err := parseMimeConfig(simulatedFile)
+			Expect(err).To(BeNil(), "should parse valid file properly")
+			Expect(len(parsedArgs)).To(Equal(3), "parsed arguments should have len 3")
+			Expect(parsedArgs[0]).To(Equal("vnc"), "first argument should be")
+			Expect(parsedArgs[1]).To(Equal("--namespace=default"), "second argument should be")
+			Expect(parsedArgs[2]).To(Equal("my-vm"), "third argument should be")
+		})
+	})
+
+	Context("with invalid file read", func() {
+		It("should return error when without vnc or console", func() {
+			simulatedArgs := "systemctl restart cups"
+
+			_, err := parseMimeConfig(simulatedArgs)
+			Expect(err.Error()).To(Equal("Protocol have to be one of: vnc, console. Got: systemctl"), "should catch wrong protocol as first argument")
+		})
+
+		It("should return error when more than 3 options are passed", func() {
+			simulatedArgs := "systemctl restart cups; systemctl disable cups"
+
+			_, err := parseMimeConfig(simulatedArgs)
+			Expect(err.Error()).To(Equal("Invalid file format, 3 parameters required, 6 received"), "should catch wrong number of parameters in file")
+		})
+
+		DescribeTable("should allow valid name in third token",
+			func(token string) {
+				simulatedArgs := `vnc cups ` + token
+
+				_, err := parseMimeConfig(simulatedArgs)
+				Expect(err).To(BeNil())
+			},
+			Entry("VM name: vmname", "vmname"),
+			Entry("VM name: vm_name", "vm_name"),
+			Entry("VM name: vm-name", "vm-name"),
+			Entry("VM name: vm-name123", "vm-name123"),
+			Entry("VM name: vm-name-123", "vm-name-123"),
+			Entry("VM name: vm-name_123", "vm-name_123"),
+		)
+
+		DescribeTable("should catch illegal character in second token",
+			func(token string) {
+				simulatedArgs := `vnc ` + token + `restart cups`
+
+				_, err := parseMimeConfig(simulatedArgs)
+
+				Expect(err).ToNot(BeNil(), "parsing should fail")
+				Expect(err.Error()).To(Equal(`Token containing illegal character: ` + token + `restart`))
+			},
+			Entry("Char ;", ";"),
+			Entry("Char [", "["),
+			Entry("Char ]", "]"),
+			Entry("Char !", "!"),
+			Entry("Char @", "@"),
+			Entry("Char #", "#"),
+			Entry("Char $", "$"),
+			Entry("Char %", "%"),
+			Entry("Char ^", "^"),
+			Entry("Char *", "*"),
+			Entry("Char (", "("),
+			Entry("Char )", ")"),
+			Entry("Char {", "{"),
+			Entry("Char }", "}"),
+			Entry("Char :", ":"),
+			Entry("Char '", "'"),
+			Entry(`Char "`, `"`),
+			Entry(`Char \`, `\`),
+			Entry(`Char |`, `|`),
+			Entry(`Char /`, `/`),
+			Entry(`Char .`, `.`),
+			Entry(`Char ,`, `,`),
+			Entry(`Char ~`, `~`),
+			Entry("Char `", "`"),
+			Entry("Char =", "="),
+			Entry("Char +", "+"),
+		)
+	})
+
+	Context("with invalid temporary config file", func() {
+		It("should modify nothing", func() {
+			passedArgs := []string{"dummyArgumentThatNeverWillWork.OnThisOrOtherCOmputer"}
+
+			parsedArgs, err := parseMime(passedArgs)
+
+			Expect(err).To(BeNil(), "nothing should happen")
+			Expect(parsedArgs).To(BeNil(), "arguments should be put through")
+		})
+
+		It("shoudl detect valid file, but mark missing", func() {
+			passedArgs := []string{"test.vvv"}
+
+			parsedArgs, err := parseMime(passedArgs)
+
+			Expect(err.Error()).To(Equal("File does not exist"), "nothing should happen")
+			Expect(parsedArgs).To(BeNil(), "nothing should be parsed")
+		})
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+})

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -38,7 +38,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().Patch(vmName, gomock.Any(), gomock.Any()).Return(runningVM, nil)
 
 			cmd := tests.NewVirtctlCommand("start", vmName)
-			Expect(cmd.Execute()).To(BeNil())
+			Expect(cmd()).To(BeNil())
 		})
 
 		It("with spec:running:false", func() {
@@ -52,7 +52,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().Patch(vmName, gomock.Any(), gomock.Any()).Return(stoppedVM, nil)
 
 			cmd := tests.NewVirtctlCommand("stop", vmName)
-			Expect(cmd.Execute()).To(BeNil())
+			Expect(cmd()).To(BeNil())
 		})
 
 		It("with spec:running:false when it's false already ", func() {
@@ -62,7 +62,7 @@ var _ = Describe("VirtualMachine", func() {
 			kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface)
 			vmInterface.EXPECT().Get(vm.Name, gomock.Any()).Return(vm, nil)
 
-			cmd := tests.NewRepeatableVirtctlCommand("stop", vmName)
+			cmd := tests.NewVirtctlCommand("stop", vmName)
 			Expect(cmd()).NotTo(BeNil())
 		})
 
@@ -77,7 +77,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().Restart(vmName).Return(nil)
 
 			cmd := tests.NewVirtctlCommand("restart", vmName)
-			Expect(cmd.Execute()).To(BeNil())
+			Expect(cmd()).To(BeNil())
 		})
 
 		It("should return an error", func() {
@@ -87,7 +87,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInterface.EXPECT().Get(vm.Name, gomock.Any()).Return(vm, errors.New(vmName))
 
 			cmd := tests.NewVirtctlCommand("restart", vmName)
-			Expect(cmd.Execute()).To(Equal(errors.New("Error fetching VirtualMachine: " + vmName)))
+			Expect(cmd()).To(Equal(errors.New("Error fetching VirtualMachine: " + vmName)))
 		})
 	})
 

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Expose", func() {
 			const serviceName = "cluster-ip-vmi"
 			It("[test_id:1531]Should expose a Cluster IP service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
 				err := virtctl()
 				Expect(err).ToNot(HaveOccurred())
@@ -98,7 +98,7 @@ var _ = Describe("Expose", func() {
 			const servicePort = "27017"
 			const serviceName = "cluster-ip-target-vmi"
 			It("[test_id:1532]Should expose a ClusterIP service and connect to the vm on port 80", func() {
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", "http")
 				err := virtctl()
 				Expect(err).ToNot(HaveOccurred())
@@ -123,7 +123,7 @@ var _ = Describe("Expose", func() {
 		Context("Expose ClusterIP service wiht ports on the vmi defined", func() {
 			const serviceName = "cluster-ip-target-multiple-ports-vmi"
 			It("[test_id:1533]Should expose a ClusterIP service and connect to all ports defined on the vmi", func() {
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--name", serviceName)
 				err := virtctl()
 				Expect(err).ToNot(HaveOccurred())
@@ -152,7 +152,7 @@ var _ = Describe("Expose", func() {
 
 			It("[test_id:1534]Should expose a NodePort service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
 					"--type", "NodePort")
 				err := virtctl()
@@ -202,7 +202,7 @@ var _ = Describe("Expose", func() {
 
 			It("[test_id:1535]Should expose a ClusterIP service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					udpVM.Namespace, udpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
 					"--protocol", "UDP")
 				err := virtctl()
@@ -234,7 +234,7 @@ var _ = Describe("Expose", func() {
 
 			It("[test_id:1536]Should expose a NodePort service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					udpVM.Namespace, udpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
 					"--type", "NodePort", "--protocol", "UDP")
 				err := virtctl()
@@ -316,7 +316,7 @@ var _ = Describe("Expose", func() {
 
 			It("[test_id:1537]Should create a ClusterIP service on VMRS and connect to it", func() {
 				By("Expose a service on the VMRS using virtctl")
-				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", "--namespace",
+				virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", "--namespace",
 					vmrs.Namespace, vmrs.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
 				err = virtctl()
 				Expect(err).ToNot(HaveOccurred())
@@ -358,13 +358,13 @@ var _ = Describe("Expose", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Exposing a service to the VM using virtctl")
-			virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachine", "--namespace",
+			virtctl := tests.NewVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachine", "--namespace",
 				vm.Namespace, vm.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
 			err = virtctl()
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Calling the start command")
-			virtctl = tests.NewRepeatableVirtctlCommand("start", "--namespace", vm.Namespace, vm.Name)
+			virtctl = tests.NewVirtctlCommand("start", "--namespace", vm.Namespace, vm.Name)
 			err = virtctl()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -437,7 +437,7 @@ var _ = Describe("Expose", func() {
 				vmiUIdBeforeRestart := vmi.GetObjectMeta().GetUID()
 
 				By("Restarting the running VM.")
-				virtctl := tests.NewRepeatableVirtctlCommand("restart", "--namespace", vmObj.Namespace, vmObj.Name)
+				virtctl := tests.NewVirtctlCommand("restart", "--namespace", vmObj.Namespace, vmObj.Name)
 				err = virtctl()
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -52,7 +52,7 @@ var _ = Describe("ImageUpload", func() {
 
 			By("Upload image")
 
-			virtctlCmd := tests.NewRepeatableVirtctlCommand("image-upload",
+			virtctlCmd := tests.NewVirtctlCommand("image-upload",
 				"--namespace", namespace,
 				"--image-path", imagePath,
 				"--pvc-name", pvcName,

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -42,7 +42,6 @@ import (
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/cobra"
 	k8sv1 "k8s.io/api/core/v1"
 	k8sextv1beta1 "k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -2175,7 +2174,7 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 
 type VMIExpecterFactory func(*v1.VirtualMachineInstance) (expect.Expecter, error)
 
-func NewVirtctlCommand(args ...string) *cobra.Command {
+func NewVirtctlCommand(args ...string) func() error {
 	commandline := []string{}
 	master := flag.Lookup("master").Value
 	if master != nil && master.String() != "" {
@@ -2185,15 +2184,9 @@ func NewVirtctlCommand(args ...string) *cobra.Command {
 	if kubeconfig != nil && kubeconfig.String() != "" {
 		commandline = append(commandline, "--kubeconfig", kubeconfig.String())
 	}
-	cmd := virtctl.NewVirtctlCommand()
-	cmd.SetArgs(append(commandline, args...))
-	return cmd
-}
 
-func NewRepeatableVirtctlCommand(args ...string) func() error {
 	return func() error {
-		cmd := NewVirtctlCommand(args...)
-		return cmd.Execute()
+		return virtctl.Execute(append(commandline, args...))
 	}
 }
 

--- a/tests/virctl_test.go
+++ b/tests/virctl_test.go
@@ -1,0 +1,118 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	"flag"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("Virctl command", func() {
+
+	flag.Parse()
+
+	Context("with valid config file", func() {
+
+		It("should try to open VNC", func() {
+
+			tempConfig, err := ioutil.TempFile(os.TempDir(), "kubevirt-test.*.vvv")
+			if err != nil {
+				Fail("Cannot create the temporary file")
+			}
+			defer func() {
+				err := tempConfig.Close()
+				if err != nil {
+					Fail("Cannot close the file")
+				}
+			}()
+
+			data := []byte("vnc " + tests.NamespaceTestDefault + " vmi_test_123")
+			_, err = tempConfig.Write(data)
+
+			virctl := tests.NewVirtctlCommand(tempConfig.Name())
+
+			err = virctl()
+			Expect(strings.HasPrefix(err.Error(), "Can't access VMI vmi_test_123")).To(BeTrue(), "should not be able to properly connect")
+		})
+	})
+
+	Context("with normal command", func() {
+
+		It("should work normally", func() {
+			r, w, _ := os.Pipe()
+			tmp := os.Stdout
+			defer func() {
+				os.Stdout = tmp
+			}()
+			os.Stdout = w
+
+			go func() {
+				defer GinkgoRecover()
+
+				virtctl := tests.NewVirtctlCommand("help")
+				virtctl()
+
+				w.Close()
+			}()
+
+			stdout, _ := ioutil.ReadAll(r)
+			Expect(strings.HasPrefix(string(stdout), "virtctl controls virtual machine related operations on your kubernetes cluster")).To(BeTrue(), "should run help normally")
+		})
+
+	})
+
+	Context("with an invalid file", func() {
+
+		It("should reject wrong file format", func() {
+			tempConfig, err := ioutil.TempFile(os.TempDir(), "kubevirt-test.*.vvv")
+			if err != nil {
+				Fail("Cannot create the temporary file")
+			}
+			defer func() {
+				err := tempConfig.Close()
+				if err != nil {
+					Fail("Cannot close the file")
+				}
+			}()
+
+			data := []byte("vnc vmi_test_123")
+			_, err = tempConfig.Write(data)
+
+			virctl := tests.NewVirtctlCommand(tempConfig.Name())
+
+			err = virctl()
+			Expect(err.Error()).To(Equal("Invalid file format, 3 parameters required, 2 received"), "should reject the invalid file")
+		})
+
+		It("should ignore non .vvv file and continue as normal", func() {
+			virtctl := tests.NewVirtctlCommand("/tmp/kubevirt-test.233242342.novvv")
+			err := virtctl()
+			Expect(err.Error()).To(Equal(`unknown command "/tmp/kubevirt-test.233242342.novvv" for "virtctl"`), "should report unknown command")
+		})
+
+	})
+})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -436,7 +436,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				newVMI := newVirtualMachine(false)
 
 				By("Invoking virtctl start")
-				virtctl := tests.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVMI.Namespace, newVMI.Name)
+				virtctl := tests.NewVirtctlCommand(vm.COMMAND_START, "--namespace", newVMI.Namespace, newVMI.Name)
 
 				err = virtctl()
 				Expect(err).ToNot(HaveOccurred())
@@ -466,7 +466,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				newVMI := newVirtualMachine(true)
 
 				By("Invoking virtctl stop")
-				virtctl := tests.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", newVMI.Namespace, newVMI.Name)
+				virtctl := tests.NewVirtctlCommand(vm.COMMAND_STOP, "--namespace", newVMI.Namespace, newVMI.Name)
 
 				By("Ensuring VMI is running")
 				Eventually(func() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**What this PR does / why we need it**:
This PR introduces reading config files used to open either VNC or console to the VM, which is designed to be used when opening connection to vm from webui. It allows virtctl to be registered as browser mime extension.
The webui sends file containg protocol and vmname on
single line. File is parsed and parameters are passed
to the virctl, which opens the connection.

This is temporary workaround until the proper
proxy is in place.

@stu-gott currently it relies on vicrtl located in the same folder. Where should I point it to properly?

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds virctl support for opening config file to start vnc or console. It is designed to be used as MIME extension in web browser.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1895)
<!-- Reviewable:end -->
