### PR TITLE
[Testing] Add VMI pod eviction and node drain functional tests

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -979,7 +979,7 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 			tests.CleanNodes()
 		})
 
-		Context("with a VMI running with an eviction strategy set", func() {
+		Context("[ref_id:2293] with a VMI running with an eviction strategy set", func() {
 
 			var vmi *v1.VirtualMachineInstance
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -470,6 +470,9 @@ func CleanNodes() {
 
 			if taint.Key == "kubevirt.io/drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				found = true
+			} else if taint.Key == "kubevirt.io/alt-drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
+				// this key is used in testing as a custom alternate drain key
+				found = true
 			} else {
 				taints = append(taints, taint)
 			}
@@ -482,6 +485,10 @@ func CleanNodes() {
 				found = true
 				delete(new.Labels, k)
 			}
+		}
+
+		if node.Spec.Unschedulable {
+			new.Spec.Unschedulable = false
 		}
 
 		if !found {


### PR DESCRIPTION
**What this PR does / why we need it**:

Covers more pod eviction and node drain test cases for migration

**Release note**:
```release-note
NONE
```
