### PR TITLE
Remove DataVolume feature gate in favor of dynamic CDI api detection

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -254,7 +254,7 @@ func (app *virtHandlerApp) Run() {
 		gracefulShutdownInformer,
 		int(app.WatchdogTimeoutDuration.Seconds()),
 		app.MaxDevices,
-		virtconfig.NewClusterConfig(factory.ConfigMap(), app.namespace),
+		virtconfig.NewClusterConfig(factory.ConfigMap(), factory.CRD(), app.namespace),
 		app.migrationTLSConfig,
 	)
 

--- a/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
@@ -77,6 +77,14 @@ rules:
   verbs:
   - watch
   - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -242,6 +250,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -301,6 +317,14 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -188,6 +188,14 @@ rules:
   - watch
   - list
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - secrets
@@ -282,6 +290,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachineinstances
@@ -309,6 +325,14 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -16,15 +16,15 @@ const (
 )
 
 func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
-	informer, _ := NewFakeInformerFor(&v1.ConfigMap{})
+	configMapInformer, _ := NewFakeInformerFor(&v1.ConfigMap{})
 	crdInformer, _ := NewFakeInformerFor(&extv1beta1.CustomResourceDefinition{})
 
 	copy := copy(cfgMap)
-	informer.GetStore().Add(copy)
+	configMapInformer.GetStore().Add(copy)
 
 	AddDataVolumeAPI(crdInformer)
 
-	return virtconfig.NewClusterConfig(informer, crdInformer, namespace), informer, crdInformer
+	return virtconfig.NewClusterConfig(configMapInformer, crdInformer, namespace), configMapInformer, crdInformer
 }
 
 func RemoveDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
@@ -41,9 +41,9 @@ func AddDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
 	})
 }
 
