### PR TITLE
Handled the case of external provider in cluster build

### DIFF
--- a/hack/cluster-build.sh
+++ b/hack/cluster-build.sh
@@ -50,6 +50,8 @@ done
 if [[ $KUBEVIRT_PROVIDER =~ okd.* ]]; then
     nodes=("master-0" "worker-0")
     pull_command="podman"
+elif [[ $KUBEVIRT_PROVIDER == "external" ]]; then
+    nodes=() # in case of external provider we have no control over the nodes
 else
     nodes=()
     for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do


### PR DESCRIPTION
**What this PR does / why we need it**:
make cluster-build fails in case of `$KUBEVIRT_PROVIDER == "external"`

`cluster-build.sh`  handle the cases of okd and k8s as default in order to  if the images on the nodes are of the proper version.
With external providers though, we don't have control on the node names nor to how to ssh into them.

**Release note:**
```release-note
NONE
```
