### PR TITLE
Vfiosh

### DIFF
--- a/tools/util/vfio.sh
+++ b/tools/util/vfio.sh
@@ -12,7 +12,12 @@ for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
     pfroot=$(dirname $file)
 
     # enable all available VFs. If this fails we skip the device continuing with the others.
-    cat $file > $pfroot/sriov_numvfs || continue
+    cat $file > $pfroot/sriov_numvfs
+    if [ $? -ne 0 ]; then
+        echo "Skipping $pfroot, not able to activate virtual functions for it"
+        continue
+    fi
+
 
     # bind all VFs with vfio
     for virtfn in $(ls -d $pfroot/virtfn*); do

--- a/tools/util/vfio.sh
+++ b/tools/util/vfio.sh
@@ -11,7 +11,7 @@ modprobe vfio-pci
 for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
     pfroot=$(dirname $file)
 
-    # enable all available VFs
+    # enable all available VFs. If this fails we skip the device continuing with the others.
     cat $file > $pfroot/sriov_numvfs || continue
 
     # bind all VFs with vfio
@@ -19,7 +19,7 @@ for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
         pciid=$(basename $(readlink $virtfn))
         if [ -e $virtfn/driver/unbind ]; then
             echo $pciid > $virtfn/driver/unbind
-            echo $(lspci -n -s $pciid | sed 's/:/ /g' | awk -e '{print $4 " " $5}') > /sys/bus/pci/drivers/vfio-pci/new_id
         fi
+        echo $(lspci -n -s $pciid | sed 's/:/ /g' | awk '{print $4 " " $5}') > /sys/bus/pci/drivers/vfio-pci/new_id
     done
 done

--- a/tools/util/vfio.sh
+++ b/tools/util/vfio.sh
@@ -12,7 +12,7 @@ for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
     pfroot=$(dirname $file)
 
     # enable all available VFs
-    cat $file > $pfroot/sriov_numvfs
+    cat $file > $pfroot/sriov_numvfs || continue
 
     # bind all VFs with vfio
     for virtfn in $(ls -d $pfroot/virtfn*); do


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a couple of problems I found in the setup script while working on CI for sr-iov devices:

- Some devices do not allow us to write on `sriov_numvfs` in order to activate the virtual functions. In that case we want to skip them and enable the ones that allow us to do so
- When no driver was bound to the device, the script skipped it and did not bind it to the vfio-pci driver

**Release note:**

```release-note
NONE
```
