### PR TITLE
support i440 chips

### DIFF
--- a/pkg/virt-config/virt-properties.go
+++ b/pkg/virt-config/virt-properties.go
@@ -33,7 +33,7 @@ import (
 func SupportedEmulatedMachines() []string {
 	config := os.Getenv(emulatedMachinesEnvVar)
 	if len(config) == 0 {
-		return []string{"q35*", "pc-q35*"}
+		return []string{"q35*", "pc-q35*", "pc*"}
 	}
 
 	vals := strings.Split(config, ",")


### PR DESCRIPTION


**What this PR does / why we need it**:
Some legacy networking appliances require very specific machine emulation in the pc- variety from the virt-launcher. such as 

```
[root@c1 /]# virsh capabilities | egrep "<machine"
      <machine maxCpus='255'>pc-i440fx-3.0</machine>
      <machine canonical='pc-i440fx-3.0' maxCpus='255'>pc</machine>
      <machine maxCpus='1'>isapc</machine>
      <machine maxCpus='255'>pc-1.1</machine>
      <machine maxCpus='255'>pc-1.2</machine>
      <machine maxCpus='255'>pc-1.3</machine>
      <machine maxCpus='255'>pc-i440fx-2.8</machine>
      <machine maxCpus='255'>pc-1.0</machine>
      <machine maxCpus='255'>pc-i440fx-2.9</machine>
      <machine maxCpus='255'>pc-i440fx-2.6</machine>
      <machine maxCpus='255'>pc-i440fx-2.7</machine>
      <machine maxCpus='128'>xenfv</machine>
      <machine maxCpus='255'>pc-i440fx-2.3</machine>
      <machine maxCpus='255'>pc-i440fx-2.4</machine>
      <machine maxCpus='255'>pc-i440fx-2.5</machine>
      <machine maxCpus='255'>pc-i440fx-2.1</machine>
      <machine maxCpus='255'>pc-i440fx-2.2</machine>
      <machine maxCpus='255'>pc-i440fx-2.0</machine>
      <machine maxCpus='288'>pc-q35-2.11</machine>
      <machine maxCpus='288'>pc-q35-2.12</machine>
      <machine maxCpus='288'>pc-q35-3.0</machine>
      <machine canonical='pc-q35-3.0' maxCpus='288'>q35</machine>
      <machine maxCpus='1'>xenpv</machine>
      <machine maxCpus='288'>pc-q35-2.10</machine>
      <machine maxCpus='255'>pc-i440fx-1.7</machine>
      <machine maxCpus='288'>pc-q35-2.9</machine>
      <machine maxCpus='255'>pc-0.15</machine>
      <machine maxCpus='255'>pc-i440fx-1.5</machine>
      <machine maxCpus='255'>pc-q35-2.7</machine>
      <machine maxCpus='255'>pc-i440fx-1.6</machine>
      <machine maxCpus='255'>pc-i440fx-2.11</machine>
      <machine maxCpus='288'>pc-q35-2.8</machine>
      <machine maxCpus='255'>pc-0.13</machine>
      <machine maxCpus='255'>pc-0.14</machine>
      <machine maxCpus='255'>pc-i440fx-2.12</machine>
      <machine maxCpus='255'>pc-q35-2.4</machine>
      <machine maxCpus='255'>pc-q35-2.5</machine>
      <machine maxCpus='255'>pc-q35-2.6</machine>
      <machine maxCpus='255'>pc-i440fx-1.4</machine>
      <machine maxCpus='255'>pc-i440fx-2.10</machine>
      <machine maxCpus='255'>pc-0.11</machine>
      <machine maxCpus='255'>pc-0.12</machine>
      <machine maxCpus='255'>pc-0.10</machine>
      <machine maxCpus='255'>pc-i440fx-3.0</machine>
      <machine canonical='pc-i440fx-3.0' maxCpus='255'>pc</machine>
      <machine maxCpus='1'>isapc</machine>
      <machine maxCpus='255'>pc-1.1</machine>
      <machine maxCpus='255'>pc-1.2</machine>
      <machine maxCpus='255'>pc-1.3</machine>
      <machine maxCpus='255'>pc-i440fx-2.8</machine>
      <machine maxCpus='255'>pc-1.0</machine>
      <machine maxCpus='255'>pc-i440fx-2.9</machine>
      <machine maxCpus='255'>pc-i440fx-2.6</machine>
      <machine maxCpus='255'>pc-i440fx-2.7</machine>
      <machine maxCpus='128'>xenfv</machine>
      <machine maxCpus='255'>pc-i440fx-2.3</machine>
      <machine maxCpus='255'>pc-i440fx-2.4</machine>
      <machine maxCpus='255'>pc-i440fx-2.5</machine>
      <machine maxCpus='255'>pc-i440fx-2.1</machine>
      <machine maxCpus='255'>pc-i440fx-2.2</machine>
      <machine maxCpus='255'>pc-i440fx-2.0</machine>
      <machine maxCpus='288'>pc-q35-2.11</machine>
      <machine maxCpus='288'>pc-q35-2.12</machine>
      <machine maxCpus='288'>pc-q35-3.0</machine>
      <machine canonical='pc-q35-3.0' maxCpus='288'>q35</machine>
      <machine maxCpus='1'>xenpv</machine>
      <machine maxCpus='288'>pc-q35-2.10</machine>
      <machine maxCpus='255'>pc-i440fx-1.7</machine>
      <machine maxCpus='288'>pc-q35-2.9</machine>
      <machine maxCpus='255'>pc-0.15</machine>
      <machine maxCpus='255'>pc-i440fx-1.5</machine>
      <machine maxCpus='255'>pc-q35-2.7</machine>
      <machine maxCpus='255'>pc-i440fx-1.6</machine>
      <machine maxCpus='255'>pc-i440fx-2.11</machine>
      <machine maxCpus='288'>pc-q35-2.8</machine>
      <machine maxCpus='255'>pc-0.13</machine>
      <machine maxCpus='255'>pc-i440fx-2.12</machine>
      <machine maxCpus='255'>pc-0.14</machine>
      <machine maxCpus='255'>pc-q35-2.4</machine>
      <machine maxCpus='255'>pc-q35-2.5</machine>
      <machine maxCpus='255'>pc-q35-2.6</machine>
      <machine maxCpus='255'>pc-i440fx-1.4</machine>
      <machine maxCpus='255'>pc-i440fx-2.10</machine>
      <machine maxCpus='255'>pc-0.11</machine>
      <machine maxCpus='255'>pc-0.12</machine>
      <machine maxCpus='255'>pc-0.10</machine>
```


**Special notes for your reviewer**:

**Release note**:
```NONE

```
