### PR TITLE
Move the put verb of the subresources rules from cluster roles to operator rules

### DIFF
--- a/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
@@ -60,7 +60,6 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
-  - put
 - apiGroups:
   - kubevirt.io
   resources:
@@ -102,7 +101,6 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
-  - put
 - apiGroups:
   - kubevirt.io
   resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -117,6 +117,14 @@ rules:
   - create
   - delete
 - apiGroups:
+  - subresources.kubevirt.io
+  resources:
+  - virtualmachines/start
+  - virtualmachines/stop
+  - virtualmachines/restart
+  verbs:
+  - put
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
@@ -336,7 +344,6 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
-  - put
 - apiGroups:
   - kubevirt.io
   resources:
@@ -369,7 +376,6 @@ rules:
   - virtualmachines/restart
   verbs:
   - update
-  - put
 - apiGroups:
   - kubevirt.io
   resources:

--- a/pkg/virt-operator/creation/rbac/cluster.go
+++ b/pkg/virt-operator/creation/rbac/cluster.go
@@ -139,7 +139,6 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"update",
-					"put",
 				},
 			},
 			{
@@ -198,7 +197,6 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"update",
-					"put",
 				},
 			},
 			{

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -213,6 +213,22 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 					"get", "list", "watch", "create", "delete",
 				},
 			},
+			{
+				// this is needed for being able to update from older versions (<= v0.18), which included the removed
+				// "put" verb on subresources for admin and edit cluster roles.
+				// Remove this when upgrade path from v0.18 and earlier is not supported anymore
+				APIGroups: []string{
+					"subresources.kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachines/start",
+					"virtualmachines/stop",
+					"virtualmachines/restart",
+				},
+				Verbs: []string{
+					"put",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In an earlier commit the put verb was removed, because it is not needed
and even isn't a valid verb. Unfortunately that broke updates, because
the operator needs all rules of previous versions, so the put verb was
re-addeed. With this commit the put verb is moved from the cluster roles
to the operator's rules, in order to be able to remove it completely as
soon as an upgrade path from the current version v0.18 is not supported
anymore.

**Special notes for your reviewer**:
PR where put was removed: https://github.com/kubevirt/kubevirt/pull/2391
PR where put was re-added: https://github.com/kubevirt/kubevirt/pull/2440

/cc @davidvossel 
/cc @rmohr 

**Release note**:
```release-note
NONE
```
