### PR TITLE
Move SR-IOV functional tests into a separate suite

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -273,7 +273,7 @@ elif [[ $TARGET =~ multus.* ]]; then
 elif [[ $TARGET =~ genie.* ]]; then
   ginko_params="$ginko_params --ginkgo.focus=Genie|Networking|VMIlifecycle|Expose"
 else
-  ginko_params="$ginko_params --ginkgo.skip=Multus|Genie"
+  ginko_params="$ginko_params --ginkgo.skip=Multus|Genie|SRIOV"
 fi
 
 # Prepare RHEL PV for Template testing

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2571,13 +2571,6 @@ func SkipIfNoRhelImage(virtClient kubecli.KubevirtClient) {
 	}
 }
 
-func SkipIfNoSriovDevicePlugin(virtClient kubecli.KubevirtClient) {
-	_, err := virtClient.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Get("kube-sriov-device-plugin-amd64", metav1.GetOptions{})
-	if err != nil {
-		Skip("Skip srio tests that required sriov device plugin")
-	}
-}
-
 func SkipIfUseFlannel(virtClient kubecli.KubevirtClient) {
 	labelSelector := "app=flannel"
 	flannelpod, err := virtClient.CoreV1().Pods(metav1.NamespaceSystem).List(metav1.ListOptions{LabelSelector: labelSelector})

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -588,7 +588,6 @@ var _ = Describe("SRIOV", func() {
 	tests.PanicOnError(err)
 
 	tests.BeforeAll(func() {
-		tests.SkipIfNoSriovDevicePlugin(virtClient)
 		tests.BeforeTestCleanup()
 		// Create two sriov networks referring to the same resource name
 		result := virtClient.RestClient().


### PR DESCRIPTION
This will allow us to target just SR-IOV specific tests for SR-IOV
test lane. This also makes it so that these tests are not even triggered for
multus CI jobs since we know we don't deploy SR-IOV components there.

In the future we will add a CI job for SR-IOV that will run the new SRIOV
suite.

```release-note
NONE
```