### PR TITLE
drop unused check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,6 @@ distclean: clean
 deps-update:
 	SYNC_VENDOR=true hack/dockerized "GO111MODULE=on go mod tidy && GO111MODULE=on go mod vendor && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
 
-check:
-	hack/dockerized "./hack/check.sh"
-
 builder-cache-push:
 	hack/builder-cache.sh push
 


### PR DESCRIPTION
`make check` is calling `./hack/check.sh`, but `hack/check.sh` doesn't
exist. Let's drop the target.

Creating PR in case it is as easy as removing the target. If you think that check should perform other targets (I'm for it) or you know where `check.sh` went, tell me.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
