### PR TITLE
Add opt-out to disable linux-bridge on pod network

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -142,6 +142,9 @@ func (mutator *VMIsMutator) setDefaultNetworkInterface(obj *v1.VirtualMachineIns
 		iface := v1.NetworkInterfaceType(mutator.ClusterConfig.GetDefaultNetworkInterface())
 		switch iface {
 		case v1.BridgeInterface:
+			if !mutator.ClusterConfig.IsBridgeInterfaceOnPodNetworkEnabled() {
+				return fmt.Errorf("Bridge interface is not enabled in kubevirt-config")
+			}
 			obj.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		case v1.MasqueradeInterface:
 			obj.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -636,6 +636,12 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					Message: fmt.Sprintf("Masquerade interface only implemented with pod network"),
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
+			} else if iface.InterfaceBindingMethod.Bridge != nil && networkData.NetworkSource.Pod != nil && !config.IsBridgeInterfaceOnPodNetworkEnabled() {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: "Bridge on pod network configuration is not enabled under kubevirt-config",
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+				})
 			}
 
 			// Check if the interface name is unique

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -53,6 +53,18 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when invalid, it should return the default", "invalid", false),
 	)
 
+	table.DescribeTable(" when permitBridgeInterfaceOnPodNetwork", func(value string, result bool) {
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{"permitBridgeInterfaceOnPodNetwork": value},
+		})
+		Expect(clusterConfig.IsBridgeInterfaceOnPodNetworkEnabled()).To(Equal(result))
+	},
+		table.Entry("is true, IsBridgeInterfaceOnPodNetworkEnabled should return true", "true", true),
+		table.Entry("is false, IsBridgeInterfaceOnPodNetworkEnabled should return false", "false", false),
+		table.Entry("when unset, IsBridgeInterfaceOnPodNetworkEnabled should return true", "", true),
+		table.Entry("when invalid, IsBridgeInterfaceOnPodNetworkEnabled should return the default", "invalid", true),
+	)
+
 	table.DescribeTable(" when imagePullPolicy", func(value string, result kubev1.PullPolicy) {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.ImagePullPolicyKey: value},

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -51,6 +51,7 @@ const (
 	SmbiosConfigDefaultFamily                       = "KubeVirt"
 	SmbiosConfigDefaultManufacturer                 = "KubeVirt"
 	SmbiosConfigDefaultProduct                      = "None"
+	DefaultPermitBridgeInterfaceOnPodNetwork        = true
 )
 
 func (c *ClusterConfig) IsUseEmulation() bool {
@@ -103,4 +104,8 @@ func (c *ClusterConfig) IsSlirpInterfaceEnabled() bool {
 
 func (c *ClusterConfig) GetSMBIOS() *cmdv1.SMBios {
 	return c.getConfig().SmbiosConfig
+}
+
+func (c *ClusterConfig) IsBridgeInterfaceOnPodNetworkEnabled() bool {
+	return c.getConfig().PermitBridgeInterfaceOnPodNetwork
 }

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -47,8 +47,9 @@ func main() {
 	config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
 		Data: map[string]string{
 			// Required to validate DataVolume usage
-			virtconfig.FeatureGatesKey:      "DataVolumes,LiveMigration,SRIOV",
-			virtconfig.PermitSlirpInterface: "true",
+			virtconfig.FeatureGatesKey:                   "DataVolumes,LiveMigration,SRIOV",
+			virtconfig.PermitSlirpInterface:              "true",
+			virtconfig.PermitBridgeInterfaceOnPodNetwork: "true",
 		},
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
in this PR we added a flag(default value is true) which signals whether
we allow to configure a bridge network interface on a pod network or not,
and a validating web-hook to check the flag value 
and allow the VM creation or not ,accordingly.

We would like to have the option to 
forbid  bridge binding method on a pod network for several reasons:

VMs are expect to keep their MAC when restarted, 
so we would like to control the MAC address.
Some CNIs would let us choose the MAC address when binding with bridge, 
but some like openShift-SDN and OVN-kubernetes , do not.
 
Another thing is that with bridge binding method 
the VM gets it's IP from the background pod, 
and the last becomes IP-less. 
This could lead to issues when performing kubectl restart 
( see @phoracek  PR regarding this issue - 
https://github.com/kubevirt/kubevirt/pull/2100), 
and also networking with sidecars becomes an issue
 since the connection to the sidecar relies on the pod which 
,as explained, lost his network capabilities.  

```release-note
a flag and a validating web-hook were added
in order to have the option to disable bridge binding method on pod network.
```