### PR TITLE
Use list format for CNI annotations for Multus attachments

### DIFF
--- a/cluster/k8s-multus-1.13.3/provider.sh
+++ b/cluster/k8s-multus-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.13.3@sha256:d562b9c7d0192fdf7b2570887d05191bc7ecbf75555b5bc0ddb9782eab5a7517"
+image="k8s-multus-1.13.3@sha256:2ae2dfd20adf163e9cb3923c713932353670692d119f330e547aa1881872de58"
 
 source cluster/ephemeral-provider-common.sh
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1072,8 +1072,10 @@ func getCniAnnotations(vmi *v1.VirtualMachineInstance) (cniAnnotations map[strin
 	for _, network := range vmi.Spec.Networks {
 		// Set the type for the first network. All other networks must have same type.
 		if network.Multus != nil {
+			namespace, networkName := getNamespaceAndNetworkName(vmi, network.Multus.NetworkName)
 			ifaceMap := map[string]string{
-				"name":      network.Multus.NetworkName,
+				"name":      networkName,
+				"namespace": namespace,
 				"interface": fmt.Sprintf("net%d", next_idx+1),
 			}
 			next_idx = next_idx + 1

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1068,13 +1068,15 @@ func getCniAnnotations(vmi *v1.VirtualMachineInstance) (cniAnnotations map[strin
 	ifaceListMap := make([]map[string]string, 0)
 	cniAnnotations = make(map[string]string, 0)
 
-	for idx, network := range vmi.Spec.Networks {
+	next_idx := 0
+	for _, network := range vmi.Spec.Networks {
 		// Set the type for the first network. All other networks must have same type.
 		if network.Multus != nil {
 			ifaceMap := map[string]string{
 				"name":      network.Multus.NetworkName,
-				"interface": fmt.Sprintf("net%d", idx+1),
+				"interface": fmt.Sprintf("net%d", next_idx+1),
 			}
+			next_idx = next_idx + 1
 			ifaceListMap = append(ifaceListMap, ifaceMap)
 		} else if network.Genie != nil {
 			// We have to handle Genie separately because it doesn't support JSON format.

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -170,7 +170,11 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(Equal(true))
-				Expect(value).To(Equal("default,test1"))
+				expectedIfaces := ("[" +
+					"{\"interface\":\"net1\",\"name\":\"default\"}," +
+					"{\"interface\":\"net2\",\"name\":\"test1\"}" +
+					"]")
+				Expect(value).To(Equal(expectedIfaces))
 			})
 		})
 		Context("with genie annotation", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -90,6 +90,15 @@ var _ = Describe("Template", func() {
 			err := networkClient.Tracker().Create(gvr, network, "default")
 			Expect(err).To(Not(HaveOccurred()))
 		}
+		// create a network in a different namespace
+		network := &networkv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test1",
+				Namespace: "other-namespace",
+			},
+		}
+		err := networkClient.Tracker().Create(gvr, network, "other-namespace")
+		Expect(err).To(Not(HaveOccurred()))
 	})
 
 	Describe("Rendering", func() {
@@ -162,6 +171,10 @@ var _ = Describe("Template", func() {
 								NetworkSource: v1.NetworkSource{
 									Multus: &v1.CniNetwork{NetworkName: "test1"},
 								}},
+							{Name: "other-test1",
+								NetworkSource: v1.NetworkSource{
+									Multus: &v1.CniNetwork{NetworkName: "other-namespace/test1"},
+								}},
 						},
 					},
 				}
@@ -171,8 +184,9 @@ var _ = Describe("Template", func() {
 				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
 				Expect(ok).To(Equal(true))
 				expectedIfaces := ("[" +
-					"{\"interface\":\"net1\",\"name\":\"default\"}," +
-					"{\"interface\":\"net2\",\"name\":\"test1\"}" +
+					"{\"interface\":\"net1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"net2\",\"name\":\"test1\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"net3\",\"name\":\"test1\",\"namespace\":\"other-namespace\"}" +
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})


### PR DESCRIPTION
This new format is compatible with what TungstenFabric expects. The new
format should still work for other use cases.

Note that we still pass a non-JSON annotation value for Genie that
doesn't support JSON lists. (yet?)

Co-Authored-By: Ihar Hrachyshka <ihar@redhat.com>

```release-note
Switch to JSON format for Multus CNI annotations. This should enable support
for TungstenFabric, among other things.
```