### PR TITLE
Add RNG to all Fedora examples

### DIFF
--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -39,6 +39,7 @@ objects:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            rng: {}
           machine:
             type: ""
           resources:

--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -15,6 +15,7 @@ spec:
       - disk:
           bus: virtio
         name: cloudinitdisk
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-genie-multiple-net.yaml
+++ b/examples/vmi-genie-multiple-net.yaml
@@ -20,6 +20,7 @@ spec:
         name: default
       - bridge: {}
         name: ptp
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-genie-ptp.yaml
+++ b/examples/vmi-genie-ptp.yaml
@@ -18,6 +18,7 @@ spec:
       interfaces:
       - bridge: {}
         name: ptp
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -22,6 +22,7 @@ spec:
         - name: http
           port: 80
           protocol: TCP
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -20,6 +20,7 @@ spec:
         name: default
       - bridge: {}
         name: ptp
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -18,6 +18,7 @@ spec:
       interfaces:
       - bridge: {}
         name: ptp
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-slirp.yaml
+++ b/examples/vmi-slirp.yaml
@@ -22,6 +22,7 @@ spec:
           port: 80
           protocol: TCP
         slirp: {}
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -20,6 +20,7 @@ spec:
         name: default
       - name: sriov-net
         sriov: {}
+      rng: {}
     machine:
       type: ""
     resources:

--- a/examples/vmi-with-sidecar-hook.yaml
+++ b/examples/vmi-with-sidecar-hook.yaml
@@ -18,6 +18,7 @@ spec:
       - disk:
           bus: virtio
         name: cloudinitdisk
+      rng: {}
     machine:
       type: ""
     resources:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -119,6 +119,12 @@ func getBaseVMI(name string) *v1.VirtualMachineInstance {
 	}
 }
 
+func initFedora(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec {
+	addContainerDisk(spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
+	addRNG(spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	return spec
+}
+
 func addRNG(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec {
 	spec.Domain.Devices.Rng = &v1.Rng{}
 	return spec
@@ -307,10 +313,7 @@ func GetVMISata() *v1.VirtualMachineInstance {
 func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiFedora)
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
-
-	addContainerDisk(&vmi.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vmi.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
-
+	initFedora(&vmi.Spec)
 	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
 	return vmi
 }
@@ -334,8 +337,7 @@ func GetVMISlirp() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{v1.Network{Name: "testSlirp", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
 
 	slirp := &v1.InterfaceSlirp{}
@@ -350,8 +352,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{v1.Network{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
 
 	masquerade := &v1.InterfaceMasquerade{}
@@ -365,8 +366,7 @@ func GetVMISRIOV() *v1.VirtualMachineInstance {
 	vm := getBaseVMI(VmiSRIOV)
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "sriov-net", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "sriov/sriov-network"}}}}
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
@@ -379,8 +379,7 @@ func GetVMIMultusPtp() *v1.VirtualMachineInstance {
 	vm := getBaseVMI(VmiMultusPtp)
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{{Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\n")
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -392,8 +391,7 @@ func GetVMIMultusMultipleNet() *v1.VirtualMachineInstance {
 	vm := getBaseVMI(VmiMultusMultipleNet)
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork(), {Name: "ptp", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "ptp-conf"}}}}
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
@@ -408,8 +406,7 @@ func GetVMIGeniePtp() *v1.VirtualMachineInstance {
 	vm.Spec.Networks = []v1.Network{
 		{Name: "ptp", NetworkSource: v1.NetworkSource{Genie: &v1.GenieNetwork{NetworkName: "ptp"}}},
 	}
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\n")
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
@@ -426,8 +423,7 @@ func GetVMIGenieMultipleNet() *v1.VirtualMachineInstance {
 		{Name: "default", NetworkSource: v1.NetworkSource{Genie: &v1.GenieNetwork{NetworkName: "flannel"}}},
 		{Name: "ptp", NetworkSource: v1.NetworkSource{Genie: &v1.GenieNetwork{NetworkName: "ptp"}}},
 	}
-	addContainerDisk(&vm.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" | passwd fedora --stdin\ndhclient eth1\n")
 
 	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
@@ -563,8 +559,7 @@ func GetVMCirros() *v1.VirtualMachine {
 
 func GetTemplateFedora() *Template {
 	vm := getBaseVM("", map[string]string{"kubevirt-vm": "vm-${NAME}", "kubevirt.io/os": "fedora27"})
-	addContainerDisk(&vm.Spec.Template.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vm.Spec.Template.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vm.Spec.Template.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec.Template.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
 
 	template := getBaseTemplate(vm, "4096Mi", "4")
@@ -851,8 +846,7 @@ func GetVMIWithHookSidecar() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiWithHookSidecar)
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 
-	addContainerDisk(&vmi.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageFedora, DockerTag), busVirtio)
-	addRNG(&vmi.Spec) // without RNG, newer fedora images may hang waiting for entropy sources
+	initFedora(&vmi.Spec)
 	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
 
 	vmi.ObjectMeta.Annotations = map[string]string{


### PR DESCRIPTION
This is needed on newer guest kernels that may lock booting process waiting for entropy that never arrives. (With this fix, RNG used is external to guest state.)

```release-note
NONE
```