### PR TITLE
Openshift 3.11 provider with cluster-network-operator

### DIFF
--- a/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:3e962ef5042e6e03a25eea263d7474dd63e65e809d8d7b6ac3cf349e10dc13d9"
+image="os-3.11.0-multus@sha256:278b5eb240fcf968add7bb2ae32b629ac056b56b8dd1d2d33446edb44f7e27b3"


### PR DESCRIPTION
Update the Openshift 3.11 provider to use the cluster network operator.

The operator install all the components:
 * multus
 * linux-bridge
 * bridge-marker
 * kubemacpool
 * sriov-cni
 * sriov-device-plugin

This provider will update the os-3.11.0-multus image.


**Special notes for your reviewer**:
The provider build PR https://github.com/kubevirt/kubevirtci/pull/79

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update os-3.11-multus provider
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2281)
<!-- Reviewable:end -->
