### PR TITLE
Fix virtio-win functional test

### DIFF
--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -189,9 +189,10 @@ var _ = Describe("ContainerDisk", func() {
 
 				_, err = expecter.ExpectBatch([]expect.Batcher{
 					// mount virtio cdrom and check files are there
-					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom /mnt\n"},
+					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: "0"},
+					&expect.BSnd{S: "cd /media/cdrom\n"},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: "0"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The virtio-win functional test needs this change in order to pass. This is one of the tests that prevents our CI lanes from passing. 


**Release note**:

```release-note
NONE
```
