### PR TITLE
Dedicated SELinux profile for virt-launcher

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -62,7 +62,7 @@ container_image(
     name = "version-container",
     base = "@fedora//image",
     directory = "/",
-    files = ["//:get-version"],
+    files = ["//:get-version", ":base_container.cil", ":virt_launcher.cil"],
 )
 
 container_image(

--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -62,7 +62,11 @@ container_image(
     name = "version-container",
     base = "@fedora//image",
     directory = "/",
-    files = ["//:get-version", ":base_container.cil", ":virt_launcher.cil"],
+    files = [
+        ":base_container.cil",
+        ":virt_launcher.cil",
+        "//:get-version",
+    ],
 )
 
 container_image(

--- a/cmd/virt-handler/base_container.cil
+++ b/cmd/virt-handler/base_container.cil
@@ -1,0 +1,10 @@
+(block container
+(type process)
+(roletype system_r process)
+(typeattributeset domain (process ))
+(typeattributeset container_domain (process ))
+(typeattributeset svirt_sandbox_domain (process ))
+(allow process proc_type (file (getattr open read)))
+(allow process cpu_online_t (file (getattr open read)))
+(allow container_runtime_t process (key (create link read search setattr view write)))
+)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -214,6 +214,10 @@ func (app *virtHandlerApp) Run() {
 				panic(err)
 			}
 		}
+		err = se.InstallPolicy("/var/run/kubevirt")
+		if err != nil {
+			panic(fmt.Errorf("failed to install virt-launcher selinux policy: %v", err))
+		}
 	} else if err != nil {
 		//an error occured
 		panic(fmt.Errorf("failed to detect the presence of selinux: %v", err))

--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -1,0 +1,13 @@
+(block virt_launcher
+    (blockinherit container)
+    (typeattributeset sandbox_net_domain (process))
+    (allow process kernel_t (system (module_request)))
+    (allow process mtrr_device_t (file (write)))
+    (allow process self (tun_socket (relabelfrom)))
+    (allow process self (tun_socket (relabelto)))
+    (allow process tmp_t (dir (write add_name open getattr setattr read link search remove_name reparent lock ioctl)))
+    (allow process tmp_t (file (setattr open read write create getattr append ioctl lock)))
+    (allow process container_share_t (dir (write add_name)))
+    (allow process container_share_t (file (create setattr write )))
+    (allow process container_var_run_t (dir (write add_name open getattr setattr read link search remove_name reparent lock ioctl)))
+    (allow process container_var_run_t (file (setattr open read write create getattr append ioctl lock))))

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -892,7 +892,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			SecurityContext: &k8sv1.PodSecurityContext{
 				RunAsUser: &userId,
 				SELinuxOptions: &k8sv1.SELinuxOptions{
-					Type: "spc_t",
+					Type: "virt_launcher.process",
 				},
 			},
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -16,6 +16,7 @@ type execFunc = func(binary string, args ...string) ([]byte, error)
 func defaultExecFunc(binary string, args ...string) ([]byte, error) {
 	return exec.Command(binary, args...).CombinedOutput()
 }
+
 var POLICY_FILES = []string{"base_container", "virt_launcher"}
 
 type SELinuxImpl struct {

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -136,19 +136,13 @@ func (se *SELinuxImpl) Restore(dir string) (err error) {
 func (*SELinuxImpl) InstallPolicy(dir string) (err error) {
 	for _, policyName := range POLICY_FILES {
 		fileDest := dir + "/" + policyName + ".cil"
-		modules, err := exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "exec", "--", "/usr/sbin/semodule", "-l").CombinedOutput()
+		err := copyPolicy(policyName, dir)
 		if err != nil {
-			return fmt.Errorf("failed to retrive a list of installed modules, err: % v", err)
+			return fmt.Errorf("failed to copy policy %v - err: % v", fileDest, err)
 		}
-		if !strings.Contains(string(modules), policyName) {
-			err := copyPolicy(policyName, dir)
-			if err != nil {
-				return fmt.Errorf("failed to copy policy %v - err: % v", fileDest, err)
-			}
-			_, err = exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "exec", "--", "/usr/sbin/semodule", "-i", fileDest).CombinedOutput()
-			if err != nil {
-				return fmt.Errorf("failed to install policy %v - err: % v", fileDest, err)
-			}
+		_, err = exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "exec", "--", "/usr/sbin/semodule", "-i", fileDest).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to install policy %v - err: % v", fileDest, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR remote the currently used `spc_t` selinux label from the vmipods lets virt-handler install a custom SELinux policy for virt-launcher.
This policy extends the standard `container_t` policy with additional permissions required for virt-launcher.

**Which issue(s) this PR fixes** :
Fixes #

```release-note
NONE
```
