### PR TITLE
hyperv: add feature gate and node selector

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -44,13 +44,21 @@ const (
 // We cannot rely on automatic invocation of 'init' method because this initialization
 // code assumes a cluster is available to pull the configmap from
 func Init() {
-	cfgMap := getConfigMap()
+	InitFromConfigMap(getConfigMap())
+}
+
+func InitFromConfigMap(cfgMap *k8sv1.ConfigMap) {
 	if val, ok := cfgMap.Data[FeatureGatesKey]; ok {
 		os.Setenv(featureGateEnvVar, val)
 	}
 	if val, ok := cfgMap.Data[emulatedMachinesKey]; ok {
 		os.Setenv(emulatedMachinesEnvVar, val)
 	}
+}
+
+func Clear() {
+	os.Unsetenv(featureGateEnvVar)
+	os.Unsetenv(emulatedMachinesEnvVar)
 }
 
 func getConfigMap() *k8sv1.ConfigMap {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -30,12 +30,13 @@ import (
 )
 
 const (
-	dataVolumesGate      = "DataVolumes"
-	cpuManager           = "CPUManager"
-	ignitionGate         = "ExperimentalIgnitionSupport"
-	liveMigrationGate    = "LiveMigration"
-	SRIOVGate            = "SRIOV"
-	CPUNodeDiscoveryGate = "CPUNodeDiscovery"
+	dataVolumesGate       = "DataVolumes"
+	cpuManager            = "CPUManager"
+	ignitionGate          = "ExperimentalIgnitionSupport"
+	liveMigrationGate     = "LiveMigration"
+	SRIOVGate             = "SRIOV"
+	CPUNodeDiscoveryGate  = "CPUNodeDiscovery"
+	HypervStrictCheckGate = "HypervStrictCheck"
 )
 
 func DataVolumesEnabled() bool {
@@ -56,4 +57,8 @@ func LiveMigrationEnabled() bool {
 
 func SRIOVEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
+}
+
+func HypervStrictCheckEnabled() bool {
+	return strings.Contains(os.Getenv(featureGateEnvVar), HypervStrictCheckGate)
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -70,6 +70,7 @@ const LibvirtStartupDelay = 10
 //to match a VirtualMachineInstance CPU model(Family) and/or features to nodes that support them.
 const NFD_CPU_MODEL_PREFIX = "feature.node.kubernetes.io/cpu-model-"
 const NFD_CPU_FEATURE_PREFIX = "feature.node.kubernetes.io/cpu-feature-"
+const NFD_KVM_INFO_PREFIX = "feature.node.kubernetes.io/kvm-info-cap-hyperv-"
 
 const MULTUS_RESOURCE_NAME_ANNOTATION = "k8s.v1.cni.cncf.io/resourceName"
 const MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION = "v1.multus-cni.io/default-network"
@@ -184,6 +185,43 @@ func IsCPUNodeDiscoveryEnabled(store cache.Store) bool {
 		return true
 	}
 	return false
+}
+
+func isFeatureStateEnabled(fs *v1.FeatureState) bool {
+	return fs != nil && fs.Enabled != nil && *fs.Enabled
+}
+
+func getHypervNodeSelectors(vmi *v1.VirtualMachineInstance) (map[string]string, error) {
+	if vmi.Spec.Domain.Features == nil || vmi.Spec.Domain.Features.Hyperv == nil {
+		return nil, nil
+	}
+
+	nodeSelectors := make(map[string]string)
+	// The following HyperV features don't require support from the host kernel, according to inspection
+	// of the QEMU sources (4.0 - adb3321bfd)
+	// VAPIC, Relaxed, Spinlocks, VendorID
+	// see https://schd.ws/hosted_files/devconfcz2019/cf/vkuznets_enlightening_kvm_devconf2019.pdf
+	// to learn about dependencies between enlightenments
+
+	hyperv := vmi.Spec.Domain.Features.Hyperv // shortcut
+	if isFeatureStateEnabled(hyperv.VPIndex) {
+		nodeSelectors[NFD_KVM_INFO_PREFIX+"vpindex"] = "true"
+	}
+	if isFeatureStateEnabled(hyperv.Runtime) {
+		nodeSelectors[NFD_KVM_INFO_PREFIX+"runtime"] = "true"
+	}
+	if isFeatureStateEnabled(hyperv.Reset) {
+		nodeSelectors[NFD_KVM_INFO_PREFIX+"reset"] = "true"
+	}
+	if isFeatureStateEnabled(hyperv.SyNIC) {
+		nodeSelectors[NFD_KVM_INFO_PREFIX+"synic"] = "true"
+		// TODO: SyNIC depends on vp-index on QEMU level. We should enforce this constraint.
+	}
+	if isFeatureStateEnabled(hyperv.SyNICTimer) {
+		nodeSelectors[NFD_KVM_INFO_PREFIX+"synictimer"] = "true"
+		// TODO: SyNICTimer depends on SyNIC and Relaxed. We should enforce this constraint.
+	}
+	return nodeSelectors, nil
 }
 
 func CPUModelLabelFromCPUModel(vmi *v1.VirtualMachineInstance) (label string, err error) {
@@ -789,6 +827,16 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 		for _, cpuFeatureLable := range CPUFeatureLabelsFromCPUFeatures(vmi) {
 			nodeSelector[cpuFeatureLable] = "true"
+		}
+	}
+
+	if virtconfig.HypervStrictCheckEnabled() {
+		hvNodeSelectors, err := getHypervNodeSelectors(vmi)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range hvNodeSelectors {
+			nodeSelector[k] = v
 		}
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -101,6 +101,10 @@ var _ = Describe("Template", func() {
 		Expect(err).To(Not(HaveOccurred()))
 	})
 
+	AfterEach(func() {
+		virtconfig.Clear()
+	})
+
 	Describe("Rendering", func() {
 		Context("launch template with correct parameters", func() {
 			It("should work", func() {
@@ -442,6 +446,148 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("kubernetes.io/hostname", "node02"))
 				Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("node-role.kubernetes.io/compute", "true"))
+			})
+
+			It("should not add node selector for hyperv nodes if VMI does not request hyperv features", func() {
+				cfgMap := kubev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceKubevirt,
+						Name:      "kubevirt-config",
+					},
+					Data: map[string]string{virtconfig.FeatureGatesKey: virtconfig.HypervStrictCheckGate},
+				}
+				virtconfig.InitFromConfigMap(&cfgMap)
+
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Features: &v1.Features{
+								Hyperv: &v1.FeatureHyperv{},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
+			})
+
+			It("should not add node selector for hyperv nodes if VMI requests hyperv features, but feature gate is disabled", func() {
+				enabled := true
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Features: &v1.Features{
+								Hyperv: &v1.FeatureHyperv{
+									SyNIC: &v1.FeatureState{
+										Enabled: &enabled,
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
+			})
+
+			It("should add node selector for hyperv nodes if VMI requests hyperv features which depend on host kernel", func() {
+				cfgMap := kubev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceKubevirt,
+						Name:      "kubevirt-config",
+					},
+					Data: map[string]string{virtconfig.FeatureGatesKey: virtconfig.HypervStrictCheckGate},
+				}
+				virtconfig.InitFromConfigMap(&cfgMap)
+
+				enabled := true
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Features: &v1.Features{
+								Hyperv: &v1.FeatureHyperv{
+									SyNIC: &v1.FeatureState{
+										Enabled: &enabled,
+									},
+									SyNICTimer: &v1.FeatureState{
+										Enabled: &enabled,
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"synic", "true"))
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"synictimer", "true"))
+			})
+
+			It("should not add node selector for hyperv nodes if VMI requests hyperv features which do not depend on host kernel", func() {
+				cfgMap := kubev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespaceKubevirt,
+						Name:      "kubevirt-config",
+					},
+					Data: map[string]string{virtconfig.FeatureGatesKey: virtconfig.HypervStrictCheckGate},
+				}
+				virtconfig.InitFromConfigMap(&cfgMap)
+
+				var retries uint32 = 4095
+				enabled := true
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{
+							Features: &v1.Features{
+								Hyperv: &v1.FeatureHyperv{
+									Relaxed: &v1.FeatureState{
+										Enabled: &enabled,
+									},
+									VAPIC: &v1.FeatureState{
+										Enabled: &enabled,
+									},
+									Spinlocks: &v1.FeatureSpinlocks{
+										Enabled: &enabled,
+										Retries: &retries,
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
 			})
 
 			It("should add default cpu/memory resources to the sidecar container if cpu pinning was requested", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add support to check HyperV support on the host side, depending on the labels.
Label will be added by https://github.com/fromanirh/kvm-info-nfd-plugin

**Special notes for your reviewer**:
Fixes possible, although rare, VM launch failures if hyperv features are requested on not up-to-date hosts, see:
https://lists.ovirt.org/archives/list/users@ovirt.org/thread/GHUBLKYNM4G5QOIEFY5H7QKPLBDU5H7Z/#GHUBLKYNM4G5QOIEFY5H7QKPLBDU5H7Z

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add feature gate to enable strict checking of the hyperv support from the host
```
