### PR TITLE
Set the minimum memory limit to 1M

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -1210,6 +1210,17 @@ var _ = Describe("Validating Webhook", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
+		It("should reject small requests.memory size value", func() {
+			vm := v1.NewMinimalVMI("testvm")
+
+			vm.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64m"),
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
+		})
 		It("should reject negative limits.memory size value", func() {
 			vm := v1.NewMinimalVMI("testvm")
 


### PR DESCRIPTION
If the user has specified too small amount of memory, the virtual machine cannot be created and creation will fail with error:

> "server error. command Launcher.Sync failed: \"LibvirtError(Code=27, Domain=20, Message='XML error: Memory size must be specified via \u003cmemory\u003e or in the \u003cnuma\u003e configuration')\""

**What this PR does / why we need it**:

This PR increases the minimum amount of memory that can be specified.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1674388

**Special notes for your reviewer**:

@fabiand @stu-gott please review

```release-note
Added check for the amount of requested initial VMI memory. The minimum value is 1M.
```