### PR TITLE
virtctl image-upload: add support for creating BlockVolume PVCs

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -69,6 +69,7 @@ var (
 
 	uploadPodWaitSecs uint = 60
 	accessMode             = "ReadWriteOnce"
+	blockVolume            = false
 	noCreate               = false
 )
 
@@ -111,6 +112,7 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd.Flags().StringVar(&pvcSize, "pvc-size", "", "The size of the PVC to create (ex. 10Gi, 500Mi).")
 	cmd.Flags().StringVar(&storageClass, "storage-class", "", "The storage class for the PVC.")
 	cmd.Flags().StringVar(&accessMode, "access-mode", accessMode, "The access mode for the PVC.")
+	cmd.Flags().BoolVar(&blockVolume, "block-volume", blockVolume, "Create a PVC with VolumeMode=Block (default Filesystem).")
 	cmd.Flags().StringVar(&imagePath, "image-path", "", "Path to the local VM image.")
 	cmd.MarkFlagRequired("image-path")
 	cmd.Flags().BoolVar(&noCreate, "no-create", noCreate, "Don't attempt to create a new PVC.")
@@ -152,7 +154,7 @@ func (c *command) run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		pvc, err = createUploadPVC(virtClient, namespace, pvcName, pvcSize, storageClass, accessMode)
+		pvc, err = createUploadPVC(virtClient, namespace, pvcName, pvcSize, storageClass, accessMode, blockVolume)
 		if err != nil {
 			return err
 		}
@@ -343,7 +345,7 @@ func waitUploadPodRunning(client kubernetes.Interface, namespace, name string, i
 	return err
 }
 
-func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string) (*v1.PersistentVolumeClaim, error) {
+func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*v1.PersistentVolumeClaim, error) {
 	quantity, err := resource.ParseQuantity(size)
 	if err != nil {
 		return nil, err
@@ -372,6 +374,11 @@ func createUploadPVC(client kubernetes.Interface, namespace, name, size, storage
 
 	if accessMode != "" {
 		pvc.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
+	}
+
+	if blockVolume {
+		volMode := v1.PersistentVolumeBlock
+		pvc.Spec.VolumeMode = &volMode
 	}
 
 	pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a --block-volume option to create the new PVC with VolumeMode=Block.
This can then be used to provision PVCs that can be used for
live-migration on raw block with RWX access-mode.

For example, here with a Ceph-CSI storageclass named "csi-rbd":

```
  $ virtctl image-upload \
        --access-mode=ReadWriteMany --block-volume \
        --pvc-name=fedora-30-gold-block \
        --pvc-size=6Gi --storage-class=csi-rbd \
        --image-path=Fedora-Cloud-Base-30-1.2.x86_64.raw
```

**Special notes for your reviewer**:
The `--block-volume` option is a boolean, but maybe there is interest in `--volume-mode=Block` to match the PVC.Spec closer? That feels less user-friendly to me though.

**Release note**:
```release-note
NONE
```
