### PR TITLE
Allow setting an imagePullPolicy for containerDisks

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4267,6 +4267,10 @@
       "description": "Image is the name of the image with the embedded disk.",
       "type": "string"
      },
+     "imagePullPolicy": {
+      "description": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n+optional",
+      "type": "string"
+     },
      "imagePullSecret": {
       "description": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
       "type": "string"

--- a/pkg/api/v1/openapi_generated.go
+++ b/pkg/api/v1/openapi_generated.go
@@ -522,6 +522,13 @@ func schema_kubevirt_pkg_api_v1_ContainerDiskSource(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
+					"imagePullPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"image"},
 			},

--- a/pkg/api/v1/schema.go
+++ b/pkg/api/v1/schema.go
@@ -551,6 +551,13 @@ type ContainerDiskSource struct {
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 	// Path defines the path to disk file in the container
 	Path string `json:"path,omitempty"`
+	// Image pull policy.
+	// One of Always, Never, IfNotPresent.
+	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+	// Cannot be updated.
+	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+	// +optional
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // Exactly one of its members must be set.

--- a/pkg/api/v1/schema_swagger_generated.go
+++ b/pkg/api/v1/schema_swagger_generated.go
@@ -270,6 +270,7 @@ func (ContainerDiskSource) SwaggerDoc() map[string]string {
 		"image":           "Image is the name of the image with the embedded disk.",
 		"imagePullSecret": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
 		"path":            "Path defines the path to disk file in the container",
+		"imagePullPolicy": "Image pull policy.\nOne of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n+optional",
 	}
 }
 

--- a/pkg/container-disk/BUILD.bazel
+++ b/pkg/container-disk/BUILD.bazel
@@ -27,5 +27,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -123,7 +123,7 @@ func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, po
 			container := kubev1.Container{
 				Name:            diskContainerName,
 				Image:           diskContainerImage,
-				ImagePullPolicy: kubev1.PullIfNotPresent,
+				ImagePullPolicy: volume.ContainerDisk.ImagePullPolicy,
 				Command:         []string{"/entry-point.sh"},
 				Env: []kubev1.EnvVar{
 					{

--- a/pkg/container-disk/container-disk_test.go
+++ b/pkg/container-disk/container-disk_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v12 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/kubevirt/pkg/api/v1"
 )
@@ -92,6 +93,8 @@ var _ = Describe("ContainerDisk", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(containers)).To(Equal(2))
+				Expect(containers[0].ImagePullPolicy).To(Equal(v12.PullAlways))
+				Expect(containers[1].ImagePullPolicy).To(Equal(v12.PullAlways))
 			})
 		})
 	})
@@ -108,7 +111,8 @@ func appendContainerDisk(vmi *v1.VirtualMachineInstance, diskName string) {
 		Name: diskName,
 		VolumeSource: v1.VolumeSource{
 			ContainerDisk: &v1.ContainerDiskSource{
-				Image: "someimage:v1.2.3.4",
+				Image:           "someimage:v1.2.3.4",
+				ImagePullPolicy: v12.PullAlways,
 			},
 		},
 	})

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1266,15 +1266,24 @@ func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace st
 }
 
 func GetComputeContainerOfPod(pod *k8sv1.Pod) *k8sv1.Container {
+	return GetContainerOfPod(pod, "compute")
+}
+
+func GetContainerDiskContainerOfPod(pod *k8sv1.Pod, volumeName string) *k8sv1.Container {
+	diskContainerName := fmt.Sprintf("volume%s", volumeName)
+	return GetContainerOfPod(pod, diskContainerName)
+}
+
+func GetContainerOfPod(pod *k8sv1.Pod, containerName string) *k8sv1.Container {
 	var computeContainer *k8sv1.Container
 	for _, container := range pod.Spec.Containers {
-		if container.Name == "compute" {
+		if container.Name == containerName {
 			computeContainer = &container
 			break
 		}
 	}
 	if computeContainer == nil {
-		PanicOnError(fmt.Errorf("could not find the compute container"))
+		PanicOnError(fmt.Errorf("could not find the %s container", containerName))
 	}
 	return computeContainer
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If people use :latest or other floating tags, there is now a way to get
the updated images. KubeVirt now follows exactly the Pod behaviour:

 * `:latest` defaults to `Always`
 * No tag defaults to `Always`
 * Everything else defaults to `IfNotPresent`.

See https://kubernetes.io/docs/concepts/containers/images/ for further details.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Add `imagePullPolicy` to containerDisks and follow Pod default for ImagePullPolicy
```
