### PR TITLE
Properly count PRs by not counting merges by maintainers.

### DIFF
--- a/hack/release-announce.sh
+++ b/hack/release-announce.sh
@@ -41,7 +41,7 @@ EOF
 }
 
 shortlog() {
-    git shortlog -sne $RELSPANREF | sed "s/^/    /"
+    git shortlog -sne --no-merges $RELSPANREF | sed "s/^/    /"
 }
 
 functest() {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes the PRs count when generating the release notes. It was giving maintainers credit for PRs they merged. By ignoring the merges the counts are correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