-func UpdateFakeClusterConfig(informer cache.SharedIndexInformer, cfgMap *v1.ConfigMap) {
+func UpdateFakeClusterConfig(configMapInformer cache.SharedIndexInformer, cfgMap *v1.ConfigMap) {
 	copy := copy(cfgMap)
-	informer.GetStore().Update(copy)
+	configMapInformer.GetStore().Update(copy)
 }
 
 func copy(cfgMap *v1.ConfigMap) *v1.ConfigMap {

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -21,13 +21,9 @@ func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cach
 
 	copy := copy(cfgMap)
 	informer.GetStore().Add(copy)
-	crdInformer.GetStore().Add(&extv1beta1.CustomResourceDefinition{
-		Spec: extv1beta1.CustomResourceDefinitionSpec{
-			Names: extv1beta1.CustomResourceDefinitionNames{
-				Kind: "DataVolume",
-			},
-		},
-	})
+
+	AddDataVolumeAPI(crdInformer)
+
 	return virtconfig.NewClusterConfig(informer, crdInformer, namespace), informer, crdInformer
 }
 

--- a/pkg/testutils/mock_config.go
+++ b/pkg/testutils/mock_config.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	v1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/cache"
@@ -14,11 +15,34 @@ const (
 	namespace     = "kubevirt"
 )
 
-func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.SharedIndexInformer) {
+func NewFakeClusterConfig(cfgMap *v1.ConfigMap) (*virtconfig.ClusterConfig, cache.SharedIndexInformer, cache.SharedIndexInformer) {
 	informer, _ := NewFakeInformerFor(&v1.ConfigMap{})
+	crdInformer, _ := NewFakeInformerFor(&extv1beta1.CustomResourceDefinition{})
+
 	copy := copy(cfgMap)
 	informer.GetStore().Add(copy)
-	return virtconfig.NewClusterConfig(informer, namespace), informer
+	crdInformer.GetStore().Add(&extv1beta1.CustomResourceDefinition{
+		Spec: extv1beta1.CustomResourceDefinitionSpec{
+			Names: extv1beta1.CustomResourceDefinitionNames{
+				Kind: "DataVolume",
+			},
+		},
+	})
+	return virtconfig.NewClusterConfig(informer, crdInformer, namespace), informer, crdInformer
+}
+
+func RemoveDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Replace(nil, "")
+}
+
+func AddDataVolumeAPI(crdInformer cache.SharedIndexInformer) {
+	crdInformer.GetStore().Add(&extv1beta1.CustomResourceDefinition{
+		Spec: extv1beta1.CustomResourceDefinitionSpec{
+			Names: extv1beta1.CustomResourceDefinitionNames{
+				Kind: "DataVolume",
+			},
+		},
+	})
 }
 
 func UpdateFakeClusterConfig(informer cache.SharedIndexInformer, cfgMap *v1.ConfigMap) {

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -1021,6 +1021,7 @@ func (app *virtAPIApp) Run() {
 	webhookInformers := webhooks.GetInformers()
 	kubeInformerFactory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, app.namespace)
 	configMapInformer := kubeInformerFactory.ConfigMap()
+	crdInformer := kubeInformerFactory.CRD()
 
 	stopChan := make(chan struct{}, 1)
 	defer close(stopChan)
@@ -1028,6 +1029,7 @@ func (app *virtAPIApp) Run() {
 	go webhookInformers.VMIPresetInformer.Run(stopChan)
 	go webhookInformers.NamespaceLimitsInformer.Run(stopChan)
 	go configMapInformer.Run(stopChan)
+	go crdInformer.Run(stopChan)
 
 	cache.WaitForCacheSync(stopChan,
 		webhookInformers.VMIInformer.HasSynced,
@@ -1035,7 +1037,7 @@ func (app *virtAPIApp) Run() {
 		webhookInformers.NamespaceLimitsInformer.HasSynced,
 		configMapInformer.HasSynced)
 
-	app.clusterConfig = virtconfig.NewClusterConfig(configMapInformer, app.namespace)
+	app.clusterConfig = virtconfig.NewClusterConfig(configMapInformer, crdInformer, app.namespace)
 
 	// Verify/create webhook endpoint.
 	err = app.createWebhook()

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -92,7 +92,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi.Status.Phase = v1.Running
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
 
-			config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+			config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", pvcCache, app.VirtCli, config)
 
 			pod, err := templateService.RenderLaunchManifest(vmi)
@@ -265,7 +265,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			vmi.Status.Phase = v1.Running
 			vmi.ObjectMeta.SetUID(uuid.NewUUID())
 
-			config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+			config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 			templateService := services.NewTemplateService("whatever", "whatever", "whatever", "whatever", pvcCache, app.VirtCli, config)
 
 			pod, err := templateService.RenderLaunchManifest(vmi)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -135,7 +135,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		)
 
 		mutator = &VMIsMutator{}
-		mutator.ClusterConfig, configMapInformer = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		mutator.ClusterConfig, configMapInformer, _ = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 	})
 
 	It("should apply presets on VMI create", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 var _ = Describe("Validating MigrationCreate Admitter", func() {
-	config, configMapInformer := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+	config, configMapInformer, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 	migrationCreateAdmitter := &MigrationCreateAdmitter{ClusterConfig: config}
 
 	enableFeatureGate := func(featureGate string) {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter_test.go
@@ -37,7 +37,7 @@ import (
 
 var _ = Describe("Validating MigrationUpdate Admitter", func() {
 	migrationUpdateAdmitter := &MigrationUpdateAdmitter{}
-	_, configMapInformer := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+	_, configMapInformer, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 	enableFeatureGate := func(featureGate string) {
 		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1245,10 +1245,10 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 			volumeSourceSetCount++
 		}
 		if volume.DataVolume != nil {
-			if !config.DataVolumesEnabled() {
+			if !config.HasDataVolumeAPI() {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "DataVolume feature gate is not enabled",
+					Message: "DataVolume api is not present in cluster. CDI must be installed for DataVolume support.",
 					Field:   field.Index(idx).String(),
 				})
 			}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 var _ = Describe("Validating VMICreate Admitter", func() {
-	config, configMapInformer := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+	config, configMapInformer, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 	vmiCreateAdmitter := &VMICreateAdmitter{ClusterConfig: config}
 
 	dnsConfigTestOption := "test"
@@ -2330,7 +2330,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 })
 
 var _ = Describe("Function getNumberOfPodInterfaces()", func() {
-	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+	config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 	It("should work for empty network list", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var _ = Describe("Validating VMIRS Admitter", func() {
-	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+	config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 	vmirsAdmitter := &VMIRSAdmitter{ClusterConfig: config}
 
 	table.DescribeTable("should reject documents containing unknown or missing fields for", func(data string, validationResult string, gvr metav1.GroupVersionResource, review func(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse) {

--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -164,17 +164,9 @@ func (c *ClusterConfig) crdAddedDeleted(obj interface{}) {
 		go c.configModifiedCallback()
 	}
 }
-func (c *ClusterConfig) crdUpdated(old, cur interface{}) {
-	crd := cur.(*extv1beta1.CustomResourceDefinition)
-	if !isDataVolumeCrd(crd) {
-		return
-	}
 
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.configModifiedCallback != nil {
-		go c.configModifiedCallback()
-	}
+func (c *ClusterConfig) crdUpdated(old, cur interface{}) {
+	c.crdAddedDeleted(cur)
 }
 
 func defaultClusterConfig() *Config {

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -28,7 +28,7 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	table.DescribeTable(" when useEmulation", func(value string, result bool) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{"debug.useEmulation": value},
 		})
 		Expect(clusterConfig.IsUseEmulation()).To(Equal(result))
@@ -40,7 +40,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when permitSlirpInterface", func(value string, result bool) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{"permitSlirpInterface": value},
 		})
 		Expect(clusterConfig.IsSlirpInterfaceEnabled()).To(Equal(result))
@@ -52,7 +52,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when imagePullPolicy", func(value string, result kubev1.PullPolicy) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.ImagePullPolicyKey: value},
 		})
 		Expect(clusterConfig.GetImagePullPolicy()).To(Equal(result))
@@ -65,7 +65,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when lessPVCSpaceToleration", func(value string, result int) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.LessPVCSpaceTolerationKey: value},
 		})
 		Expect(clusterConfig.GetLessPVCSpaceToleration()).To(Equal(result))
@@ -76,7 +76,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when defaultNetworkInterface", func(value string, result string) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.NetworkInterfaceKey: value},
 		})
 		Expect(clusterConfig.GetDefaultNetworkInterface()).To(Equal(result))
@@ -94,7 +94,7 @@ var _ = Describe("ConfigMap", func() {
 		"node-role.kubernetes.io/compute": "true",
 	}
 	table.DescribeTable(" when nodeSelectors", func(value string, result map[string]string) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.NodeSelectorsKey: value},
 		})
 		Expect(clusterConfig.GetNodeSelectors()).To(Equal(result))
@@ -105,7 +105,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when machineType", func(value string, result string) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MachineTypeKey: value},
 		})
 		Expect(clusterConfig.GetMachineType()).To(Equal(result))
@@ -115,7 +115,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when cpuModel", func(value string, result string) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.CpuModelKey: value},
 		})
 		Expect(clusterConfig.GetCPUModel()).To(Equal(result))
@@ -125,7 +125,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when cpuRequest", func(value string, result string) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.CpuRequestKey: value},
 		})
 		cpuRequest := clusterConfig.GetCPURequest()
