### PR TITLE
Fix migration with sata disks

### DIFF
--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -347,7 +347,9 @@ func (m *migrationProxy) createUnixListener() error {
 func (m *migrationProxy) StopListening() {
 
 	close(m.stopChan)
-	m.listener.Close()
+	if m.listener != nil {
+		m.listener.Close()
+	}
 }
 
 func handleConnection(fd net.Conn, targetAddress string, targetProtocol string, stopChan chan struct{}) {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -686,11 +686,14 @@ type GraphicsListen struct {
 }
 
 type Address struct {
-	Type     string `xml:"type,attr"`
-	Domain   string `xml:"domain,attr"`
-	Bus      string `xml:"bus,attr"`
-	Slot     string `xml:"slot,attr"`
-	Function string `xml:"function,attr"`
+	Type       string `xml:"type,attr"`
+	Domain     string `xml:"domain,attr,omitempty"`
+	Bus        string `xml:"bus,attr"`
+	Slot       string `xml:"slot,attr,omitempty"`
+	Function   string `xml:"function,attr,omitempty"`
+	Controller string `xml:"controller,attr,omitempty"`
+	Target     string `xml:"target,attr,omitempty"`
+	Unit       string `xml:"unit,attr,omitempty"`
 }
 
 //END Video -------------------


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the XML address field to be able to parse non-PCI address.
Live migration with two or more non-pci disks fails due to a wrong parsing or the address field.

```release-note
None
```
