### PR TITLE
prometheus: metrics: add VMI info to labels

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -283,7 +283,7 @@ func (app *virtHandlerApp) Run() {
 		glog.Fatalf("unable to generate certificates: %v", err)
 	}
 
-	promvm.SetupCollector(app.VirtShareDir)
+	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride)
 
 	// Bootstrapping. From here on the startup order matters
 	stop := make(chan struct{})

--- a/pkg/monitoring/vms/prometheus/BUILD.bazel
+++ b/pkg/monitoring/vms/prometheus/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/monitoring/vms/prometheus",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/api/v1:go_default_library",
+        "//pkg/kubecli:go_default_library",
         "//pkg/log:go_default_library",
+        "//pkg/util/lookup:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
@@ -21,12 +24,13 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "collector_suite_test.go",
         "collector_test.go",
+        "prometheus_suite_test.go",
         "prometheus_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/api/v1:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/monitoring/vms/prometheus/collector.go
+++ b/pkg/monitoring/vms/prometheus/collector.go
@@ -23,13 +23,16 @@ import (
 	"sync"
 	"time"
 
+	k6tv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
 )
 
 const collectionTimeout time.Duration = 10 * time.Second // "long enough", crude heuristic
 
+type vmiSocketMap map[string]*k6tv1.VirtualMachineInstance
+
 type metricsScraper interface {
-	Scrape(key string)
+	Scrape(key string, vmi *k6tv1.VirtualMachineInstance)
 }
 
 type concurrentCollector struct {
@@ -43,12 +46,12 @@ func NewConcurrentCollector() *concurrentCollector {
 	}
 }
 
