### PR TITLE
tests: skip ignition tests if ExperimentalIgnitionSupport is not enabled

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3401,6 +3401,10 @@ func HasCDI() bool {
 	return HasFeature("DataVolumes")
 }
 
+func HasExperimentalIgnitionSupport() bool {
+	return HasFeature("ExperimentalIgnitionSupport")
+}
+
 func HasLiveMigration() bool {
 	return HasFeature("LiveMigration")
 }

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -65,6 +65,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
+		if !tests.HasExperimentalIgnitionSupport() {
+			Skip("ExperimentalIgnitionSupport feature gate is not enabled in kubevirt-config")
+		}
 	})
 
 	Describe("[rfe_id:151][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Skip Ignition tests (i.e those from `tests/vmi_ignition_test.go`) if ExperimentalIgnitionSupport feature gate is not enabled instead of running them and seeing them fail.

This is the same behaviour as:
- DataVolume tests (`tests/datavolume_test.go`) which are skipped when DataVolumes feature gate is not enabled 
- Migrations tests (`tests/migration_test.go`) which are skipped when LiveMigration feature gate is not enabled. 

See also #2153.

**Special notes for your reviewer**:

Please also cherry-pick this PR on 0.17 release series.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
