### PR TITLE
Limit bazel to a maximum of 4 parallel jobs

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -160,6 +160,7 @@ cat >.bazelrc <<EOF
 startup --host_jvm_args=-Dbazel.DigestFunction=sha256
 build --remote_local_fallback
 build --remote_http_cache=${BAZEL_CACHE}
+build --jobs=4
 EOF
 
 # build all images with the basic repeat logic


### PR DESCRIPTION
**What this PR does / why we need it**:

Bazel tries to come up with a reasonable number of concurrent jobs, but it's capabilities to detect what's available are limited inside docker containers. Limit it for CI to a reasonable number. Otherwise on concurrent builds we can easily see average CPU utilization values above 150 with 12 parallel builds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
