### PR TITLE
increase timeout waiting for virthandler

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -514,7 +514,7 @@ var _ = Describe("VMIlifecycle", func() {
 						ds.Status.DesiredNumberScheduled == virtHandlerAvailablePods &&
 						ds.Status.NumberReady == virtHandlerAvailablePods &&
 						ds.Status.UpdatedNumberScheduled == virtHandlerAvailablePods
-				}, 60*time.Second, 1*time.Second).Should(Equal(true), "Virthandler should be ready to work")
+				}, 120*time.Second, 1*time.Second).Should(Equal(true), "Virthandler should be ready to work")
 			})
 		})
 


### PR DESCRIPTION
increase timeout waiting for virthandler

(cherry picked from commit 3b30f8d105f0cef8d659bd97f7c9c4702ac46037)
Signed-off-by: Tareq Alayan <talayan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
