### PR TITLE
add anti affinity to virt pods

### DIFF
--- a/manifests/generated/virt-api.yaml.in
+++ b/manifests/generated/virt-api.yaml.in
@@ -38,6 +38,16 @@ spec:
         prometheus.kubevirt.io: ""
       name: virt-api
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: kubevirt.io
+                operator: In
+                values:
+                - virt-api
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - virt-api

--- a/manifests/generated/virt-api.yaml.in
+++ b/manifests/generated/virt-api.yaml.in
@@ -40,14 +40,16 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: kubevirt.io
-                operator: In
-                values:
-                - virt-api
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: kubevirt.io
+                  operator: In
+                  values:
+                  - virt-api
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       containers:
       - command:
         - virt-api

--- a/manifests/generated/virt-controller.yaml.in
+++ b/manifests/generated/virt-controller.yaml.in
@@ -22,6 +22,16 @@ spec:
         prometheus.kubevirt.io: ""
       name: virt-controller
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: kubevirt.io
+                operator: In
+                values:
+                - virt-controller
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - virt-controller

--- a/manifests/generated/virt-controller.yaml.in
+++ b/manifests/generated/virt-controller.yaml.in
@@ -24,14 +24,16 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: kubevirt.io
-                operator: In
-                values:
-                - virt-controller
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: kubevirt.io
+                  operator: In
+                  values:
+                  - virt-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       containers:
       - command:
         - virt-controller

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -246,18 +246,21 @@ func newBaseDeployment(name string, namespace string, repository string, version
 func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOperator, values []string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      key,
-								Operator: operator,
-								Values:   values,
+					Weight: 1,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      key,
+									Operator: operator,
+									Values:   values,
+								},
 							},
 						},
+						TopologyKey: topologyKey,
 					},
-					TopologyKey: topologyKey,
 				},
 			},
 		},

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -180,7 +180,7 @@ func NewApiServerService(namespace string) *corev1.Service {
 	}
 }
 
-func newPodTemplateSpec(name string, repository string, version string, pullPolicy corev1.PullPolicy) (*corev1.PodTemplateSpec, error) {
+func newPodTemplateSpec(name string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity) (*corev1.PodTemplateSpec, error) {
 
 	tolerations, err := criticalAddonsToleration()
 	if err != nil {
@@ -200,6 +200,7 @@ func newPodTemplateSpec(name string, repository string, version string, pullPoli
 			Name: name,
 		},
 		Spec: corev1.PodSpec{
+			Affinity: podAffinity,
 			Containers: []corev1.Container{
 				{
 					Name:            name,
@@ -211,9 +212,9 @@ func newPodTemplateSpec(name string, repository string, version string, pullPoli
 	}, nil
 }
 
-func newBaseDeployment(name string, namespace string, repository string, version string, pullPolicy corev1.PullPolicy) (*appsv1.Deployment, error) {
+func newBaseDeployment(name string, namespace string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity) (*appsv1.Deployment, error) {
 
-	podTemplateSpec, err := newPodTemplateSpec(name, repository, version, pullPolicy)
+	podTemplateSpec, err := newPodTemplateSpec(name, repository, version, pullPolicy, podAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +243,30 @@ func newBaseDeployment(name string, namespace string, repository string, version
 	}, nil
 }
 
+func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOperator, values []string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      key,
+								Operator: operator,
+								Values:   values,
+							},
+						},
+					},
+					TopologyKey: topologyKey,
+				},
+			},
+		},
+	}
+}
+
 func NewApiServerDeployment(namespace string, repository string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.Deployment, error) {
-	deployment, err := newBaseDeployment("virt-api", namespace, repository, version, pullPolicy)
+	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-api"})
+	deployment, err := newBaseDeployment("virt-api", namespace, repository, version, pullPolicy, podAntiAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +316,8 @@ func NewApiServerDeployment(namespace string, repository string, version string,
 }
 
 func NewControllerDeployment(namespace string, repository string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.Deployment, error) {
-	deployment, err := newBaseDeployment("virt-controller", namespace, repository, version, pullPolicy)
+	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-controller"})
+	deployment, err := newBaseDeployment("virt-controller", namespace, repository, version, pullPolicy, podAntiAffinity)
 	if err != nil {
 		return nil, err
 	}
@@ -354,8 +378,7 @@ func NewControllerDeployment(namespace string, repository string, version string
 }
 
 func NewHandlerDaemonSet(namespace string, repository string, version string, pullPolicy corev1.PullPolicy, verbosity string) (*appsv1.DaemonSet, error) {
-
-	podTemplateSpec, err := newPodTemplateSpec("virt-handler", repository, version, pullPolicy)
+	podTemplateSpec, err := newPodTemplateSpec("virt-handler", repository, version, pullPolicy, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-operator/util/readycheck.go
+++ b/pkg/virt-operator/util/readycheck.go
@@ -88,12 +88,7 @@ func DeploymentIsReady(kv *v1.KubeVirt, deployment *appsv1.Deployment, stores St
 		return false
 	}
 
-	var specReplicas int32 = 1
-	if deployment.Spec.Replicas != nil {
-		specReplicas = *deployment.Spec.Replicas
-	}
-	if specReplicas != deployment.Status.Replicas ||
-		deployment.Status.Replicas != deployment.Status.ReadyReplicas {
+	if deployment.Status.Replicas == 0 || deployment.Status.ReadyReplicas == 0 {
 		log.Log.V(4).Infof("Deployment %v not ready yet", deployment.Name)
 		return false
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds pod antiAffinity to virt pods (virt-api, virt-controller).
When user uses 2 or more nodes and one died, virt pods from the node which died will not be scheduled on the node which already contains virt pods, e.g. virt-api will not be scheduled on the node which already has virt-api pod and stays in pending status. 
@rmohr, @davidvossel, @petrkotas, @stu-gott, @fabiand  please review.
 
**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1671511

**Special notes for your reviewer**:

**Release note**:
```
Add pod antiAffinity to virt pods (virt-api, virt-controller)
```
