### PR TITLE
Add a helper tool to register all SR-IOV VFs with vfio

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -66,6 +66,10 @@ you may need to configure the host as follows:
 $ echo "options vfio_iommu_type1 allow_unsafe_interrupts=1" > /etc/modprobe.d/iommu_unsafe_interrupts.conf
 ```
 
+Finally, we need to unbind each device from its respective network driver and
+register it with vfio subsystem. You can find an example on how to do it under:
+`tools/util/vfio.sh`
+
 Now you are ready to set up your cluster.
 
 # Set up kubernetes cluster

--- a/tools/util/vfio.sh
+++ b/tools/util/vfio.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# This script enables VFs for all available SR-IOV capable PFs, and registers
+# all of them with vfio subsystem. This is so that SR-IOV device plugin can
+# then allocate these VFIO enabled devices to pods and have libvirt pass them
+# into qemu using vfio device type.
+
+# first, load the kernel module if not already
+modprobe vfio-pci
+
+for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
+    pfroot=$(dirname $file)
+
+    # enable all available VFs
+    cat $file > $pfroot/sriov_numvfs
+
+    # bind all VFs with vfio
+    for virtfn in $(ls -d $pfroot/virtfn*); do
+        pciid=$(basename $(readlink $virtfn))
+        if [ -e $virtfn/driver/unbind ]; then
+            echo $pciid > $virtfn/driver/unbind
+            echo $(lspci -n -s $pciid | sed 's/:/ /g' | awk -e '{print $4 " " $5}') > /sys/bus/pci/drivers/vfio-pci/new_id
+        fi
+    done
+done


### PR DESCRIPTION
Kubevirt expects all VFs that are allocated by SR-IOV device plugin to have
been pre-registered with vfio. This action is managed outside kubevirt, and in
the future we may want to automate it via e.g. machine state / network
operator, but to help an admin, let's include the helper tool that can guide on
how to configure hosts for SR-IOV attachment via kubevirt.

```release-note
NONE
```