### PR TITLE
Add test attributes to network-policy test and network capabilities requirements.

### DIFF
--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Expose", func() {
 	tests.PanicOnError(err)
 	const testPort = 1500
 
-	Context("Expose service on a VM", func() {
+	Context("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose service on a VM", func() {
 		var tcpVM *v1.VirtualMachineInstance
 		tests.BeforeAll(func() {
 			tcpVM = newLabeledVM("vm", virtClient)
@@ -67,7 +67,7 @@ var _ = Describe("Expose", func() {
 		Context("Expose ClusterIP service", func() {
 			const servicePort = "27017"
 			const serviceName = "cluster-ip-vmi"
-			It("Should expose a Cluster IP service on a VMI and connect to it", func() {
+			It("[test_id:1531]Should expose a Cluster IP service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
@@ -97,7 +97,7 @@ var _ = Describe("Expose", func() {
 		Context("Expose ClusterIP service with string target-port", func() {
 			const servicePort = "27017"
 			const serviceName = "cluster-ip-target-vmi"
-			It("Should expose a ClusterIP service and connect to the vm on port 80", func() {
+			It("[test_id:1532]Should expose a ClusterIP service and connect to the vm on port 80", func() {
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", "http")
 				err := virtctl()
@@ -122,7 +122,7 @@ var _ = Describe("Expose", func() {
 
 		Context("Expose ClusterIP service wiht ports on the vmi defined", func() {
 			const serviceName = "cluster-ip-target-multiple-ports-vmi"
-			It("Should expose a ClusterIP service and connect to all ports defined on the vmi", func() {
+			It("[test_id:1533]Should expose a ClusterIP service and connect to all ports defined on the vmi", func() {
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--name", serviceName)
 				err := virtctl()
@@ -150,7 +150,7 @@ var _ = Describe("Expose", func() {
 			const servicePort = "27017"
 			const serviceName = "node-port-vmi"
 
-			It("Should expose a NodePort service on a VMI and connect to it", func() {
+			It("[test_id:1534]Should expose a NodePort service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
@@ -200,7 +200,7 @@ var _ = Describe("Expose", func() {
 			const servicePort = "28017"
 			const serviceName = "cluster-ip-udp-vmi"
 
-			It("Should expose a ClusterIP service on a VMI and connect to it", func() {
+			It("[test_id:1535]Should expose a ClusterIP service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					udpVM.Namespace, udpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
@@ -232,7 +232,7 @@ var _ = Describe("Expose", func() {
 			const servicePort = "29017"
 			const serviceName = "node-port-udp-vmi"
 
-			It("Should expose a NodePort service on a VMI and connect to it", func() {
+			It("[test_id:1536]Should expose a NodePort service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					udpVM.Namespace, udpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
@@ -297,7 +297,7 @@ var _ = Describe("Expose", func() {
 				return int(rs.Status.ReadyReplicas)
 			}, 120*time.Second, 1*time.Second).Should(Equal(numberOfVMs))
 
-			By("add an 'hello world' server on each VMI in the replica set")
+			By("Add an 'hello world' server on each VMI in the replica set")
 			// TODO: add label to list options
 			// check size of list
 			// remove check for owner
@@ -314,7 +314,7 @@ var _ = Describe("Expose", func() {
 			const servicePort = "27017"
 			const serviceName = "cluster-ip-vmirs"
 
-			It("Should create a ClusterIP service on VMRS and connect to it", func() {
+			It("[test_id:1537]Should create a ClusterIP service on VMRS and connect to it", func() {
 				By("Expose a service on the VMRS using virtctl")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", "--namespace",
 					vmrs.Namespace, vmrs.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
@@ -387,7 +387,7 @@ var _ = Describe("Expose", func() {
 		})
 
 		Context("Expose ClusterIP service", func() {
-			It("Connect to ClusterIP services that was set when VM was offline", func() {
+			It("[test_id:1538]Connect to ClusterIP services that was set when VM was offline", func() {
 				By("Getting back the cluster IP given for the service")
 				svc, err := virtClient.CoreV1().Services(vm.Namespace).Get(serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Networking", func() {
 		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
 	}
 
-	Describe("Multiple virtual machines connectivity", func() {
+	Describe("[rfe_id:150][crit:medium][vendor:cnv-qe@redhat.com][level:component]Multiple virtual machines connectivity", func() {
 		tests.BeforeAll(func() {
 			tests.BeforeTestCleanup()
 
@@ -229,10 +229,10 @@ var _ = Describe("Networking", func() {
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
-			table.Entry("the Inbound VirtualMachineInstance", "InboundVMI"),
-			table.Entry("the Inbound VirtualMachineInstance with pod network connectivity explicitly set", "InboundVMIWithPodNetworkSet"),
-			table.Entry("the Inbound VirtualMachineInstance with custom MAC address", "InboundVMIWithCustomMacAddress"),
-			table.Entry("the internet", "Internet"),
+			table.Entry("[test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
+			table.Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", "InboundVMIWithPodNetworkSet"),
+			table.Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", "InboundVMIWithCustomMacAddress"),
+			table.Entry("[test_id:1542]the internet", "Internet"),
 		)
 
 		table.DescribeTable("should be reachable via the propagated IP from a Pod", func(op v12.NodeSelectorOperator, hostNetwork bool) {
@@ -269,10 +269,10 @@ var _ = Describe("Networking", func() {
 			phase := waitForPodToFinish(job)
 			Expect(phase).To(Equal(v12.PodSucceeded))
 		},
-			table.Entry("on the same node from Pod", v12.NodeSelectorOpIn, false),
-			table.Entry("on a different node from Pod", v12.NodeSelectorOpNotIn, false),
-			table.Entry("on the same node from Node", v12.NodeSelectorOpIn, true),
-			table.Entry("on a different node from Node", v12.NodeSelectorOpNotIn, true),
+			table.Entry("[test_id:1543]on the same node from Pod", v12.NodeSelectorOpIn, false),
+			table.Entry("[test_id:1544]on a different node from Pod", v12.NodeSelectorOpNotIn, false),
+			table.Entry("[test_id:1545]on the same node from Node", v12.NodeSelectorOpIn, true),
+			table.Entry("[test_id:1546]on a different node from Node", v12.NodeSelectorOpNotIn, true),
 		)
 
 		Context("with a service matching the vmi exposed", func() {
@@ -295,7 +295,7 @@ var _ = Describe("Networking", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 			})
-			It(" should be able to reach the vmi based on labels specified on the vmi", func() {
+			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", func() {
 
 				By("starting a pod which tries to reach the vmi via the defined service")
 				job := tests.NewHelloWorldJob(fmt.Sprintf("%s.%s", "myservice", inboundVMI.Namespace), strconv.Itoa(testPort))
@@ -306,7 +306,7 @@ var _ = Describe("Networking", func() {
 				phase := waitForPodToFinish(job)
 				Expect(phase).To(Equal(v12.PodSucceeded))
 			})
-			It("should fail to reach the vmi if an invalid servicename is used", func() {
+			It("[test_id:1548]should fail to reach the vmi if an invalid servicename is used", func() {
 
 				By("starting a pod which tries to reach the vmi via a non-existent service")
 				job := tests.NewHelloWorldJob(fmt.Sprintf("%s.%s", "wrongservice", inboundVMI.Namespace), strconv.Itoa(testPort))
@@ -345,7 +345,7 @@ var _ = Describe("Networking", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("should be able to reach the vmi via its unique fully qualified domain name", func() {
+			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", func() {
 				By("starting a pod which tries to reach the vm via the defined service")
 				job := tests.NewHelloWorldJob(fmt.Sprintf("%s.%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain, inboundVMI.Namespace), strconv.Itoa(testPort))
 				job, err = virtClient.CoreV1().Pods(inboundVMI.Namespace).Create(job)
@@ -361,9 +361,9 @@ var _ = Describe("Networking", func() {
 			})
 		})
 
-		Context("VirtualMachineInstance with default interface model", func() {
+		Context("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with default interface model", func() {
 			// Unless an explicit interface model is specified, the default interface model is virtio.
-			It("should expose the right device type to the guest", func() {
+			It("[test_id:1550]should expose the right device type to the guest", func() {
 				By("checking the device vendor in /sys/class")
 
 				// Taken from https://wiki.osdev.org/Virtio#Technical_Details
@@ -375,7 +375,7 @@ var _ = Describe("Networking", func() {
 				}
 			})
 
-			It("should reject the creation of virtual machine with unsupported interface model", func() {
+			It("[test_id:1551]should reject the creation of virtual machine with unsupported interface model", func() {
 				// Create a virtual machine with an unsupported interface model
 				customIfVMI := NewRandomVMIWithInvalidNetworkInterface()
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(customIfVMI)


### PR DESCRIPTION
Add test attributes to:
- VM-pods network-policy test cases.
- Basic network capabilities test cases.
