### PR TITLE
Pin dependencies to prevent the update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,3 +99,19 @@ require (
 )
 
 replace github.com/k8snetworkplumbingwg/network-attachment-definition-client => github.com/booxter/network-attachment-definition-client v0.0.0-20181121221720-d76adb95b0b7
+
+replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
+
+replace k8s.io/api => k8s.io/api v0.0.0-20190222213804-5cb15d344471
+
+replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
+
+replace github.com/go-kit/kit => github.com/go-kit/kit v0.3.0
+
+replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v11.0.0+incompatible
+
+replace kubevirt.io/containerized-data-importer => kubevirt.io/containerized-data-importer v1.8.1-0.20190530153240-6734c225525a
+
+replace github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.0.0-20160913182117-3b1ae45394a2 h1:BD5IDvMK5RQqnDi7Fbizwoad9Uus/Hs/xJ1zMYVXlS8=
 cloud.google.com/go v0.0.0-20160913182117-3b1ae45394a2/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/Azure/go-autorest v11.0.0+incompatible h1:eiSNFBmiWLzcjYsTkq8XZ0KRlvirsX0eyFQ8ZyCTgiQ=
+github.com/Azure/go-autorest v11.0.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest v11.1.0+incompatible h1:9DfMsQdUMEtg1jKRTjtkNZsvOuZXJOMl4dN1kiQwAc8=
 github.com/Azure/go-autorest v11.1.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVkjK4=
@@ -44,6 +46,8 @@ github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7a
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.0.0-20160928073314-fe6fe28ba0d5 h1:IfzbcUJo+hWSycd6UMAOEiMaw8jZy8hD9neO4rd8M7Y=
 github.com/go-kit/kit v0.0.0-20160928073314-fe6fe28ba0d5/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.3.0 h1:QZEva+odUF/G+yz7yjQLwUQxnSAS4S45V9+4O02yJ1Q=
+github.com/go-kit/kit v0.3.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -248,6 +252,8 @@ k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 kubevirt.io/containerized-data-importer v1.8.1-0.20190516083534-83c12eaae2ed h1:LlA3Ss/dn65wYofQDo2hRY+Asq4aWVE6IC/WPCqKJoA=
 kubevirt.io/containerized-data-importer v1.8.1-0.20190516083534-83c12eaae2ed/go.mod h1:qF594BtRRkruyrqLwt3zbLCWdPIQNs1qWh4LR1cOzy0=
+kubevirt.io/containerized-data-importer v1.8.1-0.20190530153240-6734c225525a h1:E7jvLY4VVoLhjY7bG+MWf/7ntDiYfUfGGO9s/oNkUmo=
+kubevirt.io/containerized-data-importer v1.8.1-0.20190530153240-6734c225525a/go.mod h1:qF594BtRRkruyrqLwt3zbLCWdPIQNs1qWh4LR1cOzy0=
 kubevirt.io/qe-tools v0.1.3-0.20190512140058-934db0579e0c h1:9FawJ0jS2NvLLE3oyBvnEgv+vVl0aIVKrgXuhLoWfjw=
 kubevirt.io/qe-tools v0.1.3-0.20190512140058-934db0579e0c/go.mod h1:PJyH/YXC4W0AmxfheDmXWMbLNsMSboVGXKpMAwfKzVE=
 sigs.k8s.io/controller-runtime v0.1.9 h1:ZcnTZfnCGynyToVwHsqV3bMoGXwViYlnUF8kfMgghK8=

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/config.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/config.go
@@ -19,6 +19,10 @@ import (
 	"net/url"
 )
 
