### PR TITLE
Bug fix on: virtctl image-upload fails when a trailing slash is added to the upload proxy URL

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -25,6 +25,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -51,7 +53,8 @@ const (
 
 	uploadPodWaitInterval = 2 * time.Second
 
-	uploadProxyURI = "/v1alpha1/upload"
+	//UploadProxyURI is a URI of the upoad proxy
+	UploadProxyURI = "/v1alpha1/upload"
 )
 
 var (
@@ -202,8 +205,27 @@ func getHTTPClient(insecure bool) *http.Client {
 	return client
 }
 
+//ConstructUploadProxyPath - receives uploadproxy adress and concatenates to it URI
+func ConstructUploadProxyPath(uploadProxyURL string) (string, error) {
+	u, err := url.Parse(uploadProxyURL)
+
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.Contains(uploadProxyURL, UploadProxyURI) {
+		u.Path = path.Join(u.Path, UploadProxyURI)
+	}
+
+	return u.String(), nil
+}
+
 func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) error {
-	url := uploadProxyURL + uploadProxyURI
+
+	url, err := ConstructUploadProxyPath(uploadProxyURL)
+	if err != nil {
+		return err
+	}
 
 	fi, err := file.Stat()
 	if err != nil {


### PR DESCRIPTION
 virtctl image-upload fails when a trailing slash is added to the upload proxy URL

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bug fix on: virtctl image-upload fails when a trailing slash is added to the upload proxy URL
```
