### PR TITLE
Fix some bazel targets and travis push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ bazel-push-images:
 bazel-tests:
 	hack/dockerized "bazel test --test_output=errors -- //pkg/... "
 
-generate: bazel-generate
+generate:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"
+	SYNC_VENDOR=true hack/dockerized "./hack/bazel-generate.sh"
 
 apidocs:
 	hack/dockerized "./hack/generate.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1 html"
@@ -56,12 +57,10 @@ distclean: clean
 	rm -rf vendor/
 
 deps-install:
-	SYNC_VENDOR=true hack/dockerized "glide install --strip-vendor && ./hack/bazel-generate.sh"
-	hack/dep-prune.sh
+	SYNC_VENDOR=true hack/dockerized "glide install --strip-vendor && hack/dep-prune.sh && ./hack/bazel-generate.sh"
 
 deps-update:
-	SYNC_VENDOR=true hack/dockerized "glide cc && glide update --strip-vendor && ./hack/bazel-generate.sh"
-	hack/dep-prune.sh
+	SYNC_VENDOR=true hack/dockerized "glide cc && glide update --strip-vendor && hack/dep-prune.sh && ./hack/bazel-generate.sh"
 
 docker: build
 	hack/build-docker.sh build ${WHAT}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -96,10 +96,10 @@ _rsync \
     "rsync://root@127.0.0.1:${RSYNCD_PORT}/build"
 
 volumes="-v ${BUILDER}:/root:rw,z"
-# if exists, append .docker directory as volume
-if [ -d "${HOME}/.docker" ]; then
-    volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
-fi
+
+# append .docker directory as volume
+mkdir -p "${HOME}/.docker"
+volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
 
 # Ensure that a bazel server is running
 


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Ensure we propagate `docker login` to bazel if it happens after the bazel server start.
 * Ensure we only run gazelle after code generation or dependency pudates are done.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
