### PR TITLE
[Testing] Add test to fail when deleting nonexist VM

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1131,6 +1131,15 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			waitForVMIStart(virtClient, vmi)
 		})
 
+		It("[test_id:233][posneg:negative]should fail when deleting nonexistent VM", func() {
+			vmi := tests.NewRandomVMWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+
+			By("Creating VM with DataVolumeTemplate entry with k8s client binary")
+			_, stdErr, err := tests.RunCommand(k8sClient, "delete", "vm", vmi.Name)
+			Expect(err).To(HaveOccurred())
+			Expect(strings.HasPrefix(stdErr, "Error from server (NotFound): virtualmachines.kubevirt.io")).To(BeTrue(), "should fail when deleting non existent VM")
+		})
+
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Expand test coverage for deleting non-existent VM with oc/kubectl.
It will fail when the VM does not exist




**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2265)
<!-- Reviewable:end -->
