### PR TITLE
release-notes: Favor slack over irc

### DIFF
--- a/hack/release-announce.sh
+++ b/hack/release-announce.sh
@@ -87,7 +87,7 @@ $(functest)
 Additional Resources
 --------------------
 - Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
-- IRC: <irc://irc.freenode.net/#kubevirt>
+- Slack: <https://kubernetes.slack.com/messages/virtualization>
 - An easy to use demo: <https://github.com/kubevirt/demo>
 - [How to contribute][contributing]
 - [License][license]


### PR DESCRIPTION
In the past few months a lot of communication shifted from IRC to slack.
Time to adjust the rleease notes to guide users to slack.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

```release-note
NONE
```
