### PR TITLE
Make OLM package name configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ deploy:
     condition: $TRAVIS_BRANCH != revert-*
 - provider: script
   script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt"
-    DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" sh -c 'make bazel-push-images && make manifests && make olm-push'
+    DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub"
+    sh -c 'make bazel-push-images && make manifests && make olm-push'
   skip_cleanup: true
   file:
   on:

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ verify-build:
 manifests:
 	hack/dockerized "CSV_VERSION=${CSV_VERSION} QUAY_REPOSITORY=${QUAY_REPOSITORY} \
 	  DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} \
-	  IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh"
+	  IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} PACKAGE_NAME=${PACKAGE_NAME} ./hack/build-manifests.sh"
 
 .release-functest:
 	make functest > .release-functest 2>&1
@@ -127,7 +127,8 @@ olm-verify:
 	hack/dockerized "./hack/olm.sh verify"
 
 olm-push:
-	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} CSV_VERSION=${CSV_VERSION} QUAY_USERNAME=${QUAY_USERNAME} QUAY_PASSWORD=${QUAY_PASSWORD} QUAY_REPOSITORY=${QUAY_REPOSITORY} ./hack/olm.sh push"
+	hack/dockerized "DOCKER_TAG=${DOCKER_TAG} CSV_VERSION=${CSV_VERSION} QUAY_USERNAME=${QUAY_USERNAME} \
+	    QUAY_PASSWORD=${QUAY_PASSWORD} QUAY_REPOSITORY=${QUAY_REPOSITORY} PACKAGE_NAME=${PACKAGE_NAME} ./hack/olm.sh push"
 
 .PHONY: \
 	go-build \

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -72,6 +72,7 @@ for arg in $args; do
         --verbosity=${verbosity} \
         --csv-version=${csv_version} \
         --kubevirt-logo-path=${kubevirt_logo_path} \
+        --package-name=${package_name} \
         --input-file=${infile} \
         --bundle-out-dir=${bundle_out_dir} \
         --quay-repository=${QUAY_REPOSITORY} >${outfile}
@@ -86,6 +87,7 @@ for arg in $args; do
         --verbosity=${verbosity} \
         --csv-version=${csv_version} \
         --kubevirt-logo-path=${kubevirt_logo_path} \
+        --package-name=${package_name} \
         --input-file=${infile} \
         --quay-repository=${QUAY_REPOSITORY} >${template_outfile}
 done

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -9,6 +9,7 @@ namespace=kubevirt
 cdi_namespace=cdi
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}
 verbosity=${VERBOSITY:-2}
+package_name=${PACKAGE_NAME:-kubevirt-dev}
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -1,6 +1,6 @@
 unset binaries docker_images docker_prefix docker_tag docker_tag_alt manifest_templates \
     master_ip network_provider kubeconfig manifest_docker_prefix namespace image_pull_policy verbosity \
-    csv_version
+    csv_version package_name
 
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-${PROVIDER}}
 
@@ -15,4 +15,4 @@ test -f "${KUBEVIRT_PATH}hack/config-local.sh" && source ${KUBEVIRT_PATH}hack/co
 
 export binaries docker_images docker_prefix docker_tag docker_tag_alt manifest_templates \
     master_ip network_provider kubeconfig manifest_docker_prefix namespace image_pull_policy verbosity \
-    csv_version
+    csv_version package_name

--- a/hack/olm.sh
+++ b/hack/olm.sh
@@ -65,7 +65,7 @@ push)
         }' | jq -r '.token')
 
     echo "pushing bundle"
-    operator-courier push "$BUNDLE_DIR" "$QUAY_REPOSITORY" kubevirt "$csv_version" "$AUTH_TOKEN"
+    operator-courier push "$BUNDLE_DIR" "$QUAY_REPOSITORY" "$package_name" "$csv_version" "$AUTH_TOKEN"
 
     ;;
 esac

--- a/manifests/release/olm/bundle/kubevirt-package.yaml.in
+++ b/manifests/release/olm/bundle/kubevirt-package.yaml.in
@@ -1,4 +1,4 @@
-packageName: kubevirt
+packageName: {{.PackageName}}
 channels:
   - name: beta
     currentCSV: kubevirtoperator.{{.CsvVersion}}

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -53,6 +53,7 @@ type templateData struct {
 	OperatorDeploymentSpec string
 	OperatorRules          string
 	KubeVirtLogo           string
+	PackageName            string
 	GeneratedManifests     map[string]string
 }
 
@@ -69,6 +70,7 @@ func main() {
 	processFiles := flag.Bool("process-files", false, "")
 	processVars := flag.Bool("process-vars", false, "")
 	kubeVirtLogoPath := flag.String("kubevirt-logo-path", "", "")
+	packageName := flag.String("package-name", "", "")
 	bundleOutDir := flag.String("bundle-out-dir", "", "")
 	quayRepository := flag.String("quay-repository", "", "")
 
@@ -96,6 +98,7 @@ func main() {
 		data.OperatorDeploymentSpec = getOperatorDeploymentSpec(data)
 		data.OperatorRules = getOperatorRules()
 		data.KubeVirtLogo = getKubeVirtLogo(*kubeVirtLogoPath)
+		data.PackageName = *packageName
 		// prevent loading latest bundle from Quay for every file, only do it for the CSV manifest
 		data.ReplacesCsvVersion = ""
 		if strings.Contains(*inputFile, ".csv.yaml") && *bundleOutDir != "" && data.QuayRepository != "" {
@@ -131,6 +134,7 @@ func main() {
 		data.OperatorDeploymentSpec = "{{.OperatorDeploymentSpec}}"
 		data.OperatorRules = "{{.OperatorRules}}"
 		data.KubeVirtLogo = "{{.KubeVirtLogo}}"
+		data.PackageName = "{{.PackageName}}"
 	}
 
 	if *processFiles {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make OLM package name configurable, because it has to be unique per Marketplace instance, but might be pulled from multiple sources (e.g. operatorhub.io vs KubeVirt's Quay repo vs. developer's Quay repo)

**Special notes for your reviewer**:
- The package name for KubeVirt's Quay repo changed to "kubevirt-operatorhub"  (feel free to propose a better name)
- That will make it possible to use "kubevirt" for operatorhub.io
- Default value is "kubevirt-dev" for development

**Release note**:
```release-note
NONE
```
