### PR TITLE
PodSecurityPolicy Support added when admission controller is enabled, duplicate of 2298

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -285,6 +285,18 @@ spec:
           verbs:
           - put
         - apiGroups:
+          - policy
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - use
+        - apiGroups:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations
@@ -458,6 +470,14 @@ spec:
           verbs:
           - create
         - apiGroups:
+          - policy
+          resourceNames:
+          - kubevirt-launcher-psp
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
+        - apiGroups:
           - kubevirt.io
           resources:
           - virtualmachineinstances
@@ -507,6 +527,14 @@ spec:
           - secrets
           verbs:
           - create
+        - apiGroups:
+          - policy
+          resourceNames:
+          - kubevirt-privileged-psp
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
         - apiGroups:
           - subresources.kubevirt.io
           resources:

--- a/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
@@ -161,6 +161,26 @@ metadata:
   name: kubevirt-controller
   namespace: {{.Namespace}}
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kubevirt-launcher-psp
+spec:
+  allowedCapabilities:
+  - NET_ADMIN
+  - SYS_NICE
+  - SYS_RESOURCE
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -258,6 +278,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-launcher-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -341,6 +369,30 @@ subjects:
   name: kubevirt-handler
   namespace: {{.Namespace}}
 ---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kubevirt-privileged-psp
+spec:
+  allowedHostPaths:
+  - pathPrefix: /var/run/kubevirt-libvirt-runtimes
+  - pathPrefix: /var/run/kubevirt
+  - pathPrefix: /var/run/kubevirt-private
+  - pathPrefix: /var/lib/kubelet/device-plugins
+  fsGroup:
+    rule: RunAsAny
+  hostIPC: true
+  hostPID: true
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -363,6 +415,14 @@ rules:
   - secrets
   verbs:
   - create
+- apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-privileged-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -140,6 +140,18 @@ rules:
   verbs:
   - put
 - apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - use
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
@@ -313,6 +325,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-launcher-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachineinstances
@@ -362,6 +382,14 @@ rules:
   - secrets
   verbs:
   - create
+- apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-privileged-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - subresources.kubevirt.io
   resources:

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -114,6 +114,9 @@ type KubeInformerFactory interface {
 	// ClusterRoleBinding
 	OperatorClusterRoleBinding() cache.SharedIndexInformer
 
+	// PodSecurityPolicy
+	OperatorPodSecurityPolicy() cache.SharedIndexInformer
+
 	// Roles
 	OperatorRole() cache.SharedIndexInformer
 
@@ -374,6 +377,19 @@ func (f *kubeInformerFactory) OperatorClusterRoleBinding() cache.SharedIndexInfo
 		return cache.NewSharedIndexInformer(lw, &rbacv1.ClusterRoleBinding{}, f.defaultResync, cache.Indexers{})
 	})
 }
