### PR TITLE
Create a fedora 30 container disk

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -189,6 +189,7 @@ container_bundle(
         "$(container_prefix)/alpine-container-disk-demo:$(container_tag)": "//cmd/container-disk-v1alpha:alpine-container-disk-image",
         "$(container_prefix)/cirros-container-disk-demo:$(container_tag)": "//cmd/container-disk-v1alpha:cirros-container-disk-image",
         "$(container_prefix)/fedora-cloud-container-disk-demo:$(container_tag)": "//cmd/container-disk-v1alpha:fedora-cloud-container-disk-image",
+        "$(container_prefix)/fedora30-cloud-container-disk-demo:$(container_tag)": "//cmd/container-disk-v1alpha:fedora30-cloud-container-disk-image",
         "$(container_prefix)/virtio-container-disk:$(container_tag)": "//cmd/container-disk-v1alpha:virtio-container-disk-image",
         # testing images
         "$(container_prefix)/disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -87,6 +87,14 @@ http_file(
 )
 
 http_file(
+    name = "fedora30_image",
+    sha256 = "72b6ae7b4ed09a4dccd6e966e1b3ac69bd97da419de9760b410e837ba00b4e26",
+    urls = [
+        "https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2",
+    ],
+)
+
+http_file(
     name = "virtio_win_image",
     sha256 = "594678f509ba6827c7b75d076ecfb64d45c6ad95e9fccba7258e6eee9a6a3560",
     urls = [

--- a/cmd/container-disk-v1alpha/BUILD.bazel
+++ b/cmd/container-disk-v1alpha/BUILD.bazel
@@ -112,6 +112,30 @@ container_image(
 )
 
 genrule(
+    name = "fedora30-cloud-iso",
+    srcs = ["@fedora30_image//file"],
+    outs = ["disk/fedora30.qcow2"],
+    cmd = "mkdir disk && cat $(location @fedora30_image//file) > $@",
+)
+
+pkg_tar(
+    name = "fedora30-cloud-iso-tar",
+    srcs = [":fedora30-cloud-iso"],
+    mode = "0644",
+    package_dir = "disk",
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "fedora30-cloud-container-disk-image",
+    base = ":container-disk-v1alpha-image",
+    directory = "/",
+    entrypoint = ["/entry-point.sh"],
+    tars = [":fedora30-cloud-iso-tar"],
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "virtio-win-iso",
     srcs = ["@virtio_win_image//file"],
     outs = ["disk/virtio-win.iso"],


### PR DESCRIPTION
This PR create a new container disk for fedora 30 cloud image.

This PR don't change the fedora we already have
it's create a new container disk for now.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
container disk for fedora 30 cloud image
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2256)
<!-- Reviewable:end -->
