### PR TITLE
fix virt-launcher panic after migration cancellation on crio

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -122,7 +122,11 @@ func (l *LibvirtConnection) NewStream(flags libvirt.StreamFlags) (Stream, error)
 
 func (l *LibvirtConnection) Close() (int, error) {
 	close(l.stop)
-	return l.Connect.Close()
+	if l.Connect != nil {
+		return l.Connect.Close()
+	} else {
+		return 0, nil
+	}
 }
 
 func (l *LibvirtConnection) DomainEventLifecycleRegister(callback libvirt.DomainEventLifecycleCallback) (err error) {
@@ -243,9 +247,12 @@ func (l *LibvirtConnection) installWatchdog(checkInterval time.Duration) {
 				return
 
 			case <-time.After(checkInterval):
-				l.reconnectIfNecessary()
-
-				alive, err := l.Connect.IsAlive()
+				var alive bool
+				var err error
+				err = l.reconnectIfNecessary()
+				if l.Connect != nil {
+					alive, err = l.Connect.IsAlive()
+				}
 
 				// If the connection is ok, continue
 				if alive {


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases, destination virt-launcher panics after migration cancellation, on CRIO.
This PR handles the panic and let the virt-launcher exit cleanly.

Fixes #2243 

```release-note
NONE
```
