### PR TITLE
snap

### DIFF
--- a/pkg/snap/snapcraft.yaml
+++ b/pkg/snap/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: kubevirt
+summary: Virtualization.
+description:| Kubernetes Virtualization API and runtime in order to define and manage virtual machines. 
+  
+adopt-info: kubevirt
+
+grade: stable
+confinement: classic
+
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
+apps:
+  kubevirt:
+    command: bin/kubevirt
+    plugs:
+      - home
+      - network
+      - removable-media
+
+parts:
+  kubevirt:
+  plugin: nil 
+    source: https://github.com/kubevirt/kubevirt.git
+    source-type: git
+    override-pull: |
+      git clone https://github.com/kubevirt/kubevirt.git src/github.com/kubevirt/kubevirt
+       cd src/github.com/kubevirt/kubevirt
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
+      override-build: |
+      export GOPATH=$PWD
+      cd src/github.com/kubevirt/kubevirt
+      env CGO_ENABLED=0 GOOS=linux \
+      go build --ldflags "-s -w \
+        -X 'github.com/kubevirt/kubevirt/version.GitCommit=$(git rev-list -1 HEAD)' \
+        -X 'github.com/kubevirt/kubevirt/version.Version=$(git describe --tags --abbrev=0)'" \
+        -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/kubevirt
+    build-snaps:
+      - go
+    build-packages:
+      - git
+      - sed


### PR DESCRIPTION
Includes snapcraft.yaml to build [snap](https://snapcraft.io/).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Provides a .yaml file to package the runtime for kubevirt as a snap. Snap makes the setup and install process easier for the end user by auto-updating to new versions or auto-rollback to previous version if the newest version breaks.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
