### PR TITLE
possibility to set machine type from kubevirt-config

### DIFF
--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -123,9 +123,6 @@ func SetDefaults_VirtualMachineInstance(obj *VirtualMachineInstance) {
 	if obj.Spec.Domain.Features == nil {
 		obj.Spec.Domain.Features = &Features{}
 	}
-	if obj.Spec.Domain.Machine.Type == "" {
-		obj.Spec.Domain.Machine.Type = "q35"
-	}
 
 	setDefaults_Disk(obj)
 	SetDefaults_NetworkInterface(obj)

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -67,7 +67,7 @@ var exampleJSON = `{
         "dedicatedCpuPlacement": true
       },
       "machine": {
-        "type": "q35"
+        "type": ""
       },
       "firmware": {
         "uuid": "28a42a60-44ef-4428-9c10-1a6aee94627f"

--- a/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/log:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/preset_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/preset_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(vmCPUModel))
 		})
 
-		It("Should has empty cpu model when cpu model is not set", func() {
+		It("Should have empty cpu model when cpu model is not set", func() {
 			cfgMap = k8sv1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "kubevirt",

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -64,6 +64,22 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when invalid, it should return the default", "invalid", kubev1.PullIfNotPresent),
 	)
 
+	table.DescribeTable(" when machineType", func(value string, result string) {
+		cfgMap := kubev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: "1234",
+				Namespace:       "kubevirt",
+				Name:            "kubevirt-config",
+			},
+			Data: map[string]string{machineTypeKey: value},
+		}
+		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
+		Expect(clusterConfig.GetMachineType()).To(Equal(result))
+	},
+		table.Entry("when set, it should return the value", "pc-q35-3.0", "pc-q35-3.0"),
+		table.Entry("when unset, it should return the default", "", DefaultMachineType),
+	)
+
 	It("Should return migration config values if specified as json", func() {
 		cfgMap := kubev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virtctl:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/xml"
 	goerrors "errors"
 	"flag"
 	"fmt"
@@ -71,6 +72,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	launcherApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virtctl"
 	vmsgen "kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
@@ -3337,4 +3339,20 @@ func AppendEmptyDisk(vmi *v1.VirtualMachineInstance, diskName, busName, diskSize
 			},
 		},
 	})
+}
+
+func GetRunningVMISpec(vmi *v1.VirtualMachineInstance) (*launcherApi.DomainSpec, error) {
+	runningVMISpec := launcherApi.DomainSpec{}
+	cli, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return nil, err
+	}
+
+	domXML, err := GetRunningVirtualMachineInstanceDomainXML(cli, vmi)
+	if err != nil {
+		return nil, err
+	}
+
+	err = xml.Unmarshal([]byte(domXML), &runningVMISpec)
+	return &runningVMISpec, err
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"encoding/xml"
 	"flag"
 	"fmt"
 	"regexp"
@@ -43,7 +42,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
 	hw_utils "kubevirt.io/kubevirt/pkg/util/hardware"
-	launcherApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -1076,6 +1074,56 @@ var _ = Describe("Configurations", func() {
 		})
 	})
 
+	Context("with machine type settings", func() {
+		defaultMachineTypeKey := "machine-type"
+
+		AfterEach(func() {
+			cfgMap, err := virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			cfgMap.Data[defaultMachineTypeKey] = ""
+
+			_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should set machine type from VMI spec", func() {
+			vmi := tests.NewRandomVMI()
+			vmi.Spec.Domain.Machine.Type = "pc-q35-3.0"
+			tests.RunVMIAndExpectLaunch(vmi, false, 30)
+			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(runningVMISpec.OS.Type.Machine).To(Equal("pc-q35-3.0"))
+		})
+
+		It("should set default machine type when it is not provided", func() {
+			vmi := tests.NewRandomVMI()
+			vmi.Spec.Domain.Machine.Type = ""
+			tests.RunVMIAndExpectLaunch(vmi, false, 30)
+			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
+		})
+
+		It("should set machine type from kubevirt-confg", func() {
+			cfgMap, err := virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, metav1.GetOptions{})
+			Expect(err).To(BeNil())
+			cfgMap.Data[defaultMachineTypeKey] = "pc-q35-3.0"
+			_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			vmi := tests.NewRandomVMI()
+			vmi.Spec.Domain.Machine.Type = ""
+			tests.RunVMIAndExpectLaunch(vmi, false, 30)
+			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(runningVMISpec.OS.Type.Machine).To(Equal("pc-q35-3.0"))
+		})
+	})
+
 	Context("[rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache settings", func() {
 		blockPVName := "block-pv-" + rand.String(48)
 
@@ -1106,10 +1154,7 @@ var _ = Describe("Configurations", func() {
 			tests.AddHostDisk(vmi, "/run/kubevirt-private/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "hostdisk")
 			tests.RunVMIAndExpectLaunch(vmi, false, 60)
 
-			runningVMISpec := launcherApi.DomainSpec{}
-			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
-			Expect(err).ToNot(HaveOccurred())
-			err = xml.Unmarshal([]byte(domXml), &runningVMISpec)
+			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
 			disks := runningVMISpec.Devices.Disks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The feature allows to read machine type from kubevirt-config configMap

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
todo:
- [x] integration tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Read machine type from kubevirt-config
```
