### PR TITLE
Fix disappearing vnc socket

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -302,6 +302,26 @@ func waitForFinalNotify(deleteNotificationSent chan watch.Event,
 	}
 }
 
+// writeProtectPrivateDir waits until the kubevirt private vnc socket exists and than mark its folder as read only
+// this is a workaround preventing QEMU from deleting its sockets prematurely as described in a bug https://bugs.launchpad.net/qemu/+bug/1795100
+// once the QEMU 4.0 is released the need for this workaround goes away
+// Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1683964
+func writeProtectPrivateDir(uid string) {
+	vncAppeared := false
+	// waits maximum of 20s for vnc file to appear
+	for i := 0; i < 20; i++ {
+		if _, err := os.Stat(filepath.Join("/var/run/kubevirt-private", uid, "virt-vnc")); os.IsNotExist(err) {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		vncAppeared = true
+		break
+	}
+	if vncAppeared {
+		os.Chmod(filepath.Join("/var/run/kubevirt-private", uid), 0444)
+	}
+}
+
 func main() {
 	qemuTimeout := pflag.Duration("qemu-timeout", defaultStartTimeout, "Amount of time to wait for qemu")
 	virtShareDir := pflag.String("kubevirt-share-dir", "/var/run/kubevirt", "Shared directory between virt-handler and virt-launcher")
@@ -431,6 +451,12 @@ func main() {
 			gracefulShutdownTriggerFile,
 			*gracePeriodSeconds,
 			shutdownCallback)
+
+		// waits until virt-vnc socket is ready and than mark its parent folder as read only
+		// workaround preventing QEMU from deleting socket prematurely
+		// the code need to be executed after the QEMU reports VM is running, so the wait
+		// for socket creation is the shortest possible
+		go writeProtectPrivateDir(*uid)
 
 		// This is a wait loop that monitors the qemu pid. When the pid
 		// exits, the wait loop breaks.

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -57,7 +57,7 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		Context("with VNC connection", func() {
 
-			It("[test_id:1611]should allow accessing the VNC device", func() {
+			vncConnect := func() {
 				pipeInReader, _ := io.Pipe()
 				pipeOutReader, pipeOutWriter := io.Pipe()
 				defer pipeInReader.Close()
@@ -113,6 +113,17 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				By("Checking the response from VNC server")
 				Expect(response).To(Equal("RFB 003.008\n"))
 				Expect(err).To(BeNil())
+			}
+
+			It("[test_id:1611]should allow accessing the VNC device", func() {
+				vncConnect()
+			})
+
+			It("should allow accessing the VNC device multiple times", func() {
+
+				for i := 0; i < 10; i++ {
+					vncConnect()
+				}
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds workaround preventing QEMU from deleting its
vnc socket file prematurely.

The workaround waits until the socket file is created
and than sets its parent folder as read only.

The workaround will not be required when the QEMU 4.0
with fix https://bugs.launchpad.net/qemu/+bug/1795100
gets released.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=1683964

**Special notes for your reviewer**:
This is a temporary workaround until QEMU 4.0 with https://git.qemu.org/?p=qemu.git;a=commit;h=feff02089113839d233e40a9bd7134241de12d1d is released. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix reconnect issue with VNC.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2171)
<!-- Reviewable:end -->
