### PR TITLE
Don't wait for 10 seconds if we can't immediately connect to libvirt

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -37,7 +37,7 @@ import (
 )
 
 const ConnectionTimeout = 15 * time.Second
-const ConnectionInterval = 10 * time.Second
+const ConnectionInterval = 500 * time.Millisecond
 
 // TODO: Should we handle libvirt connection errors transparent or panic?
 type Connection interface {
@@ -343,6 +343,7 @@ func NewConnection(uri string, user string, pass string, checkInterval time.Dura
 	err = utilwait.PollImmediate(ConnectionInterval, ConnectionTimeout, func() (done bool, err error) {
 		virConn, err = newConnection(uri, user, pass)
 		if err != nil {
+			logger.V(1).Infof("Connecting to libvirt daemon failed: %v", err)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

If there is a little bit of load on systems it can happen that libvirt
does not yet accept client connections, when we try the first time.
Don't wait for 10 seconds if that happens. Retry faster. Normally the next try half a second later connects successfully.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Boots the VMIs faster, saves a few minutes per test-lane.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
