### PR TITLE
Align run strategy error handling

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3800,6 +3800,9 @@
       "200": {
        "description": "OK"
       },
+      "400": {
+       "description": "Bad Request"
+      },
       "404": {
        "description": "Not Found"
       },
@@ -3835,6 +3838,9 @@
       "200": {
        "description": "OK"
       },
+      "400": {
+       "description": "Bad Request"
+      },
       "404": {
        "description": "Not Found"
       },
@@ -3869,6 +3875,9 @@
      "responses": {
       "200": {
        "description": "OK"
+      },
+      "400": {
+       "description": "Bad Request"
       },
       "404": {
        "description": "Not Found"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 A quick start guide to get KubeVirt up and running inside our container based
 development cluster.
 
-## I just want it built and run it on my cluser
+## I just want it built and run it on my cluster
 
 First, point the `Makefile` to the docker registry of your choice:
 
@@ -148,7 +148,7 @@ After a successful build you can run the *unit tests*:
 
 They do not need a running KubeVirt environment to succeed.
 To run the *functional tests*, make sure you have set
-up a dockerizied environment. Then run
+up a dockerized environment. Then run
 
 ```bash
     make cluster-sync # synchronize with your code, if necessary

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -202,7 +202,8 @@ func (app *virtAPIApp) composeSubresources() {
 		Operation("restart").
 		Doc("Restart a VirtualMachine object.").
 		Returns(http.StatusOK, "OK", nil).
-		Returns(http.StatusNotFound, "Not Found", nil))
+		Returns(http.StatusNotFound, "Not Found", nil).
+		Returns(http.StatusBadRequest, "Bad Request", nil))
 
 	subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("start")).
 		To(subresourceApp.StartVMRequestHandler).
@@ -210,7 +211,8 @@ func (app *virtAPIApp) composeSubresources() {
 		Operation("start").
 		Doc("Start a VirtualMachine object.").
 		Returns(http.StatusOK, "OK", nil).
-		Returns(http.StatusNotFound, "Not Found", nil))
+		Returns(http.StatusNotFound, "Not Found", nil).
+		Returns(http.StatusBadRequest, "Bad Request", nil))
 
 	subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("stop")).
 		To(subresourceApp.StopVMRequestHandler).
@@ -218,7 +220,8 @@ func (app *virtAPIApp) composeSubresources() {
 		Operation("stop").
 		Doc("Stop a VirtualMachine object.").
 		Returns(http.StatusOK, "OK", nil).
-		Returns(http.StatusNotFound, "Not Found", nil))
+		Returns(http.StatusNotFound, "Not Found", nil).
+		Returns(http.StatusBadRequest, "Bad Request", nil))
 
 	subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("console")).
 		To(subresourceApp.ConsoleRequestHandler).

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -288,7 +288,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			return
 		}
 	}
-	if vmi != nil && !vmi.IsFinal() && vmi.Status.Phase != v1.Unknown {
+	if vmi != nil && !vmi.IsFinal() && vmi.Status.Phase != v1.Unknown && vmi.Status.Phase != v1.VmPhaseUnset {
 		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is already running"))
 		return
 	}
@@ -376,7 +376,7 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 			return
 		}
 	}
-	if vmi == nil || vmi.IsFinal() || vmi.Status.Phase == v1.Unknown {
+	if vmi == nil || vmi.IsFinal() || vmi.Status.Phase == v1.Unknown || vmi.Status.Phase == v1.VmPhaseUnset {
 		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is not running"))
 		return
 	}

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -246,8 +246,8 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 			response.WriteError(http.StatusInternalServerError, err)
 			return
 		}
-		// If there's no VMI, just request to start
-		startOnly = true
+		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is not running"))
+		return
 	}
 
 	bodyString := ""
@@ -288,6 +288,18 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 		return
 	}
 
+	vmi, err := app.VirtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			response.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+	}
+	if vmi != nil {
+		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is already running"))
+		return
+	}
+
 	bodyString := ""
 	patchType := types.MergePatchType
 
@@ -307,20 +319,12 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 		patchType = types.JSONPatchType
 
 		needsRestart := false
-		vmi, err := app.VirtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				response.WriteError(http.StatusInternalServerError, err)
-				return
-			}
-		} else {
-			if (runStrategy == v1.RunStrategyRerunOnFailure && vmi.Status.Phase == v1.Succeeded) ||
-				(runStrategy == v1.RunStrategyManual && vmi.IsFinal()) {
-				needsRestart = true
-			} else if runStrategy == v1.RunStrategyRerunOnFailure && vmi.Status.Phase == v1.Failed {
-				response.WriteError(http.StatusBadRequest, fmt.Errorf("runstrategy rerunonerror does not support starting VM from failed state"))
-				return
-			}
+		if (runStrategy == v1.RunStrategyRerunOnFailure && vmi.Status.Phase == v1.Succeeded) ||
+			(runStrategy == v1.RunStrategyManual && vmi.IsFinal()) {
+			needsRestart = true
+		} else if runStrategy == v1.RunStrategyRerunOnFailure && vmi.Status.Phase == v1.Failed {
+			response.WriteError(http.StatusBadRequest, fmt.Errorf("runstrategy rerunonerror does not support starting VM from failed state"))
+			return
 		}
 
 		if needsRestart {
@@ -355,12 +359,27 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 }
 
 func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, response *restful.Response) {
+	// RunStrategyHalted         -> doesn't make sense
+	// RunStrategyManual         -> send stop request
+	// RunStrategyAlways         -> spec.running = false
+	// RunStrategyRerunOnFailure -> spec.running = false
+
 	name := request.PathParameter("name")
 	namespace := request.PathParameter("namespace")
 
 	vm, code, err := app.fetchVirtualMachine(name, namespace)
 	if err != nil {
 		response.WriteError(code, err)
+		return
+	}
+
+	vmi, err := app.VirtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			response.WriteError(http.StatusInternalServerError, err)
+			return
+		}
+		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is not running"))
 		return
 	}
 
@@ -371,33 +390,19 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		response.WriteError(http.StatusInternalServerError, err)
 		return
 	}
-	// RunStrategyHalted         -> doesn't make sense
-	// RunStrategyManual         -> send stop request
-	// RunStrategyAlways         -> spec.running = false
-	// RunStrategyRerunOnFailure -> spec.running = false
 	switch runStrategy {
 	case v1.RunStrategyHalted:
-		response.WriteError(http.StatusInternalServerError, fmt.Errorf("runstrategy halted does not support manual stop requests"))
+		response.WriteError(http.StatusBadRequest, fmt.Errorf("runstrategy halted does not support manual stop requests"))
 		return
 	case v1.RunStrategyManual:
 		// pass the buck and ask virt-controller to stop the VM. this way the
 		// VM will retain RunStrategy = manual
-		vmi, err := app.VirtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+		patchType = types.JSONPatchType
+		bodyString, err = getChangeRequestJson(vm,
+			v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				response.WriteError(http.StatusInternalServerError, err)
-				return
-			}
-			response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is not running"))
+			response.WriteError(http.StatusInternalServerError, err)
 			return
-		} else {
-			patchType = types.JSONPatchType
-			bodyString, err = getChangeRequestJson(vm,
-				v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID})
-			if err != nil {
-				response.WriteError(http.StatusInternalServerError, err)
-				return
-			}
 		}
 	case v1.RunStrategyRerunOnFailure, v1.RunStrategyAlways:
 		bodyString = getRunningJson(vm, false)

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -288,7 +288,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			return
 		}
 	}
-	if vmi != nil && vmi.IsRunning() {
+	if vmi != nil && !vmi.IsFinal() && vmi.Status.Phase != v1.Unknown {
 		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is already running"))
 		return
 	}
@@ -371,9 +371,12 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 		if !errors.IsNotFound(err) {
 			response.WriteError(http.StatusInternalServerError, err)
 			return
+		} else {
+			response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is not running"))
+			return
 		}
 	}
-	if vmi == nil || !vmi.IsRunning() {
+	if vmi == nil || vmi.IsFinal() || vmi.Status.Phase == v1.Unknown {
 		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is not running"))
 		return
 	}

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -288,8 +288,10 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			return
 		}
 	} else {
-		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is already running"))
-		return
+		if vmi != nil && vmi.Status.Phase != v1.Succeeded && vmi.Status.Phase != v1.Failed {
+			response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is already running"))
+			return
+		}
 	}
 
 	bodyString := ""

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -239,7 +239,6 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 		return
 	}
 
-	startOnly := false
 	vmi, err := app.VirtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -250,15 +249,9 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 		return
 	}
 
-	bodyString := ""
-	if startOnly {
-		bodyString, err = getChangeRequestJson(vm,
-			v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest})
-	} else {
-		bodyString, err = getChangeRequestJson(vm,
-			v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID},
-			v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest})
-	}
+	bodyString, err := getChangeRequestJson(vm,
+		v1.VirtualMachineStateChangeRequest{Action: v1.StopRequest, UID: &vmi.UID},
+		v1.VirtualMachineStateChangeRequest{Action: v1.StartRequest})
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
 		return
@@ -294,8 +287,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			response.WriteError(http.StatusInternalServerError, err)
 			return
 		}
-	}
-	if vmi != nil {
+	} else {
 		response.WriteError(http.StatusBadRequest, fmt.Errorf("VM is already running"))
 		return
 	}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -959,8 +959,8 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 	})
 })
 
-func newVirtualMachineWithRunStrategy(runStrategy v1.VirtualMachineRunStrategy) v1.VirtualMachine {
-	return v1.VirtualMachine{
+func newVirtualMachineWithRunStrategy(runStrategy v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
+	return &v1.VirtualMachine{
 		ObjectMeta: k8smetav1.ObjectMeta{
 			Name: "testvm",
 		},

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -627,7 +627,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"),
-					ghttp.RespondWithJSONEncoded(http.StatusNotFound, nil),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 				),
 			)
 
@@ -653,7 +653,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvm"),
-					ghttp.RespondWithJSONEncoded(http.StatusNotFound, nil),
+					ghttp.RespondWithJSONEncoded(http.StatusOK, vmi),
 				),
 			)
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Subresource Api", func() {
 		})
 
 		Context("With manual RunStrategy", func() {
-			It("Should restart when VM is not running", func() {
+			It("Should not restart when VM is not running", func() {
 				vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
 				vm.Spec.RunStrategy = &manual
 				vm.Spec.Running = nil
@@ -129,18 +129,9 @@ var _ = Describe("Subresource Api", func() {
 				vm, err := virtCli.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Starting VM via Restart subresource")
+				By("Trying to start VM via Restart subresource")
 				err = virtCli.VirtualMachine(tests.NamespaceTestDefault).Restart(vm.Name)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Waiting for VMI to start")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					newVMI, err := virtCli.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
-					if err != nil {
-						return v1.VmPhaseUnset
-					}
-					return newVMI.Status.Phase
-				}, 90*time.Second, 1*time.Second).Should(Equal(v1.Running))
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("Should restart when VM is running", func() {
@@ -152,8 +143,8 @@ var _ = Describe("Subresource Api", func() {
 				vm, err := virtCli.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Starting VM via Restart subresource")
-				err = virtCli.VirtualMachine(tests.NamespaceTestDefault).Restart(vm.Name)
+				By("Starting VM via Start subresource")
+				err = virtCli.VirtualMachine(tests.NamespaceTestDefault).Start(vm.Name)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for VMI to start")

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -879,9 +879,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					stopCommand := tests.NewRepeatableVirtctlCommand(vm.COMMAND_STOP, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 					restartCommand := tests.NewRepeatableVirtctlCommand(vm.COMMAND_RESTART, "--namespace", virtualMachine.Namespace, virtualMachine.Name)
 
-					By("Invoking virtctl restart")
+					By("Invoking virtctl restart should fail")
 					err = restartCommand()
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).To(HaveOccurred())
+
+					By("Invoking virtctl start")
+					err = startCommand()
+					Expect(err).NotTo(HaveOccurred())
 
 					By("Waiting for VMI to be ready")
 					Eventually(func() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Aligns error handling behavior in Subresource API of `Start`-, `Stop`- and `RestartVMRequestHandler` by checking for an existing `VMI` as precondition in order
* to fail for `StartVMRequestHandler` if a `VMI` exists, and 
* to fail for `StopVMRequestHandler` and `RestartVMRequestHandler` if a `VMI` does not exist.

Add couple of tests for different run strategies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
-

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
