### PR TITLE
Add Categories `all` to CRDs

### DIFF
--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -15,6 +15,8 @@ spec:
     type: string
   group: kubevirt.io
   names:
+    categories:
+    - all
     kind: KubeVirt
     plural: kubevirts
     shortNames:

--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -19,6 +19,8 @@ spec:
     type: string
   group: kubevirt.io
   names:
+    categories:
+    - all
     kind: VirtualMachine
     plural: virtualmachines
     shortNames:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -21,6 +21,8 @@ spec:
     type: string
   group: kubevirt.io
   names:
+    categories:
+    - all
     kind: VirtualMachineInstance
     plural: virtualmachineinstances
     shortNames:

--- a/manifests/generated/vmim-resource.yaml
+++ b/manifests/generated/vmim-resource.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: kubevirt.io
   names:
+    categories:
+    - all
     kind: VirtualMachineInstanceMigration
     plural: virtualmachineinstancemigrations
     shortNames:

--- a/manifests/generated/vmipreset-resource.yaml
+++ b/manifests/generated/vmipreset-resource.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: kubevirt.io
   names:
+    categories:
+    - all
     kind: VirtualMachineInstancePreset
     plural: virtualmachineinstancepresets
     shortNames:

--- a/manifests/generated/vmirs-resource.yaml
+++ b/manifests/generated/vmirs-resource.yaml
@@ -25,6 +25,8 @@ spec:
     type: date
   group: kubevirt.io
   names:
+    categories:
+    - all
     kind: VirtualMachineInstanceReplicaSet
     plural: virtualmachineinstancereplicasets
     shortNames:

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -97,6 +97,9 @@ func NewVirtualMachineInstanceCrd() *extv1beta1.CustomResourceDefinition {
 			Singular:   "virtualmachineinstance",
 			Kind:       virtv1.VirtualMachineInstanceGroupVersionKind.Kind,
 			ShortNames: []string{"vmi", "vmis"},
+			Categories: []string{
+				"all",
+			},
 		},
 		AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
 			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
@@ -123,6 +126,9 @@ func NewVirtualMachineCrd() *extv1beta1.CustomResourceDefinition {
 			Singular:   "virtualmachine",
 			Kind:       virtv1.VirtualMachineGroupVersionKind.Kind,
 			ShortNames: []string{"vm", "vms"},
+			Categories: []string{
+				"all",
+			},
 		},
 		AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
 			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
@@ -148,6 +154,9 @@ func NewPresetCrd() *extv1beta1.CustomResourceDefinition {
 			Singular:   "virtualmachineinstancepreset",
 			Kind:       virtv1.VirtualMachineInstancePresetGroupVersionKind.Kind,
 			ShortNames: []string{"vmipreset", "vmipresets"},
+			Categories: []string{
+				"all",
+			},
 		},
 	}
 
@@ -169,6 +178,9 @@ func NewReplicaSetCrd() *extv1beta1.CustomResourceDefinition {
 			Singular:   "virtualmachineinstancereplicaset",
 			Kind:       virtv1.VirtualMachineInstanceReplicaSetGroupVersionKind.Kind,
 			ShortNames: []string{"vmirs", "vmirss"},
+			Categories: []string{
+				"all",
+			},
 		},
 		AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
 			{Name: "Desired", Type: "integer", JSONPath: ".spec.replicas",
@@ -205,6 +217,9 @@ func NewVirtualMachineInstanceMigrationCrd() *extv1beta1.CustomResourceDefinitio
 			Singular:   "virtualmachineinstancemigration",
 			Kind:       virtv1.VirtualMachineInstanceMigrationGroupVersionKind.Kind,
 			ShortNames: []string{"vmim", "vmims"},
+			Categories: []string{
+				"all",
+			},
 		},
 	}
 
@@ -240,6 +255,9 @@ func NewKubeVirtCrd() *extv1beta1.CustomResourceDefinition {
 			Singular:   "kubevirt",
 			Kind:       virtv1.KubeVirtGroupVersionKind.Kind,
 			ShortNames: []string{"kv", "kvs"},
+			Categories: []string{
+				"all",
+			},
 		},
 		AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
 			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},


### PR DESCRIPTION
**What this PR does / why we need it**:

As a user I expect a `kubectl get all` command to in fact get all of my Kubernetes objects including CRDs (kubevirt objects).  Currently the Kubevirt CRDs do not include the "Categories: all" parameter, therefore they're not included in the get all response.

This PR adds the "all" category, so now a get all will include Kubevirt objects like vm, vmi, vmim (and all other Kubevirt) objects in the specified namespace.

**Release note**:

```release-note
Add ability to view Kubevirt objects when issuing a `kubectl get all` command.
```
