### PR TITLE
Get rid of cpu label error message

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1549,7 +1549,10 @@ func (d *VirtualMachineController) updateNodeCpuManagerLabel() {
 	isEnabled := false
 	for _, entry := range entries {
 		content, err := ioutil.ReadFile(entry)
-		if err != nil {
+		if os.IsNotExist(err) {
+			// processes can disappear anytime, it is ok if they don't exist anymore
+			continue
+		} else if err != nil {
 			log.DefaultLogger().Reason(err).Errorf("failed to set a cpu manager label on host %s", d.host)
 			return
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Errors like

```
{"component":"virt-handler","level":"error","msg":"failed to set a cpu manager label on host node02","pos":"vm.go:1688","reason":"open /proc/16842/cmdline: no such file or directory","timestamp":"2019-07-15T17:13:25.027192Z"}
```

can not occur anymore because we now explicitly handle disappeared
processes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
