### PR TITLE
Fix failing usb function test

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -395,7 +395,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 				By("Checking the number of usb under guest OS")
 				_, err = expecter.ExpectBatch([]expect.Batcher{
-					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
+					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* 2>/dev/null | wc -l\n"},
 					&expect.BExp{R: "0"},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of usb")


### PR DESCRIPTION
**What this PR does / why we need it**:

The error coming from the 'ls' command was causing the expector to fail. We just need to send stderr to dev/null and the test passes. 

```release-note
NONE
```
