### PR TITLE
Ensure that QOS  class guaranteed is indeed supported like documented

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5468,6 +5468,7 @@
      }
     }
    },
+   "v1.PodQOSClass": {},
    "v1.Port": {
     "description": "Port repesents a port to expose from the virtual machine.\nDefault protocol TCP.\nThe port field is mandatory",
     "required": [
@@ -6440,6 +6441,10 @@
      "phase": {
       "description": "Phase is the status of the VirtualMachineInstance in kubernetes world. It is not the VirtualMachineInstance status, but partially correlates to it.",
       "type": "string"
+     },
+     "qosClass": {
+      "description": "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements\nSee PodQOSClass type for available QOS classes\nMore info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n+optional",
+      "$ref": "#/definitions/v1.PodQOSClass"
      },
      "reason": {
       "description": "A brief CamelCase message indicating details about why the VMI is in this state. e.g. 'NodeUnresponsive'\n+optional",

--- a/pkg/container-disk/BUILD.bazel
+++ b/pkg/container-disk/BUILD.bazel
@@ -28,5 +28,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
     ],
 )

--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -113,7 +113,7 @@ func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, po
 			diskContainerName := fmt.Sprintf("volume%s", volume.Name)
 			diskContainerImage := volume.ContainerDisk.Image
 			resources := kubev1.ResourceRequirements{}
-			if vmi.IsCPUDedicated() {
+			if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
 				resources.Limits = make(kubev1.ResourceList)
 				// TODO(vladikr): adjust the correct cpu/mem values - this is mainly needed to allow QemuImg to run correctly
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("400m")

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -82,18 +82,23 @@ type Informers struct {
 	VMIInformer             cache.SharedIndexInformer
 }
 
+// XXX fix this, this is a huge mess. Move informers to Admitter and Mutator structs.
+var mutex sync.Mutex
+
 func GetInformers() *Informers {
-	once.Do(func() {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if webhookInformers == nil {
 		webhookInformers = newInformers()
-	})
+	}
 	return webhookInformers
 }
 
 // SetInformers created for unittest usage only
 func SetInformers(informers *Informers) {
-	once.Do(func() {
-		webhookInformers = informers
-	})
+	mutex.Lock()
+	defer mutex.Unlock()
+	webhookInformers = informers
 }
 
 func newInformers() *Informers {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -794,7 +794,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		resources := k8sv1.ResourceRequirements{}
 		// add default cpu and memory limits to enable cpu pinning if requested
 		// TODO(vladikr): make the hookSidecar express resources
-		if vmi.IsCPUDedicated() {
+		if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
 			resources.Limits = make(k8sv1.ResourceList)
 			resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("200m")
 			resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("64M")

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -294,6 +294,13 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 	case vmi.IsScheduling():
 		switch {
 		case podExists:
+			// ensure that the QOS class on the VMI matches to Pods QOS class
+			if pod.Status.QOSClass == "" {
+				vmiCopy.Status.QOSClass = nil
+			} else {
+				vmiCopy.Status.QOSClass = &pod.Status.QOSClass
+			}
+
 			// Add PodScheduled False condition to the VM
 			if cond := conditionManager.GetPodConditionWithStatus(pod, k8sv1.PodScheduled, k8sv1.ConditionFalse); cond != nil {
 				conditionManager.AddPodCondition(vmiCopy, cond)

--- a/staging/src/kubevirt.io/client-go/api/v1/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/api/v1/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -2590,6 +2590,15 @@ func (in *VirtualMachineInstanceStatus) DeepCopyInto(out *VirtualMachineInstance
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.QOSClass != nil {
+		in, out := &in.QOSClass, &out.QOSClass
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(core_v1.PodQOSClass)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -3299,6 +3299,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceStatus(ref common.
 							Format:      "",
 						},
 					},
+					"qosClass": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -46,6 +46,7 @@ func (VirtualMachineInstanceStatus) SwaggerDoc() map[string]string {
 		"interfaces":      "Interfaces represent the details of available network interfaces.",
 		"migrationState":  "Represents the status of a live migration",
 		"migrationMethod": "Represents the method using which the vmi can be migrated: live migration or block migration",
+		"qosClass":        "The Quality of Service (QOS) classification assigned to the virtual machine instance based on resource requirements\nSee PodQOSClass type for available QOS classes\nMore info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types_test.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_test.go
@@ -26,12 +26,43 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/client-go/log"
 )
 
 var _ = Describe("PodSelectors", func() {
+
+	It("should detect if VMIs want guaranteed QOS", func() {
+		vmi := NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Resources = ResourceRequirements{
+			Requests: k8sv1.ResourceList{
+				k8sv1.ResourceCPU:    resource.MustParse("1"),
+				k8sv1.ResourceMemory: resource.MustParse("64M"),
+			},
+			Limits: k8sv1.ResourceList{
+				k8sv1.ResourceCPU:    resource.MustParse("1"),
+				k8sv1.ResourceMemory: resource.MustParse("64M"),
+			},
+		}
+		Expect(vmi.WantsToHaveQOSGuaranteed()).To(BeTrue())
+	})
+
+	It("should detect if VMIs don't want guaranteed QOS", func() {
+		vmi := NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Resources = ResourceRequirements{
+			Requests: k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse("64M"),
+			},
+			Limits: k8sv1.ResourceList{
+				k8sv1.ResourceCPU:    resource.MustParse("1"),
+				k8sv1.ResourceMemory: resource.MustParse("64M"),
+			},
+		}
+		Expect(vmi.WantsToHaveQOSGuaranteed()).To(BeFalse())
+	})
+
 	Context("Pod affinity rules", func() {
 
 		It("should work", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Ensure that QOS class *guaranteed* can be achieved by setting limits and requests to identical values, also when no dedicated cpus are asked for.
 * Ensure that WOS class *guaranteed* can be achieved by only setting limits. Limits are copied to requests in this case, like it is done for pods.
 * Add tests to ensure that this behaviour will not break.
 * Add a `status.qosClass` field like it exists on pods, to make it easier to discover the qos class.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix QOS guaranteed support if VMIs without dedicated CPUs want this QOS class.
```
