### PR TITLE
Upload images only after endpoint is marked ready

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -276,7 +276,22 @@ func waitUploadPodRunning(client kubernetes.Interface, namespace, name string, i
 
 		podPhase, _ := pvc.Annotations[PodPhaseAnnotation]
 
-		done := (podPhase == string(v1.PodRunning)) && (len(endpoints.Subsets) > 0)
+		done := false
+		availableEndpoint := false
+		for _, subset := range endpoints.Subsets {
+			if len(subset.Addresses) > 0 {
+				// we're looking to make sure the service endpoint has
+				// the upload pod marked as being available, which means
+				// that it is ready to accept connections
+				availableEndpoint = true
+				break
+			}
+		}
+		running := (podPhase == string(v1.PodRunning))
+
+		if running && availableEndpoint {
+			done = true
+		}
 
 		if !done && !loggedStatus {
 			fmt.Printf("Waiting for PVC %s upload pod to be running...\n", name)

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -124,7 +124,13 @@ var _ = Describe("ImageUpload", func() {
 				Namespace: pvcNamespace,
 			},
 			Subsets: []v1.EndpointSubset{
-				{},
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP: "10.10.10.10",
+						},
+					},
+				},
 			},
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

A pod can be "Running" but not marked as "Ready".  virtctl needs to wait until the upload service has detected an endpoint is available before proceeding with the upload. Waiting for the pod's phase to be Running isn't enough.

This is half of a fix for flaky upload behavior. The other half needs to be fixed by CDI. For us to benefit from virtctl waiting for the "Ready" condition, cdi needs to add a tcp readiness probe to the uploadserver pod. I've filled that bug with CDI here, https://github.com/kubevirt/containerized-data-importer/issues/621

**Release note**:
```release-note
NONE
```
