### PR TITLE
Use sriov network multus name from HCO for VMI example

### DIFF
--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -29,7 +29,7 @@ spec:
   - name: default
     pod: {}
   - multus:
-      networkName: sriov-net
+      networkName: sriov/sriov-network
     name: sriov-net
   terminationGracePeriodSeconds: 0
   volumes:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -355,7 +355,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vm := getBaseVMI(VmiSRIOV)
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
-	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "sriov-net"}}}}
+	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "sriov/sriov-network"}}}}
 	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
 


### PR DESCRIPTION
While there is no canonical name for the network, it seems like a
better choice to use the name of the network that is produced by
hyperconverged operator (HCO) that is also maintained by kubevirt
org. This allows to apply the example VMI manifest to a cluster deployed
with HCO without any changes. (Except perhaps the image registry.)

```release-note
NONE
```