### PR TITLE
HyperV: add support for new flags added in libvirt >= 4.7.0

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4388,6 +4388,14 @@
    "v1.FeatureHyperv": {
     "description": "Hyperv specific features.",
     "properties": {
+     "frequencies": {
+      "description": "Frequencies improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
+     "reenlightenment": {
+      "description": "Reenlightenment improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
      "relaxed": {
       "description": "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
@@ -4410,6 +4418,10 @@
      },
      "synictimer": {
       "description": "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
+     "tlbflush": {
+      "description": "TLBFlush improves performances in overcommited environments\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "vapic": {

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -685,6 +685,33 @@ func (in *FeatureHyperv) DeepCopyInto(out *FeatureHyperv) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.Frequencies != nil {
+		in, out := &in.Frequencies, &out.Frequencies
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.Reenlightenment != nil {
+		in, out := &in.Reenlightenment, &out.Reenlightenment
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.TLBFlush != nil {
+		in, out := &in.TLBFlush, &out.TLBFlush
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -37,15 +37,18 @@ var _ = Describe("Defaults", func() {
 			ACPI: FeatureState{},
 			APIC: &FeatureAPIC{},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{},
-				VAPIC:      &FeatureState{},
-				Spinlocks:  &FeatureSpinlocks{},
-				VPIndex:    &FeatureState{},
-				Runtime:    &FeatureState{},
-				SyNIC:      &FeatureState{},
-				SyNICTimer: &FeatureState{},
-				Reset:      &FeatureState{},
-				VendorID:   &FeatureVendorID{},
+				Relaxed:         &FeatureState{},
+				VAPIC:           &FeatureState{},
+				Spinlocks:       &FeatureSpinlocks{},
+				VPIndex:         &FeatureState{},
+				Runtime:         &FeatureState{},
+				SyNIC:           &FeatureState{},
+				SyNICTimer:      &FeatureState{},
+				Reset:           &FeatureState{},
+				VendorID:        &FeatureVendorID{},
+				Frequencies:     &FeatureState{},
+				Reenlightenment: &FeatureState{},
+				TLBFlush:        &FeatureState{},
 			},
 		}
 		SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -65,6 +68,9 @@ var _ = Describe("Defaults", func() {
 		Expect(*hyperv.SyNICTimer.Enabled).To(BeTrue())
 		Expect(*hyperv.Reset.Enabled).To(BeTrue())
 		Expect(*hyperv.VendorID.Enabled).To(BeTrue())
+		Expect(*hyperv.Frequencies.Enabled).To(BeTrue())
+		Expect(*hyperv.Reenlightenment.Enabled).To(BeTrue())
+		Expect(*hyperv.TLBFlush.Enabled).To(BeTrue())
 	})
 
 	It("should not override defined feature states", func() {
@@ -77,15 +83,18 @@ var _ = Describe("Defaults", func() {
 			ACPI: FeatureState{Enabled: _true},
 			APIC: &FeatureAPIC{Enabled: _false},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{Enabled: _true},
-				VAPIC:      &FeatureState{Enabled: _false},
-				Spinlocks:  &FeatureSpinlocks{Enabled: _true},
-				VPIndex:    &FeatureState{Enabled: _false},
-				Runtime:    &FeatureState{Enabled: _true},
-				SyNIC:      &FeatureState{Enabled: _false},
-				SyNICTimer: &FeatureState{Enabled: _true},
-				Reset:      &FeatureState{Enabled: _false},
-				VendorID:   &FeatureVendorID{Enabled: _true},
+				Relaxed:         &FeatureState{Enabled: _true},
+				VAPIC:           &FeatureState{Enabled: _false},
+				Spinlocks:       &FeatureSpinlocks{Enabled: _true},
+				VPIndex:         &FeatureState{Enabled: _false},
+				Runtime:         &FeatureState{Enabled: _true},
+				SyNIC:           &FeatureState{Enabled: _false},
+				SyNICTimer:      &FeatureState{Enabled: _true},
+				Reset:           &FeatureState{Enabled: _false},
+				VendorID:        &FeatureVendorID{Enabled: _true},
+				Frequencies:     &FeatureState{Enabled: _false},
+				Reenlightenment: &FeatureState{Enabled: _false},
+				TLBFlush:        &FeatureState{Enabled: _true},
 			},
 		}
 		SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -105,20 +114,26 @@ var _ = Describe("Defaults", func() {
 		Expect(*hyperv.SyNICTimer.Enabled).To(BeTrue())
 		Expect(*hyperv.Reset.Enabled).To(BeFalse())
 		Expect(*hyperv.VendorID.Enabled).To(BeTrue())
+		Expect(*hyperv.Frequencies.Enabled).To(BeFalse())
+		Expect(*hyperv.Reenlightenment.Enabled).To(BeFalse())
+		Expect(*hyperv.TLBFlush.Enabled).To(BeTrue())
 
 		vmi.Spec.Domain.Features = &Features{
 			ACPI: FeatureState{Enabled: _false},
 			APIC: &FeatureAPIC{Enabled: _true},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{Enabled: _false},
-				VAPIC:      &FeatureState{Enabled: _true},
-				Spinlocks:  &FeatureSpinlocks{Enabled: _false},
-				VPIndex:    &FeatureState{Enabled: _true},
-				Runtime:    &FeatureState{Enabled: _false},
-				SyNIC:      &FeatureState{Enabled: _true},
-				SyNICTimer: &FeatureState{Enabled: _false},
-				Reset:      &FeatureState{Enabled: _true},
-				VendorID:   &FeatureVendorID{Enabled: _false},
+				Relaxed:         &FeatureState{Enabled: _false},
+				VAPIC:           &FeatureState{Enabled: _true},
+				Spinlocks:       &FeatureSpinlocks{Enabled: _false},
+				VPIndex:         &FeatureState{Enabled: _true},
+				Runtime:         &FeatureState{Enabled: _false},
+				SyNIC:           &FeatureState{Enabled: _true},
+				SyNICTimer:      &FeatureState{Enabled: _false},
+				Reset:           &FeatureState{Enabled: _true},
+				VendorID:        &FeatureVendorID{Enabled: _false},
+				Frequencies:     &FeatureState{Enabled: _false},
+				Reenlightenment: &FeatureState{Enabled: _false},
+				TLBFlush:        &FeatureState{Enabled: _true},
 			},
 		}
 		SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -138,6 +153,9 @@ var _ = Describe("Defaults", func() {
 		Expect(*hyperv.SyNICTimer.Enabled).To(BeFalse())
 		Expect(*hyperv.Reset.Enabled).To(BeTrue())
 		Expect(*hyperv.VendorID.Enabled).To(BeFalse())
+		Expect(*hyperv.Frequencies.Enabled).To(BeFalse())
+		Expect(*hyperv.Reenlightenment.Enabled).To(BeFalse())
+		Expect(*hyperv.TLBFlush.Enabled).To(BeTrue())
 	})
 
 	It("should set dis defaults", func() {

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -868,6 +868,24 @@ func schema_kubevirt_pkg_api_v1_FeatureHyperv(ref common.ReferenceCallback) comm
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureVendorID"),
 						},
 					},
+					"frequencies": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Frequencies improve Hyper-V on KVM (TSC clock source) Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
+					"reenlightenment": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Reenlightenment improve Hyper-V on KVM (TSC clock source) Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
+					"tlbflush": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TLBFlush improves performances in overcommited environments Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -720,6 +720,18 @@ type FeatureHyperv struct {
 	// Defaults to the machine type setting.
 	// +optional
 	VendorID *FeatureVendorID `json:"vendorid,omitempty"`
+	// Frequencies improve Hyper-V on KVM (TSC clock source)
+	// Defaults to the machine type setting.
+	// +optional
+	Frequencies *FeatureState `json:"frequencies,omitempty"`
+	// Reenlightenment improve Hyper-V on KVM (TSC clock source)
+	// Defaults to the machine type setting.
+	// +optional
+	Reenlightenment *FeatureState `json:"reenlightenment,omitempty"`
+	// TLBFlush improves performances in overcommited environments
+	// Defaults to the machine type setting.
+	// +optional
+	TLBFlush *FeatureState `json:"tlbflush,omitempty"`
 }
 
 // WatchdogAction defines the watchdog action, if a watchdog gets triggered.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -322,16 +322,19 @@ func (FeatureVendorID) SwaggerDoc() map[string]string {
 
 func (FeatureHyperv) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":           "Hyperv specific features.",
-		"relaxed":    "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
-		"vapic":      "VAPIC indicates whether virtual APIC is enabled.\nDefaults to the machine type setting.\n+optional",
-		"spinlocks":  "Spinlocks indicates if spinlocks should be made available to the guest.\n+optional",
-		"vpindex":    "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.\nDefaults to the machine type setting.\n+optional",
-		"runtime":    "Runtime.\nDefaults to the machine type setting.\n+optional",
-		"synic":      "SyNIC enable Synthetic Interrupt Controller.\nDefaults to the machine type setting.\n+optional",
-		"synictimer": "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
-		"reset":      "Reset enables Hyperv reboot/reset for the vmi.\nDefaults to the machine type setting.\n+optional",
-		"vendorid":   "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
+		"":                "Hyperv specific features.",
+		"relaxed":         "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
+		"vapic":           "VAPIC indicates whether virtual APIC is enabled.\nDefaults to the machine type setting.\n+optional",
+		"spinlocks":       "Spinlocks indicates if spinlocks should be made available to the guest.\n+optional",
+		"vpindex":         "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.\nDefaults to the machine type setting.\n+optional",
+		"runtime":         "Runtime.\nDefaults to the machine type setting.\n+optional",
+		"synic":           "SyNIC enable Synthetic Interrupt Controller.\nDefaults to the machine type setting.\n+optional",
+		"synictimer":      "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
+		"reset":           "Reset enables Hyperv reboot/reset for the vmi.\nDefaults to the machine type setting.\n+optional",
+		"vendorid":        "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
+		"frequencies":     "Frequencies improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+		"reenlightenment": "Reenlightenment improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+		"tlbflush":        "TLBFlush improves performances in overcommited environments\nDefaults to the machine type setting.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -337,10 +337,10 @@ var _ = Describe("Schema", func() {
 			UUID: "28a42a60-44ef-4428-9c10-1a6aee94627f",
 		}
 		exampleVMI.Spec.Domain.CPU = &CPU{
-			Cores:                 3,
-			Sockets:               1,
-			Threads:               1,
-			Model:                 "Conroe",
+			Cores:   3,
+			Sockets: 1,
+			Threads: 1,
+			Model:   "Conroe",
 			DedicatedCPUPlacement: true,
 		}
 		exampleVMI.Spec.Networks = []Network{

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -337,10 +337,10 @@ var _ = Describe("Schema", func() {
 			UUID: "28a42a60-44ef-4428-9c10-1a6aee94627f",
 		}
 		exampleVMI.Spec.Domain.CPU = &CPU{
-			Cores:   3,
-			Sockets: 1,
-			Threads: 1,
-			Model:   "Conroe",
+			Cores:                 3,
+			Sockets:               1,
+			Threads:               1,
+			Model:                 "Conroe",
 			DedicatedCPUPlacement: true,
 		}
 		exampleVMI.Spec.Networks = []Network{

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -118,6 +118,15 @@ var exampleJSON = `{
           "vendorid": {
             "enabled": true,
             "vendorid": "vendor"
+          },
+          "frequencies": {
+            "enabled": false
+          },
+          "reenlightenment": {
+            "enabled": false
+          },
+          "tlbflush": {
+            "enabled": true
           }
         }
       },
@@ -298,15 +307,18 @@ var _ = Describe("Schema", func() {
 			ACPI: FeatureState{Enabled: _false},
 			APIC: &FeatureAPIC{Enabled: _true},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{Enabled: _true},
-				VAPIC:      &FeatureState{Enabled: _false},
-				Spinlocks:  &FeatureSpinlocks{Enabled: _true},
-				VPIndex:    &FeatureState{Enabled: _false},
-				Runtime:    &FeatureState{Enabled: _true},
-				SyNIC:      &FeatureState{Enabled: _false},
-				SyNICTimer: &FeatureState{Enabled: _true},
-				Reset:      &FeatureState{Enabled: _false},
-				VendorID:   &FeatureVendorID{Enabled: _true, VendorID: "vendor"},
+				Relaxed:         &FeatureState{Enabled: _true},
+				VAPIC:           &FeatureState{Enabled: _false},
+				Spinlocks:       &FeatureSpinlocks{Enabled: _true},
+				VPIndex:         &FeatureState{Enabled: _false},
+				Runtime:         &FeatureState{Enabled: _true},
+				SyNIC:           &FeatureState{Enabled: _false},
+				SyNICTimer:      &FeatureState{Enabled: _true},
+				Reset:           &FeatureState{Enabled: _false},
+				VendorID:        &FeatureVendorID{Enabled: _true, VendorID: "vendor"},
+				Frequencies:     &FeatureState{Enabled: _false},
+				Reenlightenment: &FeatureState{Enabled: _false},
+				TLBFlush:        &FeatureState{Enabled: _true},
 			},
 		}
 		exampleVMI.Spec.Domain.Clock = &Clock{

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -104,6 +104,15 @@ func SetObjectDefaults_VirtualMachine(in *VirtualMachine) {
 				if in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID != nil {
 					SetDefaults_FeatureVendorID(in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID)
 				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+				}
 			}
 		}
 		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {
@@ -181,6 +190,15 @@ func SetObjectDefaults_VirtualMachineInstance(in *VirtualMachineInstance) {
 			}
 			if in.Spec.Domain.Features.Hyperv.VendorID != nil {
 				SetDefaults_FeatureVendorID(in.Spec.Domain.Features.Hyperv.VendorID)
+			}
+			if in.Spec.Domain.Features.Hyperv.Frequencies != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Frequencies)
+			}
+			if in.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Reenlightenment)
+			}
+			if in.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.TLBFlush)
 			}
 		}
 	}
@@ -266,6 +284,15 @@ func SetObjectDefaults_VirtualMachineInstancePreset(in *VirtualMachineInstancePr
 				if in.Spec.Domain.Features.Hyperv.VendorID != nil {
 					SetDefaults_FeatureVendorID(in.Spec.Domain.Features.Hyperv.VendorID)
 				}
+				if in.Spec.Domain.Features.Hyperv.Frequencies != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Frequencies)
+				}
+				if in.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Reenlightenment)
+				}
+				if in.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.TLBFlush)
+				}
 			}
 		}
 		for i := range in.Spec.Domain.Devices.Disks {
@@ -350,6 +377,15 @@ func SetObjectDefaults_VirtualMachineInstanceReplicaSet(in *VirtualMachineInstan
 				}
 				if in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID != nil {
 					SetDefaults_FeatureVendorID(in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
 				}
 			}
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -1148,7 +1148,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		if hyField, enabled := hyperVL2FlagEnabled(field, spec.Domain.Features.Hyperv); enabled && !virtconfig.HyperVL2Enabled() {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("SRIOV feature gate is not enabled in kubevirt-config"),
+				Message: fmt.Sprintf("HyperVL2 feature gate is not enabled in kubevirt-config"),
 				Field:   hyField,
 			})
 		}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -35,6 +35,7 @@ const (
 	liveMigrationGate    = "LiveMigration"
 	SRIOVGate            = "SRIOV"
 	CPUNodeDiscoveryGate = "CPUNodeDiscovery"
+	HyperVL2Gate         = "HyperVL2"
 )
 
 func DataVolumesEnabled() bool {
@@ -51,4 +52,8 @@ func LiveMigrationEnabled() bool {
 
 func SRIOVEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
+}
+
+func HyperVL2Enabled() bool {
+	return strings.Contains(os.Getenv(featureGateEnvVar), HyperVL2Gate)
 }

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -501,6 +501,9 @@ func Convert_v1_FeatureHyperv_To_api_FeatureHyperv(source *v1.FeatureHyperv, hyp
 	hyperv.SyNICTimer = convertFeatureState(source.SyNICTimer)
 	hyperv.VAPIC = convertFeatureState(source.VAPIC)
 	hyperv.VPIndex = convertFeatureState(source.VPIndex)
+	hyperv.Frequencies = convertFeatureState(source.Frequencies)
+	hyperv.Reenlightenment = convertFeatureState(source.Reenlightenment)
+	hyperv.TLBFlush = convertFeatureState(source.TLBFlush)
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -137,15 +137,18 @@ var _ = Describe("Converter", func() {
 			vmi.Spec.Domain.Features = &v1.Features{
 				APIC: &v1.FeatureAPIC{},
 				Hyperv: &v1.FeatureHyperv{
-					Relaxed:    &v1.FeatureState{Enabled: &_false},
-					VAPIC:      &v1.FeatureState{Enabled: &_true},
-					Spinlocks:  &v1.FeatureSpinlocks{Enabled: &_true},
-					VPIndex:    &v1.FeatureState{Enabled: &_true},
-					Runtime:    &v1.FeatureState{Enabled: &_false},
-					SyNIC:      &v1.FeatureState{Enabled: &_true},
-					SyNICTimer: &v1.FeatureState{Enabled: &_false},
-					Reset:      &v1.FeatureState{Enabled: &_true},
-					VendorID:   &v1.FeatureVendorID{Enabled: &_false, VendorID: "myvendor"},
+					Relaxed:         &v1.FeatureState{Enabled: &_false},
+					VAPIC:           &v1.FeatureState{Enabled: &_true},
+					Spinlocks:       &v1.FeatureSpinlocks{Enabled: &_true},
+					VPIndex:         &v1.FeatureState{Enabled: &_true},
+					Runtime:         &v1.FeatureState{Enabled: &_false},
+					SyNIC:           &v1.FeatureState{Enabled: &_true},
+					SyNICTimer:      &v1.FeatureState{Enabled: &_false},
+					Reset:           &v1.FeatureState{Enabled: &_true},
+					VendorID:        &v1.FeatureVendorID{Enabled: &_false, VendorID: "myvendor"},
+					Frequencies:     &v1.FeatureState{Enabled: &_false},
+					Reenlightenment: &v1.FeatureState{Enabled: &_false},
+					TLBFlush:        &v1.FeatureState{Enabled: &_true},
 				},
 			}
 			vmi.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
@@ -502,6 +505,9 @@ var _ = Describe("Converter", func() {
       <stimer state="off"></stimer>
       <reset state="on"></reset>
       <vendor_id state="off" value="myvendor"></vendor_id>
+      <frequencies state="off"></frequencies>
+      <reenlightenment state="off"></reenlightenment>
+      <tlbflush state="on"></tlbflush>
     </hyperv>
   </features>
   <cpu mode="host-model">

--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -1284,6 +1284,33 @@ func (in *FeatureHyperv) DeepCopyInto(out *FeatureHyperv) {
 			**out = **in
 		}
 	}
+	if in.Frequencies != nil {
+		in, out := &in.Frequencies, &out.Frequencies
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
+	if in.Reenlightenment != nil {
+		in, out := &in.Reenlightenment, &out.Reenlightenment
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
+	if in.TLBFlush != nil {
+		in, out := &in.TLBFlush, &out.TLBFlush
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -180,15 +180,18 @@ type Features struct {
 }
 
 type FeatureHyperv struct {
-	Relaxed    *FeatureState     `xml:"relaxed,omitempty"`
-	VAPIC      *FeatureState     `xml:"vapic,omitempty"`
-	Spinlocks  *FeatureSpinlocks `xml:"spinlocks,omitempty"`
-	VPIndex    *FeatureState     `xml:"vpindex,omitempty"`
-	Runtime    *FeatureState     `xml:"runtime,omitempty"`
-	SyNIC      *FeatureState     `xml:"synic,omitempty"`
-	SyNICTimer *FeatureState     `xml:"stimer,omitempty"`
-	Reset      *FeatureState     `xml:"reset,omitempty"`
-	VendorID   *FeatureVendorID  `xml:"vendor_id,omitempty"`
+	Relaxed         *FeatureState     `xml:"relaxed,omitempty"`
+	VAPIC           *FeatureState     `xml:"vapic,omitempty"`
+	Spinlocks       *FeatureSpinlocks `xml:"spinlocks,omitempty"`
+	VPIndex         *FeatureState     `xml:"vpindex,omitempty"`
+	Runtime         *FeatureState     `xml:"runtime,omitempty"`
+	SyNIC           *FeatureState     `xml:"synic,omitempty"`
+	SyNICTimer      *FeatureState     `xml:"stimer,omitempty"`
+	Reset           *FeatureState     `xml:"reset,omitempty"`
+	VendorID        *FeatureVendorID  `xml:"vendor_id,omitempty"`
+	Frequencies     *FeatureState     `xml:"frequencies,omitempty"`
+	Reenlightenment *FeatureState     `xml:"reenlightenment,omitempty"`
+	TLBFlush        *FeatureState     `xml:"tlbflush,omitempty"`
 }
 
 type FeatureSpinlocks struct {


### PR DESCRIPTION
WIP
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds support for the last HyperV highlightenments
added in libvirt 4.7.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/1919

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
add support for HyperV enlightenments added in libvirt >= 4.7.0
```
