### PR TITLE
Change the network lanes focus and exclude

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -245,10 +245,13 @@ EOF
   # Run only Windows tests
   ginko_params="$ginko_params --ginkgo.focus=Windows"
 
-elif [[ $TARGET =~ multus.* ]] || [[ $TARGET =~ genie.* ]]; then
-  # Run networking tests only (general networking, multus, genie, ...)
-  # If multus or genie is not present the test will  be skipped base on per-test checks
-  ginko_params="$ginko_params --ginkgo.focus=Networking|VMIlifecycle|Expose|Networkpolicy"
+elif [[ $TARGET =~ multus.* ]]; then
+  # Run networking tests only (general networking, multus, ...)
+  ginko_params="$ginko_params --ginkgo.focus=Multus|Networking|VMIlifecycle|Expose|Networkpolicy"
+elif [[ $TARGET =~ genie.* ]]; then
+  ginko_params="$ginko_params --ginkgo.focus=Genie|Networking|VMIlifecycle|Expose|Networkpolicy"
+else
+    ginko_params="$ginko_params --ginkgo.skip=Multus"
 fi
 
 # Prepare RHEL PV for Template testing

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -38,18 +38,18 @@ if [[ $TARGET =~ openshift-.* ]]; then
   # of old vms does not go fast enough they run out of memory.
   # To still allow continuing with the tests, give more memory in CI.
   export KUBEVIRT_MEMORY_SIZE=6144M
-  if [[ $TARGET =~ .*-crio-.* ]]; then
+  if [[ $TARGET =~ .*-crio ]]; then
     export KUBEVIRT_PROVIDER="os-3.11.0-crio"
-  elif [[ $TARGET =~ .*-multus-.* ]]; then
+  elif [[ $TARGET =~ .*-multus ]]; then
     export KUBEVIRT_PROVIDER="os-3.11.0-multus"
   else
     export KUBEVIRT_PROVIDER="os-3.11.0"
   fi
-elif [[ $TARGET =~ .*-1.10.4-.* ]]; then
+elif [[ $TARGET =~ .*-1.10.4 ]]; then
   export KUBEVIRT_PROVIDER="k8s-1.10.11"
-elif [[ $TARGET =~ .*-multus-1.12.2-.* ]]; then
+elif [[ $TARGET =~ .*-multus-1.12.2 ]]; then
   export KUBEVIRT_PROVIDER="k8s-multus-1.12.2"
-elif [[ $TARGET =~ .*-genie-1.11.1-.* ]]; then
+elif [[ $TARGET =~ .*-genie-1.11.1 ]]; then
   export KUBEVIRT_PROVIDER="k8s-genie-1.11.1"
 else
   export KUBEVIRT_PROVIDER="k8s-1.11.0"
@@ -244,18 +244,18 @@ spec:
 EOF
   # Run only Windows tests
   ginko_params="$ginko_params --ginkgo.focus=Windows"
-
 elif [[ $TARGET =~ multus.* ]]; then
-  # Run networking tests only (general networking, multus, ...)
-  ginko_params="$ginko_params --ginkgo.focus=Multus|Networking|VMIlifecycle|Expose|Networkpolicy"
+  ginko_params="$ginko_params --ginkgo.focus=Multus|Networking|VMIlifecycle|Expose"
 elif [[ $TARGET =~ genie.* ]]; then
-  ginko_params="$ginko_params --ginkgo.focus=Genie|Networking|VMIlifecycle|Expose|Networkpolicy"
+  ginko_params="$ginko_params --ginkgo.focus=Genie|Networking|VMIlifecycle|Expose"
 else
-    ginko_params="$ginko_params --ginkgo.skip=Multus"
+  ginko_params="$ginko_params --ginkgo.skip=Multus|Genie"
 fi
 
 # Prepare RHEL PV for Template testing
 if [[ $TARGET =~ openshift-.* ]]; then
+  ginko_params="$ginko_params|Networkpolicy"
+
   kubectl create -f - <<EOF
 ---
 apiVersion: v1

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2322,20 +2322,6 @@ func SkipIfNoSriovDevicePlugin(virtClient kubecli.KubevirtClient) {
 	}
 }
 
