### PR TITLE
Reject migration of VMIs with non-migratable condition

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -864,13 +864,17 @@ var _ = Describe("Validating Webhook", func() {
 
 		It("should reject Migration spec for non-migratable VMIs", func() {
 			vmi := v1.NewMinimalVMI("testmigratevmi3")
-			vmi.Status.Phase = v1.Succeeded
+			vmi.Status.Phase = v1.Running
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
 					Type:    v1.VirtualMachineInstanceIsMigratable,
 					Status:  k8sv1.ConditionFalse,
 					Reason:  v1.VirtualMachineInstanceReasonDisksNotMigratable,
 					Message: "cannot migrate VMI with mixes shared and non-shared volumes",
+				},
+				{
+					Type:   v1.VirtualMachineInstanceReady,
+					Status: k8sv1.ConditionTrue,
 				},
 			}
 
@@ -900,6 +904,7 @@ var _ = Describe("Validating Webhook", func() {
 
 			resp := admitMigrationCreate(ar)
 			Expect(resp.Allowed).To(Equal(false))
+			Expect(resp.Result.Message).To(ContainSubstring("DisksNotLiveMigratable"))
 		})
 
 		It("should reject Migration on update if spec changes", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an API validation that should reject migration of VMIs with a non-migratable condition
and adds a functional test to verify this.

**Which issue(s) this PR fixes**
Fixes #2072

```release-note
NONE
```
