### PR TITLE
Add support for generating cloud-init network-config

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4101,7 +4101,7 @@
       "type": "string"
      },
      "networkDataBase64": {
-      "description": "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
+      "description": "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.\n+ optional",
       "type": "string"
      },
      "networkDataSecretRef": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4096,6 +4096,18 @@
    "v1.CloudInitNoCloudSource": {
     "description": "Represents a cloud-init nocloud user data source.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
     "properties": {
+     "networkData": {
+      "description": "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
+      "type": "string"
+     },
+     "networkDataBase64": {
+      "description": "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
+      "type": "string"
+     },
+     "networkDataSecretRef": {
+      "description": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.\n+ optional",
+      "$ref": "#/definitions/v1.LocalObjectReference"
+     },
      "secretRef": {
       "description": "UserDataSecretRef references a k8s secret that contains NoCloud userdata.\n+ optional",
       "$ref": "#/definitions/v1.LocalObjectReference"

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -216,6 +216,15 @@ func (in *CloudInitNoCloudSource) DeepCopyInto(out *CloudInitNoCloudSource) {
 			**out = **in
 		}
 	}
+	if in.NetworkDataSecretRef != nil {
+		in, out := &in.NetworkDataSecretRef, &out.NetworkDataSecretRef
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(core_v1.LocalObjectReference)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -339,6 +339,26 @@ func schema_kubevirt_pkg_api_v1_CloudInitNoCloudSource(ref common.ReferenceCallb
 							Format:      "",
 						},
 					},
+					"networkDataSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.",
+							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
+						},
+					},
+					"networkDataBase64": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkData contains NoCloud inline cloud-init networkdata.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"networkData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NetworkData contains NoCloud inline cloud-init networkdata.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -347,7 +347,7 @@ func schema_kubevirt_pkg_api_v1_CloudInitNoCloudSource(ref common.ReferenceCallb
 					},
 					"networkDataBase64": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NetworkData contains NoCloud inline cloud-init networkdata.",
+							Description: "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -107,7 +107,7 @@ type CloudInitNoCloudSource struct {
 	// NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.
 	// + optional
 	NetworkDataSecretRef *v1.LocalObjectReference `json:"networkDataSecretRef,omitempty"`
