### PR TITLE
hyperv: add feature gate and node selector

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -44,13 +44,21 @@ const (
 // We cannot rely on automatic invocation of 'init' method because this initialization
 // code assumes a cluster is available to pull the configmap from
 func Init() {
-	cfgMap := getConfigMap()
+	InitFromConfigMap(getConfigMap())
+}
+
+func InitFromConfigMap(cfgMap *k8sv1.ConfigMap) {
 	if val, ok := cfgMap.Data[FeatureGatesKey]; ok {
 		os.Setenv(featureGateEnvVar, val)
 	}
 	if val, ok := cfgMap.Data[emulatedMachinesKey]; ok {
 		os.Setenv(emulatedMachinesEnvVar, val)
 	}
+}
+
+func Clear() {
+	os.Unsetenv(featureGateEnvVar)
+	os.Unsetenv(emulatedMachinesEnvVar)
 }
 
 func getConfigMap() *k8sv1.ConfigMap {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -58,7 +58,3 @@ func LiveMigrationEnabled() bool {
 func SRIOVEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
 }
-
-func HypervSupportEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), HypervSupportGate)
-}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -36,6 +36,7 @@ const (
 	liveMigrationGate    = "LiveMigration"
 	SRIOVGate            = "SRIOV"
 	CPUNodeDiscoveryGate = "CPUNodeDiscovery"
+	HypervSupportGate    = "HypervSupport"
 )
 
 func DataVolumesEnabled() bool {
@@ -56,4 +57,8 @@ func LiveMigrationEnabled() bool {
 
 func SRIOVEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
+}
+
+func HypervSupportEnabled() bool {
+	return strings.Contains(os.Getenv(featureGateEnvVar), HypervSupportGate)
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -58,3 +58,7 @@ func LiveMigrationEnabled() bool {
 func SRIOVEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
 }
+
+func HypervSupportEnabled() bool {
+	return strings.Contains(os.Getenv(featureGateEnvVar), HypervSupportGate)
+}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -78,6 +78,8 @@ const MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION = "v1.multus-cni.io/default-network"
 // Istio list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound traffic in envoy
 const ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
 
+const KVMInfoHypervSupportLabel = NFD_KVM_INFO_PREFIX + "hyperv"
+
 type TemplateService interface {
 	RenderLaunchManifest(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
 }
@@ -246,10 +248,6 @@ func CPUFeatureLabelsFromCPUFeatures(vmi *v1.VirtualMachineInstance) []string {
 		}
 	}
 	return labels
-}
-
-func KVMInfoHypervSupportLabel() string {
-	return NFD_KVM_INFO_PREFIX + "hyperv"
 }
 
 func SetNodeAffinityForForbiddenFeaturePolicy(vmi *v1.VirtualMachineInstance, pod *k8sv1.Pod) {
@@ -838,8 +836,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	}
 
 	if isHyperVSupportRequired(t.configMapStore) && isHypervVMI(vmi) {
-		key := KVMInfoHypervSupportLabel()
-		nodeSelector[key] = "true"
+		nodeSelector[KVMInfoHypervSupportLabel] = "true"
 	}
 
 	nodeSelector[v1.NodeSchedulable] = "true"

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -189,17 +189,6 @@ func IsCPUNodeDiscoveryEnabled(store cache.Store) bool {
 	return false
 }
 
-func isHyperVSupportRequired(store cache.Store) bool {
-	value, err := getConfigMapEntry(store, virtconfig.FeatureGatesKey)
-	if err != nil {
-		return false
-	}
-	if !strings.Contains(value, virtconfig.HypervSupportGate) {
-		return false
-	}
-	return true
-}
-
 func isFeatureStateEnabled(fs *v1.FeatureState) bool {
 	return fs != nil && fs.Enabled != nil && *fs.Enabled
 }
@@ -835,7 +824,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 	}
 
