### PR TITLE
Propagate MAC address to multus via annotations

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1080,6 +1080,15 @@ func getNetworkToResourceMap(virtClient kubecli.KubevirtClient, vmi *v1.VirtualM
 	return
 }
 
+func getIfaceByName(vmi *v1.VirtualMachineInstance, name string) *v1.Interface {
+	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if iface.Name == name {
+			return &iface
+		}
+	}
+	return nil
+}
+
 func getCniAnnotations(vmi *v1.VirtualMachineInstance) (cniAnnotations map[string]string, err error) {
 	ifaceList := make([]string, 0)
 	ifaceListMap := make([]map[string]string, 0)
@@ -1094,6 +1103,15 @@ func getCniAnnotations(vmi *v1.VirtualMachineInstance) (cniAnnotations map[strin
 				"name":      networkName,
 				"namespace": namespace,
 				"interface": fmt.Sprintf("net%d", next_idx+1),
+			}
+			iface := getIfaceByName(vmi, network.Name)
+			if iface != nil && iface.MacAddress != "" {
+				// De-facto Standard doesn't define exact string format for
+				// MAC addresses pasted down to CNI.  Here we just pass through
+				// whatever the value our API layer accepted as legit.
+				// Note: while standard allows for 20-byte InfiniBand addresses,
+				// we forbid them in API.
+				ifaceMap["mac"] = iface.MacAddress
 			}
 			next_idx = next_idx + 1
 			ifaceListMap = append(ifaceListMap, ifaceMap)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -190,6 +190,50 @@ var _ = Describe("Template", func() {
 					"]")
 				Expect(value).To(Equal(expectedIfaces))
 			})
+			It("should add MAC address in the pod annotation", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Devices: v1.Devices{
+								Interfaces: []v1.Interface{
+									v1.Interface{
+										Name: "test1",
+										InterfaceBindingMethod: v1.InterfaceBindingMethod{
+											SRIOV: &v1.InterfaceSRIOV{},
+										},
+										MacAddress: "de:ad:00:00:be:af",
+									},
+								},
+							},
+						},
+						Networks: []v1.Network{
+							{Name: "default",
+								NetworkSource: v1.NetworkSource{
+									Multus: &v1.CniNetwork{NetworkName: "default"},
+								}},
+							{Name: "test1",
+								NetworkSource: v1.NetworkSource{
+									Multus: &v1.CniNetwork{NetworkName: "test1"},
+								}},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				value, ok := pod.Annotations["k8s.v1.cni.cncf.io/networks"]
+				Expect(ok).To(Equal(true))
+				expectedIfaces := ("[" +
+					"{\"interface\":\"net1\",\"name\":\"default\",\"namespace\":\"default\"}," +
+					"{\"interface\":\"net2\",\"mac\":\"de:ad:00:00:be:af\",\"name\":\"test1\",\"namespace\":\"default\"}" +
+					"]")
+				Expect(value).To(Equal(expectedIfaces))
+			})
 		})
 		Context("with genie annotation", func() {
 			It("should add genie networks in the pod annotation", func() {

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -198,7 +198,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 		if changed {
 			mac, err = Handler.GetMacDetails(iface)
 			if err != nil {
-				log.Log.Reason(err).Errorf("updated MAC for interface: %s - %s", iface, mac)
+				log.Log.Reason(err).Errorf("updated MAC for interface: %s - %s -> %s", iface, currentMac, mac)
 				return nil, err
 			}
 			break

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -22,10 +22,12 @@ package tests_test
 import (
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -39,10 +41,11 @@ import (
 )
 
 const (
-	postUrl      = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
-	ovsConfCRD   = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"type\": \"ovs\", \"bridge\": \"br1\", \"vlan\": 100 }"}}`
-	ptpConfCRD   = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"name\": \"mynet\", \"type\": \"ptp\", \"ipam\": { \"type\": \"host-local\", \"subnet\": \"10.1.1.0/24\" } }"}}`
-	sriovConfCRD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s","annotations":{"k8s.v1.cni.cncf.io/resourceName":"intel.com/sriov"}},"spec":{"config":"{ \"name\": \"sriov\", \"type\": \"sriov\", \"ipam\": { \"type\": \"host-local\", \"subnet\": \"10.1.1.0/24\" } }"}}`
+	postUrl              = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s"
+	ovsConfCRD           = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"type\": \"ovs\", \"bridge\": \"br1\", \"vlan\": 100 }"}}`
+	ptpConfCRD           = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"name\": \"mynet\", \"type\": \"ptp\", \"ipam\": { \"type\": \"host-local\", \"subnet\": \"10.1.1.0/24\" } }"}}`
+	ptpConfWithTuningCRD = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s"},"spec":{"config":"{ \"cniVersion\": \"0.3.1\", \"name\": \"mynet\", \"plugins\": [{\"type\": \"ptp\", \"ipam\": { \"type\": \"host-local\", \"subnet\": \"10.1.1.0/24\" }},{\"type\": \"tuning\"}]}"}}`
+	sriovConfCRD         = `{"apiVersion":"k8s.cni.cncf.io/v1","kind":"NetworkAttachmentDefinition","metadata":{"name":"%s","namespace":"%s","annotations":{"k8s.v1.cni.cncf.io/resourceName":"intel.com/sriov"}},"spec":{"config":"{ \"name\": \"sriov\", \"type\": \"sriov\", \"ipam\": { \"type\": \"host-local\", \"subnet\": \"10.1.1.0/24\" } }"}}`
 )
 
 var _ = Describe("Multus", func() {
@@ -127,6 +130,14 @@ var _ = Describe("Multus", func() {
 			Do()
 		Expect(result.Error()).NotTo(HaveOccurred())
 
+		// Create ptp crd with tuning plugin enabled
+		result = virtClient.RestClient().
+			Post().
+			RequestURI(fmt.Sprintf(postUrl, tests.NamespaceTestDefault, "ptp-conf-tuning")).
+			Body([]byte(fmt.Sprintf(ptpConfWithTuningCRD, "ptp-conf-tuning", tests.NamespaceTestDefault))).
+			Do()
+		Expect(result.Error()).NotTo(HaveOccurred())
+
 		// Create two sriov networks referring to the same resource name
 		result = virtClient.RestClient().
 			Post().
@@ -142,7 +153,7 @@ var _ = Describe("Multus", func() {
 		Expect(result.Error()).NotTo(HaveOccurred())
 	})
 
-	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance uisng different types of interfaces.", func() {
+	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.", func() {
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
 			AfterEach(func() {
 				virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(detachedVMI.Name, &v13.DeleteOptions{})
@@ -222,6 +233,63 @@ var _ = Describe("Multus", func() {
 
 				pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
 			})
+		})
+
+		Context("VirtualMachineInstance with cni ptp plugin interface with custom MAC address", func() {
+			AfterEach(func() {
+				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne})
+			})
+
+			table.DescribeTable("configure valid custom MAC address on ptp interface", func(networkName string) {
+				customMacAddress := "50:00:00:00:90:0d"
+				ptpInterface := v1.Interface{
+					Name: "ptp",
+					InterfaceBindingMethod: v1.InterfaceBindingMethod{
+						Bridge: &v1.InterfaceBridge{},
+					},
+				}
+				ptpNetwork := v1.Network{
+					Name: "ptp",
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.CniNetwork{
+							NetworkName: networkName,
+						},
+					},
+				}
+
+				interfaces := []v1.Interface{ptpInterface}
+				networks := []v1.Network{ptpNetwork}
+
+				By("Creating a VM with custom MAC address on its ptp interface.")
+				interfaces[0].MacAddress = customMacAddress
+				vmiOne = createVMIOnNode(interfaces, networks)
+				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
+
+				By("Configuring static IP address to ptp interface.")
+				configInterface(vmiOne, "eth0", "10.1.1.1/24", "localhost:~#")
+
+				By("Verifying the desired custom MAC is the one that was actually configured on the interface.")
+				ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
+				err = tests.CheckForTextExpecter(vmiOne, []expect.Batcher{
+					&expect.BSnd{S: ipLinkShow},
+					&expect.BExp{R: "1"},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
+				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, tests.NamespaceTestDefault)
+				out, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					"compute",
+					[]string{"sh", "-c", "ip a"},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
+			},
+				table.Entry("when not using tuning plugin", "ptp-conf"),
+				table.Entry("when using tuning plugin", "ptp-conf-tuning"),
+			)
 		})
 
 		Context("VirtualMachineInstance with sriov plugin interface", func() {
@@ -439,6 +507,17 @@ var _ = Describe("Multus", func() {
 					&expect.BExp{R: "1"},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
+				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmiOne, tests.NamespaceTestDefault)
+				out, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					vmiPod,
+					"compute",
+					[]string{"sh", "-c", "ip a"},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
 
 				By("Ping from the VM with the custom MAC to the other VM.")
 				pingVirtualMachine(vmiOne, "10.1.1.2", "localhost:~#")


### PR DESCRIPTION
Now that annotations are JSON payloads, we can propagate more of
attributes through them to help CNI configure devices as per VMI spec.

```release-note
Propagate interface MAC address to Multus CNI plugin
```