### PR TITLE
Switch back to go based unit test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ goveralls: go-build
 go-test: go-build
 	SYNC_OUT=false hack/dockerized "./hack/build-go.sh test ${WHAT}"
 
-test: bazel-tests
+test: go-test
 
 functest:
 	hack/dockerized "hack/build-func-tests.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:

We need an extra check for bazel to veify that _suite_test.go files are
in the same package like all other _test.go files of a suite. Otherwise
bazel potentially misses tests it needs to re-run.

Until then run tests via go again.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
