### PR TITLE
api-reference: fix order of versions on main page

### DIFF
--- a/hack/gen-swagger-doc/deploy.sh
+++ b/hack/gen-swagger-doc/deploy.sh
@@ -33,7 +33,7 @@ Content of this repository is generated from OpenAPI specification of
 * [master](${GITHUB_IO_FQDN}/master/index.html)
 __EOF__
 find * -type d -regex "^v[0-9.]*" \
-    -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" \; >>README.md
+    -exec echo "* [{}](${GITHUB_IO_FQDN}/{}/index.html)" \; | sort -r --version-sort -t '[' --key 2 >>README.md
 
 git config --global user.email "travis@travis-ci.org"
 git config --global user.name "Travis CI"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fix order of versions on main page.

For example: 
```
* [v0.10.0](github.com/v0.10.0/index.html)
* [v0.11.0](github.com/v0.11.0/index.html)
* [v0.11.1](github.com/v0.11.1/index.html)
* [v0.9.5](github.com/v0.9.5/index.html)
* [v0.9.6](github.com/v0.9.6/index.html)
```
Transforms to
```
* [v0.11.1](github.com/v0.11.1/index.html)
* [v0.11.0](github.com/v0.11.0/index.html)
* [v0.10.0](github.com/v0.10.0/index.html)
* [v0.9.6](github.com/v0.9.6/index.html)
* [v0.9.5](github.com/v0.9.5/index.html)
```
Signed-off-by: Lukas Bednar <lbednar@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
