### PR TITLE
Revert "Make memory request configurable"

### DIFF
--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"github.com/pborman/uuid"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -108,6 +110,13 @@ func SetDefaults_Firmware(obj *Firmware) {
 }
 
 func SetDefaults_VirtualMachineInstance(obj *VirtualMachineInstance) {
+	// FIXME we need proper validation and configurable defaulting instead of this
+	if _, exists := obj.Spec.Domain.Resources.Requests[v1.ResourceMemory]; !exists {
+		if obj.Spec.Domain.Resources.Requests == nil {
+			obj.Spec.Domain.Resources.Requests = v1.ResourceList{}
+		}
+		obj.Spec.Domain.Resources.Requests[v1.ResourceMemory] = resource.MustParse("8192Ki")
+	}
 	if obj.Spec.Domain.Firmware == nil {
 		obj.Spec.Domain.Firmware = &Firmware{}
 	}

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -4,16 +4,10 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-)
-
-const (
-	configMapName = "kubevirt-config"
-	namespace     = "kubevirt"
 )
 
 func MakeFakeClusterConfig(configMaps []v1.ConfigMap, stopChan chan struct{}) *virtconfig.ClusterConfig {
@@ -32,28 +26,5 @@ func MakeFakeClusterConfig(configMaps []v1.ConfigMap, stopChan chan struct{}) *v
 	cmInformer := cache.NewSharedIndexInformer(cmListWatch, &v1.ConfigMap{}, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	go cmInformer.Run(stopChan)
 	cache.WaitForCacheSync(stopChan, cmInformer.HasSynced)
-	return virtconfig.NewClusterConfig(cmInformer.GetStore(), namespace)
-}
-
-func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.Store) {
-	store := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	copy := copy(cfgMap)
-	store.Add(copy)
-	return virtconfig.NewClusterConfig(store, namespace), store
-}
-
-func UpdateFakeClusterConfig(store cache.Store, cfgMap *v1.ConfigMap) {
-	copy := copy(cfgMap)
-	store.Update(copy)
-}
-
-func copy(cfgMap *v1.ConfigMap) *v1.ConfigMap {
-	copy := cfgMap.DeepCopy()
-	copy.ObjectMeta = v12.ObjectMeta{
-		Namespace: namespace,
-		Name:      configMapName,
-		// Change the resource version, or the config will not be updated
-		ResourceVersion: rand.String(10),
-	}
-	return copy
+	return virtconfig.NewClusterConfig(cmInformer.GetStore(), "kubevirt")
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -107,7 +107,6 @@ type virtAPIApp struct {
 	aggregatorClient *aggregatorclient.Clientset
 	authorizor       rest.VirtApiAuthorizor
 	certsDirectory   string
-	clusterConfig    *virtconfig.ClusterConfig
 
 	signingCertBytes           []byte
 	certBytes                  []byte
@@ -749,16 +748,16 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 	}
 
 	http.HandleFunc(vmiCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMICreate(w, r, app.clusterConfig)
+		validating_webhook.ServeVMICreate(w, r)
 	})
 	http.HandleFunc(vmiUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIUpdate(w, r)
 	})
 	http.HandleFunc(vmValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMs(w, r, app.clusterConfig)
+		validating_webhook.ServeVMs(w, r)
 	})
 	http.HandleFunc(vmirsValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)
