### PR TITLE
add default cluster cpu model

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1013,11 +1013,13 @@ func (app *virtAPIApp) Run() {
 	go webhookInformers.VMIInformer.Run(stopChan)
 	go webhookInformers.VMIPresetInformer.Run(stopChan)
 	go webhookInformers.NamespaceLimitsInformer.Run(stopChan)
+	go webhookInformers.ConfigMapInformer.Run(stopChan)
 
 	cache.WaitForCacheSync(stopChan,
 		webhookInformers.VMIInformer.HasSynced,
 		webhookInformers.VMIPresetInformer.HasSynced,
-		webhookInformers.NamespaceLimitsInformer.HasSynced)
+		webhookInformers.NamespaceLimitsInformer.HasSynced,
+		webhookInformers.ConfigMapInformer.HasSynced)
 
 	// Verify/create webhook endpoint.
 	err = app.createWebhook()

--- a/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/api/v1:go_default_library",
         "//pkg/log:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -105,6 +105,8 @@ func mutateVMIs(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 			},
 		}
 	}
+	// Apply default cpu model
+	setDefaultCPUModel(&vmi, informers.ConfigMapInformer.GetStore())
 
 	// Apply namespace limits
 	applyNamespaceLimitRangeValues(&vmi, informers.NamespaceLimitsInformer)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
@@ -123,11 +123,12 @@ var _ = Describe("Mutating Webhook", func() {
 			}
 			namespaceLimitInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 			namespaceLimitInformer.GetIndexer().Add(namespaceLimit)
-
+			configMapInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 			webhooks.SetInformers(
 				&webhooks.Informers{
 					VMIPresetInformer:       presetInformer,
 					NamespaceLimitsInformer: namespaceLimitInformer,
+					ConfigMapInformer:       configMapInformer,
 				},
 			)
 		})

--- a/pkg/virt-api/webhooks/mutating-webhook/preset.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/preset.go
@@ -31,11 +31,11 @@ import (
 
 	kubev1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
 	exclusionMarking   = "virtualmachineinstancepresets.admission.kubevirt.io/exclude"
-	namespaceKubevirt  = "kubevirt"
 	configMapName      = "kubevirt-config"
 	defaultCPUModelKey = "default-cpu-model"
 )
