### PR TITLE
See if higher timeout helps

### DIFF
--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -559,7 +559,7 @@ var _ = Describe("Storage", func() {
 				// Without userdata the hostname isn't set correctly and the login expecter fails...
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
-				tests.RunVMIAndExpectLaunch(vmi, 90)
+				tests.RunVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
 				expecter, err := tests.LoggedInCirrosExpecter(vmi)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1372,7 +1372,7 @@ var _ = Describe("Configurations", func() {
 			tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
 			tests.AddPVCDisk(vmi, "block-pvc", "virtio", blockPVName)
 			tests.AddHostDisk(vmi, "/run/kubevirt-private/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "hostdisk")
-			tests.RunVMIAndExpectLaunch(vmi, 60)
+			tests.RunVMIAndExpectLaunch(vmi, 180)
 
 			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

These two tests fail pretty often, try to increase timeouts:

```

Storage Starting a VirtualMachineInstance [rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component] With Cirros BlockMode PVC [test_id:1015] should be successfully started 

Configurations [rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache settings [test_id:1681]should set appropriate cache modes
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
