### PR TITLE
Don't change the mac on interfaces in pod namespace

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -224,3 +224,13 @@ func (_mr *_MockNetworkHandlerRecorder) IptablesAppendRule(arg0, arg1 interface{
 	_s := append([]interface{}{arg0, arg1}, arg2...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IptablesAppendRule", _s...)
 }
+
+func (_m *MockNetworkHandler) NeighDelete(iface string, macAddress string) error {
+	ret := _m.ctrl.Call(_m, "NeighDelete", iface, macAddress)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) NeighDelete(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NeighDelete", arg0, arg1)
+}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -213,21 +213,6 @@ func (b *BridgePodInterface) discoverPodNetworkInterface() error {
 }
 
 func (b *BridgePodInterface) preparePodNetworkInterfaces() error {
-	// Set interface link to down to change its MAC address
-	if err := Handler.LinkSetDown(b.podNicLink); err != nil {
-		log.Log.Reason(err).Errorf("failed to bring link down for interface: %s", b.podInterfaceName)
-		return err
-	}
-
-	if _, err := Handler.SetRandomMac(b.podInterfaceName); err != nil {
-		return err
-	}
-
-	if err := Handler.LinkSetUp(b.podNicLink); err != nil {
-		log.Log.Reason(err).Errorf("failed to bring link up for interface: %s", b.podInterfaceName)
-		return err
-	}
-
 	if err := b.createBridge(); err != nil {
 		return err
 	}
@@ -247,6 +232,10 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces() error {
 	if err := Handler.LinkSetLearningOff(b.podNicLink); err != nil {
 		log.Log.Reason(err).Errorf("failed to disable mac learning for interface: %s", b.podInterfaceName)
 		return err
+	}
+
+	if err := Handler.NeighDelete(b.podInterfaceName, b.vif.MAC.String()); err != nil {
+		log.Log.Reason(err).Errorf("failed to remove interface %s from bridge forward database", b.podInterfaceName)
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -70,12 +70,10 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork = NewMockNetworkHandler(ctrl)
 		Handler = mockNetwork
 		testMac := "12:34:56:78:9A:BC"
-		updateTestMac := "AF:B3:1F:78:2A:CA"
 		dummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 1, MTU: 1410}}
 		address := &net.IPNet{IP: net.IPv4(10, 35, 0, 6), Mask: net.CIDRMask(24, 32)}
 		gw := net.IPv4(10, 35, 0, 1)
 		fakeMac, _ = net.ParseMAC(testMac)
-		updateFakeMac, _ = net.ParseMAC(updateTestMac)
 		fakeAddr = netlink.Addr{IPNet: address}
 		addrList = []netlink.Addr{fakeAddr}
 		routeAddr = netlink.Route{Gw: gw}
@@ -122,7 +120,6 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
 		mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(nil)
 		mockNetwork.EXPECT().LinkSetDown(dummy).Return(nil)
-		mockNetwork.EXPECT().SetRandomMac(podInterface).Return(updateFakeMac, nil)
 		mockNetwork.EXPECT().LinkSetUp(dummy).Return(nil)
 		mockNetwork.EXPECT().LinkSetLearningOff(dummy).Return(nil)
 		mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
@@ -132,6 +129,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkSetMaster(dummy, bridgeTest).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName, nil)
+		mockNetwork.EXPECT().NeighDelete(podInterface, testNic.MAC.String())
 
 		// For masquerade tests
 		mockNetwork.EXPECT().ParseAddr(masqueradeGwStr).Return(masqueradeGwAddr, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

Related to this issue https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/kubevirt-dev/oWWTpLTmkww
    
The issue is related to macvlan, The problem with macvlan is when we change the mac address on the pod interface and pass it to the virtual machine the traffic will not be able to return.
    

    macvlan:
    
                                       +---------------+
                                        | network stack |
                                        +---------------+
                                            |  |  |  |
                                  +---------+  |  |  +------------------+
                                  |            |  +------------------+  |
                                  |            +------------------+  |  |
                                  |                               |  |  |
                                  |            aa  +----------+   |  |  |
                                  | eth0     +-----| macvlan0 |---+  |  |
                                  |         /      +----------+      |  |
     Wire   +------+       +---------------+   bb  +----------+      |  |
    --------| eth0 |------/ if dst mac is /--------| macvlan1 |------+  |
            +------+     +---------------+ \       +----------+         |
                                            \  cc  +----------+         |
                                             +-----| macvlan2 |---------+
                                                   +----------+
    
the "if dst mac is" is dynamic so when we change it the packet are not going to that interface anymore this is why we saw the arp request but not the response
    
This commit remove the new mac address generation for the interface inside the pod namespace.
Instead we remove the pod interface connected to the bridge from the forward database of the linux bridge using the follow command.
    
`bridge fdb delete <mac-address> dev <interface> master`
    
There is no implementation of this command in the netlink package so I implement it using command execute for now.
I opened a PR https://github.com/vishvananda/netlink/issues/439 under the netlink repository.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/kubevirt-dev/oWWTpLTmkww


```release-note
Remove mac from the forward database of the linux bridge instead of changing it 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2192)
<!-- Reviewable:end -->
