### PR TITLE
Fix functional test flag parsing

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -32,7 +31,7 @@ import (
 
 var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:component]User Access", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()

--- a/tests/config.go
+++ b/tests/config.go
@@ -22,6 +22,7 @@ package tests
 import (
 	"encoding/json"
 	"flag"
+
 	"fmt"
 	"io/ioutil"
 	"os"

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -19,7 +19,6 @@
 package tests_test
 
 import (
-	"flag"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -34,7 +33,7 @@ import (
 
 var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component]Config", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -35,7 +34,7 @@ import (
 
 var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]Console", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -42,7 +41,7 @@ import (
 const InvalidDataVolumeUrl = "http://127.0.0.1/invalid"
 
 var _ = Describe("DataVolume Integration", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -1,7 +1,6 @@
 package tests_test
 
 import (
-	"flag"
 	"strconv"
 	"time"
 
@@ -52,7 +51,7 @@ func waitForJobToCompleteWithStatus(virtClient *kubecli.KubevirtClient, jobPod *
 
 var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -1,7 +1,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,7 +26,7 @@ const (
 
 var _ = Describe("ImageUpload", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	namespace := tests.NamespaceTestDefault
 	pvcName := "alpine-pvc"

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -21,7 +21,7 @@ package tests_test
 
 import (
 	"encoding/json"
-	"flag"
+
 	"fmt"
 	"sort"
 	"strconv"
@@ -46,7 +46,7 @@ import (
 )
 
 var _ = Describe("Infrastructure", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -22,7 +22,7 @@ package tests_test
 import (
 	"crypto/tls"
 	"encoding/json"
-	"flag"
+
 	"fmt"
 	"time"
 
@@ -46,7 +46,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system] VM Live Migration", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -1,7 +1,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 
 	expect "github.com/google/goexpect"
@@ -41,7 +40,7 @@ func assertPingFail(ip string, vmi *v1.VirtualMachineInstance) {
 
 var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -21,7 +21,7 @@ package tests_test
 
 import (
 	"encoding/json"
-	"flag"
+
 	"fmt"
 	"regexp"
 	"strings"
@@ -40,7 +40,7 @@ import (
 )
 
 var _ = Describe("Operator", func() {
-	flag.Parse()
+	tests.FlagParse()
 	var originalKv *v1.KubeVirt
 	var originalKubeVirtConfig *k8sv1.ConfigMap
 	var err error

--- a/tests/probes_test.go
+++ b/tests/probes_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"flag"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -16,7 +14,7 @@ import (
 )
 
 var _ = Describe("[ref_id:1182]Probes", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/registry_disk_test.go
+++ b/tests/registry_disk_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"strings"
 	"time"
 
@@ -39,7 +38,7 @@ import (
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]ContainerDisk", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"strings"
@@ -43,7 +42,7 @@ import (
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstanceReplicaSet", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"flag"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -12,7 +10,7 @@ import (
 
 var _ = PDescribe("Ensure stable functionality", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -53,7 +52,7 @@ const (
 type VMICreationFunc func(string) *v1.VirtualMachineInstance
 
 var _ = Describe("Storage", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -36,7 +35,7 @@ import (
 
 var _ = Describe("Subresource Api", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtCli, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -48,7 +47,7 @@ const (
 )
 
 var _ = Describe("Templates", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -109,6 +109,11 @@ func init() {
 	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
 
+}
+
+func FlagParse() {
+	flag.Parse()
+
 	// When the flags are not provided, copy the values from normal version tag and prefix
 	if KubeVirtUtilityVersionTag == "" {
 		KubeVirtUtilityVersionTag = KubeVirtVersionTag

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"runtime"
 
@@ -33,7 +32,7 @@ import (
 
 var _ = Describe("Version", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -48,7 +47,7 @@ import (
 
 var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachine", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -38,7 +37,7 @@ const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
 
 var _ = Describe("CloudInitHookSidecars", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -48,7 +47,7 @@ const (
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component]CloudInit UserData", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -48,7 +47,7 @@ import (
 
 var _ = Describe("Configurations", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_genie_test.go
+++ b/tests/vmi_genie_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"time"
 
@@ -37,7 +36,7 @@ import (
 
 var _ = Describe("Genie", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ const hookSidecarImage = "example-hook-sidecar"
 
 var _ = Describe("HookSidecars", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -35,7 +34,7 @@ import (
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component]IgnitionData", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -21,7 +21,7 @@ package tests_test
 
 import (
 	"encoding/xml"
-	"flag"
+
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -39,7 +39,7 @@ import (
 )
 
 var _ = Describe("IOThreads", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -74,7 +73,7 @@ func addNodeAffinityToVMI(vmi *v1.VirtualMachineInstance, nodeName string) {
 
 var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]VMIlifecycle", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"time"
 
 	expect "github.com/google/goexpect"
@@ -35,7 +34,7 @@ import (
 
 var _ = Describe("Health Monitoring", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -21,7 +21,7 @@ package tests_test
 
 import (
 	"encoding/xml"
-	"flag"
+
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -38,7 +38,7 @@ import (
 )
 
 var _ = Describe("MultiQueue", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 	"time"
@@ -50,7 +49,7 @@ const (
 
 var _ = Describe("Multus", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -46,7 +45,7 @@ import (
 
 var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"strings"
 	"time"
 
@@ -38,7 +37,7 @@ import (
 
 var _ = Describe("Slirp Networking", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -20,8 +20,6 @@
 package tests_test
 
 import (
-	"flag"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +30,7 @@ import (
 )
 
 var _ = Describe("VMIDefaults", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
 	"strings"
@@ -40,7 +39,7 @@ import (
 )
 
 var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]VMIPreset", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,7 +40,7 @@ import (
 
 var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]VNC", func() {
 
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -56,7 +55,7 @@ const (
 )
 
 var _ = Describe("Windows VirtualMachineInstance", func() {
-	flag.Parse()
+	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()
 	tests.PanicOnError(err)


### PR DESCRIPTION
func test utility defaults are not set correctly.  The flags weren't being parsed in the init function, so the utility defaults weren't set to the expected values. 

fixes issue unintentionally introduced by pr #2354 

```release-note
NONE
```
