### PR TITLE
This change will add the support of annotations

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -762,8 +762,14 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	hostName := dns.SanitizeHostname(vmi)
 
+	vmiAnnotations := vmi.ObjectMeta.Annotations
+
 	annotationsList := map[string]string{
 		v1.DomainAnnotation: domain,
+	}
+
+	for key, value := range vmiAnnotations {
+		annotationsList[key] = value
 	}
 
 	cniNetworks, cniAnnotation := getCniInterfaceList(vmi)

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -233,6 +233,23 @@ var _ = Describe("Config", func() {
 
 	})
 
+	Context("With a Annotation List defined", func() {
+
+		testAnnotationList := map[string]string{
+			"key1": "value1",
+		}
+
+		It("Should be the annotation list the same for a pod and vmi", func() {
+			By("Running VMI")
+			vmi := tests.NewRandomVMIWithAnnotations(testAnnotationList)
+			tests.RunVMIAndExpectLaunch(vmi, false, 90)
+
+			By("Checking if Annotation has been attached to the pod")
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			Expect(vmiPod.ObjectMeta.Annotations["key1"]).To(Equal(testAnnotationList["key1"]))
+		})
+	})
+
 	Context("With a ServiceAccount defined", func() {
 
 		virtClient, err := kubecli.GetKubevirtClient()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1754,6 +1754,16 @@ func AddServiceAccountDisk(vmi *v1.VirtualMachineInstance, serviceAccountName st
 	})
 }
 
+func NewRandomVMIWithAnnotations(annotationList map[string]string) *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithPVC(DiskAlpineHostPath)
+	AddAnnotation(vmi, annotationList)
+	return vmi
+}
+
+func AddAnnotation(vmi *v1.VirtualMachineInstance, annotationList map[string]string) {
+	vmi.ObjectMeta.Annotations = annotationList
+}
+
 func NewRandomVMIWithSlirpInterfaceEphemeralDiskAndUserdata(containerImage string, userData string, Ports []v1.Port) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(containerImage, userData)
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", Ports: Ports, InterfaceBindingMethod: v1.InterfaceBindingMethod{Slirp: &v1.InterfaceSlirp{}}}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Custom Annotations defined in the VMI should be copied to the Pod definition

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This PR adds support for defining Annotations in the VMI which are copied to the Pod definition
```
