### PR TITLE
fix multus duplicate ip allocation

### DIFF
--- a/cluster/k8s-multus-1.13.3/provider.sh
+++ b/cluster/k8s-multus-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.13.3@sha256:23cd2fca6e9d2468256921b4fd7bd5e9aaf0e3b03af742066883e39e5d29d349"
+image="k8s-multus-1.13.3@sha256:d037d12a7c847067b051a627925a344ffcfe191adf5b53dc84ccdabbac510995"
 
 source cluster/ephemeral-provider-common.sh
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
fix multus duplicate ip allocation

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

before this update multus configuration creates a cni config calling flannel using the name "flannel.1"
this creates a duplication because coredns pod start by calling flannel directly and the name there is "cbr0".

when we call flannel via multus the name was "name": "flannel.1" this creates a new directory on the host
/var/lib/cni/networks/flannel.1 for allocated ips and allocate same ip that was allocated by flannel with the name cbr0 to the coredns pods.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2134)
<!-- Reviewable:end -->
