### PR TITLE
hyperv: update support to features exposed in libvirt >= 4.10

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4464,11 +4464,11 @@
     "description": "Hyperv specific features.",
     "properties": {
      "evmcs": {
-      "description": "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic\nDefaults to the machine type setting.\n+optional",
+      "description": "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "frequencies": {
-      "description": "Frequencies improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+      "description": "Frequencies improve Hyper-V on KVM (TSC clock source).\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "ipi": {
@@ -4476,7 +4476,7 @@
       "$ref": "#/definitions/v1.FeatureState"
      },
      "reenlightenment": {
-      "description": "Reenlightenment improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+      "description": "Reenlightenment improve Hyper-V on KVM (TSC clock source).\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "relaxed": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4463,12 +4463,28 @@
    "v1.FeatureHyperv": {
     "description": "Hyperv specific features.",
     "properties": {
+     "evmcs": {
+      "description": "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
+     "frequencies": {
+      "description": "Frequencies improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
+     "ipi": {
+      "description": "IPI improves performances in overcommited environments. Requires vpindex.\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
+     "reenlightenment": {
+      "description": "Reenlightenment improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
      "relaxed": {
       "description": "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "reset": {
-      "description": "Reset enables Hyperv reboot/reset for the vmi.\nDefaults to the machine type setting.\n+optional",
+      "description": "Reset enables Hyperv reboot/reset for the vmi. Requires synic.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "runtime": {
@@ -4485,6 +4501,10 @@
      },
      "synictimer": {
       "description": "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
+      "$ref": "#/definitions/v1.FeatureState"
+     },
+     "tlbflush": {
+      "description": "TLBFlush improves performances in overcommited environments. Requires vpindex.\nDefaults to the machine type setting.\n+optional",
       "$ref": "#/definitions/v1.FeatureState"
      },
      "vapic": {

--- a/pkg/api/v1/deepcopy_generated.go
+++ b/pkg/api/v1/deepcopy_generated.go
@@ -791,6 +791,51 @@ func (in *FeatureHyperv) DeepCopyInto(out *FeatureHyperv) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.Frequencies != nil {
+		in, out := &in.Frequencies, &out.Frequencies
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.Reenlightenment != nil {
+		in, out := &in.Reenlightenment, &out.Reenlightenment
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.TLBFlush != nil {
+		in, out := &in.TLBFlush, &out.TLBFlush
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.IPI != nil {
+		in, out := &in.IPI, &out.IPI
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.EVMCS != nil {
+		in, out := &in.EVMCS, &out.EVMCS
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -44,15 +44,18 @@ var _ = Describe("Defaults", func() {
 			SMM:  &FeatureState{},
 			APIC: &FeatureAPIC{},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{},
-				VAPIC:      &FeatureState{},
-				Spinlocks:  &FeatureSpinlocks{},
-				VPIndex:    &FeatureState{},
-				Runtime:    &FeatureState{},
-				SyNIC:      &FeatureState{},
-				SyNICTimer: &FeatureState{},
-				Reset:      &FeatureState{},
-				VendorID:   &FeatureVendorID{},
+				Relaxed:         &FeatureState{},
+				VAPIC:           &FeatureState{},
+				Spinlocks:       &FeatureSpinlocks{},
+				VPIndex:         &FeatureState{},
+				Runtime:         &FeatureState{},
+				SyNIC:           &FeatureState{},
+				SyNICTimer:      &FeatureState{},
+				Reset:           &FeatureState{},
+				VendorID:        &FeatureVendorID{},
+				Frequencies:     &FeatureState{},
+				Reenlightenment: &FeatureState{},
+				TLBFlush:        &FeatureState{},
 			},
 		}
 		SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -73,6 +76,9 @@ var _ = Describe("Defaults", func() {
 		Expect(*hyperv.SyNICTimer.Enabled).To(BeTrue())
 		Expect(*hyperv.Reset.Enabled).To(BeTrue())
 		Expect(*hyperv.VendorID.Enabled).To(BeTrue())
+		Expect(*hyperv.Frequencies.Enabled).To(BeTrue())
+		Expect(*hyperv.Reenlightenment.Enabled).To(BeTrue())
+		Expect(*hyperv.TLBFlush.Enabled).To(BeTrue())
 	})
 
 	It("should not override defined feature states", func() {
@@ -85,15 +91,18 @@ var _ = Describe("Defaults", func() {
 			ACPI: FeatureState{Enabled: _true},
 			APIC: &FeatureAPIC{Enabled: _false},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{Enabled: _true},
-				VAPIC:      &FeatureState{Enabled: _false},
-				Spinlocks:  &FeatureSpinlocks{Enabled: _true},
-				VPIndex:    &FeatureState{Enabled: _false},
-				Runtime:    &FeatureState{Enabled: _true},
-				SyNIC:      &FeatureState{Enabled: _false},
-				SyNICTimer: &FeatureState{Enabled: _true},
-				Reset:      &FeatureState{Enabled: _false},
-				VendorID:   &FeatureVendorID{Enabled: _true},
+				Relaxed:         &FeatureState{Enabled: _true},
+				VAPIC:           &FeatureState{Enabled: _false},
+				Spinlocks:       &FeatureSpinlocks{Enabled: _true},
+				VPIndex:         &FeatureState{Enabled: _false},
+				Runtime:         &FeatureState{Enabled: _true},
+				SyNIC:           &FeatureState{Enabled: _false},
+				SyNICTimer:      &FeatureState{Enabled: _true},
+				Reset:           &FeatureState{Enabled: _false},
+				VendorID:        &FeatureVendorID{Enabled: _true},
+				Frequencies:     &FeatureState{Enabled: _false},
+				Reenlightenment: &FeatureState{Enabled: _false},
+				TLBFlush:        &FeatureState{Enabled: _true},
 			},
 		}
 		SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -113,20 +122,26 @@ var _ = Describe("Defaults", func() {
 		Expect(*hyperv.SyNICTimer.Enabled).To(BeTrue())
 		Expect(*hyperv.Reset.Enabled).To(BeFalse())
 		Expect(*hyperv.VendorID.Enabled).To(BeTrue())
+		Expect(*hyperv.Frequencies.Enabled).To(BeFalse())
+		Expect(*hyperv.Reenlightenment.Enabled).To(BeFalse())
+		Expect(*hyperv.TLBFlush.Enabled).To(BeTrue())
 
 		vmi.Spec.Domain.Features = &Features{
 			ACPI: FeatureState{Enabled: _false},
 			APIC: &FeatureAPIC{Enabled: _true},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{Enabled: _false},
-				VAPIC:      &FeatureState{Enabled: _true},
-				Spinlocks:  &FeatureSpinlocks{Enabled: _false},
-				VPIndex:    &FeatureState{Enabled: _true},
-				Runtime:    &FeatureState{Enabled: _false},
-				SyNIC:      &FeatureState{Enabled: _true},
-				SyNICTimer: &FeatureState{Enabled: _false},
-				Reset:      &FeatureState{Enabled: _true},
-				VendorID:   &FeatureVendorID{Enabled: _false},
+				Relaxed:         &FeatureState{Enabled: _false},
+				VAPIC:           &FeatureState{Enabled: _true},
+				Spinlocks:       &FeatureSpinlocks{Enabled: _false},
+				VPIndex:         &FeatureState{Enabled: _true},
+				Runtime:         &FeatureState{Enabled: _false},
+				SyNIC:           &FeatureState{Enabled: _true},
+				SyNICTimer:      &FeatureState{Enabled: _false},
+				Reset:           &FeatureState{Enabled: _true},
+				VendorID:        &FeatureVendorID{Enabled: _false},
+				Frequencies:     &FeatureState{Enabled: _false},
+				Reenlightenment: &FeatureState{Enabled: _false},
+				TLBFlush:        &FeatureState{Enabled: _true},
 			},
 		}
 		SetObjectDefaults_VirtualMachineInstance(vmi)
@@ -146,6 +161,9 @@ var _ = Describe("Defaults", func() {
 		Expect(*hyperv.SyNICTimer.Enabled).To(BeFalse())
 		Expect(*hyperv.Reset.Enabled).To(BeTrue())
 		Expect(*hyperv.VendorID.Enabled).To(BeFalse())
+		Expect(*hyperv.Frequencies.Enabled).To(BeFalse())
+		Expect(*hyperv.Reenlightenment.Enabled).To(BeFalse())
+		Expect(*hyperv.TLBFlush.Enabled).To(BeTrue())
 	})
 
 	It("should set dis defaults", func() {

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -983,7 +983,7 @@ func schema_kubevirt_pkg_api_v1_FeatureHyperv(ref common.ReferenceCallback) comm
 					},
 					"reset": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Reset enables Hyperv reboot/reset for the vmi. Defaults to the machine type setting.",
+							Description: "Reset enables Hyperv reboot/reset for the vmi. Requires synic. Defaults to the machine type setting.",
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 						},
 					},
@@ -991,6 +991,36 @@ func schema_kubevirt_pkg_api_v1_FeatureHyperv(ref common.ReferenceCallback) comm
 						SchemaProps: spec.SchemaProps{
 							Description: "VendorID allows setting the hypervisor vendor id. Defaults to the machine type setting.",
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureVendorID"),
+						},
+					},
+					"frequencies": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Frequencies improve Hyper-V on KVM (TSC clock source) Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
+					"reenlightenment": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Reenlightenment improve Hyper-V on KVM (TSC clock source) Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
+					"tlbflush": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TLBFlush improves performances in overcommited environments. Requires vpindex. Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
+					"ipi": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IPI improves performances in overcommited environments. Requires vpindex. Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
+						},
+					},
+					"evmcs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic Defaults to the machine type setting.",
+							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 						},
 					},
 				},

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -995,13 +995,13 @@ func schema_kubevirt_pkg_api_v1_FeatureHyperv(ref common.ReferenceCallback) comm
 					},
 					"frequencies": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Frequencies improve Hyper-V on KVM (TSC clock source) Defaults to the machine type setting.",
+							Description: "Frequencies improve Hyper-V on KVM (TSC clock source). Defaults to the machine type setting.",
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 						},
 					},
 					"reenlightenment": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Reenlightenment improve Hyper-V on KVM (TSC clock source) Defaults to the machine type setting.",
+							Description: "Reenlightenment improve Hyper-V on KVM (TSC clock source). Defaults to the machine type setting.",
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 						},
 					},
@@ -1019,7 +1019,7 @@ func schema_kubevirt_pkg_api_v1_FeatureHyperv(ref common.ReferenceCallback) comm
 					},
 					"evmcs": {
 						SchemaProps: spec.SchemaProps{
-							Description: "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic Defaults to the machine type setting.",
+							Description: "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic. Defaults to the machine type setting.",
 							Ref:         ref("kubevirt.io/kubevirt/pkg/api/v1.FeatureState"),
 						},
 					},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -797,11 +797,11 @@ type FeatureHyperv struct {
 	// Defaults to the machine type setting.
 	// +optional
 	VendorID *FeatureVendorID `json:"vendorid,omitempty"`
-	// Frequencies improve Hyper-V on KVM (TSC clock source)
+	// Frequencies improve Hyper-V on KVM (TSC clock source).
 	// Defaults to the machine type setting.
 	// +optional
 	Frequencies *FeatureState `json:"frequencies,omitempty"`
-	// Reenlightenment improve Hyper-V on KVM (TSC clock source)
+	// Reenlightenment improve Hyper-V on KVM (TSC clock source).
 	// Defaults to the machine type setting.
 	// +optional
 	Reenlightenment *FeatureState `json:"reenlightenment,omitempty"`
@@ -813,7 +813,7 @@ type FeatureHyperv struct {
 	// Defaults to the machine type setting.
 	// +optional
 	IPI *FeatureState `json:"ipi,omitempty"`
-	// EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic
+	// EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic.
 	// Defaults to the machine type setting.
 	// +optional
 	EVMCS *FeatureState `json:"evmcs,omitempty"`

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -789,7 +789,7 @@ type FeatureHyperv struct {
 	// Defaults to the machine type setting.
 	// +optional
 	SyNICTimer *FeatureState `json:"synictimer,omitempty"`
-	// Reset enables Hyperv reboot/reset for the vmi.
+	// Reset enables Hyperv reboot/reset for the vmi. Requires synic.
 	// Defaults to the machine type setting.
 	// +optional
 	Reset *FeatureState `json:"reset,omitempty"`
@@ -797,6 +797,26 @@ type FeatureHyperv struct {
 	// Defaults to the machine type setting.
 	// +optional
 	VendorID *FeatureVendorID `json:"vendorid,omitempty"`
+	// Frequencies improve Hyper-V on KVM (TSC clock source)
+	// Defaults to the machine type setting.
+	// +optional
+	Frequencies *FeatureState `json:"frequencies,omitempty"`
+	// Reenlightenment improve Hyper-V on KVM (TSC clock source)
+	// Defaults to the machine type setting.
+	// +optional
+	Reenlightenment *FeatureState `json:"reenlightenment,omitempty"`
+	// TLBFlush improves performances in overcommited environments. Requires vpindex.
+	// Defaults to the machine type setting.
+	// +optional
+	TLBFlush *FeatureState `json:"tlbflush,omitempty"`
+	// IPI improves performances in overcommited environments. Requires vpindex.
+	// Defaults to the machine type setting.
+	// +optional
+	IPI *FeatureState `json:"ipi,omitempty"`
+	// EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic
+	// Defaults to the machine type setting.
+	// +optional
+	EVMCS *FeatureState `json:"evmcs,omitempty"`
 }
 
 // WatchdogAction defines the watchdog action, if a watchdog gets triggered.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -376,11 +376,11 @@ func (FeatureHyperv) SwaggerDoc() map[string]string {
 		"synictimer":      "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
 		"reset":           "Reset enables Hyperv reboot/reset for the vmi. Requires synic.\nDefaults to the machine type setting.\n+optional",
 		"vendorid":        "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
-		"frequencies":     "Frequencies improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
-		"reenlightenment": "Reenlightenment improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+		"frequencies":     "Frequencies improve Hyper-V on KVM (TSC clock source).\nDefaults to the machine type setting.\n+optional",
+		"reenlightenment": "Reenlightenment improve Hyper-V on KVM (TSC clock source).\nDefaults to the machine type setting.\n+optional",
 		"tlbflush":        "TLBFlush improves performances in overcommited environments. Requires vpindex.\nDefaults to the machine type setting.\n+optional",
 		"ipi":             "IPI improves performances in overcommited environments. Requires vpindex.\nDefaults to the machine type setting.\n+optional",
-		"evmcs":           "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic\nDefaults to the machine type setting.\n+optional",
+		"evmcs":           "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic.\nDefaults to the machine type setting.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -366,16 +366,21 @@ func (FeatureVendorID) SwaggerDoc() map[string]string {
 
 func (FeatureHyperv) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":           "Hyperv specific features.",
-		"relaxed":    "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
-		"vapic":      "VAPIC indicates whether virtual APIC is enabled.\nDefaults to the machine type setting.\n+optional",
-		"spinlocks":  "Spinlocks indicates if spinlocks should be made available to the guest.\n+optional",
-		"vpindex":    "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.\nDefaults to the machine type setting.\n+optional",
-		"runtime":    "Runtime.\nDefaults to the machine type setting.\n+optional",
-		"synic":      "SyNIC enable Synthetic Interrupt Controller.\nDefaults to the machine type setting.\n+optional",
-		"synictimer": "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
-		"reset":      "Reset enables Hyperv reboot/reset for the vmi.\nDefaults to the machine type setting.\n+optional",
-		"vendorid":   "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
+		"":                "Hyperv specific features.",
+		"relaxed":         "Relaxed relaxes constraints on timer.\nDefaults to the machine type setting.\n+optional",
+		"vapic":           "VAPIC indicates whether virtual APIC is enabled.\nDefaults to the machine type setting.\n+optional",
+		"spinlocks":       "Spinlocks indicates if spinlocks should be made available to the guest.\n+optional",
+		"vpindex":         "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors.\nDefaults to the machine type setting.\n+optional",
+		"runtime":         "Runtime.\nDefaults to the machine type setting.\n+optional",
+		"synic":           "SyNIC enable Synthetic Interrupt Controller.\nDefaults to the machine type setting.\n+optional",
+		"synictimer":      "SyNICTimer enable Synthetic Interrupt Controller timer.\nDefaults to the machine type setting.\n+optional",
+		"reset":           "Reset enables Hyperv reboot/reset for the vmi. Requires synic.\nDefaults to the machine type setting.\n+optional",
+		"vendorid":        "VendorID allows setting the hypervisor vendor id.\nDefaults to the machine type setting.\n+optional",
+		"frequencies":     "Frequencies improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+		"reenlightenment": "Reenlightenment improve Hyper-V on KVM (TSC clock source)\nDefaults to the machine type setting.\n+optional",
+		"tlbflush":        "TLBFlush improves performances in overcommited environments. Requires vpindex.\nDefaults to the machine type setting.\n+optional",
+		"ipi":             "IPI improves performances in overcommited environments. Requires vpindex.\nDefaults to the machine type setting.\n+optional",
+		"evmcs":           "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic\nDefaults to the machine type setting.\n+optional",
 	}
 }
 

--- a/pkg/api/v1/schema_test.go
+++ b/pkg/api/v1/schema_test.go
@@ -128,6 +128,15 @@ var exampleJSON = `{
           "vendorid": {
             "enabled": true,
             "vendorid": "vendor"
+          },
+          "frequencies": {
+            "enabled": false
+          },
+          "reenlightenment": {
+            "enabled": false
+          },
+          "tlbflush": {
+            "enabled": true
           }
         },
         "smm": {
@@ -332,15 +341,18 @@ var _ = Describe("Schema", func() {
 			SMM:  &FeatureState{Enabled: _true},
 			APIC: &FeatureAPIC{Enabled: _true},
 			Hyperv: &FeatureHyperv{
-				Relaxed:    &FeatureState{Enabled: _true},
-				VAPIC:      &FeatureState{Enabled: _false},
-				Spinlocks:  &FeatureSpinlocks{Enabled: _true},
-				VPIndex:    &FeatureState{Enabled: _false},
-				Runtime:    &FeatureState{Enabled: _true},
-				SyNIC:      &FeatureState{Enabled: _false},
-				SyNICTimer: &FeatureState{Enabled: _true},
-				Reset:      &FeatureState{Enabled: _false},
-				VendorID:   &FeatureVendorID{Enabled: _true, VendorID: "vendor"},
+				Relaxed:         &FeatureState{Enabled: _true},
+				VAPIC:           &FeatureState{Enabled: _false},
+				Spinlocks:       &FeatureSpinlocks{Enabled: _true},
+				VPIndex:         &FeatureState{Enabled: _false},
+				Runtime:         &FeatureState{Enabled: _true},
+				SyNIC:           &FeatureState{Enabled: _false},
+				SyNICTimer:      &FeatureState{Enabled: _true},
+				Reset:           &FeatureState{Enabled: _false},
+				VendorID:        &FeatureVendorID{Enabled: _true, VendorID: "vendor"},
+				Frequencies:     &FeatureState{Enabled: _false},
+				Reenlightenment: &FeatureState{Enabled: _false},
+				TLBFlush:        &FeatureState{Enabled: _true},
 			},
 		}
 		exampleVMI.Spec.Domain.Clock = &Clock{

--- a/pkg/api/v1/zz_generated.defaults.go
+++ b/pkg/api/v1/zz_generated.defaults.go
@@ -104,6 +104,21 @@ func SetObjectDefaults_VirtualMachine(in *VirtualMachine) {
 				if in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID != nil {
 					SetDefaults_FeatureVendorID(in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID)
 				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.IPI != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.IPI)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS)
+				}
 			}
 			if in.Spec.Template.Spec.Domain.Features.SMM != nil {
 				SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.SMM)
@@ -184,6 +199,21 @@ func SetObjectDefaults_VirtualMachineInstance(in *VirtualMachineInstance) {
 			}
 			if in.Spec.Domain.Features.Hyperv.VendorID != nil {
 				SetDefaults_FeatureVendorID(in.Spec.Domain.Features.Hyperv.VendorID)
+			}
+			if in.Spec.Domain.Features.Hyperv.Frequencies != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Frequencies)
+			}
+			if in.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Reenlightenment)
+			}
+			if in.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.TLBFlush)
+			}
+			if in.Spec.Domain.Features.Hyperv.IPI != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.IPI)
+			}
+			if in.Spec.Domain.Features.Hyperv.EVMCS != nil {
+				SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.EVMCS)
 			}
 		}
 		if in.Spec.Domain.Features.SMM != nil {
@@ -272,6 +302,21 @@ func SetObjectDefaults_VirtualMachineInstancePreset(in *VirtualMachineInstancePr
 				if in.Spec.Domain.Features.Hyperv.VendorID != nil {
 					SetDefaults_FeatureVendorID(in.Spec.Domain.Features.Hyperv.VendorID)
 				}
+				if in.Spec.Domain.Features.Hyperv.Frequencies != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Frequencies)
+				}
+				if in.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.Reenlightenment)
+				}
+				if in.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.TLBFlush)
+				}
+				if in.Spec.Domain.Features.Hyperv.IPI != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.IPI)
+				}
+				if in.Spec.Domain.Features.Hyperv.EVMCS != nil {
+					SetDefaults_FeatureState(in.Spec.Domain.Features.Hyperv.EVMCS)
+				}
 			}
 			if in.Spec.Domain.Features.SMM != nil {
 				SetDefaults_FeatureState(in.Spec.Domain.Features.SMM)
@@ -359,6 +404,21 @@ func SetObjectDefaults_VirtualMachineInstanceReplicaSet(in *VirtualMachineInstan
 				}
 				if in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID != nil {
 					SetDefaults_FeatureVendorID(in.Spec.Template.Spec.Domain.Features.Hyperv.VendorID)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Frequencies)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.Reenlightenment)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.TLBFlush)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.IPI != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.IPI)
+				}
+				if in.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS != nil {
+					SetDefaults_FeatureState(in.Spec.Template.Spec.Domain.Features.Hyperv.EVMCS)
 				}
 			}
 			if in.Spec.Template.Spec.Domain.Features.SMM != nil {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -205,7 +205,13 @@ func getHypervNodeSelectors(vmi *v1.VirtualMachineInstance) (map[string]string, 
 	// The following HyperV features don't require support from the host kernel, according to inspection
 	// of the QEMU sources (4.0 - adb3321bfd)
 	// VAPIC, Relaxed, Spinlocks, VendorID
-	// see https://schd.ws/hosted_files/devconfcz2019/cf/vkuznets_enlightening_kvm_devconf2019.pdf
+	// VPIndex, SyNIC: depend on both MSR and capability
+	// IPI, TLBFlush: depend on KVM Capabilities
+	// Runtime, Reset, SyNICTimer, Frequencies, Reenlightenment: depend on KVM MSRs availability
+	// EVMCS: depends on KVM capability, but the only way to know that is enable it, QEMU doesn't do
+	// any check before that, so we leave it out
+	//
+	// see also https://schd.ws/hosted_files/devconfcz2019/cf/vkuznets_enlightening_kvm_devconf2019.pdf
 	// to learn about dependencies between enlightenments
 
 	hyperv := vmi.Spec.Domain.Features.Hyperv // shortcut
@@ -231,6 +237,22 @@ func getHypervNodeSelectors(vmi *v1.VirtualMachineInstance) (map[string]string, 
 			// TODO: SyNICTimer depends on SyNIC and Relaxed. We should enforce this constraint.
 			Feature: hyperv.SyNICTimer,
 			Label:   "synictimer",
+		},
+		hvFeatureLabel{
+			Feature: hyperv.Frequencies,
+			Label:   "frequencies",
+		},
+		hvFeatureLabel{
+			Feature: hyperv.Reenlightenment,
+			Label:   "reenlightenment",
+		},
+		hvFeatureLabel{
+			Feature: hyperv.TLBFlush,
+			Label:   "tlbflush",
+		},
+		hvFeatureLabel{
+			Feature: hyperv.IPI,
+			Label:   "ipi",
 		},
 	}
 	for _, hv := range hvFeatureLabels {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -494,6 +494,9 @@ var _ = Describe("Template", func() {
 									SyNIC: &v1.FeatureState{
 										Enabled: &enabled,
 									},
+									Reenlightenment: &v1.FeatureState{
+										Enabled: &enabled,
+									},
 								},
 							},
 						},
@@ -533,6 +536,12 @@ var _ = Describe("Template", func() {
 									SyNICTimer: &v1.FeatureState{
 										Enabled: &enabled,
 									},
+									Frequencies: &v1.FeatureState{
+										Enabled: &enabled,
+									},
+									IPI: &v1.FeatureState{
+										Enabled: &enabled,
+									},
 								},
 							},
 						},
@@ -544,6 +553,8 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"synic", "true"))
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"synictimer", "true"))
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"frequencies", "true"))
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"ipi", "true"))
 			})
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features which do not depend on host kernel", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -550,6 +550,11 @@ func Convert_v1_FeatureHyperv_To_api_FeatureHyperv(source *v1.FeatureHyperv, hyp
 	hyperv.SyNICTimer = convertFeatureState(source.SyNICTimer)
 	hyperv.VAPIC = convertFeatureState(source.VAPIC)
 	hyperv.VPIndex = convertFeatureState(source.VPIndex)
+	hyperv.Frequencies = convertFeatureState(source.Frequencies)
+	hyperv.Reenlightenment = convertFeatureState(source.Reenlightenment)
+	hyperv.TLBFlush = convertFeatureState(source.TLBFlush)
+	hyperv.IPI = convertFeatureState(source.IPI)
+	hyperv.EVMCS = convertFeatureState(source.EVMCS)
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -138,15 +138,20 @@ var _ = Describe("Converter", func() {
 				APIC: &v1.FeatureAPIC{},
 				SMM:  &v1.FeatureState{},
 				Hyperv: &v1.FeatureHyperv{
-					Relaxed:    &v1.FeatureState{Enabled: &_false},
-					VAPIC:      &v1.FeatureState{Enabled: &_true},
-					Spinlocks:  &v1.FeatureSpinlocks{Enabled: &_true},
-					VPIndex:    &v1.FeatureState{Enabled: &_true},
-					Runtime:    &v1.FeatureState{Enabled: &_false},
-					SyNIC:      &v1.FeatureState{Enabled: &_true},
-					SyNICTimer: &v1.FeatureState{Enabled: &_false},
-					Reset:      &v1.FeatureState{Enabled: &_true},
-					VendorID:   &v1.FeatureVendorID{Enabled: &_false, VendorID: "myvendor"},
+					Relaxed:         &v1.FeatureState{Enabled: &_false},
+					VAPIC:           &v1.FeatureState{Enabled: &_true},
+					Spinlocks:       &v1.FeatureSpinlocks{Enabled: &_true},
+					VPIndex:         &v1.FeatureState{Enabled: &_true},
+					Runtime:         &v1.FeatureState{Enabled: &_false},
+					SyNIC:           &v1.FeatureState{Enabled: &_true},
+					SyNICTimer:      &v1.FeatureState{Enabled: &_false},
+					Reset:           &v1.FeatureState{Enabled: &_true},
+					VendorID:        &v1.FeatureVendorID{Enabled: &_false, VendorID: "myvendor"},
+					Frequencies:     &v1.FeatureState{Enabled: &_false},
+					Reenlightenment: &v1.FeatureState{Enabled: &_false},
+					TLBFlush:        &v1.FeatureState{Enabled: &_true},
+					IPI:             &v1.FeatureState{Enabled: &_true},
+					EVMCS:           &v1.FeatureState{Enabled: &_false},
 				},
 			}
 			vmi.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
@@ -517,6 +522,11 @@ var _ = Describe("Converter", func() {
       <stimer state="off"></stimer>
       <reset state="on"></reset>
       <vendor_id state="off" value="myvendor"></vendor_id>
+      <frequencies state="off"></frequencies>
+      <reenlightenment state="off"></reenlightenment>
+      <tlbflush state="on"></tlbflush>
+      <ipi state="on"></ipi>
+      <evmcs state="off"></evmcs>
     </hyperv>
     <smm></smm>
   </features>

--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -1312,6 +1312,51 @@ func (in *FeatureHyperv) DeepCopyInto(out *FeatureHyperv) {
 			**out = **in
 		}
 	}
+	if in.Frequencies != nil {
+		in, out := &in.Frequencies, &out.Frequencies
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
+	if in.Reenlightenment != nil {
+		in, out := &in.Reenlightenment, &out.Reenlightenment
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
+	if in.TLBFlush != nil {
+		in, out := &in.TLBFlush, &out.TLBFlush
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
+	if in.IPI != nil {
+		in, out := &in.IPI, &out.IPI
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
+	if in.EVMCS != nil {
+		in, out := &in.EVMCS, &out.EVMCS
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(FeatureState)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -194,15 +194,20 @@ type Features struct {
 }
 
 type FeatureHyperv struct {
-	Relaxed    *FeatureState     `xml:"relaxed,omitempty"`
-	VAPIC      *FeatureState     `xml:"vapic,omitempty"`
-	Spinlocks  *FeatureSpinlocks `xml:"spinlocks,omitempty"`
-	VPIndex    *FeatureState     `xml:"vpindex,omitempty"`
-	Runtime    *FeatureState     `xml:"runtime,omitempty"`
-	SyNIC      *FeatureState     `xml:"synic,omitempty"`
-	SyNICTimer *FeatureState     `xml:"stimer,omitempty"`
-	Reset      *FeatureState     `xml:"reset,omitempty"`
-	VendorID   *FeatureVendorID  `xml:"vendor_id,omitempty"`
+	Relaxed         *FeatureState     `xml:"relaxed,omitempty"`
+	VAPIC           *FeatureState     `xml:"vapic,omitempty"`
+	Spinlocks       *FeatureSpinlocks `xml:"spinlocks,omitempty"`
+	VPIndex         *FeatureState     `xml:"vpindex,omitempty"`
+	Runtime         *FeatureState     `xml:"runtime,omitempty"`
+	SyNIC           *FeatureState     `xml:"synic,omitempty"`
+	SyNICTimer      *FeatureState     `xml:"stimer,omitempty"`
+	Reset           *FeatureState     `xml:"reset,omitempty"`
+	VendorID        *FeatureVendorID  `xml:"vendor_id,omitempty"`
+	Frequencies     *FeatureState     `xml:"frequencies,omitempty"`
+	Reenlightenment *FeatureState     `xml:"reenlightenment,omitempty"`
+	TLBFlush        *FeatureState     `xml:"tlbflush,omitempty"`
+	IPI             *FeatureState     `xml:"ipi,omitempty"`
+	EVMCS           *FeatureState     `xml:"evmcs,omitempty"`
 }
 
 type FeatureSpinlocks struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Update hyperv support to libvirt 4.10 and onwards. Since we ship libvirt 5.1 in virt-launcher containers, we can use all the new hyperv features

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/1919

**Special notes for your reviewer**:
Requires labels as provided by https://github.com/fromanirh/kvm-info-nfd-plugin >= 0.4.0
It will be handled by nfd configuration

**Release note**:
```release-note
Add support for hyperv enlightenments provided by libvirt >= 4.10
```
