### PR TITLE
Use sidecar from dockerhub

### DIFF
--- a/cluster/examples/vmi-with-sidecar-hook.yaml
+++ b/cluster/examples/vmi-with-sidecar-hook.yaml
@@ -3,7 +3,7 @@ apiVersion: kubevirt.io/v1alpha2
 kind: VirtualMachineInstance
 metadata:
   annotations:
-    hooks.kubevirt.io/hookSidecars: '[{"image": "registry:5000/kubevirt/example-hook-sidecar:devel"}]'
+    hooks.kubevirt.io/hookSidecars: '[{"image": "kubevirt/example-hook-sidecar:devel"}]'
     smbios.vm.kubevirt.io/baseBoardManufacturer: Radical Edward
   labels:
     special: vmi-with-sidecar-hook

--- a/cmd/example-hook-sidecar/README.md
+++ b/cmd/example-hook-sidecar/README.md
@@ -5,7 +5,7 @@ To use this hook, use following annotations:
 ```yaml
 annotations:
   # Request the hook sidecar
-  hooks.kubevirt.io/hookSidecars: '[{"image": "registry:5000/kubevirt/example-hook-sidecar:devel"}]'
+  hooks.kubevirt.io/hookSidecars: '[{"image": "kubevirt/example-hook-sidecar:devel"}]'
   # Overwrite base board manufacturer name
   smbios.vm.kubevirt.io/baseBoardManufacturer: "Radical Edward"
 ```

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -833,7 +833,7 @@ func GetVMIWithHookSidecar() *v1.VirtualMachineInstance {
 	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
 
 	vmi.ObjectMeta.Annotations = map[string]string{
-		"hooks.kubevirt.io/hookSidecars":              `[{"image": "registry:5000/kubevirt/example-hook-sidecar:devel"}]`,
+		"hooks.kubevirt.io/hookSidecars":              `[{"image": "kubevirt/example-hook-sidecar:devel"}]`,
 		"smbios.vm.kubevirt.io/baseBoardManufacturer": "Radical Edward",
 	}
 	return vmi


### PR DESCRIPTION
**What this PR does / why we need it**:
Doc fix for sidecar example: For the first try it's easier to download the sidecar from docker hub
instead of compiling it.

```release-note
NONE
```