### PR TITLE
metrics: fix prefix kubevirt_vm -> kubevirt_vmi

### DIFF
--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -60,7 +60,7 @@ var (
 
 	// lower level metrics
 	storageIopsDesc = prometheus.NewDesc(
-		"kubevirt_vm_storage_iops_total",
+		"kubevirt_vmi_storage_iops_total",
 		"I/O operation performed.",
 		[]string{
 			"node", "namespace", "name",
@@ -69,7 +69,7 @@ var (
 		nil,
 	)
 	storageTrafficDesc = prometheus.NewDesc(
-		"kubevirt_vm_storage_traffic_bytes_total",
+		"kubevirt_vmi_storage_traffic_bytes_total",
 		"storage traffic.",
 		[]string{
 			"node", "namespace", "name",
@@ -78,7 +78,7 @@ var (
 		nil,
 	)
 	storageTimesDesc = prometheus.NewDesc(
-		"kubevirt_vm_storage_times_ms_total",
+		"kubevirt_vmi_storage_times_ms_total",
 		"storage operation time.",
 		[]string{
 			"node", "namespace", "name",
@@ -87,7 +87,7 @@ var (
 		nil,
 	)
 	vcpuUsageDesc = prometheus.NewDesc(
-		"kubevirt_vm_vcpu_seconds",
+		"kubevirt_vmi_vcpu_seconds",
 		"Vcpu elapsed time.",
 		[]string{
 			"node", "namespace", "name",
@@ -96,7 +96,7 @@ var (
 		nil,
 	)
 	networkTrafficBytesDesc = prometheus.NewDesc(
-		"kubevirt_vm_network_traffic_bytes_total",
+		"kubevirt_vmi_network_traffic_bytes_total",
 		"network traffic.",
 		[]string{
 			"node", "namespace", "name",
@@ -105,7 +105,7 @@ var (
 		nil,
 	)
 	networkTrafficPktsDesc = prometheus.NewDesc(
-		"kubevirt_vm_network_traffic_packets_total",
+		"kubevirt_vmi_network_traffic_packets_total",
 		"network traffic.",
 		[]string{
 			"node", "namespace", "name",
@@ -114,7 +114,7 @@ var (
 		nil,
 	)
 	networkErrorsDesc = prometheus.NewDesc(
-		"kubevirt_vm_network_errors_total",
+		"kubevirt_vmi_network_errors_total",
 		"network errors.",
 		[]string{
 			"node", "namespace", "name",
@@ -123,7 +123,7 @@ var (
 		nil,
 	)
 	memoryAvailableDesc = prometheus.NewDesc(
-		"kubevirt_vm_memory_available_bytes",
+		"kubevirt_vmi_memory_available_bytes",
 		"amount of usable memory as seen by the domain.",
 		[]string{
 			"node", "namespace", "name",
@@ -132,7 +132,7 @@ var (
 		nil,
 	)
 	memoryResidentDesc = prometheus.NewDesc(
-		"kubevirt_vm_memory_resident_bytes",
+		"kubevirt_vmi_memory_resident_bytes",
 		"resident set size of the process running the domain",
 		[]string{
 			"node", "namespace", "name",
@@ -142,7 +142,7 @@ var (
 	)
 
 	swapTrafficDesc = prometheus.NewDesc(
-		"kubevirt_vm_memory_swap_traffic_bytes_total",
+		"kubevirt_vmi_memory_swap_traffic_bytes_total",
 		"swap memory traffic.",
 		[]string{
 			"node", "namespace", "name",

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -232,12 +232,12 @@ var _ = Describe("Infrastructure", func() {
 			lines := takeMetricsWithPrefix(out, "kubevirt")
 			metrics, err := parseMetricsToMap(lines)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(metrics).To(HaveKey(ContainSubstring("kubevirt_vm_storage_")))
+			Expect(metrics).To(HaveKey(ContainSubstring("kubevirt_vmi_storage_")))
 
 			By("Checking the collected metrics")
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
-				if strings.HasPrefix(key, "kubevirt_vm_storage_") && strings.Contains(key, "vdb") {
+				if strings.HasPrefix(key, "kubevirt_vmi_storage_") && strings.Contains(key, "vdb") {
 					value := metrics[key]
 					Expect(value).To(BeNumerically(">", float64(0.0)))
 				}
@@ -271,12 +271,12 @@ var _ = Describe("Infrastructure", func() {
 			lines := takeMetricsWithPrefix(out, "kubevirt")
 			metrics, err := parseMetricsToMap(lines)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(metrics).To(HaveKey(ContainSubstring("kubevirt_vm_network_")))
+			Expect(metrics).To(HaveKey(ContainSubstring("kubevirt_vmi_network_")))
 
 			By("Checking the collected metrics")
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
-				if strings.HasPrefix(key, "kubevirt_vm_network_") {
+				if strings.HasPrefix(key, "kubevirt_vmi_network_") {
 					value := metrics[key]
 					Expect(value).To(BeNumerically(">=", float64(0.0)))
 				}
@@ -284,7 +284,7 @@ var _ = Describe("Infrastructure", func() {
 		}, 300)
 
 		It("should include the memory metrics for a running VM", func() {
-			_, _, metrics := newRandomVMIWithMetrics(virtClient, "kubevirt_vm_memory_")
+			_, _, metrics := newRandomVMIWithMetrics(virtClient, "kubevirt_vmi_memory_")
 			By("Checking the collected metrics")
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
@@ -295,7 +295,7 @@ var _ = Describe("Infrastructure", func() {
 		}, 300)
 
 		It("should include VMI infos for a running VM", func() {
-			vmis, nodeName, metrics := newRandomVMIWithMetrics(virtClient, "kubevirt_vm_")
+			vmis, nodeName, metrics := newRandomVMIWithMetrics(virtClient, "kubevirt_vmi_")
 			Expect(vmis).To(HaveLen(1))
 
 			vmi := vmis[0]

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -304,11 +304,16 @@ var _ = Describe("Infrastructure", func() {
 			for _, key := range keys {
 				// we don't care about the ordering of the labels
 				// TODO: vmi.Status.NodeName is "" sometimes. Are we faster than the update?
-				Expect(key).To(SatisfyAll(
-					ContainSubstring(`node="%s"`, nodeName),
-					ContainSubstring(`namespace="%s"`, vmi.Namespace),
-					ContainSubstring(`name="%s"`, vmi.Name),
-				))
+				if strings.HasPrefix(key, "kubevirt_vmi_phase_count") {
+					// special case: namespace and name don't make sense for this metric
+					Expect(key).To(ContainSubstring(`node="%s"`, nodeName))
+				} else {
+					Expect(key).To(SatisfyAll(
+						ContainSubstring(`node="%s"`, nodeName),
+						ContainSubstring(`namespace="%s"`, vmi.Namespace),
+						ContainSubstring(`name="%s"`, vmi.Name),
+					))
+				}
 			}
 		}, 300)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix the prefix of the kubevirt metrics to reflect that they are about virtual machine *instances*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #Resolves: https://github.com/kubevirt/kubevirt/issues/2504

**Special notes for your reviewer**:
See discussion on https://github.com/kubevirt/kubevirt/pull/2501

**Release note**:
```release-note
VMI-related metrics have been renamed from `kubevirt_vm_` to `kubevirt_vmi_` to better reflect their purpose.
```
