### PR TITLE
Live Migration without tunneling

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5848,6 +5848,10 @@
       "description": "The time the migration action began",
       "type": "string"
      },
+     "targetDirectMigrationNodePorts": {
+      "description": "The list of ports opened for live migration on the destination node",
+      "type": "object"
+     },
      "targetNode": {
       "description": "The target node that the VMI is moving to",
       "type": "string"
@@ -5859,6 +5863,10 @@
      "targetNodeDomainDetected": {
       "description": "The Target Node has seen the Domain Start Event",
       "type": "boolean"
+     },
+     "targetPod": {
+      "description": "The target pod that the VMI is moving to",
+      "type": "string"
      }
     }
    },

--- a/images/cdi-http-import-server/Dockerfile
+++ b/images/cdi-http-import-server/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf install -y nginx qemu-guest-agent qemu-img scsi-target-utils \
 
 RUN mkdir -p /usr/share/nginx/html/images \
     && curl http://dl-cdn.alpinelinux.org/alpine/v3.7/releases/x86_64/alpine-virt-3.7.0-x86_64.iso > /usr/share/nginx/html/images/alpine.iso \
+    && curl https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img > /usr/share/nginx/html/images/cirros.img \
     && rm -f /etc/nginx/nginx.conf
 
 RUN cp /usr/bin/qemu-ga /usr/share/nginx/html/

--- a/images/cdi-http-import-server/entry-point.sh
+++ b/images/cdi-http-import-server/entry-point.sh
@@ -22,16 +22,26 @@
 trap 'echo "Graceful exit"; exit 0' SIGINT SIGQUIT SIGTERM
 
 ALPINE_IMAGE_PATH=/usr/share/nginx/html/images/alpine.iso
+CIRROS_IMAGE_PATH=/usr/share/nginx/html/images/cirros.img
 IMAGE_PATH=/images
+IMAGE_NAME=${IMAGE_NAME:-cirros}
+
+case "$IMAGE_NAME" in
+cirros) CONVERT_PATH=$CIRROS_IMAGE_PATH ;;
+alpine) CONVERT_PATH=$ALPINE_IMAGE_PATH ;;
+*)
+    echo "failed to find image $IMAGE_NAME"
+    ;;
+esac
 
 if [ -n "$AS_ISCSI" ]; then
     mkdir -p $IMAGE_PATH
-    /usr/bin/qemu-img convert $ALPINE_IMAGE_PATH $IMAGE_PATH/alpine.raw
+    /usr/bin/qemu-img convert -O raw $CONVERT_PATH $IMAGE_PATH/disk.raw
     if [ $? -ne 0 ]; then
-        echo "Failed to convert image $ALPINE_IMAGE_PATH to .raw file"
+        echo "Failed to convert image $CONVERT_PATH to .raw file"
         exit 1
     fi
 
     touch /tmp/healthy
-    bash expose-as-iscsi.sh "${IMAGE_PATH}/alpine.raw"
+    bash expose-as-iscsi.sh "${IMAGE_PATH}/disk.raw"
 fi

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -2014,6 +2014,13 @@ func (in *VirtualMachineInstanceMigrationState) DeepCopyInto(out *VirtualMachine
 			*out = (*in).DeepCopy()
 		}
 	}
