### PR TITLE
Pull in latest CI cluster

### DIFF
--- a/cluster-up/cluster/ephemeral-provider-common.sh
+++ b/cluster-up/cluster/ephemeral-provider-common.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-_cli_container="kubevirtci/gocli@sha256:b52e44d4e44e4c03811a42af9136492fd22f725523c4a3b9258ca9556447736d"
+_cli_container="kubevirtci/gocli@sha256:caf1c3f63dc5f3137795084e492a48c802a7ef2e7f7fbe1d67e5cff684d376a3"
 _cli_with_tty="docker run --privileged --net=host --rm -t -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 _cli="docker run --privileged --net=host --rm ${USE_TTY} -v /var/run/docker.sock:/var/run/docker.sock ${_cli_container}"
 
@@ -20,6 +20,7 @@ function prepare_config() {
 master_ip=$(_main_ip)
 kubeconfig=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
 kubectl=${BASE_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+gocli=${BASE_PATH}/../cluster-up/cli.sh
 docker_prefix=localhost:$(_port registry)/kubevirt
 manifest_docker_prefix=registry:5000/kubevirt
 EOF
@@ -30,7 +31,7 @@ function _registry_volume() {
 }
 
 function _add_common_params() {
-    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 5 --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
+    local params="--nodes ${KUBEVIRT_NUM_NODES} --memory ${KUBEVIRT_MEMORY_SIZE} --cpu 5 --secondary-nics ${KUBEVIRT_NUM_SECONDARY_NICS} --random-ports --background --prefix $provider_prefix --registry-volume $(_registry_volume) kubevirtci/${image} ${KUBEVIRT_PROVIDER_EXTRA_ARGS}"
     if [[ $TARGET =~ windows.* ]] && [ -n "$WINDOWS_NFS_DIR" ]; then
         params=" --nfs-data $WINDOWS_NFS_DIR $params"
     elif [[ $TARGET =~ os-.* ]] && [ -n "$RHEL_NFS_DIR" ]; then

--- a/cluster-up/cluster/k8s-1.11.0/provider.sh
+++ b/cluster-up/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:3412f158ecad53543c9b0aa8468db84dd043f01832a66f0db90327b7dc36a8e8"
+image="k8s-1.11.0@sha256:2104f70ac71cee8985c0cb69eacab41bd706e6e5f6afbcc91b31a34c716871ac"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-1.11.0/provider.sh
+++ b/cluster-up/cluster/k8s-1.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.11.0@sha256:2104f70ac71cee8985c0cb69eacab41bd706e6e5f6afbcc91b31a34c716871ac"
+image="k8s-1.11.0@sha256:fafdf8581ff22cf7dc6be7c55923a74ff9b55b39c9e28e6703c5530e313ea18e"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.13.3@sha256:9c2b78e11c25b3fd0b24b0ed684a112052dff03eee4ca4bdcc4f3168f9a14396"
+image="k8s-1.13.3@sha256:1b6211919c9b1b2bb79d7c92a233721ae504f1ff17a111a897e3c3ceb64f3cd0"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-1.13.3@sha256:1b6211919c9b1b2bb79d7c92a233721ae504f1ff17a111a897e3c3ceb64f3cd0"
+image="k8s-1.13.3@sha256:27c22aa6f029a4eed19dde729aeccaad8c554bc689527d4db5be4042103365b2"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
+++ b/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-genie-1.11.1@sha256:bd3c56acfd0bdad24e204a49e41d2192eab4cad282a1bb9bed01790874ba8b58"
+image="k8s-genie-1.11.1@sha256:f61813c7c41cdd51f235b28fb574a39dc71e421c388dc85c4019912d4a4421bb"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
+++ b/cluster-up/cluster/k8s-genie-1.11.1/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-genie-1.11.1@sha256:f61813c7c41cdd51f235b28fb574a39dc71e421c388dc85c4019912d4a4421bb"
+image="k8s-genie-1.11.1@sha256:0b8b144d44319a3c5397e9bd72d30744899c460bb57e5e9481076e022672540f"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.13.3@sha256:8418163abbc4acddefa26a63706446af9fd67aab20388a5e8d453cff0c0169f1"
+image="k8s-multus-1.13.3@sha256:4ceee57c99649df85664dd0434b1f98c69c2d75012110c4e7c8f6b5c41ce4b25"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
+++ b/cluster-up/cluster/k8s-multus-1.13.3/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="k8s-multus-1.13.3@sha256:4ceee57c99649df85664dd0434b1f98c69c2d75012110c4e7c8f6b5c41ce4b25"
+image="k8s-multus-1.13.3@sha256:3e9ae19d106c9cc77bd6f991931d1c59676f17b5e68246d04585ad641bb39b02"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/okd-4.1.0/provider.sh
+++ b/cluster-up/cluster/okd-4.1.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="okd-4.1.0@sha256:8a89ea659ffcfc6402d7d6ee43418bf2194b27ea74c239699e8268e29639aaa4"
+image="okd-4.1.0@sha256:2b65ed85e98470794408df955bb1716fa7b555d3e221262030f223d1d315bfce"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/okd-4.1.2/README.md
+++ b/cluster-up/cluster/okd-4.1.2/README.md
@@ -1,0 +1,44 @@
+# OKD 4.1.2 in ephemeral containers
+
+Provides a pre-deployed OKD with version 4.1.2 purely in docker
+containers with libvirt. The provided VMs are completely ephemeral and are
+recreated on every cluster restart. The KubeVirt containers are built on the
+local machine and are the pushed to a registry which is exposed at
+`localhost:5000`.
+
+## Bringing the cluster up
+
+```bash
+export KUBEVIRT_PROVIDER=okd-4.1.2
+make cluster-up
+```
+
+The cluster can be accessed as usual:
+
+```bash
+$ cluster/kubectl.sh get nodes
+NAME                          STATUS  ROLES    AGE   VERSION
+test-1-hw7kn-master-0         Ready   master   40m   v1.13.4+9252851b0
+test-1-hw7kn-worker-0-7w268   Ready   worker   35m   v1.13.4+9252851b0
+```
+
+## Bringing the cluster down
+
+```bash
+export KUBEVIRT_PROVIDER=okd-4.1.2
+make cluster-down
+```
+
+This destroys the whole cluster. Recreating the cluster is fast, since OKD is
+already pre-deployed. The only state which is kept is the state of the local
+docker registry.
+
+## Destroying the docker registry state
+
+The docker registry survives a `make cluster-down`. It's state is stored in a
+docker volume called `kubevirt_registry`. If the volume gets too big or the
+volume contains corrupt data, it can be deleted with
+
+```bash
+docker volume rm kubevirt_registry
+```

--- a/cluster-up/cluster/okd-4.1.2/provider.sh
+++ b/cluster-up/cluster/okd-4.1.2/provider.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+image="okd-4.1.2@sha256:7cdb7357a7d9e8055ae2b26a9d8c926fb81440c3c5cf917407ec51297c31479f"
+
+source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
+
+function _port() {
+    ${_cli} ports --prefix $provider_prefix --container-name cluster "$@"
+}
+
+function up() {
+    params="--random-ports --background --prefix $provider_prefix --master-cpu 5 --workers-cpu 5 --registry-volume $(_registry_volume) kubevirtci/${image}"
+    if [[ ! -z "${RHEL_NFS_DIR}" ]]; then
+        params=" --nfs-data $RHEL_NFS_DIR ${params}"
+    fi
+
+    if [[ ! -z "${OKD_CONSOLE_PORT}" ]]; then
+        params=" --ocp-console-port $OKD_CONSOLE_PORT ${params}"
+    fi
+
+    ${_cli} run okd ${params}
+
+    # Copy k8s config and kubectl
+    cluster_container_id=$(docker ps -f "name=$provider_prefix-cluster" --format "{{.ID}}")
+    docker cp $cluster_container_id:/bin/oc ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    chmod u+x ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl
+    docker cp $cluster_container_id:/root/install/auth/kubeconfig ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+
+    # Set server and disable tls check
+    export KUBECONFIG=${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubeconfig
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --server=https://$(_main_ip):$(_port k8s)
+    ${KUBEVIRTCI_CONFIG_PATH}/$KUBEVIRT_PROVIDER/.kubectl config set-cluster test-1 --insecure-skip-tls-verify=true
+
+    # Make sure that local config is correct
+    prepare_config
+}

--- a/cluster-up/cluster/os-3.11.0-crio/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-crio@sha256:862be28595834f8fa686f4f77869ee0ca051ef612fc66b4728034ac786a1a67f"
+image="os-3.11.0-crio@sha256:b0b7dad9e2a2777f99899668101172fcf5f7961168172d7c53b47f2be1c25782"

--- a/cluster-up/cluster/os-3.11.0-crio/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-crio/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-crio@sha256:3f11a6f437fcdf2d70de4fcc31e0383656f994d0d05f9a83face114ea7254bc0"
+image="os-3.11.0-crio@sha256:862be28595834f8fa686f4f77869ee0ca051ef612fc66b4728034ac786a1a67f"

--- a/cluster-up/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:ffd92718c888645e0a55f750a7c9091eefc17c850e09b1490ad0fc9425c88459"
+image="os-3.11.0-multus@sha256:7444f827d1fcf8bf8c8a12936bab5c91bd4b95941f62f465163e726de14fd5b6"

--- a/cluster-up/cluster/os-3.11.0-multus/provider.sh
+++ b/cluster-up/cluster/os-3.11.0-multus/provider.sh
@@ -4,4 +4,4 @@ set -e
 
 source ${KUBEVIRTCI_PATH}/cluster/os-3.11.0/provider.sh
 
-image="os-3.11.0-multus@sha256:b799a707e2c42caa1e3a7e7677cd14bbd834b3e3f6f1bce48b7a32d705e383fb"
+image="os-3.11.0-multus@sha256:ffd92718c888645e0a55f750a7c9091eefc17c850e09b1490ad0fc9425c88459"

--- a/cluster-up/cluster/os-3.11.0/provider.sh
+++ b/cluster-up/cluster/os-3.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.11.0@sha256:812068b83cdda9fcf53386009faa10b8fcb40ccf733cc968f1b8e40c99808d00"
+image="os-3.11.0@sha256:0560f1c6df59babedcba0b6ad5f56b794fe65673dd0d32fdcac6d2d1590aae81"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/cluster/os-3.11.0/provider.sh
+++ b/cluster-up/cluster/os-3.11.0/provider.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-image="os-3.11.0@sha256:2d0a8f59dfebe181f550c4fbcd90d491a56a7d642d761c32a3c7732644325c0b"
+image="os-3.11.0@sha256:812068b83cdda9fcf53386009faa10b8fcb40ccf733cc968f1b8e40c99808d00"
 
 source ${KUBEVIRTCI_PATH}/cluster/ephemeral-provider-common.sh
 

--- a/cluster-up/hack/common.sh
+++ b/cluster-up/hack/common.sh
@@ -17,6 +17,7 @@ fi
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.13.3}
 KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-5120M}
+KUBEVIRT_NUM_SECONDARY_NICS=${KUBEVIRT_NUM_NODES:-0}
 
 # If on a developer setup, expose ocp on 8443, so that the openshift web console can be used (the port is important because of auth redirects)
 if [ -z "${JOB_NAME}" ]; then

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -7,7 +7,7 @@ cdi_namespace=cdi
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}
 verbosity=${VERBOSITY:-2}
 package_name=${PACKAGE_NAME:-kubevirt-dev}
-kubevirtci_git_hash="c411ed2b6580b525e2535b440a1cd83f0f837f9c"
+kubevirtci_git_hash="b185a724521961fb480a9c70d4470268c32e925d"
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -7,7 +7,7 @@ cdi_namespace=cdi
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}
 verbosity=${VERBOSITY:-2}
 package_name=${PACKAGE_NAME:-kubevirt-dev}
-kubevirtci_git_hash="b185a724521961fb480a9c70d4470268c32e925d"
+kubevirtci_git_hash="ecedee38641dd8982b41f3c4be1bb012910a97eb"
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -7,7 +7,7 @@ cdi_namespace=cdi
 image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}
 verbosity=${VERBOSITY:-2}
 package_name=${PACKAGE_NAME:-kubevirt-dev}
-kubevirtci_git_hash="45cdf80da619866cdab36295de25a8aeea7eccbc"
+kubevirtci_git_hash="c411ed2b6580b525e2535b440a1cd83f0f837f9c"
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Pull in latest CI cluster with

- increased pod limit on os clusters to 110
- updated local volume provisioner
- new OKD 4.1.2 provider
- audit logging enabled
- some fixes and additions to gocli

For a complete list see https://github.com/kubevirt/kubevirtci/commits/master

**Release note**:
```release-note
NONE
```
