### PR TITLE
Make secret lookup of virt-handler and virt-api more robust

### DIFF
--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -118,10 +118,6 @@ var _ = Describe("Virt-api", func() {
 		It("should generate certs the first time it is run", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/api/v1/namespaces/kubevirt/secrets/"+virtApiCertSecretName),
-					ghttp.RespondWithJSONEncoded(http.StatusNotFound, nil),
-				),
-				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("POST", "/api/v1/namespaces/kubevirt/secrets"),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
 				),
@@ -165,6 +161,10 @@ var _ = Describe("Virt-api", func() {
 			}
 
 			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("POST", "/api/v1/namespaces/kubevirt/secrets"),
+					ghttp.RespondWithJSONEncoded(http.StatusConflict, nil),
+				),
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("GET", "/api/v1/namespaces/kubevirt/secrets/"+virtApiCertSecretName),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, secret),


### PR DESCRIPTION
**What this PR does / why we need it**:

virt-handler and virt-api create certificates and upload them in a
secret if it does not already exists. When deploying or updating
kubevirt the instances tend to do the GET and POST at roughly the same
time which leads to restarts of the instances which loose the race.

Handle this gracefully by always first try to to a POST and fall back if
the secret already exists. This avoids unnecessary restarts during
initialization.

Symptoms are:

```
virt-controller-69b5465d46-9chss          1/1     Running   1         20m
virt-controller-69b5465d46-xswjg          1/1     Running   0          20m
virt-handler-9cclz                        1/1     Running   1          20m
virt-handler-fbxt2                        1/1     Running   0          20m
```

Note the **1** in the restart column for one controller and one handler instance.

Further the crashing instance emitted an error like this:

```
ERROR: logging before flag.Parse: F0624 12:31:08.418416    3949 virt-handler.go:254] Error loading self signed certificates: secrets "kubevirt-virt-handler-certs" already exists
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
