### PR TITLE
remove cdi object's finalizer so cleanup.sh doesn't block

### DIFF
--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -36,6 +36,7 @@ set +e
     _kubectl -n ${namespace} delete kv kubevirt
 )
 _kubectl -n ${namespace} patch kv kubevirt --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
+_kubectl patch cdi cdi --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
 
 set -e
 


### PR DESCRIPTION
**What this PR does / why we need it**:

'make cluster-clean' blocks because it can't delete the cdi operators CRD. This is due to a finalizer.  We have to account for the same thing with our kubevirt operator's CRD. 

```release-note
NONE
```
