### PR TITLE
Fix swagger spec generation for our subresources

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -264,7 +264,7 @@ func (app *virtAPIApp) composeSubresources() {
 					Namespaced: true,
 				},
 				{
-					Name:       "virtualmachineinstances/restart",
+					Name:       "virtualmachines/restart",
 					Namespaced: true,
 				},
 				{
@@ -329,11 +329,11 @@ func (app *virtAPIApp) composeSubresources() {
 		Returns(http.StatusNotFound, "Not Found", nil))
 
 	once := sync.Once{}
+	var openapispec *spec.Swagger
 	ws.Route(ws.GET("openapi/v2").
 		Consumes(restful.MIME_JSON).
 		Produces(restful.MIME_JSON).
 		To(func(request *restful.Request, response *restful.Response) {
-			var openapispec *spec.Swagger
 			once.Do(func() {
 				openapispec = openapi.LoadOpenAPISpec([]*restful.WebService{ws, subws})
 				openapispec.Info.Version = version.Get().String()

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -117,6 +117,16 @@ var _ = Describe("Subresource Api", func() {
 			})
 		})
 	})
+
+	Describe("the openapi spec for the subresources", func() {
+		It("should be aggregated into the the apiserver openapi spec", func() {
+			Eventually(func() string {
+				spec, err := virtCli.RestClient().Get().AbsPath("/openapi/v2").DoRaw()
+				Expect(err).ToNot(HaveOccurred())
+				return string(spec)
+			}, 60*time.Second, 1*time.Second).Should(ContainSubstring("subresources.kubevirt.io"))
+		})
+	})
 })
 
 func testClientJob(virtCli kubecli.KubevirtClient, withServiceAccount bool, resource string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

We only generate the openapi spec once and then serve the content from
memory for the subresources. By accident the variable which is used as
storage was also part of the once closure, which lead to only serving
the spec once and null in subsequent calls.

The symptome was a recurring error in the apiserver log, without impact on functionality:

```
E0207 20:04:08.320152       1 controller.go:165] updating "v1alpha3.subresources.kubevirt.io" to AggregationController failed with: ERROR $root is missing required properties: info, swagger
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2013 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
