### PR TITLE
Backport restart fix

### DIFF
--- a/manifests/generated/rbac.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac.authorization.k8s.yaml.in
@@ -50,9 +50,15 @@ rules:
   resources:
   - virtualmachineinstances/console
   - virtualmachineinstances/vnc
-  - virtualmachines/restart
   verbs:
   - get
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachines/restart
+  verbs:
+  - put
+  - update
 - apiGroups:
   - kubevirt.io
   resources:
@@ -83,9 +89,15 @@ rules:
   resources:
   - virtualmachineinstances/console
   - virtualmachineinstances/vnc
-  - virtualmachines/restart
   verbs:
   - get
+- apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachines/restart
+  verbs:
+  - put
+  - update
 - apiGroups:
   - kubevirt.io
   resources:

--- a/pkg/virt-operator/creation/rbac/cluster.go
+++ b/pkg/virt-operator/creation/rbac/cluster.go
@@ -204,10 +204,20 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"virtualmachineinstances/console",
 					"virtualmachineinstances/vnc",
-					"virtualmachines/restart",
 				},
 				Verbs: []string{
 					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					"subresources.kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachines/restart",
+				},
+				Verbs: []string{
+					"put", "update",
 				},
 			},
 			{
@@ -250,10 +260,20 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"virtualmachineinstances/console",
 					"virtualmachineinstances/vnc",
-					"virtualmachines/restart",
 				},
 				Verbs: []string{
 					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					"subresources.kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachines/restart",
+				},
+				Verbs: []string{
+					"put", "update",
 				},
 			},
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes RBAC for virtctl restart
Backport of https://github.com/kubevirt/kubevirt/pull/1942/files

**Special notes for your reviewer**:
do not merge yet
/hold 

**Release note**:
```release-note
NONE
```
