### PR TITLE
cleanup in setting default cpu model

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -119,9 +119,7 @@ func mutateVMIs(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	// Set VMI defaults
 	log.Log.Object(&vmi).V(4).Info("Apply defaults")
 	setDefaultCPUModel(&vmi, config.GetCPUModel())
-	if vmi.Spec.Domain.Machine.Type == "" {
-		vmi.Spec.Domain.Machine.Type = config.GetMachineType()
-	}
+	setDefaultMachineType(&vmi, config.GetMachineType())
 	kubev1.SetObjectDefaults_VirtualMachineInstance(&vmi)
 
 	// Add foreground finalizer
@@ -219,6 +217,12 @@ func setDefaultCPUModel(vmi *kubev1.VirtualMachineInstance, defaultCPUModel stri
 			//set is as vmi cpu model
 			vmi.Spec.Domain.CPU.Model = defaultCPUModel
 		}
+	}
+}
+
+func setDefaultMachineType(vmi *kubev1.VirtualMachineInstance, defaultMachineType string) {
+	if vmi.Spec.Domain.Machine.Type == "" {
+		vmi.Spec.Domain.Machine.Type = defaultMachineType
 	}
 }
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Mutating Webhook", func() {
 		memory, _ := resource.ParseQuantity("64M")
 		limitMemory, _ := resource.ParseQuantity("128M")
 		cpuModelFromConfig := "Haswell"
+		machineTypeFromConfig := "pc-q35-3.0"
 
 		getVMISpecMetaFromResponse := func() (*v1.VirtualMachineInstanceSpec, *k8smetav1.ObjectMeta) {
 			vmiBytes, err := json.Marshal(vmi)
@@ -153,16 +154,23 @@ var _ = Describe("Mutating Webhook", func() {
 
 		It("should apply configurable defaults on VMI create", func() {
 			setDefaultCPUModel(vmi, cpuModelFromConfig)
+			setDefaultMachineType(vmi, machineTypeFromConfig)
 			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(cpuModelFromConfig))
+			Expect(vmi.Spec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
 		})
 
 		It("should not override specified properties with defaults on VMI create", func() {
 			vmCPUModel := "EPYC"
+			vmMachineType := "q35"
 			vmi.Spec.Domain.CPU = &v1.CPU{
 				Model: vmCPUModel,
 			}
+			vmi.Spec.Domain.Machine.Type = vmMachineType
+
 			setDefaultCPUModel(vmi, cpuModelFromConfig)
+			setDefaultMachineType(vmi, machineTypeFromConfig)
 			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(vmCPUModel))
+			Expect(vmi.Spec.Domain.Machine.Type).To(Equal(vmMachineType))
 		})
 
 		It("should apply foreground finalizer on VMI create", func() {

--- a/pkg/virt-api/webhooks/mutating-webhook/preset_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/preset_test.go
@@ -27,7 +27,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
@@ -516,72 +515,6 @@ var _ = Describe("Mutating Webhook Presets", func() {
 
 			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
 			Expect(int(vmi.Spec.Domain.CPU.Cores)).To(Equal(4))
-		})
-	})
-
-	Context("Apply default cpu model", func() {
-		var vmi v1.VirtualMachineInstance
-		var configMapIndexer cache.Indexer
-		var defaultCPUModel = "Haswell"
-		var cfgMap k8sv1.ConfigMap
-
-		BeforeEach(func() {
-			configMapIndexer = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, nil)
-			vmi = v1.VirtualMachineInstance{Spec: v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}}
-		})
-
-		It("Should set default cpu model when vmi doesn't have it", func() {
-			cfgMap = k8sv1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "kubevirt",
-					Name:      "kubevirt-config",
-				},
-				Data: map[string]string{
-					defaultCPUModelKey: defaultCPUModel,
-				},
-			}
-			configMapIndexer.Add(&cfgMap)
-			setDefaultCPUModel(&vmi, configMapIndexer)
-
-			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
-			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(defaultCPUModel))
-		})
-
-		It("Should not set default cpu model when vmi does have it", func() {
-			cfgMap = k8sv1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "kubevirt",
-					Name:      "kubevirt-config",
-				},
-				Data: map[string]string{
-					defaultCPUModelKey: defaultCPUModel,
-				},
-			}
-			configMapIndexer.Add(&cfgMap)
-
-			vmCPUModel := "EPYC"
-			vmi.Spec.Domain.CPU = &v1.CPU{
-				Model: vmCPUModel,
-			}
-			setDefaultCPUModel(&vmi, configMapIndexer)
-
-			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
-			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(vmCPUModel))
-		})
-
-		It("Should have empty cpu model when cpu model is not set", func() {
-			cfgMap = k8sv1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "kubevirt",
-					Name:      "kubevirt-config",
-				},
-				Data: map[string]string{},
-			}
-			configMapIndexer.Add(&cfgMap)
-			vmi.Spec.Domain.CPU = &v1.CPU{}
-			setDefaultCPUModel(&vmi, configMapIndexer)
-			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
-			Expect(vmi.Spec.Domain.CPU.Model).To(BeEmpty())
 		})
 	})
 

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -49,6 +49,7 @@ const (
 	useEmulationKey        = "debug.useEmulation"
 	imagePullPolicyKey     = "dev.imagePullPolicy"
 	migrationsConfigKey    = "migrations"
+	cpuModelKey            = "default-cpu-model"
 
 	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
 	ParallelMigrationsPerClusterDefault      uint32 = 5
@@ -162,6 +163,7 @@ type Config struct {
 	MigrationConfig *MigrationConfig
 	ImagePullPolicy k8sv1.PullPolicy
 	MachineType     string
+	CPUModel        string
 }
 
 type MigrationConfig struct {
@@ -196,6 +198,10 @@ func (c *ClusterConfig) GetImagePullPolicy() (policy k8sv1.PullPolicy) {
 
 func (c *ClusterConfig) GetMachineType() string {
 	return c.getConfig().MachineType
+}
+
+func (c *ClusterConfig) GetCPUModel() string {
+	return c.getConfig().CPUModel
 }
 
 // setConfig parses the provided config map and updates the provided config.
@@ -246,6 +252,10 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	// set machine type
 	if machineType := strings.TrimSpace(configMap.Data[machineTypeKey]); machineType != "" {
 		config.MachineType = machineType
+	}
+
+	if cpuModel := strings.TrimSpace(configMap.Data[cpuModelKey]); cpuModel != "" {
+		config.CPUModel = cpuModel
 	}
 
 	return nil

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -80,6 +80,22 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when unset, it should return the default", "", DefaultMachineType),
 	)
 
+	table.DescribeTable(" when cpuModel", func(value string, result string) {
+		cfgMap := kubev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "1234",
+				Namespace:       "kubevirt",
+				Name:            "kubevirt-config",
+			},
+			Data: map[string]string{cpuModelKey: value},
+		}
+		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
+		Expect(clusterConfig.GetCPUModel()).To(Equal(result))
+	},
+		table.Entry("when set, it should return the value", "Haswell", "Haswell"),
+		table.Entry("when unset, it should return empty string", "", ""),
+	)
+
 	It("Should return migration config values if specified as json", func() {
 		cfgMap := kubev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR changes the way the default CPU model is fetched from kubevirt-config. It is now fetched via the virt-config package. This allows concentrating all configurable virt-properties in a single place and provides a unified way to access them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```