### PR TITLE
Make operator resilient against discovery errors

### DIFF
--- a/pkg/virt-operator/util/BUILD.bazel
+++ b/pkg/virt-operator/util/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	secv1 "github.com/openshift/api/security/v1"
+	"k8s.io/client-go/discovery"
 
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,8 +122,18 @@ func SetOperatorVersion(kv *virtv1.KubeVirt) {
 func IsOnOpenshift(clientset kubecli.KubevirtClient) (bool, error) {
 
 	apis, err := clientset.DiscoveryClient().ServerResources()
-	if err != nil {
+	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
 		return false, err
+	}
+
+	// In case of an error, check if security.openshift.io is the reason (unlikely).
+	// If it is, we are obviously on an openshift cluster.
+	// Otherwise we can do a positive check.
+	if discovery.IsGroupDiscoveryFailedError(err) {
+		e := err.(*discovery.ErrGroupDiscoveryFailed)
+		if _, exists := e.Groups[secv1.GroupVersion]; exists {
+			return true, nil
+		}
 	}
 
 	for _, api := range apis {


### PR DESCRIPTION
**What this PR does / why we need it**:

In case some aggregated apiservers are not online the operator would wail, if one of them is online.
To omit that, analyse which groups are failing and if we care about them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Make the operator resilient against group discovery errors, when aggregated apiservers are unavailable.
```
