### PR TITLE
Tunable guest management overhead

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5583,15 +5583,15 @@
    "v1.ResourceRequirements": {
     "properties": {
      "limits": {
-      "description": "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+      "description": "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
       "type": "object"
      },
      "overcommitGuestOverhead": {
-      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
+      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.\nDeprecated: set requests.memory-overhead to 0 instead.",
       "type": "boolean"
      },
      "requests": {
-      "description": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
+      "description": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
       "type": "object"
      }
     }

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5590,6 +5590,10 @@
       "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.\nDeprecated: set requests.memory-overhead to 0 instead.",
       "type": "boolean"
      },
+     "platformMemoryOverhead": {
+      "description": "KubevirtMemoryOverhead describes the memory overhead that results from the libraries\nand other dependencies used by the Kubevirt platform. It applies when \"memory-overhead\"\nis not specified as part of Limits and therefore determined by the system.\nIf omitted, the cluster-level setting applies.\n+optional",
+      "type": "string"
+     },
      "requests": {
       "description": "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
       "type": "object"

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -235,6 +235,17 @@ func (mutator *VMIsMutator) setDefaultResourceRequests(vmi *v1.VirtualMachineIns
 		}
 	}
 
+	if _, exists := resources.Requests[v1.ResourceMemoryOverhead]; !exists {
+		if resources.Requests == nil {
+			resources.Requests = k8sv1.ResourceList{}
+		}
+		if vmi.Spec.Domain.Resources.OvercommitGuestOverhead {
+			resources.Requests[v1.ResourceMemoryOverhead] = resource.MustParse("0")
+		} else {
+			resources.Requests[v1.ResourceMemoryOverhead] = resources.Limits[v1.ResourceMemoryOverhead]
+		}
+	}
+
 	if _, exists := resources.Requests[k8sv1.ResourceCPU]; !exists {
 		if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.DedicatedCPUPlacement {
 			return

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -288,7 +288,11 @@ func (mutator *VMIsMutator) getMemoryOverhead(vmi *v1.VirtualMachineInstance) *r
 	overhead.Add(*pagetableMemory)
 
 	// Add fixed overhead for shared libraries and such
-	overhead.Add(mutator.ClusterConfig.GetKubevirtMemoryOverhead())
+	if vmiPlatformOverhead := domain.Resources.KubevirtMemoryOverhead; vmiPlatformOverhead != nil {
+		overhead.Add(*vmiPlatformOverhead)
+	} else {
+		overhead.Add(mutator.ClusterConfig.GetKubevirtMemoryOverhead())
+	}
 
 	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
 	// overhead per vcpu in MiB

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -56,6 +56,7 @@ const (
 	NetworkInterfaceKey       = "default-network-interface"
 	PermitSlirpInterface      = "permitSlirpInterface"
 	NodeDrainTaintDefaultKey  = "kubevirt.io/drain"
+	KubevirtMemoryOverheadKey = "platform-memory-overhead"
 )
 
 func getConfigMap() *k8sv1.ConfigMap {
@@ -123,6 +124,7 @@ func defaultClusterConfig() *Config {
 	emulatedMachinesDefault := strings.Split(DefaultEmulatedMachines, ",")
 	nodeSelectorsDefault, _ := parseNodeSelectors(DefaultNodeSelectors)
 	defaultNetworkInterface := DefaultNetworkInterface
+	kubevirtMemoryOverheadDefault := resource.MustParse(DefaultKubevirtMemoryOverhead)
 	return &Config{
 		ResourceVersion: "0",
 		ImagePullPolicy: DefaultImagePullPolicy,
@@ -145,6 +147,7 @@ func defaultClusterConfig() *Config {
 		NodeSelectors:          nodeSelectorsDefault,
 		NetworkInterface:       defaultNetworkInterface,
 		PermitSlirpInterface:   DefaultPermitSlirpInterface,
+		KubevirtMemoryOverhead: kubevirtMemoryOverheadDefault,
 	}
 }
 
@@ -163,6 +166,7 @@ type Config struct {
 	NodeSelectors          map[string]string
 	NetworkInterface       string
 	PermitSlirpInterface   bool
+	KubevirtMemoryOverhead resource.Quantity
 }
 
 type MigrationConfig struct {
@@ -302,6 +306,11 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	default:
 		return fmt.Errorf("invalid default-network-interface in config: %v", iface)
 	}
+
+	if kubevirtMemoryOverhead := strings.TrimSpace(configMap.Data[KubevirtMemoryOverheadKey]); kubevirtMemoryOverhead != "" {
+		config.KubevirtMemoryOverhead = resource.MustParse(kubevirtMemoryOverhead)
+	}
+
 	return nil
 }
 

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -135,6 +135,17 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when unset, it should return the default", "", virtconfig.DefaultCPURequest),
 	)
 
+	table.DescribeTable(" when kubevirtMemoryOverhead", func(value string, result string) {
+		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{virtconfig.KubevirtMemoryOverheadKey: value},
+		})
+		memoryOverhead := clusterConfig.GetKubevirtMemoryOverhead()
+		Expect(memoryOverhead.String()).To(Equal(result))
+	},
+		table.Entry("when set, it should return the value", "512Mi", "512Mi"),
+		table.Entry("when unset, it should return the default", "", virtconfig.DefaultKubevirtMemoryOverhead),
+	)
+
 	table.DescribeTable(" when memoryOvercommit", func(value string, result int) {
 		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MemoryOvercommitKey: value},

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -46,6 +46,7 @@ const (
 	DefaultUseEmulation                             = false
 	DefaultUnsafeMigrationOverride                  = false
 	DefaultPermitSlirpInterface                     = false
+	DefaultKubevirtMemoryOverhead                   = "128M" // TODO account for the overhead of kubevirt components running in the pod
 )
 
 func (c *ClusterConfig) IsUseEmulation() bool {
@@ -94,4 +95,8 @@ func (c *ClusterConfig) GetDefaultNetworkInterface() string {
 
 func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {
 	return c.getConfig().PermitSlirpInterface
+}
+
+func (c *ClusterConfig) GetKubevirtMemoryOverhead() resource.Quantity {
+	return c.getConfig().KubevirtMemoryOverhead
 }

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["template.go"],
+    srcs = [
+        "template.go",
+        "utils.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-controller/services",
     visibility = ["//visibility:public"],
     deps = [
@@ -21,6 +24,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -571,11 +571,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 	} else {
 		// Add overhead memory
-		if memoryRequest, ok := resources.Requests[k8sv1.ResourceMemory]; ok {
-			memoryOverheadRequest := vmiResources.Requests[v1.ResourceMemoryOverhead]
-			memoryRequest.Add(memoryOverheadRequest)
-			resources.Requests[k8sv1.ResourceMemory] = memoryRequest
-		}
+		memoryRequest := resources.Requests[k8sv1.ResourceMemory]
+		memoryOverheadRequest := vmiResources.Requests[v1.ResourceMemoryOverhead]
+		memoryRequest.Add(memoryOverheadRequest)
+		resources.Requests[k8sv1.ResourceMemory] = memoryRequest
 
 		if memoryLimit, ok := resources.Limits[k8sv1.ResourceMemory]; ok {
 			memoryOverheadLimit := vmiResources.Limits[v1.ResourceMemoryOverhead]

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -818,11 +818,12 @@ var _ = Describe("Template", func() {
 							CPU: &v1.CPU{Cores: 3},
 							Resources: v1.ResourceRequirements{
 								Requests: kubev1.ResourceList{
-									kubev1.ResourceCPU:    resource.MustParse("1m"),
-									kubev1.ResourceMemory: resource.MustParse("64M"),
+									kubev1.ResourceCPU:        resource.MustParse("1m"),
+									kubev1.ResourceMemory:     resource.MustParse("64M"),
+									v1.ResourceMemoryOverhead: resource.MustParse("179M"),
 								},
 								Limits: kubev1.ResourceList{
-									v1.ResourceMemoryOverhead: resource.MustParse("178331648"),
+									v1.ResourceMemoryOverhead: resource.MustParse("179M"),
 								},
 							},
 						},
@@ -858,7 +859,8 @@ var _ = Describe("Template", func() {
 							},
 							Resources: v1.ResourceRequirements{
 								Requests: kubev1.ResourceList{
-									kubev1.ResourceMemory: resource.MustParse("64M"),
+									kubev1.ResourceMemory:     resource.MustParse("64M"),
+									v1.ResourceMemoryOverhead: resource.MustParse("162M"),
 								},
 								Limits: kubev1.ResourceList{
 									kubev1.ResourceMemory:     resource.MustParse("64M"),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -786,12 +786,13 @@ var _ = Describe("Template", func() {
 					Spec: v1.VirtualMachineInstanceSpec{
 						Domain: v1.DomainSpec{
 							Resources: v1.ResourceRequirements{
-								OvercommitGuestOverhead: true,
 								Requests: kubev1.ResourceList{
-									kubev1.ResourceMemory: resource.MustParse("1G"),
+									kubev1.ResourceMemory:     resource.MustParse("1G"),
+									v1.ResourceMemoryOverhead: resource.MustParse("0"),
 								},
 								Limits: kubev1.ResourceList{
-									kubev1.ResourceMemory: resource.MustParse("2G"),
+									kubev1.ResourceMemory:     resource.MustParse("2G"),
+									v1.ResourceMemoryOverhead: resource.MustParse("0"),
 								},
 							},
 						},

--- a/pkg/virt-controller/services/utils.go
+++ b/pkg/virt-controller/services/utils.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017, 2018 Red Hat, Inc.
+ *
+ */
+
+package services
+
+// TODO: use helpers that exist in kubernetes for this
+
+import (
+	"strings"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var standardContainerResources = sets.NewString(
+	string(k8sv1.ResourceCPU),
+	string(k8sv1.ResourceMemory),
+	string(k8sv1.ResourceEphemeralStorage),
+)
+
+// IsStandardContainerResourceName returns true if the container can make a resource request
+// for the specified resource
+func IsStandardContainerResourceName(str string) bool {
+	return standardContainerResources.Has(str) || IsHugePageResourceName(k8sv1.ResourceName(str))
+}
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name k8sv1.ResourceName) bool {
+	return strings.HasPrefix(string(name), k8sv1.ResourceHugePagesPrefix)
+}

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -1784,6 +1784,15 @@ func (in *ResourceRequirements) DeepCopyInto(out *ResourceRequirements) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.KubevirtMemoryOverhead != nil {
+		in, out := &in.KubevirtMemoryOverhead, &out.KubevirtMemoryOverhead
+		if *in == nil {
+			*out = nil
+		} else {
+			x := (*in).DeepCopy()
+			*out = &x
+		}
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -2148,7 +2148,7 @@ func schema_kubevirtio_client_go_api_v1_ResourceRequirements(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"requests": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
+							Description: "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
@@ -2161,7 +2161,7 @@ func schema_kubevirtio_client_go_api_v1_ResourceRequirements(ref common.Referenc
 					},
 					"limits": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
+							Description: "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
@@ -2174,7 +2174,7 @@ func schema_kubevirtio_client_go_api_v1_ResourceRequirements(ref common.Referenc
 					},
 					"overcommitGuestOverhead": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
+							Description: "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false. Deprecated: set requests.memory-overhead to 0 instead.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -2179,6 +2179,12 @@ func schema_kubevirtio_client_go_api_v1_ResourceRequirements(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"platformMemoryOverhead": {
+						SchemaProps: spec.SchemaProps{
+							Description: "KubevirtMemoryOverhead describes the memory overhead that results from the libraries and other dependencies used by the Kubevirt platform. It applies when \"memory-overhead\" is not specified as part of Limits and therefore determined by the system. If omitted, the cluster-level setting applies.",
+							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -201,16 +201,17 @@ type EFI struct {
 // +k8s:openapi-gen=true
 type ResourceRequirements struct {
 	// Requests is a description of the initial vmi resources.
-	// Valid resource keys are "memory" and "cpu".
+	// Valid resource keys are "memory", "memory-overhead" and "cpu".
 	// +optional
 	Requests v1.ResourceList `json:"requests,omitempty"`
 	// Limits describes the maximum amount of compute resources allowed.
-	// Valid resource keys are "memory" and "cpu".
+	// Valid resource keys are "memory", "memory-overhead" and "cpu".
 	// +optional
 	Limits v1.ResourceList `json:"limits,omitempty"`
 	// Don't ask the scheduler to take the guest-management overhead into account. Instead
 	// put the overhead only into the container's memory limit. This can lead to crashes if
 	// all memory is in use on a node. Defaults to false.
+	// Deprecated: set requests.memory-overhead to 0 instead.
 	OvercommitGuestOverhead bool `json:"overcommitGuestOverhead,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -213,6 +213,12 @@ type ResourceRequirements struct {
 	// all memory is in use on a node. Defaults to false.
 	// Deprecated: set requests.memory-overhead to 0 instead.
 	OvercommitGuestOverhead bool `json:"overcommitGuestOverhead,omitempty"`
+	// KubevirtMemoryOverhead describes the memory overhead that results from the libraries
+	// and other dependencies used by the Kubevirt platform. It applies when "memory-overhead"
+	// is not specified as part of Limits and therefore determined by the system.
+	// If omitted, the cluster-level setting applies.
+	// +optional
+	KubevirtMemoryOverhead *resource.Quantity `json:"platformMemoryOverhead,omitempty"`
 }
 
 // CPU allows specifying the CPU topology.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -97,6 +97,7 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 		"requests":                "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
 		"limits":                  "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
 		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.\nDeprecated: set requests.memory-overhead to 0 instead.",
+		"platformMemoryOverhead":  "KubevirtMemoryOverhead describes the memory overhead that results from the libraries\nand other dependencies used by the Kubevirt platform. It applies when \"memory-overhead\"\nis not specified as part of Limits and therefore determined by the system.\nIf omitted, the cluster-level setting applies.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -94,9 +94,9 @@ func (EFI) SwaggerDoc() map[string]string {
 
 func (ResourceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"requests":                "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
-		"limits":                  "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
-		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
+		"requests":                "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
+		"limits":                  "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\", \"memory-overhead\" and \"cpu\".\n+optional",
+		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.\nDeprecated: set requests.memory-overhead to 0 instead.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -49,6 +49,8 @@ import (
 const GroupName = "kubevirt.io"
 const SubresourceGroupName = "subresources.kubevirt.io"
 
+const ResourceMemoryOverhead k8sv1.ResourceName = "memory-overhead"
+
 const DefaultGracePeriodSeconds int64 = 30
 
 // GroupVersion is group version used to register these objects

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -448,7 +448,7 @@ var _ = Describe("Configurations", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				guestMemory := resource.MustParse("256Mi")
 				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64Mi")
-				vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+				vmi.Spec.Domain.Resources.Requests[v1.ResourceMemoryOverhead] = resource.MustParse("0")
 				vmi.Spec.Domain.Memory = &v1.Memory{
 					Guest: &guestMemory,
 				}
@@ -490,7 +490,7 @@ var _ = Describe("Configurations", func() {
 		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test", func() {
 			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("128M")
-			vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+			vmi.Spec.Domain.Resources.Requests[v1.ResourceMemoryOverhead] = resource.MustParse("0")
 
 			// Create VMI inside BeforeEach because it gets cleanedup, see BeforeEach at the top
 			BeforeEach(func() {
@@ -507,7 +507,8 @@ var _ = Describe("Configurations", func() {
 			It("[test_id:731]Check OverCommit status on VMI", func() {
 				overcommitVmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(overcommitVmi.Spec.Domain.Resources.OvercommitGuestOverhead).To(BeTrue())
+				memoryOverhead := overcommitVmi.Spec.Domain.Resources.Requests[v1.ResourceMemoryOverhead]
+				Expect(memoryOverhead.Value()).To(BeZero())
 			})
 			It("[test_id:731]Check Free memory on the VMI", func() {
 				By("Expecting console")

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -71,9 +71,9 @@ var _ = Describe("[rfe_id:609]VMIheadless", func() {
 			It("[test_id:737][posneg:positive]should match memory with overcommit enabled", func() {
 				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
 					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("100M"),
+						kubev1.ResourceMemory:     resource.MustParse("100M"),
+						v1.ResourceMemoryOverhead: resource.MustParse("0"),
 					},
-					OvercommitGuestOverhead: true,
 				}
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR changes the handling of memory overhead:
1. It can be set as part of the Requests and Limits sections. That way, we can drop the `OvercommitGuestOverhead` boolean from the API and instead users can set "memory-overhead" to zero in the Requests section.
2. When the memory overhead is not specified in the Limits section, it is calculated automatically by the system as before.
3. The memory overhead imposed by shared libraries and such dependencies in kubevirt can now be configurable at the cluster level. This is useful when one wants to fix the default we chose (128M) or to support deploying additional sidecar containers uniformly across the cluster.
4. The memory overhead can also be specified as part of the VMI spec. This overrides the cluster default. This granularity can be useful when deploying sidecar containers with only some of the VMIs.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TBD
```
