### PR TITLE
Return fedora 28 image for container disk

### DIFF
--- a/images/fedora-cloud-container-disk-demo/Dockerfile
+++ b/images/fedora-cloud-container-disk-demo/Dockerfile
@@ -21,4 +21,4 @@ FROM kubevirt/container-disk-v1alpha
 LABEL maintainer="The KubeVirt Project <kubevirt-dev@googlegroups.com>"
 
 # Add fedora cloud disk image
-RUN curl -g -L https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-29-1.2.x86_64.qcow2 > /disk/fedora.qcow2
+RUN curl -g -L https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2 > /disk/fedora.qcow2


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fedora 29 image in container disk demo, is not working properly in kubevirt.
This pr returns fedora back to image 28, which was working correctly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1917 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/1918)
<!-- Reviewable:end -->
