### PR TITLE
[Release-0.17] Replace SCC strategic merge patch with JSON patch. 

### DIFF
--- a/pkg/virt-operator/install-strategy/create.go
+++ b/pkg/virt-operator/install-strategy/create.go
@@ -1358,10 +1358,12 @@ func addOrRemoveSSC(targetStrategy *InstallStrategy,
 		if !ok {
 			return fmt.Errorf("couldn't cast object to SecurityContextConstraints: %+v", privSCCObj)
 		}
+
+		oldUsers := privSCC.Users
 		privSCCCopy := privSCC.DeepCopy()
+		users := privSCCCopy.Users
 
 		modified := false
-		users := privSCCCopy.Users
 
 		// remove users from previous
 		if curSccPriv != nil && !addOnly {
@@ -1392,13 +1394,19 @@ func addOrRemoveSSC(targetStrategy *InstallStrategy,
 		}
 
 		if modified {
+			oldUserBytes, err := json.Marshal(oldUsers)
+			if err != nil {
+				return err
+			}
 			userBytes, err := json.Marshal(users)
 			if err != nil {
 				return err
 			}
 
-			data := []byte(fmt.Sprintf(`{"users": %s}`, userBytes))
-			_, err = scc.SecurityContextConstraints().Patch(sccPriv.TargetSCC, types.StrategicMergePatchType, data)
+			test := fmt.Sprintf(`{ "op": "test", "path": "/users", "value": %s }`, string(oldUserBytes))
+			patch := fmt.Sprintf(`{ "op": "replace", "path": "/users", "value": %s }`, string(userBytes))
+
+			_, err = scc.SecurityContextConstraints().Patch(sccPriv.TargetSCC, types.JSONPatchType, []byte(fmt.Sprintf("[ %s, %s ]", test, patch)))
 			if err != nil {
 				return fmt.Errorf("unable to patch scc: %v", err)
 			}

--- a/pkg/virt-operator/install-strategy/delete.go
+++ b/pkg/virt-operator/install-strategy/delete.go
@@ -278,10 +278,13 @@ func DeleteAll(kv *v1.KubeVirt,
 		if !ok {
 			return fmt.Errorf("couldn't cast object to SecurityContextConstraints: %+v", privSCCObj)
 		}
+
+		oldUsers := privSCC.Users
 		privSCCCopy := privSCC.DeepCopy()
+		users := privSCCCopy.Users
 
 		modified := false
-		users := privSCCCopy.Users
+
 		for _, acc := range sccPriv.ServiceAccounts {
 			removed := false
 			users, removed = remove(users, acc)
@@ -289,13 +292,19 @@ func DeleteAll(kv *v1.KubeVirt,
 		}
 
 		if modified {
+			oldUserBytes, err := json.Marshal(oldUsers)
+			if err != nil {
+				return err
+			}
 			userBytes, err := json.Marshal(users)
 			if err != nil {
 				return err
 			}
 
-			data := []byte(fmt.Sprintf(`{"users": %s}`, userBytes))
-			_, err = scc.SecurityContextConstraints().Patch(sccPriv.TargetSCC, types.StrategicMergePatchType, data)
+			test := fmt.Sprintf(`{ "op": "test", "path": "/users", "value": %s }`, string(oldUserBytes))
+			patch := fmt.Sprintf(`{ "op": "replace", "path": "/users", "value": %s }`, string(userBytes))
+
+			_, err = scc.SecurityContextConstraints().Patch(sccPriv.TargetSCC, types.JSONPatchType, []byte(fmt.Sprintf("[ %s, %s ]", test, patch)))
 			if err != nil {
 				return fmt.Errorf("unable to patch scc: %v", err)
 			}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -20,7 +20,6 @@
 package virt_operator
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -847,15 +846,13 @@ var _ = Describe("KubeVirt Operator", func() {
 		}
 		return true, nil, nil
 	}
-	expectUsers := func(userBytes []byte, count int) {
-
-		type _users struct {
-			Users []string `json:"users"`
-		}
-		users := &_users{}
-
-		json.Unmarshal(userBytes, users)
-		ExpectWithOffset(2, len(users.Users)).To(Equal(count))
+	expectUsersDeleted := func(userBytes []byte) {
+		deletePatch := `[ { "op": "test", "path": "/users", "value": ["someUser","system:serviceaccount:kubevirt-test:kubevirt-handler","system:serviceaccount:kubevirt-test:kubevirt-apiserver","system:serviceaccount:kubevirt-test:kubevirt-controller"] }, { "op": "replace", "path": "/users", "value": ["someUser"] } ]`
+		Expect(userBytes).To(Equal([]byte(deletePatch)))
+	}
+	expectUsersAdded := func(userBytes []byte) {
+		addPatch := `[ { "op": "test", "path": "/users", "value": ["someUser"] }, { "op": "replace", "path": "/users", "value": ["someUser","system:serviceaccount:kubevirt-test:kubevirt-handler","system:serviceaccount:kubevirt-test:kubevirt-apiserver","system:serviceaccount:kubevirt-test:kubevirt-controller"] } ]`
+		Expect(userBytes).To(Equal([]byte(addPatch)))
 	}
 
 	shouldExpectInstallStrategyDeletion := func() {
@@ -882,7 +879,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 		secClient.Fake.PrependReactor("patch", "securitycontextconstraints", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			patch, _ := action.(testing.PatchAction)
-			expectUsers(patch.GetPatch(), 1)
+			expectUsersDeleted(patch.GetPatch())
 			return true, nil, nil
 		})
 		extClient.Fake.PrependReactor("delete", "customresourcedefinitions", genericDeleteFunc)
@@ -930,7 +927,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 		secClient.Fake.PrependReactor("patch", "securitycontextconstraints", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 			patch, _ := action.(testing.PatchAction)
-			expectUsers(patch.GetPatch(), 4)
+			expectUsersAdded(patch.GetPatch())
 			return true, nil, nil
 		})
 		extClient.Fake.PrependReactor("create", "customresourcedefinitions", genericCreateFunc)


### PR DESCRIPTION
This is a backport to the release-0.17 stable branch.

Some versions of OpenShift don't support StrategicMerge patch type for SCC objects. This prevents virt-operator from installing kubevirt on those versions of OpenShift.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1709677

```release-note
NONE
```
