### PR TITLE
Look for correct package when downloading bundles from Quay

### DIFF
--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -106,7 +106,7 @@ func main() {
 		// prevent loading latest bundle from Quay for every file, only do it for the CSV manifest
 		data.ReplacesCsvVersion = ""
 		if strings.Contains(*inputFile, ".csv.yaml") && *bundleOutDir != "" && data.QuayRepository != "" {
-			bundleHelper, err := helper.NewBundleHelper(*quayRepository)
+			bundleHelper, err := helper.NewBundleHelper(*quayRepository, *packageName)
 			if err != nil {
 				panic(err)
 			}

--- a/tools/marketplace/main.go
+++ b/tools/marketplace/main.go
@@ -27,10 +27,11 @@ import (
 
 func main() {
 
-	repo := flag.String("quay-repository", "kubevirt", "the Quay.io repository name, defaults to kubevirt")
+	ns := flag.String("quay-namespace", "kubevirt", "the Quay.io namespace, defaults to kubevirt")
+	pkg := flag.String("package", "kubevirt-operatorhub", "the package name, defaults to kubevirt-operatorhub")
 	flag.Parse()
 
-	bh, err := helper.NewBundleHelper(*repo)
+	bh, err := helper.NewBundleHelper(*ns, *pkg)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Look for correct package when downloading bundles from Quay, because we now have several packages (kubevirt, cdi, ...) in the kubevirt namespace.

Also fixed naming a bit, the top level organizational thing in Quay is called namespace, below that are repositories (=applications, bundles, packages)

**Release note**:
```release-note
NONE
```
