### PR TITLE
Fix race condition when retrieving exit status of virt-launcher

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -455,6 +455,7 @@ func ForkAndMonitor(qemuProcessCommandPrefix string) error {
 		return err
 	}
 
+	exitStatus := make(chan syscall.WaitStatus, 10)
 	sigs := make(chan os.Signal, 10)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGCHLD)
 	go func() {
@@ -466,6 +467,15 @@ func ForkAndMonitor(qemuProcessCommandPrefix string) error {
 				if err != nil {
 					log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)
 				}
+
+				// there's a race between cmd.Wait() and syscall.Wait4 when
+				// cleaning up the cmd's pid after it exits. This allows us
+				// to detect the correct exit code regardless of which wait
+				// wins the race.
+				if wpid == cmd.Process.Pid {
+					exitStatus <- wstatus
+				}
+
 			default:
 				log.Log.V(3).Log("signalling virt-launcher to shut down")
 				err := cmd.Process.Signal(syscall.SIGTERM)
@@ -480,13 +490,19 @@ func ForkAndMonitor(qemuProcessCommandPrefix string) error {
 	// wait for virt-launcher and collect the exit code
 	exitCode := 0
 	if err := cmd.Wait(); err != nil {
-		exitCode = 1
-		if exiterr, ok := err.(*exec.ExitError); ok {
-			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-				exitCode = status.ExitStatus()
+		select {
+		case status := <-exitStatus:
+			exitCode = int(status)
+		default:
+			exitCode = 1
+			if exiterr, ok := err.(*exec.ExitError); ok {
+				if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+					exitCode = status.ExitStatus()
+				}
 			}
+			log.Log.Reason(err).Error("dirty virt-launcher shutdown")
 		}
-		log.Log.Reason(err).Error("dirty virt-launcher shutdown")
+
 	}
 	// give qemu some time to shut down in case it survived virt-handler
 	pid, _ := virtlauncher.FindPid(qemuProcessCommandPrefix)


### PR DESCRIPTION
**What this PR does / why we need it**:

The virt-launcher pod occasionally has a non-zero exit code even when everything shutdown properly. We see this log message.

```
{"component":"virt-launcher","level":"error","msg":"dirty virt-launcher shutdown","pos":"virt-launcher.go:489","reason":"wait: no child processes","timestamp":"2019-02-21T15:13:54.043143Z"}
```

What's happening is we have a race condition occurring during the pid cleanup.  We're both calling cmd.Wait() and syscall.Wait4() in separate goroutines. If syscall.Wait4() wins, the cmd.Wait() returns an error saying there are no child processes.

We need both the cmd.Wait and the syscall.Wait4 in this case because we have to clean up qemu and libvirt pids. In order to properly retrieve the exit code for virt-launcher's forked instance, we need to account for this race condition though. 

```release-note
NONE
```
