### PR TITLE
Fix console test under the OpenShift

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -56,6 +56,10 @@ for i in ${namespaces[@]}; do
         _kubectl -n ${i} delete secrets -l ${label}
         _kubectl -n ${i} delete customresourcedefinitions -l ${label}
 
+        if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]]; then
+            _kubectl -n ${i} delete scc -l ${label}
+        fi
+
         # W/A for https://github.com/kubernetes/kubernetes/issues/65818
         if [[ "$KUBEVIRT_PROVIDER" =~ .*.10..* ]]; then
             # k8s version 1.10.* does not have --wait parameter

--- a/pkg/kubecli/vmi.go
+++ b/pkg/kubecli/vmi.go
@@ -255,37 +255,40 @@ type connectionStruct struct {
 func (v *vmis) SerialConsole(name string, timeout time.Duration) (StreamInterface, error) {
 	timeoutChan := time.Tick(timeout)
 	connectionChan := make(chan connectionStruct)
-	isWaiting := true
 
 	go func() {
-		con, err := v.asyncSubresourceHelper(name, "console")
-		for err != nil && isWaiting {
-			if asyncSubresourceError, ok := err.(*AsyncSubresourceError); ok {
-				if asyncSubresourceError.GetStatusCode() == http.StatusBadRequest {
-					// Sleep to prevent denial of service on the api server
-					time.Sleep(1 * time.Second)
-					con, err = v.asyncSubresourceHelper(name, "console")
-				} else {
-					connectionChan <- connectionStruct{con: nil, err: asyncSubresourceError}
+		for {
+
+			select {
+			case <-timeoutChan:
+				connectionChan <- connectionStruct{
+					con: nil,
+					err: fmt.Errorf("Timeout trying to connect to the virtual machine instance"),
+				}
+				return
+			default:
+			}
+
+			con, err := v.asyncSubresourceHelper(name, "console")
+			if err != nil {
+				asyncSubresourceError, ok := err.(*AsyncSubresourceError)
+				// return if response status code does not equal to 400
+				if !ok || asyncSubresourceError.GetStatusCode() != http.StatusBadRequest {
+					connectionChan <- connectionStruct{con: nil, err: err}
 					return
 				}
-			} else {
-				connectionChan <- connectionStruct{con: nil, err: err}
-				return
+
+				time.Sleep(1 * time.Second)
+				continue
 			}
-		}
-		if isWaiting {
+
 			connectionChan <- connectionStruct{con: con, err: nil}
+			return
 		}
 	}()
 
-	select {
-	case <-timeoutChan:
-		isWaiting = false
-		return nil, fmt.Errorf("Timeout trying to connect to the virtual machine instance")
-	case conStruct := <-connectionChan:
-		return conStruct.con, conStruct.err
-	}
+	conStruct := <-connectionChan
+	return conStruct.con, conStruct.err
 }
 
 type AsyncSubresourceError struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- remove kubevirt-test scc
- refactor SerialConsole method to use iteration instead of recursion
- wait until we really get console error under the console test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Under the OpenShift when I open an additional console, first one get
error `websocket: close 1006 (abnormal closure): unexpected EOF`,
I think it is ok because we wrote data, but can someone confirm it?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