-func SkipIfNoMultusProvider(virtClient kubecli.KubevirtClient) {
-	_, err := virtClient.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Get("kube-multus-ds-amd64", metav1.GetOptions{})
-	if err != nil {
-		Skip("Skip multus tests that required multus cni plugin")
-	}
-}
-
-func SkipIfNoGenieProvider(virtClient kubecli.KubevirtClient) {
-	_, err := virtClient.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Get("genie-plugin", metav1.GetOptions{})
-	if err != nil {
-		Skip("Skip genie tests that required genie cni plugin")
-	}
-}
-
 func SkipIfUseFlannel(virtClient kubecli.KubevirtClient) {
 	labelSelector := "app=flannel"
 	flannelpod, err := virtClient.CoreV1().Pods(metav1.NamespaceSystem).List(metav1.ListOptions{LabelSelector: labelSelector})

--- a/tests/vmi_genie_test.go
+++ b/tests/vmi_genie_test.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("Genie Networking", func() {
+var _ = Describe("Genie", func() {
 
 	flag.Parse()
 
@@ -44,7 +44,6 @@ var _ = Describe("Genie Networking", func() {
 	var detachedVMI *v1.VirtualMachineInstance
 
 	tests.BeforeAll(func() {
-		tests.SkipIfNoGenieProvider(virtClient)
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -45,7 +45,7 @@ const (
 	sriovConfCRD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s","annotations":{"k8s.v1.cni.cncf.io/resourceName":"intel.com/sriov"}},"spec":{"config":"{ \"name\": \"sriov\", \"type\": \"sriov\", \"ipam\": { \"type\": \"host-local\", \"subnet\": \"10.1.1.0/24\" } }"}}`
 )
 
-var _ = Describe("Multus Networking", func() {
+var _ = Describe("Multus", func() {
 
 	flag.Parse()
 
@@ -86,7 +86,6 @@ var _ = Describe("Multus Networking", func() {
 	}
 
 	tests.BeforeAll(func() {
-		tests.SkipIfNoMultusProvider(virtClient)
 		tests.BeforeTestCleanup()
 		result := virtClient.RestClient().
 			Post().


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Using ginkgo flags I remove the skip functions.
Make focus and skip related to the lanes in the test.sh files.

So if Genie or Multus are not install the lane will fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Related to and issue of skipping multus tests because of daemonset name.

Example:

https://jenkins.ovirt.org/job/kubevirt_kubevirt_standard-check-pr/3347/artifact/ci_build_summary.html
check-patch.openshift-3.11-multus.el7.x86_64

```
S [SKIPPING] in Spec Setup (BeforeEach) [0.002 seconds]
Multus Networking
/root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:48
  VirtualMachineInstance with cni ptp plugin interface [BeforeEach]
  /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:127
    should create a virtual machine with one interface
    /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:137

    Skip multus tests that required multus cni plugin

    /root/go/src/kubevirt.io/kubevirt/tests/utils.go:2275
------------------------------
S [SKIPPING] in Spec Setup (BeforeEach) [0.002 seconds]
Multus Networking
/root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:48
  VirtualMachineInstance with cni ptp plugin interface [BeforeEach]
  /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:127
    should create a virtual machine with one interface with network definition from different namespace
    /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:154

    Skip multus tests that required multus cni plugin

    /root/go/src/kubevirt.io/kubevirt/tests/utils.go:2275
------------------------------
S [SKIPPING] in Spec Setup (BeforeEach) [0.002 seconds]
Multus Networking
/root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:48
  VirtualMachineInstance with cni ptp plugin interface [BeforeEach]
  /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:127
    should create a virtual machine with two interfaces
    /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:171

    Skip multus tests that required multus cni plugin

    /root/go/src/kubevirt.io/kubevirt/tests/utils.go:2275
------------------------------
S [SKIPPING] in Spec Setup (BeforeEach) [0.002 seconds]
Multus Networking
/root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:48
  VirtualMachineInstance with sriov plugin interface [BeforeEach]
  /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:210
    should create a virtual machine with sriov interface
    /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:218

    Skip multus tests that required multus cni plugin

    /root/go/src/kubevirt.io/kubevirt/tests/utils.go:2275
------------------------------
S [SKIPPING] in Spec Setup (BeforeEach) [0.002 seconds]
Multus Networking
/root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:48
  VirtualMachineInstance with sriov plugin interface [BeforeEach]
  /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:210
    should create a virtual machine with two sriov interfaces referring the same resource
    /root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:274

    Skip multus tests that required multus cni plugin

    /root/go/src/kubevirt.io/kubevirt/tests/utils.go:2275
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change network lanes focus and exclude 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2007)
<!-- Reviewable:end -->
