### PR TITLE
Add regression test for wrong pci address in VM

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1310,6 +1310,35 @@ var _ = Describe("Configurations", func() {
 
 			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress, "\\$")
 		})
+
+		It("[test_id:1020]should not create the VM with wrong PCI adress", func() {
+			By("setting disk1 Pci address")
+
+			wrongPciAddress := "0000:04:10.0"
+
+			vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress = wrongPciAddress
+			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			var vmiCondition v1.VirtualMachineInstanceCondition
+			Eventually(func() bool {
+				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				if len(vmi.Status.Conditions) > 0 {
+					for _, cond := range vmi.Status.Conditions {
+						if cond.Type == v1.VirtualMachineInstanceConditionType(v1.VirtualMachineInstanceSynchronized) && cond.Status == kubev1.ConditionFalse {
+							vmiCondition = cond
+							return true
+						}
+					}
+				}
+				return false
+			}, 120*time.Second, time.Second).Should(BeTrue())
+			Expect(vmiCondition.Message).To(ContainSubstring("Invalid PCI address " + wrongPciAddress))
+			Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
+		})
 	})
 	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", func() {
 		var nodes *kubev1.NodeList


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This tests introduces regression test, where VM creation is blocked due to wrong PCI address.

Explanation:
For PCI address "0000:YY:XX.0" where XX > 0 and YY > 0.
if XX is (0,1,2) - kubevirt will block it (Bugzilla 1645069 ).
Ff XX > 0 then libvirt will block it ( as seen in the error msg in Bug 1645069)
and then allow only one slot , only 0 when YY is > 0.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2375)
<!-- Reviewable:end -->
