### PR TITLE
Use nftable rules for coreOS servers on masquerade

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -82,7 +82,7 @@ type NetworkHandler interface {
 	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions)
-	UseIptables() error
+	UseIptables() bool
 	IptablesNewChain(table, chain string) error
 	IptablesAppendRule(table, chain string, rulespec ...string) error
 	NftablesNewChain(table, chain string) error
@@ -128,15 +128,18 @@ func (h *NetworkUtilsHandler) AddrAdd(link netlink.Link, addr *netlink.Addr) err
 func (h *NetworkUtilsHandler) LinkSetMaster(link netlink.Link, master *netlink.Bridge) error {
 	return netlink.LinkSetMaster(link, master)
 }
-func (h *NetworkUtilsHandler) UseIptables() error {
+func (h *NetworkUtilsHandler) UseIptables() bool {
 	iptablesObject, err := iptables.New()
 	if err != nil {
-		return err
+		return false
 	}
 
 	_, err = iptablesObject.List("nat", "OUTPUT")
+	if err != nil {
+		return false
+	}
 
-	return err
+	return true
 }
 func (h *NetworkUtilsHandler) IptablesNewChain(table, chain string) error {
 	iptablesObject, err := iptables.New()

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"os/exec"
 
 	"io/ioutil"
 	"net"
@@ -81,8 +82,13 @@ type NetworkHandler interface {
 	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions)
+	UseIptables() error
 	IptablesNewChain(table, chain string) error
 	IptablesAppendRule(table, chain string, rulespec ...string) error
+	NftablesNewChain(table, chain string) error
+	NftablesAppendRule(table, chain string, rulespec ...string) error
+	NftablesNewTable(table string) error
+	NftablesLoad(fnName string) error
 }
 
 type NetworkUtilsHandler struct{}
@@ -122,6 +128,16 @@ func (h *NetworkUtilsHandler) AddrAdd(link netlink.Link, addr *netlink.Addr) err
 func (h *NetworkUtilsHandler) LinkSetMaster(link netlink.Link, master *netlink.Bridge) error {
 	return netlink.LinkSetMaster(link, master)
 }
+func (h *NetworkUtilsHandler) UseIptables() error {
+	iptablesObject, err := iptables.New()
+	if err != nil {
+		return err
+	}
+
+	_, err = iptablesObject.List("nat", "OUTPUT")
+
+	return err
+}
 func (h *NetworkUtilsHandler) IptablesNewChain(table, chain string) error {
 	iptablesObject, err := iptables.New()
 	if err != nil {
@@ -137,6 +153,39 @@ func (h *NetworkUtilsHandler) IptablesAppendRule(table, chain string, rulespec .
 	}
 
 	return iptablesObject.Append(table, chain, rulespec...)
+}
+func (h *NetworkUtilsHandler) NftablesNewChain(table, chain string) error {
+	output, err := exec.Command("nft", "add", "chain", "ip", table, chain).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s", string(output))
+	}
+
+	return nil
+}
+func (h *NetworkUtilsHandler) NftablesAppendRule(table, chain string, rulespec ...string) error {
+	cmd := append([]string{"add", "rule", "ip", table, chain}, rulespec...)
+	output, err := exec.Command("nft", cmd...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to apped new nfrule error %s", string(output))
+	}
+
+	return nil
+}
+func (h *NetworkUtilsHandler) NftablesNewTable(table string) error {
+	output, err := exec.Command("nft", "add", "table", table).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create new nftable error %s", string(output))
+	}
+
+	return nil
+}
+func (h *NetworkUtilsHandler) NftablesLoad(fnName string) error {
+	output, err := exec.Command("nft", "-f", fmt.Sprintf("/etc/nftables/%s.nft", fnName)).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to load nftable %s error %s", fnName, string(output))
+	}
+
+	return nil
 }
 func (h *NetworkUtilsHandler) GetHostAndGwAddressesFromCIDR(s string) (string, string, error) {
 	ip, ipnet, err := net.ParseCIDR(s)

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -200,6 +200,16 @@ func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2, arg3 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2, arg3)
 }
 