-	// NetworkData contains NoCloud inline cloud-init networkdata.
+	// NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.
 	// + optional
 	NetworkDataBase64 string `json:"networkDataBase64,omitempty"`
 	// NetworkData contains NoCloud inline cloud-init networkdata.

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -104,6 +104,15 @@ type CloudInitNoCloudSource struct {
 	// UserData contains NoCloud inline cloud-init userdata.
 	// + optional
 	UserData string `json:"userData,omitempty"`
+	// NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.
+	// + optional
+	NetworkDataSecretRef *v1.LocalObjectReference `json:"networkDataSecretRef,omitempty"`
+	// NetworkData contains NoCloud inline cloud-init networkdata.
+	// + optional
+	NetworkDataBase64 string `json:"networkDataBase64,omitempty"`
+	// NetworkData contains NoCloud inline cloud-init networkdata.
+	// + optional
+	NetworkData string `json:"networkData,omitempty"`
 }
 
 // ---

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -36,10 +36,13 @@ func (ServiceAccountVolumeSource) SwaggerDoc() map[string]string {
 
 func (CloudInitNoCloudSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":               "Represents a cloud-init nocloud user data source.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
-		"secretRef":      "UserDataSecretRef references a k8s secret that contains NoCloud userdata.\n+ optional",
-		"userDataBase64": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.\n+ optional",
-		"userData":       "UserData contains NoCloud inline cloud-init userdata.\n+ optional",
+		"":                     "Represents a cloud-init nocloud user data source.\nMore info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+		"secretRef":            "UserDataSecretRef references a k8s secret that contains NoCloud userdata.\n+ optional",
+		"userDataBase64":       "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.\n+ optional",
+		"userData":             "UserData contains NoCloud inline cloud-init userdata.\n+ optional",
+		"networkDataSecretRef": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.\n+ optional",
+		"networkDataBase64":    "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
+		"networkData":          "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -41,7 +41,7 @@ func (CloudInitNoCloudSource) SwaggerDoc() map[string]string {
 		"userDataBase64":       "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.\n+ optional",
 		"userData":             "UserData contains NoCloud inline cloud-init userdata.\n+ optional",
 		"networkDataSecretRef": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.\n+ optional",
-		"networkDataBase64":    "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
+		"networkDataBase64":    "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.\n+ optional",
 		"networkData":          "NetworkData contains NoCloud inline cloud-init networkdata.\n+ optional",
 	}
 }

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -187,6 +187,9 @@ var exampleJSON = `{
         "cloudInitNoCloud": {
           "secretRef": {
             "name": "testsecret"
+          },
+          "networkDataSecretRef": {
+            "name": "testnetworksecret"
           }
         }
       },
@@ -284,6 +287,9 @@ var _ = Describe("Schema", func() {
 					CloudInitNoCloud: &CloudInitNoCloudSource{
 						UserDataSecretRef: &v1.LocalObjectReference{
 							Name: "testsecret",
+						},
+						NetworkDataSecretRef: &v1.LocalObjectReference{
+							Name: "testnetworksecret",
 						},
 					},
 				},

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -120,17 +120,6 @@ func GetDomainBasePath(domain string, namespace string) string {
 	return fmt.Sprintf("%s/%s/%s", cloudInitLocalDir, namespace, domain)
 }
 
-func validateArgs(source *v1.CloudInitNoCloudSource) error {
-	precond.MustNotBeNil(source)
-
-	// TODO what if I only want the metadata to e.g. set up the network
-	if source.UserDataBase64 == "" {
-		return fmt.Errorf("userDataBase64 is required for no-cloud data source")
-	}
-
-	return nil
-}
-
 func RemoveLocalData(domain string, namespace string) error {
 	domainBasePath := GetDomainBasePath(domain, namespace)
 	err := os.RemoveAll(domainBasePath)
@@ -157,22 +146,40 @@ func ResolveSecrets(source *v1.CloudInitNoCloudSource, namespace string, clients
 	precond.CheckNotEmpty(namespace)
 	precond.CheckNotNil(clientset)
 
-	if source.UserDataSecretRef == nil {
+	if source.UserDataSecretRef == nil && source.NetworkDataSecretRef == nil {
 		return nil
 	}
-	secretID := source.UserDataSecretRef.Name
 
-	secret, err := clientset.CoreV1().Secrets(namespace).Get(secretID, metav1.GetOptions{})
-	if err != nil {
-		return err
+	if source.UserDataSecretRef != nil {
+		secretID := source.UserDataSecretRef.Name
+
+		secret, err := clientset.CoreV1().Secrets(namespace).Get(secretID, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		userData, ok := secret.Data["userdata"]
+		if ok == false {
+			return fmt.Errorf("no user-data value found in k8s secret %s %v", secretID, err)
+		}
+		source.UserData = string(userData)
 	}
 
-	userData, ok := secret.Data["userdata"]
-	if ok == false {
-		return fmt.Errorf("no user-data value found in k8s secret %s %v", secretID, err)
+	if source.NetworkDataSecretRef != nil {
+		secretID := source.NetworkDataSecretRef.Name
+
+		secret, err := clientset.CoreV1().Secrets(namespace).Get(secretID, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		networkData, ok := secret.Data["networkdata"]
+		if ok == false {
+			return fmt.Errorf("no network-data value found in k8s secret %s %v", secretID, err)
+		}
+		source.NetworkData = string(networkData)
 	}
 
-	source.UserData = string(userData)
 	return nil
 }
 
@@ -189,8 +196,10 @@ func GenerateLocalData(vmiName string, hostname string, namespace string, source
 
 	metaFile := fmt.Sprintf("%s/%s", domainBasePath, "meta-data")
 	userFile := fmt.Sprintf("%s/%s", domainBasePath, "user-data")
+	networkFile := fmt.Sprintf("%s/%s", domainBasePath, "network-config")
 	iso := fmt.Sprintf("%s/%s", domainBasePath, NoCloudFile)
 	isoStaging := fmt.Sprintf("%s/%s.staging", domainBasePath, NoCloudFile)
+
 	var userData []byte
 	if source.UserData != "" {
 		userData = []byte(source.UserData)
@@ -202,10 +211,22 @@ func GenerateLocalData(vmiName string, hostname string, namespace string, source
 	} else {
 		return fmt.Errorf("userDataBase64 or userData is required for no-cloud data source")
 	}
+
+	var networkData []byte
+	if source.NetworkData != "" {
+		networkData = []byte(source.NetworkData)
+	} else if source.NetworkDataBase64 != "" {
+		networkData, err = base64.StdEncoding.DecodeString(source.NetworkDataBase64)
+		if err != nil {
+			return err
+		}
+	}
+
 	metaData := []byte(fmt.Sprintf("{ \"instance-id\": \"%s.%s\", \"local-hostname\": \"%s\" }\n", vmiName, namespace, hostname))
 
 	diskutils.RemoveFile(userFile)
 	diskutils.RemoveFile(metaFile)
+	diskutils.RemoveFile(networkFile)
 	diskutils.RemoveFile(isoStaging)
 
 	err = ioutil.WriteFile(userFile, userData, 0644)
@@ -217,15 +238,25 @@ func GenerateLocalData(vmiName string, hostname string, namespace string, source
 		return err
 	}
 
-	files := make([]string, 0, 2)
+	files := make([]string, 0, 3)
 	files = append(files, metaFile)
 	files = append(files, userFile)
+
+	if len(networkData) > 0 {
+		err = ioutil.WriteFile(networkFile, networkData, 0644)
+		if err != nil {
+			return err
+		}
+		files = append(files, networkFile)
+	}
+
 	err = cloudInitIsoFunc(isoStaging, files)
 	if err != nil {
 		return err
 	}
 	diskutils.RemoveFile(metaFile)
 	diskutils.RemoveFile(userFile)
+	diskutils.RemoveFile(networkFile)
 
 	err = diskutils.SetFileOwnership(cloudInitOwner, isoStaging)
 	if err != nil {

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -160,7 +160,7 @@ func ResolveSecrets(source *v1.CloudInitNoCloudSource, namespace string, clients
 
 		userData, ok := secret.Data["userdata"]
 		if ok == false {
-			return fmt.Errorf("no user-data value found in k8s secret %s %v", secretID, err)
+			return fmt.Errorf("userdata key not found in k8s secret %s %v", secretID, err)
 		}
 		source.UserData = string(userData)
 	}
@@ -175,7 +175,7 @@ func ResolveSecrets(source *v1.CloudInitNoCloudSource, namespace string, clients
 
 		networkData, ok := secret.Data["networkdata"]
 		if ok == false {
-			return fmt.Errorf("no network-data value found in k8s secret %s %v", secretID, err)
+			return fmt.Errorf("networkdata key not found in k8s secret %s %v", secretID, err)
 		}
 		source.NetworkData = string(networkData)
 	}

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -282,7 +282,7 @@ var _ = Describe("CloudInit", func() {
 
 					userSecret := &k8sv1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "userData",
+							Name:      "userDataSecretName",
 							Namespace: namespace,
 						},
 						Type: "Opaque",
@@ -295,7 +295,7 @@ var _ = Describe("CloudInit", func() {
 					virtClient.EXPECT().CoreV1().Return(userClient.CoreV1()).AnyTimes()
 
 					cloudInitData := &v1.CloudInitNoCloudSource{
-						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userData"},
+						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userDataSecretName"},
 					}
 
 					err := ResolveSecrets(cloudInitData, namespace, virtClient)
@@ -311,7 +311,7 @@ var _ = Describe("CloudInit", func() {
 
 					userSecret := &k8sv1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "userData",
+							Name:      "userDataSecretName",
 							Namespace: namespace,
 						},
 						Type: "Opaque",
@@ -323,7 +323,7 @@ var _ = Describe("CloudInit", func() {
 
 					networkSecret := &k8sv1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "networkData",
+							Name:      "networkDataSecretName",
 							Namespace: namespace,
 						},
 						Type: "Opaque",
@@ -339,8 +339,8 @@ var _ = Describe("CloudInit", func() {
 					)
 
 					cloudInitData := &v1.CloudInitNoCloudSource{
-						UserDataSecretRef:    &k8sv1.LocalObjectReference{Name: "userData"},
-						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkData"},
+						UserDataSecretRef:    &k8sv1.LocalObjectReference{Name: "userDataSecretName"},
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkDataSecretName"},
 					}
 
 					err := ResolveSecrets(cloudInitData, namespace, virtClient)
@@ -370,11 +370,11 @@ var _ = Describe("CloudInit", func() {
 					virtClient.EXPECT().CoreV1().Return(fakeClient.CoreV1())
 
 					cloudInitData := &v1.CloudInitNoCloudSource{
-						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userData"},
+						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userDataSecretName"},
 					}
 
 					err := ResolveSecrets(cloudInitData, namespace, virtClient)
-					Expect(err.Error()).To(Equal("secrets \"userData\" not found"))
+					Expect(err.Error()).To(Equal("secrets \"userDataSecretName\" not found"))
 				})
 			})
 			Context("with NetworkDataSecretRef defined without a secret", func() {
@@ -386,11 +386,11 @@ var _ = Describe("CloudInit", func() {
 					virtClient.EXPECT().CoreV1().Return(fakeClient.CoreV1())
 
 					cloudInitData := &v1.CloudInitNoCloudSource{
-						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkData"},
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkDataSecretName"},
 					}
 
 					err := ResolveSecrets(cloudInitData, namespace, virtClient)
-					Expect(err.Error()).To(Equal("secrets \"networkData\" not found"))
+					Expect(err.Error()).To(Equal("secrets \"networkDataSecretName\" not found"))
 				})
 			})
 			Context("with UserDataSecretRef defined with a misnamed secret", func() {
@@ -400,7 +400,7 @@ var _ = Describe("CloudInit", func() {
 					namespace := "testing"
 					userSecret := &k8sv1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "userData",
+							Name:      "userDataSecretName",
 							Namespace: namespace,
 						},
 						Type: "Opaque",
@@ -412,11 +412,11 @@ var _ = Describe("CloudInit", func() {
 					virtClient.EXPECT().CoreV1().Return(userClient.CoreV1()).AnyTimes()
 
 					cloudInitData := &v1.CloudInitNoCloudSource{
-						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userData"},
+						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userDataSecretName"},
 					}
 
 					err := ResolveSecrets(cloudInitData, namespace, virtClient)
-					Expect(err.Error()).To(Equal("no user-data value found in k8s secret userData <nil>"))
+					Expect(err.Error()).To(Equal("userdata key not found in k8s secret userDataSecretName <nil>"))
 				})
 			})
 			Context("with NetworkDataSecretRef defined with a misnamed secret", func() {
@@ -426,7 +426,7 @@ var _ = Describe("CloudInit", func() {
 					namespace := "testing"
 					networkSecret := &k8sv1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "networkData",
+							Name:      "networkDataSecretName",
 							Namespace: namespace,
 						},
 						Type: "Opaque",
@@ -438,11 +438,11 @@ var _ = Describe("CloudInit", func() {
 					virtClient.EXPECT().CoreV1().Return(networkClient.CoreV1())
 
 					cloudInitData := &v1.CloudInitNoCloudSource{
-						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkData"},
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkDataSecretName"},
 					}
 
 					err := ResolveSecrets(cloudInitData, namespace, virtClient)
-					Expect(err.Error()).To(Equal("no network-data value found in k8s secret networkData <nil>"))
+					Expect(err.Error()).To(Equal("networkdata key not found in k8s secret networkDataSecretName <nil>"))
 				})
 			})
 		})

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -29,14 +29,23 @@ import (
 	"os/user"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/precond"
 )
 
 var _ = Describe("CloudInit", func() {
+
+	var ctrl *gomock.Controller
+	var virtClient *kubecli.MockKubevirtClient
 
 	tmpDir, _ := ioutil.TempDir("", "cloudinittest")
 
@@ -195,6 +204,17 @@ var _ = Describe("CloudInit", func() {
 					verifyCloudInitIso(cloudInitData)
 				})
 			})
+			Context("with cloudInitNoCloud userDataBase64 and networkDataBase64 volume source", func() {
+				It("should success", func() {
+					userData := "fake\nuser\ndata\n"
+					networkData := "fake\nnetwork\ndata\n"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataBase64:    base64.StdEncoding.EncodeToString([]byte(userData)),
+						NetworkDataBase64: base64.StdEncoding.EncodeToString([]byte(networkData)),
+					}
+					verifyCloudInitIso(cloudInitData)
+				})
+			})
 			Context("with cloudInitNoCloud userData volume source", func() {
 				It("should success", func() {
 					userData := "fake\nuser\ndata\n"
@@ -202,6 +222,216 @@ var _ = Describe("CloudInit", func() {
 						UserData: userData,
 					}
 					verifyCloudInitIso(cloudInitData)
+				})
+			})
+			Context("with bad cloudInitNoCloud UserDataBase64", func() {
+				It("should fail", func() {
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataBase64: "#######garbage******",
+					}
+					namespace := "fake-namespace"
+					domain := "fake-domain"
+					err := GenerateLocalData(domain, domain, namespace, cloudInitData)
+					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
+				})
+			})
+			Context("with bad cloudInitNoCloud NetworkDataBase64", func() {
+				It("should fail", func() {
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserData:          "fake",
+						NetworkDataBase64: "#######garbage******",
+					}
+					namespace := "fake-namespace"
+					domain := "fake-domain"
+					err := GenerateLocalData(domain, domain, namespace, cloudInitData)
+					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
+				})
+			})
+			Context("with cloudInitNoCloud networkData source", func() {
+				It("should fail", func() {
+					networkData := "FakeNetwork"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						NetworkData: networkData,
+					}
+					namespace := "fake-namespace"
+					domain := "fake-domain"
+					err := GenerateLocalData(domain, domain, namespace, cloudInitData)
+					Expect(err).Should(MatchError("userDataBase64 or userData is required for no-cloud data source"))
+				})
+
+			})
+		})
+		Describe("A new VirtualMachineInstance definition", func() {
+			Context("with cloudInitNoCloud userDataSecretRef", func() {
+				It("should succeed", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+
+					namespace := "testing"
+
+					userSecret := &k8sv1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "userData",
+							Namespace: namespace,
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{
+							"userdata": []byte("secretUserData"),
+						},
+					}
+
+					userClient := fake.NewSimpleClientset(userSecret)
+					virtClient.EXPECT().CoreV1().Return(userClient.CoreV1()).AnyTimes()
+
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userData"},
+					}
+
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err).To(BeNil())
+					Expect(cloudInitData.UserData).To(Equal("secretUserData"))
+				})
+			})
+			Context("with cloudInitNoCloud userDataSecretRef and networkDataSecretRef", func() {
+				It("should succeed", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+					namespace := "testing"
+
+					userSecret := &k8sv1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "userData",
+							Namespace: namespace,
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{
+							"userdata": []byte("secretUserData"),
+						},
+					}
+					userClient := fake.NewSimpleClientset(userSecret)
+
+					networkSecret := &k8sv1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "networkData",
+							Namespace: namespace,
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{
+							"networkdata": []byte("secretNetworkData"),
+						},
+					}
+					networkClient := fake.NewSimpleClientset(networkSecret)
+
+					gomock.InOrder(
+						virtClient.EXPECT().CoreV1().Return(userClient.CoreV1()),
+						virtClient.EXPECT().CoreV1().Return(networkClient.CoreV1()),
+					)
+
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataSecretRef:    &k8sv1.LocalObjectReference{Name: "userData"},
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkData"},
+					}
+
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err).To(BeNil())
+					Expect(cloudInitData.UserData).To(Equal("secretUserData"))
+					Expect(cloudInitData.NetworkData).To(Equal("secretNetworkData"))
+				})
+			})
+			Context("with nothing", func() {
+				It("should succeed", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+					namespace := "testing"
+					fakeClient := fake.NewSimpleClientset()
+					virtClient.EXPECT().CoreV1().Return(fakeClient.CoreV1())
+					cloudInitData := &v1.CloudInitNoCloudSource{}
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err).To(BeNil())
+				})
+			})
+			Context("with UserDataSecretRef defined without a secret", func() {
+				It("should fail", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+					namespace := "testing"
+					fakeClient := fake.NewSimpleClientset()
+					virtClient.EXPECT().CoreV1().Return(fakeClient.CoreV1())
+
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userData"},
+					}
+
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err.Error()).To(Equal("secrets \"userData\" not found"))
+				})
+			})
+			Context("with NetworkDataSecretRef defined without a secret", func() {
+				It("should fail", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+					namespace := "testing"
+					fakeClient := fake.NewSimpleClientset()
+					virtClient.EXPECT().CoreV1().Return(fakeClient.CoreV1())
+
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkData"},
+					}
+
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err.Error()).To(Equal("secrets \"networkData\" not found"))
+				})
+			})
+			Context("with UserDataSecretRef defined with a misnamed secret", func() {
+				It("should fail", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+					namespace := "testing"
+					userSecret := &k8sv1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "userData",
+							Namespace: namespace,
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{
+							"baduserdata": []byte("secretUserData"),
+						},
+					}
+					userClient := fake.NewSimpleClientset(userSecret)
+					virtClient.EXPECT().CoreV1().Return(userClient.CoreV1()).AnyTimes()
+
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataSecretRef: &k8sv1.LocalObjectReference{Name: "userData"},
+					}
+
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err.Error()).To(Equal("no user-data value found in k8s secret userData <nil>"))
+				})
+			})
+			Context("with NetworkDataSecretRef defined with a misnamed secret", func() {
+				It("should fail", func() {
+					ctrl = gomock.NewController(GinkgoT())
+					virtClient = kubecli.NewMockKubevirtClient(ctrl)
+					namespace := "testing"
+					networkSecret := &k8sv1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "networkData",
+							Namespace: namespace,
+						},
+						Type: "Opaque",
+						Data: map[string][]byte{
+							"badnetworkdata": []byte("secretNetworkData"),
+						},
+					}
+					networkClient := fake.NewSimpleClientset(networkSecret)
+					virtClient.EXPECT().CoreV1().Return(networkClient.CoreV1())
+
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{Name: "networkData"},
+					}
+
+					err := ResolveSecrets(cloudInitData, namespace, virtClient)
+					Expect(err.Error()).To(Equal("no network-data value found in k8s secret networkData <nil>"))
 				})
 			})
 		})

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -204,6 +204,17 @@ var _ = Describe("CloudInit", func() {
 					verifyCloudInitIso(cloudInitData)
 				})
 			})
+			Context("with cloudInitNoCloud userDataBase64 and networkData volume source", func() {
+				It("should success", func() {
+					userData := "fake\nuser\ndata\n"
+					networkData := "fake\nnetwork\ndata\n"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
+						NetworkData:    networkData,
+					}
+					verifyCloudInitIso(cloudInitData)
+				})
+			})
 			Context("with cloudInitNoCloud userDataBase64 and networkDataBase64 volume source", func() {
 				It("should success", func() {
 					userData := "fake\nuser\ndata\n"

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -1437,12 +1437,10 @@ var _ = Describe("Validating Webhook", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			order := uint(1)
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, []v1.Disk{
-				{Name: "testdisk", VolumeName: "testvolume1", BootOrder: &order,
-					DiskDevice: v1.DiskDevice{
-						Disk: &v1.DiskTarget{}}},
-				{Name: "testdisk2", VolumeName: "testvolume2", BootOrder: &order,
-					DiskDevice: v1.DiskDevice{
-						Disk: &v1.DiskTarget{}}}}...)
+				{Name: "testvolume1", BootOrder: &order, DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{}}},
+				{Name: "testvolume2", BootOrder: &order, DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{}}}}...)
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, []v1.Volume{
 				{Name: "testvolume1", VolumeSource: v1.VolumeSource{
@@ -2786,13 +2784,8 @@ var _ = Describe("Validating Webhook", func() {
 		It("should reject disk with invalid cache mode", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name:       "testdisk",
-				VolumeName: "testvolume",
-				Cache:      "unspported",
-				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{},
-				},
-			})
+				Name: "testdisk", Cache: "unspported", DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{}}})
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
 			Expect(len(causes)).To(Equal(1))
@@ -2806,12 +2799,7 @@ var _ = Describe("Validating Webhook", func() {
 			for i := 0; i <= arrayLenMax; i++ {
 				name := strconv.Itoa(i)
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-					Name:       "testdisk" + name,
-					VolumeName: "testvolume" + name,
-					DiskDevice: v1.DiskDevice{
-						Disk: &v1.DiskTarget{},
-					},
-				})
+					Name: "testdisk" + name, DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{}}})
 			}
 
 			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -42,6 +43,7 @@ import (
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 var _ = Describe("Validating Webhook", func() {
@@ -979,6 +981,44 @@ var _ = Describe("Validating Webhook", func() {
 	})
 
 	Context("with VirtualMachineInstance spec", func() {
+		It("should accept valid machine type", func() {
+			supportedMachines := virtconfig.SupportedEmulatedMachines()
+			if len(supportedMachines) > 0 {
+				vmi := v1.NewMinimalVMI("testvmi")
+				vmi.Spec.Domain.Machine.Type = supportedMachines[0]
+
+				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+				Expect(len(causes)).To(Equal(0))
+			}
+		})
+		It("should reject invalid machine type", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Machine.Type = "test"
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake.domain.machine.type"))
+			Expect(causes[0].Message).To(ContainSubstring("fake.domain.machine.type is not supported: test (allowed values:"))
+		})
+
+		It("should accept valid hostname", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Hostname = "test"
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(0))
+		})
+		It("should reject invalid hostname", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Hostname = "test+bad"
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake.hostname"))
+			Expect(causes[0].Message).To(ContainSubstring("does not conform to the kubernetes DNS_LABEL rules : "))
+		})
 		It("should accept valid subdomain name", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Subdomain = "testsubdomain"
@@ -1251,6 +1291,43 @@ var _ = Describe("Validating Webhook", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
 			Expect(len(causes)).To(Equal(0))
 		})
+		It("should reject incorrect memory and hugepages size values", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}
+			vmi.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{}}
+			vmi.Spec.Domain.Memory.Hugepages.PageSize = "10Mi"
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
+			Expect(causes[0].Message).To(Equal("fake.domain.resources.requests.memory '64Mi' " +
+				"is not a multiple of the page size fake.domain.hugepages.size '10Mi'"))
+		})
+		It("should reject setting guest memory and hugepages", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			guestMemory := resource.MustParse("64Mi")
+
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64Mi"),
+			}
+			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
+			vmi.Spec.Domain.Memory = &v1.Memory{
+				Hugepages: &v1.Hugepages{},
+				Guest:     &guestMemory,
+			}
+			vmi.Spec.Domain.Memory.Hugepages.PageSize = "2Mi"
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
+			Expect(causes[0].Message).To(ContainSubstring("'fake.domain.memory.guest' and " +
+				"'fake.domain.memory.hugepages.size' must not be set at the same time"))
+		})
 		table.DescribeTable("should verify LUN is mapped to PVC volume",
 			func(volume *v1.Volume, expectedErrors int) {
 				vmi := v1.NewMinimalVMI("testvmi")
@@ -1287,6 +1364,97 @@ var _ = Describe("Validating Webhook", func() {
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
 			Expect(len(causes)).To(Equal(0))
+		})
+
+		It("should accept interface and network lists equal to max element length", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+			for i := 1; i < arrayLenMax; i++ {
+				networkName := fmt.Sprintf("default%d", i)
+
+				vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces,
+					v1.Interface{Name: networkName,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{}}})
+
+				vmi.Spec.Networks = append(vmi.Spec.Networks,
+					v1.Network{Name: networkName, NetworkSource: v1.NetworkSource{
+						Multus: &v1.CniNetwork{NetworkName: networkName}}})
+			}
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(0))
+		})
+		It("should reject interface lists greater than max element length", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+			for i := 0; i < arrayLenMax; i++ {
+				networkName := fmt.Sprintf("default%d", i)
+				vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces,
+					v1.Interface{Name: networkName,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{}}})
+			}
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.domain.devices.interfaces "+
+				"list exceeds the %d element limit in length", arrayLenMax)))
+		})
+		It("should reject network lists greater than max element length", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+			for i := 0; i < arrayLenMax; i++ {
+				networkName := fmt.Sprintf("default%d", i)
+				vmi.Spec.Networks = append(vmi.Spec.Networks,
+					v1.Network{Name: networkName, NetworkSource: v1.NetworkSource{
+						Multus: &v1.CniNetwork{NetworkName: networkName}}})
+			}
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.networks "+
+				"list exceeds the %d element limit in length", arrayLenMax)))
+		})
+		It("should reject volume lists greater than max element length", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			for i := 0; i <= arrayLenMax; i++ {
+				volumeName := "testVolume"
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+					Name: volumeName,
+					VolumeSource: v1.VolumeSource{
+						ContainerDisk: &v1.ContainerDiskSource{},
+					},
+				})
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			// if this is processed correctly, it should result in a single error
+			// If multiple causes occurred, then the spec was processed too far.
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.volumes"))
+		})
+		It("should reject disks with the same boot order", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			order := uint(1)
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, []v1.Disk{
+				{Name: "testdisk", VolumeName: "testvolume1", BootOrder: &order,
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{}}},
+				{Name: "testdisk2", VolumeName: "testvolume2", BootOrder: &order,
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{}}}}...)
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, []v1.Volume{
+				{Name: "testvolume1", VolumeSource: v1.VolumeSource{
+					ContainerDisk: &v1.ContainerDiskSource{}}},
+				{Name: "testvolume2", VolumeSource: v1.VolumeSource{
+					ContainerDisk: &v1.ContainerDiskSource{}}}}...)
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].bootOrder"))
+			Expect(causes[0].Message).To(Equal("Boot order for " +
+				"fake.domain.devices.disks[1].bootOrder already set for a different device."))
 		})
 		It("should reject interface lists with more than one interface with the same name", func() {
 			vm := v1.NewMinimalVMI("testvm")
@@ -1929,6 +2097,25 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
 		})
+
+		It("should allow valid ioThreadsPolicy", func() {
+			vmi := v1.NewMinimalVMI("testvm")
+			var ioThreadPolicy v1.IOThreadsPolicy
+			ioThreadPolicy = "auto"
+			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(0))
+		})
+
+		It("should reject invalid ioThreadsPolicy", func() {
+			vmi := v1.NewMinimalVMI("testvm")
+			var ioThreadPolicy v1.IOThreadsPolicy
+			ioThreadPolicy = "bad"
+			vmi.Spec.Domain.IOThreadsPolicy = &ioThreadPolicy
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Message).To(Equal(fmt.Sprintf("Invalid IOThreadsPolicy (%s)", ioThreadPolicy)))
+		})
 	})
 	Context("with cpu pinning", func() {
 		var vmi *v1.VirtualMachineInstance
@@ -2019,7 +2206,7 @@ var _ = Describe("Validating Webhook", func() {
 				Expect(len(causes)).To(Equal(0))
 			},
 			table.Entry("with pvc volume source", v1.VolumeSource{PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{}}),
-			table.Entry("with cloud-init volume source", v1.VolumeSource{CloudInitNoCloud: &v1.CloudInitNoCloudSource{UserData: "fake"}}),
+			table.Entry("with cloud-init volume source", v1.VolumeSource{CloudInitNoCloud: &v1.CloudInitNoCloudSource{UserData: "fake", NetworkData: "fake"}}),
 			table.Entry("with containerDisk volume source", v1.VolumeSource{ContainerDisk: &v1.ContainerDiskSource{}}),
 			table.Entry("with ephemeral volume source", v1.VolumeSource{Ephemeral: &v1.EphemeralVolumeSource{}}),
 			table.Entry("with emptyDisk volume source", v1.VolumeSource{EmptyDisk: &v1.EmptyDiskSource{}}),
@@ -2041,6 +2228,21 @@ var _ = Describe("Validating Webhook", func() {
 			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake[0]"))
+		})
+		It("should reject DataVolume when DataVolume name is not set", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name:         "testvolume",
+				VolumeSource: v1.VolumeSource{DataVolume: &v1.DataVolumeSource{Name: ""}},
+			})
+
+			os.Setenv("FEATURE_GATES", "DataVolumes")
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueRequired"))
+			Expect(causes[0].Field).To(Equal("fake[0].name"))
+			Expect(causes[0].Message).To(Equal("DataVolume 'name' must be set"))
 		})
 		It("should reject volume with no volume source set", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
@@ -2088,6 +2290,26 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake[1].name"))
 		})
+		It("should reject volume count > arrayLenMax", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			for i := 0; i <= arrayLenMax; i++ {
+				name := strconv.Itoa(i)
+
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+					Name: "testvolume" + name,
+					VolumeSource: v1.VolumeSource{
+						ContainerDisk: &v1.ContainerDiskSource{},
+					},
+				})
+			}
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake"))
+			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake list exceeds the %d element limit in length", arrayLenMax)))
+		})
+
 		table.DescribeTable("should verify cloud-init userdata length", func(userDataLen int, expectedErrors int, base64Encode bool) {
 			vmi := v1.NewMinimalVMI("testvmi")
 
@@ -2112,14 +2334,46 @@ var _ = Describe("Validating Webhook", func() {
 			}
 		},
 			table.Entry("should accept userdata under max limit", 10, 0, false),
-			table.Entry("should accept userdata equal max limit", cloudInitMaxLen, 0, false),
-			table.Entry("should reject userdata greater than max limit", cloudInitMaxLen+1, 1, false),
+			table.Entry("should accept userdata equal max limit", cloudInitUserMaxLen, 0, false),
+			table.Entry("should reject userdata greater than max limit", cloudInitUserMaxLen+1, 1, false),
 			table.Entry("should accept userdata base64 under max limit", 10, 0, true),
-			table.Entry("should accept userdata base64 equal max limit", cloudInitMaxLen, 0, true),
-			table.Entry("should reject userdata base64 greater than max limit", cloudInitMaxLen+1, 1, true),
+			table.Entry("should accept userdata base64 equal max limit", cloudInitUserMaxLen, 0, true),
+			table.Entry("should reject userdata base64 greater than max limit", cloudInitUserMaxLen+1, 1, true),
 		)
 
-		It("should reject cloud-init with invalid base64 data", func() {
+		table.DescribeTable("should verify cloud-init networkdata length", func(networkDataLen int, expectedErrors int, base64Encode bool) {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			// generate fake networkdata
+			networkdata := ""
+			for i := 0; i < networkDataLen; i++ {
+				networkdata = fmt.Sprintf("%sa", networkdata)
+			}
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{VolumeSource: v1.VolumeSource{CloudInitNoCloud: &v1.CloudInitNoCloudSource{}}})
+			vmi.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.UserData = "#config"
+
+			if base64Encode {
+				vmi.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(networkdata))
+			} else {
+				vmi.Spec.Volumes[0].VolumeSource.CloudInitNoCloud.NetworkData = networkdata
+			}
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
+			Expect(len(causes)).To(Equal(expectedErrors))
+			for _, cause := range causes {
+				Expect(cause.Field).To(ContainSubstring("fake[0].cloudInitNoCloud"))
+			}
+		},
+			table.Entry("should accept networkdata under max limit", 10, 0, false),
+			table.Entry("should accept networkdata equal max limit", cloudInitNetworkMaxLen, 0, false),
+			table.Entry("should reject networkdata greater than max limit", cloudInitNetworkMaxLen+1, 1, false),
+			table.Entry("should accept networkdata base64 under max limit", 10, 0, true),
+			table.Entry("should accept networkdata base64 equal max limit", cloudInitNetworkMaxLen, 0, true),
+			table.Entry("should reject networkdata base64 greater than max limit", cloudInitNetworkMaxLen+1, 1, true),
+		)
+
+		It("should reject cloud-init with invalid base64 userdata", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
@@ -2133,6 +2387,62 @@ var _ = Describe("Validating Webhook", func() {
 			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake[0].cloudInitNoCloud.userDataBase64"))
+		})
+
+		It("should reject cloud-init with invalid base64 networkdata", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				VolumeSource: v1.VolumeSource{
+					CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+						UserData:          "fake",
+						NetworkDataBase64: "#######garbage******",
+					},
+				},
+			})
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake[0].cloudInitNoCloud.networkDataBase64"))
+		})
+
+		It("should reject cloud-init with multiple userdata sources", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				VolumeSource: v1.VolumeSource{
+					CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+						UserData: "fake",
+						UserDataSecretRef: &k8sv1.LocalObjectReference{
+							Name: "fake",
+						},
+					},
+				},
+			})
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake[0].cloudInitNoCloud"))
+		})
+
+		It("should reject cloud-init with multiple networkdata sources", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				VolumeSource: v1.VolumeSource{
+					CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+						UserData:    "fake",
+						NetworkData: "fake",
+						NetworkDataSecretRef: &k8sv1.LocalObjectReference{
+							Name: "fake",
+						},
+					},
+				},
+			})
+
+			causes := validateVolumes(k8sfield.NewPath("fake"), vmi.Spec.Volumes)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake[0].cloudInitNoCloud"))
 		})
 
 		It("should reject hostDisk without required parameters", func() {
@@ -2471,6 +2781,45 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(len(causes)).To(Equal(2))
 			Expect(causes[0].Field).To(Equal("fake[0].disk.bus"))
 			Expect(causes[1].Field).To(Equal("fake[1].lun.bus"))
+		})
+
+		It("should reject disk with invalid cache mode", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "testdisk",
+				VolumeName: "testvolume",
+				Cache:      "unspported",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{},
+				},
+			})
+
+			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake[0].cache"))
+			Expect(causes[0].Message).To(Equal("fake[0].cache has invalid value unspported"))
+		})
+
+		It("should reject disk count > arrayLenMax", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			for i := 0; i <= arrayLenMax; i++ {
+				name := strconv.Itoa(i)
+				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+					Name:       "testdisk" + name,
+					VolumeName: "testvolume" + name,
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{},
+					},
+				})
+			}
+
+			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(1))
+			Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+			Expect(causes[0].Field).To(Equal("fake"))
+			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake list exceeds the %d "+
+				"element limit in length", arrayLenMax)))
 		})
 
 		It("should reject invalid SN characters", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -240,7 +240,8 @@ var _ = Describe("Converter", func() {
 					Name: "nocloud",
 					VolumeSource: v1.VolumeSource{
 						CloudInitNoCloud: &v1.CloudInitNoCloudSource{
-							UserDataBase64: "1234",
+							UserDataBase64:    "1234",
+							NetworkDataBase64: "1234",
 						},
 					},
 				},
@@ -248,7 +249,8 @@ var _ = Describe("Converter", func() {
 					Name: "cdrom_tray_unspecified",
 					VolumeSource: v1.VolumeSource{
 						CloudInitNoCloud: &v1.CloudInitNoCloudSource{
-							UserDataBase64: "1234",
+							UserDataBase64:    "1234",
+							NetworkDataBase64: "1234",
 						},
 					},
 				},

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -398,9 +398,8 @@ func StubOutNetworkForTest() {
 
 func addCloudInitDisk(vmi *v1.VirtualMachineInstance, userData string, networkData string) {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       "cloudinit",
-		VolumeName: "cloudinit",
-		Cache:      v1.CacheNone,
+		Name:  "cloudinit",
+		Cache: v1.CacheNone,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -45,7 +45,6 @@ import (
 var _ = Describe("Manager", func() {
 	var mockConn *cli.MockConnection
 	var mockDomain *cli.MockVirDomain
-	var mockNetwork *network.MockNetworkHandler
 	var ctrl *gomock.Controller
 	testVmName := "testvmi"
 	testNamespace := "testnamespace"
@@ -75,8 +74,6 @@ var _ = Describe("Manager", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockConn = cli.NewMockConnection(ctrl)
 		mockDomain = cli.NewMockVirDomain(ctrl)
-		mockNetwork = network.NewMockNetworkHandler(ctrl)
-		network.Handler = mockNetwork
 	})
 
 	expectIsolationDetectionForVMI := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1471,8 +1471,7 @@ func AddUserData(vmi *v1.VirtualMachineInstance, name string, userData string) {
 
 func AddCloudInitData(vmi *v1.VirtualMachineInstance, name, userData, networkData string, b64encode bool) {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name:       name,
-		VolumeName: name,
+		Name: name,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1444,6 +1444,12 @@ func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData st
 	return vmi
 }
 
+func NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(containerImage, userData, networkData string, b64encode bool) *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
+	AddCloudInitData(vmi, "disk1", userData, networkData, b64encode)
+	return vmi
+}
+
 func AddUserData(vmi *v1.VirtualMachineInstance, name string, userData string) {
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: name,
@@ -1461,6 +1467,39 @@ func AddUserData(vmi *v1.VirtualMachineInstance, name string, userData string) {
 			},
 		},
 	})
+}
+
+func AddCloudInitData(vmi *v1.VirtualMachineInstance, name, userData, networkData string, b64encode bool) {
+	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+		Name:       name,
+		VolumeName: name,
+		DiskDevice: v1.DiskDevice{
+			Disk: &v1.DiskTarget{
+				Bus: "virtio",
+			},
+		},
+	})
+	if b64encode {
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: name,
+			VolumeSource: v1.VolumeSource{
+				CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+					UserDataBase64:    base64.StdEncoding.EncodeToString([]byte(userData)),
+					NetworkDataBase64: base64.StdEncoding.EncodeToString([]byte(networkData)),
+				},
+			},
+		})
+	} else {
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: name,
+			VolumeSource: v1.VolumeSource{
+				CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+					UserData:    userData,
+					NetworkData: networkData,
+				},
+			},
+		})
+	}
 }
 
 func NewRandomVMIWithPVC(claimName string) *v1.VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add support for generating cloud-init network-config

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for generating cloud-init network-config
```
