### PR TITLE
Create the ovs br1 on worker nodes for ocp 3.11

### DIFF
--- a/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:278b5eb240fcf968add7bb2ae32b629ac056b56b8dd1d2d33446edb44f7e27b3"
+image="os-3.11.0-multus@sha256:b799a707e2c42caa1e3a7e7677cd14bbd834b3e3f6f1bce48b7a32d705e383fb"


### PR DESCRIPTION
This PR fixes an issue on the ocp provider.

When we request more the one node for the cluster the additional workers
are reinstalled using the openshift-ansible scale-up playbook.

This playbook removes all the ovs configuration done previously,
so this PR just run on every node using the ovs daemonset installed in the
cluster and recreate the br1 bridge if not exist.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2325)
<!-- Reviewable:end -->