@@ -136,7 +136,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when memoryOvercommit", func(value string, result int) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MemoryOvercommitKey: value},
 		})
 		Expect(clusterConfig.GetMemoryOvercommit()).To(Equal(result))
@@ -146,7 +146,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	table.DescribeTable(" when emulatedMachines", func(value string, result []string) {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.EmulatedMachinesKey: value},
 		})
 		emulatedMachines := clusterConfig.GetEmulatedMachines()
@@ -157,7 +157,7 @@ var _ = Describe("ConfigMap", func() {
 	)
 
 	It("Should return migration config values if specified as json", func() {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10, "parallelMigrationsPerCluster": 20, "bandwidthPerMigration": "110Mi", "progressTimeout" : 5, "completionTimeoutPerGiB": 5, "unsafeMigrationOverride": true, "allowAutoConverge": true}`},
 		})
 		result := clusterConfig.GetMigrationConfig()
@@ -171,7 +171,7 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should return migration config values if specified as yaml", func() {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `"parallelOutboundMigrationsPerNode" : 10
 "parallelMigrationsPerCluster": 20
 "bandwidthPerMigration": "110Mi"`},
@@ -183,7 +183,7 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should return defaults if parts of the config are not set", func() {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10}`},
 		})
 		result := clusterConfig.GetMigrationConfig()
@@ -193,7 +193,7 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should update the config if a newer version is available", func() {
-		clusterConfig, store := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, store, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10}`},
 		})
 		result := clusterConfig.GetMigrationConfig()
@@ -208,7 +208,7 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should stick with the last good config", func() {
-		clusterConfig, store := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, store, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10}`},
 		})
 		result := clusterConfig.GetMigrationConfig()
