### PR TITLE
[Testing] polarion match for service account test

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -240,14 +240,14 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 		serviceAccountPath := config.ServiceAccountSourceDir
 
-		It("[test_id:998]Should be the fs layout the same for a pod and vmi", func() {
+		It("[test_id:998]Should be the namespace and token the same for a pod and vmi", func() {
 			By("Running VMI")
 			vmi := tests.NewRandomVMIWithServiceAccount("default")
 			tests.RunVMIAndExpectLaunch(vmi, 90)
 
 			By("Checking if ServiceAccount has been attached to the pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-			podOutput, err := tests.ExecuteCommandOnPod(
+			namespace, err := tests.ExecuteCommandOnPod(
 				virtClient,
 				vmiPod,
 				vmiPod.Spec.Containers[0].Name,
@@ -255,8 +255,18 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					serviceAccountPath + "/namespace",
 				},
 			)
+
 			Expect(err).To(BeNil())
-			Expect(podOutput).To(Equal(tests.NamespaceTestDefault))
+			Expect(namespace).To(Equal(tests.NamespaceTestDefault))
+
+			token, err := tests.ExecuteCommandOnPod(
+				virtClient,
+				vmiPod,
+				vmiPod.Spec.Containers[0].Name,
+				[]string{"tail", "-c", "20",
+					serviceAccountPath + "/token",
+				},
+			)
 
 			By("Checking mounted iso image")
 			expecter, err := tests.LoggedInAlpineExpecter(vmi)
@@ -270,6 +280,8 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BExp{R: "0"},
 				&expect.BSnd{S: "cat /mnt/namespace\n"},
 				&expect.BExp{R: tests.NamespaceTestDefault},
+				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
+				&expect.BExp{R: token},
 			}, 200*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <mfranczy@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Polarion match for service account tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