+
+func (f *kubeInformerFactory) OperatorPodSecurityPolicy() cache.SharedIndexInformer {
+	return f.getInformer("OperatorPodSecurityPolicyInformer", func() cache.SharedIndexInformer {
+		labelSelector, err := labels.Parse(OperatorLabel)
+		if err != nil {
+			panic(err)
+		}
+
+		lw := NewListWatchFromClient(f.clientSet.PolicyV1beta1().RESTClient(), "podsecuritypolicies", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
+		return cache.NewSharedIndexInformer(lw, &v1beta1.PodSecurityPolicy{}, f.defaultResync, cache.Indexers{})
+	})
+}
+
 func (f *kubeInformerFactory) OperatorRole() cache.SharedIndexInformer {
 	return f.getInformer("OperatorRoleInformer", func() cache.SharedIndexInformer {
 		labelSelector, err := labels.Parse(OperatorLabel)

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -127,6 +127,7 @@ func Execute() {
 
 	app.informers = util.Informers{
 		ServiceAccount:           app.informerFactory.OperatorServiceAccount(),
+		PodSecurityPolicy:        app.informerFactory.OperatorPodSecurityPolicy(),
 		ClusterRole:              app.informerFactory.OperatorClusterRole(),
 		ClusterRoleBinding:       app.informerFactory.OperatorClusterRoleBinding(),
 		Role:                     app.informerFactory.OperatorRole(),
@@ -146,6 +147,7 @@ func Execute() {
 		ServiceAccountCache:           app.informerFactory.OperatorServiceAccount().GetStore(),
 		ClusterRoleCache:              app.informerFactory.OperatorClusterRole().GetStore(),
 		ClusterRoleBindingCache:       app.informerFactory.OperatorClusterRoleBinding().GetStore(),
+		PodSecurityPolicyCache:        app.informerFactory.OperatorPodSecurityPolicy().GetStore(),
 		RoleCache:                     app.informerFactory.OperatorRole().GetStore(),
 		RoleBindingCache:              app.informerFactory.OperatorRoleBinding().GetStore(),
 		CrdCache:                      app.informerFactory.OperatorCRD().GetStore(),

--- a/pkg/virt-operator/creation/rbac/BUILD.bazel
+++ b/pkg/virt-operator/creation/rbac/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -20,6 +20,7 @@ package rbac
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	pspv1b1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -29,6 +30,7 @@ import (
 func GetAllController(namespace string) []interface{} {
 	return []interface{}{
 		newControllerServiceAccount(namespace),
+		newControllerPodSecurityPolicy(),
 		newControllerClusterRole(),
 		newControllerClusterRoleBinding(namespace),
 	}
@@ -45,6 +47,41 @@ func newControllerServiceAccount(namespace string) *corev1.ServiceAccount {
 			Name:      "kubevirt-controller",
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
+			},
+		},
+	}
+}
+
+func newControllerPodSecurityPolicy() *pspv1b1.PodSecurityPolicy {
+	return &pspv1b1.PodSecurityPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy/v1beta1",
+			Kind:       "PodSecurityPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt-launcher-psp",
+		},
+		Spec: pspv1b1.PodSecurityPolicySpec{
+			Privileged: false,
+			AllowedCapabilities: []corev1.Capability{
+				"NET_ADMIN",
+				"SYS_NICE",
+				"SYS_RESOURCE",
+			},
+			SELinux: pspv1b1.SELinuxStrategyOptions{
+				Rule: pspv1b1.SELinuxStrategyRunAsAny,
+			},
+			RunAsUser: pspv1b1.RunAsUserStrategyOptions{
+				Rule: pspv1b1.RunAsUserStrategyRunAsAny,
+			},
+			SupplementalGroups: pspv1b1.SupplementalGroupsStrategyOptions{
+				Rule: pspv1b1.SupplementalGroupsStrategyRunAsAny,
+			},
+			FSGroup: pspv1b1.FSGroupStrategyOptions{
+				Rule: pspv1b1.FSGroupStrategyRunAsAny,
+			},
+			Volumes: []pspv1b1.FSType{
+				"*",
 			},
 		},
 	}
@@ -184,6 +221,20 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"create",
+				},
+			},
+			{
+				APIGroups: []string{
+					"policy",
+				},
+				Resources: []string{
+					"podsecuritypolicies",
+				},
+				ResourceNames: []string{
+					"kubevirt-launcher-psp",
+				},
+				Verbs: []string{
+					"use",
 				},
 			},
 		},

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -252,6 +252,23 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 					"put",
 				},
 			},
+			{
+				APIGroups: []string{
+					"policy",
+				},
+				Resources: []string{
+					"podsecuritypolicies",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"delete",
+					"update",
+					"use",
+				},
+			},
 		},
 	}
 

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -75,6 +75,7 @@ func NewKubeVirtController(
 		kubeVirtExpectations: util.Expectations{
 			ServiceAccount:           controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("ServiceAccount")),
 			ClusterRole:              controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("ClusterRole")),
+			PodSecurityPolicy:        controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("PodSecurityPolicy")),
 			ClusterRoleBinding:       controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("ClusterRoleBinding")),
 			Role:                     controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("Role")),
 			RoleBinding:              controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("RoleBinding")),
@@ -107,6 +108,18 @@ func NewKubeVirtController(
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.genericUpdateHandler(oldObj, newObj, c.kubeVirtExpectations.ServiceAccount)
+		},
+	})
+
+	c.informers.PodSecurityPolicy.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.genericAddHandler(obj, c.kubeVirtExpectations.PodSecurityPolicy)
+		},
+		DeleteFunc: func(obj interface{}) {
+			c.genericDeleteHandler(obj, c.kubeVirtExpectations.PodSecurityPolicy)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.genericUpdateHandler(oldObj, newObj, c.kubeVirtExpectations.PodSecurityPolicy)
 		},
 	})
 
