### PR TITLE
pod resources are set everytime when cpu spec is set

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -62,6 +62,10 @@ func ParseCPUSetLine(cpusetLine string) (cpusList []int, err error) {
 //GetNumberOfVCPUs returns number of vCPUs
 //It counts sockets*cores*threads
 func GetNumberOfVCPUs(cpuSpec *v1.CPU) int64 {
+	if cpuSpec == nil {
+		return int64(0)
+	}
+
 	vCPUs := cpuSpec.Cores
 	if cpuSpec.Sockets != 0 {
 		if vCPUs == 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
pod resources are set everytime when cpu spec is set

This PR updates resources.request for pod when vmi is created. Previously pod resources were set only, when user sets, that cpu is dedicated. This patch updates it, that when user sets `Spec.Domain.CPU`, then pod resources.requests is set to number of vcpu (sockets*cores*threads) (without this pod resources are empty, eventhough user is requesting e.g. 8vcpus).

@MarSik, @fromanirh, @yanirq, @petrkotas, @fabiand, @vladikr  please review

**Release note**:
```release-note
pod resources are set everytime when cpu spec is set
```
