### PR TITLE
Reintroduce remove-viewer vnc support on windows

### DIFF
--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -201,7 +201,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 				viewResChan <- err
 				return
 			}
-		case "linux":
+		case "linux", "windows":
 			_, err := exec.LookPath(REMOTE_VIEWER)
 			if exec.ErrNotFound == err {
 				viewResChan <- fmt.Errorf("could not find the remote-viewer binary in $PATH")


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to run `virtctl vnc` on windows, `remote-viewer` needs to be on
the search path in windows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1713

**Special notes for your reviewer**:

/hold

Does someone have a windows machine to test this? According to one user it worked in the past before we introduced darwin support and unconditionally ran the linux branch.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add remote-viewer support on windows to virtctl
```
