### PR TITLE
Run make target under the travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
 - if diff <(git grep -c '') <(git grep -cI '') | egrep -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*'
   | grep '^<'; then echo "Binary files are present in git repostory."; false; fi
-- make build
+- make
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make`. Please run it and commit the changes"; git status --porcelain; false; fi
 - if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" ]]; then make goveralls; else make bazel-tests; fi

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ olm-push:
 	bazel-build-images \
 	bazel-push-images \
 	bazel-tests \
-	build \
 	test \
 	clean \
 	distclean \

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -96,7 +96,7 @@ function kubevirt::version::ldflag() {
     local key=${1}
     local val=${2}
 
-    echo "-X kubevirt.io/client-go/version.${key}=${val}"
+    echo "-X kubevirt.io/kubevirt/vendor/kubevirt.io/client-go/version.${key}=${val}"
 }
 
 # Prints the value that needs to be passed to the -ldflags parameter of go build


### PR DESCRIPTION
Before we run `make build` but this target does not exist anymore.
In additional it should version of packages when it compiled with pure `go`.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
