### PR TITLE
Functional Testing Release Updates

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -25,10 +25,15 @@ DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
 source hack/common.sh
 source hack/config.sh
 
+_auto_detected_latest_release_tag=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+
+latest_release_tag=${LATEST_RELEASE_TAG:-$_auto_detected_latest_release_tag}
+latest_release_registry=${LATEST_RELEASE_REGISTRY:-"index.docker.io/kubevirt"}
+
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
 if [[ ${TARGET} == openshift* ]]; then
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 210m ${FUNC_TEST_ARGS} -installed-namespace=${namespace}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 210m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -latest-release-tag=${latest_release_tag} -latest-release-registry=${latest_release_registry}

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -25,10 +25,10 @@ DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
 source hack/common.sh
 source hack/config.sh
 
-_auto_detected_latest_release_tag=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+_auto_detected_previous_release_tag=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
 
-latest_release_tag=${LATEST_RELEASE_TAG:-$_auto_detected_latest_release_tag}
-latest_release_registry=${LATEST_RELEASE_REGISTRY:-"index.docker.io/kubevirt"}
+previous_release_tag=${PREVIOUS_RELEASE_TAG:-$_auto_detected_previous_release_tag}
+previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-"index.docker.io/kubevirt"}
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
@@ -36,4 +36,4 @@ if [[ ${TARGET} == openshift* ]]; then
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 210m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -latest-release-tag=${latest_release_tag} -latest-release-registry=${latest_release_registry}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 210m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry}

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -25,10 +25,17 @@ DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
 source hack/common.sh
 source hack/config.sh
 
-_auto_detected_previous_release_tag=$(curl -s https://github.com/kubevirt/kubevirt/releases/latest | grep -o "v[0-9]\.[0-9]*\.[0-9]*")
+# This git command returns the most recent tag created in a specific branch
+# Example: if working in the release-0.17 branch, it will return v0.17.2 (or whatever the latest tag is today in release-0.17)
+# Example: if working in master, it will return v0.18.0 (or whatever the latest tag is today)
+#
+# These git tags happen to correspond exactly to our container tags, so the convention works well
+# for determining the release we should be testing updates with.
+_default_previous_release_tag=$(git describe --tags --abbrev=0 "$(git rev-parse HEAD)")
+_default_previous_release_registry="index.docker.io/kubevirt"
 
-previous_release_tag=${PREVIOUS_RELEASE_TAG:-$_auto_detected_previous_release_tag}
-previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-"index.docker.io/kubevirt"}
+previous_release_tag=${PREVIOUS_RELEASE_TAG:-$_default_previous_release_tag}
+previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_release_registry}
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -507,7 +507,7 @@ spec:
 			sanityCheckDeploymentsDeleted()
 
 			// Install Previous Release of KubeVirt
-			By("Creating KubeVirt Object with Prefious Release")
+			By(fmt.Sprintf("Creating KubeVirt Object with Previous Release: %s using registry %s", previousImageTag, previousImageRegistry))
 			kv := copyOriginalKv()
 			kv.Name = "kubevirt-release-install"
 			kv.Spec.ImageTag = previousImageTag

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -91,8 +91,8 @@ var KubeVirtKubectlPath = ""
 var KubeVirtOcPath = ""
 var KubeVirtVirtctlPath = ""
 var KubeVirtInstallNamespace string
-var LatestReleaseTag = ""
-var LatestReleaseRegistry = ""
+var PreviousReleaseTag = ""
+var PreviousReleaseRegistry = ""
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -110,8 +110,8 @@ func init() {
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "kubevirt", "Set the namespace KubeVirt is installed in")
 	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
-	flag.StringVar(&LatestReleaseTag, "latest-release-tag", "", "Set tag of the release to test updating from")
-	flag.StringVar(&LatestReleaseRegistry, "latest-release-registry", "", "Set registry of the release to test updating from")
+	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
+	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "", "Set registry of the release to test updating from")
 
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -91,6 +91,8 @@ var KubeVirtKubectlPath = ""
 var KubeVirtOcPath = ""
 var KubeVirtVirtctlPath = ""
 var KubeVirtInstallNamespace string
+var LatestReleaseTag = ""
+var LatestReleaseRegistry = ""
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -108,6 +110,8 @@ func init() {
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "kubevirt", "Set the namespace KubeVirt is installed in")
 	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
+	flag.StringVar(&LatestReleaseTag, "latest-release-tag", "", "Set tag of the release to test updating from")
+	flag.StringVar(&LatestReleaseRegistry, "latest-release-registry", "", "Set registry of the release to test updating from")
 
 }
 


### PR DESCRIPTION
In version v0.17.0 we introduced the ability to update KubeVirt using the KubeVirt operator. Part of our commitment there is to guarantee an update path between each KubeVirt release.

This functional test is meant to act as a guarantee that we don't inadvertently break the update path from the previous release to the trunk of master.

```release-note
NONE
```
