### PR TITLE
Log new / old MAC address on success

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -200,7 +200,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 			if err != nil {
 				return nil, err
 			}
-			log.Log.Infof("updated MAC for interface: %s - %s -> %s", iface, currentMac, mac)
+			log.Log.Infof("updated MAC for %s interface: old: %s -> new: %s", iface, currentMac, mac)
 			break
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -198,9 +198,9 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 		if changed {
 			mac, err = Handler.GetMacDetails(iface)
 			if err != nil {
-				log.Log.Reason(err).Errorf("updated MAC for interface: %s - %s -> %s", iface, currentMac, mac)
 				return nil, err
 			}
+			log.Log.Infof("updated MAC for interface: %s - %s -> %s", iface, currentMac, mac)
 			break
 		}
 	}


### PR DESCRIPTION
A previous commit (aaade4bcdc2f9561f9ae92b86bd6a206e33ee922) incorrectly
hid the log message under error condition branch. The commit did it
because it was assumed by the author and reviewers that if Errorf is
used then it means that the message is indicating an error in program
flow.

In reality, the message belongs to no-error branch of the program flow.
So the issue is not the condition under which the message is logged but
the log level used for it.

This commit returns the message where it was before the incorrect
commit, only switching the log level to INFO.

```release-note
NONE
```