### PR TITLE
Don't allow live migration with a bridge interface

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -125,11 +125,11 @@ func (mutator *VMIsMutator) setDefaultNetworkInterface(obj *v1.VirtualMachineIns
 	if len(obj.Spec.Networks) == 0 {
 		iface := mutator.ClusterConfig.GetDefaultNetworkInterface()
 		switch iface {
-		case "bridge":
+		case v1.BridgeInterface:
 			obj.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-		case "masquerade":
+		case v1.MasqueradeInterface:
 			obj.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-		case "slirp":
+		case v1.SlirpInterface:
 			defaultIface := v1.DefaultSlirpNetworkInterface()
 			if mutator.ClusterConfig.IsSlirpInterfaceDisabled() {
 				defaultIface = v1.DefaultMasqueradeNetworkInterface()

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -341,19 +341,17 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 	table.DescribeTable("should set default network interface",
 		func(iface string) {
 			expectedIface := "bridge"
-			disableSlirp := "true"
 			switch iface {
-			case "masquerade", "disableSlirp":
+			case "masquerade":
 				expectedIface = "masquerade"
 			case "slirp":
-				disableSlirp = "false"
 				expectedIface = "slirp"
 			}
 
 			testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
 				Data: map[string]string{
-					virtconfig.NetworkInterfaceKey: expectedIface,
-					virtconfig.DisableSlirp:        disableSlirp,
+					virtconfig.NetworkInterfaceKey:  expectedIface,
+					virtconfig.PermitSlirpInterface: "true",
 				},
 			})
 
@@ -361,7 +359,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			switch expectedIface {
 			case "bridge":
 				Expect(vmiSpec.Domain.Devices.Interfaces[0].Bridge).NotTo(BeNil())
-			case "masquerade", "disableSlirp":
+			case "masquerade":
 				Expect(vmiSpec.Domain.Devices.Interfaces[0].Masquerade).NotTo(BeNil())
 			case "slirp":
 				Expect(vmiSpec.Domain.Devices.Interfaces[0].Slirp).NotTo(BeNil())
@@ -370,7 +368,6 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		table.Entry("as bridge", "bridge"),
 		table.Entry("as masquerade", "masquerade"),
 		table.Entry("as slirp", "slirp"),
-		table.Entry("as masquerade when slirp is disabled", "disableSlirp"),
 	)
 	It("should not override specified properties with defaults on VMI create", func() {
 		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -338,6 +338,40 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		),
 	)
 
+	table.DescribeTable("should set default network interface",
+		func(iface string) {
+			expectedIface := "bridge"
+			disableSlirp := "true"
+			switch iface {
+			case "masquerade", "disableSlirp":
+				expectedIface = "masquerade"
+			case "slirp":
+				disableSlirp = "false"
+				expectedIface = "slirp"
+			}
+
+			testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
+				Data: map[string]string{
+					virtconfig.NetworkInterfaceKey: expectedIface,
+					virtconfig.DisableSlirp:        disableSlirp,
+				},
+			})
+
+			vmiSpec, _ := getVMISpecMetaFromResponse()
+			switch expectedIface {
+			case "bridge":
+				Expect(vmiSpec.Domain.Devices.Interfaces[0].Bridge).NotTo(BeNil())
+			case "masquerade", "disableSlirp":
+				Expect(vmiSpec.Domain.Devices.Interfaces[0].Masquerade).NotTo(BeNil())
+			case "slirp":
+				Expect(vmiSpec.Domain.Devices.Interfaces[0].Slirp).NotTo(BeNil())
+			}
+		},
+		table.Entry("as bridge", "bridge"),
+		table.Entry("as masquerade", "masquerade"),
+		table.Entry("as slirp", "slirp"),
+		table.Entry("as masquerade when slirp is disabled", "disableSlirp"),
+	)
 	It("should not override specified properties with defaults on VMI create", func() {
 		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
 			Data: map[string]string{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -619,7 +619,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					Message: fmt.Sprintf("Slirp interface only implemented with pod network"),
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
-			} else if iface.Slirp != nil && networkData.Pod != nil && config.IsSlirpInterfaceDisabled() {
+			} else if iface.Slirp != nil && networkData.Pod != nil && !config.IsSlirpInterfaceEnabled() {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: fmt.Sprintf("Slirp interface is not enabled in kubevirt-config"),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -619,6 +619,12 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					Message: fmt.Sprintf("Slirp interface only implemented with pod network"),
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
+			} else if iface.Slirp != nil && networkData.Pod != nil && config.IsSlirpInterfaceDisabled() {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("Slirp interface is not enabled in kubevirt-config"),
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+				})
 			} else if iface.Masquerade != nil && networkData.Pod == nil {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	}
 	enableSlirpInterface := func() {
 		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
-			Data: map[string]string{virtconfig.DisableSlirp: "false"},
+			Data: map[string]string{virtconfig.PermitSlirpInterface: "true"},
 		})
 	}
 

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/cache"
 
