### PR TITLE
Add utility flags for downstream repo selection

### DIFF
--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -247,7 +247,7 @@ func testClientJob(virtCli kubecli.KubevirtClient, withServiceAccount bool, reso
 			Containers: []k8sv1.Container{
 				{
 					Name:    name,
-					Image:   fmt.Sprintf("%s/subresource-access-test:%s", tests.KubeVirtRepoPrefix, tests.KubeVirtVersionTag),
+					Image:   fmt.Sprintf("%s/subresource-access-test:%s", tests.KubeVirtUtilityRepoPrefix, tests.KubeVirtUtilityVersionTag),
 					Command: []string{"/subresource-access-test", resource},
 				},
 			},

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -89,7 +89,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#FAKE")
 		vmi.ObjectMeta.Annotations = map[string]string{
-			"hooks.kubevirt.io/hookSidecars": fmt.Sprintf(`[{"image": "%s/%s:%s", "imagePullPolicy": "IfNotPresent"}]`, tests.KubeVirtRepoPrefix, cloudinitHookSidecarImage, tests.KubeVirtVersionTag),
+			"hooks.kubevirt.io/hookSidecars": fmt.Sprintf(`[{"image": "%s/%s:%s", "imagePullPolicy": "IfNotPresent"}]`, tests.KubeVirtUtilityRepoPrefix, cloudinitHookSidecarImage, tests.KubeVirtUtilityVersionTag),
 		}
 	})
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -135,7 +135,7 @@ func getVmDomainXml(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstan
 
 func RenderSidecar(version string) map[string]string {
 	return map[string]string{
-		"hooks.kubevirt.io/hookSidecars":              fmt.Sprintf(`[{"args": ["--version", "%s"],"image": "%s/%s:%s", "imagePullPolicy": "IfNotPresent"}]`, version, tests.KubeVirtRepoPrefix, hookSidecarImage, tests.KubeVirtVersionTag),
+		"hooks.kubevirt.io/hookSidecars":              fmt.Sprintf(`[{"args": ["--version", "%s"],"image": "%s/%s:%s", "imagePullPolicy": "IfNotPresent"}]`, version, tests.KubeVirtUtilityRepoPrefix, hookSidecarImage, tests.KubeVirtUtilityVersionTag),
 		"smbios.vm.kubevirt.io/baseBoardManufacturer": "Radical Edward",
 	}
 }

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 					Containers: []k8sv1.Container{
 						{
 							Name:    winrmCli,
-							Image:   fmt.Sprintf("%s/%s:%s", tests.KubeVirtRepoPrefix, winrmCli, tests.KubeVirtVersionTag),
+							Image:   fmt.Sprintf("%s/%s:%s", tests.KubeVirtUtilityRepoPrefix, winrmCli, tests.KubeVirtUtilityVersionTag),
 							Command: []string{"sleep"},
 							Args:    []string{"3600"},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Added flags enable to select different tags for upstream and downstream,
since they are not the same. Even when the code is the same. 
Moreover testing containers are only provided from upstream repository,
and are not mirrored. Therefore different docker prefix have to be used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=1716432

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2354)
<!-- Reviewable:end -->
