### PR TITLE
Replace default requested memory with cluster overcommit ratio

### DIFF
--- a/pkg/api/v1/BUILD.bazel
+++ b/pkg/api/v1/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "schema_swagger_generated.go",
         "types.go",
         "types_swagger_generated.go",
+        "utils.go",
         "zz_generated.defaults.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/api/v1",

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -893,16 +893,6 @@ type I6300ESBWatchdog struct {
 	Action WatchdogAction `json:"action,omitempty"`
 }
 
-// TODO ballooning, rng, cpu ...
-
-func NewMinimalDomainSpec() DomainSpec {
-	domain := DomainSpec{}
-	domain.Resources.Requests = v1.ResourceList{
-		v1.ResourceMemory: resource.MustParse("8192Ki"),
-	}
-	return domain
-}
-
 // ---
 // +k8s:openapi-gen=true
 type Interface struct {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
-	"kubevirt.io/kubevirt/pkg/precond"
 )
 
 // GroupName is the group name use in this package
@@ -548,21 +547,6 @@ const (
 
 func (s SyncEvent) String() string {
 	return string(s)
-}
-
-func NewMinimalVMI(vmiName string) *VirtualMachineInstance {
-	return NewMinimalVMIWithNS(k8sv1.NamespaceDefault, vmiName)
-}
-
-func NewMinimalVMIWithNS(namespace string, vmiName string) *VirtualMachineInstance {
-	precond.CheckNotEmpty(vmiName)
-	vmi := NewVMIReferenceFromNameWithNS(namespace, vmiName)
-	vmi.Spec = VirtualMachineInstanceSpec{Domain: NewMinimalDomainSpec()}
-	vmi.TypeMeta = metav1.TypeMeta{
-		APIVersion: GroupVersion.String(),
-		Kind:       "VirtualMachineInstance",
-	}
-	return vmi
 }
 
 // TODO Namespace could be different, also store it somewhere in the domain, so that we can report deletes on handler startup properly

--- a/pkg/api/v1/types_test.go
+++ b/pkg/api/v1/types_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
+	k8sv1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/log"
@@ -37,7 +37,7 @@ var _ = Describe("PodSelectors", func() {
 		It("should work", func() {
 			vmi := NewMinimalVMI("testvmi")
 			vmi.Status.NodeName = "test-node"
-			pod := &v1.Pod{}
+			pod := &k8sv1.Pod{}
 			affinity := UpdateAntiAffinityFromVMINode(pod, vmi)
 			newSelector := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
 			Expect(newSelector).ToNot(BeNil())
@@ -50,20 +50,20 @@ var _ = Describe("PodSelectors", func() {
 			vmi := NewMinimalVMI("testvmi")
 			vmi.Status.NodeName = "test-node"
 
-			existingTerm := v1.NodeSelectorTerm{}
-			secondExistingTerm := v1.NodeSelectorTerm{
-				MatchExpressions: []v1.NodeSelectorRequirement{
+			existingTerm := k8sv1.NodeSelectorTerm{}
+			secondExistingTerm := k8sv1.NodeSelectorTerm{
+				MatchExpressions: []k8sv1.NodeSelectorRequirement{
 					{},
 				},
 			}
 
-			pod := &v1.Pod{
-				Spec: v1.PodSpec{
-					Affinity: &v1.Affinity{
-						PodAffinity: &v1.PodAffinity{},
-						NodeAffinity: &v1.NodeAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-								NodeSelectorTerms: []v1.NodeSelectorTerm{
+			pod := &k8sv1.Pod{
+				Spec: k8sv1.PodSpec{
+					Affinity: &k8sv1.Affinity{
+						PodAffinity: &k8sv1.PodAffinity{},
+						NodeAffinity: &k8sv1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+								NodeSelectorTerms: []k8sv1.NodeSelectorTerm{
 									existingTerm,
 									secondExistingTerm,
 								},

--- a/pkg/api/v1/utils.go
+++ b/pkg/api/v1/utils.go
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017 Red Hat, Inc.
+ *
+ */
+
+package v1
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/pkg/precond"
+)
+
+// This is meant for testing
+func NewMinimalVMI(name string) *VirtualMachineInstance {
+	return NewMinimalVMIWithNS(k8sv1.NamespaceDefault, name)
+}
+
+// This is meant for testing
+func NewMinimalVMIWithNS(namespace, name string) *VirtualMachineInstance {
+	precond.CheckNotEmpty(name)
+	vmi := NewVMIReferenceFromNameWithNS(namespace, name)
+	vmi.Spec = VirtualMachineInstanceSpec{Domain: DomainSpec{}}
+	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: resource.MustParse("8192Ki"),
+	}
+	vmi.TypeMeta = k8smetav1.TypeMeta{
+		APIVersion: GroupVersion.String(),
+		Kind:       "VirtualMachineInstance",
+	}
+	return vmi
+}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -132,16 +132,12 @@ func (mutator *VMIsMutator) setDefaultMachineType(vmi *v1.VirtualMachineInstance
 }
 
 func (mutator *VMIsMutator) setDefaultResourceRequests(vmi *v1.VirtualMachineInstance) {
-	if _, exists := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory]; !exists {
-		if vmi.Spec.Domain.Resources.Requests == nil {
-			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
-		}
-		vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = mutator.ClusterConfig.GetMemoryRequest()
-	}
-
 	if _, exists := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU]; !exists {
 		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.DedicatedCPUPlacement {
 			return
+		}
+		if vmi.Spec.Domain.Resources.Requests == nil {
+			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 		}
 		vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = mutator.ClusterConfig.GetCPURequest()
 	}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -144,6 +144,7 @@ func (mutator *VMIsMutator) setDefaultResourceRequests(vmi *v1.VirtualMachineIns
 			}
 		}
 		if memory != nil && memory.Value() > 0 {
+			log.Log.Object(vmi).V(4).Info("Setting memory-request in light of memory-overcommit")
 			if vmi.Spec.Domain.Resources.Requests == nil {
 				vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{}
 			}

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -110,15 +110,14 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when unset, it should return the default", "", virtconfig.DefaultCPURequest),
 	)
 
-	table.DescribeTable(" when memoryRequest", func(value string, result string) {
+	table.DescribeTable(" when memoryOvercommit", func(value string, result int) {
 		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
-			Data: map[string]string{virtconfig.MemoryRequestKey: value},
+			Data: map[string]string{virtconfig.MemoryOvercommitKey: value},
 		})
-		memoryRequest := clusterConfig.GetMemoryRequest()
-		Expect(memoryRequest.String()).To(Equal(result))
+		Expect(clusterConfig.GetMemoryOvercommit()).To(Equal(result))
 	},
-		table.Entry("when set, it should return the value", "512Mi", "512Mi"),
-		table.Entry("when unset, it should return the default", "", virtconfig.DefaultMemoryRequest),
+		table.Entry("when set, it should return the value", "150", 150),
+		table.Entry("when unset, it should return the default", "", virtconfig.DefaultMemoryOvercommit),
 	)
 
 	table.DescribeTable(" when emulatedMachines", func(value string, result []string) {

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1356,31 +1356,25 @@ func QuantityToMebiByte(quantity resource.Quantity) (uint64, error) {
 }
 
 func boolToOnOff(value *bool, defaultOn bool) string {
-	if value == nil {
-		if defaultOn {
-			return "on"
-		}
-		return "off"
-	}
-
-	if *value {
-		return "on"
-	}
-	return "off"
+	return boolToString(value, defaultOn, "on", "off")
 }
 
 func boolToYesNo(value *bool, defaultYes bool) string {
-	if value == nil {
-		if defaultYes {
-			return "yes"
+	return boolToString(value, defaultYes, "yes", "no")
+}
+
+func boolToString(value *bool, defaultPositive bool, positive string, negative string) string {
+	toString := func(value bool) string {
+		if value {
+			return positive
 		}
-		return "no"
+		return negative
 	}
 
-	if *value {
-		return "yes"
+	if value == nil {
+		return toString(defaultPositive)
 	}
-	return "no"
+	return toString(*value)
 }
 
 // returns nameservers [][]byte, searchdomains []string, error

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -697,11 +697,8 @@ var _ = Describe("getSRIOVPCIAddresses", func() {
 	})
 })
 
-func newVMI(namespace string, name string) *v1.VirtualMachineInstance {
-	vmi := &v1.VirtualMachineInstance{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec:       v1.VirtualMachineInstanceSpec{Domain: v1.NewMinimalDomainSpec()},
-	}
+func newVMI(namespace, name string) *v1.VirtualMachineInstance {
+	vmi := v1.NewMinimalVMIWithNS(namespace, name)
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
 }

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -42,6 +42,5 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -31,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
@@ -490,17 +489,8 @@ var _ = Describe("Pod Network", func() {
 })
 
 func newVMI(namespace, name string) *v1.VirtualMachineInstance {
-	vmi := &v1.VirtualMachineInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: v1.VirtualMachineInstanceSpec{
-			Domain:   v1.NewMinimalDomainSpec(),
-			Networks: []v1.Network{*v1.DefaultPodNetwork()},
-		},
-	}
-
+	vmi := v1.NewMinimalVMIWithNS(namespace, name)
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	return vmi
 }
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -634,7 +634,7 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
-				// Need to wait for cloud init to finnish and start the agent inside the vmi.
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				Eventually(func() bool {
 					updatedVmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -154,6 +154,8 @@ const (
 )
 
 const SubresourceTestLabel = "subresource-access-test-pod"
+const namespaceKubevirt = "kubevirt"
+const kubevirtConfig = "kubevirt-config"
 
 const (
 	// tests.NamespaceTestDefault is the default namespace, to test non-infrastructure related KubeVirt objects.
@@ -3617,5 +3619,15 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: "0"},
 	}, 60*time.Second)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func UpdateClusterConfigValue(key string, value string) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	cfgMap, err := virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	cfgMap.Data[key] = value
+	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Update(cfgMap)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -301,19 +301,11 @@ var _ = Describe("Configurations", func() {
 
 		Context("with cluster memory overcommit being applied", func() {
 			BeforeEach(func() {
-				cfgMap, err := virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, metav1.GetOptions{})
-				Expect(err).To(BeNil())
-				cfgMap.Data["memory-overcommit"] = "200"
-				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValue("memory-overcommit", "200")
 			})
 
 			AfterEach(func() {
-				cfgMap, err := virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, metav1.GetOptions{})
-				Expect(err).To(BeNil())
-				cfgMap.Data["memory-overcommit"] = ""
-				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValue("memory-overcommit", "")
 			})
 
 			It("should set requested amount of memory according to the specified virtual memory", func() {
@@ -1104,13 +1096,7 @@ var _ = Describe("Configurations", func() {
 		defaultMachineTypeKey := "machine-type"
 
 		AfterEach(func() {
-			cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			cfgMap.Data[defaultMachineTypeKey] = ""
-
-			_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-			Expect(err).ToNot(HaveOccurred())
+			tests.UpdateClusterConfigValue(defaultMachineTypeKey, "")
 		})
 
 		It("should set machine type from VMI spec", func() {
@@ -1134,11 +1120,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set machine type from kubevirt-config", func() {
-			cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
-			Expect(err).To(BeNil())
-			cfgMap.Data[defaultMachineTypeKey] = "pc-q35-3.0"
-			_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-			Expect(err).ToNot(HaveOccurred())
+			tests.UpdateClusterConfigValue(defaultMachineTypeKey, "pc-q35-3.0")
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Machine.Type = ""
@@ -1154,13 +1136,7 @@ var _ = Describe("Configurations", func() {
 		defaultCPURequestKey := "cpu-request"
 
 		AfterEach(func() {
-			cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			cfgMap.Data[defaultCPURequestKey] = ""
-
-			_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-			Expect(err).ToNot(HaveOccurred())
+			tests.UpdateClusterConfigValue(defaultCPURequestKey, "")
 		})
 
 		It("should set CPU request from VMI spec", func() {
@@ -1190,11 +1166,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set CPU request from kubevirt-config", func() {
-			cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
-			Expect(err).To(BeNil())
-			cfgMap.Data[defaultCPURequestKey] = "800m"
-			_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-			Expect(err).ToNot(HaveOccurred())
+			tests.UpdateClusterConfigValue(defaultCPURequestKey, "800m")
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Resources = v1.ResourceRequirements{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -289,6 +289,16 @@ var _ = Describe("Configurations", func() {
 			})
 		})
 
+		Context("with no memory requested", func() {
+			It("should failed to the VMI creation", func() {
+				vmi := tests.NewRandomVMI()
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{}
+				By("Starting a VirtualMachineInstance")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
 		Context("with EFI bootloader method", func() {
 
 			It("[test_id:1668]should use EFI", func() {
@@ -532,7 +542,8 @@ var _ = Describe("Configurations", func() {
 					vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 					vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
-							kubev1.ResourceCPU: resource.MustParse("800m"),
+							kubev1.ResourceCPU:    resource.MustParse("800m"),
+							kubev1.ResourceMemory: resource.MustParse("512M"),
 						},
 					}
 					vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
@@ -1512,7 +1523,8 @@ var _ = Describe("Configurations", func() {
 				}
 				Vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU: resource.MustParse("1"),
+						kubev1.ResourceCPU:    resource.MustParse("1"),
+						kubev1.ResourceMemory: resource.MustParse("64M"),
 					},
 				}
 				Vmi.Spec.NodeSelector = map[string]string{v1.CPUManager: "true"}

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -22,6 +22,8 @@ package tests_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
@@ -46,6 +48,11 @@ var _ = Describe("VMIDefaults", func() {
 				Devices: v1.Devices{
 					Disks: []v1.Disk{
 						{Name: "testdisk"},
+					},
+				},
+				Resources: v1.ResourceRequirements{
+					Requests: k8sv1.ResourceList{
+						k8sv1.ResourceMemory: resource.MustParse("8192Ki"),
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR removes the debatable default configuration of memory-request of a VMI altogether.

First, memory-request is not set to 8Mi when not specified. When no memory is specified (either guest-memory, hugepages or memory-request), the appropriate (existing) validation error is returned.

Second, when either hugepages or guest-request is specified but memory-request is not set - the memory-request is set according to a new configurable ratio that sets the "cluster memory overcommit". For instance, if guest-memory is set to 3072M and this ration is set to 150% then memory-request would be set to 2048M.

If both guest-memory and hugepages are set, we keep returning an error.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Memory-overcommit can now be set at the cluster-level via `kubevirt-config` using the `memory-overcommit` key (in percentage). This renders default memory-request redundant.
```