-	"kubevirt.io/client-go/api/v1"
+	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -54,7 +54,7 @@ const (
 	LessPVCSpaceTolerationKey = "pvc-tolerate-less-space-up-to-percent"
 	NodeSelectorsKey          = "node-selectors"
 	NetworkInterfaceKey       = "default-network-interface"
-	DisableSlirp              = "disableSlirp"
+	PermitSlirpInterface      = "permitSlirpInterface"
 
 	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
 	ParallelMigrationsPerClusterDefault      uint32 = 5
@@ -156,7 +156,7 @@ func defaultClusterConfig() *Config {
 		LessPVCSpaceToleration: DefaultLessPVCSpaceToleration,
 		NodeSelectors:          nodeSelectorsDefault,
 		NetworkInterface:       defaultNetworkInterface,
-		DisableSlirpInterface:  true,
+		PermitSlirpInterface:   false,
 	}
 }
 
@@ -174,7 +174,7 @@ type Config struct {
 	LessPVCSpaceToleration int
 	NodeSelectors          map[string]string
 	NetworkInterface       string
-	DisableSlirpInterface  bool
+	PermitSlirpInterface   bool
 }
 
 type MigrationConfig struct {
@@ -240,8 +240,8 @@ func (c *ClusterConfig) GetDefaultNetworkInterface() string {
 	return c.getConfig().NetworkInterface
 }
 
-func (c *ClusterConfig) IsSlirpInterfaceDisabled() bool {
-	return c.getConfig().DisableSlirpInterface
+func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {
+	return c.getConfig().PermitSlirpInterface
 }
 
 // setConfig parses the provided config map and updates the provided config.
@@ -339,16 +339,16 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	}
 
 	// disable slirp
-	disableSlirp := strings.TrimSpace(configMap.Data[DisableSlirp])
-	switch disableSlirp {
+	permitSlirp := strings.TrimSpace(configMap.Data[PermitSlirpInterface])
+	switch permitSlirp {
 	case "":
 		// keep the default
 	case "true":
-		config.DisableSlirpInterface = true
+		config.PermitSlirpInterface = true
 	case "false":
-		config.DisableSlirpInterface = false
+		config.PermitSlirpInterface = false
 	default:
-		return fmt.Errorf("invalid value for disableSlirp in config: %v", disableSlirp)
+		return fmt.Errorf("invalid value for permitSlirpInterfaces in config: %v", permitSlirp)
 	}
 
 	// set default network interface

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/cache"
 
+	"kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -355,7 +356,7 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	switch iface {
 	case "":
 		// keep the default
-	case "bridge", "slirp", "masquerade":
+	case string(v1.BridgeInterface), string(v1.SlirpInterface), string(v1.MasqueradeInterface):
 		config.NetworkInterface = iface
 	default:
 		return fmt.Errorf("invalid default-network-interface in config: %v", iface)

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -39,16 +39,16 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when invalid, it should return the default", "invalid", false),
 	)
 
-	table.DescribeTable(" when disableSlirp", func(value string, result bool) {
+	table.DescribeTable(" when permitSlirpInterface", func(value string, result bool) {
 		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
-			Data: map[string]string{"disableSlirp": value},
+			Data: map[string]string{"permitSlirpInterface": value},
 		})
-		Expect(clusterConfig.IsSlirpInterfaceDisabled()).To(Equal(result))
+		Expect(clusterConfig.IsSlirpInterfaceEnabled()).To(Equal(result))
 	},
 		table.Entry("is true, it should return true", "true", true),
 		table.Entry("is false, it should return false", "false", false),
-		table.Entry("when unset, it should return false", "", true),
-		table.Entry("when invalid, it should return the default", "invalid", true),
+		table.Entry("when unset, it should return false", "", false),
+		table.Entry("when invalid, it should return the default", "invalid", false),
 	)
 
 	table.DescribeTable(" when imagePullPolicy", func(value string, result kubev1.PullPolicy) {

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -39,6 +39,18 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when invalid, it should return the default", "invalid", false),
 	)
 
+	table.DescribeTable(" when disableSlirp", func(value string, result bool) {
+		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{"disableSlirp": value},
+		})
+		Expect(clusterConfig.IsSlirpInterfaceDisabled()).To(Equal(result))
+	},
+		table.Entry("is true, it should return true", "true", true),
+		table.Entry("is false, it should return false", "false", false),
+		table.Entry("when unset, it should return false", "", true),
+		table.Entry("when invalid, it should return the default", "invalid", true),
+	)
+
 	table.DescribeTable(" when imagePullPolicy", func(value string, result kubev1.PullPolicy) {
 		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.ImagePullPolicyKey: value},
@@ -61,6 +73,19 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("is set, it should return correct value", "5", 5),
 		table.Entry("is unset, it should return the default", "", virtconfig.DefaultLessPVCSpaceToleration),
 		table.Entry("is invalid, it should return the default", "-1", virtconfig.DefaultLessPVCSpaceToleration),
+	)
+
+	table.DescribeTable(" when defaultNetworkInterface", func(value string, result string) {
+		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{virtconfig.NetworkInterfaceKey: value},
+		})
+		Expect(clusterConfig.GetDefaultNetworkInterface()).To(Equal(result))
+	},
+		table.Entry("is bridge, it should return bridge", "bridge", "bridge"),
+		table.Entry("is slirp, it should return slirp", "slirp", "slirp"),
+		table.Entry("is masquerade, it should return masquerade", "masquerade", "masquerade"),
+		table.Entry("when unset, it should return the default", "", "bridge"),
+		table.Entry("when invalid, it should return the default", "invalid", "bridge"),
 	)
 
 	nodeSelectorsStr := "kubernetes.io/hostname=node02\nnode-role.kubernetes.io/compute=true\n"

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -353,7 +353,7 @@ var _ = Describe("Converter", func() {
 			}
 
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 
 			vmi.Spec.Domain.Firmware = &v1.Firmware{
 				UUID:   "e4686d2c-6e8d-4335-b8fd-81bee22f4814",
@@ -932,7 +932,7 @@ var _ = Describe("Converter", func() {
 		It("should fail to convert if non network source are present", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			name := "otherName"
-			iface := v1.DefaultNetworkInterface()
+			iface := v1.DefaultBridgeNetworkInterface()
 			net := v1.DefaultPodNetwork()
 			iface.Name = name
 			net.Name = name
@@ -1000,7 +1000,7 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			name1 := "Name"
 
-			iface1 := v1.DefaultNetworkInterface()
+			iface1 := v1.DefaultBridgeNetworkInterface()
 			iface1.Name = name1
 			net1 := v1.DefaultPodNetwork()
 			net1.Name = name1
@@ -1026,9 +1026,9 @@ var _ = Describe("Converter", func() {
 		It("Should set domain interface source correctly for multus", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultNetworkInterface(),
-				*v1.DefaultNetworkInterface(),
-				*v1.DefaultNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
 			}
 			vmi.Spec.Domain.Devices.Interfaces[0].Name = "red1"
 			vmi.Spec.Domain.Devices.Interfaces[1].Name = "red2"
@@ -1064,8 +1064,8 @@ var _ = Describe("Converter", func() {
 		It("Should set domain interface source correctly for default multus", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultNetworkInterface(),
-				*v1.DefaultNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
 			}
 			vmi.Spec.Domain.Devices.Interfaces[0].Name = "red1"
 			vmi.Spec.Domain.Devices.Interfaces[1].Name = "red2"
@@ -1093,8 +1093,8 @@ var _ = Describe("Converter", func() {
 		It("Should set domain interface source correctly for genie", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				*v1.DefaultNetworkInterface(),
-				*v1.DefaultNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
+				*v1.DefaultBridgeNetworkInterface(),
 			}
 			vmi.Spec.Domain.Devices.Interfaces[0].Name = "red1"
 			vmi.Spec.Domain.Devices.Interfaces[1].Name = "red2"
@@ -1123,8 +1123,8 @@ var _ = Describe("Converter", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			name1 := "Name1"
 			name2 := "Name2"
-			iface1 := v1.DefaultNetworkInterface()
-			iface2 := v1.DefaultNetworkInterface()
+			iface1 := v1.DefaultBridgeNetworkInterface()
+			iface2 := v1.DefaultBridgeNetworkInterface()
 			net1 := v1.DefaultPodNetwork()
 			net2 := v1.DefaultPodNetwork()
 			iface1.Name = name1
@@ -1168,7 +1168,7 @@ var _ = Describe("Converter", func() {
 			net1 := v1.DefaultPodNetwork()
 			net1.Name = name1
 
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface1, *v1.DefaultNetworkInterface()}
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{iface1, *v1.DefaultBridgeNetworkInterface()}
 			vmi.Spec.Domain.Devices.Interfaces[1].Name = "red1"
 
 			vmi.Spec.Networks = []v1.Network{*net1,
@@ -1557,6 +1557,8 @@ var _ = Describe("Converter", func() {
 				},
 			}
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = True()
 			vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
@@ -1589,6 +1591,8 @@ var _ = Describe("Converter", func() {
 			},
 		}
 		v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+		vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 
 		sriovInterface := v1.Interface{
 			Name: "sriov",

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Network", func() {
 			domain := &api.Domain{}
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 			api.SetObjectDefaults_Domain(domain)
-			iface := v1.DefaultNetworkInterface()
+			iface := v1.DefaultBridgeNetworkInterface()
 			defaultNet := v1.DefaultPodNetwork()
 
 			mockNetworkInterface.EXPECT().Plug(vm, iface, defaultNet, domain, podInterface)
@@ -69,7 +69,7 @@ var _ = Describe("Network", func() {
 			domain := &api.Domain{}
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 			api.SetObjectDefaults_Domain(domain)
-			iface := v1.DefaultNetworkInterface()
+			iface := v1.DefaultBridgeNetworkInterface()
 			cniNet := &v1.Network{
 				Name: "default",
 				NetworkSource: v1.NetworkSource{
@@ -149,7 +149,7 @@ var _ = Describe("Network", func() {
 			domain := &api.Domain{}
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 			api.SetObjectDefaults_Domain(domain)
-			iface := v1.DefaultNetworkInterface()
+			iface := v1.DefaultBridgeNetworkInterface()
 			cniNet := &v1.Network{
 				Name: "default",
 				NetworkSource: v1.NetworkSource{

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -496,7 +496,7 @@ func newVMI(namespace, name string) *v1.VirtualMachineInstance {
 
 func newVMIBridgeInterface(namespace string, name string) *v1.VirtualMachineInstance {
 	vmi := newVMI(namespace, name)
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/defaults.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/defaults.go
@@ -117,7 +117,6 @@ func SetDefaults_VirtualMachineInstance(obj *VirtualMachineInstance) {
 	}
 
 	setDefaults_Disk(obj)
-	SetDefaults_NetworkInterface(obj)
 }
 
 func setDefaults_Disk(obj *VirtualMachineInstance) {
@@ -151,12 +150,12 @@ func SetDefaults_NetworkInterface(obj *VirtualMachineInstance) {
 
 	// Override only when nothing is specified
 	if len(obj.Spec.Networks) == 0 {
-		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultNetworkInterface()}
+		obj.Spec.Domain.Devices.Interfaces = []Interface{*DefaultBridgeNetworkInterface()}
 		obj.Spec.Networks = []Network{*DefaultPodNetwork()}
 	}
 }
 
-func DefaultNetworkInterface() *Interface {
+func DefaultBridgeNetworkInterface() *Interface {
 	iface := &Interface{
 		Name: "default",
 		InterfaceBindingMethod: InterfaceBindingMethod{
@@ -171,6 +170,16 @@ func DefaultSlirpNetworkInterface() *Interface {
 		Name: "default",
 		InterfaceBindingMethod: InterfaceBindingMethod{
 			Slirp: &InterfaceSlirp{},
+		},
+	}
+	return iface
+}
+
+func DefaultMasqueradeNetworkInterface() *Interface {
+	iface := &Interface{
+		Name: "default",
+		InterfaceBindingMethod: InterfaceBindingMethod{
+			Masquerade: &InterfaceMasquerade{},
 		},
 	}
 	return iface

--- a/staging/src/kubevirt.io/client-go/api/v1/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/defaults_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Defaults", func() {
 
 	It("should add interface and pod network by default", func() {
 		vmi := &VirtualMachineInstance{}
-		SetObjectDefaults_VirtualMachineInstance(vmi)
+		SetDefaults_NetworkInterface(vmi)
 		Expect(len(vmi.Spec.Domain.Devices.Interfaces)).NotTo(BeZero())
 		Expect(len(vmi.Spec.Networks)).NotTo(BeZero())
 	})

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -314,6 +314,8 @@ const (
 	VirtualMachineInstanceIsMigratable VirtualMachineInstanceConditionType = "LiveMigratable"
 	// Reason means that VMI is not live migratioable because of it's disks collection
 	VirtualMachineInstanceReasonDisksNotMigratable = "DisksNotLiveMigratable"
+	// Reason means that VMI is not live migratioable because of it's network interfaces collection
+	VirtualMachineInstanceReasonInterfaceNotMigratable = "InterfaceNotLiveMigratable"
 )
 
 // +k8s:openapi-gen=true

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1074,6 +1074,19 @@ const (
 
 // ---
 // +k8s:openapi-gen=true
+type NetworkInterfaceType string
+
+const (
+	// Virtual machine instance bride interface
+	BridgeInterface NetworkInterfaceType = "bridge"
+	// Virtual machine instance slirp interface
+	SlirpInterface NetworkInterfaceType = "slirp"
+	// Virtual machine instance masquerade interface
+	MasqueradeInterface NetworkInterfaceType = "masquerade"
+)
+
+// ---
+// +k8s:openapi-gen=true
 type DriverCache string
 
 const (

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2060,7 +2060,7 @@ func NewRandomVMIWithMasqueradeInterfaceEphemeralDiskAndUserdata(containerImage 
 }
 
 func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultNetworkInterface()}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 }
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -465,6 +465,10 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
+			tests.UpdateClusterConfigValue("permitSlirpInterface", "true")
+		})
+		AfterEach(func() {
+			tests.UpdateClusterConfigValue("permitSlirpInterface", "false")
 		})
 
 		It("[test_id:1773]should configure custom MAC address", func() {

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -499,7 +499,7 @@ func GetVMIWindows() *v1.VirtualMachineInstance {
 				},
 			},
 			Devices: v1.Devices{
-				Interfaces: []v1.Interface{*v1.DefaultNetworkInterface()},
+				Interfaces: []v1.Interface{*v1.DefaultBridgeNetworkInterface()},
 			},
 		},
 		Networks: []v1.Network{*v1.DefaultPodNetwork()},

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -47,8 +47,8 @@ func main() {
 	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
 		Data: map[string]string{
 			// Required to validate DataVolume usage
-			virtconfig.FeatureGatesKey: "DataVolumes,LiveMigration,SRIOV",
-			virtconfig.DisableSlirp:    "false",
+			virtconfig.FeatureGatesKey:      "DataVolumes,LiveMigration,SRIOV",
+			virtconfig.PermitSlirpInterface: "true",
 		},
 	})
 

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -48,6 +48,7 @@ func main() {
 		Data: map[string]string{
 			// Required to validate DataVolume usage
 			virtconfig.FeatureGatesKey: "DataVolumes,LiveMigration,SRIOV",
+			virtconfig.DisableSlirp:    "false",
 		},
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents VMIs with a bridge interface connected to a pod network from live migrating.
It also allows setting the default network interface for the pod network in the kubevirt-config.

Slirp interface can also be disabled in the kubevirt-config

**Release note**:
```release-note
NONE
```
