### PR TITLE
Telemetry metrics

### DIFF
--- a/pkg/monitoring/vms/prometheus/BUILD.bazel
+++ b/pkg/monitoring/vms/prometheus/BUILD.bazel
@@ -36,5 +36,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -50,10 +50,10 @@ var (
 
 	// higher-level, telemetry-friendly metrics
 	vmiCountDesc = prometheus.NewDesc(
-		"kubevirt_vmi_status_count",
-		"VMI status.",
+		"kubevirt_vmi_phase_count",
+		"VMI phase.",
 		[]string{
-			"node", "status",
+			"node", "phase",
 		},
 		nil,
 	)
@@ -376,17 +376,17 @@ func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats
 }
 
 func updateTelemetry(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
-	statusMap := make(map[string]uint64)
+	phasesMap := make(map[string]uint64)
 
 	for _, vmi := range vmis {
-		statusMap[strings.ToLower(string(vmi.Status.Phase))] += 1
+		phasesMap[strings.ToLower(string(vmi.Status.Phase))] += 1
 	}
 
-	for status, count := range statusMap {
+	for phase, count := range phasesMap {
 		mv, err := prometheus.NewConstMetric(
 			vmiCountDesc, prometheus.GaugeValue,
 			float64(count),
-			nodeName, status,
+			nodeName, phase,
 		)
 		if err != nil {
 			continue

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -375,12 +375,18 @@ func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats
 	}
 }
 
-func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
+func makeVMIsPhasesMap(vmis []*k6tv1.VirtualMachineInstance) map[string]uint64 {
 	phasesMap := make(map[string]uint64)
 
 	for _, vmi := range vmis {
 		phasesMap[strings.ToLower(string(vmi.Status.Phase))] += 1
 	}
+
+	return phasesMap
+}
+
+func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
+	phasesMap := makeVMIsPhasesMap(vmis)
 
 	for phase, count := range phasesMap {
 		mv, err := prometheus.NewConstMetric(

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -375,7 +375,7 @@ func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats
 	}
 }
 
-func updateTelemetry(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
+func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
 	phasesMap := make(map[string]uint64)
 
 	for _, vmi := range vmis {
@@ -469,7 +469,7 @@ func (co *Collector) Collect(ch chan<- prometheus.Metric) {
 	scraper := &prometheusScraper{ch: ch}
 	co.concCollector.Collect(socketToVMIs, scraper, collectionTimeout)
 
-	updateTelemetry(co.nodeName, vmis, ch)
+	updateVMIsPhase(co.nodeName, vmis, ch)
 	return
 }
 

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -306,6 +306,19 @@ var _ = Describe("Infrastructure", func() {
 				Expect(key).To(ContainSubstring(fmt.Sprintf("name=\"%s\"", vmi.Name)))
 			}
 		}, 300)
+
+		It("should include VMI telemetry for a running VM", func() {
+			_, _, _, metrics := newRandomVMIWithMetrics(virtClient, "kubevirt_vmi_")
+			By("Checking the collected metrics")
+			keys := getKeysFromMetrics(metrics)
+
+			for _, key := range keys {
+				if strings.Contains(key, "running") {
+					value := metrics[key]
+					Expect(value).To(BeNumerically("==", float64(1.0)))
+				}
+			}
+		}, 300)
 	})
 
 	Describe("Start a VirtualMachineInstance", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -303,9 +303,9 @@ var _ = Describe("Infrastructure", func() {
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
 				// we don't care about the ordering of the labels
-				Expect(key).To(ContainSubstring(fmt.Sprintf("node=%s", nodeName)))
-				Expect(key).To(ContainSubstring(fmt.Sprintf("namespace=%s", vmi.Namespace)))
-				Expect(key).To(ContainSubstring(fmt.Sprintf("name=%s", vmi.Name)))
+				Expect(key).To(ContainSubstring(fmt.Sprintf("node=\"%s\"", nodeName)))
+				Expect(key).To(ContainSubstring(fmt.Sprintf("namespace=\"%s\"", vmi.Namespace)))
+				Expect(key).To(ContainSubstring(fmt.Sprintf("name=\"%s\"", vmi.Name)))
 			}
 		}, 300)
 	})

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Infrastructure", func() {
 			keys := getKeysFromMetrics(metrics)
 
 			for _, key := range keys {
-				if strings.Contains(key, "running") {
+				if strings.Contains(key, "phase=\"running\"") {
 					value := metrics[key]
 					Expect(value).To(BeNumerically("==", float64(1.0)))
 				}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -301,9 +301,11 @@ var _ = Describe("Infrastructure", func() {
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
 				// we don't care about the ordering of the labels
-				Expect(key).To(ContainSubstring(fmt.Sprintf("node=\"%s\"", nodeName)))
-				Expect(key).To(ContainSubstring(fmt.Sprintf("namespace=\"%s\"", vmi.Namespace)))
-				Expect(key).To(ContainSubstring(fmt.Sprintf("name=\"%s\"", vmi.Name)))
+				Expect(key).To(SatisfyAll(
+					ContainSubstring("node=\"%s\"", nodeName),
+					ContainSubstring("namespace=\"%s\"", vmi.Namespace),
+					ContainSubstring("name=\"%s\"", vmi.Name),
+				))
 			}
 		}, 300)
 
@@ -315,7 +317,7 @@ var _ = Describe("Infrastructure", func() {
 			for _, key := range keys {
 				if strings.Contains(key, "phase=\"running\"") {
 					value := metrics[key]
-					Expect(value).To(BeNumerically("==", float64(1.0)))
+					Expect(value).To(Equal(float64(1.0)))
 				}
 			}
 		}, 300)
@@ -467,7 +469,7 @@ func newRandomVMIWithMetrics(virtClient kubecli.KubevirtClient, metricPrefix str
 	// troubleshooting helper
 	fmt.Fprintf(GinkgoWriter, "metrics [%s]:\nlines=%s\n%#v\n", metricPrefix, lines, metrics)
 	Expect(len(metrics)).To(BeNumerically(">=", float64(1.0)))
-	Expect(len(metrics)).To(Equal(len(lines)))
+	Expect(metrics).To(HaveLen(len(lines)))
 
 	return vmi, nodeName, obj, metrics
 }

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -302,9 +302,9 @@ var _ = Describe("Infrastructure", func() {
 			for _, key := range keys {
 				// we don't care about the ordering of the labels
 				Expect(key).To(SatisfyAll(
-					ContainSubstring("node=\"%s\"", nodeName),
-					ContainSubstring("namespace=\"%s\"", vmi.Namespace),
-					ContainSubstring("name=\"%s\"", vmi.Name),
+					ContainSubstring(`node="%s"`, nodeName),
+					ContainSubstring(`namespace="%s"`, vmi.Namespace),
+					ContainSubstring(`name="%s"`, vmi.Name),
 				))
 			}
 		}, 300)
@@ -315,7 +315,7 @@ var _ = Describe("Infrastructure", func() {
 			keys := getKeysFromMetrics(metrics)
 
 			for _, key := range keys {
-				if strings.Contains(key, "phase=\"running\"") {
+				if strings.Contains(key, `phase="running"`) {
 					value := metrics[key]
 					Expect(value).To(Equal(float64(1.0)))
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add VMI count metrics. This is to be used first for the openshift telemeter integration (https://github.com/openshift/telemeter/pull/194), but in general we want to expose higher level metrics to be consumed by other components

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes N/A

**Special notes for your reviewer**:
I'm not 100% satisfied by the design, so comments are welcome. Is virt-handler the best place?
Do we want to differentiate between higher level (like this one) and lower level (like, say, the storage I/P metrics)?

```release-note
Add metric to report the VMI count.
```
