### PR TITLE
Fixed api test

### DIFF
--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -393,7 +393,7 @@ xw==
 			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 		}, 5)
 
-		It("should not found if endpoint does not exists", func() {
+		It("should return ok on root URL", func() {
 			app.authorizor = authorizorMock
 			authorizorMock.EXPECT().
 				Authorize(gomock.Not(gomock.Nil())).
@@ -402,7 +402,7 @@ xw==
 			app.Compose()
 			resp, err := http.Get(backend.URL)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		}, 5)
 
 		It("should have a test endpoint", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed API test. Caused by a "race condition" between 2 PRs.
A request on the root URL returns ok now, see https://github.com/kubevirt/kubevirt/pull/1930/files#diff-c1554c7ddce93d205a705bd71f9431b3R275

**Release note**:
```release-note
NONE
```
