### PR TITLE
Print MAC and IP at DHCP server start

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -52,6 +52,18 @@ type VIF struct {
 	Mtu     uint16
 }
 
+func (vif VIF) String() string {
+	return fmt.Sprintf(
+		"VIF: { Name: %s, IP: %s, Mask: %s, MAC: %s, Gateway: %s, MTU: %d}",
+		vif.Name,
+		vif.IP.IP,
+		vif.IP.Mask,
+		vif.MAC,
+		vif.Gateway,
+		vif.Mtu,
+	)
+}
+
 type NetworkHandler interface {
 	LinkByName(name string) (netlink.Link, error)
 	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_network.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_network.go
@@ -31,14 +31,14 @@ func (_m *MockNetworkInterface) EXPECT() *_MockNetworkInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockNetworkInterface) Plug(iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
-	ret := _m.ctrl.Call(_m, "Plug", iface, network, domain, podInterfaceName)
+func (_m *MockNetworkInterface) Plug(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
+	ret := _m.ctrl.Call(_m, "Plug", vmi, iface, network, domain, podInterfaceName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkInterfaceRecorder) Plug(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Plug", arg0, arg1, arg2, arg3)
+func (_mr *_MockNetworkInterfaceRecorder) Plug(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Plug", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockNetworkInterface) Unplug() {

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -41,7 +41,7 @@ var NetworkInterfaceFactory = getNetworkClass
 var podInterfaceName = podInterface
 
 type NetworkInterface interface {
-	Plug(iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error
+	Plug(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error
 	Unplug()
 }
 
@@ -80,7 +80,7 @@ func SetupNetworkInterfaces(vmi *v1.VirtualMachineInstance, domain *api.Domain) 
 			podInterfaceName = podInterface
 		}
 
-		err = vif.Plug(&iface, network, domain, podInterfaceName)
+		err = vif.Plug(vmi, &iface, network, domain, podInterfaceName)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Network", func() {
 			iface := v1.DefaultNetworkInterface()
 			defaultNet := v1.DefaultPodNetwork()
 
-			mockNetworkInterface.EXPECT().Plug(iface, defaultNet, domain, podInterface)
+			mockNetworkInterface.EXPECT().Plug(vm, iface, defaultNet, domain, podInterface)
 			err := SetupNetworkInterfaces(vm, domain)
 			Expect(err).To(BeNil())
 		})
@@ -78,7 +78,7 @@ var _ = Describe("Network", func() {
 			}
 			vm.Spec.Networks = []v1.Network{*cniNet}
 
-			mockNetworkInterface.EXPECT().Plug(iface, cniNet, domain, "net1")
+			mockNetworkInterface.EXPECT().Plug(vm, iface, cniNet, domain, "net1")
 			err := SetupNetworkInterfaces(vm, domain)
 			Expect(err).To(BeNil())
 		})
@@ -99,7 +99,7 @@ var _ = Describe("Network", func() {
 			}
 			vm.Spec.Networks = []v1.Network{*cniNet}
 
-			mockNetworkInterface.EXPECT().Plug(iface, cniNet, domain, genieInterfaceName)
+			mockNetworkInterface.EXPECT().Plug(vm, iface, cniNet, domain, genieInterfaceName)
 			err := SetupNetworkInterfaces(vm, domain)
 			Expect(err).To(BeNil())
 		})

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Pod Network", func() {
 					vmi := newVMIBridgeInterface("testnamespace", "testVmName")
 					api.SetObjectDefaults_Domain(domain)
 					vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
-					driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
+					driver, err := getBinding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
 					Expect(err).ToNot(HaveOccurred())
 					bridge, ok := driver.(*BridgePodInterface)
 					Expect(ok).To(BeTrue())
@@ -354,8 +354,9 @@ var _ = Describe("Pod Network", func() {
 						SRIOV: &v1.InterfaceSRIOV{},
 					},
 				}
+				vmi := newVMI("testnamespace", "testVmName")
 				podiface := PodInterface{}
-				err := podiface.Plug(iface, net, domain, "fakeiface")
+				err := podiface.Plug(vmi, iface, net, domain, "fakeiface")
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -376,7 +377,7 @@ var _ = Describe("Pod Network", func() {
 
 				api.SetObjectDefaults_Domain(domain)
 
-				driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
+				driver, err := getBinding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
 				Expect(err).ToNot(HaveOccurred())
 				TestRunPlug(driver)
 				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
@@ -391,7 +392,7 @@ var _ = Describe("Pod Network", func() {
 				api.SetObjectDefaults_Domain(domain)
 				vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 
-				driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
+				driver, err := getBinding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
 				Expect(err).ToNot(HaveOccurred())
 				TestRunPlug(driver)
 				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(0))
@@ -417,7 +418,7 @@ var _ = Describe("Pod Network", func() {
 						Name: "default",
 					}})
 
-				driver, err := getBinding(&vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
+				driver, err := getBinding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, podInterface)
 				Expect(err).ToNot(HaveOccurred())
 				TestRunPlug(driver)
 				Expect(len(domain.Spec.Devices.Interfaces)).To(Equal(1))


### PR DESCRIPTION
It cover both masquerade and bridge scenarios

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It prints the pod interface type, VIF and VMI info to easy tracking issues after the VMI is destroyed.
example:

{"component":"virt-launcher","kind":"","level":"info","msg":"bridge pod interface: VIF: { Name: eth0, IP: 10.244.0.23, Mask: ffffff00, MAC: 0a:58:0a:f4:00:17, Gateway: 10.244.0.1, MTU: 1450}","name":"vmi-ephemeral","namespace":"default","pos":"podinterface.go:258","timestamp":"2019-03-02T12:45:01.973777Z","uid":"f6d624f1-3ce8-11e9-8cbf-525500d15501"}

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1867

**Special notes for your reviewer**: 

Don't know if we need to print something with SLIRP

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
