### PR TITLE
docs: remove incorrect suggestion to configure udev rules for sriov vfio

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -66,16 +66,6 @@ you may need to configure the host as follows:
 $ echo "options vfio_iommu_type1 allow_unsafe_interrupts=1" > /etc/modprobe.d/iommu_unsafe_interrupts.conf
 ```
 
-Also, make sure that vfio devices are accessible to kvm group by configuring udev rules:
-
-```
-$ cat /etc/udev/rules.d/10-qemu-hw-users.rules
-SUBSYSTEM=="vfio", OWNER="root", GROUP="root", MODE="0666"
-KERNEL=="vfio", SUBSYSTEM=="misc", OWNER="root", GROUP="root", MODE="0666"
-KERNEL=="kvm", GROUP="root", MODE="0666"
-$ udevadm control --reload-rules && udevadm trigger
-```
-
 Now you are ready to set up your cluster.
 
 # Set up kubernetes cluster


### PR DESCRIPTION
Default rules should suffice for kubevirt managed vfio devices.


```release-notes
NONE
```