+		validating_webhook.ServeVMIRS(w, r)
 	})
 	http.HandleFunc(vmipresetValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIPreset(w, r)
@@ -867,7 +866,7 @@ func (app *virtAPIApp) createMutatingWebhook() error {
 	}
 
 	http.HandleFunc(vmiMutatePath, func(w http.ResponseWriter, r *http.Request) {
-		mutating_webhook.ServeVMIs(w, r, app.clusterConfig)
+		mutating_webhook.ServeVMIs(w, r)
 	})
 	http.HandleFunc(migrationMutatePath, func(w http.ResponseWriter, r *http.Request) {
 		mutating_webhook.ServeMigrationCreate(w, r)
@@ -1051,8 +1050,6 @@ func (app *virtAPIApp) Run() {
 		webhookInformers.VMIPresetInformer.HasSynced,
 		webhookInformers.NamespaceLimitsInformer.HasSynced,
 		webhookInformers.ConfigMapInformer.HasSynced)
-
-	app.clusterConfig = virtconfig.NewClusterConfig(webhookInformers.ConfigMapInformer.GetStore(), app.namespace)
 
 	// Verify/create webhook endpoint.
 	err = app.createWebhook()

--- a/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/api/v1:go_default_library",
         "//pkg/log:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
@@ -39,7 +40,6 @@ go_test(
         "//pkg/log:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
-        "//pkg/virt-config:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook_test.go
@@ -34,7 +34,6 @@ import (
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 var _ = Describe("Mutating Webhook", func() {
@@ -45,14 +44,11 @@ var _ = Describe("Mutating Webhook", func() {
 		var presetInformer cache.SharedIndexInformer
 		var namespaceLimit *k8sv1.LimitRange
 		var namespaceLimitInformer cache.SharedIndexInformer
-		var configMapStore cache.Store
-		var mutator *VMIsMutator
 
-		memoryLimit := "128M"
+		memory, _ := resource.ParseQuantity("64M")
+		limitMemory, _ := resource.ParseQuantity("128M")
 		cpuModelFromConfig := "Haswell"
 		machineTypeFromConfig := "pc-q35-3.0"
-		cpuRequestFromConfig := "800m"
-		memoryRequestFromConfig := "256Mi"
 
 		getVMISpecMetaFromResponse := func() (*v1.VirtualMachineInstanceSpec, *k8smetav1.ObjectMeta) {
 			vmiBytes, err := json.Marshal(vmi)
@@ -67,7 +63,7 @@ var _ = Describe("Mutating Webhook", func() {
 				},
 			}
 			By("Mutating the VMI")
-			resp := mutator.mutate(ar)
+			resp := mutateVMIs(ar)
 			Expect(resp.Allowed).To(Equal(true))
 
 			By("Getting the VMI spec from the response")
@@ -91,7 +87,11 @@ var _ = Describe("Mutating Webhook", func() {
 				},
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
-						Resources: v1.ResourceRequirements{},
+						Resources: v1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								"memory": memory,
+							},
+						},
 					},
 				},
 			}
@@ -117,7 +117,7 @@ var _ = Describe("Mutating Webhook", func() {
 						{
 							Type: k8sv1.LimitTypeContainer,
 							Default: k8sv1.ResourceList{
-								k8sv1.ResourceMemory: resource.MustParse(memoryLimit),
+								k8sv1.ResourceMemory: limitMemory,
 							},
 						},
 					},
@@ -133,9 +133,6 @@ var _ = Describe("Mutating Webhook", func() {
 					ConfigMapInformer:       configMapInformer,
 				},
 			)
-
-			mutator = &VMIsMutator{}
-			mutator.clusterConfig, configMapStore = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		})
 
 		It("should apply presets on VMI create", func() {
@@ -146,7 +143,7 @@ var _ = Describe("Mutating Webhook", func() {
 
 		It("should apply namespace limit ranges on VMI create", func() {
 			vmiSpec, _ := getVMISpecMetaFromResponse()
-			Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal(memoryLimit))
+			Expect(vmiSpec.Domain.Resources.Limits.Memory().String()).To(Equal("128M"))
 		})
 
 		It("should apply defaults on VMI create", func() {
@@ -154,48 +151,31 @@ var _ = Describe("Mutating Webhook", func() {
 			Expect(vmiSpec.Domain.Machine.Type).To(Equal("q35"))
 			Expect(vmiSpec.Domain.CPU.Model).To(Equal(""))
 			Expect(vmiSpec.Domain.Resources.Requests.Cpu().String()).To(Equal("100m"))
-			Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal("8Mi"))
 		})
 
 		It("should apply configurable defaults on VMI create", func() {
-			testutils.UpdateFakeClusterConfig(configMapStore, &k8sv1.ConfigMap{
-				Data: map[string]string{
-					virtconfig.CpuModelKey:      cpuModelFromConfig,
-					virtconfig.MachineTypeKey:   machineTypeFromConfig,
-					virtconfig.MemoryRequestKey: memoryRequestFromConfig,
-					virtconfig.CpuRequestKey:    cpuRequestFromConfig,
-				},
-			})
-
-			vmiSpec, _ := getVMISpecMetaFromResponse()
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(cpuModelFromConfig))
-			Expect(vmiSpec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
-			Expect(vmiSpec.Domain.Resources.Requests.Cpu().String()).To(Equal(cpuRequestFromConfig))
-			Expect(vmiSpec.Domain.Resources.Requests.Memory().String()).To(Equal(memoryRequestFromConfig))
+			setDefaultCPUModel(vmi, cpuModelFromConfig)
+			setDefaultMachineType(vmi, machineTypeFromConfig)
+			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(cpuModelFromConfig))
+			Expect(vmi.Spec.Domain.Machine.Type).To(Equal(machineTypeFromConfig))
 		})
 
 		It("should not override specified properties with defaults on VMI create", func() {
-			testutils.UpdateFakeClusterConfig(configMapStore, &k8sv1.ConfigMap{
-				Data: map[string]string{
-					virtconfig.CpuModelKey:      cpuModelFromConfig,
-					virtconfig.MachineTypeKey:   machineTypeFromConfig,
-					virtconfig.MemoryRequestKey: memoryRequestFromConfig,
-					virtconfig.CpuRequestKey:    cpuRequestFromConfig,
-				},
-			})
-
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-				k8sv1.ResourceCPU:    resource.MustParse("600m"),
-				k8sv1.ResourceMemory: resource.MustParse("512Mi"),
+			vmCPUModel := "EPYC"
+			vmMachineType := "q35"
+			cpu := "600m"
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse(cpu)
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Model: vmCPUModel,
 			}
-			vmi.Spec.Domain.CPU = &v1.CPU{Model: "EPYC"}
-			vmi.Spec.Domain.Machine.Type = "q35"
+			vmi.Spec.Domain.Machine.Type = vmMachineType
 
 			vmiSpec, _ := getVMISpecMetaFromResponse()
-			Expect(vmiSpec.Domain.CPU.Model).To(Equal(vmi.Spec.Domain.CPU.Model))
-			Expect(vmiSpec.Domain.Machine.Type).To(Equal(vmi.Spec.Domain.Machine.Type))
-			Expect(vmiSpec.Domain.Resources.Requests.Cpu()).To(Equal(vmi.Spec.Domain.Resources.Requests.Cpu()))
-			Expect(vmiSpec.Domain.Resources.Requests.Memory()).To(Equal(vmi.Spec.Domain.Resources.Requests.Memory()))
+			setDefaultCPUModel(vmi, cpuModelFromConfig)
+			setDefaultMachineType(vmi, machineTypeFromConfig)
+			Expect(vmi.Spec.Domain.CPU.Model).To(Equal(vmCPUModel))
+			Expect(vmi.Spec.Domain.Machine.Type).To(Equal(vmMachineType))
+			Expect(vmiSpec.Domain.Resources.Requests.Cpu().String()).To(Equal(cpu))
 		})
 
 		It("should apply foreground finalizer on VMI create", func() {
@@ -220,8 +200,7 @@ var _ = Describe("Mutating Webhook", func() {
 			}
 
 			By("Mutating the Migration")
-			mutator := &MigrationCreateMutator{}
-			resp := mutator.mutate(ar)
+			resp := mutateMigrationCreate(ar)
 			Expect(resp.Allowed).To(Equal(true))
 
 			By("Getting the VMI spec from the response")

--- a/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/log:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config-map.go",
         "feature-gates.go",
+        "virt-properties.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-config",
     visibility = ["//visibility:public"],

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -40,17 +40,17 @@ import (
 )
 
 const (
-	configMapName       = "kubevirt-config"
-	featureGateEnvVar   = "FEATURE_GATES"
-	FeatureGatesKey     = "feature-gates"
-	emulatedMachinesKey = "emulated-machines"
-	MachineTypeKey      = "machine-type"
-	useEmulationKey     = "debug.useEmulation"
-	imagePullPolicyKey  = "dev.imagePullPolicy"
-	migrationsConfigKey = "migrations"
-	CpuModelKey         = "default-cpu-model"
-	CpuRequestKey       = "cpu-request"
-	MemoryRequestKey    = "memory-request"
+	configMapName          = "kubevirt-config"
+	featureGateEnvVar      = "FEATURE_GATES"
+	FeatureGatesKey        = "feature-gates"
+	emulatedMachinesEnvVar = "VIRT_EMULATED_MACHINES"
+	emulatedMachinesKey    = "emulated-machines"
+	machineTypeKey         = "machine-type"
+	useEmulationKey        = "debug.useEmulation"
+	imagePullPolicyKey     = "dev.imagePullPolicy"
+	migrationsConfigKey    = "migrations"
+	cpuModelKey            = "default-cpu-model"
+	cpuRequestKey          = "cpu-request"
 
 	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
 	ParallelMigrationsPerClusterDefault      uint32 = 5
@@ -59,8 +59,6 @@ const (
 	MigrationCompletionTimeoutPerGiB         int64  = 800
 	DefaultMachineType                              = "q35"
 	DefaultCPURequest                               = "100m"
-	DefaultMemoryRequest                            = "8Mi"
-	DefaultEmulatedMachines                         = "q35*,pc-q35*"
 
 	NodeDrainTaintDefaultKey = "kubevirt.io/drain"
 )
@@ -75,10 +73,14 @@ func InitFromConfigMap(cfgMap *k8sv1.ConfigMap) {
 	if val, ok := cfgMap.Data[FeatureGatesKey]; ok {
 		os.Setenv(featureGateEnvVar, val)
 	}
+	if val, ok := cfgMap.Data[emulatedMachinesKey]; ok {
+		os.Setenv(emulatedMachinesEnvVar, val)
+	}
 }
 
 func Clear() {
 	os.Unsetenv(featureGateEnvVar)
+	os.Unsetenv(emulatedMachinesEnvVar)
 }
 
 func getConfigMap() *k8sv1.ConfigMap {
@@ -142,8 +144,6 @@ func defaultClusterConfig() *Config {
 	progressTimeout := MigrationProgressTimeout
 	completionTimeoutPerGiB := MigrationCompletionTimeoutPerGiB
 	cpuRequestDefault := resource.MustParse(DefaultCPURequest)
-	memoryRequestDefault := resource.MustParse(DefaultMemoryRequest)
-	emulatedMachinesDefault := strings.Split(DefaultEmulatedMachines, ",")
 	return &Config{
 		ResourceVersion: "0",
 		ImagePullPolicy: k8sv1.PullIfNotPresent,
@@ -157,23 +157,19 @@ func defaultClusterConfig() *Config {
 			CompletionTimeoutPerGiB:           &completionTimeoutPerGiB,
 			UnsafeMigrationOverride:           false,
 		},
-		MachineType:      DefaultMachineType,
-		CPURequest:       cpuRequestDefault,
-		MemoryRequest:    memoryRequestDefault,
-		EmulatedMachines: emulatedMachinesDefault,
+		MachineType: DefaultMachineType,
+		CPURequest:  cpuRequestDefault,
 	}
 }
 
 type Config struct {
-	ResourceVersion  string
-	UseEmulation     bool
-	MigrationConfig  *MigrationConfig
-	ImagePullPolicy  k8sv1.PullPolicy
-	MachineType      string
-	CPUModel         string
-	CPURequest       resource.Quantity
-	MemoryRequest    resource.Quantity
-	EmulatedMachines []string
+	ResourceVersion string
+	UseEmulation    bool
+	MigrationConfig *MigrationConfig
+	ImagePullPolicy k8sv1.PullPolicy
+	MachineType     string
+	CPUModel        string
+	CPURequest      resource.Quantity
 }
 
 type MigrationConfig struct {
@@ -217,14 +213,6 @@ func (c *ClusterConfig) GetCPUModel() string {
 
 func (c *ClusterConfig) GetCPURequest() resource.Quantity {
 	return c.getConfig().CPURequest
-}
-
-func (c *ClusterConfig) GetMemoryRequest() resource.Quantity {
-	return c.getConfig().MemoryRequest
-}
-
-func (c *ClusterConfig) GetEmulatedMachines() []string {
-	return c.getConfig().EmulatedMachines
 }
 
 // setConfig parses the provided config map and updates the provided config.
@@ -273,28 +261,16 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	}
 
 	// set machine type
-	if machineType := strings.TrimSpace(configMap.Data[MachineTypeKey]); machineType != "" {
+	if machineType := strings.TrimSpace(configMap.Data[machineTypeKey]); machineType != "" {
 		config.MachineType = machineType
 	}
 
-	if cpuModel := strings.TrimSpace(configMap.Data[CpuModelKey]); cpuModel != "" {
+	if cpuModel := strings.TrimSpace(configMap.Data[cpuModelKey]); cpuModel != "" {
 		config.CPUModel = cpuModel
 	}
 
-	if cpuRequest := strings.TrimSpace(configMap.Data[CpuRequestKey]); cpuRequest != "" {
+	if cpuRequest := strings.TrimSpace(configMap.Data[cpuRequestKey]); cpuRequest != "" {
 		config.CPURequest = resource.MustParse(cpuRequest)
-	}
-
-	if memoryRequest := strings.TrimSpace(configMap.Data[MemoryRequestKey]); memoryRequest != "" {
-		config.MemoryRequest = resource.MustParse(memoryRequest)
-	}
-
-	if emulatedMachines := strings.TrimSpace(configMap.Data[emulatedMachinesKey]); emulatedMachines != "" {
-		vals := strings.Split(emulatedMachines, ",")
-		for i := range vals {
-			vals[i] = strings.TrimSpace(vals[i])
-		}
-		config.EmulatedMachines = vals
 	}
 
 	return nil

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -1,9 +1,6 @@
 package virtconfig
 
 import (
-	"regexp"
-	"strings"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -74,7 +71,7 @@ var _ = Describe("ConfigMap", func() {
 				Namespace:       "kubevirt",
 				Name:            "kubevirt-config",
 			},
-			Data: map[string]string{MachineTypeKey: value},
+			Data: map[string]string{machineTypeKey: value},
 		}
 		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
 		Expect(clusterConfig.GetMachineType()).To(Equal(result))
@@ -90,7 +87,7 @@ var _ = Describe("ConfigMap", func() {
 				Namespace:       "kubevirt",
 				Name:            "kubevirt-config",
 			},
-			Data: map[string]string{CpuModelKey: value},
+			Data: map[string]string{cpuModelKey: value},
 		}
 		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
 		Expect(clusterConfig.GetCPUModel()).To(Equal(result))
@@ -106,7 +103,7 @@ var _ = Describe("ConfigMap", func() {
 				Namespace:       "kubevirt",
 				Name:            "kubevirt-config",
 			},
-			Data: map[string]string{CpuRequestKey: value},
+			Data: map[string]string{cpuRequestKey: value},
 		}
 		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
 		cpuRequest := clusterConfig.GetCPURequest()
@@ -114,40 +111,6 @@ var _ = Describe("ConfigMap", func() {
 	},
 		table.Entry("when set, it should return the value", "400m", "400m"),
 		table.Entry("when unset, it should return the default", "", DefaultCPURequest),
-	)
-
-	table.DescribeTable(" when memoryRequest", func(value string, result string) {
-		cfgMap := kubev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				ResourceVersion: "1234",
-				Namespace:       "kubevirt",
-				Name:            "kubevirt-config",
-			},
-			Data: map[string]string{MemoryRequestKey: value},
-		}
-		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
-		memoryRequest := clusterConfig.GetMemoryRequest()
-		Expect(memoryRequest.String()).To(Equal(result))
-	},
-		table.Entry("when set, it should return the value", "512Mi", "512Mi"),
-		table.Entry("when unset, it should return the default", "", DefaultMemoryRequest),
-	)
-
-	table.DescribeTable(" when emulatedMachines", func(value string, result []string) {
-		cfgMap := kubev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				ResourceVersion: "1234",
-				Namespace:       "kubevirt",
-				Name:            "kubevirt-config",
-			},
-			Data: map[string]string{emulatedMachinesKey: value},
-		}
-		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{cfgMap}, stopChan)
-		emulatedMachines := clusterConfig.GetEmulatedMachines()
-		Expect(emulatedMachines).To(ConsistOf(result))
-	},
-		table.Entry("when set, it should return the value", "q35, i440*", []string{"q35", "i440*"}),
-		table.Entry("when unset, it should return the defaults", "", strings.Split(DefaultEmulatedMachines, ",")),
 	)
 
 	It("Should return migration config values if specified as json", func() {
@@ -281,18 +244,6 @@ var _ = Describe("ConfigMap", func() {
 		clusterConfig, _ := MakeClusterConfig([]kubev1.ConfigMap{}, stopChan)
 		result := clusterConfig.GetMigrationConfig()
 		Expect(*result.ParallelOutboundMigrationsPerNode).To(BeNumerically("==", 2))
-	})
-
-	It("should contain a default machine type that is supported by default", func() {
-		isDefaultMachineTypeSupported := func() bool {
-			for _, val := range strings.Split(DefaultEmulatedMachines, ",") {
-				if regexp.MustCompile(val).MatchString(DefaultMachineType) {
-					return true
-				}
-			}
-			return false
-		}
-		Expect(isDefaultMachineTypeSupported()).To(BeTrue())
 	})
 })
 

--- a/pkg/virt-config/virt-properties.go
+++ b/pkg/virt-config/virt-properties.go
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017, 2018 Red Hat, Inc.
+ *
+ */
+
+package virtconfig
+
+/*
+ This module is intended for retrieving virt related properties that might
+ be overridden by kubevirt-config configmap.
+ Note that the virtconfig package needs to be initialized before using this (see config-map.Init)
+*/
+
+import (
+	"os"
+	"strings"
+)
+
+func SupportedEmulatedMachines() []string {
+	config := os.Getenv(emulatedMachinesEnvVar)
+	if len(config) == 0 {
+		return []string{"q35*", "pc-q35*"}
+	}
+
+	vals := strings.Split(config, ",")
+	for i := range vals {
+		vals[i] = strings.TrimSpace(vals[i])
+	}
+	return vals
+}

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Converter", func() {
 				},
 			}
 			vmi.Spec.Domain.Resources.Limits = make(k8sv1.ResourceList)
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{k8sv1.ResourceMemory: resource.MustParse("8192Ki")}
+			vmi.Spec.Domain.Resources.Requests = make(k8sv1.ResourceList)
 			vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 				{
 					Bus:  "virtio",
@@ -1435,10 +1435,7 @@ var _ = Describe("Converter", func() {
 			}
 
 			vmi.Spec.Domain.Devices.BlockMultiQueue = True()
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-				k8sv1.ResourceMemory: resource.MustParse("8192Ki"),
-				k8sv1.ResourceCPU:    resource.MustParse("2"),
-			}
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
 		})
 
 		It("should assign queues to a device if requested", func() {
@@ -1559,10 +1556,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = True()
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-				k8sv1.ResourceMemory: resource.MustParse("8192Ki"),
-				k8sv1.ResourceCPU:    resource.MustParse("2"),
-			}
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
 		})
 
 		It("should assign queues to a device if requested", func() {

--- a/tools/vms-generator/BUILD.bazel
+++ b/tools/vms-generator/BUILD.bazel
@@ -7,11 +7,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks/validating-webhook:go_default_library",
         "//tools/util:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -27,12 +27,10 @@ import (
 
 	"kubevirt.io/kubevirt/tools/util"
 
-	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
-	"kubevirt.io/kubevirt/pkg/testutils"
 	validating_webhook "kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook"
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
@@ -125,24 +123,21 @@ func main() {
 		return nil
 	}
 
-	// This is a hack to satisfy validating_webhook's functions that need a ClusterConfig
-	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
-
 	// Having no generics is lots of fun
 	for name, obj := range vms {
-		causes := validating_webhook.ValidateVirtualMachineSpec(k8sfield.NewPath("spec"), &obj.Spec, config)
+		causes := validating_webhook.ValidateVirtualMachineSpec(k8sfield.NewPath("spec"), &obj.Spec)
 		handleCauses(causes, name, "vm")
 		handleError(dumpObject(name, *obj))
 	}
 
 	for name, obj := range vmis {
-		causes := validating_webhook.ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &obj.Spec, config)
+		causes := validating_webhook.ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec"), &obj.Spec)
 		handleCauses(causes, name, "vmi")
 		handleError(dumpObject(name, *obj))
 	}
 
 	for name, obj := range vmireplicasets {
-		causes := validating_webhook.ValidateVMIRSSpec(k8sfield.NewPath("spec"), &obj.Spec, config)
+		causes := validating_webhook.ValidateVMIRSSpec(k8sfield.NewPath("spec"), &obj.Spec)
 		handleCauses(causes, name, "vmi replica set")
 		handleError(dumpObject(name, *obj))
 	}


### PR DESCRIPTION
Reverts kubevirt/kubevirt#2203

```release-note
REVERTS for further discussion: "The default requested memory for Virtual Machine Instances can now be overridden via kubevirt-config using the 'memory-request' key"
```