### PR TITLE
Add run vm test for user on ocp

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -39,7 +39,7 @@ previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_releas
 
 functest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
 
-if [[ ${TARGET} == openshift* ]]; then
+if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} == okd-* ]]; then
     oc=${kubectl}
 fi
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1188,6 +1188,100 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(strings.HasPrefix(stdErr, "Error from server (NotFound): virtualmachines.kubevirt.io")).To(BeTrue(), "should fail when deleting non existent VM")
 		})
 
+		Context("as ordinary OCP user trough test service account", func() {
+			BeforeEach(func() {
+				tests.SkipIfNoCmd("oc")
+			})
+
+			const testUser = "testuser"
+			var token string
+
+			Context("should succeed with right rights", func() {
+				BeforeEach(func() {
+					By("Ensuring the cluster has new test serviceaccount")
+					stdOut, stdErr, err := tests.RunCommand(k8sClient, "create", "serviceaccount", testUser)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+
+					By("Ensuring user has the admin rights for the test namespace project")
+					// This simulates the ordinary user as an admin in his project
+					stdOut, stdErr, err = tests.RunCommand(k8sClient, "adm", "policy", "add-role-to-user", "admin", fmt.Sprintf("system:serviceaccount:%s:%s", tests.NamespaceTestDefault, testUser))
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+
+					token, stdErr, err = tests.RunCommand(k8sClient, "serviceaccounts", "get-token", testUser)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+				})
+
+				AfterEach(func() {
+					stdOut, stdErr, err := tests.RunCommand(k8sClient, "adm", "policy", "remove-role-from-user", "admin", fmt.Sprintf("system:serviceaccount:%s:%s", tests.NamespaceTestDefault, testUser))
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+
+					stdOut, stdErr, err = tests.RunCommand(k8sClient, "delete", "serviceaccount", testUser)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+				})
+
+				It("[test_id:2839]should create VM via command line", func() {
+					vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+
+					vmJson, err = tests.GenerateVMJson(vm, workDir)
+					Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
+
+					By("Creating VM using k8s client binary")
+					stdOut, stdErr, err := tests.RunCommand(k8sClient, "--token", token, "create", "-f", vmJson)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+
+					By("Waiting for VMI to start")
+					waitForVMIStart(virtClient, vmi)
+
+					By("Listing running pods")
+					stdout, _, err := tests.RunCommand(k8sClient, "--token", token, "get", "pods")
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Ensuring pod is running")
+					expectedPodName := getExpectedPodName(vm)
+					podRunningRe, err := regexp.Compile(fmt.Sprintf("%s.*Running", expectedPodName))
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(podRunningRe.FindString(stdout)).ToNot(Equal(""), "Pod is not Running")
+
+					By("Checking that VM is running")
+					stdout, _, err = tests.RunCommand(k8sClient, "--token", token, "describe", "vmis", vm.GetName())
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
+				})
+			})
+
+			Context("should fail without right rights", func() {
+				BeforeEach(func() {
+					By("Ensuring the cluster has new test serviceaccount")
+					stdOut, stdErr, err := tests.RunCommandWithNS("", k8sClient, "create", "serviceaccount", testUser)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+
+					token, stdErr, err = tests.RunCommandWithNS("", k8sClient, "serviceaccounts", "get-token", testUser)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+				})
+
+				AfterEach(func() {
+					stdOut, stdErr, err := tests.RunCommandWithNS("", k8sClient, "delete", "serviceaccount", testUser)
+					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
+				})
+
+				It("should create VM via command line", func() {
+					vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+					vm := tests.NewRandomVirtualMachine(vmi, true)
+
+					vmJson, err = tests.GenerateVMJson(vm, workDir)
+					Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
+
+					By("Creating VM using k8s client binary")
+					stdOut, stdErr, err := tests.RunCommand(k8sClient, "--token", token, "create", "-f", vmJson)
+					Expect(err).To(HaveOccurred(), "The call for VM creation should fail")
+					Expect(stdOut+stdErr).To(ContainSubstring("no RBAC policy matched"), "should be rejected due to not access rights")
+				})
+			})
+		})
+
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add the run VM test for ordinary user for OCP cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2497)
<!-- Reviewable:end -->
