### PR TITLE
KubeVirt Operator: allow installing in different namespaces

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -725,11 +725,6 @@ func (app *virtAPIApp) createValidatingWebhook() error {
 			return err
 		}
 	} else {
-		for _, webhook := range webhookRegistration.Webhooks {
-			if webhook.ClientConfig.Service != nil && webhook.ClientConfig.Service.Namespace != app.namespace {
-				return fmt.Errorf("ValidatingAdmissionWebhook [%s] is already registered using services endpoints in a different namespace. Existing webhook registration must be deleted before virt-api can proceed.", virtWebhookValidator)
-			}
-		}
 
 		// update registered webhook with our data
 		webhookRegistration.Webhooks = webHooks
@@ -843,12 +838,6 @@ func (app *virtAPIApp) createMutatingWebhook() error {
 		}
 	} else {
 
-		for _, webhook := range webhookRegistration.Webhooks {
-			if webhook.ClientConfig.Service != nil && webhook.ClientConfig.Service.Namespace != app.namespace {
-				return fmt.Errorf("MutatingAdmissionWebhook [%s] is already registered using services endpoints in a different namespace. Existing webhook registration must be deleted before virt-api can proceed.", virtWebhookMutator)
-			}
-		}
-
 		// update registered webhook with our data
 		webhookRegistration.Webhooks = webHooks
 
@@ -915,9 +904,6 @@ func (app *virtAPIApp) createSubresourceApiservice() error {
 			return err
 		}
 	} else {
-		if apiService.Spec.Service != nil && apiService.Spec.Service.Namespace != app.namespace {
-			return fmt.Errorf("apiservice [%s] is already registered in a different namespace. Existing apiservice registration must be deleted before virt-api can proceed.", subresourceApiservice.Name)
-		}
 
 		// Always update spec to latest.
 		apiService.Spec = app.subresourceApiservice().Spec

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -300,19 +300,6 @@ var _ = Describe("Virt-api", func() {
 			Expect(err).ToNot(HaveOccurred())
 		}, 5)
 
-		It("should fail if apiservice is at different namespace", func() {
-			badApiService := app.subresourceApiservice()
-			badApiService.Spec.Service.Namespace = "differentnamespace"
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/apiregistration.k8s.io/v1beta1/apiservices/"+subresourceAggregatedApiName),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, badApiService),
-				),
-			)
-			err := app.createSubresourceApiservice()
-			Expect(err).To(HaveOccurred())
-		}, 5)
-
 		It("should return internal error on authorizor error", func() {
 			app.authorizor = authorizorMock
 			authorizorMock.EXPECT().
@@ -447,20 +434,6 @@ var _ = Describe("Virt-api", func() {
 			Expect(err).ToNot(HaveOccurred())
 		}, 5)
 
-		It("should fail if validating webhook service at different namespace", func() {
-			expectedValidatingWebhooks.Webhooks[0].ClientConfig.Service.Namespace = "WrongNamespace"
-
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/admissionregistration.k8s.io/v1beta1/validatingwebhookconfigurations/virt-api-validator"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, expectedValidatingWebhooks),
-				),
-			)
-
-			err := app.createValidatingWebhook()
-			Expect(err).To(HaveOccurred())
-		}, 5)
-
 		It("should register mutating webhook if not found", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -493,21 +466,6 @@ var _ = Describe("Virt-api", func() {
 
 			err := app.createMutatingWebhook()
 			Expect(err).ToNot(HaveOccurred())
-		}, 5)
-
-		It("should fail if validating webhook service at different namespace", func() {
-
-			expectedMutatingWebhooks.Webhooks[0].ClientConfig.Service.Namespace = "WrongNamespace"
-
-			server.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/apis/admissionregistration.k8s.io/v1beta1/mutatingwebhookconfigurations/virt-api-mutator"),
-					ghttp.RespondWithJSONEncoded(http.StatusOK, expectedMutatingWebhooks),
-				),
-			)
-
-			err := app.createMutatingWebhook()
-			Expect(err).To(HaveOccurred())
 		}, 5)
 
 		It("should have default values for flags", func() {

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -167,7 +167,7 @@ func Execute() {
 	}
 
 	app.kubeVirtRecorder = app.getNewRecorder(k8sv1.NamespaceAll, "virt-operator")
-	app.kubeVirtController = *NewKubeVirtController(app.clientSet, app.kubeVirtInformer, app.kubeVirtRecorder, app.stores, app.informers)
+	app.kubeVirtController = *NewKubeVirtController(app.clientSet, app.kubeVirtInformer, app.kubeVirtRecorder, app.stores, app.informers, app.operatorNamespace)
 
 	image := os.Getenv(util.OperatorImageEnvName)
 	if image == "" {

--- a/pkg/virt-operator/install-strategy/BUILD.bazel
+++ b/pkg/virt-operator/install-strategy/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/virt-operator/creation/components:go_default_library",
         "//pkg/virt-operator/creation/rbac:go_default_library",
         "//pkg/virt-operator/util:go_default_library",

--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -37,7 +37,6 @@ import (
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
-	kvutil "kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/rbac"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
@@ -115,7 +114,7 @@ func DumpInstallStrategyToConfigMap(clientset kubecli.KubevirtClient) error {
 	imageTag := conf.ImageTag
 	imageRegistry := conf.ImageRegistry
 
-	namespace, err := kvutil.GetNamespace()
+	namespace, err := util.GetTargetInstallNamespace()
 	if err != nil {
 		return err
 	}
@@ -289,8 +288,9 @@ func LoadInstallStrategyFromCache(stores util.Stores, namespace string, imageTag
 		config, ok := obj.(*corev1.ConfigMap)
 		if !ok {
 			continue
-		}
-		if config.ObjectMeta.Annotations == nil {
+		} else if config.ObjectMeta.Annotations == nil {
+			continue
+		} else if config.ObjectMeta.Namespace != namespace {
 			continue
 		}
 

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -218,7 +218,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		informers.InfrastructurePod, infrastructurePodSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		stores.InfrastructurePodCache = informers.InfrastructurePod.GetStore()
 
-		controller = NewKubeVirtController(virtClient, kvInformer, recorder, stores, informers)
+		controller = NewKubeVirtController(virtClient, kvInformer, recorder, stores, informers, NAMESPACE)
 
 		// Wrap our workqueue to have a way to detect when we are done processing updates
 		mockQueue = testutils.NewMockWorkQueue(controller.queue)

--- a/pkg/virt-operator/util/BUILD.bazel
+++ b/pkg/virt-operator/util/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/openshift/api/security/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -23,16 +23,28 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	kvutil "kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
 	// Name of env var containing the operator's image name
-	OperatorImageEnvName = "OPERATOR_IMAGE"
+	OperatorImageEnvName   = "OPERATOR_IMAGE"
+	TargetInstallNamespace = "TARGET_INSTALL_NAMESPACE"
 )
 
 type KubeVirtDeploymentConfig struct {
 	ImageRegistry string
 	ImageTag      string
+}
+
+func GetTargetInstallNamespace() (string, error) {
+	ns := os.Getenv(TargetInstallNamespace)
+	if ns == "" {
+		return kvutil.GetNamespace()
+	}
+
+	return ns, nil
 }
 
 func GetConfig() KubeVirtDeploymentConfig {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -49,17 +49,30 @@ var _ = Describe("Operator", func() {
 	tests.PanicOnError(err)
 
 	getKvList := func() []v1.KubeVirt {
-		var kvList *v1.KubeVirtList
+		var kvListInstallNS *v1.KubeVirtList
+		var kvListDefaultNS *v1.KubeVirtList
+		var items []v1.KubeVirt
+
 		var err error
 
 		Eventually(func() error {
 
-			kvList, err = virtClient.KubeVirt(tests.KubeVirtInstallNamespace).List(&metav1.ListOptions{})
+			kvListInstallNS, err = virtClient.KubeVirt(tests.KubeVirtInstallNamespace).List(&metav1.ListOptions{})
 
 			return err
 		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
-		return kvList.Items
+		Eventually(func() error {
+
+			kvListDefaultNS, err = virtClient.KubeVirt(tests.NamespaceTestDefault).List(&metav1.ListOptions{})
+
+			return err
+		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		items = append(items, kvListInstallNS.Items...)
+		items = append(items, kvListDefaultNS.Items...)
+
+		return items
 	}
 
 	getCurrentKv := func() *v1.KubeVirt {
@@ -83,24 +96,28 @@ var _ = Describe("Operator", func() {
 
 	createKv := func(newKv *v1.KubeVirt) {
 		Eventually(func() error {
-			_, err = virtClient.KubeVirt(tests.KubeVirtInstallNamespace).Create(newKv)
+			_, err = virtClient.KubeVirt(newKv.Namespace).Create(newKv)
 			return err
 		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
-	sanityCheckDeploymentsExist := func() {
+	sanityCheckDeploymentsExistWithNS := func(namespace string) {
 		Eventually(func() error {
-			_, err := virtClient.ExtensionsV1beta1().Deployments(tests.KubeVirtInstallNamespace).Get("virt-api", metav1.GetOptions{})
+			_, err := virtClient.ExtensionsV1beta1().Deployments(namespace).Get("virt-api", metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 
-			_, err = virtClient.ExtensionsV1beta1().Deployments(tests.KubeVirtInstallNamespace).Get("virt-controller", metav1.GetOptions{})
+			_, err = virtClient.ExtensionsV1beta1().Deployments(namespace).Get("virt-controller", metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			return nil
 		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	}
+
+	sanityCheckDeploymentsExist := func() {
+		sanityCheckDeploymentsExistWithNS(tests.KubeVirtInstallNamespace)
 	}
 
 	sanityCheckDeploymentsDeleted := func() {
@@ -119,11 +136,11 @@ var _ = Describe("Operator", func() {
 		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
-	allPodsAreReady := func(expectedVersion string) {
+	allPodsAreReadyWithNS := func(expectedVersion string, namespace string) {
 		Eventually(func() error {
 			podsReadyAndOwned := 0
 
-			pods, err := virtClient.CoreV1().Pods(tests.KubeVirtInstallNamespace).List(metav1.ListOptions{LabelSelector: "kubevirt.io"})
+			pods, err := virtClient.CoreV1().Pods(namespace).List(metav1.ListOptions{LabelSelector: "kubevirt.io"})
 			if err != nil {
 				return err
 			}
@@ -163,9 +180,13 @@ var _ = Describe("Operator", func() {
 		}, 120*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 	}
 
+	allPodsAreReady := func(expectedVersion string) {
+		allPodsAreReadyWithNS(expectedVersion, tests.KubeVirtInstallNamespace)
+	}
+
 	waitForUpdateCondition := func(kv *v1.KubeVirt) {
 		Eventually(func() error {
-			kv, err := virtClient.KubeVirt(tests.KubeVirtInstallNamespace).Get(kv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(kv.Namespace).Get(kv.Name, &metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -231,7 +252,7 @@ var _ = Describe("Operator", func() {
 
 	waitForKv := func(newKv *v1.KubeVirt) {
 		Eventually(func() error {
-			kv, err := virtClient.KubeVirt(tests.KubeVirtInstallNamespace).Get(newKv.Name, &metav1.GetOptions{})
+			kv, err := virtClient.KubeVirt(newKv.Namespace).Get(newKv.Name, &metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
@@ -297,13 +318,11 @@ var _ = Describe("Operator", func() {
 
 	deleteAllKvAndWait := func(ignoreOriginal bool) {
 		Eventually(func() error {
-			kvList, err := virtClient.KubeVirt(tests.KubeVirtInstallNamespace).List(&metav1.ListOptions{})
-			if err != nil {
-				return err
-			}
+
+			kvs := getKvList()
 
 			deleteCount := 0
-			for _, kv := range kvList.Items {
+			for _, kv := range kvs {
 
 				if ignoreOriginal && kv.Name == originalKv.Name {
 					continue
@@ -408,6 +427,34 @@ var _ = Describe("Operator", func() {
 			// We're just verifying that a few common components that
 			// should always exist get re-deployed.
 			sanityCheckDeploymentsExist()
+		})
+
+		It("should be able to delete and re-create kubevirt install in a different namespace", func() {
+			allPodsAreReady(tests.KubeVirtVersionTag)
+			sanityCheckDeploymentsExist()
+
+			By("Deleting KubeVirt object")
+			deleteAllKvAndWait(false)
+
+			// this is just verifying some common known components do in fact get deleted.
+			By("Sanity Checking Deployments infrastructure is deleted")
+			sanityCheckDeploymentsDeleted()
+
+			By("Creating KubeVirt Object")
+			newKV := copyOriginalKv()
+			newKV.Name = "kubevirt-test-default-namespace"
+			newKV.Namespace = tests.NamespaceTestDefault
+
+			createKv(newKV)
+
+			By("Creating KubeVirt Object Created and Ready Condition")
+			waitForKv(newKV)
+
+			By("Verifying infrastructure is Ready")
+			allPodsAreReadyWithNS(tests.KubeVirtVersionTag, newKV.Namespace)
+			// We're just verifying that a few common components that
+			// should always exist get re-deployed.
+			sanityCheckDeploymentsExistWithNS(newKV.Namespace)
 		})
 
 		It("should be able to create kubevirt install with custom image tag", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to allow kubevirt to be installed independently of what namespace virt-operator lives in, we had to correct many assumptions that were being made in both virt-operator an virt-api.  

- virt-operator now knows how generate install strategies regardless of the namespace kubevirt is being installed into.
- virt-api now lets webhook and aggregated api registrations be updated to point to services in different namespaces. This is safe now that virt-operator ensures only one kubevirt install can exist on a cluster at a time across all namespaces.
- tests/operator_test.go now has a functional test to verify we can delete kubevirt installed in one namespace, and install kubevirt in another namespace. 

Fixes #2275

```release-note
Fixes issue that prevented kubevirt from being able to install in namespaces outside of the one virt-operator lives in. 
```
