### PR TITLE
Updating operator should update operand when no custom image tag is used

### DIFF
--- a/manifests/generated/virt-operator.yaml.in
+++ b/manifests/generated/virt-operator.yaml.in
@@ -11,7 +11,8 @@ spec:
   selector:
     matchLabels:
       kubevirt.io: virt-operator
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -520,6 +520,9 @@ func NewOperatorDeployment(namespace string, repository string, version string, 
 					virtv1.AppLabel: name,
 				},
 			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -595,11 +595,7 @@ func (c *KubeVirtController) deleteAllInstallStrategy() error {
 
 func (c *KubeVirtController) getImageTag(kv *v1.KubeVirt) string {
 	if kv.Spec.ImageTag == "" {
-		if kv.Status.TargetKubeVirtVersion != "" {
-			return kv.Status.TargetKubeVirtVersion
-		} else {
-			return c.config.ImageTag
-		}
+		return c.config.ImageTag
 	}
 
 	return kv.Spec.ImageTag
@@ -607,11 +603,7 @@ func (c *KubeVirtController) getImageTag(kv *v1.KubeVirt) string {
 
 func (c *KubeVirtController) getImageRegistry(kv *v1.KubeVirt) string {
 	if kv.Spec.ImageRegistry == "" {
-		if kv.Status.TargetKubeVirtRegistry != "" {
-			return kv.Status.TargetKubeVirtRegistry
-		} else {
-			return c.config.ImageRegistry
-		}
+		return c.config.ImageRegistry
 	}
 
 	return kv.Spec.ImageRegistry

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -20,8 +20,10 @@
 package tests_test
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"regexp"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -216,6 +218,35 @@ var _ = Describe("Operator", func() {
 		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
+	patchOperatorVersion := func(imageTag string) {
+		Eventually(func() error {
+
+			operator, err := virtClient.AppsV1().Deployments(tests.KubeVirtInstallNamespace).Get("virt-operator", metav1.GetOptions{})
+
+			imageRegEx := regexp.MustCompile(`^(.*)/virt-operator(:.*)?$`)
+			matches := imageRegEx.FindAllStringSubmatch(operator.Spec.Template.Spec.Containers[0].Image, 1)
+			registry := matches[0][1]
+			newImage := fmt.Sprintf("%s/virt-operator:%s", registry, imageTag)
+
+			operator.Spec.Template.Spec.Containers[0].Image = newImage
+			for idx, env := range operator.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "OPERATOR_IMAGE" {
+					env.Value = newImage
+					operator.Spec.Template.Spec.Containers[0].Env[idx] = env
+					break
+				}
+			}
+
+			newTemplate, _ := json.Marshal(operator.Spec.Template)
+
+			op := fmt.Sprintf(`[{ "op": "replace", "path": "/spec/template", "value": %s }]`, string(newTemplate))
+
+			_, err = virtClient.AppsV1().Deployments(tests.KubeVirtInstallNamespace).Patch("virt-operator", types.JSONPatchType, []byte(op))
+
+			return err
+		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	}
+
 	deleteAllKvAndWait := func(ignoreOriginal bool) {
 		Eventually(func() error {
 			kvList, err := virtClient.KubeVirt(tests.KubeVirtInstallNamespace).List(&metav1.ListOptions{})
@@ -262,6 +293,7 @@ var _ = Describe("Operator", func() {
 		if len(kvs) == 0 {
 			createKv(copyOriginalKv())
 		}
+		patchOperatorVersion(tests.KubeVirtVersionTag)
 		waitForKv(originalKv)
 		allPodsAreReady(tests.KubeVirtVersionTag)
 	})
@@ -374,6 +406,43 @@ var _ = Describe("Operator", func() {
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false)
 
+		})
+
+		It("should be able to update kubevirt install when operator updates if no custom image tag is set", func() {
+
+			if tests.KubeVirtVersionTagAlt == "" {
+				Skip("Skip operator custom image tag test because alt tag is not present")
+			}
+
+			kv := copyOriginalKv()
+
+			allPodsAreReady(tests.KubeVirtVersionTag)
+			sanityCheckDeploymentsExist()
+
+			By("Update Virt-Operator using  Alt Tag")
+			patchOperatorVersion(tests.KubeVirtVersionTagAlt)
+
+			// should result in kubevirt cr entering updating state
+			By("Wait for Updating Condition")
+			waitForUpdateCondition(kv)
+
+			By("Waiting for KV to stabilize")
+			waitForKv(kv)
+
+			By("Verifying infrastructure Is Updated")
+			allPodsAreReady(tests.KubeVirtVersionTagAlt)
+
+			By("Restore Operator Version using original image tag. ")
+			patchOperatorVersion(tests.KubeVirtVersionTag)
+
+			By("Wait for Updating Condition")
+			waitForUpdateCondition(kv)
+
+			By("Waiting for KV to stabilize")
+			waitForKv(kv)
+
+			By("Verifying infrastructure Is Restored to original version")
+			allPodsAreReady(tests.KubeVirtVersionTag)
 		})
 
 		It("should fail if KV object already exists", func() {


### PR DESCRIPTION

**What this PR does / why we need it**:

The HCO (hyperconverged-operator) is moving to a pattern where the operator by default installs operands of the same "version". It is also assumed that updating an operator will update the underlying operand.

With the changes in this PR, if no ImageTag is set and the operator's version changes, then the underlying KubeVirt infrastructure will update to match the updated operator's version. This meets the requirements necessary to integrate with the HCO. 

**Examples**

This spec will result in KubeVirt being installed and updated to match the operator's version. This means if the operator is updated, the kubevirt infrastructure will be updated as well to match the operator.
```
apiVersion: kubevirt.io/v1alpha3
kind: KubeVirt
metadata:
  name: kubevirt
  namespace: some-namespace
spec:
```

This spec will result in KubeVirt's version being decoupled from the operators entirely.  If the operator updates, the version of KubeVirt will remain the same until someone changes the 'imageTag' option on the KubeVirt CR. 
```
apiVersion: kubevirt.io/v1alpha3
kind: KubeVirt
metadata:
  name: kubevirt
  namespace: some-namespace
spec:
    imageTag: v0.16.0
```


**Release note**:
```release-note
Updating virt-operator updates kubevirt infrastructure when no custom image tag is set in KubeVirt CR.
```
