### PR TITLE
Fix some inconsistencies introduces with the bazel switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@ tools/vms-generator/vms-generator
 .coverprofile
 coverage.html
 manifests/**/*.tmp
-bazel-*
-.bazelrc
+/bazel-*
+/.bazelrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 
 deploy:
 - provider: script
-  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && CONTAINER_PREFIX="index.docker.io/kubevirt" CONTAINER_TAG="latest" make bazel-push-images
+  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt" DOCKER_TAG="latest" make bazel-push-images
   skip_cleanup: true
   on:
     branch: master
@@ -39,7 +39,7 @@ deploy:
     all_branches: true
     condition: $TRAVIS_BRANCH != revert-*
 - provider: script
-  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && CONTAINER_PREFIX="index.docker.io/kubevirt" CONTAINER_TAG="$TRAVIS_TAG" make bazel-push-images
+  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt" DOCKER_TAG="$TRAVIS_TAG" make bazel-push-images
   skip_cleanup: true
   file:
   on:

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,7 @@ bazel-build:
 		//cmd/..."
 
 bazel-push-images:
-	hack/dockerized "bazel run \
-		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
-		--workspace_status_command=./hack/print-workspace-status.sh \
-		--define container_prefix=${DOCKER_PREFIX} \
-		--define container_tag=${DOCKER_TAG} \
-		//:push-images"
+	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} ./hack/bazel-push-images.sh"
 
 bazel-tests:
 	hack/dockerized "bazel test --test_output=errors -- //pkg/... "

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ bazel-push-images:
 	hack/dockerized "bazel run \
 		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
 		--workspace_status_command=./hack/print-workspace-status.sh \
-		--define container_prefix=${CONTAINER_PREFIX} \
-		--define container_tag=${CONTAINER_TAG} \
+		--define container_prefix=${DOCKER_PREFIX} \
+		--define container_tag=${DOCKER_TAG} \
 		//:push-images"
 
 bazel-tests:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,9 +159,9 @@ _go_image_repos()
 
 http_archive(
     name = "io_bazel_rules_container_rpm",
-    sha256 = "7ace5bc7aa10697196d3c48ef5d73b0fc52b6e27c0bad3ce10751f66c5cc383c",
-    strip_prefix = "rules_container_rpm-0.0.3",
-    urls = ["https://github.com/rmohr/rules_container_rpm/archive/v0.0.3.tar.gz"],
+    sha256 = "b419c25576e148e537a93fafdc10cb78faf1174558d853754727b586793e71d1",
+    strip_prefix = "rules_container_rpm-0.0.4",
+    urls = ["https://github.com/rmohr/rules_container_rpm/archive/v0.0.4.tar.gz"],
 )
 
 # Get container-disk-v1alpha RPM's

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -41,7 +41,7 @@ function _add_common_params() {
 function build() {
     # Build everyting and publish it
     ${KUBEVIRT_PATH}hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh"
-    CONTAINER_PREFIX=${docker_prefix} CONTAINER_TAG=${docker_tag} make bazel-push-images
+    DOCKER_PREFIX=${docker_prefix} DOCKER_TAG=${docker_tag} make bazel-push-images
 
     # Make sure that all nodes use the newest images
     container=""

--- a/cluster/external/provider.sh
+++ b/cluster/external/provider.sh
@@ -31,6 +31,6 @@ function down() {
 
 function build() {
     # Build code and manifests
-    ${KUBEVIRT_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-manifests.sh"
-    make push
+    ${KUBEVIRT_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG} DOCKER_PREFIX=${docker_prefix} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-manifests.sh"
+    DOCKER_PREFIX=${docker_prefix} DOCKER_TAG=${docker_tag} make bazel-push-images
 }

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+set -e
+
+source hack/common.sh
+source hack/config.sh
+
+bazel run \
+    --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+    --workspace_status_command=./hack/print-workspace-status.sh \
+    --define container_prefix=${docker_prefix} \
+    --define container_tag=${docker_tag} \
+    //:push-images


### PR DESCRIPTION
**What this PR does / why we need it**:

* Keep DOCKER_PREFIX and DOCKER_TAG also for bazel right now. If we change that, let's change it for everything to CONTAINER_TAG and CONTAINER_PREFIX.
 * Allow builds with bazel on non-amd64 platforms if bazel is installed and bazel is run outside of our build containers. Use the newest rpm rules which don't perform arch or os checks when invoking rpm.
 * Respect hack/config-* settings when invoking `make bazel-push-images`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
