### PR TITLE
Fix version clash in sidecar manager

### DIFF
--- a/cmd/example-hook-sidecar/BUILD.bazel
+++ b/cmd/example-hook-sidecar/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
         "//pkg/hooks:go_default_library",
         "//pkg/hooks/info:go_default_library",
         "//pkg/hooks/v1alpha1:go_default_library",
+        "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -35,6 +35,8 @@ type HookSidecarList []HookSidecar
 type HookSidecar struct {
 	Image           string           `json:"image"`
 	ImagePullPolicy k8sv1.PullPolicy `json:"imagePullPolicy"`
+	Command         []string         `json:"command,omitempty"`
+	Args            []string         `json:"args,omitempty"`
 }
 
 func UnmarshalHookSidecarList(vmiObject *v1.VirtualMachineInstance) (HookSidecarList, error) {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -818,10 +818,12 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("200m")
 			resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("64M")
 		}
-		containers = append(containers, k8sv1.Container{
+		sidecar := k8sv1.Container{
 			Name:            fmt.Sprintf("hook-sidecar-%d", i),
 			Image:           requestedHookSidecar.Image,
 			ImagePullPolicy: requestedHookSidecar.ImagePullPolicy,
+			Command:         requestedHookSidecar.Command,
+			Args:            requestedHookSidecar.Args,
 			Resources:       resources,
 			VolumeMounts: []k8sv1.VolumeMount{
 				k8sv1.VolumeMount{
@@ -829,7 +831,8 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 					MountPath: hooks.HookSocketsSharedDirectory,
 				},
 			},
-		})
+		}
+		containers = append(containers, sidecar)
 	}
 
 	// XXX: reduce test time. Adding one more container delays the start.

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -91,6 +91,8 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/config:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/hooks/v1alpha1:go_default_library",
+        "//pkg/hooks/v1alpha2:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
Mixing grpc versions caused an endless failure loop during vm creation.
**Which issue(s) this PR fixes**:
Fixes #2052

**Special notes for your reviewer**:
I am open for suggestions how to beautify the code in the hook manager.
Currently every version needs to be seperated which leads to many lines of boilerplate code..
**Release note**:
```release-note
NONE
```