### PR TITLE
Run bazel build server always in the background

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -180,6 +180,7 @@ build --remote_http_cache=http://bazel-cache.kubevirt-prow.svc.cluster.local:808
 EOF
 
 make cluster-sync
+hack/dockerized bazel shutdown
 
 # OpenShift is running important containers under default namespace
 namespaces=(kubevirt default)

--- a/cluster/ephemeral-provider-common.sh
+++ b/cluster/ephemeral-provider-common.sh
@@ -41,7 +41,7 @@ function _add_common_params() {
 function build() {
     # Build everyting and publish it
     ${KUBEVIRT_PATH}hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh"
-    DOCKER_PREFIX=${docker_prefix} DOCKER_TAG=${docker_tag} make bazel-push-images
+    hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/bazel-push-images.sh"
 
     # Make sure that all nodes use the newest images
     container=""

--- a/hack/bazel-server.sh
+++ b/hack/bazel-server.sh
@@ -1,0 +1,2 @@
+BAZEL_PID=$(bazel info | grep server_pid | cut -d " " -f 2)
+while kill -0 $BAZEL_PID 2>/dev/null; do sleep 1; done

--- a/hack/bazel-server.sh
+++ b/hack/bazel-server.sh
@@ -1,2 +1,5 @@
 BAZEL_PID=$(bazel info | grep server_pid | cut -d " " -f 2)
 while kill -0 $BAZEL_PID 2>/dev/null; do sleep 1; done
+# Might not be necessary, just to be sure that exec shutdowns always succeed
+# and are not killed by docker.
+sleep 1

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -101,9 +101,15 @@ if [ -d "${HOME}/.docker" ]; then
     volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
 fi
 
+# Ensure that a bazel server is running
+
+if [ -z "$(docker ps --format '{{.Names}}' | grep ${BUILDER}-bazel-server)" ]; then
+    docker run --network host -d ${volumes} --security-opt label:disable --name ${BUILDER}-bazel-server -w "/root/go/src/kubevirt.io/kubevirt" --rm ${BUILDER} hack/bazel-server.sh
+fi
+
 # Run the command
 test -t 1 && USE_TTY="-it"
-docker run --network host --rm ${volumes} --security-opt label:disable ${USE_TTY} -w "/root/go/src/kubevirt.io/kubevirt" ${BUILDER} "$@"
+docker exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "$@"
 
 # Copy the whole kubevirt data out to get generated sources and formatting changes
 _rsync \


### PR DESCRIPTION
**What this PR does / why we need it**:

Speed up all bazel related operations because it does not have to run in
batch mode.

In the background start a bazel server in the container which will be up for three hours, like it is the default for bazel servers, and only do `docker exec` in that container. This ensures that bazel operations are fully cached between bazel command invokations which drastically speeds up development.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
