### PR TITLE
Enable setting serial number for a VM

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4541,6 +4541,10 @@
       "description": "Settings to control the bootloader that is used.\n+optional",
       "$ref": "#/definitions/v1.Bootloader"
      },
+     "serial": {
+      "description": "The system-serial-number in SMBIOS",
+      "type": "string"
+     },
      "uuid": {
       "description": "UUID reported by the vmi bios.\nDefaults to a random generated uid.",
       "type": "string"

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1090,6 +1090,13 @@ func schema_kubevirt_pkg_api_v1_Firmware(ref common.ReferenceCallback) common.Op
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.Bootloader"),
 						},
 					},
+					"serial": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The system-serial-number in SMBIOS",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -254,6 +254,8 @@ type Firmware struct {
 	// Settings to control the bootloader that is used.
 	// +optional
 	Bootloader *Bootloader `json:"bootloader,omitempty"`
+	// The system-serial-number in SMBIOS
+	Serial string `json:"serial,omitempty"`
 }
 
 // ---

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -124,6 +124,7 @@ func (Firmware) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"uuid":       "UUID reported by the vmi bios.\nDefaults to a random generated uid.",
 		"bootloader": "Settings to control the bootloader that is used.\n+optional",
+		"serial":     "The system-serial-number in SMBIOS",
 	}
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -3242,6 +3242,35 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		Expect(causes).To(HaveLen(1))
 		Expect(causes[0].Field).To(ContainSubstring("bootOrder"))
 	})
+	It("should reject a serial number whose length is greater than 256", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		sn := strings.Repeat("1", maxStrLen+1)
+
+		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
+
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(ContainSubstring("serial"))
+	})
+	It("should reject a serial number with invalid characters", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		sn := "$$$$"
+
+		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
+
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Field).To(ContainSubstring("serial"))
+	})
+	It("should accept a valid serial number", func() {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		sn := "6a1a24a1-4061-4607-8bf4-a3963d0c5895"
+
+		spec.Domain.Firmware = &v1.Firmware{Serial: sn}
+
+		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec)
+		Expect(len(causes)).To(Equal(0))
+	})
 })
 
 type virtualMachineBuilder struct {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -618,6 +618,10 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				Template: EFIVarsPath,
 			}
 		}
+
+		if len(vmi.Spec.Domain.Firmware.Serial) > 0 {
+			domain.Spec.SysInfo.System = append(domain.Spec.SysInfo.System, Entry{Name: "serial", Value: string(vmi.Spec.Domain.Firmware.Serial)})
+		}
 	}
 
 	// Take memory from the requested memory

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -344,7 +344,8 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
 
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
-				UUID: "e4686d2c-6e8d-4335-b8fd-81bee22f4814",
+				UUID:   "e4686d2c-6e8d-4335-b8fd-81bee22f4814",
+				Serial: "e4686d2c-6e8d-4335-b8fd-81bee22f4815",
 			}
 
 			gracePerod := int64(5)
@@ -362,6 +363,7 @@ var _ = Describe("Converter", func() {
   <sysinfo type="smbios">
     <system>
       <entry name="uuid">e4686d2c-6e8d-4335-b8fd-81bee22f4814</entry>
+      <entry name="serial">e4686d2c-6e8d-4335-b8fd-81bee22f4815</entry>
     </system>
     <bios></bios>
     <baseBoard></baseBoard>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Kubevirt currently lacks the ability to specify a serial number for a virtual machine.
This PR adds the ability to specify a custom serial number (see https://bugzilla.redhat.com/show_bug.cgi?id=918138).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Custom serial number can be set for a VMI via the `spec.domain.firmware.serial` attribute.
```
