### PR TITLE
virtctl: use basename when printing help

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -40,7 +40,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "console (VMI)",
 		Short:   "Connect to a console of a virtual machine instance.",
-		Example: templates.PrepareTemplate(usage()),
+		Example: usage(),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Console{clientConfig: clientConfig}
@@ -59,9 +59,9 @@ type Console struct {
 
 func usage() string {
 	usage := `  # Connect to the console on VirtualMachineInstance 'myvmi':
-  {{.ProgramName}} console myvmi
+  {{ProgramName}} console myvmi
   # Configure one minute timeout (default 5 minutes)
-  {{.ProgramName}} console --timeout=1 myvmi`
+  {{ProgramName}} console --timeout=1 myvmi`
 
 	return usage
 }

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -40,7 +40,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "console (VMI)",
 		Short:   "Connect to a console of a virtual machine instance.",
-		Example: usage(),
+		Example: templates.PrepareTemplate(usage()),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Console{clientConfig: clientConfig}
@@ -59,9 +59,9 @@ type Console struct {
 
 func usage() string {
 	usage := `  # Connect to the console on VirtualMachineInstance 'myvmi':
-  virtctl console myvmi
+  {{.ProgramName}} console myvmi
   # Configure one minute timeout (default 5 minutes)
-  virtctl console --timeout=1 myvmi`
+  {{.ProgramName}} console --timeout=1 myvmi`
 
 	return usage
 }

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -50,7 +50,7 @@ Also if no labels are specified, the new service will re-use the labels from the
 Possible types are (case insensitive, both single and plurant forms):
         
 virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplicaset (vmirs)`,
-		Example: templates.PrepareTemplate(usage()),
+		Example: usage(),
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_EXPOSE, clientConfig: clientConfig}
@@ -76,13 +76,13 @@ virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplica
 
 func usage() string {
 	usage := `  # Expose SSH to a virtual machine instance called 'myvm' on each node via a NodePort service:
-  {{.ProgramName}} expose vmi myvm --port=22 --name=myvm-ssh --type=NodePort
+  {{ProgramName}} expose vmi myvm --port=22 --name=myvm-ssh --type=NodePort
 
   # Expose all defined pod-network ports of a virtual machine instance replicaset on a service:
-  {{.ProgramName}} expose vmirs myvmirs --name=vmirs-service
+  {{ProgramName}} expose vmirs myvmirs --name=vmirs-service
 
   # Expose port 8080 as port 80 from a virtual machine instance replicaset on a service:
-  {{.ProgramName}} expose vmirs myvmirs --port=80 --target-port=8080 --name=vmirs-service`
+  {{ProgramName}} expose vmirs myvmirs --port=80 --target-port=8080 --name=vmirs-service`
 	return usage
 }
 

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -50,7 +50,7 @@ Also if no labels are specified, the new service will re-use the labels from the
 Possible types are (case insensitive, both single and plurant forms):
         
 virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplicaset (vmirs)`,
-		Example: usage(),
+		Example: templates.PrepareTemplate(usage()),
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_EXPOSE, clientConfig: clientConfig}
@@ -76,13 +76,13 @@ virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplica
 
 func usage() string {
 	usage := `  # Expose SSH to a virtual machine instance called 'myvm' on each node via a NodePort service:
-  virtctl expose vmi myvm --port=22 --name=myvm-ssh --type=NodePort
+  {{.ProgramName}} expose vmi myvm --port=22 --name=myvm-ssh --type=NodePort
 
   # Expose all defined pod-network ports of a virtual machine instance replicaset on a service:
-  virtctl expose vmirs myvmirs --name=vmirs-service
+  {{.ProgramName}} expose vmirs myvmirs --name=vmirs-service
 
   # Expose port 8080 as port 80 from a virtual machine instance replicaset on a service:
-  virtctl expose vmirs myvmirs --port=80 --target-port=8080 --name=vmirs-service`
+  {{.ProgramName}} expose vmirs myvmirs --port=80 --target-port=8080 --name=vmirs-service`
 	return usage
 }
 

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -97,7 +97,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "image-upload",
 		Short:   "Upload a VM image to a PersistentVolumeClaim.",
