### PR TITLE
[WIP] keep original pod ip on a dummy interface 

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -73,6 +73,7 @@ type NetworkHandler interface {
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
 	LinkSetDown(link netlink.Link) error
 	LinkSetUp(link netlink.Link) error
+	LinkSetName(link netlink.Link, name string) error
 	LinkAdd(link netlink.Link) error
 	LinkSetLearningOff(link netlink.Link) error
 	ParseAddr(s string) (*netlink.Addr, error)
@@ -112,6 +113,9 @@ func (h *NetworkUtilsHandler) LinkSetDown(link netlink.Link) error {
 }
 func (h *NetworkUtilsHandler) LinkSetUp(link netlink.Link) error {
 	return netlink.LinkSetUp(link)
+}
+func (h *NetworkUtilsHandler) LinkSetName(link netlink.Link, name string) error {
+	return netlink.LinkSetName(link, name)
 }
 func (h *NetworkUtilsHandler) LinkAdd(link netlink.Link) error {
 	return netlink.LinkAdd(link)

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -106,6 +106,16 @@ func (_mr *_MockNetworkHandlerRecorder) LinkSetUp(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetUp", arg0)
 }
 
+func (_m *MockNetworkHandler) LinkSetName(link netlink.Link, name string) error {
+	ret := _m.ctrl.Call(_m, "LinkSetName", link, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) LinkSetName(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetName", arg0, arg1)
+}
+
 func (_m *MockNetworkHandler) LinkAdd(link netlink.Link) error {
 	ret := _m.ctrl.Call(_m, "LinkAdd", link)
 	ret0, _ := ret[0].(error)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -101,7 +101,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	}
 
 	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
-		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0/brport/learning"})
+		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0-nic/brport/learning"})
 		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When kubelet is restarted, it goes over all pods, peeks in their
respective network namespaces and tries to detect their IP in order
to update their Pod objects.

However, with the bridge binding mode, we move this IP address to VM
and the pod interface is left IP-less. That causes kubelet's IP check
to fail and results in pod removal.

With this patch, we use a dummy interface named after the pod interface
to keep the pod IP address. When kubelet performs the check, it sees
interface with expectected name (eth0) and reports its IP address on
Pod object.

Fixes #2076

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix pod default network IP reporting: network bridge binding method keeps original pod address on dummy interface
```
