### PR TITLE
Move feature gates to ClusterConfig

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -177,7 +177,7 @@ func (app *virtHandlerApp) Run() {
 		gracefulShutdownInformer,
 		int(app.WatchdogTimeoutDuration.Seconds()),
 		app.MaxDevices,
-		virtconfig.NewClusterConfig(factory.ConfigMap().GetStore(), namespace),
+		virtconfig.NewClusterConfig(factory.ConfigMap(), namespace),
 	)
 
 	certsDirectory, err := ioutil.TempDir("", "certsdir")

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -3,9 +3,7 @@ package testutils
 import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -15,25 +13,6 @@ const (
 	configMapName = "kubevirt-config"
 	namespace     = "kubevirt"
 )
-
-func MakeFakeClusterConfig(configMaps []v1.ConfigMap, stopChan chan struct{}) *virtconfig.ClusterConfig {
-	cmListWatch := &cache.ListWatch{
-		ListFunc: func(options v12.ListOptions) (runtime.Object, error) {
-			return &v1.ConfigMapList{Items: configMaps}, nil
-		},
-		WatchFunc: func(options v12.ListOptions) (watch.Interface, error) {
-			fakeWatch := watch.NewFake()
-			for _, cfgMap := range configMaps {
-				fakeWatch.Add(&cfgMap)
-			}
-			return fakeWatch, nil
-		},
-	}
-	cmInformer := cache.NewSharedIndexInformer(cmListWatch, &v1.ConfigMap{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	go cmInformer.Run(stopChan)
-	cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
-	return virtconfig.NewClusterConfig(cmInformer, namespace)
-}
 
 func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.SharedIndexInformer) {
 	informer, _ := NewFakeInformerFor(&v1.ConfigMap{})

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -32,19 +32,19 @@ func MakeFakeClusterConfig(configMaps []v1.ConfigMap, stopChan chan struct{}) *v
 	cmInformer := cache.NewSharedIndexInformer(cmListWatch, &v1.ConfigMap{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	go cmInformer.Run(stopChan)
 	cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
-	return virtconfig.NewClusterConfig(cmInformer.GetStore(), namespace)
+	return virtconfig.NewClusterConfig(cmInformer, namespace)
 }
 
-func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.Store) {
-	store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.SharedIndexInformer) {
+	informer, _ := NewFakeInformerFor(&v1.ConfigMap{})
 	copy := copy(cfgMap)
-	store.Add(copy)
-	return virtconfig.NewClusterConfig(store, namespace), store
+	informer.GetStore().Add(copy)
+	return virtconfig.NewClusterConfig(informer, namespace), informer
 }
 
-func UpdateFakeClusterConfig(store cache.Store, cfgMap *v1.ConfigMap) {
+func UpdateFakeClusterConfig(informer cache.SharedIndexInformer, cfgMap *v1.ConfigMap) {
 	copy := copy(cfgMap)
-	store.Update(copy)
+	informer.GetStore().Update(copy)
 }
 
 func copy(cfgMap *v1.ConfigMap) *v1.ConfigMap {

--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -133,8 +133,6 @@ func NewVirtApi() VirtApi {
 }
 
 func (app *virtAPIApp) Execute() {
-	virtconfig.Init()
-
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		panic(err)

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1053,7 +1053,7 @@ func (app *virtAPIApp) Run() {
 		webhookInformers.NamespaceLimitsInformer.HasSynced,
 		configMapInformer.HasSynced)
 
-	app.clusterConfig = virtconfig.NewClusterConfig(configMapInformer.GetStore(), app.namespace)
+	app.clusterConfig = virtconfig.NewClusterConfig(configMapInformer, app.namespace)
 
 	// Verify/create webhook endpoint.
 	err = app.createWebhook()

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -764,7 +764,7 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 		validating_webhook.ServeVMIPreset(w, r)
 	})
 	http.HandleFunc(migrationCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeMigrationCreate(w, r)
+		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig)
 	})
 	http.HandleFunc(migrationUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationUpdate(w, r)

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",
+        "//pkg/testutils:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/gorilla/websocket:go_default_library",

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -42,6 +42,7 @@ import (
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
@@ -89,7 +90,9 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Status.Phase = v1.Running
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
-			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", configCache, pvcCache, app.VirtCli)
+
+			config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", configCache, pvcCache, app.VirtCli, config)
 
 			pod, err := templateService.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -261,7 +264,8 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi.Status.Phase = v1.Running
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
 
-			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", configCache, pvcCache, app.VirtCli)
+			config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", configCache, pvcCache, app.VirtCli, config)
 
 			pod, err := templateService.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
@@ -125,12 +125,10 @@ var _ = Describe("Mutating Webhook", func() {
 			}
 			namespaceLimitInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})
 			namespaceLimitInformer.GetIndexer().Add(namespaceLimit)
-			configMapInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 			webhooks.SetInformers(
 				&webhooks.Informers{
 					VMIPresetInformer:       presetInformer,
 					NamespaceLimitsInformer: namespaceLimitInformer,
-					ConfigMapInformer:       configMapInformer,
 				},
 			)
 

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Mutating Webhook", func() {
 		var presetInformer cache.SharedIndexInformer
 		var namespaceLimit *k8sv1.LimitRange
 		var namespaceLimitInformer cache.SharedIndexInformer
-		var configMapStore cache.Store
+		var configMapInformer cache.SharedIndexInformer
 		var mutator *VMIsMutator
 
 		memoryLimit := "128M"
@@ -133,7 +133,7 @@ var _ = Describe("Mutating Webhook", func() {
 			)
 
 			mutator = &VMIsMutator{}
-			mutator.clusterConfig, configMapStore = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+			mutator.clusterConfig, configMapInformer = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		})
 
 		It("should apply presets on VMI create", func() {
@@ -156,7 +156,7 @@ var _ = Describe("Mutating Webhook", func() {
 		})
 
 		It("should apply configurable defaults on VMI create", func() {
-			testutils.UpdateFakeClusterConfig(configMapStore, &k8sv1.ConfigMap{
+			testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
 				Data: map[string]string{
 					virtconfig.CpuModelKey:      cpuModelFromConfig,
 					virtconfig.MachineTypeKey:   machineTypeFromConfig,
@@ -173,7 +173,7 @@ var _ = Describe("Mutating Webhook", func() {
 		})
 
 		It("should not override specified properties with defaults on VMI create", func() {
-			testutils.UpdateFakeClusterConfig(configMapStore, &k8sv1.ConfigMap{
+			testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
 				Data: map[string]string{
 					virtconfig.CpuModelKey:      cpuModelFromConfig,
 					virtconfig.MachineTypeKey:   machineTypeFromConfig,

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -80,7 +80,6 @@ type Informers struct {
 	VMIPresetInformer       cache.SharedIndexInformer
 	NamespaceLimitsInformer cache.SharedIndexInformer
 	VMIInformer             cache.SharedIndexInformer
-	ConfigMapInformer       cache.SharedIndexInformer
 }
 
 func GetInformers() *Informers {
@@ -111,7 +110,6 @@ func newInformers() *Informers {
 		VMIInformer:             kubeInformerFactory.VMI(),
 		VMIPresetInformer:       kubeInformerFactory.VirtualMachinePreset(),
 		NamespaceLimitsInformer: kubeInformerFactory.LimitRanges(),
-		ConfigMapInformer:       kubeInformerFactory.ConfigMap(),
 	}
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/log:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -271,7 +271,7 @@ func validateBootloader(field *k8sfield.Path, bootloader *v1.Bootloader) []metav
 	return causes
 }
 
-func validateVolumes(field *k8sfield.Path, volumes []v1.Volume) []metav1.StatusCause {
+func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconfig.ClusterConfig) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 	nameMap := make(map[string]int)
 
@@ -322,7 +322,7 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume) []metav1.StatusC
 			volumeSourceSetCount++
 		}
 		if volume.DataVolume != nil {
-			if !virtconfig.DataVolumesEnabled() {
+			if !config.DataVolumesEnabled() {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: "DataVolume feature gate is not enabled",
@@ -1421,7 +1421,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	}
 
 	causes = append(causes, validateDomainSpec(field.Child("domain"), &spec.Domain)...)
-	causes = append(causes, validateVolumes(field.Child("volumes"), spec.Volumes)...)
+	causes = append(causes, validateVolumes(field.Child("volumes"), spec.Volumes, config)...)
 	if spec.DNSPolicy != "" {
 		causes = append(causes, validateDNSPolicy(&spec.DNSPolicy, field.Child("dnsPolicy"))...)
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -49,7 +49,7 @@ import (
 var _ = Describe("Validating Webhook", func() {
 	var vmiInformer cache.SharedIndexInformer
 	var config *virtconfig.ClusterConfig
-	var configMapStore cache.Store
+	var configMapInformer cache.SharedIndexInformer
 	dnsConfigTestOption := "test"
 	var vmiCreateAdmitter *VMICreateAdmitter
 	var vmirsAdmitter *VMIRSAdmitter
@@ -62,12 +62,12 @@ var _ = Describe("Validating Webhook", func() {
 	notRunning := false
 
 	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeClusterConfig(configMapStore, &k8sv1.ConfigMap{
+		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
 			Data: map[string]string{virtconfig.FeatureGatesKey: featureGate},
 		})
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeClusterConfig(configMapStore, &k8sv1.ConfigMap{})
+		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{})
 	}
 
 	BeforeSuite(func() {
@@ -75,7 +75,7 @@ var _ = Describe("Validating Webhook", func() {
 		webhooks.SetInformers(&webhooks.Informers{
 			VMIInformer: vmiInformer,
 		})
-		config, configMapStore = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		config, configMapInformer = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		vmiCreateAdmitter = &VMICreateAdmitter{clusterConfig: config}
 		vmirsAdmitter = &VMIRSAdmitter{clusterConfig: config}
 		vmsAdmitter = &VMsAdmitter{clusterConfig: config}

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook_test.go
@@ -72,10 +72,8 @@ var _ = Describe("Validating Webhook", func() {
 
 	BeforeSuite(func() {
 		vmiInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
-		configMapInformer, _ := testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		webhooks.SetInformers(&webhooks.Informers{
-			VMIInformer:       vmiInformer,
-			ConfigMapInformer: configMapInformer,
+			VMIInformer: vmiInformer,
 		})
 		config, configMapStore = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		vmiCreateAdmitter = &VMICreateAdmitter{clusterConfig: config}

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -31,13 +31,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/log:go_default_library",
+        "//pkg/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
-        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -41,11 +41,11 @@ import (
 const (
 	configMapName       = "kubevirt-config"
 	FeatureGatesKey     = "feature-gates"
-	emulatedMachinesKey = "emulated-machines"
+	EmulatedMachinesKey = "emulated-machines"
 	MachineTypeKey      = "machine-type"
 	useEmulationKey     = "debug.useEmulation"
-	imagePullPolicyKey  = "dev.imagePullPolicy"
-	migrationsConfigKey = "migrations"
+	ImagePullPolicyKey  = "dev.imagePullPolicy"
+	MigrationsConfigKey = "migrations"
 	CpuModelKey         = "default-cpu-model"
 	CpuRequestKey       = "cpu-request"
 	MemoryRequestKey    = "memory-request"
@@ -218,7 +218,7 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	config.ResourceVersion = configMap.ResourceVersion
 
 	// set migration options
-	rawConfig := strings.TrimSpace(configMap.Data[migrationsConfigKey])
+	rawConfig := strings.TrimSpace(configMap.Data[MigrationsConfigKey])
 	if rawConfig != "" {
 		// only sets values if they were specified, default values stay intact
 		err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(rawConfig), 1024).Decode(config.MigrationConfig)
@@ -228,7 +228,7 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	}
 
 	// set image pull policy
-	policy := strings.TrimSpace(configMap.Data[imagePullPolicyKey])
+	policy := strings.TrimSpace(configMap.Data[ImagePullPolicyKey])
 	switch policy {
 	case "":
 		// keep the default
@@ -272,7 +272,7 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 		config.MemoryRequest = resource.MustParse(memoryRequest)
 	}
 
-	if emulatedMachines := strings.TrimSpace(configMap.Data[emulatedMachinesKey]); emulatedMachines != "" {
+	if emulatedMachines := strings.TrimSpace(configMap.Data[EmulatedMachinesKey]); emulatedMachines != "" {
 		vals := strings.Split(emulatedMachines, ",")
 		for i := range vals {
 			vals[i] = strings.TrimSpace(vals[i])

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -21,7 +21,6 @@ package virtconfig
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -41,7 +40,6 @@ import (
 
 const (
 	configMapName       = "kubevirt-config"
-	featureGateEnvVar   = "FEATURE_GATES"
 	FeatureGatesKey     = "feature-gates"
 	emulatedMachinesKey = "emulated-machines"
 	MachineTypeKey      = "machine-type"
@@ -64,14 +62,6 @@ const (
 
 	NodeDrainTaintDefaultKey = "kubevirt.io/drain"
 )
-
-// We cannot rely on automatic invocation of 'init' method because this initialization
-// code assumes a cluster is available to pull the configmap from
-func Init() {
-	if val, ok := getConfigMap().Data[FeatureGatesKey]; ok {
-		os.Setenv(featureGateEnvVar, val)
-	}
-}
 
 func getConfigMap() *k8sv1.ConfigMap {
 	virtClient, err := kubecli.GetKubevirtClient()

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -174,6 +174,7 @@ type Config struct {
 	CPURequest       resource.Quantity
 	MemoryRequest    resource.Quantity
 	EmulatedMachines []string
+	FeatureGates     string
 }
 
 type MigrationConfig struct {
@@ -295,6 +296,10 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 			vals[i] = strings.TrimSpace(vals[i])
 		}
 		config.EmulatedMachines = vals
+	}
+
+	if featureGates := strings.TrimSpace(configMap.Data[FeatureGatesKey]); featureGates != "" {
+		config.FeatureGates = featureGates
 	}
 
 	return nil

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -68,17 +68,9 @@ const (
 // We cannot rely on automatic invocation of 'init' method because this initialization
 // code assumes a cluster is available to pull the configmap from
 func Init() {
-	InitFromConfigMap(getConfigMap())
-}
-
-func InitFromConfigMap(cfgMap *k8sv1.ConfigMap) {
-	if val, ok := cfgMap.Data[FeatureGatesKey]; ok {
+	if val, ok := getConfigMap().Data[FeatureGatesKey]; ok {
 		os.Setenv(featureGateEnvVar, val)
 	}
-}
-
-func Clear() {
-	os.Unsetenv(featureGateEnvVar)
 }
 
 func getConfigMap() *k8sv1.ConfigMap {

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -312,5 +312,5 @@ func MakeClusterConfig(configMaps []kubev1.ConfigMap, stopChan chan struct{}) (*
 	cmInformer := cache.NewSharedIndexInformer(cmListWatch, &kubev1.ConfigMap{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	go cmInformer.Run(stopChan)
 	cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
-	return NewClusterConfig(cmInformer.GetStore(), "kubevirt"), cmInformer.GetStore()
+	return NewClusterConfig(cmInformer, "kubevirt"), cmInformer.GetStore()
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -63,6 +63,6 @@ func SRIOVEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
 }
 
-func HypervStrictCheckEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), HypervStrictCheckGate)
+func (config *ClusterConfig) HypervStrictCheckEnabled() bool {
+	return config.isFeatureGateEnabled(HypervStrictCheckGate)
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -65,3 +65,7 @@ func (config *ClusterConfig) SRIOVEnabled() bool {
 func (config *ClusterConfig) HypervStrictCheckEnabled() bool {
 	return config.isFeatureGateEnabled(HypervStrictCheckGate)
 }
+
+func (config *ClusterConfig) CPUNodeDiscoveryEnabled() bool {
+	return config.isFeatureGateEnabled(CPUNodeDiscoveryGate)
+}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -39,6 +39,10 @@ const (
 	HypervStrictCheckGate = "HypervStrictCheck"
 )
 
+func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
+	return strings.Contains(c.getConfig().FeatureGates, featureGate)
+}
+
 func DataVolumesEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), dataVolumesGate)
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -55,8 +55,8 @@ func IgnitionEnabled() bool {
 	return strings.Contains(os.Getenv(featureGateEnvVar), ignitionGate)
 }
 
-func LiveMigrationEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), liveMigrationGate)
+func (config *ClusterConfig) LiveMigrationEnabled() bool {
+	return config.isFeatureGateEnabled(liveMigrationGate)
 }
 
 func SRIOVEnabled() bool {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -25,7 +25,6 @@ package virtconfig
 */
 
 import (
-	"os"
 	"strings"
 )
 
@@ -51,16 +50,16 @@ func (config *ClusterConfig) CPUManagerEnabled() bool {
 	return config.isFeatureGateEnabled(cpuManager)
 }
 
-func IgnitionEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), ignitionGate)
+func (config *ClusterConfig) IgnitionEnabled() bool {
+	return config.isFeatureGateEnabled(ignitionGate)
 }
 
 func (config *ClusterConfig) LiveMigrationEnabled() bool {
 	return config.isFeatureGateEnabled(liveMigrationGate)
 }
 
-func SRIOVEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), SRIOVGate)
+func (config *ClusterConfig) SRIOVEnabled() bool {
+	return config.isFeatureGateEnabled(SRIOVGate)
 }
 
 func (config *ClusterConfig) HypervStrictCheckEnabled() bool {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -47,8 +47,8 @@ func (config *ClusterConfig) DataVolumesEnabled() bool {
 	return config.isFeatureGateEnabled(dataVolumesGate)
 }
 
-func CPUManagerEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), cpuManager)
+func (config *ClusterConfig) CPUManagerEnabled() bool {
+	return config.isFeatureGateEnabled(cpuManager)
 }
 
 func IgnitionEnabled() bool {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -43,8 +43,8 @@ func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
 	return strings.Contains(c.getConfig().FeatureGates, featureGate)
 }
 
-func DataVolumesEnabled() bool {
-	return strings.Contains(os.Getenv(featureGateEnvVar), dataVolumesGate)
+func (config *ClusterConfig) DataVolumesEnabled() bool {
+	return config.isFeatureGateEnabled(dataVolumesGate)
 }
 
 func CPUManagerEnabled() bool {

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//pkg/hooks:go_default_library",
         "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",
+        "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -90,6 +90,7 @@ type templateService struct {
 	configMapStore             cache.Store
 	persistentVolumeClaimStore cache.Store
 	virtClient                 kubecli.KubevirtClient
+	clusterConfig              *virtconfig.ClusterConfig
 }
 
 type PvcNotFoundError error
@@ -876,7 +877,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 	}
 
-	if virtconfig.HypervStrictCheckEnabled() {
+	if t.clusterConfig.HypervStrictCheckEnabled() {
 		hvNodeSelectors := getHypervNodeSelectors(vmi)
 		for k, v := range hvNodeSelectors {
 			nodeSelector[k] = v
@@ -1237,7 +1238,8 @@ func NewTemplateService(launcherImage string,
 	imagePullSecret string,
 	configMapCache cache.Store,
 	persistentVolumeClaimCache cache.Store,
-	virtClient kubecli.KubevirtClient) TemplateService {
+	virtClient kubecli.KubevirtClient,
+	clusterConfig *virtconfig.ClusterConfig) TemplateService {
 
 	precond.MustNotBeEmpty(launcherImage)
 	svc := templateService{
@@ -1248,6 +1250,7 @@ func NewTemplateService(launcherImage string,
 		configMapStore:             configMapCache,
 		persistentVolumeClaimStore: persistentVolumeClaimCache,
 		virtClient:                 virtClient,
+		clusterConfig:              clusterConfig,
 	}
 	return &svc
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -179,15 +179,6 @@ func isSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-func IsCPUNodeDiscoveryEnabled(store cache.Store) bool {
-	if value, err := getConfigMapEntry(store, virtconfig.FeatureGatesKey); err != nil {
-		return false
-	} else if strings.Contains(value, virtconfig.CPUNodeDiscoveryGate) {
-		return true
-	}
-	return false
-}
-
 func isFeatureStateEnabled(fs *v1.FeatureState) bool {
 	return fs != nil && fs.Enabled != nil && *fs.Enabled
 }
@@ -866,7 +857,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		nodeSelector[k] = v
 
 	}
-	if IsCPUNodeDiscoveryEnabled(t.configMapStore) {
+	if t.clusterConfig.CPUNodeDiscoveryEnabled() {
 		if cpuModelLabel, err := CPUModelLabelFromCPUModel(vmi); err == nil {
 			if vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
 				nodeSelector[cpuModelLabel] = "true"
@@ -1011,7 +1002,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		pod.Spec.Affinity = vmi.Spec.Affinity.DeepCopy()
 	}
 
-	if IsCPUNodeDiscoveryEnabled(t.configMapStore) {
+	if t.clusterConfig.CPUNodeDiscoveryEnabled() {
 		SetNodeAffinityForForbiddenFeaturePolicy(vmi, &pod)
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -388,15 +388,7 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should add node selector for node discovery feature to template", func() {
-
-				cfgMap := kubev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: namespaceKubevirt,
-						Name:      "kubevirt-config",
-					},
-					Data: map[string]string{virtconfig.FeatureGatesKey: virtconfig.CPUNodeDiscoveryGate},
-				}
-				cmCache.Add(&cfgMap)
+				enableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
 
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -57,15 +57,15 @@ var _ = Describe("Template", func() {
 
 	ctrl := gomock.NewController(GinkgoT())
 	virtClient := kubecli.NewMockKubevirtClient(ctrl)
-	config, configMapStore := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
+	config, configMapInformer := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
 
 	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeClusterConfig(configMapStore, &kubev1.ConfigMap{
+		testutils.UpdateFakeClusterConfig(configMapInformer, &kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.FeatureGatesKey: featureGate},
 		})
 	}
 	disableFeatureGates := func() {
-		testutils.UpdateFakeClusterConfig(configMapStore, &kubev1.ConfigMap{})
+		testutils.UpdateFakeClusterConfig(configMapInformer, &kubev1.ConfigMap{})
 	}
 
 	BeforeEach(func() {

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -292,7 +292,9 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.imagePullSecret,
 		vca.configMapCache,
 		vca.persistentVolumeClaimCache,
-		virtClient)
+		virtClient,
+		vca.clusterConfig,
+	)
 
 	vca.vmiController = NewVMIController(vca.templateService, vca.vmiInformer, vca.podInformer, vca.vmiRecorder, vca.clientSet, vca.configMapInformer, vca.dataVolumeInformer)
 	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "node-controller")

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -129,8 +129,6 @@ func Execute() {
 
 	service.Setup(&app)
 
-	virtconfig.Init()
-
 	app.readyChan = make(chan bool, 1)
 
 	log.InitializeLogging("virt-controller")

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -163,7 +163,7 @@ func Execute() {
 
 	app.configMapInformer = app.informerFactory.ConfigMap()
 	app.configMapCache = app.configMapInformer.GetStore()
-	app.clusterConfig = virtconfig.NewClusterConfig(app.configMapInformer.GetStore(), app.kubevirtNamespace)
+	app.clusterConfig = virtconfig.NewClusterConfig(app.configMapInformer, app.kubevirtNamespace)
 
 	app.persistentVolumeClaimInformer = app.informerFactory.PersistentVolumeClaim()
 	app.persistentVolumeClaimCache = app.persistentVolumeClaimInformer.GetStore()

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -72,8 +72,9 @@ var _ = Describe("Evacuation", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
 		nodeInformer, nodeSource = testutils.NewFakeInformerFor(&v12.Node{})
 		recorder = record.NewFakeRecorder(100)
+		config, _ := testutils.NewFakeClusterConfig(&v12.ConfigMap{})
 
-		controller = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, recorder, virtClient, testutils.MakeFakeClusterConfig(nil, stop))
+		controller = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, recorder, virtClient, config)
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 		controller.Queue = mockQueue
 		migrationFeeder = testutils.NewMigrationFeeder(mockQueue, migrationSource)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -65,7 +65,6 @@ var _ = Describe("Migration watcher", func() {
 	var virtClient *kubecli.MockKubevirtClient
 	var kubeClient *fake.Clientset
 	var networkClient *fakenetworkclient.Clientset
-	var configMapInformer cache.SharedIndexInformer
 	var pvcInformer cache.SharedIndexInformer
 
 	shouldExpectPodCreation := func(uid types.UID, migrationUid types.UID, expectedAntiAffinityCount int, expectedAffinityCount int, expectedNodeAffinityCount int) {
@@ -162,9 +161,8 @@ var _ = Describe("Migration watcher", func() {
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(100)
 
-		configMapInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
-		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		config, configMapInformer := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 		controller = NewMigrationController(
 			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore(), virtClient, config),

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -164,15 +164,16 @@ var _ = Describe("Migration watcher", func() {
 
 		configMapInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 		controller = NewMigrationController(
-			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore(), virtClient),
+			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore(), virtClient, config),
 			vmiInformer,
 			podInformer,
 			migrationInformer,
 			recorder,
 			virtClient,
-			testutils.MakeFakeClusterConfig(nil, stop),
+			config,
 		)
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -163,9 +163,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		recorder = record.NewFakeRecorder(100)
 
 		configMapInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
+		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		controller = NewVMIController(
-			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore(), virtClient),
+			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore(), virtClient, config),
 			vmiInformer,
 			podInformer,
 			recorder,

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -66,7 +66,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var virtClient *kubecli.MockKubevirtClient
 	var kubeClient *fake.Clientset
 	var networkClient *fakenetworkclient.Clientset
-	var configMapInformer cache.SharedIndexInformer
 	var pvcInformer cache.SharedIndexInformer
 
 	var dataVolumeSource *framework.FakeControllerSource
@@ -162,8 +161,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		recorder = record.NewFakeRecorder(100)
 
-		configMapInformer, _ = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
-		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		config, configMapInformer := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		controller = NewVMIController(
 			services.NewTemplateService("a", "b", "c", "d", configMapInformer.GetStore(), pvcInformer.GetStore(), virtClient, config),

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1518,8 +1518,7 @@ func (d *VirtualMachineController) heartBeat(interval time.Duration, stopCh chan
 			log.DefaultLogger().V(4).Infof("Heartbeat sent")
 			// Label the node if cpu manager is running on it
 			// This is a temporary workaround until k8s bug #66525 is resolved
-			virtconfig.Init()
-			if virtconfig.CPUManagerEnabled() {
+			if d.clusterConfig.CPUManagerEnabled() {
 				d.updateNodeCpuManagerLabel()
 			}
 		}, interval, 1.2, true, stopCh)

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -105,6 +105,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 		mockWatchdog = &MockWatchdog{shareDir}
 		mockGracefulShutdown = &MockGracefulShutdown{shareDir}
+		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 		controller = NewController(recorder,
 			virtClient,
@@ -117,7 +118,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			gracefulShutdownInformer,
 			1,
 			10,
-			testutils.MakeFakeClusterConfig(nil, stop),
+			config,
 		)
 
 		testUUID = uuid.NewUUID()

--- a/tools/vms-generator/BUILD.bazel
+++ b/tools/vms-generator/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/api/v1:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks/validating-webhook:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//tools/util:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -34,6 +34,7 @@ import (
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	validating_webhook "kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
 
@@ -43,8 +44,12 @@ func main() {
 	genDir := flag.String("generated-vms-dir", "", "")
 	flag.Parse()
 
-	// Required to validate DataVolume usage
-	os.Setenv("FEATURE_GATES", "DataVolumes,LiveMigration,SRIOV")
+	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
+		Data: map[string]string{
+			// Required to validate DataVolume usage
+			virtconfig.FeatureGatesKey: "DataVolumes,LiveMigration,SRIOV",
+		},
+	})
 
 	var vms = map[string]*v1.VirtualMachine{
 		utils.VmCirros:           utils.GetVMCirros(),
@@ -124,9 +129,6 @@ func main() {
 
 		return nil
 	}
-
-	// This is a hack to satisfy validating_webhook's functions that need a ClusterConfig
-	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 	// Having no generics is lots of fun
 	for name, obj := range vms {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR continues #2203 and leverage the newly introduced `ClusterConfig` also for feature-gates.
This way, the code is more structured and easier to test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
