### PR TITLE
provider.sh: Call prepare_config in the build funtion.

### DIFF
--- a/cluster/external/provider.sh
+++ b/cluster/external/provider.sh
@@ -30,6 +30,7 @@ function down() {
 }
 
 function build() {
+    prepare_config
     # Build code and manifests
     ${KUBEVIRT_PATH}hack/dockerized "DOCKER_TAG=${DOCKER_TAG} DOCKER_PREFIX=${docker_prefix} KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER} ./hack/build-manifests.sh"
     DOCKER_PREFIX=${docker_prefix} DOCKER_TAG=${docker_tag} make bazel-push-images


### PR DESCRIPTION
Set up the configuration before starting the
code and manifest build. 

Signed-off-by: Nitesh Konkar niteshkonkar@in.ibm.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