@@ -285,8 +285,12 @@ func isVMIExcluded(vmi *kubev1.VirtualMachineInstance) bool {
 func setDefaultCPUModel(vmi *kubev1.VirtualMachineInstance, configMapStore cache.Store) {
 	//if vmi doesn't have cpu topology or cpu model set
 	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
+		namespace, err := util.GetNamespace()
+		if err != nil {
+			return
+		}
 		// if default cluster cpu model is defined
-		if obj, exists, err := configMapStore.GetByKey(namespaceKubevirt + "/" + configMapName); err == nil && exists {
+		if obj, exists, err := configMapStore.GetByKey(namespace + "/" + configMapName); err == nil && exists {
 			if obj.(*k8sv1.ConfigMap).Data[defaultCPUModelKey] != "" {
 				// create cpu topology struct
 				if vmi.Spec.Domain.CPU == nil {

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -80,6 +80,7 @@ type Informers struct {
 	VMIPresetInformer       cache.SharedIndexInformer
 	NamespaceLimitsInformer cache.SharedIndexInformer
 	VMIInformer             cache.SharedIndexInformer
+	ConfigMapInformer       cache.SharedIndexInformer
 }
 
 func GetInformers() *Informers {
@@ -110,6 +111,7 @@ func newInformers() *Informers {
 		VMIInformer:             kubeInformerFactory.VMI(),
 		VMIPresetInformer:       kubeInformerFactory.VirtualMachinePreset(),
 		NamespaceLimitsInformer: kubeInformerFactory.LimitRanges(),
+		ConfigMapInformer:       kubeInformerFactory.ConfigMap(),
 	}
 }
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -49,6 +49,8 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
+const kubevirtConfig = "kubevirt-config"
+
 func newCirrosVMI() *v1.VirtualMachineInstance {
 	return tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 }
@@ -632,6 +634,91 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		})
 
+		Context("with default cpu model", func() {
+			var cfgMap *k8sv1.ConfigMap
+			var originalData map[string]string
+			var options metav1.GetOptions
+			var defaultCPUModelKey = "default-cpu-model"
+			var defaultCPUModel = "Conroe"
+			var vmiCPUModel = "SandyBridge"
+
+			//store old kubevirt-config
+			BeforeEach(func() {
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
+				Expect(err).ToNot(HaveOccurred())
+				originalData = cfgMap.Data
+			})
+
+			//replace new kubevirt-config with old config
+			AfterEach(func() {
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
+				Expect(err).ToNot(HaveOccurred())
+				cfgMap.Data = originalData
+				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+				Expect(err).ToNot(HaveOccurred())
+				time.Sleep(5 * time.Second)
+			})
+
+			It("should set default cpu model when vmi doesn't have it set", func() {
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
+				Expect(err).ToNot(HaveOccurred(), "Expect config map to be loaded without error")
+
+				cfgMap.Data[defaultCPUModelKey] = defaultCPUModel
+				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+				Expect(err).ToNot(HaveOccurred(), "Expect config map to be updated without error")
+
+				time.Sleep(5 * time.Second)
+
+				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+
+				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal("Conroe"), "Expected default CPU model")
+
+			})
+
+			It("should not set default cpu model when vmi has it set", func() {
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
+				Expect(err).ToNot(HaveOccurred(), "Expect config map to be loaded without error")
+
+				cfgMap.Data[defaultCPUModelKey] = defaultCPUModel
+
+				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+				Expect(err).ToNot(HaveOccurred(), "Expect config map to be updated without error")
+
+				time.Sleep(5 * time.Second)
+
+				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Model: vmiCPUModel,
+				}
+				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+				Expect(curVMI.Spec.Domain.CPU.Model).To(Equal(vmiCPUModel), "Expected vmi CPU model")
+
+			})
+
+			It("should not set cpu model when vmi does not have it set and default cpu model is not set", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
+				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
+
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
+				Expect(curVMI.Spec.Domain.CPU).To(BeNil(), "Expected CPU to be nil")
+			})
+		})
+
 		Context("with node feature discovery", func() {
 
 			var options metav1.GetOptions
@@ -648,20 +735,17 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				originalLabels = node.GetObjectMeta().GetLabels()
 
 				options = metav1.GetOptions{}
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get("kubevirt-config", options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalFeatureGates = cfgMap.Data[virtconfig.FeatureGatesKey]
 				cfgMap.Data[virtconfig.FeatureGatesKey] = virtconfig.CPUNodeDiscoveryGate
 				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
 				Expect(err).ToNot(HaveOccurred())
-
-				//FIXME improve the detection if virt-controller already received the config-map change
-				time.Sleep(time.Millisecond * 500)
-
+				time.Sleep(5 * time.Second)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get("kubevirt-config", options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				cfgMap.Data[virtconfig.FeatureGatesKey] = originalFeatureGates
 				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
@@ -673,8 +757,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				_, err = virtClient.CoreV1().Nodes().Update(n)
 				Expect(err).ToNot(HaveOccurred())
 
-				//FIXME improve the detection if virt-controller already received the config-map change
-				time.Sleep(time.Millisecond * 500)
+				time.Sleep(5 * time.Second)
 			})
 
 			It("[test_id:1639]the vmi with cpu.model matching a nfd label on a node should be scheduled", func() {
@@ -1339,7 +1422,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 func shouldUseEmulation(virtClient kubecli.KubevirtClient) bool {
 	useEmulation := false
 	options := metav1.GetOptions{}
-	cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", options)
+	cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 	if err == nil {
 		val, ok := cfgMap.Data["debug.useEmulation"]
 		useEmulation = ok && (val == "true")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds default cluster cpu model. Default cpu model can be set in kubevirt-config.
```apiVersion: v1
kind: ConfigMap
metadata:
  name: kubevirt-config
data:
  default-cpu-model: "EPYC"
```
Default cpu model is set only when vmi doesn't have cpu model defined. When vmi has cpu model, then vmi's cpu model is preferred. When default cpu model is not set and vmi doesn't have cpu model defined, then `host-model` is set.

**Which issue(s) this PR fixes** 
Fixes #1247 

**Release note**:
```release-note
add default cpu model
```
