### PR TITLE
Fix migration unit test race condition

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -398,7 +398,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 			params.MigrateDisksSet = true
 		}
 		// start live migration tracking
-		migrationErrorChan := make(chan error)
+		migrationErrorChan := make(chan error, 1)
 		defer close(migrationErrorChan)
 		go liveMigrationMonitor(vmi, dom, l, options, migrationErrorChan)
 		err = dom.MigrateToURI3(dstUri, params, migrateFlags)


### PR DESCRIPTION

**What this PR does / why we need it**:

The migration unit tests are reporting a race condition. It's isolated to how the unit test is written.

The same boolean can't be set and read by separate goroutines. This was fixed by passing the boolean over a channel. 

I also made the migration err channel non blocking on the "send". 

```
WARNING: DATA RACE
Write at 0x00c0016f306c by goroutine 28:
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.glob..func2.7.2.2()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager_test.go:407 +0x1fa
  runtime.call64()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/runtime/asm_amd64.s:523 +0x3a
  reflect.Value.Call()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/reflect/value.go:308 +0xc0
  kubevirt.io/kubevirt/vendor/github.com/golang/mock/gomock.(*Call).DoAndReturn.func1()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/golang/mock/gomock/call.go:123 +0x53b
  kubevirt.io/kubevirt/vendor/github.com/golang/mock/gomock.(*Controller).Call()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/golang/mock/gomock/controller.go:221 +0x144
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli.(*MockConnection).DomainDefineXML()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go:46 +0x156
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util.SetDomainSpecStr()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util/libvirt_helper.go:94 +0x2d9
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.(*LibvirtDomainManager).setDomainSpecWithHooks()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager.go:1144 +0x11b
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.(*LibvirtDomainManager).setMigrationResultHelper()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager.go:237 +0x62f
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.(*LibvirtDomainManager).setMigrationResult.func1()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager.go:154 +0x80
  kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait.pollImmediateInternal()
      /root/go/src/kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:245 +0x38
  kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait.PollImmediate()
      /root/go/src/kubevirt.io/kubevirt/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:241 +0x5e
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.(*LibvirtDomainManager).setMigrationResult()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager.go:153 +0x1ab
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.liveMigrationMonitor()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager.go:469 +0x13a8

Previous read at 0x00c0016f306c by goroutine 16:
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.glob..func2.7.2.3()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager_test.go:421 +0x46
  runtime.call32()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/runtime/asm_amd64.s:522 +0x3a
  reflect.Value.Call()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/reflect/value.go:308 +0xc0
  kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).pollActual()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:73 +0xc4
  kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).match()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:109 +0x102
  kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).Should()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:49 +0xc1
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.glob..func2.7.2()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager_test.go:422 +0x171e
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0xbd
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).run()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0x16a
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/leafnodes/it_node.go:26 +0xa2
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).runSample()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:215 +0x766
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).Run()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:138 +0x145
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:200 +0x172
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:170 +0x4b6
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:66 +0x149
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).Run()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:62 +0x3e1
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo.RunSpecsWithCustomReporters()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:221 +0x367
  kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo.RunSpecs()
      /root/go/src/kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:202 +0x99
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap_test.TestVirtwrap()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/virtwrap_suite_test.go:15 +0x148
  testing.tRunner()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/testing/testing.go:827 +0x162

Goroutine 28 (running) created at:
  kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap.(*LibvirtDomainManager).asyncMigrate.func1()
      /root/go/src/kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/manager.go:403 +0x1125

Goroutine 16 (running) created at:
  testing.(*T).Run()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/testing/testing.go:878 +0x659
  testing.runTests.func1()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/testing/testing.go:827 +0x162
  testing.runTests()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /gimme/.gimme/versions/go1.11.5.linux.amd64/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:44 +0x221

```


**Release note**:

```release-note
NONE
```
