### PR TITLE
virtctl imageupload auto detects ingress/route

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of passing Upload Proxy URL as argument to `virtctl imageupload`, the tool will lookup for CDIConfig object and find the  Upload Proxy URL (if Ingress/Route exists).
If it doesn't exist, the program will exit with an error message.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl image upload now auto detects Ingress/Route details
```
