### PR TITLE
Fix logic around failed DataVolume retry

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -396,7 +396,7 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 
 				if deleteAfterTimestamp == 0 {
 					dataVolumeCopy := curDataVolume.DeepCopy()
-					deleteAfterTimestamp := now + int64(rand.Intn(dataVolumeDeleteJitterSeconds)+10)
+					deleteAfterTimestamp = now + int64(rand.Intn(dataVolumeDeleteJitterSeconds)+10)
 					if dataVolumeCopy.Annotations == nil {
 						dataVolumeCopy.Annotations = map[string]string{}
 					}
@@ -408,7 +408,7 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 				}
 
 				if curDataVolume.DeletionTimestamp == nil {
-					if deleteAfterTimestamp >= now {
+					if now >= deleteAfterTimestamp {
 						// By deleting the failed DataVolume,
 						// a new DataVolume will be created to take it's place.
 						c.dataVolumeExpectations.ExpectDeletions(vmKey, []string{controller.DataVolumeKey(curDataVolume)})
@@ -418,7 +418,7 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 							return ready, err
 						}
 					} else {
-						timeLeft := now - deleteAfterTimestamp
+						timeLeft := deleteAfterTimestamp - now
 						c.Queue.AddAfter(vmKey, time.Duration(timeLeft)*time.Second)
 					}
 				}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -175,6 +175,61 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		})
 
+		It("should not failed DataVolume for VirtualMachineInstance until after timeout", func() {
+			vm, _ := DefaultVirtualMachine(true)
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv1",
+					},
+				},
+			})
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv2",
+					},
+				},
+			})
+
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dv1",
+				},
+			})
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dv2",
+				},
+			})
+			addVirtualMachine(vm)
+
+			existingDataVolume1 := createDataVolumeManifest(&vm.Spec.DataVolumeTemplates[0], vm)
+			existingDataVolume1.Namespace = "default"
+			existingDataVolume1.Status.Phase = cdiv1.Failed
+
+			// set the delete after timestamp way into the future
+			existingDataVolume1.Annotations[dataVolumeDeleteAfterTimestampAnno] = strconv.FormatInt(time.Now().UTC().Unix()+60, 10)
+
+			existingDataVolume2 := createDataVolumeManifest(&vm.Spec.DataVolumeTemplates[1], vm)
+			existingDataVolume2.Namespace = "default"
+			existingDataVolume2.Status.Phase = cdiv1.Succeeded
+
+			dataVolumeFeeder.Add(existingDataVolume1)
+			dataVolumeFeeder.Add(existingDataVolume2)
+
+			deletionCount := 0
+
+			vmInterface.EXPECT().Update(gomock.Any()).Times(1).Return(vm, nil)
+
+			controller.Execute()
+
+			Expect(deletionCount).To(Equal(0))
+			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
+		})
+
 		It("should delete failed DataVolume for VirtualMachineInstance", func() {
 			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -175,7 +175,7 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
 		})
 
-		It("should not failed DataVolume for VirtualMachineInstance until after timeout", func() {
+		It("should not delete failed DataVolume for VirtualMachineInstance until after timeout", func() {
 			vm, _ := DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
 				Name: "test1",

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -120,7 +120,7 @@ var _ = Describe("DataVolume Integration", func() {
 
 				By("Waiting for VMI to be created")
 				Eventually(func() v1.VirtualMachineInstancePhase {
-					vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vm.GetName(), &metav1.GetOptions{})
+					vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.GetName(), &metav1.GetOptions{})
 					if err != nil {
 						Expect(err.Error()).To(ContainSubstring("not found"),
 							"A 404 while VMI is being created would be normal. All other errors are unexpected")


### PR DESCRIPTION

**What this PR does / why we need it**:

When DataVolume import fails, our VM controller is not properly retrying after a randomized time.

This partially fixes #1858. However, there are more issues to investigate on the CDI side to understand why we're consistently having so many DataVolume import failures. 

**Which issue(s) this PR fixes** 
Fixes #1858


**Release note**:

```release-note
Fix for failed DataVolumeTemplate retry in VirtualMachine instance
```