+const (
+	activeDirectoryAPIVersion = "1.0"
+)
+
 // OAuthConfig represents the endpoints needed
 // in OAuth operations
 type OAuthConfig struct {
@@ -42,25 +46,11 @@ func validateStringParam(param, name string) error {
 
 // NewOAuthConfig returns an OAuthConfig with tenant specific urls
 func NewOAuthConfig(activeDirectoryEndpoint, tenantID string) (*OAuthConfig, error) {
-	apiVer := "1.0"
-	return NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, tenantID, &apiVer)
-}
-
-// NewOAuthConfigWithAPIVersion returns an OAuthConfig with tenant specific urls.
-// If apiVersion is not nil the "api-version" query parameter will be appended to the endpoint URLs with the specified value.
-func NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, tenantID string, apiVersion *string) (*OAuthConfig, error) {
 	if err := validateStringParam(activeDirectoryEndpoint, "activeDirectoryEndpoint"); err != nil {
 		return nil, err
 	}
-	api := ""
 	// it's legal for tenantID to be empty so don't validate it
-	if apiVersion != nil {
-		if err := validateStringParam(*apiVersion, "apiVersion"); err != nil {
-			return nil, err
-		}
-		api = fmt.Sprintf("?api-version=%s", *apiVersion)
-	}
-	const activeDirectoryEndpointTemplate = "%s/oauth2/%s%s"
+	const activeDirectoryEndpointTemplate = "%s/oauth2/%s?api-version=%s"
 	u, err := url.Parse(activeDirectoryEndpoint)
 	if err != nil {
 		return nil, err
@@ -69,15 +59,15 @@ func NewOAuthConfigWithAPIVersion(activeDirectoryEndpoint, tenantID string, apiV
 	if err != nil {
 		return nil, err
 	}
-	authorizeURL, err := u.Parse(fmt.Sprintf(activeDirectoryEndpointTemplate, tenantID, "authorize", api))
+	authorizeURL, err := u.Parse(fmt.Sprintf(activeDirectoryEndpointTemplate, tenantID, "authorize", activeDirectoryAPIVersion))
 	if err != nil {
 		return nil, err
 	}
-	tokenURL, err := u.Parse(fmt.Sprintf(activeDirectoryEndpointTemplate, tenantID, "token", api))
+	tokenURL, err := u.Parse(fmt.Sprintf(activeDirectoryEndpointTemplate, tenantID, "token", activeDirectoryAPIVersion))
 	if err != nil {
 		return nil, err
 	}
-	deviceCodeURL, err := u.Parse(fmt.Sprintf(activeDirectoryEndpointTemplate, tenantID, "devicecode", api))
+	deviceCodeURL, err := u.Parse(fmt.Sprintf(activeDirectoryEndpointTemplate, tenantID, "devicecode", activeDirectoryAPIVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/Azure/go-autorest/autorest/adal/token.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/adal/token.go
@@ -226,8 +226,6 @@ func (secret *ServicePrincipalCertificateSecret) SignJwt(spt *ServicePrincipalTo
 
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["x5t"] = thumbprint
-	x5c := []string{base64.StdEncoding.EncodeToString(secret.Certificate.Raw)}
-	token.Header["x5c"] = x5c
 	token.Claims = jwt.MapClaims{
 		"aud": spt.inner.OauthConfig.TokenEndpoint.String(),
 		"iss": spt.inner.ClientID,

--- a/vendor/github.com/Azure/go-autorest/version/version.go
+++ b/vendor/github.com/Azure/go-autorest/version/version.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Number contains the semantic version of this SDK.
-const Number = "v11.1.0"
+const Number = "v11.0.0"
 
 var (
 	userAgent = fmt.Sprintf("Go/%s (%s-%s) go-autorest/%s",

--- a/vendor/github.com/go-kit/kit/log/README.md
+++ b/vendor/github.com/go-kit/kit/log/README.md
@@ -68,7 +68,7 @@ import (
 )
 
 func main() {
-	logger := kitlog.NewJSONLogger(log.NewSyncWriter(os.Stdout))
+	logger := kitlog.NewJSONLogger(kitlog.NewSyncWriter(os.Stdout))
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
 	stdlog.Print("I sure like pie")
 }

--- a/vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1/types.go
+++ b/vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1/types.go
@@ -152,6 +152,12 @@ const (
 	// CloneInProgress represents a data volume with a current phase of CloneInProgress
 	CloneInProgress DataVolumePhase = "CloneInProgress"
 
+	// SnapshotForSmartCloneInProgress represents a data volume with a current phase of SnapshotForSmartCloneInProgress
+	SnapshotForSmartCloneInProgress DataVolumePhase = "SnapshotForSmartCloneInProgress"
+
+	// SmartClonePVCInProgress represents a data volume with a current phase of SmartClonePVCInProgress
+	SmartClonePVCInProgress DataVolumePhase = "SmartClonePVCInProgress"
+
 	// UploadScheduled represents a data volume with a current phase of UploadScheduled
 	UploadScheduled DataVolumePhase = "UploadScheduled"
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # cloud.google.com/go v0.0.0-20160913182117-3b1ae45394a2
 cloud.google.com/go/compute/metadata
 cloud.google.com/go/internal
-# github.com/Azure/go-autorest v11.1.0+incompatible
+# github.com/Azure/go-autorest v11.1.0+incompatible => github.com/Azure/go-autorest v11.0.0+incompatible
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/adal
 github.com/Azure/go-autorest/autorest/azure
@@ -41,7 +41,7 @@ github.com/ghodss/yaml
 # github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 github.com/globalsign/mgo/bson
 github.com/globalsign/mgo/internal/json
-# github.com/go-kit/kit v0.0.0-20160928073314-fe6fe28ba0d5
+# github.com/go-kit/kit v0.0.0-20160928073314-fe6fe28ba0d5 => github.com/go-kit/kit v0.3.0
 github.com/go-kit/kit/log
 github.com/go-kit/kit/endpoint
 github.com/go-kit/kit/transport/http
@@ -203,7 +203,7 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 # github.com/openshift/api v3.9.1-0.20190401220125-3a6077f1f910+incompatible
 github.com/openshift/api/security/v1
-# github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a
+# github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a => github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
 github.com/openshift/client-go/security/clientset/versioned/scheme
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1/fake
@@ -354,7 +354,7 @@ gopkg.in/ini.v1
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.2.1
 gopkg.in/yaml.v2
-# k8s.io/api v0.0.0-20190222213804-5cb15d344471
+# k8s.io/api v0.0.0-20190222213804-5cb15d344471 => k8s.io/api v0.0.0-20190222213804-5cb15d344471
 k8s.io/api/core/v1
 k8s.io/api/autoscaling/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -388,7 +388,7 @@ k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
+# k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236 => k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
@@ -396,7 +396,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextension
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake
-# k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
+# k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628 => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/fields
@@ -445,7 +445,7 @@ k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/apis/meta/internalversion
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/third_party/forked/golang/netutil
-# k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
+# k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4 => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
 k8s.io/client-go/rest
 k8s.io/client-go/kubernetes/scheme
 k8s.io/client-go/kubernetes/typed/core/v1
@@ -646,7 +646,7 @@ k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme
 # k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
-# kubevirt.io/containerized-data-importer v1.8.1-0.20190516083534-83c12eaae2ed
+# kubevirt.io/containerized-data-importer v1.8.1-0.20190516083534-83c12eaae2ed => kubevirt.io/containerized-data-importer v1.8.1-0.20190530153240-6734c225525a
 kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1
 kubevirt.io/containerized-data-importer/pkg/client/informers/externalversions
 kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned


### PR DESCRIPTION
- k8s dependencies
- client-go dependencies
- Azure and go-kit dependencies

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR pin some dependencies to prevent their update as a side effect of `make deps-update`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
