### PR TITLE
Prepare automation test script for prow

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -235,7 +235,7 @@ kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"
 
-ginko_params="--ginkgo.noColor --junit-output=$ARTIFACTS_PATH/tests.junit.xml"
+ginko_params="--ginkgo.noColor --junit-output=$ARTIFACTS_PATH/junit.functest.xml"
 
 # Prepare PV for Windows testing
 if [[ $TARGET =~ windows.* ]]; then

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -29,7 +29,7 @@
 set -ex
 
 export WORKSPACE="${WORKSPACE:-$PWD}"
-readonly ARTIFACTS_PATH="$WORKSPACE/exported-artifacts"
+readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 
 if [[ $TARGET =~ windows.* ]]; then
@@ -140,17 +140,7 @@ fi
 
 kubectl() { cluster/kubectl.sh "$@"; }
 
-
-# If run on CI use random kubevirt system-namespaces
-if [ -n "${JOB_NAME}" ]; then
-  export NAMESPACE="kubevirt-system-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)"
-  cat >hack/config-local.sh <<EOF
-namespace=${NAMESPACE}
-EOF
-else
-  export NAMESPACE="${NAMESPACE:-kubevirt}"
-fi
-
+export NAMESPACE="${NAMESPACE:-kubevirt}"
 
 # Make sure that the VM is properly shut down on exit
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM SIGSTOP

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -283,14 +283,14 @@ func (_mr *_MockVirDomainRecorder) ShutdownFlags(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShutdownFlags", arg0)
 }
 
