### PR TITLE
Garbage Collect Completed VMI Pods

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -850,7 +850,7 @@ func (c *VMIController) garbageCollectMatchingCompletedPods(vmi *virtv1.VirtualM
 	reEnqueueAfter := int64(0)
 
 	for _, pod := range pods {
-		if pod.Name == currentPod.Name {
+		if currentPod != nil && pod.Name == currentPod.Name {
 			continue
 		}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

After migrations, we leave a trail of completed VMI pods around.

This PR garbage collects completed pods that succeeded after a brief ttl timeout. The TTL allows automation (like CI) to capture logs of the completed pods for debugging.  Pods that terminate in a Failed state are not garbage collected because they may need investigation. 


```release-note
Successful completed VMI Pods are garbage collected after migration
```