@@ -433,6 +446,7 @@ func (c *KubeVirtController) Run(threadiness int, stopCh <-chan struct{}) {
 	cache.WaitForCacheSync(stopCh, c.informers.ServiceAccount.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.ClusterRole.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.ClusterRoleBinding.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.informers.PodSecurityPolicy.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.Role.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.RoleBinding.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.Crd.HasSynced)

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -43,6 +43,7 @@ type Stores struct {
 	InfrastructurePodCache        cache.Store
 	PodDisruptionBudgetCache      cache.Store
 	IsOnOpenshift                 bool
+	PodSecurityPolicyCache        cache.Store
 }
 
 func (s *Stores) AllEmpty() bool {
@@ -57,7 +58,8 @@ func (s *Stores) AllEmpty() bool {
 		IsStoreEmpty(s.DaemonSetCache) &&
 		IsStoreEmpty(s.ValidationWebhookCache) &&
 		IsStoreEmpty(s.PodDisruptionBudgetCache) &&
-		IsSCCStoreEmpty(s.SCCCache)
+		IsSCCStoreEmpty(s.SCCCache) &&
+		IsStoreEmpty(s.PodSecurityPolicyCache)
 	// Don't add InstallStrategyConfigMapCache to this list. The install
 	// strategies persist even after deletion and updates.
 }
@@ -98,10 +100,12 @@ type Expectations struct {
 	InstallStrategyConfigMap *controller.UIDTrackingControllerExpectations
 	InstallStrategyJob       *controller.UIDTrackingControllerExpectations
 	PodDisruptionBudget      *controller.UIDTrackingControllerExpectations
+	PodSecurityPolicy        *controller.UIDTrackingControllerExpectations
 }
 
 type Informers struct {
 	ServiceAccount           cache.SharedIndexInformer
+	PodSecurityPolicy        cache.SharedIndexInformer
 	ClusterRole              cache.SharedIndexInformer
 	ClusterRoleBinding       cache.SharedIndexInformer
 	Role                     cache.SharedIndexInformer
@@ -133,6 +137,7 @@ func (e *Expectations) DeleteExpectations(key string) {
 	e.InstallStrategyConfigMap.DeleteExpectations(key)
 	e.InstallStrategyJob.DeleteExpectations(key)
 	e.PodDisruptionBudget.DeleteExpectations(key)
+	e.PodSecurityPolicy.DeleteExpectations(key)
 }
 
 func (e *Expectations) ResetExpectations(key string) {
@@ -150,6 +155,7 @@ func (e *Expectations) ResetExpectations(key string) {
 	e.InstallStrategyConfigMap.SetExpectations(key, 0, 0)
 	e.InstallStrategyJob.SetExpectations(key, 0, 0)
 	e.PodDisruptionBudget.SetExpectations(key, 0, 0)
+	e.PodSecurityPolicy.SetExpectations(key, 0, 0)
 }
 
 func (e *Expectations) SatisfiedExpectations(key string) bool {
@@ -166,5 +172,6 @@ func (e *Expectations) SatisfiedExpectations(key string) bool {
 		e.SCC.SatisfiedExpectations(key) &&
 		e.InstallStrategyConfigMap.SatisfiedExpectations(key) &&
 		e.InstallStrategyJob.SatisfiedExpectations(key) &&
-		e.PodDisruptionBudget.SatisfiedExpectations(key)
+		e.PodDisruptionBudget.SatisfiedExpectations(key) &&
+		e.PodSecurityPolicy.SatisfiedExpectations(key)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
PodSecurityPolicy support is required when admission controller is enabled.
If admission controller is enabled, virt-handler couldn't be started without proper pod security defined.

To fix this problem, following logic added:
1, defined PodSecurityPolicy kubevirt-privileged-psp
2, role kubevirt-handler could use psp "Kubevirt-privileged-psp"
3, role kubevirt-operator could write/read PodSecurityPolicy
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2221 

**Special notes for your reviewer**:
PodSecurityPolicy "kubevirt-privileged-psp" is created.
Attachment is detailed information.

This is duplicate of PR #2298.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