-func (_m *MockVirDomain) Undefine() error {
-	ret := _m.ctrl.Call(_m, "Undefine")
+func (_m *MockVirDomain) UndefineFlags(flags libvirt_go.DomainUndefineFlagsValues) error {
+	ret := _m.ctrl.Call(_m, "UndefineFlags", flags)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockVirDomainRecorder) Undefine() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Undefine")
+func (_mr *_MockVirDomainRecorder) UndefineFlags(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UndefineFlags", arg0)
 }
 
 func (_m *MockVirDomain) GetName() (string, error) {

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -322,7 +322,7 @@ type VirDomain interface {
 	Resume() error
 	DestroyFlags(flags libvirt.DomainDestroyFlags) error
 	ShutdownFlags(flags libvirt.DomainShutdownFlags) error
-	Undefine() error
+	UndefineFlags(flags libvirt.DomainUndefineFlagsValues) error
 	GetName() (string, error)
 	GetUUIDString() (string, error)
 	GetXMLDesc(flags libvirt.DomainXMLFlags) (string, error)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1086,7 +1086,7 @@ func (l *LibvirtDomainManager) DeleteVMI(vmi *v1.VirtualMachineInstance) error {
 	}
 	defer dom.Free()
 
-	err = dom.Undefine()
+	err = dom.UndefineFlags(libvirt.DOMAIN_UNDEFINE_NVRAM)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Undefining the domain failed.")
 		return err

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -548,7 +548,7 @@ var _ = Describe("Manager", func() {
 				// Make sure that we always free the domain after use
 				mockDomain.EXPECT().Free()
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
-				mockDomain.EXPECT().Undefine().Return(nil)
+				mockDomain.EXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_NVRAM).Return(nil)
 				manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0)
 				err := manager.DeleteVMI(newVMI(testNamespace, testVmName))
 				Expect(err).To(BeNil())

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
@@ -431,6 +432,9 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				By("Verifying the VMI is back up AFTER restart (in Running status with new UID).")
 				Eventually(func() bool {
 					vmi, err = virtClient.VirtualMachineInstance(vmObj.Namespace).Get(vmObj.Name, &k8smetav1.GetOptions{})
+					if errors.IsNotFound(err) {
+						return false
+					}
 					Expect(err).ToNot(HaveOccurred())
 					vmiUIdAfterRestart := vmi.GetObjectMeta().GetUID()
 					newUId := (vmiUIdAfterRestart != vmiUIdBeforeRestart)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -198,7 +198,6 @@ type ObjectEventWatcher struct {
 	resourceVersion        string
 	startType              startType
 	dontFailOnMissingEvent bool
-	abort                  chan struct{}
 }
 
 func NewObjectEventWatcher(object runtime.Object) *ObjectEventWatcher {
@@ -324,7 +323,7 @@ func (w *ObjectEventWatcher) Watch(abortChan chan struct{}, processFunc ProcessF
 	if w.timeout != nil {
 		select {
 		case <-done:
-		case <-w.abort:
+		case <-abortChan:
 		case <-time.After(*w.timeout):
 			if !w.dontFailOnMissingEvent {
 				Fail(fmt.Sprintf("Waited for %v seconds on the event stream to match a specific event", w.timeout.Seconds()), 1)
@@ -332,8 +331,8 @@ func (w *ObjectEventWatcher) Watch(abortChan chan struct{}, processFunc ProcessF
 		}
 	} else {
 		select {
+		case <-abortChan:
 		case <-done:
-		case <-w.abort:
 		}
 	}
 }

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -55,9 +55,6 @@ var _ = Describe("Multus", func() {
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)
 
-	var detachedVMI *v1.VirtualMachineInstance
-	var vmiOne *v1.VirtualMachineInstance
-	var vmiTwo *v1.VirtualMachineInstance
 	var nodes *k8sv1.NodeList
 
 	defaultInterface := v1.Interface{
@@ -89,6 +86,19 @@ var _ = Describe("Multus", func() {
 			},
 		},
 	}
+
+	AfterEach(func() {
+		// Multus tests need to ensure that old VMIs are gone
+		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestDefault).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
+		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestAlternative).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
+		Eventually(func() int {
+			list1, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v13.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			list2, err := virtClient.VirtualMachineInstance(tests.NamespaceTestAlternative).List(&v13.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return len(list1.Items) + len(list2.Items)
+		}, 180*time.Second, 1*time.Second).Should(BeZero())
+	})
 
 	createVMIOnNode := func(interfaces []v1.Interface, networks []v1.Network) *v1.VirtualMachineInstance {
 		vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskAlpine), "#!/bin/bash\n")
@@ -155,18 +165,10 @@ var _ = Describe("Multus", func() {
 
 	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.", func() {
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
-			AfterEach(func() {
-				virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(detachedVMI.Name, &v13.DeleteOptions{})
-				fmt.Printf("Waiting for vmi %s in %s namespace to be removed, this can take a while ...\n", detachedVMI.Name, tests.NamespaceTestDefault)
-				EventuallyWithOffset(1, func() bool {
-					return errors.IsNotFound(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(detachedVMI.Name, nil))
-				}, 180*time.Second, 1*time.Second).
-					Should(BeTrue())
-			})
 
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
-				detachedVMI = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -183,7 +185,7 @@ var _ = Describe("Multus", func() {
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
-				detachedVMI = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -200,7 +202,7 @@ var _ = Describe("Multus", func() {
 
 			It("[test_id:1753]should create a virtual machine with two interfaces", func() {
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
-				detachedVMI = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{
 					defaultInterface,
@@ -236,17 +238,9 @@ var _ = Describe("Multus", func() {
 		})
 
 		Context("VirtualMachineInstance with multus network as default network", func() {
-			AfterEach(func() {
-				virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(detachedVMI.Name, &v13.DeleteOptions{})
-				fmt.Printf("Waiting for vmi %s in %s namespace to be removed, this can take a while ...\n", detachedVMI.Name, tests.NamespaceTestDefault)
-				EventuallyWithOffset(1, func() bool {
-					return errors.IsNotFound(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(detachedVMI.Name, nil))
-				}, 180*time.Second, 1*time.Second).
-					Should(BeTrue())
-			})
 
 			It("should create a virtual machine with one interface with multus default network definition", func() {
-				detachedVMI = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 				detachedVMI.Spec.Networks = []v1.Network{
 					{Name: "ptp", NetworkSource: v1.NetworkSource{
@@ -281,9 +275,6 @@ var _ = Describe("Multus", func() {
 		})
 
 		Context("VirtualMachineInstance with cni ptp plugin interface with custom MAC address", func() {
-			AfterEach(func() {
-				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne})
-			})
 
 			table.DescribeTable("configure valid custom MAC address on ptp interface", func(networkName string) {
 				customMacAddress := "50:00:00:00:90:0d"
@@ -307,7 +298,7 @@ var _ = Describe("Multus", func() {
 
 				By("Creating a VM with custom MAC address on its ptp interface.")
 				interfaces[0].MacAddress = customMacAddress
-				vmiOne = createVMIOnNode(interfaces, networks)
+				vmiOne := createVMIOnNode(interfaces, networks)
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 
 				By("Configuring static IP address to ptp interface.")
@@ -341,14 +332,11 @@ var _ = Describe("Multus", func() {
 			BeforeEach(func() {
 				tests.SkipIfNoSriovDevicePlugin(virtClient)
 			})
-			AfterEach(func() {
-				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne})
-			})
 
 			It("[test_id:1754]should create a virtual machine with sriov interface", func() {
 				// since neither cirros nor alpine has drivers for Intel NICs, we are left with fedora
 				userData := "#cloud-config\npassword: fedora\nchpasswd: { expire: False }\n"
-				vmiOne = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userData)
+				vmiOne := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userData)
 				tests.AddExplicitPodNetworkInterface(vmiOne)
 
 				iface := v1.Interface{Name: "sriov", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}
@@ -404,7 +392,7 @@ var _ = Describe("Multus", func() {
 			It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
 				// since neither cirros nor alpine has drivers for Intel NICs, we are left with fedora
 				userData := "#cloud-config\npassword: fedora\nchpasswd: { expire: False }\n"
-				vmiOne = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userData)
+				vmiOne := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userData)
 				tests.AddExplicitPodNetworkInterface(vmiOne)
 
 				for _, name := range []string{"sriov", "sriov2"} {
@@ -464,17 +452,14 @@ var _ = Describe("Multus", func() {
 		})
 
 		Context("VirtualMachineInstance with ovs-cni plugin interface", func() {
-			AfterEach(func() {
-				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne, vmiTwo})
-			})
 
 			It("[test_id:1577]should create two virtual machines with one interface", func() {
 				By("checking virtual machine instance can ping the secondary virtual machine instance using ovs-cni plugin")
 				interfaces := []v1.Interface{ovsInterface}
 				networks := []v1.Network{ovsNetwork}
 
-				vmiOne = createVMIOnNode(interfaces, networks)
-				vmiTwo = createVMIOnNode(interfaces, networks)
+				vmiOne := createVMIOnNode(interfaces, networks)
+				vmiTwo := createVMIOnNode(interfaces, networks)
 
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
@@ -502,8 +487,8 @@ var _ = Describe("Multus", func() {
 					ovsNetwork,
 				}
 
-				vmiOne = createVMIOnNode(interfaces, networks)
-				vmiTwo = createVMIOnNode(interfaces, networks)
+				vmiOne := createVMIOnNode(interfaces, networks)
+				vmiTwo := createVMIOnNode(interfaces, networks)
 
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
@@ -527,18 +512,14 @@ var _ = Describe("Multus", func() {
 			ovsIfIdx := 0
 			customMacAddress := "50:00:00:00:90:0d"
 
-			AfterEach(func() {
-				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne, vmiTwo})
-			})
-
 			It("[test_id:676]should configure valid custom MAC address on ovs-cni interface.", func() {
 				By("Creating a VM with ovs-cni network interface and default MAC address.")
-				vmiTwo = createVMIOnNode(interfaces, networks)
+				vmiTwo := createVMIOnNode(interfaces, networks)
 				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
 
 				By("Creating another VM with custom MAC address on its ovs-cni interface.")
 				interfaces[ovsIfIdx].MacAddress = customMacAddress
-				vmiOne = createVMIOnNode(interfaces, networks)
+				vmiOne := createVMIOnNode(interfaces, networks)
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 
 				By("Configuring static IP address to the ovs interface.")
@@ -569,9 +550,6 @@ var _ = Describe("Multus", func() {
 			})
 		})
 		Context("Single VirtualMachineInstance with ovs-cni plugin interface", func() {
-			AfterEach(func() {
-				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{vmiOne})
-			})
 
 			It("[test_id:1756]should report all interfaces in Status", func() {
 				interfaces := []v1.Interface{
@@ -583,7 +561,7 @@ var _ = Describe("Multus", func() {
 					ovsNetwork,
 				}
 
-				vmiOne = createVMIOnNode(interfaces, networks)
+				vmiOne := createVMIOnNode(interfaces, networks)
 
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 
@@ -645,11 +623,6 @@ var _ = Describe("Multus", func() {
 
 	Describe("[rfe_id:1758][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition", func() {
 		Context("with quemu guest agent", func() {
-			var agentVMI *v1.VirtualMachineInstance
-
-			AfterEach(func() {
-				deleteVMIs(virtClient, []*v1.VirtualMachineInstance{agentVMI})
-			})
 
 			It("[test_id:1757] should report guest interfaces in VMI status", func() {
 				interfaces := []v1.Interface{
@@ -678,7 +651,7 @@ var _ = Describe("Multus", func() {
                     chmod +x /usr/local/bin/qemu-ga
                     systemd-run --unit=guestagent /usr/local/bin/qemu-ga
                 `, ep1Ip, ep2Ip, ep1IpV6, ep2IpV6, tests.GuestAgentHttpUrl)
-				agentVMI = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userdata)
+				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userdata)
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks
@@ -736,17 +709,6 @@ var _ = Describe("Multus", func() {
 		})
 	})
 })
-
-func deleteVMIs(virtClient kubecli.KubevirtClient, vmis []*v1.VirtualMachineInstance) {
-	for _, deleteVMI := range vmis {
-		virtClient.VirtualMachineInstance("default").Delete(deleteVMI.Name, &v13.DeleteOptions{})
-		fmt.Printf("Waiting for vmi %s in %s namespace to be removed, this can take a while ...\n", deleteVMI.Name, tests.NamespaceTestDefault)
-		EventuallyWithOffset(1, func() bool {
-			return errors.IsNotFound(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(deleteVMI.Name, nil))
-		}, 180*time.Second, 1*time.Second).
-			Should(BeTrue())
-	}
-}
 
 func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAddress, prompt string) {
 	cmdCheck := fmt.Sprintf("ip addr add %s dev %s\n", interfaceAddress, interfaceName)


### PR DESCRIPTION
**What this PR does / why we need it**:

* Ensure that junit test results get stored in the ${ARTIFACTS} directory, so that they get uploaded.
* Fix undefine issues if VMIs have a NVRAM field set:

```
{"component":"virt-handler","kind":"VirtualMachineInstance","level":"error","msg":"Synchronizing the VirtualMachineInstance failed.","name":"testvmidvsb7gw9h2rh24wz98fjz2nwbnzrkn5nw5sfsclxthzb7ft5","namespace":"kubevirt-test-default","pos":"vm.go:869","reason":"server error. command Delete failed: \"LibvirtError(Code=55, Domain=10, Message='Requested operation is not valid: cannot undefine domain with nvram')\"","timestamp":"2019-04-20T08:47:53.998182Z","uid":"e9ecd302-6348-11e9-973f-525500d15501"}
```

 * Fix flaky expose test which sometimes fails while it waits for a VM to be restarted
 * Fix event watcher, which could not be aborted properly and could run into tricky to interpret timeouts

**Special notes for your reviewer**:

/hold
/wip

**Release note**:

```release-note
NONE
```
