### PR TITLE
Fix expectations in disruptionbudget controller

### DIFF
--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -235,15 +235,14 @@ func (c *DisruptionBudgetController) resolveControllerRef(namespace string, cont
 	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineInstanceGroupVersionKind.Kind {
 		return nil
 	}
-	vmi, exists, err := c.vmiInformer.GetStore().GetByKey(namespace + "/" + controllerRef.Name)
-	if err != nil {
-		return nil
-	}
-	if !exists {
-		return nil
-	}
 
-	return vmi.(*virtv1.VirtualMachineInstance)
+	return &virtv1.VirtualMachineInstance{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      controllerRef.Name,
+			Namespace: namespace,
+			UID:       controllerRef.UID,
+		},
+	}
 }
 
 // Run runs the passed in NodeController.
@@ -339,7 +338,7 @@ func (c *DisruptionBudgetController) sync(key string, vmi *virtv1.VirtualMachine
 		} else if !wantsToMigrate && pdb != nil {
 			// We don't want migrations on evictions, if there is a pdb, remove it
 			delete = true
-		} else if wantsToMigrate && pdb == nil {
+		} else if wantsToMigrate && vmi.DeletionTimestamp == nil && pdb == nil {
 			// No pdb and we want migrations on evictions
 			create = true
 		} else if wantsToMigrate && pdb != nil {

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -156,6 +156,56 @@ var _ = Describe("Disruptionbudget", func() {
 			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
 		})
 
+		It("should recreate the PDB if the VMI is recreated", func() {
+			vmi := newVirtualMachine("testvm")
+			vmi.Spec.EvictionStrategy = newEvictionStrategy()
+			addVirtualMachine(vmi)
+			pdb := newPodDisruptionBudget(vmi)
+			pdbFeeder.Add(pdb)
+
+			controller.Execute()
+
+			vmiFeeder.Delete(vmi)
+			shouldExpectPDBDeletion(pdb)
+			controller.Execute()
+			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+
+			pdbFeeder.Delete(pdb)
+			vmi.UID = "45356"
+			vmiFeeder.Add(vmi)
+			shouldExpectPDBCreation(vmi.UID)
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulCreatePodDisruptionBudgetReason)
+		})
+
+		It("should delete a PDB which belongs to an old VMI", func() {
+			vmi := newVirtualMachine("testvm")
+			vmi.Spec.EvictionStrategy = newEvictionStrategy()
+			pdb := newPodDisruptionBudget(vmi)
+			pdbFeeder.Add(pdb)
+			// new UID means new VMI
+			vmi.UID = "changed"
+			addVirtualMachine(vmi)
+
+			shouldExpectPDBDeletion(pdb)
+			controller.Execute()
+			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+		})
+
+		It("should not create a PDB for VMIs which are already marked for deletion", func() {
+			vmi := newVirtualMachine("testvm")
+			vmi.Spec.EvictionStrategy = newEvictionStrategy()
+			now := v13.Now()
+			vmi.DeletionTimestamp = &now
+			addVirtualMachine(vmi)
+
+			controller.Execute()
+
+			vmiFeeder.Delete(vmi)
+			controller.Execute()
+		})
+
 		It("should remove the pdb if the VMI does not want to be migrated anymore", func() {
 			vmi := newVirtualMachine("testvm")
 			vmi.Spec.EvictionStrategy = newEvictionStrategy()

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -754,7 +754,8 @@ func (c *VMController) addVirtualMachine(obj interface{}) {
 		log.Log.Object(vmi).V(4).Info("Looking for VirtualMachineInstance Ref")
 		vm := c.resolveControllerRef(vmi.Namespace, controllerRef)
 		if vm == nil {
-			log.Log.Object(vmi).Errorf("Cant find the matching VM for VirtualMachineInstance: %s", vmi.Name)
+			// not managed by us
+			log.Log.Object(vmi).V(4).Infof("Cant find the matching VM for VirtualMachineInstance: %s", vmi.Name)
 			return
 		}
 		vmKey, err := controller.KeyFunc(vm)


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Satisfy delete expectation when recreating VMIs (they were not
   satisfied and VMIs got no new PDB when recreating it).
 * Don't recreate PDBs for VMIs which are already marked for deletion
   (when scling VMIs down, PDBs got deleted and recreated until they
   eventually converged).
 * Don't write an error log message if VMIs which are not managed by VMs
   are encountered by the VM controller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```