+func (_m *MockNetworkHandler) UseIptables() bool {
+	ret := _m.ctrl.Call(_m, "UseIptables")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) UseIptables() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UseIptables")
+}
+
 func (_m *MockNetworkHandler) IptablesNewChain(table string, chain string) error {
 	ret := _m.ctrl.Call(_m, "IptablesNewChain", table, chain)
 	ret0, _ := ret[0].(error)
@@ -223,4 +233,49 @@ func (_m *MockNetworkHandler) IptablesAppendRule(table string, chain string, rul
 func (_mr *_MockNetworkHandlerRecorder) IptablesAppendRule(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	_s := append([]interface{}{arg0, arg1}, arg2...)
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IptablesAppendRule", _s...)
+}
+
+func (_m *MockNetworkHandler) NftablesNewChain(table string, chain string) error {
+	ret := _m.ctrl.Call(_m, "NftablesNewChain", table, chain)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) NftablesNewChain(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NftablesNewChain", arg0, arg1)
+}
+
+func (_m *MockNetworkHandler) NftablesAppendRule(table string, chain string, rulespec ...string) error {
+	_s := []interface{}{table, chain}
+	for _, _x := range rulespec {
+		_s = append(_s, _x)
+	}
+	ret := _m.ctrl.Call(_m, "NftablesAppendRule", _s...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) NftablesAppendRule(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	_s := append([]interface{}{arg0, arg1}, arg2...)
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NftablesAppendRule", _s...)
+}
+
+func (_m *MockNetworkHandler) NftablesNewTable(table string) error {
+	ret := _m.ctrl.Call(_m, "NftablesNewTable", table)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) NftablesNewTable(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NftablesNewTable", arg0)
+}
+
+func (_m *MockNetworkHandler) NftablesLoad(fnName string) error {
+	ret := _m.ctrl.Call(_m, "NftablesLoad", fnName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) NftablesLoad(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NftablesLoad", arg0)
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -519,7 +519,7 @@ func (p *MasqueradePodInterface) createNatRules() error {
 	if Handler.UseIptables() {
 		return p.createNatRulesUsingIptables()
 	}
-	return p.createNatRulesUsingNftable()
+	return p.createNatRulesUsingNftables()
 }
 
 func (p *MasqueradePodInterface) createNatRulesUsingIptables() error {
@@ -603,7 +603,7 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables() error {
 	return nil
 }
 
-func (p *MasqueradePodInterface) createNatRulesUsingNftable() error {
+func (p *MasqueradePodInterface) createNatRulesUsingNftables() error {
 	err := Handler.NftablesLoad("ipv4-nat")
 	if err != nil {
 		return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -516,7 +516,13 @@ func (p *MasqueradePodInterface) createBridge() error {
 }
 
 func (p *MasqueradePodInterface) createNatRules() error {
+	if Handler.UseIptables() {
+		return p.createNatRulesUsingIptables()
+	}
+	return p.createNatRulesUsingNftable()
+}
 
+func (p *MasqueradePodInterface) createNatRulesUsingIptables() error {
 	err := Handler.IptablesNewChain("nat", "KUBEVIRT_PREINBOUND")
 	if err != nil {
 		return err
@@ -593,7 +599,83 @@ func (p *MasqueradePodInterface) createNatRules() error {
 			return err
 		}
 	}
-	return err
+
+	return nil
+}
+
+func (p *MasqueradePodInterface) createNatRulesUsingNftable() error {
+	err := Handler.NftablesLoad("ipv4-nat")
+	if err != nil {
+		return err
+	}
+
+	err = Handler.NftablesNewChain("nat", "KUBEVIRT_PREINBOUND")
+	if err != nil {
+		return err
+	}
+
+	err = Handler.NftablesNewChain("nat", "KUBEVIRT_POSTINBOUND")
+	if err != nil {
+		return err
+	}
+
+	err = Handler.NftablesAppendRule("nat", "postrouting", "ip", "saddr", p.vif.IP.IP.String(), "counter", "masquerade")
+	if err != nil {
+		return err
+	}
+
+	err = Handler.NftablesAppendRule("nat", "prerouting", "iifname", p.podInterfaceName, "counter", "jump", "KUBEVIRT_PREINBOUND")
+	if err != nil {
+		return err
+	}
+
+	err = Handler.NftablesAppendRule("nat", "postrouting", "oifname", p.bridgeInterfaceName, "counter", "jump", "KUBEVIRT_POSTINBOUND")
+	if err != nil {
+		return err
+	}
+
+	if len(p.iface.Ports) == 0 {
+		err = Handler.NftablesAppendRule("nat", "KUBEVIRT_PREINBOUND",
+			"counter", "dnat", "to", p.vif.IP.IP.String())
+
+		return err
+	}
+
+	for _, port := range p.iface.Ports {
+		if port.Protocol == "" {
+			port.Protocol = "tcp"
+		}
+
+		err = Handler.NftablesAppendRule("nat", "KUBEVIRT_POSTINBOUND",
+			strings.ToLower(port.Protocol),
+			"dport",
+			strconv.Itoa(int(port.Port)),
+			"counter", "snat", "to", p.gatewayAddr.IP.String())
+		if err != nil {
+			return err
+		}
+
+		err = Handler.NftablesAppendRule("nat", "KUBEVIRT_PREINBOUND",
+			strings.ToLower(port.Protocol),
+			"dport",
+			strconv.Itoa(int(port.Port)),
+			"counter", "dnat", "to", p.vif.IP.IP.String())
+		if err != nil {
+			return err
+		}
+
+		err = Handler.NftablesAppendRule("nat", "output",
+			"ip", "daddr", "127.0.0.1",
+			strings.ToLower(port.Protocol),
+			"dport",
+			strconv.Itoa(int(port.Port)),
+			"counter", "dnat", "to", p.vif.IP.IP.String())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 type SlirpPodInterface struct {

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -450,7 +450,7 @@ var _ = Describe("Pod Network", func() {
 				api.SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new VIF bind to a bridge and create a specific nat rule using nftable", func() {
+			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().UseIptables().Return(false).AnyTimes()
 				mockNetwork.EXPECT().NftablesAppendRule("nat",

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeGwAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return("10.0.2.1/30", "10.0.2.2/30", nil)
-		// Global nat rules
+		// Global nat rules using iptables
 		mockNetwork.EXPECT().IptablesNewChain("nat", gomock.Any()).Return(nil).AnyTimes()
 		mockNetwork.EXPECT().IptablesAppendRule("nat",
 			"POSTROUTING",
@@ -169,6 +169,13 @@ var _ = Describe("Pod Network", func() {
 			"DNAT",
 			"--to-destination",
 			"10.0.2.2").Return(nil).AnyTimes()
+		//Global net rules using nftable
+		mockNetwork.EXPECT().NftablesLoad("ipv4-nat").Return(nil).AnyTimes()
+		mockNetwork.EXPECT().NftablesNewChain("nat", "KUBEVIRT_PREINBOUND").Return(nil).AnyTimes()
+		mockNetwork.EXPECT().NftablesNewChain("nat", "KUBEVIRT_POSTINBOUND").Return(nil).AnyTimes()
+		mockNetwork.EXPECT().NftablesAppendRule("nat", "postrouting", "ip", "saddr", "10.0.2.2", "counter", "masquerade").Return(nil).AnyTimes()
+		mockNetwork.EXPECT().NftablesAppendRule("nat", "prerouting", "iifname", "eth0", "counter", "jump", "KUBEVIRT_PREINBOUND").Return(nil).AnyTimes()
+		mockNetwork.EXPECT().NftablesAppendRule("nat", "postrouting", "oifname", "k6t-eth0", "counter", "jump", "KUBEVIRT_POSTINBOUND").Return(nil).AnyTimes()
 
 		err := SetupPodNetwork(vm, domain)
 		Expect(err).To(BeNil())
@@ -384,8 +391,9 @@ var _ = Describe("Pod Network", func() {
 			})
 		})
 		Context("Masquerade Plug", func() {
-			It("should define a new VIF bind to a bridge and create a default nat rule", func() {
+			It("should define a new VIF bind to a bridge and create a default nat rule using iptables", func() {
 				// forward all the traffic
+				mockNetwork.EXPECT().UseIptables().Return(true).AnyTimes()
 				mockNetwork.EXPECT().IptablesAppendRule("nat",
 					"KUBEVIRT_PREINBOUND",
 					"-j",
@@ -398,8 +406,9 @@ var _ = Describe("Pod Network", func() {
 				api.SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new VIF bind to a bridge and create a specific nat rule", func() {
+			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
+				mockNetwork.EXPECT().UseIptables().Return(true).AnyTimes()
 				mockNetwork.EXPECT().IptablesAppendRule("nat",
 					"KUBEVIRT_POSTINBOUND",
 					"-p",
@@ -419,6 +428,50 @@ var _ = Describe("Pod Network", func() {
 					"--dport",
 					"80", "--destination", "127.0.0.1",
 					"-j", "DNAT", "--to-destination", "10.0.2.2").Return(nil).AnyTimes()
+				domain := NewDomainWithBridgeInterface()
+				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
+				vm.Spec.Domain.Devices.Interfaces[0].Ports = []v1.Port{{Name: "test", Port: 80, Protocol: "TCP"}}
+
+				api.SetObjectDefaults_Domain(domain)
+				TestPodInterfaceIPBinding(vm, domain)
+			})
+			It("should define a new VIF bind to a bridge and create a default nat rule using nftables", func() {
+				// forward all the traffic
+				mockNetwork.EXPECT().UseIptables().Return(false).AnyTimes()
+				mockNetwork.EXPECT().NftablesAppendRule("nat",
+					"KUBEVIRT_PREINBOUND",
+					"counter",
+					"dnat",
+					"to", "10.0.2.2").Return(nil).AnyTimes()
+
+				domain := NewDomainWithBridgeInterface()
+				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
+
+				api.SetObjectDefaults_Domain(domain)
+				TestPodInterfaceIPBinding(vm, domain)
+			})
+			It("should define a new VIF bind to a bridge and create a specific nat rule using nftable", func() {
+				// Forward a specific port
+				mockNetwork.EXPECT().UseIptables().Return(false).AnyTimes()
+				mockNetwork.EXPECT().NftablesAppendRule("nat",
+					"KUBEVIRT_POSTINBOUND",
+					"tcp",
+					"dport",
+					"80",
+					"counter", "snat", "to", "10.0.2.1").Return(nil).AnyTimes()
+				mockNetwork.EXPECT().NftablesAppendRule("nat",
+					"KUBEVIRT_PREINBOUND",
+					"tcp",
+					"dport",
+					"80",
+					"counter", "dnat", "to", "10.0.2.2").Return(nil).AnyTimes()
+				mockNetwork.EXPECT().NftablesAppendRule("nat",
+					"output",
+					"ip", "daddr", "127.0.0.1",
+					"tcp",
+					"dport",
+					"80",
+					"counter", "dnat", "to", "10.0.2.2").Return(nil).AnyTimes()
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
 				vm.Spec.Domain.Devices.Interfaces[0].Ports = []v1.Port{{Name: "test", Port: 80, Protocol: "TCP"}}


### PR DESCRIPTION
Use nftable rules for coreOS servers on masquerade

This PR check if iptables are enable and if not use nftables to configure rules for the masquerade interface binding.

related to: 
* https://github.com/kubevirt/libvirt/pull/26
* https://github.com/kubevirt/kubevirt/pull/2428

Fixes #2400

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
support nftable for coreOS
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2430)
<!-- Reviewable:end -->
