### PR TITLE
[Testing] match vm restart tests with polarion

### DIFF
--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -78,9 +78,9 @@ var _ = Describe("Subresource Api", func() {
 		})
 	})
 
-	Describe("VirtualMachine subresource", func() {
+	Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component] VirtualMachine subresource", func() {
 		Context("with a restart endpoint", func() {
-			It("should restart a VM", func() {
+			It("[test_id:1304] should restart a VM", func() {
 				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 				vm, err := virtCli.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <mfranczy@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Match VM restart tests with polarion

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
