### PR TITLE
lookup libvirt version in the all content of log file

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1458,11 +1458,9 @@ func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineI
 	}
 	Expect(podName).ToNot(BeEmpty(), "Should find pod not scheduled for deletion")
 
-	var tailLines int64 = 100
 	logsRaw, err := virtCli.CoreV1().
 		Pods(namespace).
 		GetLogs(podName, &k8sv1.PodLogOptions{
-			TailLines: &tailLines,
 			Container: "compute",
 		}).
 		DoRaw()


### PR DESCRIPTION
**What this PR does / why we need it**:
We assume that libvirt version is found when we do tail -100 libvirt.log, however the libvirt version is found on head of file and file can contain more than 100 lines. This change looks for libvirt version on all content of file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