@@ -223,7 +223,7 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("Should pick up the latest config once it is fixed and parsable again", func() {
-		clusterConfig, store := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+		clusterConfig, store, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10}`},
 		})
 		result := clusterConfig.GetMigrationConfig()
@@ -247,13 +247,13 @@ var _ = Describe("ConfigMap", func() {
 	})
 
 	It("should return the default config if no config map exists", func() {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
 		result := clusterConfig.GetMigrationConfig()
 		Expect(*result.ParallelOutboundMigrationsPerNode).To(BeNumerically("==", 2))
 	})
 
 	It("should contain a default machine type that is supported by default", func() {
-		clusterConfig, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
 		Expect(clusterConfig.GetMachineType()).To(testutils.SatisfyAnyRegexp(clusterConfig.GetEmulatedMachines()))
 	})
 })

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -42,10 +42,6 @@ func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
 	return strings.Contains(c.getConfig().FeatureGates, featureGate)
 }
 
-func (config *ClusterConfig) DataVolumesEnabled() bool {
-	return config.isFeatureGateEnabled(dataVolumesGate)
-}
-
 func (config *ClusterConfig) CPUManagerEnabled() bool {
 	return config.isFeatureGateEnabled(cpuManager)
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Template", func() {
 
 	ctrl := gomock.NewController(GinkgoT())
 	virtClient := kubecli.NewMockKubevirtClient(ctrl)
-	config, configMapInformer := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
+	config, configMapInformer, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
 
 	enableFeatureGate := func(featureGate string) {
 		testutils.UpdateFakeClusterConfig(configMapInformer, &kubev1.ConfigMap{

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Evacuation", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
 		nodeInformer, nodeSource = testutils.NewFakeInformerFor(&v12.Node{})
 		recorder = record.NewFakeRecorder(100)
-		config, _ := testutils.NewFakeClusterConfig(&v12.ConfigMap{})
+		config, _, _ := testutils.NewFakeClusterConfig(&v12.ConfigMap{})
 
 		controller = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, recorder, virtClient, config)
 		mockQueue = testutils.NewMockWorkQueue(controller.Queue)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Migration watcher", func() {
 		recorder = record.NewFakeRecorder(100)
 
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
-		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 		controller = NewMigrationController(
 			services.NewTemplateService("a", "b", "c", "d", pvcInformer.GetStore(), virtClient, config),

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -161,7 +161,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		recorder = record.NewFakeRecorder(100)
 
-		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		controller = NewVMIController(
 			services.NewTemplateService("a", "b", "c", "d", pvcInformer.GetStore(), virtClient, config),

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -122,7 +122,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 		mockWatchdog = &MockWatchdog{shareDir}
 		mockGracefulShutdown = &MockGracefulShutdown{shareDir}
-		config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+		config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 
 		controller = NewController(recorder,
 			virtClient,

--- a/pkg/virt-operator/creation/rbac/apiserver.go
+++ b/pkg/virt-operator/creation/rbac/apiserver.go
@@ -157,6 +157,19 @@ func newApiServerClusterRole() *rbacv1.ClusterRole {
 					"watch", "list",
 				},
 			},
+			{
+				APIGroups: []string{
+					"apiextensions.k8s.io",
+				},
+				Resources: []string{
+					"customresourcedefinitions",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
 		},
 	}
 }

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -162,6 +162,19 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"get", "list", "watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"apiextensions.k8s.io",
+				},
+				Resources: []string{
+					"customresourcedefinitions",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
 		},
 	}
 }

--- a/pkg/virt-operator/creation/rbac/handler.go
+++ b/pkg/virt-operator/creation/rbac/handler.go
@@ -110,6 +110,19 @@ func newHandlerClusterRole() *rbacv1.ClusterRole {
 					"create", "patch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"apiextensions.k8s.io",
+				},
+				Resources: []string{
+					"customresourcedefinitions",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
 		},
 	}
 }

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -44,7 +44,7 @@ func main() {
 	genDir := flag.String("generated-vms-dir", "", "")
 	flag.Parse()
 
-	config, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
+	config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
 		Data: map[string]string{
 			// Required to validate DataVolume usage
 			virtconfig.FeatureGatesKey:      "DataVolumes,LiveMigration,SRIOV",


### PR DESCRIPTION
The DataVolumes feature-gate shouldn't be necessary anymore. CDI integration has stabilized and there's really no reason not to always allow use of DataVolumes if CDI exists.

This PR detects if CDI exists, and enabled DataVolume support if it does.  If CDI is introduced later on, we dynamically enable support for DataVolumes by re-initializing virt-controller. 

Fixes: #1638

```release-note
Remove DataVolumes feature gate in favor of auto-detecting cdi support. 
```
