### PR TITLE
Fix max devices for virt-handler device plugins

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -166,7 +166,7 @@ func (app *virtHandlerApp) Run() {
 		domainSharedInformer,
 		gracefulShutdownInformer,
 		int(app.WatchdogTimeoutDuration.Seconds()),
-		maxDevices,
+		app.MaxDevices,
 	)
 
 	certsDirectory, err := ioutil.TempDir("", "certsdir")


### PR DESCRIPTION
We accept a flag for max-devices in virt-handler. Instead of using that, the default constant was passed to the app.

**Release note**:
```release-note
Fix a bug where max-devices was not honored.
```
