### PR TITLE
Fix loopback not found error on kind clusters

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -27,9 +27,13 @@ mkdir -p /images/datavolume1 /images/datavolume2 /images/datavolume3
 echo "converting cirros image from qcow2 to raw, and copying it to local-storage directory, and creating a loopback device from it"
 # /local-storage will be mapped to the host dir, which will also be used by the local storage provider
 qemu-img convert -f qcow2 -O raw /images/cirros/disk.img /local-storage/cirros.img.raw
-LOOP_DEVICE=$(losetup --find --show /local-storage/cirros.img.raw)
+
+mknod /dev/loop99 b 7 0
+# attempt a detach since with docker in docker scenarios the created loopback device is already busy
+losetup -d /dev/loop99 || true 
+losetup /dev/loop99 /local-storage/cirros.img.raw
 rm -f /local-storage/cirros-block-device
-ln -s $LOOP_DEVICE /local-storage/cirros-block-device
+ln -s dev/loop99 /local-storage/cirros-block-device
 
 echo "converting fedora image from qcow2 to raw"
 qemu-img convert -f qcow2 -O raw /images/fedora-cloud/disk.qcow2 /images/fedora-cloud/disk.img

--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -30,7 +30,7 @@ qemu-img convert -f qcow2 -O raw /images/cirros/disk.img /local-storage/cirros.i
 
 mknod /dev/loop99 b 7 0
 # attempt a detach since with docker in docker scenarios the created loopback device is already busy
-losetup -d /dev/loop99 || true 
+losetup -d /dev/loop99 || true
 losetup /dev/loop99 /local-storage/cirros.img.raw
 rm -f /local-storage/cirros-block-device
 ln -s dev/loop99 /local-storage/cirros-block-device


### PR DESCRIPTION
**What this PR does / why we need it**:
When running a tests on a kind cluster, the `disk-images-provider` pod crashes on start with the following error:
```
losetup: /local-storage/cirros.img.raw: failed to set up loop device: No such file or directory
```
See #2449 for details on how to reproduce it. 

This PR creates a brand new loopback device, attempts to detach it and mounts the image on it instead of relying on the fact that we are going to find an available one.

**Which issue(s) this PR fixes** :
Fixes #2449

**Release note**:

```release-note
NONE
```