### PR TITLE
Ensure consistent test package imports

### DIFF
--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,4 +1,4 @@
-package config_test
+package config
 
 import (
 	"testing"

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -1,4 +1,4 @@
-package controller_test
+package controller
 
 import (
 	"testing"

--- a/pkg/emptydisk/emptydisk_suite_test.go
+++ b/pkg/emptydisk/emptydisk_suite_test.go
@@ -1,4 +1,4 @@
-package emptydisk_test
+package emptydisk
 
 import (
 	"testing"

--- a/pkg/host-disk/host_disk_suite_test.go
+++ b/pkg/host-disk/host_disk_suite_test.go
@@ -1,4 +1,4 @@
-package hostdisk_test
+package hostdisk
 
 import (
 	"testing"

--- a/pkg/log/log_suite_test.go
+++ b/pkg/log/log_suite_test.go
@@ -1,16 +1,14 @@
-package log_test
+package log
 
 import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"kubevirt.io/kubevirt/pkg/log"
 )
 
 func TestLogging(t *testing.T) {
-	log.Log.SetIOWriter(GinkgoWriter)
+	Log.SetIOWriter(GinkgoWriter)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Logging Suite")
 }

--- a/pkg/monitoring/vms/prometheus/collector_suite_test.go
+++ b/pkg/monitoring/vms/prometheus/collector_suite_test.go
@@ -1,4 +1,4 @@
-package prometheus_test
+package prometheus
 
 import (
 	"testing"

--- a/pkg/util/net/dns/dns_suite_test.go
+++ b/pkg/util/net/dns/dns_suite_test.go
@@ -1,4 +1,4 @@
-package dns_test
+package dns
 
 import (
 	"testing"

--- a/pkg/virt-api/rest/rest_suite_test.go
+++ b/pkg/virt-api/rest/rest_suite_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package rest_test
+package rest
 
 import (
 	"testing"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_suite_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_suite_test.go
@@ -1,4 +1,4 @@
-package mutating_webhook_test
+package mutating_webhook
 
 import (
 	"testing"

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_suite_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_suite_test.go
@@ -1,4 +1,4 @@
-package validating_webhook_test
+package validating_webhook
 
 import (
 	"testing"

--- a/pkg/virt-controller/services/services_suite_test.go
+++ b/pkg/virt-controller/services/services_suite_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package services_test
+package services
 
 import (
 	"testing"

--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -21,6 +21,11 @@ go_test(
         "monitor_test.go",
         "virt_launcher_suite_test.go",
     ],
+    args = [
+        "--fake-qemu-binary-path",
+        "$(location //cmd/fake-qemu-process)",
+    ],
+    data = ["//cmd/fake-qemu-process"],
     embed = [":go_default_library"],
     deps = [
         "//pkg/log:go_default_library",

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -20,9 +20,11 @@
 package virtlauncher
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -33,6 +35,14 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/log"
 )
+
+var fakeQEMUBinary string
+
+func init() {
+	flag.StringVar(&fakeQEMUBinary, "fake-qemu-binary-path", "_out/cmd/fake-qemu-process/fake-qemu-process", "path to cirros test image")
+	flag.Parse()
+	fakeQEMUBinary = filepath.Join("../../", fakeQEMUBinary)
+}
 
 var _ = Describe("VirtLauncher", func() {
 	var mon *monitor
@@ -48,16 +58,13 @@ var _ = Describe("VirtLauncher", func() {
 	dir := os.Getenv("PWD")
 	dir = strings.TrimSuffix(dir, "pkg/virt-launcher")
 
-	processName := "fake-qemu-process"
-	processPath := dir + "/_out/cmd/fake-qemu-process/" + processName
-
 	processStarted := false
 
 	StartProcess := func() {
 		cmdLock.Lock()
 		defer cmdLock.Unlock()
 
-		cmd = exec.Command(processPath, "--uuid", uuid)
+		cmd = exec.Command(fakeQEMUBinary, "--uuid", uuid)
 		err := cmd.Start()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/virt-launcher/notify-client/client_suite_test.go
+++ b/pkg/virt-launcher/notify-client/client_suite_test.go
@@ -1,4 +1,4 @@
-package eventsclient_test
+package eventsclient
 
 import (
 	"testing"

--- a/pkg/virt-launcher/virt_launcher_suite_test.go
+++ b/pkg/virt-launcher/virt_launcher_suite_test.go
@@ -1,4 +1,4 @@
-package virtlauncher_test
+package virtlauncher
 
 import (
 	"testing"

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_suite_test.go
@@ -16,7 +16,7 @@
  * Copyright 2018 Red Hat, Inc.
  *
  */
-package agentpoller_test
+package agentpoller
 
 import (
 	"testing"

--- a/pkg/virt-launcher/virtwrap/cmd-server/cmd_server_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/cmd_server_suite_test.go
@@ -1,4 +1,4 @@
-package cmdserver_test
+package cmdserver
 
 import (
 	"testing"

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_suite_test.go
@@ -1,4 +1,4 @@
-package dhcp_test
+package dhcp
 
 import (
 	"testing"

--- a/pkg/virt-launcher/virtwrap/network/network_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_suite_test.go
@@ -1,4 +1,4 @@
-package network_test
+package network
 
 import (
 	"testing"

--- a/pkg/virt-launcher/virtwrap/statsconv/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/statsconv/BUILD.bazel
@@ -21,6 +21,10 @@ go_test(
         "converter_test.go",
         "stats_suite_test.go",
     ],
+    data = [
+        "domstats.json",
+        "domstats_expected.json",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/statsconv/stats_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/stats_suite_test.go
@@ -1,4 +1,4 @@
-package statsconv_test
+package statsconv
 
 import (
 	"testing"

--- a/pkg/virt-operator/install-strategy/install_strategy_suite_test.go
+++ b/pkg/virt-operator/install-strategy/install_strategy_suite_test.go
@@ -1,4 +1,4 @@
-package installstrategy_test
+package installstrategy
 
 import (
 	"testing"

--- a/pkg/virt-operator/util/util_suite_test.go
+++ b/pkg/virt-operator/util/util_suite_test.go
@@ -16,7 +16,7 @@
  * Copyright 2018 Red Hat, Inc.
  *
  */
-package util_test
+package util
 
 import (
 	"testing"

--- a/pkg/virt-operator/virt_operator_suite_test.go
+++ b/pkg/virt-operator/virt_operator_suite_test.go
@@ -1,4 +1,4 @@
-package virt_operator_test
+package virt_operator
 
 import (
 	"testing"


### PR DESCRIPTION
**What this PR does / why we need it**:

We had not matching package names between suite files and the actual
test files. This confuses goveralls and bazel in some cases and can lead
to not count tests for code coverage in the case of goveralls, and to
returning cached test results where bazel should actually rerun tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2127 and (maybe) https://github.com/kubevirt/kubevirt/pull/2124#issuecomment-474128377.

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
