### PR TITLE
Use newer gocli which is more robust against pull errors

### DIFF
--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/gocli@sha256:df958c060ca8d90701a1b592400b33852029979ad6d5c1d9b79683033704b690"
+_cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock kubevirtci/gocli@sha256:4a4565eb4487be95f464cb942590bbaa980a5b56acb32d955f7a9f81f4ba843c"
 
 function _main_ip() {
     echo 127.0.0.1


### PR DESCRIPTION
**What this PR does / why we need it**:

In case pulling images fails during cluster-up, gocli will retry four
times per image before giving up. That should help against flakes when
starting the cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Example symptomes which this PR can fix:

```bash
$ make cluster-up
./cluster/up.sh
Downloading .............
Error: No such image: registry:2
```

**Release note**:

```release-note
NONE
```
