### PR TITLE
Degrade sriov virt-launcher to unprivileged

### DIFF
--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1110,7 +1110,7 @@ var _ = Describe("Template", func() {
 		})
 
 		Context("with sriov interface", func() {
-			It("should run privileged", func() {
+			It("should not run privileged", func() {
 				sriovInterface := v1.InterfaceSRIOV{}
 				domain := v1.DomainSpec{}
 				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
@@ -1125,7 +1125,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
-				Expect(*pod.Spec.Containers[0].SecurityContext.Privileged).To(Equal(true))
+				Expect(*pod.Spec.Containers[0].SecurityContext.Privileged).To(Equal(false))
 			})
 			It("should mount pci related host directories", func() {
 				sriovInterface := v1.InterfaceSRIOV{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: it removes the need to run SR-IOV attached VMs as privileged pods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1784

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SR-IOV VMIs no longer run inside a privileged pod. Note: it is now required that all SR-IOV VFs that can be allocated by SR-IOV device plugin are pre-registered with vfio subsystem on deployment.
```
