### PR TITLE
metrics: prometheus: more storage metrics

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3212,3 +3212,22 @@ func GetVmPodName(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance
 
 	return podName
 }
+
+func AppendEmptyDisk(vmi *v1.VirtualMachineInstance, diskName, busName, diskSize string) {
+	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+		Name: diskName,
+		DiskDevice: v1.DiskDevice{
+			Disk: &v1.DiskTarget{
+				Bus: busName,
+			},
+		},
+	})
+	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+		Name: diskName,
+		VolumeSource: v1.VolumeSource{
+			EmptyDisk: &v1.EmptyDiskSource{
+				Capacity: resource.MustParse(diskSize),
+			},
+		},
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need few more metrics to report data which kubevirt-ui wants to consume, see
https://github.com/kubevirt/web-ui-components/pull/247

**Special notes for your reviewer**:
Add metrics to report:
- per-drive per-VM I/O traffic aka bytes read/write total
- per-drive per-VM I/O operational times aka total time spent doing I/O
  ops, needed to compute the average latency time (e.g. read latency).
```release-note
NONE
```