-	if isHyperVSupportRequired(t.configMapStore) && isHypervVMI(vmi) {
+	if virtconfig.HypervSupportEnabled() && isHypervVMI(vmi) {
 		nodeSelector[KVMInfoHypervSupportLabel] = "true"
 	}
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -202,7 +202,7 @@ func isFeatureStateEnabled(fs *v1.FeatureState) bool {
 	return fs != nil && fs.Enabled != nil && *fs.Enabled
 }
 
-func isHyperVRequestedByVMI(vmi *v1.VirtualMachineInstance) bool {
+func isHypervVMI(vmi *v1.VirtualMachineInstance) bool {
 	if vmi.Spec.Domain.Features == nil || vmi.Spec.Domain.Features.Hyperv == nil {
 		return false
 	}
@@ -837,7 +837,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 	}
 
-	if isHyperVSupportRequired(t.configMapStore) && isHyperVRequestedByVMI(vmi) {
+	if isHyperVSupportRequired(t.configMapStore) && isHypervVMI(vmi) {
 		key := KVMInfoHypervSupportLabel()
 		nodeSelector[key] = "true"
 	}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -101,6 +101,10 @@ var _ = Describe("Template", func() {
 		Expect(err).To(Not(HaveOccurred()))
 	})
 
+	AfterEach(func() {
+		virtconfig.Clear()
+	})
+
 	Describe("Rendering", func() {
 		Context("launch template with correct parameters", func() {
 			It("should work", func() {
@@ -445,7 +449,6 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should add node selector for hyperv nodes if VMI requests hyperv features", func() {
-
 				cfgMap := kubev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespaceKubevirt,
@@ -453,7 +456,7 @@ var _ = Describe("Template", func() {
 					},
 					Data: map[string]string{virtconfig.FeatureGatesKey: virtconfig.HypervSupportGate},
 				}
-				cmCache.Add(&cfgMap)
+				virtconfig.InitFromConfigMap(&cfgMap)
 
 				enabled := true
 				vmi := v1.VirtualMachineInstance{
@@ -483,7 +486,6 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should not add node selector for hyperv nodes if VMI does not request hyperv features", func() {
-
 				cfgMap := kubev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: namespaceKubevirt,
@@ -491,7 +493,7 @@ var _ = Describe("Template", func() {
 					},
 					Data: map[string]string{virtconfig.FeatureGatesKey: virtconfig.HypervSupportGate},
 				}
-				cmCache.Add(&cfgMap)
+				virtconfig.InitFromConfigMap(&cfgMap)
 
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -515,7 +517,6 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features, but feature gate is disabled", func() {
-
 				enabled := true
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -478,9 +478,8 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				label := KVMInfoHypervSupportLabel()
-				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(label, "true"))
-				Expect(pod.Spec.NodeSelector).Should(Not(HaveKeyWithValue(label, "false")))
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(KVMInfoHypervSupportLabel, "true"))
+				Expect(pod.Spec.NodeSelector).Should(Not(HaveKeyWithValue(KVMInfoHypervSupportLabel, "false")))
 			})
 
 			It("should not add node selector for hyperv nodes if VMI does not request hyperv features", func() {
@@ -512,8 +511,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				label := KVMInfoHypervSupportLabel()
-				Expect(pod.Spec.NodeSelector).Should(Not(HaveKey(label)))
+				Expect(pod.Spec.NodeSelector).Should(Not(HaveKey(KVMInfoHypervSupportLabel)))
 			})
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features, but feature gate is disabled", func() {
@@ -541,8 +539,7 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				label := KVMInfoHypervSupportLabel()
-				Expect(pod.Spec.NodeSelector).Should(Not(HaveKey(label)))
+				Expect(pod.Spec.NodeSelector).Should(Not(HaveKey(KVMInfoHypervSupportLabel)))
 			})
 
 			It("should add default cpu/memory resources to the sidecar container if cpu pinning was requested", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Existing, merged support for HyperV feature need up to date host kernel to work properly.
This PR adds a way to make sure we run hyperv-enabled requests only on hosts which can safely
run them.

We do this relying on a host label, which node-feature-discovery will add for us if it detects the host kernel is up to date

**Special notes for your reviewer**:
For backward compatibility the strict checking is *DISABLED* by default. E.g. nothing changes unless the admin explicitely asks for it.

```release-note
Adds a feature gate to ensure optimal scheduling on hyperv-enabled VMs
```