### PR TITLE
tests: make sriov suite work with mellanox cards

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3629,3 +3629,16 @@ func UpdateClusterConfigValue(key string, value string) {
 	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Update(cfgMap)
 	Expect(err).ToNot(HaveOccurred())
 }
+
+func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
+	Eventually(func() bool {
+		updatedVmi, err := virtClient.VirtualMachineInstance(NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		for _, condition := range updatedVmi.Status.Conditions {
+			if condition.Type == "AgentConnected" && condition.Status == "True" {
+				return true
+			}
+		}
+		return false
+	}, 420*time.Second, 2).Should(BeTrue(), "Should have agent connected condition")
+}

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -664,17 +664,8 @@ var _ = Describe("Multus", func() {
 				getOptions := &metav1.GetOptions{}
 				var updatedVmi *v1.VirtualMachineInstance
 
-				// Need to wait for cloud init to finnish and start the agent inside the vmi.
-				Eventually(func() bool {
-					updatedVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
-					Expect(err).ToNot(HaveOccurred())
-					for _, condition := range updatedVmi.Status.Conditions {
-						if condition.Type == "AgentConnected" && condition.Status == "True" {
-							return true
-						}
-					}
-					return false
-				}, 420*time.Second, 2).Should(BeTrue(), "Should have agent connected condition")
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
+				tests.WaitAgentConnected(virtClient, agentVMI)
 
 				Eventually(func() bool {
 					updatedVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, getOptions)

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -661,18 +661,19 @@ var _ = Describe("Multus", func() {
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 				tests.WaitForSuccessfulVMIStart(agentVMI)
 
-				getOptions := &metav1.GetOptions{}
-				var updatedVmi *v1.VirtualMachineInstance
-
 				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				tests.WaitAgentConnected(virtClient, agentVMI)
 
+				getOptions := &metav1.GetOptions{}
 				Eventually(func() bool {
-					updatedVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
+					updatedVmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
+					if err != nil {
+						return false
+					}
 					return len(updatedVmi.Status.Interfaces) == 4
 				}, 420*time.Second, 4).Should(BeTrue(), "Should have interfaces in vmi status")
 
-				updatedVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
+				updatedVmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, getOptions)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(updatedVmi.Status.Interfaces)).To(Equal(4))


### PR DESCRIPTION
Mellanox VFs require additional kernel module loaded inside the guest for
netlink device to pop up. This patch makes the fedora vmi load the kernel
module. Qemu agent is used to report back to the suite about cloud-init phase
completion.

This patch also deduplicates code of the sriov test cases as well as
introduces a single test function to wait for AgentConnected status that
is then reused in all other test cases in the tree that need this wait.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
