### PR TITLE
Protect migration pods during node drain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,3 +231,11 @@ http_file(
         "https://dl.fedoraproject.org/pub/fedora/linux/updates/28/Everything/x86_64/Packages/q/qemu-guest-agent-2.11.2-4.fc28.x86_64.rpm",
     ],
 )
+
+http_file(
+    name = "stress",
+    sha256 = "bd93021d826c98cbec15b4bf7e0800f723f986e7ed89357c56284a7efa6394b5",
+    urls = [
+        "https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/s/stress-1.0.4-20.fc28.x86_64.rpm",
+    ],
+)

--- a/images/cdi-http-import-server/BUILD.bazel
+++ b/images/cdi-http-import-server/BUILD.bazel
@@ -11,6 +11,7 @@ rpm_image(
     rpms = [
         "@qemu-img//file",
         "@qemu-guest-agent//file",
+        "@stress//file",
         "@libstdc//file",
         "@capstone//file",
         "@libaio//file",

--- a/images/cdi-http-import-server/entrypoint.sh
+++ b/images/cdi-http-import-server/entrypoint.sh
@@ -50,5 +50,6 @@ if [ -n "$AS_ISCSI" ]; then
 else
     # Expose qemu-guest-agent via nginx server
     cp /usr/bin/qemu-ga /usr/share/nginx/html/
+    cp /usr/bin/stress /usr/share/nginx/html/
     /usr/sbin/nginx
 fi

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -366,7 +366,7 @@ func (c *DisruptionBudgetController) sync(key string, vmi *virtv1.VirtualMachine
 		c.recorder.Eventf(vmi, v12.EventTypeNormal, SuccessfulDeletePodDisruptionBudgetReason, "Deleted PodDisruptionBudget %s", pdb.Name)
 		return nil
 	} else if create {
-		one := intstr.FromInt(1)
+		two := intstr.FromInt(2)
 		c.podDisruptionBudgetExpectations.ExpectCreations(key, 1)
 		createdPDB, err := c.clientset.PolicyV1beta1().PodDisruptionBudgets(vmi.Namespace).Create(&v1beta1.PodDisruptionBudget{
 			ObjectMeta: v1.ObjectMeta{
@@ -376,7 +376,7 @@ func (c *DisruptionBudgetController) sync(key string, vmi *virtv1.VirtualMachine
 				GenerateName: "kubevirt-disruption-budget-",
 			},
 			Spec: v1beta1.PodDisruptionBudgetSpec{
-				MinAvailable: &one,
+				MinAvailable: &two,
 				Selector: &v1.LabelSelector{
 					MatchLabels: map[string]string{
 						virtv1.CreatedByLabel: string(vmi.UID),

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -71,7 +71,9 @@ var _ = Describe("Disruptionbudget", func() {
 		// Expect pod creation
 		kubeClient.Fake.PrependReactor("create", "poddisruptionbudgets", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			update, ok := action.(testing.CreateAction)
+			pdb := update.GetObject().(*v1beta1.PodDisruptionBudget)
 			Expect(ok).To(BeTrue())
+			Expect(pdb.Spec.MinAvailable.String()).To(Equal("2"))
 			Expect(update.GetObject().(*v1beta1.PodDisruptionBudget).Spec.Selector.MatchLabels[v1.CreatedByLabel]).To(Equal(string(uid)))
 			return true, update.GetObject(), nil
 		})

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -387,6 +387,7 @@ var _ = Describe("Migrations", func() {
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 		})
+
 		Context("migration monitor", func() {
 			var options metav1.GetOptions
 			var cfgMap *k8sv1.ConfigMap
@@ -413,13 +414,8 @@ var _ = Describe("Migrations", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("should abort a vmi migration without progress", func() {
-
-				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskFedora))
+				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
-				tests.AddUserData(vmi, "cloud-init", fmt.Sprintf(`#!/bin/bash
-					echo "fedora" |passwd fedora --stdin
-					yum install -y stress qemu-guest-agent
-                    systemctl start  qemu-guest-agent`))
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)
@@ -517,13 +513,8 @@ var _ = Describe("Migrations", func() {
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
 			It("should be able successfully cancel a migration", func() {
-
-				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskFedora))
+				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
-				tests.AddUserData(vmi, "cloud-init", fmt.Sprintf(`#!/bin/bash
-					echo "fedora" |passwd fedora --stdin
-					yum install -y stress qemu-guest-agent
-                    systemctl start  qemu-guest-agent`))
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -636,6 +636,78 @@ var _ = Describe("Migrations", func() {
 				Expect(errors.IsTooManyRequests(err)).To(BeTrue())
 			})
 
+			It("should block the eviction api while a slow migration is in progress", func() {
+				vmi = tests.NewRandomFedoraVMIWitGuestAgent()
+				strategy := v1.EvictionStrategyLiveMigrate
+				vmi.Spec.EvictionStrategy = &strategy
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				getOptions := &metav1.GetOptions{}
+				By("Checking that the VirtualMachineInstance console has expected output")
+				expecter, expecterErr := tests.LoggedInFedoraExpecter(vmi)
+				Expect(expecterErr).To(BeNil())
+				defer expecter.Close()
+
+				var updatedVmi *v1.VirtualMachineInstance
+				// Need to wait for cloud init to finnish and start the agent inside the vmi.
+				Eventually(func() bool {
+					updatedVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, getOptions)
+					Expect(err).ToNot(HaveOccurred())
+					for _, condition := range updatedVmi.Status.Conditions {
+						if condition.Type == "AgentConnected" && condition.Status == "True" {
+							return true
+						}
+					}
+					return false
+				}, 420*time.Second, 2).Should(BeTrue(), "Should have agent connected condition")
+
+				By("Run a stress test to dirty some pages and slow down the migration")
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: "stress --vm 1 --vm-bytes 600M --vm-keep --timeout 10s\n"},
+				}, 15*time.Second)
+				Expect(err).ToNot(HaveOccurred(), "should run a stress test")
+
+				// execute a migration, wait for finalized state
+				By("Starting the Migration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				_, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Create(migration)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting until we have two available pods")
+				var pods *k8sv1.PodList
+				Eventually(func() []k8sv1.Pod {
+					labelSelector := fmt.Sprintf("%s=%s", v1.CreatedByLabel, vmi.GetUID())
+					fieldSelector := fmt.Sprintf("status.phase==%s", k8sv1.PodRunning)
+					pods, err = virtClient.CoreV1().Pods(vmi.Namespace).List(metav1.ListOptions{LabelSelector: labelSelector, FieldSelector: fieldSelector})
+					Expect(err).ToNot(HaveOccurred())
+					return pods.Items
+				}, 90*time.Second, 500*time.Millisecond).Should(HaveLen(2))
+
+				By("Verifying at least once that both pods are protected")
+				for _, pod := range pods.Items {
+					err := virtClient.CoreV1().Pods(vmi.Namespace).Evict(&v1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
+					Expect(errors.IsTooManyRequests(err)).To(BeTrue())
+				}
+				By("Verifying that both pods are protected by the PodDisruptionBudget for the whole migration")
+				Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
+					currentMigration, err := virtClient.VirtualMachineInstanceMigration(vmi.Namespace).Get(migration.Name, getOptions)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(currentMigration.Status.Phase).NotTo(Equal(v1.MigrationFailed))
+					for _, pod := range pods.Items {
+						err := virtClient.CoreV1().Pods(vmi.Namespace).Evict(&v1beta1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
+						if !errors.IsTooManyRequests(err) && currentMigration.Status.Phase != v1.MigrationRunning {
+							// In case we get an unexpected error and the migration isn't running anymore, let's not fail
+							continue
+						}
+						Expect(errors.IsTooManyRequests(err)).To(BeTrue())
+					}
+					return currentMigration.Status.Phase
+				}, 180*time.Second, 500*time.Millisecond).Should(Equal(v1.MigrationSucceeded))
+			})
+
 			Context("with node tainted", func() {
 
 				It("should migrate the VMI to another node", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -114,6 +114,7 @@ const (
 const (
 	AlpineHttpUrl     = "http://cdi-http-import-server.kubevirt/images/alpine.iso"
 	GuestAgentHttpUrl = "http://cdi-http-import-server.kubevirt/qemu-ga"
+	StressHttpUrl     = "http://cdi-http-import-server.kubevirt/stress"
 )
 
 const (
@@ -1552,6 +1553,22 @@ func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus string, 
 	})
 
 	return vmi
+}
+
+func NewRandomFedoraVMIWitGuestAgent() *v1.VirtualMachineInstance {
+	agentVMI := NewRandomVMIWithEphemeralDiskAndUserdata(ContainerDiskFor(ContainerDiskFedora), fmt.Sprintf(`#!/bin/bash
+                echo "fedora" |passwd fedora --stdin
+                mkdir -p /usr/local/bin
+                curl %s > /usr/local/bin/qemu-ga
+                chmod +x /usr/local/bin/qemu-ga
+                curl %s > /usr/local/bin/stress
+                chmod +x /usr/local/bin/stress
+                setenforce 0
+                systemd-run --unit=guestagent /usr/local/bin/qemu-ga
+                `, GuestAgentHttpUrl, StressHttpUrl))
+	agentVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+	return agentVMI
+
 }
 
 func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -812,15 +812,7 @@ var _ = Describe("Configurations", func() {
 			It("[test_id:1677]VMI condition should signal agent presence", func() {
 
 				// TODO: actually review this once the VM image is present
-				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), fmt.Sprintf(`#!/bin/bash
-                echo "fedora" |passwd fedora --stdin
-                mkdir -p /usr/local/bin
-                curl %s > /usr/local/bin/qemu-ga
-                chmod +x /usr/local/bin/qemu-ga
-                setenforce 0
-                systemd-run --unit=guestagent /usr/local/bin/qemu-ga
-                `, tests.GuestAgentHttpUrl))
-				agentVMI.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("512M")
+				agentVMI := tests.NewRandomFedoraVMIWitGuestAgent()
 
 				By("Starting a VirtualMachineInstance")
 				agentVMI, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(agentVMI)


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the PodDisruptionBudget to at least require two pods online. This avoids that evictions on a source pod may succeed because there is an overlap where the source- and the target pod are both seen as healthy.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2196 

**Special notes for your reviewer**:

**Release note**:

```release-note
Ensure long-running migrations are not disturbed by eviction calls, if the VMI has the Migrate evictionStrategy set.
```
