### PR TITLE
Port name validation

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -687,6 +687,14 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 							})
 						}
 
+						if msgs := validation.IsValidPortName(forwardPort.Name); len(msgs) != 0 {
+							causes = append(causes, metav1.StatusCause{
+								Type:    metav1.CauseTypeFieldValueInvalid,
+								Message: fmt.Sprintf("Invalid name of the port: %s", forwardPort.Name),
+								Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("name").String(),
+							})
+						}
+
 						portForwardMap[forwardPort.Name] = struct{}{}
 					}
 				}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1344,6 +1344,25 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].name"))
 		})
+		It("should reject a bad port name", func() {
+			vm := v1.NewMinimalVMI("testvm")
+			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+				Name: "default",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{
+					Masquerade: &v1.InterfaceMasquerade{},
+				},
+				Ports: []v1.Port{{Name: "Test", Port: 80}}}}
+
+			vm.Spec.Networks = []v1.Network{{
+				Name:          "default",
+				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+			},
+			}
+
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vm.Spec, config)
+			Expect(len(causes)).To(Equal(1), "unexpected number of errors")
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[0].ports[0].name"))
+		})
 		It("should reject networks with a pod network source and slirp interface with bad protocol type", func() {
 			vm := v1.NewMinimalVMI("testvm")
 			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{v1.Interface{
@@ -1410,7 +1429,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Slirp: &v1.InterfaceSlirp{},
 				},
-				Ports: []v1.Port{{Name: "testPort", Port: 80}, {Name: "testPort", Protocol: "UDP", Port: 80}}}}
+				Ports: []v1.Port{{Name: "testport", Port: 80}, {Name: "testport", Protocol: "UDP", Port: 80}}}}
 
 			vm.Spec.Networks = []v1.Network{
 				v1.Network{
@@ -1430,13 +1449,13 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Slirp: &v1.InterfaceSlirp{},
 				},
-				Ports: []v1.Port{{Name: "testPort", Port: 80}}},
+				Ports: []v1.Port{{Name: "testport", Port: 80}}},
 				v1.Interface{
 					Name: "default",
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{
 						Slirp: &v1.InterfaceSlirp{},
 					},
-					Ports: []v1.Port{{Name: "testPort", Protocol: "UDP", Port: 80}}}}
+					Ports: []v1.Port{{Name: "testport", Protocol: "UDP", Port: 80}}}}
 
 			vm.Spec.Networks = []v1.Network{
 				v1.Network{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds a port name validation for the kubevirt validating webhook.

Before this PR a port name with upper case was allowed but the pod creation was failing.

**Special notes for your reviewer**:
Related log:
```
Warning  FailedCreate  1s (x5 over 39s)  virtualmachine-controller  (combined from similar events): Error creating pod: Pod "virt-launcher-testvmilgdmt5p8tf7x4j7mt8wzpt2v924z8j4qt74mlc8dcp" is invalid: [spec.containers[1].ports[1].name: Invalid value: "testPort-tcp": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-), spec.containers[1].ports[3].name: Invalid value: "testPort-udp": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)]
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix port name validation
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2364)
<!-- Reviewable:end -->
