### PR TITLE
Don't fail virt-api start when client-ca-file doesn't exist

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -397,12 +397,14 @@ func (app *virtAPIApp) getClientCert() error {
 		app.clientCABytes = []byte(clientCA)
 	}
 
-	// request-header-ca-file doesn't always exist in all deployments.
-	// set it if the value is set though.
+	// The request-header CA is mandatory. It can be retrieved from the configmap as we do here, or it must be provided
+	// via flag on start of this apiserver. Since we don't do the latter, the former is mandatory for us
+	// see https://github.com/kubernetes-incubator/apiserver-builder-alpha/blob/master/docs/concepts/auth.md#requestheader-authentication
 	requestHeaderClientCA, ok := authConfigMap.Data["requestheader-client-ca-file"]
-	if ok {
-		app.requestHeaderClientCABytes = []byte(requestHeaderClientCA)
+	if !ok {
+		return fmt.Errorf("requestheader-client-ca-file not found in extension-apiserver-authentication ConfigMap")
 	}
+	app.requestHeaderClientCABytes = []byte(requestHeaderClientCA)
 
 	// This config map also contains information about what
 	// headers our authorizor should inspect

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -207,7 +207,7 @@ func isInfoOrHealthEndpoint(req *restful.Request) bool {
 func isAuthenticated(req *restful.Request) bool {
 	// Peer cert is required for authentication.
 	// If the peer's cert is provided, we are guaranteed
-	// it has been validated against our CA pool (client CA or request-header CA)
+	// it has been validated against our CA pool containing the requestheader CA
 	if req.Request == nil || req.Request.TLS == nil || len(req.Request.TLS.PeerCertificates) == 0 {
 		return false
 	}

--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -207,7 +207,7 @@ func isInfoOrHealthEndpoint(req *restful.Request) bool {
 func isAuthenticated(req *restful.Request) bool {
 	// Peer cert is required for authentication.
 	// If the peer's cert is provided, we are guaranteed
-	// it has been validated against our client CA pool
+	// it has been validated against our CA pool (client CA or request-header CA)
 	if req.Request == nil || req.Request.TLS == nil || len(req.Request.TLS.PeerCertificates) == 0 {
 		return false
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't fail virt-api start when client-ca-file doesn't exist, because there are clusters (e.g. EKS) which don't support client cert authentication. Actually we don't need client cert based auth at all, so usage of the client CA was removed completely. Only the requestheader CA is needed, so we fail now if that one is missing.

**Which issue(s) this PR fixes**:
Fixes #2180 

**Release note**:
```release-note
Support clusters without client CA authentication (e.g. EKS)
```
