### PR TITLE
tests: replace remaining occurrence of "local" by StorageClassLocal

### DIFF
--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -59,7 +59,7 @@ var _ = Describe("ImageUpload", func() {
 				"--pvc-size", pvcSize,
 				"--uploadproxy-url", fmt.Sprintf("https://127.0.0.1:%d", localUploadProxyPort),
 				"--wait-secs", "30",
-				"--storage-class", "local",
+				"--storage-class", tests.StorageClassLocal,
 				"--insecure")
 			err = virtctlCmd()
 			if err != nil {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1212,7 +1212,7 @@ func PanicOnError(err error) {
 func NewRandomDataVolumeWithHttpImport(imageUrl string, namespace string) *cdiv1.DataVolume {
 
 	name := "test-datavolume-" + rand.String(12)
-	storageClassName := "local"
+	storageClass := StorageClassLocal
 	quantity, err := resource.ParseQuantity("2Gi")
 	PanicOnError(err)
 	dataVolume := &cdiv1.DataVolume{
@@ -1233,7 +1233,7 @@ func NewRandomDataVolumeWithHttpImport(imageUrl string, namespace string) *cdiv1
 						"storage": quantity,
 					},
 				},
-				StorageClassName: &storageClassName,
+				StorageClassName: &storageClass,
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allows to change the storage class used during tests by modifying the code in a unique place.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
