### PR TITLE
KubeVirt CR's imagePullPolicy is not respected

### DIFF
--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -76,13 +76,13 @@ type InstallStrategy struct {
 	customSCCPrivileges []*customSCCPrivilegedAccounts
 }
 
-func NewInstallStrategyConfigMap(namespace string, imageTag string, imageRegistry string) (*corev1.ConfigMap, error) {
+func NewInstallStrategyConfigMap(namespace string, imageTag string, imageRegistry string, pullPolicy corev1.PullPolicy) (*corev1.ConfigMap, error) {
 
 	strategy, err := GenerateCurrentInstallStrategy(
 		namespace,
 		imageTag,
 		imageRegistry,
-		corev1.PullIfNotPresent,
+		pullPolicy,
 		"2")
 	if err != nil {
 		return nil, err
@@ -118,8 +118,9 @@ func DumpInstallStrategyToConfigMap(clientset kubecli.KubevirtClient) error {
 	if err != nil {
 		return err
 	}
+	pullPolicy := util.GetTargetImagePullPolicy()
 
-	configMap, err := NewInstallStrategyConfigMap(namespace, imageTag, imageRegistry)
+	configMap, err := NewInstallStrategyConfigMap(namespace, imageTag, imageRegistry, pullPolicy)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -542,6 +542,10 @@ func (c *KubeVirtController) generateInstallStrategyJob(kv *v1.KubeVirt) *batchv
 									Name:  util.TargetInstallNamespace,
 									Value: kv.Namespace,
 								},
+								{
+									Name:  util.TargetImagePullPolicy,
+									Value: string(pullPolicy),
+								},
 							},
 						},
 					},

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -418,7 +418,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 	addInstallStrategy := func(imageTag string, imageRegistry string) {
 		// install strategy config
-		resource, _ := installstrategy.NewInstallStrategyConfigMap(NAMESPACE, imageTag, imageRegistry)
+		resource, _ := installstrategy.NewInstallStrategyConfigMap(NAMESPACE, imageTag, imageRegistry, "IfNotPresent")
 
 		resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
 		addResource(resource, imageTag, imageRegistry)

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -24,6 +24,8 @@ import (
 	"regexp"
 	"strings"
 
+	k8sv1 "k8s.io/api/core/v1"
+
 	kvutil "kubevirt.io/kubevirt/pkg/util"
 )
 
@@ -31,11 +33,21 @@ const (
 	// Name of env var containing the operator's image name
 	OperatorImageEnvName   = "OPERATOR_IMAGE"
 	TargetInstallNamespace = "TARGET_INSTALL_NAMESPACE"
+	TargetImagePullPolicy  = "TARGET_IMAGE_PULL_POLICY"
 )
 
 type KubeVirtDeploymentConfig struct {
 	ImageRegistry string
 	ImageTag      string
+}
+
+func GetTargetImagePullPolicy() k8sv1.PullPolicy {
+	pullPolicy := os.Getenv(TargetImagePullPolicy)
+	if pullPolicy == "" {
+		return k8sv1.PullIfNotPresent
+	}
+
+	return k8sv1.PullPolicy(pullPolicy)
 }
 
 func GetTargetInstallNamespace() (string, error) {


### PR DESCRIPTION
It didn't matter what the imagePullPolicy was set to in the KubeVirt CR. It always defaulted to IfNotPresent



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Fixes respecting KubeVirt CR's imagePullPolicy option
```
