### PR TITLE
tests: wipe testing infrastructure properly after tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -884,7 +884,11 @@ func DeleteRawManifest(object unstructured.Unstructured) error {
 
 	uri := composeResourceURI(object)
 	uri = uri + "/" + object.GetName()
-	result := virtCli.CoreV1().RESTClient().Delete().RequestURI(uri).Do()
+
+	policy := metav1.DeletePropagationBackground
+	options := &metav1.DeleteOptions{PropagationPolicy: &policy}
+
+	result := virtCli.CoreV1().RESTClient().Delete().RequestURI(uri).Body(options).Do()
 	if result.Error() != nil && !errors.IsNotFound(result.Error()) {
 		fmt.Printf(fmt.Sprintf("ERROR: Can not delete %s err: %#v %s\n", object.GetName(), result.Error(), object))
 		panic(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Prevent orphaned pods to stay after running the functional test suite.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2158

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
