### PR TITLE
Refactor virt-config

### DIFF
--- a/pkg/virt-config/BUILD.bazel
+++ b/pkg/virt-config/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config-map.go",
         "feature-gates.go",
+        "virt-config.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-config",
     visibility = ["//visibility:public"],

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -55,26 +55,7 @@ const (
 	NodeSelectorsKey          = "node-selectors"
 	NetworkInterfaceKey       = "default-network-interface"
 	PermitSlirpInterface      = "permitSlirpInterface"
-
-	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
-	ParallelMigrationsPerClusterDefault      uint32 = 5
-	BandwithPerMigrationDefault                     = "64Mi"
-	MigrationAllowAutoConverge               bool   = false
-	MigrationProgressTimeout                 int64  = 150
-	MigrationCompletionTimeoutPerGiB         int64  = 800
-	DefaultMachineType                              = "q35"
-	DefaultCPURequest                               = "100m"
-	DefaultMemoryOvercommit                         = 100
-	DefaultEmulatedMachines                         = "q35*,pc-q35*"
-	DefaultLessPVCSpaceToleration                   = 10
-	DefaultNodeSelectors                            = ""
-	DefaultNetworkInterface                         = "bridge"
-	DefaultImagePullPolicy                          = k8sv1.PullIfNotPresent
-	DefaultUseEmulation                             = false
-	DefaultUnsafeMigrationOverride                  = false
-	DefaultPermitSlirpInterface                     = false
-
-	NodeDrainTaintDefaultKey = "kubevirt.io/drain"
+	NodeDrainTaintDefaultKey  = "kubevirt.io/drain"
 )
 
 func getConfigMap() *k8sv1.ConfigMap {
@@ -202,54 +183,6 @@ type ClusterConfig struct {
 	lastValidConfig                  *Config
 	defaultConfig                    *Config
 	lastInvalidConfigResourceVersion string
-}
-
-func (c *ClusterConfig) IsUseEmulation() bool {
-	return c.getConfig().UseEmulation
-}
-
-func (c *ClusterConfig) GetMigrationConfig() *MigrationConfig {
-	return c.getConfig().MigrationConfig
-}
-
-func (c *ClusterConfig) GetImagePullPolicy() (policy k8sv1.PullPolicy) {
-	return c.getConfig().ImagePullPolicy
-}
-
-func (c *ClusterConfig) GetMachineType() string {
-	return c.getConfig().MachineType
-}
-
-func (c *ClusterConfig) GetCPUModel() string {
-	return c.getConfig().CPUModel
-}
-
-func (c *ClusterConfig) GetCPURequest() resource.Quantity {
-	return c.getConfig().CPURequest
-}
-
-func (c *ClusterConfig) GetMemoryOvercommit() int {
-	return c.getConfig().MemoryOvercommit
-}
-
-func (c *ClusterConfig) GetEmulatedMachines() []string {
-	return c.getConfig().EmulatedMachines
-}
-
-func (c *ClusterConfig) GetLessPVCSpaceToleration() int {
-	return c.getConfig().LessPVCSpaceToleration
-}
-
-func (c *ClusterConfig) GetNodeSelectors() map[string]string {
-	return c.getConfig().NodeSelectors
-}
-
-func (c *ClusterConfig) GetDefaultNetworkInterface() string {
-	return c.getConfig().NetworkInterface
-}
-
-func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {
-	return c.getConfig().PermitSlirpInterface
 }
 
 // setConfig parses the provided config map and updates the provided config.

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -69,6 +69,10 @@ const (
 	DefaultLessPVCSpaceToleration                   = 10
 	DefaultNodeSelectors                            = ""
 	DefaultNetworkInterface                         = "bridge"
+	DefaultImagePullPolicy                          = k8sv1.PullIfNotPresent
+	DefaultUseEmulation                             = false
+	DefaultUnsafeMigrationOverride                  = false
+	DefaultPermitSlirpInterface                     = false
 
 	NodeDrainTaintDefaultKey = "kubevirt.io/drain"
 )
@@ -140,8 +144,8 @@ func defaultClusterConfig() *Config {
 	defaultNetworkInterface := DefaultNetworkInterface
 	return &Config{
 		ResourceVersion: "0",
-		ImagePullPolicy: k8sv1.PullIfNotPresent,
-		UseEmulation:    false,
+		ImagePullPolicy: DefaultImagePullPolicy,
+		UseEmulation:    DefaultUseEmulation,
 		MigrationConfig: &MigrationConfig{
 			ParallelMigrationsPerCluster:      &parallelMigrationsPerClusterDefault,
 			ParallelOutboundMigrationsPerNode: &parallelOutboundMigrationsPerNodeDefault,
@@ -149,7 +153,7 @@ func defaultClusterConfig() *Config {
 			NodeDrainTaintKey:                 &nodeDrainTaintDefaultKey,
 			ProgressTimeout:                   &progressTimeout,
 			CompletionTimeoutPerGiB:           &completionTimeoutPerGiB,
-			UnsafeMigrationOverride:           false,
+			UnsafeMigrationOverride:           DefaultUnsafeMigrationOverride,
 			AllowAutoConverge:                 allowAutoConverge,
 		},
 		MachineType:            DefaultMachineType,
@@ -159,7 +163,7 @@ func defaultClusterConfig() *Config {
 		LessPVCSpaceToleration: DefaultLessPVCSpaceToleration,
 		NodeSelectors:          nodeSelectorsDefault,
 		NetworkInterface:       defaultNetworkInterface,
-		PermitSlirpInterface:   false,
+		PermitSlirpInterface:   DefaultPermitSlirpInterface,
 	}
 }
 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -20,8 +20,7 @@
 package virtconfig
 
 /*
- This module is intended for determining whether an optional feature is enabled or not at the system-level.
- Note that the virtconfig package needs to be initialized before using this (see config-map.Init)
+ This module is intended for determining whether an optional feature is enabled or not at the cluster-level.
 */
 
 import (

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017, 2018 Red Hat, Inc.
+ *
+ */
+
+package virtconfig
+
+/*
+ This module is intended for exposing the virtualization configuration that is availabe at the cluster-level and its default settings.
+*/
+
+import (
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
+	ParallelMigrationsPerClusterDefault      uint32 = 5
+	BandwithPerMigrationDefault                     = "64Mi"
+	MigrationAllowAutoConverge               bool   = false
+	MigrationProgressTimeout                 int64  = 150
+	MigrationCompletionTimeoutPerGiB         int64  = 800
+	DefaultMachineType                              = "q35"
+	DefaultCPURequest                               = "100m"
+	DefaultMemoryOvercommit                         = 100
+	DefaultEmulatedMachines                         = "q35*,pc-q35*"
+	DefaultLessPVCSpaceToleration                   = 10
+	DefaultNodeSelectors                            = ""
+	DefaultNetworkInterface                         = "bridge"
+	DefaultImagePullPolicy                          = k8sv1.PullIfNotPresent
+	DefaultUseEmulation                             = false
+	DefaultUnsafeMigrationOverride                  = false
+	DefaultPermitSlirpInterface                     = false
+)
+
+func (c *ClusterConfig) IsUseEmulation() bool {
+	return c.getConfig().UseEmulation
+}
+
+func (c *ClusterConfig) GetMigrationConfig() *MigrationConfig {
+	return c.getConfig().MigrationConfig
+}
+
+func (c *ClusterConfig) GetImagePullPolicy() (policy k8sv1.PullPolicy) {
+	return c.getConfig().ImagePullPolicy
+}
+
+func (c *ClusterConfig) GetMachineType() string {
+	return c.getConfig().MachineType
+}
+
+func (c *ClusterConfig) GetCPUModel() string {
+	return c.getConfig().CPUModel
+}
+
+func (c *ClusterConfig) GetCPURequest() resource.Quantity {
+	return c.getConfig().CPURequest
+}
+
+func (c *ClusterConfig) GetMemoryOvercommit() int {
+	return c.getConfig().MemoryOvercommit
+}
+
+func (c *ClusterConfig) GetEmulatedMachines() []string {
+	return c.getConfig().EmulatedMachines
+}
+
+func (c *ClusterConfig) GetLessPVCSpaceToleration() int {
+	return c.getConfig().LessPVCSpaceToleration
+}
+
+func (c *ClusterConfig) GetNodeSelectors() map[string]string {
+	return c.getConfig().NodeSelectors
+}
+
+func (c *ClusterConfig) GetDefaultNetworkInterface() string {
+	return c.getConfig().NetworkInterface
+}
+
+func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {
+	return c.getConfig().PermitSlirpInterface
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR:
1. Defines default config values in kubevirt-config that were hard-coded at defaultClusterConfig as consts
2. Introduces virt-config.go that holds the configuration that should be exposed outside (besides the feature gates) and its default values. Those are separated out from config-map.go that remains with the "infrastructure" part.
3. Update the documentation of feature-gates.go

**Special notes for your reviewer**:
This PR extracts the refactoring-related changes from #2406 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
