### PR TITLE
Add error message in case of abnormal disconnect

### DIFF
--- a/pkg/virtctl/console/BUILD.bazel
+++ b/pkg/virtctl/console/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/virtctl/templates:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/gorilla/websocket:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/golang.org/x/crypto/ssh/terminal:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2017, 2018 Red Hat, Inc.
+ * Copyright 2017 - 2019 Red Hat, Inc.
  *
  */
 
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -177,6 +178,11 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 	terminal.Restore(int(os.Stdin.Fd()), state)
 
 	if err != nil {
+		if strings.Contains(err.Error(), "abnormal closure") {
+			fmt.Fprint(os.Stderr, "\nYou were disconnected from the console. This has one of the following reasons:"+
+				"\n - another user connected to the console of the target vm"+
+				"\n - network issues\n")
+		}
 		return err
 	}
 	return nil

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -24,9 +24,9 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"strings"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/client-go/tools/clientcmd"
@@ -178,7 +178,7 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 	terminal.Restore(int(os.Stdin.Fd()), state)
 
 	if err != nil {
-		if strings.Contains(err.Error(), "abnormal closure") {
+		if e, ok := err.(*websocket.CloseError); ok && e.Code == websocket.CloseAbnormalClosure {
 			fmt.Fprint(os.Stderr, "\nYou were disconnected from the console. This has one of the following reasons:"+
 				"\n - another user connected to the console of the target vm"+
 				"\n - network issues\n")


### PR DESCRIPTION
Bugzilla # 1723878: in case of abnormal disconnect provide an error
message explaining the possible reasons (i.e. another user connected
or network issues).

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1723878

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
