### PR TITLE
Forward all network traffic in masquerade

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -542,6 +542,15 @@ func (p *MasqueradePodInterface) createNatRules() error {
 		return err
 	}
 
+	if len(p.iface.Ports) == 0 {
+		err = Handler.IptablesAppendRule("nat", "KUBEVIRT_PREINBOUND",
+			"-j",
+			"DNAT",
+			"--to-destination", p.vif.IP.IP.String())
+
+		return err
+	}
+
 	for _, port := range p.iface.Ports {
 		if port.Protocol == "" {
 			port.Protocol = "tcp"


### PR DESCRIPTION
This PR will forward all the incoming traffic to the vm if not specific port was requested

```release-note
forward all ports using masquerade
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2331)
<!-- Reviewable:end -->