-		Example: usage(),
+		Example: templates.PrepareTemplate(usage()),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := command{clientConfig: clientConfig}
@@ -121,7 +121,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func usage() string {
 	usage := `  # Upload a local disk image to a newly created PersistentVolumeClaim:
-	virtctl image-upload --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --pvc-name=upload-pvc --pvc-size=10Gi --image-path=/images/fedora28.qcow2`
+	{{.ProgramName}} image-upload --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --pvc-name=upload-pvc --pvc-size=10Gi --image-path=/images/fedora28.qcow2`
 	return usage
 }
 

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -97,7 +97,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "image-upload",
 		Short:   "Upload a VM image to a PersistentVolumeClaim.",
-		Example: templates.PrepareTemplate(usage()),
+		Example: usage(),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := command{clientConfig: clientConfig}
@@ -121,7 +121,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func usage() string {
 	usage := `  # Upload a local disk image to a newly created PersistentVolumeClaim:
-	{{.ProgramName}} image-upload --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --pvc-name=upload-pvc --pvc-size=10Gi --image-path=/images/fedora28.qcow2`
+  {{ProgramName}} image-upload --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --pvc-name=upload-pvc --pvc-size=10Gi --image-path=/images/fedora28.qcow2`
 	return usage
 }
 

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -21,14 +21,26 @@ import (
 
 var programName string
 
+const symlinkAsKrewPlugin = "kubectl-virt"
+
 func NewVirtctlCommand() *cobra.Command {
+
+	// if `virtctl` is installed via krew to be used as a kubectl plugin, it's run via a symlink, so the basename then
+	// is `kubectl-virt`. In this case we want to accomodate the user by adjusting the help text (usage, examples and
+	// the like) by displaying `kubectl virt <command>` instead of `virtctl <command>`.
+	// see https://github.com/kubevirt/kubevirt/issues/2356 for more details
+	// see also templates.go
 	programName = "virtctl"
-	if filepath.Base(os.Args[0]) == "kubectl-virt" {
+	if filepath.Base(os.Args[0]) == symlinkAsKrewPlugin {
 		programName = "kubectl virt"
 	}
 
+	// used in cobra templates to display either `kubectl virt` or `virtctl`
 	cobra.AddTemplateFunc("ProgramName", func() string { return programName })
-	cobra.AddTemplateFunc("prepare", func(s string) string { return strings.Replace(s, "{{ProgramName}}", programName, -1) })
+
+	// used to enable replacement of `ProgramName` placeholder for cobra.Example, which has no template support
+	cobra.AddTemplateFunc(
+		"prepare", func(s string) string { return strings.Replace(s, "{{ProgramName}}", programName, -1) })
 
 	rootCmd := &cobra.Command{
 		Use:           programName,

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -3,6 +3,7 @@ package virtctl
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -21,8 +22,7 @@ import (
 var programName string
 
 func NewVirtctlCommand() *cobra.Command {
-	elements := strings.Split(os.Args[0], "/")
-	programName = strings.Replace(elements[len(elements)-1], "-", " ", -1)
+	programName = strings.Replace(filepath.Base(os.Args[0]), "-", " ", -1)
 
 	cobra.AddTemplateFunc("ProgramName", func() string { return programName })
 	cobra.AddTemplateFunc("prepare", func(s string) string { return strings.Replace(s, "{{ProgramName}}", programName, -1) })

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -19,9 +19,10 @@ import (
 )
 
 func NewVirtctlCommand() *cobra.Command {
+
 	rootCmd := &cobra.Command{
-		Use:           "virtctl",
-		Short:         "virtctl controls virtual machine related operations on your kubernetes cluster.",
+		Use:           templates.ProgramName(),
+		Short:         templates.PrependProgramName("controls virtual machine related operations on your kubernetes cluster."),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -56,7 +57,7 @@ func NewVirtctlCommand() *cobra.Command {
 }
 
 func Execute() {
-	log.InitializeLogging("virtctl")
+	log.InitializeLogging(templates.ProgramName())
 	if err := NewVirtctlCommand().Execute(); err != nil {
 		fmt.Println(strings.TrimSpace(err.Error()))
 		os.Exit(1)

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -18,11 +18,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/vnc"
 )
 
+var programName string
+
 func NewVirtctlCommand() *cobra.Command {
+	elements := strings.Split(os.Args[0], "/")
+	programName = strings.Replace(elements[len(elements)-1], "-", " ", -1)
+
+	cobra.AddTemplateFunc("ProgramName", func() string { return programName })
+	cobra.AddTemplateFunc("prepare", func(s string) string { return strings.Replace(s, "{{ProgramName}}", programName, -1) })
 
 	rootCmd := &cobra.Command{
-		Use:           templates.ProgramName(),
-		Short:         templates.PrependProgramName("controls virtual machine related operations on your kubernetes cluster."),
+		Use:           programName,
+		Short:         programName + " controls virtual machine related operations on your kubernetes cluster.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -57,7 +64,7 @@ func NewVirtctlCommand() *cobra.Command {
 }
 
 func Execute() {
-	log.InitializeLogging(templates.ProgramName())
+	log.InitializeLogging(programName)
 	if err := NewVirtctlCommand().Execute(); err != nil {
 		fmt.Println(strings.TrimSpace(err.Error()))
 		os.Exit(1)

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -22,7 +22,10 @@ import (
 var programName string
 
 func NewVirtctlCommand() *cobra.Command {
-	programName = strings.Replace(filepath.Base(os.Args[0]), "-", " ", -1)
+	programName = "virtctl"
+	if filepath.Base(os.Args[0]) == "kubectl-virt" {
+		programName = "kubectl virt"
+	}
 
 	cobra.AddTemplateFunc("ProgramName", func() string { return programName })
 	cobra.AddTemplateFunc("prepare", func(s string) string { return strings.Replace(s, "{{ProgramName}}", programName, -1) })

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -1,9 +1,28 @@
 package templates
 
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ProgramName() string {
+	elements := strings.Split(os.Args[0], "/")
+	return strings.Replace(elements[len(elements)-1], "-", " ", -1)
+}
+
+func PrepareTemplate(template string) string {
+	return strings.Replace(template, "{{.ProgramName}}", ProgramName(), -1)
+}
+
+func PrependProgramName(template string) string {
+	return fmt.Sprintf("%s %s", ProgramName(), template)
+}
+
 // UsageTemplate returns the usage template for all subcommands
 func UsageTemplate() string {
-	return `Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+	return PrepareTemplate(`Usage:{{if .Runnable}}
+  {{.ProgramName}} {{.Use}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
@@ -18,18 +37,18 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-Use "virtctl options" for a list of global command-line options (applies to all commands).{{end}}
-`
+Use "{{.ProgramName}} options" for a list of global command-line options (applies to all commands).{{end}}
+`)
 }
 
 // MainUsageTemplate returns the usage template for the root command
 func MainUsageTemplate() string {
-	return `Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+	return PrepareTemplate(`Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 
-Use "{{.CommandPath}} <command> --help" for more information about a given command.
-Use "{{.CommandPath}} options" for a list of global command-line options (applies to all commands).
-`
+Use "{{.ProgramName}} <command> --help" for more information about a given command.
+Use "{{.ProgramName}} options" for a list of global command-line options (applies to all commands).
+`)
 }
 
 // OptionsUsageTemplate returns a template which prints all global available commands

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -1,54 +1,35 @@
 package templates
 
-import (
-	"fmt"
-	"os"
-	"strings"
-)
-
-func ProgramName() string {
-	elements := strings.Split(os.Args[0], "/")
-	return strings.Replace(elements[len(elements)-1], "-", " ", -1)
-}
-
-func PrepareTemplate(template string) string {
-	return strings.Replace(template, "{{.ProgramName}}", ProgramName(), -1)
-}
-
-func PrependProgramName(template string) string {
-	return fmt.Sprintf("%s %s", ProgramName(), template)
-}
-
 // UsageTemplate returns the usage template for all subcommands
 func UsageTemplate() string {
-	return PrepareTemplate(`Usage:{{if .Runnable}}
-  {{.ProgramName}} {{.Use}}{{end}}{{if .HasAvailableSubCommands}}
+	return `Usage:{{if .Runnable}}
+  {{ProgramName}} {{prepare .Use}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
 
 Aliases:
   {{.NameAndAliases}}{{end}}{{if .HasExample}}
 
 Examples:
-{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{prepare .Example}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+  {{rpad .Name .NamePadding }} {{prepare .Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-Use "{{.ProgramName}} options" for a list of global command-line options (applies to all commands).{{end}}
-`)
+Use "{{ProgramName}} options" for a list of global command-line options (applies to all commands).{{end}}
+`
 }
 
 // MainUsageTemplate returns the usage template for the root command
 func MainUsageTemplate() string {
-	return PrepareTemplate(`Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+	return `Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{prepare .Short}}{{end}}{{end}}
 
-Use "{{.ProgramName}} <command> --help" for more information about a given command.
-Use "{{.ProgramName}} options" for a list of global command-line options (applies to all commands).
-`)
+Use "{{ProgramName}} <command> --help" for more information about a given command.
+Use "{{ProgramName}} options" for a list of global command-line options (applies to all commands).
+`
 }
 
 // OptionsUsageTemplate returns a template which prints all global available commands

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -17,7 +17,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
 		Short:   "Print the client and server version information.",
-		Example: usage(),
+		Example: templates.PrepareTemplate(usage()),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := Version{clientConfig: clientConfig}
@@ -31,7 +31,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func usage() string {
 	usage := "  # Print the client and server versions for the current context:\n"
-	usage += "  virtctl version"
+	usage += "  {{.ProgramName}} version"
 	return usage
 }
 

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -17,7 +17,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
 		Short:   "Print the client and server version information.",
-		Example: templates.PrepareTemplate(usage()),
+		Example: usage(),
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := Version{clientConfig: clientConfig}
@@ -31,7 +31,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func usage() string {
 	usage := "  # Print the client and server versions for the current context:\n"
-	usage += "  {{.ProgramName}} version"
+	usage += "  {{ProgramName}} version"
 	return usage
 }
 

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -40,7 +40,7 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "start (VM)",
 		Short:   "Start a virtual machine.",
-		Example: usage(COMMAND_START),
+		Example: templates.PrepareTemplate(usage(COMMAND_START)),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_START, clientConfig: clientConfig}
@@ -55,7 +55,7 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "stop (VM)",
 		Short:   "Stop a virtual machine.",
-		Example: usage(COMMAND_STOP),
+		Example: templates.PrepareTemplate(usage(COMMAND_STOP)),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
@@ -70,7 +70,7 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "restart (VM)",
 		Short:   "Restart a virtual machine.",
-		Example: usage(COMMAND_RESTART),
+		Example: templates.PrepareTemplate(usage(COMMAND_RESTART)),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
@@ -92,7 +92,7 @@ func NewCommand(command string) *Command {
 
 func usage(cmd string) string {
 	usage := fmt.Sprintf("  # %s a virtual machine called 'myvm':\n", strings.Title(cmd))
-	usage += fmt.Sprintf("  virtctl %s myvm", cmd)
+	usage += fmt.Sprintf("  {{.ProgramName}} %s myvm", cmd)
 	return usage
 }
 

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -40,7 +40,7 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "start (VM)",
 		Short:   "Start a virtual machine.",
-		Example: templates.PrepareTemplate(usage(COMMAND_START)),
+		Example: usage(COMMAND_START),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_START, clientConfig: clientConfig}
@@ -55,7 +55,7 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "stop (VM)",
 		Short:   "Stop a virtual machine.",
-		Example: templates.PrepareTemplate(usage(COMMAND_STOP)),
+		Example: usage(COMMAND_STOP),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
@@ -70,7 +70,7 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "restart (VM)",
 		Short:   "Restart a virtual machine.",
-		Example: templates.PrepareTemplate(usage(COMMAND_RESTART)),
+		Example: usage(COMMAND_RESTART),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
@@ -92,7 +92,7 @@ func NewCommand(command string) *Command {
 
 func usage(cmd string) string {
 	usage := fmt.Sprintf("  # %s a virtual machine called 'myvm':\n", strings.Title(cmd))
-	usage += fmt.Sprintf("  {{.ProgramName}} %s myvm", cmd)
+	usage += fmt.Sprintf("  {{ProgramName}} %s myvm", cmd)
 	return usage
 }
 

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -62,7 +62,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "vnc (VMI)",
 		Short:   "Open a vnc connection to a virtual machine instance.",
-		Example: usage(),
+		Example: templates.PrepareTemplate(usage()),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VNC{clientConfig: clientConfig}
@@ -290,7 +290,6 @@ func remoteViewerArgs(port int) (args []string) {
 }
 
 func usage() string {
-	usage := "  # Connect to 'testvmi' via remote-viewer:\n"
-	usage += "  virtctl vnc testvmi"
-	return usage
+	return `  # Connect to 'testvmi' via remote-viewer:\n"
+  {{.ProgramName}} vnc testvmi`
 }

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -62,7 +62,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "vnc (VMI)",
 		Short:   "Open a vnc connection to a virtual machine instance.",
-		Example: templates.PrepareTemplate(usage()),
+		Example: usage(),
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VNC{clientConfig: clientConfig}
@@ -291,5 +291,5 @@ func remoteViewerArgs(port int) (args []string) {
 
 func usage() string {
 	return `  # Connect to 'testvmi' via remote-viewer:\n"
-  {{.ProgramName}} vnc testvmi`
+  {{ProgramName}} vnc testvmi`
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replace hard coded `virtctl` by using the basename of the call,
this enables nicer output when installed via krew plugin package
manager.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2356

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
