### PR TITLE
Add ready condition to the VMI

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -215,11 +215,6 @@ func (v *VirtualMachineInstance) GetObjectMeta() metav1.Object {
 	return &v.ObjectMeta
 }
 
-func (v *VirtualMachineInstance) IsReady() bool {
-	// TODO once we support a ready condition, use it instead
-	return v.IsRunning()
-}
-
 func (v *VirtualMachineInstance) IsScheduling() bool {
 	return v.Status.Phase == Scheduling
 }

--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -36,6 +36,18 @@ func (d *VirtualMachineConditionManager) HasCondition(vmi *v1.VirtualMachineInst
 	return false
 }
 
+func (d *VirtualMachineConditionManager) HasConditionWithStatus(vmi *v1.VirtualMachineInstance, cond v1.VirtualMachineInstanceConditionType, status k8sv1.ConditionStatus) bool {
+	for _, c := range vmi.Status.Conditions {
+		if c.Type == cond {
+			if c.Status == status {
+				return true
+			}
+			return false
+		}
+	}
+	return false
+}
+
 func (d *VirtualMachineConditionManager) RemoveCondition(vmi *v1.VirtualMachineInstance, cond v1.VirtualMachineInstanceConditionType) {
 	var conds []v1.VirtualMachineInstanceCondition
 	for _, c := range vmi.Status.Conditions {
@@ -74,7 +86,7 @@ func (d *VirtualMachineConditionManager) PodHasCondition(pod *k8sv1.Pod, conditi
 	return false
 }
 
-func (d *VirtualMachineConditionManager) GetPodCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) *k8sv1.PodCondition {
+func (d *VirtualMachineConditionManager) GetPodConditionWithStatus(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) *k8sv1.PodCondition {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == conditionType {
 			if cond.Status == status {
@@ -82,6 +94,15 @@ func (d *VirtualMachineConditionManager) GetPodCondition(pod *k8sv1.Pod, conditi
 			} else {
 				return nil
 			}
+		}
+	}
+	return nil
+}
+
+func (d *VirtualMachineConditionManager) GetPodCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType) *k8sv1.PodCondition {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == conditionType {
+			return &cond
 		}
 	}
 	return nil

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -349,7 +349,7 @@ func (c *VMIReplicaSet) filterActiveVMIs(vmis []*virtv1.VirtualMachineInstance) 
 // filterReadyVMIs takes a list of VMIs and returns all VMIs which are in ready state.
 func (c *VMIReplicaSet) filterReadyVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
-		return vmi.IsReady()
+		return controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceConditionType(k8score.PodReady), k8score.ConditionTrue)
 	})
 }
 

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -574,7 +574,7 @@ func (c *VMController) filterActiveVMIs(vmis []*virtv1.VirtualMachineInstance) [
 // TODO +pkotas unify with replicaset this code is the same
 func (c *VMController) filterReadyVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
-		return vmi.IsReady()
+		return controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceConditionType(k8score.PodReady), k8score.ConditionTrue)
 	})
 }
 
@@ -927,7 +927,7 @@ func (c *VMController) updateStatus(vm *virtv1.VirtualMachine, vmi *virtv1.Virtu
 
 	ready := false
 	if created {
-		ready = vmi.IsReady()
+		ready = controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceConditionType(k8score.PodReady), k8score.ConditionTrue)
 	}
 	readyMatch := ready == vm.Status.Ready
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -15,12 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
-	framework "k8s.io/client-go/tools/cache/testing"
+	"k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/datavolumecontroller/v1alpha1"
 	cdifake "kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake"
-	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/api/v1"
 	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/testutils"
@@ -421,8 +421,9 @@ var _ = Describe("VirtualMachine", func() {
 			controller.Execute()
 		})
 
-		It("should update status to created and ready when vmi is running", func() {
+		It("should update status to created and ready when vmi is running and running", func() {
 			vm, vmi := DefaultVirtualMachine(true)
+			markAsReady(vmi)
 
 			addVirtualMachine(vm)
 			vmiFeeder.Add(vmi)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	"kubevirt.io/kubevirt/pkg/controller"
+
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/virt-config"
@@ -190,7 +192,7 @@ var _ = Describe("VMIlifecycle", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
-				Expect(vmi.IsReady()).To(BeTrue(), "VirtualMachineInstance %q is not ready: %v", vmi.Name, vmi.Status.Phase)
+				Eventually(controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady), k8sv1.ConditionTrue), 2*time.Second, 100*time.Millisecond).Should(BeTrue(), "VirtualMachineInstance %q is not ready: %v", vmi.Name, vmi.Status.Phase)
 
 				By("Obtaining serial console")
 				expecter, err := tests.LoggedInAlpineExpecter(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

Keep the pods ready condition in sync with the condition on the VMI. The
ready condition can be used by higher level controllers to determine if
the underlying pod is ready to receive traffic.

From now on `status.ready` on a VM and `status.readyReplicas` on a VMIRS
are in sync with the ready status of the pod.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1454 


**Special notes for your reviewer**:

Superseeds #1496

**Release note**:
```release-note
The "PodReady" condition is reflected on the VMI and as a consequence on `status.ready` on a VM and `status.readyReplicas` on a VMIRS
```
