### PR TITLE
Fix documentation of OvercommitGuestOverhead

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5577,7 +5577,7 @@
       "type": "object"
      },
      "overcommitGuestOverhead": {
-      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the requested memory limits. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
+      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
       "type": "boolean"
      },
      "requests": {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -989,11 +989,12 @@ func getMemoryOverhead(domain v1.DomainSpec) *resource.Quantity {
 
 	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
 	// overhead per vcpu in MiB
-	coresMemory := uint32(8)
+	coresMemory := resource.MustParse("8Mi")
 	if domain.CPU != nil {
-		coresMemory *= domain.CPU.Cores
+		value := coresMemory.Value() * int64(domain.CPU.Cores)
+		coresMemory = *resource.NewQuantity(value, coresMemory.Format)
 	}
-	overhead.Add(resource.MustParse(strconv.Itoa(int(coresMemory)) + "Mi"))
+	overhead.Add(coresMemory)
 
 	// static overhead for IOThread
 	overhead.Add(resource.MustParse("8Mi"))

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -2174,7 +2174,7 @@ func schema_kubevirtio_client_go_api_v1_ResourceRequirements(ref common.Referenc
 					},
 					"overcommitGuestOverhead": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the requested memory limits. This can lead to crashes if all memory is in use on a node. Defaults to false.",
+							Description: "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -209,7 +209,7 @@ type ResourceRequirements struct {
 	// +optional
 	Limits v1.ResourceList `json:"limits,omitempty"`
 	// Don't ask the scheduler to take the guest-management overhead into account. Instead
-	// put the overhead only into the requested memory limits. This can lead to crashes if
+	// put the overhead only into the container's memory limit. This can lead to crashes if
 	// all memory is in use on a node. Defaults to false.
 	OvercommitGuestOverhead bool `json:"overcommitGuestOverhead,omitempty"`
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -96,7 +96,7 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"requests":                "Requests is a description of the initial vmi resources.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
 		"limits":                  "Limits describes the maximum amount of compute resources allowed.\nValid resource keys are \"memory\" and \"cpu\".\n+optional",
-		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the requested memory limits. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
+		"overcommitGuestOverhead": "Don't ask the scheduler to take the guest-management overhead into account. Instead\nput the overhead only into the container's memory limit. This can lead to crashes if\nall memory is in use on a node. Defaults to false.",
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Replace a confusing part in the documentation of OvercommitGuestOverhead (requested memory limits -> container's memory limit) and also small improvement to the computation of video memory overhead.

**Special notes for your reviewer**:
The fix to the documentation was already reviewed as part of #2399 and was later separated out from that PR due to the issue fixed in #2414 .

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
