### PR TITLE
Backport: Fixed "make publish-cache" by ensuring that images were built

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ docker: build
 push: docker
 	hack/build-docker.sh push ${WHAT}
 
-push-cache:
+push-cache: docker verify-build
 	hack/build-docker.sh push-cache ${WHAT}
 
 pull-cache:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed "make publish-cache" by ensuring that images were built
Backport of https://github.com/kubevirt/kubevirt/pull/2000

/hold