### PR TITLE
Define timestamp when building containers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -160,6 +160,7 @@ container_image(
     tars = [":passwd-tar"],
     user = "1001",
     visibility = ["//visibility:public"],
+    stamp = True,
 )
 
 load(

--- a/cmd/container-disk-v1alpha/BUILD.bazel
+++ b/cmd/container-disk-v1alpha/BUILD.bazel
@@ -22,6 +22,7 @@ container_image(
     entrypoint = ["/entry-point.sh"],
     files = ["entry-point.sh"],
     visibility = ["//visibility:public"],
+    stamp = True,
 )
 
 genrule(

--- a/cmd/example-cloudinit-hook-sidecar/BUILD.bazel
+++ b/cmd/example-cloudinit-hook-sidecar/BUILD.bazel
@@ -34,4 +34,5 @@ container_image(
     entrypoint = ["/example-cloudinit-hook-sidecar"],
     files = [":example-cloudinit-hook-sidecar"],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/example-hook-sidecar/BUILD.bazel
+++ b/cmd/example-hook-sidecar/BUILD.bazel
@@ -36,4 +36,5 @@ container_image(
     entrypoint = ["/example-hook-sidecar"],
     files = [":example-hook-sidecar"],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/subresource-access-test/BUILD.bazel
+++ b/cmd/subresource-access-test/BUILD.bazel
@@ -30,4 +30,5 @@ container_image(
     files = [":subresource-access-test"],
     user = "1001",
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/virt-api/BUILD.bazel
+++ b/cmd/virt-api/BUILD.bazel
@@ -44,4 +44,5 @@ container_image(
     files = [":virt-api"],
     user = "1001",
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/virt-controller/BUILD.bazel
+++ b/cmd/virt-controller/BUILD.bazel
@@ -42,4 +42,5 @@ container_image(
     files = [":virt-controller"],
     user = "1001",
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -67,4 +67,5 @@ container_image(
     entrypoint = ["/usr/bin/virt-handler"],
     files = [":virt-handler"],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -81,4 +81,5 @@ container_image(
         ":virt-launcher-tar",
     ],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/cmd/virt-operator/BUILD.bazel
+++ b/cmd/virt-operator/BUILD.bazel
@@ -39,4 +39,5 @@ container_image(
     files = [":virt-operator"],
     user = "1001",
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -21,6 +21,9 @@ set -o nounset
 set -o pipefail
 
 export KUBEVIRT_DIR=$(dirname "${BASH_SOURCE}")/..
+export BUILD_TIMESTAMP=$(date \
+    ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} \
+    -u +'%Y-%m-%dT%H:%M:%SZ')
 
 source "${KUBEVIRT_DIR}/hack/version.sh"
 kubevirt::version::get_version_vars

--- a/images/cdi-http-import-server/BUILD.bazel
+++ b/images/cdi-http-import-server/BUILD.bazel
@@ -74,4 +74,5 @@ container_image(
         ":nginx-config-tar",
     ],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/images/disks-images-provider/BUILD.bazel
+++ b/images/disks-images-provider/BUILD.bazel
@@ -89,4 +89,5 @@ container_image(
         ":custom-tar",
     ],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/images/nfs-server/BUILD.bazel
+++ b/images/nfs-server/BUILD.bazel
@@ -19,4 +19,5 @@ container_image(
         "32767/tcp",
     ],
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/images/vm-killer/BUILD.bazel
+++ b/images/vm-killer/BUILD.bazel
@@ -7,4 +7,5 @@ container_image(
     name = "vm-killer-image",
     base = "@kubevirt-testing//image",
     visibility = ["//visibility:public"],
+    stamp = True,
 )

--- a/images/winrmcli/BUILD.bazel
+++ b/images/winrmcli/BUILD.bazel
@@ -16,4 +16,5 @@ container_image(
         "@com_github_packer_community_winrmcp//:winrmcp",
     ],
     visibility = ["//visibility:public"],
+    stamp = True,
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Hopefully, setting timestamps on container build

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


Closes #2254 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Defines build timestamp so that containers are properly tagged with date when built
```
