### PR TITLE
tests: Just "q35" type is a common machine type across images

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1092,12 +1092,12 @@ var _ = Describe("Configurations", func() {
 
 		It("should set machine type from VMI spec", func() {
 			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine.Type = "pc-q35-3.0"
+			vmi.Spec.Domain.Machine.Type = "q35"
 			tests.RunVMIAndExpectLaunch(vmi, 30)
 			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(Equal("pc-q35-3.0"))
+			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-q35"))
 		})
 
 		It("should set default machine type when it is not provided", func() {
@@ -1107,13 +1107,13 @@ var _ = Describe("Configurations", func() {
 			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("q35"))
+			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-q35"))
 		})
 
 		It("should set machine type from kubevirt-config", func() {
 			cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
 			Expect(err).To(BeNil())
-			cfgMap.Data[defaultMachineTypeKey] = "pc-q35-3.0"
+			cfgMap.Data[defaultMachineTypeKey] = "q35"
 			_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1123,7 +1123,7 @@ var _ = Describe("Configurations", func() {
 			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(Equal("pc-q35-3.0"))
+			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-q35"))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

RHEL images would not have `pc-q35-3.0` as machine types, rather it would have  `pc-q35-rhel7.6.0` , `pc-q35-rhel8.0.0`, e.t.c

We encountered this issue while running these tests on CNV builds.

```
qemu-kvm: -machine pc-q35-3.0,accel=kvm,usb=off,dump-guest-core=off: unsupported machine type\nUse -machine help to list supported machines'
```

The supported machine types on `RHEL virt-launcher pods` are as below:

```
sh-4.4# cat /etc/redhat-release 
Red Hat Enterprise Linux release 8.0 (Ootpa)
sh-4.4# /usr/libexec/qemu-kvm -machine help 
Supported machines are:
pc                   RHEL 7.6.0 PC (i440FX + PIIX, 1996) (alias of pc-i440fx-rhel7.6.0)
pc-i440fx-rhel7.6.0  RHEL 7.6.0 PC (i440FX + PIIX, 1996) (default)
pc-i440fx-rhel7.5.0  RHEL 7.5.0 PC (i440FX + PIIX, 1996)
pc-i440fx-rhel7.4.0  RHEL 7.4.0 PC (i440FX + PIIX, 1996)
pc-i440fx-rhel7.3.0  RHEL 7.3.0 PC (i440FX + PIIX, 1996)
pc-i440fx-rhel7.2.0  RHEL 7.2.0 PC (i440FX + PIIX, 1996)
pc-i440fx-rhel7.1.0  RHEL 7.1.0 PC (i440FX + PIIX, 1996)
pc-i440fx-rhel7.0.0  RHEL 7.0.0 PC (i440FX + PIIX, 1996)
q35                  RHEL-8.0.0 PC (Q35 + ICH9, 2009) (alias of pc-q35-rhel8.0.0)
pc-q35-rhel8.0.0     RHEL-8.0.0 PC (Q35 + ICH9, 2009)
pc-q35-rhel7.6.0     RHEL-7.6.0 PC (Q35 + ICH9, 2009)
pc-q35-rhel7.5.0     RHEL-7.5.0 PC (Q35 + ICH9, 2009)
pc-q35-rhel7.4.0     RHEL-7.4.0 PC (Q35 + ICH9, 2009)
pc-q35-rhel7.3.0     RHEL-7.3.0 PC (Q35 + ICH9, 2009)
none                 empty machine

```
So, thinking we could make use of just `q35` which is common to both RHEL and non-RHEL `virt images`.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE

```
