### PR TITLE
Remove unused dead code from virt-operator

### DIFF
--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -9,11 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator/creation/components",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/controller:go_default_library",
-        "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -19,55 +19,12 @@
 package components
 
 import (
-	"fmt"
-
-	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/virt-operator/util"
-
 	corev1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/kubecli"
 )
-
-func CreateCRDs(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, stores util.Stores, expectations *util.Expectations) (int, error) {
-
-	objectsAdded := 0
-	kvkey, err := controller.KeyFunc(kv)
-	if err != nil {
-		return 0, err
-	}
-
-	ext := clientset.ExtensionsClient()
-
-	crds := []*extv1beta1.CustomResourceDefinition{
-		NewVirtualMachineInstanceCrd(),
-		NewVirtualMachineCrd(),
-		NewReplicaSetCrd(),
-		NewPresetCrd(),
-		NewVirtualMachineInstanceMigrationCrd(),
-	}
-
-	for _, crd := range crds {
-		if _, exists, _ := stores.CrdCache.Get(crd); !exists {
-			expectations.Crd.RaiseExpectations(kvkey, 1, 0)
-			_, err := ext.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-			if err != nil {
-				expectations.Crd.LowerExpectations(kvkey, 1, 0)
-				return objectsAdded, fmt.Errorf("unable to create crd %+v: %v", crd, err)
-			} else if err == nil {
-				objectsAdded++
-			}
-		} else {
-			log.Log.V(4).Infof("crd %v already exists", crd.GetName())
-		}
-	}
-
-	return objectsAdded, nil
-}
 
 func newBlankCrd() *extv1beta1.CustomResourceDefinition {
 	return &extv1beta1.CustomResourceDefinition{

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -21,9 +21,6 @@ package components
 import (
 	"fmt"
 
-	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/controller"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,88 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
-
-func CreateControllers(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, config util.KubeVirtDeploymentConfig, stores util.Stores, expectations *util.Expectations) (int, error) {
-
-	objectsAdded := 0
-	core := clientset.CoreV1()
-	kvkey, err := controller.KeyFunc(kv)
-	if err != nil {
-		return 0, err
-	}
-
-	services := []*corev1.Service{
-		NewPrometheusService(kv.Namespace),
-		NewApiServerService(kv.Namespace),
-	}
-	for _, service := range services {
-		if _, exists, _ := stores.ServiceCache.Get(service); !exists {
-			expectations.Service.RaiseExpectations(kvkey, 1, 0)
-			_, err := core.Services(kv.Namespace).Create(service)
-			if err != nil {
-				expectations.Service.LowerExpectations(kvkey, 1, 0)
-				return objectsAdded, fmt.Errorf("unable to create service %+v: %v", service, err)
-			} else if err == nil {
-				objectsAdded++
-			}
-		} else {
-			log.Log.V(4).Infof("service %v already exists", service.GetName())
-		}
-	}
-
-	apps := clientset.AppsV1()
-
-	// TODO make verbosity part of the KubeVirt CRD spec?
-	verbosity := "2"
-	api, err := NewApiServerDeployment(kv.Namespace, config.ImageRegistry, config.ImageTag, kv.Spec.ImagePullPolicy, verbosity)
-	if err != nil {
-		return objectsAdded, err
-	}
-	controller, err := NewControllerDeployment(kv.Namespace, config.ImageRegistry, config.ImageTag, kv.Spec.ImagePullPolicy, verbosity)
-	if err != nil {
-		return objectsAdded, err
-	}
-
-	deployments := []*appsv1.Deployment{api, controller}
-	for _, deployment := range deployments {
-		if _, exists, _ := stores.DeploymentCache.Get(deployment); !exists {
-			expectations.Deployment.RaiseExpectations(kvkey, 1, 0)
-			_, err := apps.Deployments(kv.Namespace).Create(deployment)
-			if err != nil {
-				expectations.Deployment.LowerExpectations(kvkey, 1, 0)
-				return objectsAdded, fmt.Errorf("unable to create deployment %+v: %v", deployment, err)
-			} else if err == nil {
-				objectsAdded++
-			}
-		} else {
-			log.Log.V(4).Infof("deployment %v already exists", deployment.GetName())
-		}
-	}
-
-	handler, err := NewHandlerDaemonSet(kv.Namespace, config.ImageRegistry, config.ImageTag, kv.Spec.ImagePullPolicy, verbosity)
-	if err != nil {
-		return objectsAdded, err
-	}
-
-	if _, exists, _ := stores.DaemonSetCache.Get(handler); !exists {
-		expectations.DaemonSet.RaiseExpectations(kvkey, 1, 0)
-		_, err = apps.DaemonSets(kv.Namespace).Create(handler)
-		if err != nil {
-			expectations.DaemonSet.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create daemonset %+v: %v", handler, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("daemonset %v already exists", handler.GetName())
-	}
-
-	return objectsAdded, nil
-
-}
 
 func NewPrometheusService(namespace string) *corev1.Service {
 	return &corev1.Service{

--- a/pkg/virt-operator/creation/rbac/BUILD.bazel
+++ b/pkg/virt-operator/creation/rbac/BUILD.bazel
@@ -12,11 +12,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator/creation/rbac",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/controller:go_default_library",
-        "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-operator/creation/rbac/apiserver.go
+++ b/pkg/virt-operator/creation/rbac/apiserver.go
@@ -19,108 +19,12 @@
 package rbac
 
 import (
-	"fmt"
-
-	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/virt-operator/util"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/kubecli"
 )
-
-func CreateApiServerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, stores util.Stores, expectations *util.Expectations) (int, error) {
-
-	objectsAdded := 0
-	core := clientset.CoreV1()
-	kvkey, err := controller.KeyFunc(kv)
-	if err != nil {
-		return 0, err
-	}
-
-	sa := newApiServerServiceAccount(kv.Namespace)
-	if _, exists, _ := stores.ServiceAccountCache.Get(sa); !exists {
-		expectations.ServiceAccount.RaiseExpectations(kvkey, 1, 0)
-		_, err := core.ServiceAccounts(kv.Namespace).Create(sa)
-		if err != nil {
-			expectations.ServiceAccount.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create serviceaccount %+v: %v", sa, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("serviceaccount %v already exists", sa.GetName())
-	}
-
-	rbac := clientset.RbacV1()
-
-	cr := newApiServerClusterRole()
-	if _, exists, _ := stores.ClusterRoleCache.Get(cr); !exists {
-		expectations.ClusterRole.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.ClusterRoles().Create(cr)
-		if err != nil {
-			expectations.ClusterRole.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create clusterrole %+v: %v", cr, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("clusterrole %v already exists", cr.GetName())
-	}
-
-	clusterRoleBindings := []*rbacv1.ClusterRoleBinding{
-		newApiServerClusterRoleBinding(kv.Namespace),
-		newApiServerAuthDelegatorClusterRoleBinding(kv.Namespace),
-	}
-	for _, crb := range clusterRoleBindings {
-		if _, exists, _ := stores.ClusterRoleBindingCache.Get(crb); !exists {
-			expectations.ClusterRoleBinding.RaiseExpectations(kvkey, 1, 0)
-			_, err := rbac.ClusterRoleBindings().Create(crb)
-			if err != nil {
-				expectations.ClusterRoleBinding.LowerExpectations(kvkey, 1, 0)
-				return objectsAdded, fmt.Errorf("unable to create clusterrolebinding %+v: %v", crb, err)
-			} else if err == nil {
-				objectsAdded++
-			}
-		} else {
-			log.Log.V(4).Infof("clusterrolebinding %v already exists", crb.GetName())
-		}
-	}
-
-	r := newApiServerRole(kv.Namespace)
-	if _, exists, _ := stores.RoleCache.Get(r); !exists {
-		expectations.Role.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.Roles(kv.Namespace).Create(r)
-		if err != nil {
-			expectations.Role.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create role %+v: %v", r, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("role %v already exists", r.GetName())
-	}
-
-	rb := newApiServerRoleBinding(kv.Namespace)
-	if _, exists, _ := stores.RoleBindingCache.Get(rb); !exists {
-		expectations.RoleBinding.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.RoleBindings(kv.Namespace).Create(rb)
-		if err != nil {
-			expectations.RoleBinding.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create rolebinding %+v: %v", rb, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("rolebinding %v already exists", rb.GetName())
-	}
-
-	return objectsAdded, nil
-}
 
 func GetAllApiServer(namespace string) []interface{} {
 	return []interface{}{

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -19,75 +19,12 @@
 package rbac
 
 import (
-	"fmt"
-
-	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/virt-operator/util"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/kubecli"
 )
-
-func CreateControllerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, stores util.Stores, expectations *util.Expectations) (int, error) {
-
-	objectsAdded := 0
-	core := clientset.CoreV1()
-	kvkey, err := controller.KeyFunc(kv)
-	if err != nil {
-		return 0, err
-	}
-
-	sa := newControllerServiceAccount(kv.Namespace)
-	if _, exists, _ := stores.ServiceAccountCache.Get(sa); !exists {
-		expectations.ServiceAccount.RaiseExpectations(kvkey, 1, 0)
-		_, err := core.ServiceAccounts(kv.Namespace).Create(sa)
-		if err != nil {
-			expectations.ServiceAccount.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create serviceaccount %+v: %v", sa, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("serviceaccount %v already exists", sa.GetName())
-	}
-
-	rbac := clientset.RbacV1()
-
-	cr := newControllerClusterRole()
-	if _, exists, _ := stores.ClusterRoleCache.Get(cr); !exists {
-		expectations.ClusterRole.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.ClusterRoles().Create(cr)
-		if err != nil {
-			expectations.ClusterRole.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create clusterrole %+v: %v", cr, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("clusterrole %v already exists", cr.GetName())
-	}
-
-	crb := newControllerClusterRoleBinding(kv.Namespace)
-	if _, exists, _ := stores.ClusterRoleBindingCache.Get(crb); !exists {
-		expectations.ClusterRoleBinding.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.ClusterRoleBindings().Create(crb)
-		if err != nil {
-			expectations.ClusterRoleBinding.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create clusterrolebinding %+v: %v", crb, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.V(4).Infof("clusterrolebinding %v already exists", crb.GetName())
-	}
-
-	return objectsAdded, nil
-}
 
 func GetAllController(namespace string) []interface{} {
 	return []interface{}{

--- a/pkg/virt-operator/creation/rbac/handler.go
+++ b/pkg/virt-operator/creation/rbac/handler.go
@@ -20,103 +20,12 @@
 package rbac
 
 import (
-	"fmt"
-
-	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/virt-operator/util"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/kubecli"
 )
-
-func CreateHandlerRBAC(clientset kubecli.KubevirtClient, kv *virtv1.KubeVirt, stores util.Stores, expectations *util.Expectations) (int, error) {
-
-	objectsAdded := 0
-	core := clientset.CoreV1()
-	kvkey, err := controller.KeyFunc(kv)
-	if err != nil {
-		return 0, err
-	}
-
-	sa := newHandlerServiceAccount(kv.Namespace)
-	if _, exists, _ := stores.ServiceAccountCache.Get(sa); !exists {
-		expectations.ServiceAccount.RaiseExpectations(kvkey, 1, 0)
-		_, err := core.ServiceAccounts(kv.Namespace).Create(sa)
-		if err != nil {
-			expectations.ServiceAccount.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create serviceaccount %+v: %v", sa, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.Infof("serviceaccount %v already exists", sa.GetName())
-	}
-
-	rbac := clientset.RbacV1()
-
-	cr := newHandlerClusterRole()
-	if _, exists, _ := stores.ClusterRoleCache.Get(cr); !exists {
-		expectations.ClusterRole.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.ClusterRoles().Create(cr)
-		if err != nil {
-			expectations.ClusterRole.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create clusterrole %+v: %v", cr, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.Infof("clusterrole %v already exists", cr.GetName())
-	}
-
-	crb := newHandlerClusterRoleBinding(kv.Namespace)
-	if _, exists, _ := stores.ClusterRoleBindingCache.Get(crb); !exists {
-		expectations.ClusterRoleBinding.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.ClusterRoleBindings().Create(crb)
-		if err != nil {
-			expectations.ClusterRoleBinding.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create clusterrolebinding %+v: %v", crb, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.Infof("clusterrolebinding %v already exists", crb.GetName())
-	}
-
-	r := newHandlerRole(kv.Namespace)
-	if _, exists, _ := stores.RoleCache.Get(r); !exists {
-		expectations.Role.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.Roles(kv.Namespace).Create(r)
-		if err != nil {
-			expectations.Role.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create role %+v: %v", r, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.Infof("role %v already exists", r.GetName())
-	}
-
-	rb := newHandlerRoleBinding(kv.Namespace)
-	if _, exists, _ := stores.RoleBindingCache.Get(rb); !exists {
-		expectations.RoleBinding.RaiseExpectations(kvkey, 1, 0)
-		_, err := rbac.RoleBindings(kv.Namespace).Create(rb)
-		if err != nil {
-			expectations.RoleBinding.LowerExpectations(kvkey, 1, 0)
-			return objectsAdded, fmt.Errorf("unable to create rolebinding %+v: %v", rb, err)
-		} else if err == nil {
-			objectsAdded++
-		}
-	} else {
-		log.Log.Infof("rolebinding %v already exists", rb.GetName())
-	}
-
-	return objectsAdded, nil
-}
 
 func GetAllHandler(namespace string) []interface{} {
 	return []interface{}{


### PR DESCRIPTION
While reviewing the #2298 PR I realized there's some unused code left in virt-operator that needs to be removed. 

This logic isn't used anywhere and shouldn't impact any functionality. 

```release-note
NONE
```
