### PR TITLE
Revert "Merge pull request #2450 from fedepaol/kindimageprovider"

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -27,13 +27,9 @@ mkdir -p /images/datavolume1 /images/datavolume2 /images/datavolume3
 echo "converting cirros image from qcow2 to raw, and copying it to local-storage directory, and creating a loopback device from it"
 # /local-storage will be mapped to the host dir, which will also be used by the local storage provider
 qemu-img convert -f qcow2 -O raw /images/cirros/disk.img /local-storage/cirros.img.raw
-
-mknod /dev/loop99 b 7 0
-# attempt a detach since with docker in docker scenarios the created loopback device is already busy
-losetup -d /dev/loop99 || true
-losetup /dev/loop99 /local-storage/cirros.img.raw
+LOOP_DEVICE=$(losetup --find --show /local-storage/cirros.img.raw)
 rm -f /local-storage/cirros-block-device
-ln -s dev/loop99 /local-storage/cirros-block-device
+ln -s $LOOP_DEVICE /local-storage/cirros-block-device
 
 echo "converting fedora image from qcow2 to raw"
 qemu-img convert -f qcow2 -O raw /images/fedora-cloud/disk.qcow2 /images/fedora-cloud/disk.img


### PR DESCRIPTION


**What this PR does / why we need it**:

This reverts commit b54712d720ae7bde6400cd3bb81087f2694b2a40, reversing
changes made to 147b09fc228d03e11323595bfbb0ae3cc29c1b81.

At least these two tests are broken

```
Storage Starting a VirtualMachineInstance [rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component] With Cirros BlockMode PVC [test_id:1015] should be successfully started 

Configurations [rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache settings [test_id:1681]should set appropriate cache modes
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
