### PR TITLE
enable usb controller

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4532,6 +4532,10 @@
      "smm": {
       "description": "SMM enables/disables System Management Mode.\nTSEG not yet implemented.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
+     },
+     "usbDevice": {
+      "description": "USBDevice enables usb bus devices\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
      }
     }
    },

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -909,6 +909,15 @@ func (in *Features) DeepCopyInto(out *Features) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.USBDevice != nil {
+		in, out := &in.USBDevice, &out.USBDevice
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -1064,6 +1064,12 @@ func schema_kubevirt_pkg_api_v1_Features(ref common.ReferenceCallback) common.Op
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 						},
 					},
+					"usbDevice": {
+						SchemaProps: spec.SchemaProps{
+							Description: "USBDevice enables usb bus devices",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
 				},
 			},
 		},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -671,6 +671,9 @@ type Features struct {
 	// TSEG not yet implemented.
 	// +optional
 	SMM *FeatureState `json:"smm,omitempty"`
+	// USBDevice enables usb bus devices
+	// +optional
+	USBDevice *FeatureState `json:"usbDevice,omitempty"`
 }
 
 // Represents if a feature is enabled or disabled.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -310,10 +310,11 @@ func (HypervTimer) SwaggerDoc() map[string]string {
 
 func (Features) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"acpi":   "ACPI enables/disables ACPI insidejsondata guest.\nDefaults to enabled.\n+optional",
-		"apic":   "Defaults to the machine type setting.\n+optional",
-		"hyperv": "Defaults to the machine type setting.\n+optional",
-		"smm":    "SMM enables/disables System Management Mode.\nTSEG not yet implemented.\n+optional",
+		"acpi":      "ACPI enables/disables ACPI insidejsondata guest.\nDefaults to enabled.\n+optional",
+		"apic":      "Defaults to the machine type setting.\n+optional",
+		"hyperv":    "Defaults to the machine type setting.\n+optional",
+		"smm":       "SMM enables/disables System Management Mode.\nTSEG not yet implemented.\n+optional",
+		"usbDevice": "USBDevice enables usb bus devices\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -122,6 +122,9 @@ var exampleJSON = `{
         },
         "smm": {
           "enabled": true
+        },
+        "usbDevice": {
+          "enabled": false
         }
       },
       "devices": {
@@ -318,6 +321,7 @@ var _ = Describe("Schema", func() {
 				Reset:      &FeatureState{Enabled: _false},
 				VendorID:   &FeatureVendorID{Enabled: _true, VendorID: "vendor"},
 			},
+			USBDevice: &FeatureState{Enabled: _false},
 		}
 		exampleVMI.Spec.Domain.Clock = &Clock{
 			ClockOffset: ClockOffset{

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -108,6 +108,9 @@ func SetObjectDefaults_VirtualMachine(in *VirtualMachine) {
 			if in.Spec.Template.Spec.Domain.Features.SMM != nil {
 				SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.SMM)
 			}
+			if in.Spec.Template.Spec.Domain.Features.USBDevice != nil {
+				SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.USBDevice)
+			}
 		}
 		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {
 			a := &in.Spec.Template.Spec.Domain.Devices.Disks[i]
@@ -188,6 +191,9 @@ func SetObjectDefaults_VirtualMachineInstance(in *VirtualMachineInstance) {
 		}
 		if in.Spec.Domain.Features.SMM != nil {
 			SetDefaults_FeatureState(in.Spec.Domain.Features.SMM)
+		}
+		if in.Spec.Domain.Features.USBDevice != nil {
+			SetDefaults_FeatureState(in.Spec.Domain.Features.USBDevice)
 		}
 	}
 	for i := range in.Spec.Domain.Devices.Disks {
@@ -276,6 +282,9 @@ func SetObjectDefaults_VirtualMachineInstancePreset(in *VirtualMachineInstancePr
 			if in.Spec.Domain.Features.SMM != nil {
 				SetDefaults_FeatureState(in.Spec.Domain.Features.SMM)
 			}
+			if in.Spec.Domain.Features.USBDevice != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.USBDevice)
+			}
 		}
 		for i := range in.Spec.Domain.Devices.Disks {
 			a := &in.Spec.Domain.Devices.Disks[i]
@@ -363,6 +372,9 @@ func SetObjectDefaults_VirtualMachineInstanceReplicaSet(in *VirtualMachineInstan
 			}
 			if in.Spec.Template.Spec.Domain.Features.SMM != nil {
 				SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.SMM)
+			}
+			if in.Spec.Template.Spec.Domain.Features.USBDevice != nil {
+				SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.USBDevice)
 			}
 		}
 		for i := range in.Spec.Template.Spec.Domain.Devices.Disks {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -758,6 +758,20 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		domain.Spec.Devices.Watchdog = newWatchdog
 	}
 
+	//usb controller is turned on, only when user specify spec.domain.features.usbDevice.enabled to true,
+	//otherwise it is turned off
+	if vmi.Spec.Domain.Features == nil || vmi.Spec.Domain.Features.USBDevice == nil ||
+		(vmi.Spec.Domain.Features.USBDevice != nil && vmi.Spec.Domain.Features.USBDevice.Enabled != nil && !*vmi.Spec.Domain.Features.USBDevice.Enabled) {
+		// disable usb controller
+		domain.Spec.Devices.Controllers = []Controller{
+			{
+				Type:  "usb",
+				Index: "0",
+				Model: "none",
+			},
+		}
+	}
+
 	if vmi.Spec.Domain.Devices.Rng != nil {
 		newRng := &Rng{}
 		err := Convert_v1_Rng_To_api_Rng(vmi.Spec.Domain.Devices.Rng, newRng, c)

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -763,13 +763,11 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	if vmi.Spec.Domain.Features == nil || vmi.Spec.Domain.Features.USBDevice == nil ||
 		(vmi.Spec.Domain.Features.USBDevice != nil && vmi.Spec.Domain.Features.USBDevice.Enabled != nil && !*vmi.Spec.Domain.Features.USBDevice.Enabled) {
 		// disable usb controller
-		domain.Spec.Devices.Controllers = []Controller{
-			{
-				Type:  "usb",
-				Index: "0",
-				Model: "none",
-			},
-		}
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, Controller{
+			Type:  "usb",
+			Index: "0",
+			Model: "none",
+		})
 	}
 
 	if vmi.Spec.Domain.Devices.Rng != nil {

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -8,14 +8,6 @@ const (
 )
 
 func SetDefaults_Devices(devices *Devices) {
-	// Set default controllers, "none" means that controller disabled
-	devices.Controllers = []Controller{
-		{
-			Type:  "usb",
-			Index: "0",
-			Model: "none",
-		},
-	}
 	// Set default memballoon, "none" means that controller disabled
 	devices.Ballooning = &Ballooning{
 		Model: "none",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables usb controller which was by default turned off. USB controller is needed for this PR: https://github.com/kubevirt/kubevirt/pull/1987 to enable USB bus for tablet. USB controller is enabled only when user specify `spec.domain.features.usbDevice.enabled` to true.

**Release note**:
```release-note
enable usb controller 
```
