### PR TITLE
Take memory limit into account when setting the virtual memory

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -418,9 +418,8 @@ var _ = Describe("Configurations", func() {
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {
 			It("[test_id:1669]should show the requested guest memory inside the VMI", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				guestMemory := resource.MustParse("64M")
 				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
-				guestMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
+				guestMemory := resource.MustParse("128M")
 				vmi.Spec.Domain.Memory = &v1.Memory{
 					Guest: &guestMemory,
 				}
@@ -868,7 +867,7 @@ var _ = Describe("Configurations", func() {
 				table.Entry("[test_id:1672]hugepages-1Gi", "1Gi", "1Gi"),
 			)
 
-			Context("with usupported page size", func() {
+			Context("with unsupported page size", func() {
 				It("[test_id:1673]should failed to schedule the pod", func() {
 					nodes, err := virtClient.Core().Nodes().List(metav1.ListOptions{})
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously, the virtual memory was set according to: (1) guest memory; and then (2) memory request.
This PR changes that to: (1) guest memory; then (2) memory limit; and then (3) memory request.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The virtual memory is now set to match the memory limit, if memory limit is specified and guest memory is not.
```
