### PR TITLE
Fix some discovery errors related to virt-api

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -20,7 +20,7 @@
       "application/json"
      ],
      "summary": "Get a KubeVirt API GroupList",
-     "operationId": "getAPIGroup",
+     "operationId": "getAPIGroupList",
      "responses": {
       "200": {
        "description": "OK",
@@ -3821,6 +3821,22 @@
       }
      }
     }
+   },
+   "/openapi/v2": {
+    "get": {
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "func7",
+     "responses": {
+      "200": {
+       "description": "OK"
+      }
+     }
+    }
    }
   },
   "definitions": {
@@ -5270,6 +5286,21 @@
    },
    "v1.Rng": {
     "description": "Rng represents the random device passed from host"
+   },
+   "v1.RootPaths": {
+    "description": "RootPaths lists the paths available at root. For example: \"/healthz\", \"/apis\".",
+    "required": [
+     "paths"
+    ],
+    "properties": {
+     "paths": {
+      "description": "paths are the paths available at root.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
    },
    "v1.SecretVolumeSource": {
     "description": "SecretVolumeSource adapts a Secret into a volume.",

--- a/pkg/util/openapi/openapi.go
+++ b/pkg/util/openapi/openapi.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	restful "github.com/emicklei/go-restful"
-	restfulspec "github.com/emicklei/go-restful-openapi"
+	"github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful-openapi"
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
@@ -55,6 +55,7 @@ func addInfoToSwaggerObject(swo *spec.Swagger) {
 			},
 		},
 	}
+	swo.Swagger = "2.0"
 	swo.Security = make([]map[string][]string, 1)
 	swo.Security[0] = map[string][]string{"BearerToken": {}}
 }
@@ -67,10 +68,12 @@ func LoadOpenAPISpec(webServices []*restful.WebService) *spec.Swagger {
 	// https://github.com/kubernetes/kubernetes/issues/66899 is ready
 	// Otherwise CRDs can't use templates which contain metadata and controllers
 	// can't set conditions without timestamps
-	objectMeta := openapispec.Definitions["v1.ObjectMeta"]
-	prop := objectMeta.Properties["creationTimestamp"]
-	prop.Type = spec.StringOrArray{"string", "null"}
-	objectMeta.Properties["creationTimestamp"] = prop
+	objectMeta, exists := openapispec.Definitions["v1.ObjectMeta"]
+	if exists {
+		prop := objectMeta.Properties["creationTimestamp"]
+		prop.Type = spec.StringOrArray{"string", "null"}
+		objectMeta.Properties["creationTimestamp"] = prop
+	}
 
 	for k, s := range openapispec.Definitions {
 		if strings.HasSuffix(k, "Condition") {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Server an openapi spec for the k8s apiserver, so that we get rid of
this (harmless) errors:

```
  E0110 21:44:37.434692       1 controller.go:111] loading OpenAPI spec
    for "v1alpha2.subresources.kubevirt.io" failed with: OpenAPI spec does
    not exists
```

On clusters newer than 1.10, aggregated apiservers are expected to
return root paths and it does not like empty resource lists anymore.
Serving them to get rid of this error:

```
  E0111 10:52:59.111137       1 memcache.go:134] couldn't get resource
    list for subresources.kubevirt.io/v1alpha2: <nil>
```
and and error in the virt-api log:

```
  {"component":"virt-api","contentLength":19,"level":"info","method":
    "GET","pos":"filter.go:46","proto":"HTTP/2.0","remoteAddress":
    "10.244.0.1","statusCode":404,"timestamp":"2019-01-11T11:07:46.962139Z",
    "url":"/","username":"-"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