+	if in.TargetDirectMigrationNodePorts != nil {
+		in, out := &in.TargetDirectMigrationNodePorts, &out.TargetDirectMigrationNodePorts
+		*out = make(map[int]int, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -349,8 +349,12 @@ type VirtualMachineInstanceMigrationState struct {
 	TargetNodeDomainDetected bool `json:"targetNodeDomainDetected,omitempty"`
 	// The address of the target node to use for the migration
 	TargetNodeAddress string `json:"targetNodeAddress,omitempty"`
+	// The list of ports opened for live migration on the destination node
+	TargetDirectMigrationNodePorts map[int]int `json:"targetDirectMigrationNodePorts,omitempty"`
 	// The target node that the VMI is moving to
 	TargetNode string `json:"targetNode,omitempty"`
+	// The target pod that the VMI is moving to
+	TargetPod string `json:"targetPod,omitempty"`
 	// The source node that the VMI originated on
 	SourceNode string `json:"sourceNode,omitempty"`
 	// Indicates the migration completed

--- a/pkg/api/v1/types_swagger_generated.go
+++ b/pkg/api/v1/types_swagger_generated.go
@@ -64,15 +64,17 @@ func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 
 func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"startTimestamp":           "The time the migration action began",
-		"endTimestamp":             "The time the migration action ended",
-		"targetNodeDomainDetected": "The Target Node has seen the Domain Start Event",
-		"targetNodeAddress":        "The address of the target node to use for the migration",
-		"targetNode":               "The target node that the VMI is moving to",
-		"sourceNode":               "The source node that the VMI originated on",
-		"completed":                "Indicates the migration completed",
-		"failed":                   "Indicates that the migration failed",
-		"migrationUid":             "The VirtualMachineInstanceMigration object associated with this migration",
+		"startTimestamp":                 "The time the migration action began",
+		"endTimestamp":                   "The time the migration action ended",
+		"targetNodeDomainDetected":       "The Target Node has seen the Domain Start Event",
+		"targetNodeAddress":              "The address of the target node to use for the migration",
+		"targetDirectMigrationNodePorts": "The list of ports opened for live migration on the destination node",
+		"targetNode":                     "The target node that the VMI is moving to",
+		"targetPod":                      "The target pod that the VMI is moving to",
+		"sourceNode":                     "The source node that the VMI originated on",
+		"completed":                      "Indicates the migration completed",
+		"failed":                         "Indicates that the migration failed",
+		"migrationUid":                   "The VirtualMachineInstanceMigration object associated with this migration",
 	}
 }
 

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -431,6 +431,7 @@ func (c *MigrationController) sync(migration *virtv1.VirtualMachineInstanceMigra
 				MigrationUID: migration.UID,
 				TargetNode:   pod.Spec.NodeName,
 				SourceNode:   vmi.Status.NodeName,
+				TargetPod:    pod.Name,
 			}
 
 			// By setting this label, virt-handler on the target node will receive

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -430,6 +430,7 @@ var _ = Describe("Migration watcher", func() {
 				MigrationUID: migration.UID,
 				TargetNode:   "node01",
 				SourceNode:   "node02",
+				TargetPod:    pod.Name,
 			}
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = "node01"
 			addMigration(migration)

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"kubevirt.io/kubevirt/pkg/log"
@@ -33,19 +34,20 @@ import (
 var migrationPortsRange = []int{49152, 49153}
 
 type ProxyManager interface {
-	StartTargetListener(key string, targetUnixFile string) error
-	GetTargetListenerPort(key string) int
+	StartTargetListener(key string, targetUnixFiles []string) error
+	GetTargetListenerPorts(key string) map[int]int
 	StopTargetListener(key string)
 
-	StartSourceListener(key string, targetAddress string) error
-	GetSourceListenerFile(key string) string
+	//StartSourceListener(key string, targetAddress string) error
+	StartSourceListener(key string, targetAddress string, destSrcPortMap map[int]int) error
+	GetSourceListenerFile(key string) []string
 	StopSourceListener(key string)
 }
 
 type migrationProxyManager struct {
 	virtShareDir  string
-	sourceProxies map[string]*migrationProxy
-	targetProxies map[string]*migrationProxy
+	sourceProxies map[string][]*migrationProxy
+	targetProxies map[string][]*migrationProxy
 	managerLock   sync.Mutex
 }
 
@@ -73,8 +75,8 @@ func GetMigrationPortsList(isBlockMigration bool) (ports []int) {
 func NewMigrationProxyManager(virtShareDir string) ProxyManager {
 	return &migrationProxyManager{
 		virtShareDir:  virtShareDir,
-		sourceProxies: make(map[string]*migrationProxy),
-		targetProxies: make(map[string]*migrationProxy),
+		sourceProxies: make(map[string][]*migrationProxy),
+		targetProxies: make(map[string][]*migrationProxy),
 	}
 }
 
@@ -82,100 +84,165 @@ func SourceUnixFile(virtShareDir string, key string) string {
 	return filepath.Join(virtShareDir, "migrationproxy", key+"-source.sock")
 }
 
-func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFile string) error {
+func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles []string) error {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
-
-	curProxy, exists := m.targetProxies[key]
+	isExistingProxy := func(curProxies []*migrationProxy, targetUnixFiles []string) bool {
+		// make sure that all elements in the existing proxy match to the provided targetUnixFiles
+		if len(curProxies) != len(targetUnixFiles) {
+			return false
+		}
+		existingSocketFiles := make(map[string]bool)
+		for _, file := range targetUnixFiles {
+			existingSocketFiles[file] = true
+		}
+		for _, curProxy := range curProxies {
+			if _, ok := existingSocketFiles[curProxy.targetAddress]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+	curProxies, exists := m.targetProxies[key]
 
 	if exists {
-		if curProxy.targetAddress == targetUnixFile {
+		if isExistingProxy(curProxies, targetUnixFiles) {
 			// No Op, already exists
 			return nil
 		} else {
 			// stop the current proxy and point it somewhere new.
-			curProxy.StopListening()
+			for _, curProxy := range curProxies {
+				curProxy.StopListening()
+			}
 		}
 	}
 
-	// 0 means random port is used
-	proxy := NewTargetProxy("0.0.0.0", 0, targetUnixFile)
+	proxiesList := []*migrationProxy{}
+	for _, targetUnixFile := range targetUnixFiles {
+		// 0 means random port is used
+		proxy := NewTargetProxy("0.0.0.0", 0, targetUnixFile)
 
-	err := proxy.StartListening()
-	if err != nil {
-		proxy.StopListening()
-		return err
+		err := proxy.StartListening()
+		if err != nil {
+			proxy.StopListening()
+			return err
+		}
+		proxiesList = append(proxiesList, proxy)
+		log.Log.Infof("Proxy Target listening on port %d for key %s", proxy.tcpBindPort, key)
 	}
-
-	log.Log.Infof("Proxy Target listening on port %d for key %s", proxy.tcpBindPort, key)
-
-	m.targetProxies[key] = proxy
+	m.targetProxies[key] = proxiesList
 	return nil
-
 }
 
-func (m *migrationProxyManager) GetSourceListenerFile(key string) string {
+func (m *migrationProxyManager) GetSourceListenerFile(key string) []string {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
 
-	curProxy, exists := m.sourceProxies[key]
+	curProxies, exists := m.sourceProxies[key]
+	socketsList := []string{}
 	if exists {
-		return curProxy.unixSocketPath
+		for _, curProxy := range curProxies {
+			socketsList = append(socketsList, curProxy.unixSocketPath)
+		}
 	}
-	return ""
+	return socketsList
 }
 
-func (m *migrationProxyManager) GetTargetListenerPort(key string) int {
+func (m *migrationProxyManager) GetTargetListenerPorts(key string) map[int]int {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
 
-	curProxy, exists := m.targetProxies[key]
-	if exists {
-		return curProxy.tcpBindPort
+	getPortFromSocket := func(id string, path string) int {
+		for _, port := range migrationPortsRange {
+			key := fmt.Sprintf("%s-%d", id, port)
+			if strings.Contains(path, key) {
+				return port
+			}
+		}
+		return 0
 	}
-	return 0
+
+	curProxies, exists := m.targetProxies[key]
+	targetSrcPortMap := make(map[int]int)
+
+	if exists {
+		for _, curProxy := range curProxies {
+			targetSrcPortMap[curProxy.tcpBindPort] = getPortFromSocket(key, curProxy.targetAddress)
+		}
+	}
+	return targetSrcPortMap
 }
 
 func (m *migrationProxyManager) StopTargetListener(key string) {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
 
-	curProxy, exists := m.targetProxies[key]
+	curProxies, exists := m.targetProxies[key]
 	if exists {
-		curProxy.StopListening()
-		delete(m.targetProxies, key)
-		log.Log.Infof("Stopping proxy target %s listening on %d", key, curProxy.tcpBindPort)
+		for _, curProxy := range curProxies {
+			curProxy.StopListening()
+			delete(m.targetProxies, key)
+			log.Log.Infof("Stopping proxy target %s listening on %d", key, curProxy.tcpBindPort)
+		}
 	}
 }
 
-func (m *migrationProxyManager) StartSourceListener(key string, targetAddress string) error {
+func (m *migrationProxyManager) StartSourceListener(key string, targetAddress string, destSrcPortMap map[int]int) error {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
 
-	curProxy, exists := m.sourceProxies[key]
+	isExistingProxy := func(curProxies []*migrationProxy, targetAddress string, destSrcPortMap map[int]int) bool {
+		if len(curProxies) != len(destSrcPortMap) {
+			return false
+		}
+		destSrcLookup := make(map[string]int)
+		for dest, src := range destSrcPortMap {
+			addr := fmt.Sprintf("%s:%d", targetAddress, dest)
+			destSrcLookup[addr] = src
+		}
+		for _, curProxy := range curProxies {
+			if _, ok := destSrcLookup[curProxy.targetAddress]; !ok {
+				return false
+			}
+		}
+		return true
+	}
+
+	curProxies, exists := m.sourceProxies[key]
 
 	if exists {
-		if curProxy.targetAddress == targetAddress {
+		if isExistingProxy(curProxies, targetAddress, destSrcPortMap) {
 			// No Op, already exists
 			return nil
 		} else {
 			// stop the current proxy and point it somewhere new.
-			curProxy.StopListening()
+			for _, curProxy := range curProxies {
+				curProxy.StopListening()
+			}
 		}
 	}
-	filePath := SourceUnixFile(m.virtShareDir, key)
 
-	os.RemoveAll(filePath)
-	proxy := NewSourceProxy(filePath, targetAddress)
+	proxiesList := []*migrationProxy{}
+	for destPort, srcPort := range destSrcPortMap {
+		proxyKey := key
+		if srcPort != 0 {
+			proxyKey += fmt.Sprintf("-%d", srcPort)
+		}
+		targetFullAddr := fmt.Sprintf("%s:%d", targetAddress, destPort)
+		filePath := SourceUnixFile(m.virtShareDir, proxyKey)
 
-	err := proxy.StartListening()
-	if err != nil {
-		proxy.StopListening()
-		return err
+		os.RemoveAll(filePath)
+		proxy := NewSourceProxy(filePath, targetFullAddr)
+
+		err := proxy.StartListening()
+		if err != nil {
+			proxy.StopListening()
+			return err
+		}
+		proxiesList = append(proxiesList, proxy)
+		log.Log.Infof("Proxy Source listening on unix file %s for key %s", filePath, key)
 	}
-
-	log.Log.Infof("Proxy Source listening on unix file %s for key %s", filePath, key)
-	m.sourceProxies[key] = proxy
+	m.sourceProxies[key] = proxiesList
 	return nil
 }
 
@@ -183,10 +250,13 @@ func (m *migrationProxyManager) StopSourceListener(key string) {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
 
-	curProxy, exists := m.sourceProxies[key]
+	curProxies, exists := m.sourceProxies[key]
 	if exists {
-		curProxy.StopListening()
-		delete(m.sourceProxies, key)
+		for _, curProxy := range curProxies {
+			curProxy.StopListening()
+			os.RemoveAll(curProxy.unixSocketPath)
+			delete(m.sourceProxies, key)
+		}
 	}
 	filePath := SourceUnixFile(m.virtShareDir, key)
 	os.RemoveAll(filePath)
@@ -258,6 +328,7 @@ func (m *migrationProxy) createUnixListener() error {
 }
 
 func (m *migrationProxy) StopListening() {
+
 	close(m.stopChan)
 	m.listener.Close()
 }

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -31,14 +31,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/log"
 )
 
-var migrationPortsRange = []int{49152, 49153}
+const (
+	LibvirtDirectMigrationPort = 49152
+	LibvirtBlockMigrationPort  = 49153
+)
+
+var migrationPortsRange = []int{LibvirtDirectMigrationPort, LibvirtBlockMigrationPort}
 
 type ProxyManager interface {
 	StartTargetListener(key string, targetUnixFiles []string) error
 	GetTargetListenerPorts(key string) map[int]int
 	StopTargetListener(key string)
 
-	//StartSourceListener(key string, targetAddress string) error
 	StartSourceListener(key string, targetAddress string, destSrcPortMap map[int]int) error
 	GetSourceListenerFile(key string) []string
 	StopSourceListener(key string)

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -30,6 +30,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/log"
 )
 
+var migrationPortsRange = []int{49152, 49153}
+
 type ProxyManager interface {
 	StartTargetListener(key string, targetUnixFile string) error
 	GetTargetListenerPort(key string) int
@@ -58,6 +60,14 @@ type migrationProxy struct {
 	fdChan         chan net.Conn
 
 	listener net.Listener
+}
+
+func GetMigrationPortsList(isBlockMigration bool) (ports []int) {
+	ports = append(ports, migrationPortsRange[0])
+	if isBlockMigration {
+		ports = append(ports, migrationPortsRange[1])
+	}
+	return
 }
 
 func NewMigrationProxyManager(virtShareDir string) ProxyManager {

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -20,7 +20,6 @@
 package migrationproxy
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -134,8 +133,9 @@ var _ = Describe("MigrationProxy", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				manager := NewMigrationProxyManager(tmpDir)
-				manager.StartTargetListener("mykey", libvirtdSock)
-				manager.StartSourceListener("mykey", fmt.Sprintf("127.0.0.1:%d", manager.GetTargetListenerPort("mykey")))
+				manager.StartTargetListener("mykey", []string{libvirtdSock})
+				destSrcPortMap := manager.GetTargetListenerPorts("mykey")
+				manager.StartSourceListener("mykey", "127.0.0.1", destSrcPortMap)
 
 				defer manager.StopTargetListener("myKey")
 				defer manager.StopSourceListener("myKey")
@@ -151,7 +151,7 @@ var _ = Describe("MigrationProxy", func() {
 					numBytes <- n
 				}()
 
-				conn, err := net.Dial("unix", manager.GetSourceListenerFile("mykey"))
+				conn, err := net.Dial("unix", manager.GetSourceListenerFile("mykey")[0])
 				Expect(err).ShouldNot(HaveOccurred())
 
 				message := "some message"

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -174,7 +174,7 @@ var _ = Describe("MigrationProxy", func() {
 				go msgReader(libvirtdListener, libvirtChan)
 				go msgReader(directListener, directChan)
 
-				for _, sockFile := range manager.GetSourceListenerFile("mykey") {
+				for _, sockFile := range manager.GetSourceListenerFiles("mykey") {
 					if strings.Contains(sockFile, directMigrationPort) {
 						msgWriter(sockFile, directChan, "some direct message")
 					} else {

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -127,42 +128,59 @@ var _ = Describe("MigrationProxy", func() {
 			})
 
 			It("by creating both ends with a manager and sending a message", func() {
+				directMigrationPort := "49152"
 				libvirtdSock := tmpDir + "/libvirtd-sock"
 				libvirtdListener, err := net.Listen("unix", libvirtdSock)
+				directSock := tmpDir + "/mykey-" + directMigrationPort
+				directListener, err := net.Listen("unix", directSock)
 
 				Expect(err).ShouldNot(HaveOccurred())
 
 				manager := NewMigrationProxyManager(tmpDir)
-				manager.StartTargetListener("mykey", []string{libvirtdSock})
+				manager.StartTargetListener("mykey", []string{libvirtdSock, directSock})
 				destSrcPortMap := manager.GetTargetListenerPorts("mykey")
 				manager.StartSourceListener("mykey", "127.0.0.1", destSrcPortMap)
 
 				defer manager.StopTargetListener("myKey")
 				defer manager.StopSourceListener("myKey")
 
-				numBytes := make(chan int)
-				go func() {
-					fd, err := libvirtdListener.Accept()
+				libvirtChan := make(chan int)
+				directChan := make(chan int)
+
+				msgReader := func(listener net.Listener, numBytes chan int) {
+					fd, err := listener.Accept()
 					Expect(err).ShouldNot(HaveOccurred())
 
 					var bytes [1024]byte
 					n, err := fd.Read(bytes[0:])
 					Expect(err).ShouldNot(HaveOccurred())
 					numBytes <- n
-				}()
+				}
 
-				conn, err := net.Dial("unix", manager.GetSourceListenerFile("mykey")[0])
-				Expect(err).ShouldNot(HaveOccurred())
+				msgWriter := func(sockFile string, numBytes chan int, message string) {
+					conn, err := net.Dial("unix", sockFile)
+					Expect(err).ShouldNot(HaveOccurred())
 
-				message := "some message"
-				messageBytes := []byte(message)
-				sentLen, err := conn.Write(messageBytes)
-				Expect(err).ShouldNot(HaveOccurred())
+					messageBytes := []byte(message)
+					sentLen, err := conn.Write(messageBytes)
+					Expect(err).ShouldNot(HaveOccurred())
 
-				Expect(sentLen).To(Equal(len(messageBytes)))
+					Expect(sentLen).To(Equal(len(messageBytes)))
 
-				num := <-numBytes
-				Expect(num).To(Equal(sentLen))
+					num := <-numBytes
+					Expect(num).To(Equal(sentLen))
+				}
+
+				go msgReader(libvirtdListener, libvirtChan)
+				go msgReader(directListener, directChan)
+
+				for _, sockFile := range manager.GetSourceListenerFile("mykey") {
+					if strings.Contains(sockFile, directMigrationPort) {
+						msgWriter(sockFile, directChan, "some direct message")
+					} else {
+						msgWriter(sockFile, libvirtChan, "some libvirt message")
+					}
+				}
 			})
 		})
 	})

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1259,7 +1259,7 @@ func (d *VirtualMachineController) handlePostSyncMigrationProxy(vmi *v1.VirtualM
 	isBlockMigration := (vmi.Status.MigrationMethod == v1.BlockMigration)
 	migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
 	for _, port := range migrationPortsRange {
-		key := fmt.Sprintf("%s-%d", string(vmi.UID), port)
+		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
 		// a proxy between the target direct qemu channel and the connector in the destination pod
 		destSocketFile := migrationproxy.SourceUnixFile(d.virtShareDir, key)
 		migrationTargetSockets = append(migrationTargetSockets, destSocketFile)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -58,8 +58,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/watchdog"
 )
 
-var MigrationPortsRange = []int{49152, 49153}
-
 func NewController(
 	recorder record.EventRecorder,
 	clientset kubecli.KubevirtClient,

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1304,12 +1304,17 @@ func (d *VirtualMachineController) handleMigrationProxy(vmi *v1.VirtualMachineIn
 
 	// handle starting/stopping source migration proxy.
 	// start the source proxy once we know the target address
-	if vmi.Status.MigrationState.TargetDirectMigrationNodePorts == nil {
-		log.Log.Object(vmi).Warning("No migration proxy has been created for this vmi")
-		return nil
+	ports := map[int]int{0: 0}
+	if vmi.Status.MigrationState != nil {
+		if vmi.Status.MigrationState.TargetDirectMigrationNodePorts == nil {
+			log.Log.Object(vmi).Warning("No migration proxy has been created for this vmi")
+			return nil
+		}
+		ports = vmi.Status.MigrationState.TargetDirectMigrationNodePorts
+
 	}
 
-	for srcPort, destPort := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
+	for srcPort, destPort := range ports {
 		key := string(vmi.UID)
 		if srcPort != 0 {
 			key += fmt.Sprintf("-%d", srcPort)

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -633,10 +633,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = "othernode"
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetNode:        "othernode",
-				TargetNodeAddress: "127.0.0.1:12345",
-				SourceNode:        host,
-				MigrationUID:      "123",
+				TargetNode:                     "othernode",
+				TargetNodeAddress:              "127.0.0.1:12345",
+				SourceNode:                     host,
+				MigrationUID:                   "123",
+				TargetDirectMigrationNodePorts: map[int]int{49152: 12132},
 			}
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
@@ -652,7 +653,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmiFeeder.Add(vmi)
 
 			client.EXPECT().MigrateVirtualMachine(vmi)
-
 			controller.Execute()
 		}, 3)
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -810,7 +810,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(blockMigrate).To(BeTrue())
 			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with non-shared PVCs")))
 		})
-		It("should not be allowed to migrate a mix of shared and non-shared disks", func() {
+		It("should be allowed to migrate a mix of shared and non-shared disks", func() {
 
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
@@ -853,10 +853,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(testBlockPvc)
-			_, err := controller.checkVolumesForMigration(vmi)
-			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with mixed shared and non-shared volumes")))
+			blockMigrate, err := controller.checkVolumesForMigration(vmi)
+			Expect(blockMigrate).To(BeTrue())
+			Expect(err).To(BeNil())
 		})
-		It("should not be allowed to migrate a mix of non-shared and shared disks", func() {
+		It("should be allowed to migrate a mix of non-shared and shared disks", func() {
 
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
@@ -899,8 +900,9 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(testBlockPvc)
-			_, err := controller.checkVolumesForMigration(vmi)
-			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with mixed shared and non-shared volumes")))
+			blockMigrate, err := controller.checkVolumesForMigration(vmi)
+			Expect(blockMigrate).To(BeTrue())
+			Expect(err).To(BeNil())
 		})
 		It("should be allowed to live-migrate shared HostDisks ", func() {
 			_true := true

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -585,7 +585,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			// something has to be listening to the cmd socket
 			// for the proxy to work.
 			os.MkdirAll(cmdclient.SocketsDirectory(shareDir), os.ModePerm)
-			portsList := []int{0, 49152, 49153}
+			portsList := []int{0, 49152}
 			for _, port := range portsList {
 				key := string(vmi.UID)
 				if port != 0 {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -603,24 +603,15 @@ var _ = Describe("VirtualMachineInstance", func() {
 			err = controller.handlePostSyncMigrationProxy(vmi)
 			Expect(err).NotTo(HaveOccurred())
 
-			targetPorts := make(map[int]int)
-			for _, port := range portsList {
-				key := string(vmi.UID)
-				if port != 0 {
-					key += fmt.Sprintf("-%d", port)
-				}
-				curPort := controller.migrationProxy.GetTargetListenerPort(key)
-				targetPorts[port] = curPort
-			}
+			destSrcPorts := controller.migrationProxy.GetTargetListenerPorts(string(vmi.UID))
+			fmt.Println("destSrcPorts: ", destSrcPorts)
 			updatedVmi := vmi.DeepCopy()
 			updatedVmi.Status.MigrationState.TargetNodeAddress = controller.ipAddress
-			updatedVmi.Status.MigrationState.TargetDirectMigrationNodePorts = targetPorts
+			updatedVmi.Status.MigrationState.TargetDirectMigrationNodePorts = destSrcPorts
 
 			client.EXPECT().Ping()
 			client.EXPECT().SyncMigrationTarget(vmi)
-
 			vmiInterface.EXPECT().Update(updatedVmi)
-
 			controller.Execute()
 		}, 3)
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -900,7 +900,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
-					Name: "mydisk",
+					Name: "myvolume",
 					DiskDevice: v1.DiskDevice{
 						Disk: &v1.DiskTarget{
 							Bus: "virtio",

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -323,15 +323,14 @@ func (_mr *_MockVirDomainRecorder) OpenConsole(arg0, arg1, arg2 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "OpenConsole", arg0, arg1, arg2)
 }
 
-func (_m *MockVirDomain) Migrate(_param0 *libvirt_go.Connect, _param1 libvirt_go.DomainMigrateFlags, _param2 string, _param3 string, _param4 uint64) (*libvirt_go.Domain, error) {
-	ret := _m.ctrl.Call(_m, "Migrate", _param0, _param1, _param2, _param3, _param4)
-	ret0, _ := ret[0].(*libvirt_go.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+func (_m *MockVirDomain) MigrateToURI3(_param0 string, _param1 *libvirt_go.DomainMigrateParameters, _param2 libvirt_go.DomainMigrateFlags) error {
+	ret := _m.ctrl.Call(_m, "MigrateToURI3", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockVirDomainRecorder) Migrate(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Migrate", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockVirDomainRecorder) MigrateToURI3(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MigrateToURI3", arg0, arg1, arg2)
 }
 
 func (_m *MockVirDomain) Free() error {

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -278,7 +278,7 @@ type VirDomain interface {
 	GetXMLDesc(flags libvirt.DomainXMLFlags) (string, error)
 	GetMetadata(tipus libvirt.DomainMetadataType, uri string, flags libvirt.DomainModificationImpact) (string, error)
 	OpenConsole(devname string, stream *libvirt.Stream, flags libvirt.DomainConsoleFlags) error
-	Migrate(*libvirt.Connect, libvirt.DomainMigrateFlags, string, string, uint64) (*libvirt.Domain, error)
+	MigrateToURI3(string, *libvirt.DomainMigrateParameters, libvirt.DomainMigrateFlags) error
 	Free() error
 }
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -200,7 +200,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 }
 
 func prepateMigrationFlags(isBlockMigration bool) libvirt.DomainMigrateFlags {
-	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_TUNNELLED
+	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER
 
 	if isBlockMigration {
 		migrateFlags |= libvirt.MIGRATE_NON_SHARED_INC

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -364,14 +364,10 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		return fmt.Errorf("failed to update the hosts file: %v", err)
 	}
 
-	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetDirectMigrationNodePorts == nil {
-		return fmt.Errorf("No migration proxy has been created for this vmi")
-	}
-	for port, _ := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
+	isBlockMigration := (vmi.Status.MigrationMethod == v1.BlockMigration)
+	migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
+	for _, port := range migrationPortsRange {
 		// Prepare the direct migration proxy
-		if port == 0 {
-			continue
-		}
 		key := fmt.Sprintf("%s-%d", string(vmi.UID), port)
 		curDirectAddress := fmt.Sprintf("%s:%d", "127.0.0.1", port)
 		unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -428,7 +428,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 	migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
 	for _, port := range migrationPortsRange {
 		// Prepare the direct migration proxy
-		key := fmt.Sprintf("%s-%d", string(vmi.UID), port)
+		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
 		curDirectAddress := fmt.Sprintf("%s:%d", "127.0.0.1", port)
 		unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)
 		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -285,7 +285,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance) {
 			return
 		}
 
-		for k := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
+		for _, k := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
 			ports = append(ports, k)
 		}
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -278,8 +278,25 @@ func (l *LibvirtDomainManager) MigrateVMI(vmi *v1.VirtualMachineInstance) error 
 		return nil
 	}
 
+	if err := updateHostsFile(fmt.Sprintf("%s %s\n", "127.0.0.1", vmi.Status.MigrationState.TargetPod)); err != nil {
+		return fmt.Errorf("failed to update the hosts file: %v", err)
+	}
 	l.asyncMigrate(vmi)
 
+	return nil
+}
+
+func updateHostsFile(entry string) error {
+	file, err := os.OpenFile("/etc/hosts", os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed opening file: %s", err)
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(entry)
+	if err != nil {
+		return fmt.Errorf("failed writing to file: %s", err)
+	}
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -311,7 +311,7 @@ func (l *LibvirtDomainManager) MigrateVMI(vmi *v1.VirtualMachineInstance) error 
 	return nil
 }
 
-func updateHostsFile(entry string) error {
+var updateHostsFile = func(entry string) error {
 	file, err := os.OpenFile("/etc/hosts", os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return fmt.Errorf("failed opening file: %s", err)
@@ -364,6 +364,9 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		return fmt.Errorf("failed to update the hosts file: %v", err)
 	}
 
+	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetDirectMigrationNodePorts == nil {
+		return fmt.Errorf("No migration proxy has been created for this vmi")
+	}
 	for port, _ := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
 		// Prepare the direct migration proxy
 		if port == 0 {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -287,6 +287,7 @@ var _ = Describe("Manager", func() {
       <target bus="virtio" dev="vdd"></target>
       <driver name="qemu" type="raw" iothread="3"></driver>
       <alias name="ua-cloudinit"></alias>
+	  <readonly/>
     </disk>
   </devices>
 </domain>`

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -210,9 +210,16 @@ var _ = Describe("Manager", func() {
 
 	Context("on successful VirtualMachineInstance migrate", func() {
 		It("should prepare the target pod", func() {
-
+			updateHostsFile = func(entry string) error {
+				return nil
+			}
 			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID:                   "111222333",
+				TargetPod:                      "fakepod",
+				TargetDirectMigrationNodePorts: map[int]int{0: 33333},
+			}
 
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0)
 			err := manager.PrepareMigrationTarget(vmi, true)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Manager", func() {
 	table.DescribeTable("check migration flags",
 		func(isBlockMigration bool) {
 			flags := prepateMigrationFlags(isBlockMigration)
-			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_TUNNELLED
+			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER
 
 			if isBlockMigration {
 				expectedMigrateFlags |= libvirt.MIGRATE_NON_SHARED_INC

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -216,9 +216,8 @@ var _ = Describe("Manager", func() {
 			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				MigrationUID:                   "111222333",
-				TargetPod:                      "fakepod",
-				TargetDirectMigrationNodePorts: map[int]int{0: 33333},
+				MigrationUID: "111222333",
+				TargetPod:    "fakepod",
 			}
 
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -32,6 +32,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
@@ -254,6 +256,82 @@ var _ = Describe("Manager", func() {
 			err = manager.MigrateVMI(vmi)
 			Expect(err).To(BeNil())
 		})
+		It("should correctly collect a list of disks for migration", func() {
+			_true := true
+			var convertedDomain = `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+  <devices>
+    <disk device="disk" type="block">
+      <source dev="/dev/pvc_block_test"></source>
+      <target bus="virtio" dev="vda"></target>
+      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <alias name="ua-myvolume"></alias>
+    </disk>
+    <disk device="disk" type="file">
+      <source file="/var/run/libvirt/kubevirt-ephemeral-disk/ephemeral_pvc/disk.qcow2"></source>
+      <target bus="virtio" dev="vdb"></target>
+      <driver cache="none" name="qemu" type="qcow2" iothread="1"></driver>
+      <alias name="ua-myvolume1"></alias>
+      <backingStore type="file">
+        <format type="raw"></format>
+        <source file="/var/run/kubevirt-private/vmi-disks/ephemeral_pvc/disk.img"></source>
+      </backingStore>
+    </disk>
+    <disk device="disk" type="file">
+      <source file="/var/run/kubevirt-private/vmi-disks/myvolume/disk.img"></source>
+      <target bus="virtio" dev="vdc"></target>
+      <driver name="qemu" type="raw" iothread="2"></driver>
+      <alias name="ua-myvolumehost"></alias>
+    </disk>
+    <disk device="disk" type="file">
+      <source file="/var/run/libvirt/cloud-init-dir/mynamespace/testvmi/noCloud.iso"></source>
+      <target bus="virtio" dev="vdd"></target>
+      <driver name="qemu" type="raw" iothread="3"></driver>
+      <alias name="ua-cloudinit"></alias>
+    </disk>
+  </devices>
+</domain>`
+			vmi := newVMI(testNamespace, testVmName)
+			vmi.Spec.Volumes = []v1.Volume{
+				{
+					Name: "myvolume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "testblock",
+						},
+					},
+				},
+				{
+					Name: "myvolume1",
+					VolumeSource: v1.VolumeSource{
+						Ephemeral: &v1.EphemeralVolumeSource{
+							PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "testclaim",
+							},
+						},
+					},
+				},
+				{
+					Name: "myvolumehost",
+					VolumeSource: v1.VolumeSource{
+						HostDisk: &v1.HostDisk{
+							Path:     "/var/run/kubevirt-private/vmi-disks/volume3/disk.img",
+							Type:     v1.HostDiskExistsOrCreate,
+							Capacity: resource.MustParse("1Gi"),
+							Shared:   &_true,
+						},
+					},
+				},
+			}
+			userData := "fake\nuser\ndata\n"
+			networkData := "FakeNetwork"
+			addCloudInitDisk(vmi, userData, networkData)
+
+			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).Return(string(convertedDomain), nil)
+
+			copyDisks := getDiskTargetsForMigration(mockDomain, vmi)
+			Expect(copyDisks).Should(ConsistOf("vdb", "vdd"))
+		})
+
 	})
 
 	Context("on successful VirtualMachineInstance kill", func() {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -116,14 +116,14 @@ var _ = Describe("Migrations", func() {
 		Context("with an Alpine read only disk", func() {
 			It("should be successfully migrated multiple times with cloud-init disk", func() {
 
-				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
+				expecter, err := tests.LoggedInCirrosExpecter(vmi)
 				Expect(err).To(BeNil())
 				expecter.Close()
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -114,10 +114,10 @@ var _ = Describe("Migrations", func() {
 
 	Describe("Starting a VirtualMachineInstance ", func() {
 		Context("with an Alpine read only disk", func() {
-			It("should be successfully migrated multiple times", func() {
+			It("should be successfully migrated multiple times with cloud-init disk", func() {
 
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
-				vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.ReadOnly = true
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -551,7 +551,7 @@ var _ = Describe("Storage", func() {
 			BeforeEach(func() {
 				// Start a ISCSI POD and service
 				By("Creating a ISCSI POD")
-				iscsiTargetIP := tests.CreateISCSITargetPOD()
+				iscsiTargetIP := tests.CreateISCSITargetPOD(tests.ContainerDiskAlpine)
 				tests.CreateISCSIPvAndPvc(pvName, "1Gi", iscsiTargetIP)
 			}, 60)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2640,7 +2640,7 @@ func RemoveHostDiskImage(diskPath string, nodeName string) {
 	Eventually(getStatus, 30, 1).Should(Equal(k8sv1.PodSucceeded))
 }
 
-func CreateISCSITargetPOD() (iscsiTargetIP string) {
+func CreateISCSITargetPOD(containerDiskName ContainerDisk) (iscsiTargetIP string) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 	image := fmt.Sprintf("%s/cdi-http-import-server:%s", KubeVirtRepoPrefix, KubeVirtVersionTag)
@@ -2665,6 +2665,10 @@ func CreateISCSITargetPOD() (iscsiTargetIP string) {
 						{
 							Name:  "AS_ISCSI",
 							Value: "true",
+						},
+						{
+							Name:  "IMAGE_NAME",
+							Value: fmt.Sprintf("%s", containerDiskName),
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the need for tunneling VM migrations. It proxies all the direct connections between the source and the destination vmi pods. 
Having a direct connection between the source and the destination lets us switch to using Libvirt's virDomainMigrate3 API, which allows specifying a list of disks that are required to be copied during live migration. This will also remove the previous limitation which didn't allow us to migrate VMs with mixed (shared and non-shared) disks.


**Which issue(s) this PR fixes**
Fixes #1865 

**Special notes for your reviewer**:
Just wanted to mention a few adjustments that I had to make.

- Updating `/etc/hosts` file on the destination pod
Libvirt prevents migration between nodes with the same hostname and doesn't allow to migrate to localhost. When trying to initiate a direct migration, libvirt in the destination pods sets the pod name as a migration hostname that must be resolvable by the libvirt in the source pod. As a workaround, this PR appends the destination pod name to the /etc/hosts file to be resolved as localhost.  

 - MigrateDisks list construction
`VIR_MIGRATE_PARAM_MIGRATE_DISKS` accepts a list of disks (list of disk target names, such as /dev/vda, /dev/sdb, ...) that should be copied to the destination during the block live migration.
In order to use this method we need to filter out all the disks that shouldn't be copied, such as shared volumes, etc.. However, we don't store the disk target names anywhere. This PR contracts the disks list but comparing the domxml disk alias with the volume/disk (these are the same now) name (these should match.) 

 - Changes in the migration proxy
In addition to proxying the libvirt connection, the migration proxy will manage additional connections, via migration ports 49152 (direct connection) and 49153 (live block migration). 

**Release note**:
```release-note
Live migration direct connection will be proxied between the source and the destination pods without being tunneled via the libvirt connection.
```
