### PR TITLE
Rework namespace-limits handing

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//pkg/virt-api/webhooks:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/namespace-limits_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/namespace-limits_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
@@ -87,38 +86,6 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 			applyNamespaceLimitRangeValues(vmiCopy, namespaceLimitInformer)
 
 			Expect(vmiCopy.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("128M"))
-		})
-
-		When("namespace has more than one limit range", func() {
-			var additionalNamespaceLimit *k8sv1.LimitRange
-
-			BeforeEach(func() {
-				additionalLimitMemory, _ := resource.ParseQuantity("76M")
-				additionalNamespaceLimit = &k8sv1.LimitRange{
-					ObjectMeta: k8smetav1.ObjectMeta{
-						Name: "additional-limit-range",
-					},
-					Spec: k8sv1.LimitRangeSpec{
-						Limits: []k8sv1.LimitRangeItem{
-							{
-								Type: k8sv1.LimitTypeContainer,
-								Default: k8sv1.ResourceList{
-									k8sv1.ResourceMemory: additionalLimitMemory,
-								},
-							},
-						},
-					},
-				}
-				namespaceLimitInformer.GetIndexer().Add(additionalNamespaceLimit)
-			})
-
-			It("should apply range with minimal limit", func() {
-				vmiCopy := vmi.DeepCopy()
-				By("Applying namespace range values on the VMI")
-				applyNamespaceLimitRangeValues(vmiCopy, namespaceLimitInformer)
-
-				Expect(vmiCopy.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("76M"))
-			})
 		})
 	})
 })

--- a/pkg/virt-api/webhooks/mutating-webhook/namespace-limits_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/namespace-limits_test.go
@@ -38,7 +38,6 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 
 	memory, _ := resource.ParseQuantity("64M")
 	limitMemory, _ := resource.ParseQuantity("128M")
-	zeroMemory, _ := resource.ParseQuantity("0M")
 
 	BeforeEach(func() {
 		vmi = v1.VirtualMachineInstance{
@@ -88,25 +87,6 @@ var _ = Describe("Mutating Webhook Namespace Limits", func() {
 			applyNamespaceLimitRangeValues(vmiCopy, namespaceLimitInformer)
 
 			Expect(vmiCopy.Spec.Domain.Resources.Limits.Memory().String()).To(Equal("128M"))
-		})
-
-		When("namespace limit equals 0", func() {
-			It("should not apply namespace limits", func() {
-				vmiCopy := vmi.DeepCopy()
-
-				namespaceLimitCopy := namespaceLimit.DeepCopy()
-				namespaceLimitCopy.Spec.Limits[0].Default[k8sv1.ResourceMemory] = zeroMemory
-				namespaceLimitInformer.GetIndexer().Update(namespaceLimitCopy)
-
-				By("Applying namespace range values on the VMI")
-				applyNamespaceLimitRangeValues(vmiCopy, namespaceLimitInformer)
-				_, ok := vmiCopy.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory]
-				Expect(ok).To(Equal(false))
-			})
-
-			AfterEach(func() {
-				namespaceLimitInformer.GetIndexer().Update(namespaceLimit)
-			})
 		})
 
 		When("namespace has more than one limit range", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -768,6 +768,37 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		}
 	}
 
+	// Validate cpu if values are not negative
+	if spec.Domain.Resources.Requests.Cpu().MilliValue() < 0 {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s '%s': must be greater than or equal to 0.", field.Child("domain", "resources", "requests", "cpu").String(),
+				spec.Domain.Resources.Requests.Cpu()),
+			Field: field.Child("domain", "resources", "requests", "cpu").String(),
+		})
+	}
+
+	if spec.Domain.Resources.Limits.Cpu().MilliValue() < 0 {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s '%s': must be greater than or equal to 0.", field.Child("domain", "resources", "limits", "cpu").String(),
+				spec.Domain.Resources.Limits.Cpu()),
+			Field: field.Child("domain", "resources", "limits", "cpu").String(),
+		})
+	}
+
+	if spec.Domain.Resources.Limits.Cpu().MilliValue() > 0 &&
+		spec.Domain.Resources.Requests.Cpu().MilliValue() > spec.Domain.Resources.Limits.Cpu().MilliValue() {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s '%s' is greater than %s '%s'", field.Child("domain", "resources", "requests", "cpu").String(),
+				spec.Domain.Resources.Requests.Cpu(),
+				field.Child("domain", "resources", "limits", "cpu").String(),
+				spec.Domain.Resources.Limits.Cpu()),
+			Field: field.Child("domain", "resources", "requests", "cpu").String(),
+		})
+	}
+
 	// Validate CPU pinning
 	if spec.Domain.CPU != nil && spec.Domain.CPU.DedicatedCPUPlacement {
 		requestsMem := spec.Domain.Resources.Requests.Memory().Value()


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the current handling of namespace's LimitRanges:
1. We do not look for the LimitRange in the namespace with the minimal value of memory-limit as it is not what Kubernetes does + there is no good reason to prioritize that with the minimal value of memory-limit over the one with the minimal value of cpu-limit, for instance.
2. We apply not only the memory-default but also cpu-default and both memory- and cpu- defaultRequest.

**Special notes for your reviewer**:
Solving the potential issue discussed in #2137 about memory defaultRequest will be done separately.
This PR copies some code from Kubernetes (see references within the code) - it would be great to reuse the code in Kubernetes but it's a bit complex at the moment as it resides within an admission plugin within the main Kubernetes repo.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
