### PR TITLE
Change default interface to masquerade on functional tests

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Multus", func() {
 	defaultInterface := v1.Interface{
 		Name: "default",
 		InterfaceBindingMethod: v1.InterfaceBindingMethod{
-			Bridge: &v1.InterfaceBridge{},
+			Masquerade: &v1.InterfaceMasquerade{},
 		},
 	}
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -105,7 +105,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
 	}
 
-	Describe("Multiple virtual machines connectivity", func() {
+	Describe("Multiple virtual machines connectivity using bridge binding interface", func() {
 		tests.BeforeAll(func() {
 			tests.BeforeTestCleanup()
 
@@ -116,18 +116,29 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			inboundVMI.Labels = map[string]string{"expose": "me"}
 			inboundVMI.Spec.Subdomain = "myvmi"
 			inboundVMI.Spec.Hostname = "my-subdomain"
-			Expect(inboundVMI.Spec.Domain.Devices.Interfaces).To(BeEmpty())
+			// Remove the masquerade interface to use the default bridge one
+			inboundVMI.Spec.Domain.Devices.Interfaces = nil
+			inboundVMI.Spec.Networks = nil
 
 			// outboundVMI is used to connect to other vms
 			outboundVMI = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			// Remove the masquerade interface to use the default bridge one
+			outboundVMI.Spec.Domain.Devices.Interfaces = nil
+			outboundVMI.Spec.Networks = nil
 
 			// inboudnVMIWithPodNetworkSet adds itself in an explicit fashion to the pod network
 			inboundVMIWithPodNetworkSet = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			// Remove the masquerade interface to use the default bridge one
+			inboundVMIWithPodNetworkSet.Spec.Domain.Devices.Interfaces = nil
+			inboundVMIWithPodNetworkSet.Spec.Networks = nil
 			v1.SetDefaults_NetworkInterface(inboundVMIWithPodNetworkSet)
 			Expect(inboundVMIWithPodNetworkSet.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
 
 			// inboundVMIWithCustomMacAddress specifies a custom MAC address
 			inboundVMIWithCustomMacAddress = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			// Remove the masquerade interface to use the default bridge one
+			inboundVMIWithCustomMacAddress.Spec.Domain.Devices.Interfaces = nil
+			inboundVMIWithCustomMacAddress.Spec.Networks = nil
 			v1.SetDefaults_NetworkInterface(inboundVMIWithCustomMacAddress)
 			Expect(inboundVMIWithCustomMacAddress.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
 			inboundVMIWithCustomMacAddress.Spec.Domain.Devices.Interfaces[0].MacAddress = "de:ad:00:00:be:af"
@@ -478,6 +489,9 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			By("checking loopback is the only guest interface")
 			autoAttach := false
 			detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+			// Remove the masquerade interface to use the default bridge one
+			detachedVMI.Spec.Domain.Devices.Interfaces = nil
+			detachedVMI.Spec.Networks = nil
 			detachedVMI.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
 
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(detachedVMI)
@@ -497,7 +511,9 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			By("Creating random VirtualMachineInstance")
 			autoAttach := false
 			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
-
+			// Remove the masquerade interface to use the default bridge one
+			vmi.Spec.Domain.Devices.Interfaces = nil
+			vmi.Spec.Networks = nil
 			vmi.Spec.Domain.Devices.AutoattachPodInterface = &autoAttach
 
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
@@ -575,6 +591,9 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		It("[test_id:1777]should disable learning on pod iface", func() {
 			By("checking learning flag")
 			learningDisabledVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskAlpine), "#!/bin/bash\necho 'hello'\n")
+			// Remove the masquerade interface to use the default bridge one
+			learningDisabledVMI.Spec.Domain.Devices.Interfaces = nil
+			learningDisabledVMI.Spec.Networks = nil
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(learningDisabledVMI)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Slirp Networking", func() {
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
-			generateHelloWorldServer(vmi, virtClient, 80, "tcp")
+			tests.GenerateHelloWorldServer(vmi, 80, "tcp")
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR change the default interface for pod network to masquerade.

This PR will help reduce/eliminate the issue with unsupported 0xFE mac address for libvirt

Fixes #1494

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2343)
<!-- Reviewable:end -->
