### PR TITLE
Easy fixes

### DIFF
--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -112,9 +112,10 @@ func SetDefaults_Firmware(obj *Firmware) {
 func SetDefaults_VirtualMachineInstance(obj *VirtualMachineInstance) {
 	// FIXME we need proper validation and configurable defaulting instead of this
 	if _, exists := obj.Spec.Domain.Resources.Requests[v1.ResourceMemory]; !exists {
-		obj.Spec.Domain.Resources.Requests = v1.ResourceList{
-			v1.ResourceMemory: resource.MustParse("8192Ki"),
+		if obj.Spec.Domain.Resources.Requests == nil {
+			obj.Spec.Domain.Resources.Requests = v1.ResourceList{}
 		}
+		obj.Spec.Domain.Resources.Requests[v1.ResourceMemory] = resource.MustParse("8192Ki")
 	}
 	if obj.Spec.Domain.Firmware == nil {
 		obj.Spec.Domain.Firmware = &Firmware{}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -527,6 +527,7 @@ func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.Virtual
 	vmi.ObjectMeta = vm.Spec.Template.ObjectMeta
 	vmi.ObjectMeta.Name = basename
 	vmi.ObjectMeta.GenerateName = basename
+	vmi.ObjectMeta.Namespace = vm.ObjectMeta.Namespace
 	vmi.Spec = vm.Spec.Template.Spec
 
 	setupStableFirmwareUUID(vm, vmi)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -550,8 +550,7 @@ var _ = Describe("Configurations", func() {
 					vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
-							kubev1.ResourceCPU:    resource.MustParse("800m"),
-							kubev1.ResourceMemory: resource.MustParse("64M"),
+							kubev1.ResourceCPU: resource.MustParse("800m"),
 						},
 					}
 					vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces easy fixes to issues that were discovered while testing namespace-limits:
1. We no longer clear all settings in the resources/requests section when memory request is missing.
2. We copy the namespace from a VM to its corresponding VMI when initializing the latter.

**Special notes for your reviewer**:
There is an on-going discussion in parallel on whether or not default memory should be set by Kubevirt. It is debatable and therefore IMO it is better to fix for the current code, even if it would be changed/removed anytime soon.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```