### PR TITLE
Add okd-4.1.0-rc.0 cluster provider

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -114,7 +114,7 @@ safe_download() (
     fi
 )
 
-if [[ $TARGET =~ os-.* ]]; then
+if [[ $TARGET =~ os-.* ]] || [[ $TARGET =~ okd-.* ]]; then
     # Create images directory
     if [[ ! -d $RHEL_NFS_DIR ]]; then
         mkdir -p $RHEL_NFS_DIR
@@ -190,7 +190,14 @@ set -e
 echo "Nodes are ready:"
 kubectl get nodes
 
-make cluster-sync
+make cluster-build
+
+# I do not have good indication that OKD API server ready to serve requests, so I will just
+# repeat cluster-deploy until it succeeds
+until make cluster-deploy; do
+    sleep 1
+done
+
 hack/dockerized bazel shutdown
 
 # OpenShift is running important containers under default namespace

--- a/cluster/clean.sh
+++ b/cluster/clean.sh
@@ -81,7 +81,7 @@ for label in ${labels[@]}; do
     _kubectl delete clusterroles -l ${label}
     _kubectl delete customresourcedefinitions -l ${label}
 
-    if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]]; then
+    if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]] || [[ "$KUBEVIRT_PROVIDER" =~ okd-* ]]; then
         _kubectl delete scc -l ${label}
     fi
 

--- a/cluster/deploy.sh
+++ b/cluster/deploy.sh
@@ -49,7 +49,7 @@ EOF
 # Deploy kubevirt operator
 _kubectl apply -f ${MANIFESTS_OUT_DIR}/release/kubevirt-operator.yaml
 
-if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]]; then
+if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]] || [[ "$KUBEVIRT_PROVIDER" =~ okd-* ]]; then
     _kubectl create -f ${MANIFESTS_OUT_DIR}/testing/ocp
 
     _kubectl adm policy add-scc-to-user privileged -z kubevirt-operator -n ${namespace}

--- a/cluster/okd-4.1.0-rc.0/README.md
+++ b/cluster/okd-4.1.0-rc.0/README.md
@@ -1,0 +1,44 @@
+# OKD 4.1.0-rc.0 in ephemeral containers
+
+Provides a pre-deployed OKD with version 4.1.0-rc.0 purely in docker
+containers with libvirt. The provided VMs are completely ephemeral and are
+recreated on every cluster restart. The KubeVirt containers are built on the
+local machine and are the pushed to a registry which is exposed at
+`localhost:5000`.
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=okd-4.1.0-rc.0
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster/kubectl.sh get nodes
+NAME                          STATUS   ROLES    AGE   VERSION
+test-1-82xp6-master-0         Ready    master   62m   v1.12.4+509916ce1
+test-1-82xp6-worker-0-wxf27   Ready    worker   57m   v1.12.4+509916ce1
+```
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=okd-4.1.0-rc.0
+make cluster-down
+```
+
+This destroys the whole cluster. Recreating the cluster is fast, since OKD is
+already pre-deployed. The only state which is kept is the state of the local
+docker registry.
+
+## Destroying the docker registry state
+
+The docker registry survives a `make cluster-down`. It's state is stored in a
+docker volume called `kubevirt_registry`. If the volume gets too big or the
+volume contains corrupt data, it can be deleted with
+
+```bash
+docker volume rm kubevirt_registry
+```

--- a/cluster/okd-4.1.0-rc.0/provider.sh
+++ b/cluster/okd-4.1.0-rc.0/provider.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+image="okd-4.1.0-rc.0@sha256:7b5badcf46fceae521706161622ee447608d8ff84f831729ea98e061da49f4d7"
+
+source cluster/ephemeral-provider-common.sh
+
+function _port() {
+    ${_cli} ports --prefix $provider_prefix --container-name cluster "$@"
+}
+
+function up() {
+    params="--random-ports --background --prefix $provider_prefix --master-cpu 5 --workers-cpu 5 --registry-volume $(_registry_volume) kubevirtci/${image}"
+    if [[ ! -z "${RHEL_NFS_DIR}" ]]; then
+        params=" --nfs-data $RHEL_NFS_DIR ${params}"
+    fi
+
+    ${_cli} run okd ${params}
+
+    # Copy k8s config and kubectl
+    cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
+    docker cp $cluster_container_id:/bin/oc ${KUBEVIRT_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRT_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl
+    docker cp $cluster_container_id:/root/install/auth/kubeconfig ${KUBEVIRT_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+
+    # Set server and disable tls check
+    export KUBECONFIG=${KUBEVIRT_PATH}cluster/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRT_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRT_PATH}cluster/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --insecure-skip-tls-verify=true
+
+    # Make sure that local config is correct
+    prepare_config
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Provides the possibility to run and test KubeVirt on top of 4.1.0-rc.0 OKD cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add okd-4.1.0-rc.0 cluster provider
```
