### PR TITLE
[Testing] Add test for multiple vm creation with oc/kubectl

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1449,6 +1449,13 @@ func NewRandomVMIWithDataVolume(dataVolumeName string) *v1.VirtualMachineInstanc
 	return vmi
 }
 
+func NewRandomVMWithEphemeralDisk(containerImage string) *v1.VirtualMachine {
+	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
+	vm := NewRandomVirtualMachine(vmi, false)
+
+	return vm
+}
+
 func NewRandomVMWithDataVolume(imageUrl string, namespace string) *v1.VirtualMachine {
 	dataVolume := NewRandomDataVolumeWithHttpImport(imageUrl, namespace, k8sv1.ReadWriteOnce)
 	vmi := NewRandomVMIWithDataVolume(dataVolume.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enhances the test coverage of kubevirt by introducing the negative test rejecting multiple VM creation using `oc/kubectl create -f vm.yaml`




**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2263)
<!-- Reviewable:end -->
