### PR TITLE
Allow live migration to auto converge

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -59,6 +59,7 @@ const (
 	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
 	ParallelMigrationsPerClusterDefault      uint32 = 5
 	BandwithPerMigrationDefault                     = "64Mi"
+	MigrationAllowAutoConverge               bool   = false
 	MigrationProgressTimeout                 int64  = 150
 	MigrationCompletionTimeoutPerGiB         int64  = 800
 	DefaultMachineType                              = "q35"
@@ -130,6 +131,7 @@ func defaultClusterConfig() *Config {
 	parallelMigrationsPerClusterDefault := ParallelMigrationsPerClusterDefault
 	bandwithPerMigrationDefault := resource.MustParse(BandwithPerMigrationDefault)
 	nodeDrainTaintDefaultKey := NodeDrainTaintDefaultKey
+	allowAutoConverge := MigrationAllowAutoConverge
 	progressTimeout := MigrationProgressTimeout
 	completionTimeoutPerGiB := MigrationCompletionTimeoutPerGiB
 	cpuRequestDefault := resource.MustParse(DefaultCPURequest)
@@ -148,6 +150,7 @@ func defaultClusterConfig() *Config {
 			ProgressTimeout:                   &progressTimeout,
 			CompletionTimeoutPerGiB:           &completionTimeoutPerGiB,
 			UnsafeMigrationOverride:           false,
+			AllowAutoConverge:                 allowAutoConverge,
 		},
 		MachineType:            DefaultMachineType,
 		CPURequest:             cpuRequestDefault,
@@ -185,6 +188,7 @@ type MigrationConfig struct {
 	ProgressTimeout                   *int64             `json:"progressTimeout,omitempty"`
 	CompletionTimeoutPerGiB           *int64             `json:"completionTimeoutPerGiB,omitempty"`
 	UnsafeMigrationOverride           bool               `json:"unsafeMigrationOverride"`
+	AllowAutoConverge                 bool               `json:"allowAutoConverge"`
 }
 
 type ClusterConfig struct {

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -158,7 +158,7 @@ var _ = Describe("ConfigMap", func() {
 
 	It("Should return migration config values if specified as json", func() {
 		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
-			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10, "parallelMigrationsPerCluster": 20, "bandwidthPerMigration": "110Mi", "progressTimeout" : 5, "completionTimeoutPerGiB": 5, "unsafeMigrationOverride": true}`},
+			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10, "parallelMigrationsPerCluster": 20, "bandwidthPerMigration": "110Mi", "progressTimeout" : 5, "completionTimeoutPerGiB": 5, "unsafeMigrationOverride": true, "allowAutoConverge": true}`},
 		})
 		result := clusterConfig.GetMigrationConfig()
 		Expect(*result.ParallelOutboundMigrationsPerNode).To(BeNumerically("==", 10))
@@ -167,6 +167,7 @@ var _ = Describe("ConfigMap", func() {
 		Expect(*result.ProgressTimeout).To(BeNumerically("==", 5))
 		Expect(*result.CompletionTimeoutPerGiB).To(BeNumerically("==", 5))
 		Expect(result.UnsafeMigrationOverride).To(BeTrue())
+		Expect(result.AllowAutoConverge).To(BeTrue())
 	})
 
 	It("Should return migration config values if specified as yaml", func() {

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -66,6 +66,7 @@ type MigrationOptions struct {
 	ProgressTimeout         int64
 	CompletionTimeoutPerGiB int64
 	UnsafeMigration         bool
+	AllowAutoConverge       bool
 }
 
 type LauncherClient interface {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1377,6 +1377,7 @@ func (d *VirtualMachineController) processVmUpdate(origVMI *v1.VirtualMachineIns
 				ProgressTimeout:         *d.clusterConfig.GetMigrationConfig().ProgressTimeout,
 				CompletionTimeoutPerGiB: *d.clusterConfig.GetMigrationConfig().CompletionTimeoutPerGiB,
 				UnsafeMigration:         d.clusterConfig.GetMigrationConfig().UnsafeMigrationOverride,
+				AllowAutoConverge:       d.clusterConfig.GetMigrationConfig().AllowAutoConverge,
 			}
 			err = client.MigrateVirtualMachine(vmi, options)
 			if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -241,7 +241,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 
 }
 
-func prepareMigrationFlags(isBlockMigration bool, isUnsafeMigration bool) libvirt.DomainMigrateFlags {
+func prepareMigrationFlags(isBlockMigration bool, isUnsafeMigration bool, allowAutoConverge bool) libvirt.DomainMigrateFlags {
 	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER
 
 	if isBlockMigration {
@@ -249,6 +249,9 @@ func prepareMigrationFlags(isBlockMigration bool, isUnsafeMigration bool) libvir
 	}
 	if isUnsafeMigration {
 		migrateFlags |= libvirt.MIGRATE_UNSAFE
+	}
+	if allowAutoConverge {
+		migrateFlags |= libvirt.MIGRATE_AUTO_CONVERGE
 	}
 	return migrateFlags
 
@@ -375,7 +378,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 			return
 		}
 
-		migrateFlags := prepareMigrationFlags(isBlockMigration, options.UnsafeMigration)
+		migrateFlags := prepareMigrationFlags(isBlockMigration, options.UnsafeMigration, options.AllowAutoConverge)
 		if options.UnsafeMigration {
 			log.Log.Object(vmi).Info("UNSAFE_MIGRATION flag is set, libvirt's migration checks will be disabled!")
 		}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -576,7 +576,8 @@ var _ = Describe("Manager", func() {
 		func(migrationType string) {
 			isBlockMigration := migrationType == "block"
 			isUnsafeMigration := migrationType == "unsafe"
-			flags := prepareMigrationFlags(isBlockMigration, isUnsafeMigration)
+			allowAutoConverge := migrationType == "autoConverge"
+			flags := prepareMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge)
 			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER
 
 			if isBlockMigration {
@@ -584,11 +585,15 @@ var _ = Describe("Manager", func() {
 			} else if migrationType == "unsafe" {
 				expectedMigrateFlags |= libvirt.MIGRATE_UNSAFE
 			}
+			if allowAutoConverge {
+				expectedMigrateFlags |= libvirt.MIGRATE_AUTO_CONVERGE
+			}
 			Expect(flags).To(Equal(expectedMigrateFlags))
 		},
 		table.Entry("with block migration", "block"),
 		table.Entry("without block migration", "live"),
 		table.Entry("unsafe migration", "unsafe"),
+		table.Entry("migration auto converge", "autoConverge"),
 	)
 
 	table.DescribeTable("on successful list all domains",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -387,7 +387,7 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 
 			})
 		})
-		FContext("with auto converge enabled", func() {
+		Context("with auto converge enabled", func() {
 			var options metav1.GetOptions
 			var cfgMap *k8sv1.ConfigMap
 			var originalMigrationConfig string
@@ -395,24 +395,24 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 
-				// set unsafe migration flag
+				// set autoconverge flag
 				options = metav1.GetOptions{}
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
 				cfgMap.Data["migrations"] = `{"allowAutoConverge": true}`
 
-				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
 				Expect(err).ToNot(HaveOccurred())
 				time.Sleep(5 * time.Second)
 
 			}, 60)
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Get(kubevirtConfig, options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(namespaceKubevirt).Update(cfgMap)
+				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
 				Expect(err).ToNot(HaveOccurred())
 			}, 60)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases when the virtual machine's workload generates a high ratio of dirty pages a normal live migration will not be able to complete. Live migration will be abortted the moment it will hit the `MigrationProgressTimeout` or the `MigrationCompletionTimeout`

Qemu provides an optional functionality[1] to try to slow down down the guest CPUs execution speed.
Throttling down the CPU should hopefully lower the speed to guest memory pollution and allow the instance to successfully complete the migration.

This PR simply introduces an option to enable live migration auto converge, but enablling virt-config migration parameter `AllowAutoConverge`, while is disbaled by deafult.
 
[1] https://wiki.qemu.org/Features/AutoconvergeLiveMigration
```release-note
None
```
