### PR TITLE
[backport] Don't crash on invalid DataVolume URL

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -397,6 +397,9 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 				if deleteAfterTimestamp == 0 {
 					dataVolumeCopy := curDataVolume.DeepCopy()
 					deleteAfterTimestamp := now + int64(rand.Intn(dataVolumeDeleteJitterSeconds)+10)
+					if dataVolumeCopy.Annotations == nil {
+						dataVolumeCopy.Annotations = map[string]string{}
+					}
 					dataVolumeCopy.Annotations[dataVolumeDeleteAfterTimestampAnno] = strconv.FormatInt(deleteAfterTimestamp, 10)
 					_, err := c.clientset.CdiClient().CdiV1alpha1().DataVolumes(dataVolumeCopy.Namespace).Update(dataVolumeCopy)
 					if err != nil {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -280,6 +280,60 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
 		})
 
+		It("should handle failed DataVolume without Annotations", func() {
+			vm, _ := DefaultVirtualMachine(true)
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv1",
+					},
+				},
+			})
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv2",
+					},
+				},
+			})
+
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dv1",
+				},
+			})
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dv2",
+				},
+			})
+			addVirtualMachine(vm)
+
+			existingDataVolume1 := createDataVolumeManifest(&vm.Spec.DataVolumeTemplates[0], vm)
+			existingDataVolume1.Namespace = "default"
+			existingDataVolume1.Status.Phase = cdiv1.Failed
+			// explicitly delete the annotations field
+			existingDataVolume1.Annotations = nil
+
+			existingDataVolume2 := createDataVolumeManifest(&vm.Spec.DataVolumeTemplates[1], vm)
+			existingDataVolume2.Namespace = "default"
+			existingDataVolume2.Status.Phase = cdiv1.Succeeded
+			existingDataVolume2.Annotations = nil
+
+			dataVolumeFeeder.Add(existingDataVolume1)
+			dataVolumeFeeder.Add(existingDataVolume2)
+
+			shouldExpectDataVolumeUpdate(vm.UID, existingDataVolume1.Name)
+
+			vmInterface.EXPECT().Update(gomock.Any()).Times(1).Return(vm, nil)
+
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
+		})
+
 		It("should only start VMI once DataVolumes are complete", func() {
 
 			vm, vmi := DefaultVirtualMachine(true)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -34,6 +34,8 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
+const InvalidDataVolumeUrl = "http://127.0.0.1/invalid"
+
 var _ = Describe("DataVolume Integration", func() {
 	flag.Parse()
 
@@ -98,6 +100,35 @@ var _ = Describe("DataVolume Integration", func() {
 				}
 				err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Delete(dataVolume.Name, &metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Describe("Starting a VirtualMachine with an invalid DataVolume", func() {
+		Context("using DataVolume with invalid URL", func() {
+			It("should correctly handle invalid DataVolumes", func() {
+				// Don't actually create the DataVolume since it's invalid.
+				dataVolume := tests.NewRandomDataVolumeWithHttpImport(InvalidDataVolumeUrl, tests.NamespaceTestDefault)
+				//  Add the invalid DataVolume to a VMI
+				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+				// Create a VM for this VMI
+				vm := tests.NewRandomVirtualMachine(vmi, true)
+
+				By("Creating a VM with an invalid DataVolume")
+				_, err := virtClient.VirtualMachine(vm.Namespace).Create(vm)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for VMI to be created")
+				Eventually(func() v1.VirtualMachineInstancePhase {
+					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vm.GetName(), &metav1.GetOptions{})
+					if err != nil {
+						Expect(err.Error()).To(ContainSubstring("not found"),
+							"A 404 while VMI is being created would be normal. All other errors are unexpected")
+						return v1.VmPhaseUnset
+					}
+					return vmi.Status.Phase
+
+				}, 100*time.Second, 5*time.Second).Should(Equal(v1.Pending), "VMI with invalid DataVolume should not be scheduled")
 			})
 		})
 	})


### PR DESCRIPTION
This is a backport of #1996 to the Release 0.13 branch

**Release note**:
```release-note
NONE
```
