### PR TITLE
Improve scheduling of libvirt capability test VMIs

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3112,19 +3112,12 @@ func RunCommandOnVmiPod(vmi *v1.VirtualMachineInstance, command []string) string
 }
 
 // GetNodeLibvirtCapabilities returns node libvirt capabilities
-func GetNodeLibvirtCapabilities(nodeName string) string {
-	// Create a virt-launcher pod to fetch virsh capabilities
-	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(ContainerDiskFor(ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-	StartVmOnNode(vmi, nodeName)
-
+func GetNodeLibvirtCapabilities(vmi *v1.VirtualMachineInstance) string {
 	return RunCommandOnVmiPod(vmi, []string{"virsh", "-r", "capabilities"})
 }
 
 // GetNodeCPUInfo returns output of lscpu on the pod that runs on the specified node
-func GetNodeCPUInfo(nodeName string) string {
-	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(ContainerDiskFor(ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-	StartVmOnNode(vmi, nodeName)
-
+func GetNodeCPUInfo(vmi *v1.VirtualMachineInstance) string {
 	return RunCommandOnVmiPod(vmi, []string{"lscpu"})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Libvirt capability tests were scheduling on the first node out of a node list. This led to situations where the VMIs could not be scheduled and some tests just timed out.

Now the scheduler schedules a VMI, we grab the node from the VMI, then collect the capabilities and then run all tests on that node.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
