### PR TITLE
Fix virtcl expose

### DIFF
--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -187,7 +187,11 @@ func (o *Command) RunE(cmd *cobra.Command, args []string) error {
 	if port == 0 && len(ports) == 0 {
 		return fmt.Errorf("couldn't find port via --port flag or introspection")
 	} else if port != 0 {
-		ports = []v1.ServicePort{{Name: portName, Protocol: protocol, Port: port, TargetPort: targetPort}}
+		if strServiceType == "NodePort" {
+			ports = []v1.ServicePort{{Name: portName, Protocol: protocol, Port: port, TargetPort: targetPort, NodePort: port}}
+		} else {
+			ports = []v1.ServicePort{{Name: portName, Protocol: protocol, Port: port, TargetPort: targetPort}}
+		}
 	}
 
 	// actually create the service


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixes nodeport behaviour by getting back the functionality of using a specific port number
```
