### PR TITLE
Release Update Functional Test

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -25,10 +25,22 @@ DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
 source hack/common.sh
 source hack/config.sh
 
+# This git command returns the most recent tag created in a specific branch
+# Example: if working in the release-0.17 branch, it will return v0.17.2 (or whatever the latest tag is today in release-0.17)
+# Example: if working in master, it will return v0.18.0 (or whatever the latest tag is today)
+#
+# These git tags happen to correspond exactly to our container tags, so the convention works well
+# for determining the release we should be testing updates with.
+_default_previous_release_tag=$(git describe --tags --abbrev=0 "$(git rev-parse HEAD)")
+_default_previous_release_registry="index.docker.io/kubevirt"
+
+previous_release_tag=${PREVIOUS_RELEASE_TAG:-$_default_previous_release_tag}
+previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_release_registry}
+
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
 if [[ ${TARGET} == openshift* ]]; then
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 300m ${FUNC_TEST_ARGS} -installed-namespace=${namespace}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 300m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry}

--- a/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
@@ -60,6 +60,7 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
+  - put
 - apiGroups:
   - kubevirt.io
   resources:
@@ -101,6 +102,7 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
+  - put
 - apiGroups:
   - kubevirt.io
   resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -336,6 +336,7 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
+  - put
 - apiGroups:
   - kubevirt.io
   resources:
@@ -368,6 +369,7 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
+  - put
 - apiGroups:
   - kubevirt.io
   resources:

--- a/pkg/virt-operator/creation/rbac/cluster.go
+++ b/pkg/virt-operator/creation/rbac/cluster.go
@@ -139,6 +139,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"update",
+					"put",
 				},
 			},
 			{
@@ -197,6 +198,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"update",
+					"put",
 				},
 			},
 			{

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -131,6 +131,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -91,6 +91,8 @@ var KubeVirtKubectlPath = ""
 var KubeVirtOcPath = ""
 var KubeVirtVirtctlPath = ""
 var KubeVirtInstallNamespace string
+var PreviousReleaseTag = ""
+var PreviousReleaseRegistry = ""
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -108,6 +110,8 @@ func init() {
 	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "kubevirt", "Set the namespace KubeVirt is installed in")
 	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
+	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
+	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "", "Set registry of the release to test updating from")
 
 }
 


### PR DESCRIPTION
As part of our commitment to providing a KubeVirt update path, we need a functional test to verify we can always update from the latest release to the latest code in master. This test verifies we can update from previous releases to the current code and also sanity checks that VMI workloads are not impacted by the control plane updates.

The test was originally meant to be a part of the #2401 PR which progresses our API to 'v1'. Since we made the decision to merge #2401 after the kubevirt 0.19.0 release, I have pulled out the functional test from that PR into here.

This PR also includes a fix to RBAC that prevented updates from occurring properly.  In this case our removal of the "put" privilege for subresources.kubevirt.io prevents the latest operator from being able to properly update from 0.18.0 to master. The operator needs the aggregate privileges of both the latest version and the previous version it is updating kubevirt from to work properly. 


```release-note
Functional test for updating from previous release
```
