### PR TITLE
Fixing bug where image with an invalid format or with a backing_file still being converted to raw

### DIFF
--- a/cmd/container-disk-v1alpha/entry-point.sh
+++ b/cmd/container-disk-v1alpha/entry-point.sh
@@ -52,18 +52,22 @@ if [ $? -ne 0 ]; then
     fi
 
     IFS=","
-    echo $output | while read -r LINE; do
-    #it is not a valid image if its format is not qcow2.
-    if [ `echo $LINE | awk '$1 == "\"format\":" {print $1 }'` ]  && [ `echo $LINE | awk '$2 != "\"qcow2\"" {print $2 }'` ] ; then
-        echo "Invalid format for image $IMAGE_PATH"
-        exit 1
-    fi
-    #it is not a valid image if it has backing-filename
-    if [ `echo $LINE | awk '$1 == "\"backing-filename\":" {print $1 }'` ]; then
-        echo "Image $IMAGE_PATH is invalid because it has a backing file"
-        exit 1
-    fi
+    echo $output | while read -r LINE;
+    do
+        #it is not a valid image if its format is not qcow2.
+        if [ `echo $LINE | awk '$1 == "\"format\":" {print $1 }'` ]  && [ `echo $LINE | awk '$2 != "\"qcow2\"" {print $2 }'` ] && [ `echo $LINE | awk '$2 != "\"raw\"" {print $2 }'` ] ; then
+            echo "Invalid format for image $IMAGE_PATH"
+            exit 1
+        fi
+        #it is not a valid image if it has backing-filename
+        if [ `echo $LINE | awk '$1 == "\"backing-filename\":" {print $1 }'` ]; then
+            echo "Image $IMAGE_PATH is invalid because it has a backing file"
+            exit 1
+        fi
     done
+    if [ $? -eq 1 ]; then
+        exit 1
+    fi
 
 	IMAGE_EXTENSION="raw"
 	/usr/bin/qemu-img convert $IMAGE_PATH ${COPY_PATH}.${IMAGE_EXTENSION}


### PR DESCRIPTION
Signed-off-by: tavni <tavni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Current code has a bug where we check if the image file has an invalid format or includes backing_file and still do not exist from the script, resulting in image still being converted to raw.
This PR fixes that. 

**Which issue(s) this PR fixes** :
Fixes #1318 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
