### PR TITLE
Fixed "make publish-cache" by ensuring that images were built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ docker: build
 push: docker
 	hack/build-docker.sh push ${WHAT}
 
-push-cache:
+push-cache: docker verify-build
 	hack/build-docker.sh push-cache ${WHAT}
 
 pull-cache:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed "make publish-cache" by ensuring that images were built

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://travis-ci.org/kubevirt/kubevirt/builds/488705235

**Release note**:
```release-note
NONE
```
