### PR TITLE
tests: skip migration tests if LiveMigration is not enabled

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Migrations", func() {
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
+		if !tests.HasLiveMigration() {
+			Skip("LiveMigration feature gate is not enabled in kubevirt-config")
+		}
 
 		nodes := tests.GetAllSchedulableNodes(virtClient)
 		Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3139,8 +3139,8 @@ func StartVirtualMachine(vm *v1.VirtualMachine) *v1.VirtualMachine {
 	return updatedVM
 }
 
-func HasCDI() bool {
-	hasCDI := false
+func HasFeature(feature string) bool {
+	hasFeature := false
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 	options := metav1.GetOptions{}
@@ -3148,15 +3148,23 @@ func HasCDI() bool {
 	if err == nil {
 		val, ok := cfgMap.Data[virtconfig.FeatureGatesKey]
 		if !ok {
-			return hasCDI
+			return hasFeature
 		}
-		hasCDI = strings.Contains(val, "DataVolumes")
+		hasFeature = strings.Contains(val, feature)
 	} else {
 		if !errors.IsNotFound(err) {
 			PanicOnError(err)
 		}
 	}
-	return hasCDI
+	return hasFeature
+}
+
+func HasCDI() bool {
+	return HasFeature("DataVolumes")
+}
+
+func HasLiveMigration() bool {
+	return HasFeature("LiveMigration")
 }
 
 func StartTCPServer(vmi *v1.VirtualMachineInstance, port int) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Skip Migrations tests (i.e those from `tests/migration_test.go`) if LiveMigration feature gate is not enabled instead of running them and seeing them fail.

**Special notes for your reviewer**:

This is the same behaviour as DataVolume tests (`tests/datavolume_test.go`) which are skipped when DataVolumes feature gate is not enabled.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```