### PR TITLE
Autoamted test: Custom MAC on ovs-cni (multus) interface + fixes.

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Networking", func() {
 		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
 	}
 
-	Describe("[rfe_id:150][crit:medium][vendor:cnv-qe@redhat.com][level:component]Multiple virtual machines connectivity", func() {
+	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Multiple virtual machines connectivity", func() {
 		tests.BeforeAll(func() {
 			tests.BeforeTestCleanup()
 


### PR DESCRIPTION
Included in this PR:
1. Autoamted test: Custom MAC on ovs-cni (multus) interface.
2. Refer to the correct DaemonSet, so automated multus tests won't be skipped anymore.
3. Fix test ID's to the correct label.
4. Fix NodeAffinity usage, so VM's will be created on computre node rather than on master.
5. Fix RFE ID of L2 netowkring tests (used to be network policy RFE).