-func (cc *concurrentCollector) Collect(keys []string, scraper metricsScraper, timeout time.Duration) ([]string, bool) {
-	log.Log.V(3).Infof("Collecting VM metrics from %d sources", len(keys))
+func (cc *concurrentCollector) Collect(socketToVMIs vmiSocketMap, scraper metricsScraper, timeout time.Duration) ([]string, bool) {
+	log.Log.V(3).Infof("Collecting VM metrics from %d sources", len(socketToVMIs))
 	var busyScrapers sync.WaitGroup
 
 	skipped := []string{}
-	for _, key := range keys {
+	for key, vmi := range socketToVMIs {
 		reserved := cc.reserveKey(key)
 		if !reserved {
 			log.Log.Warningf("Source %s busy from a previous collection, skipped", key)
@@ -58,7 +61,7 @@ func (cc *concurrentCollector) Collect(keys []string, scraper metricsScraper, ti
 
 		log.Log.V(4).Infof("Source %s responsive, scraping", key)
 		busyScrapers.Add(1)
-		go cc.collectFromSource(key, scraper, &busyScrapers)
+		go cc.collectFromSource(scraper, &busyScrapers, key, vmi)
 	}
 
 	completed := true
@@ -80,12 +83,12 @@ func (cc *concurrentCollector) Collect(keys []string, scraper metricsScraper, ti
 	return skipped, completed
 }
 
-func (cc *concurrentCollector) collectFromSource(key string, scraper metricsScraper, wg *sync.WaitGroup) {
+func (cc *concurrentCollector) collectFromSource(scraper metricsScraper, wg *sync.WaitGroup, key string, vmi *k6tv1.VirtualMachineInstance) {
 	defer wg.Done()
 	defer cc.releaseKey(key)
 
 	log.Log.V(4).Infof("Getting stats from source %s", key)
-	scraper.Scrape(key)
+	scraper.Scrape(key, vmi)
 	log.Log.V(4).Infof("Updated stats from source %s", key)
 }
 

--- a/pkg/monitoring/vms/prometheus/prometheus_suite_test.go
+++ b/pkg/monitoring/vms/prometheus/prometheus_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCollector(t *testing.T) {
+func TestPrometheus(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Collector Suite")
+	RunSpecs(t, "Prometheus Suite")
 }

--- a/pkg/monitoring/vms/prometheus/prometheus_test.go
+++ b/pkg/monitoring/vms/prometheus/prometheus_test.go
@@ -25,13 +25,16 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	k6tv1 "kubevirt.io/kubevirt/pkg/api/v1"
 	"kubevirt.io/kubevirt/pkg/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 
-var _ = Describe("Prometheus", func() {
+var _ = BeforeSuite(func() {
 	log.Log.SetIOWriter(GinkgoWriter)
+})
 
+var _ = Describe("Prometheus", func() {
 	Context("on blocked source", func() {
 		It("should handle closed reporting socket", func() {
 			ch := make(chan prometheus.Metric)
@@ -48,7 +51,8 @@ var _ = Describe("Prometheus", func() {
 						RSSSet: true,
 					},
 				}
-				ps.Report("test", vmStats)
+				vmi := k6tv1.VirtualMachineInstance{}
+				ps.Report("test", &vmi, vmStats)
 			}
 			Expect(testReportPanic).ToNot(Panic())
 		})

--- a/pkg/util/lookup/BUILD.bazel
+++ b/pkg/util/lookup/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["lookup.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/util/lookup",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/v1:go_default_library",
+        "//pkg/kubecli:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)

--- a/pkg/util/lookup/lookup.go
+++ b/pkg/util/lookup/lookup.go
@@ -1,0 +1,33 @@
+package lookup
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	virtv1 "kubevirt.io/kubevirt/pkg/api/v1"
+	"kubevirt.io/kubevirt/pkg/kubecli"
+)
+
+func VirtualMachinesOnNode(cli kubecli.KubevirtClient, nodeName string) ([]*virtv1.VirtualMachineInstance, error) {
+	labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", virtv1.NodeNameLabel, nodeName))
+	if err != nil {
+		return nil, err
+	}
+	list, err := cli.VirtualMachineInstance(v1.NamespaceAll).List(&metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	vmis := []*virtv1.VirtualMachineInstance{}
+
+	for i := range list.Items {
+		vmis = append(vmis, &list.Items[i])
+	}
+	return vmis, nil
+}

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/log:go_default_library",
         "//pkg/service:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/lookup:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/leaderelectionconfig:go_default_library",

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -9,7 +9,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -20,6 +19,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/kubecli"
 	"kubevirt.io/kubevirt/pkg/log"
+	"kubevirt.io/kubevirt/pkg/util/lookup"
 )
 
 const (
@@ -177,7 +177,7 @@ func (c *NodeController) execute(key string) error {
 				return fmt.Errorf("failed to mark node %s as unschedulable: %v", nodeName, err)
 			}
 		}
-		vmis, err := c.virtualMachinesOnNode(nodeName)
+		vmis, err := lookup.VirtualMachinesOnNode(c.clientset, nodeName)
 		if err != nil {
 			logger.Reason(err).Error("Failed fetch vmis for node")
 			return err
@@ -221,27 +221,6 @@ func (c *NodeController) execute(key string) error {
 		c.Queue.AddAfter(key, c.recheckInterval)
 	}
 	return nil
-}
-
-func (c *NodeController) virtualMachinesOnNode(nodeName string) ([]*virtv1.VirtualMachineInstance, error) {
-	labelSelector, err := labels.Parse(fmt.Sprintf("%s in (%s)", virtv1.NodeNameLabel, nodeName))
-	if err != nil {
-		return nil, err
-	}
-	list, err := c.clientset.VirtualMachineInstance(v1.NamespaceAll).List(&metav1.ListOptions{
-		LabelSelector: labelSelector.String(),
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	vmis := []*virtv1.VirtualMachineInstance{}
-
-	for i := range list.Items {
-		vmis = append(vmis, &list.Items[i])
-	}
-	return vmis, nil
 }
 
 func (c *NodeController) alivePodsOnNode(nodeName string) ([]*v1.Pod, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Augment the prometheus labels with VMI-related info allowing the consumers of the Prometheus API to connect metrics to VMIs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirt/issues/2108

**Special notes for your reviewer**:
See discussion on the issue for design tenets of this PR

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prometheus metrics now expose node, name and namespace (maybe uid) of the Virtual Machine Instance they refer to.
```
