### PR TITLE
Allow using multiple host disks in the same directory

### DIFF
--- a/pkg/host-disk/host-disk_test.go
+++ b/pkg/host-disk/host-disk_test.go
@@ -103,6 +103,7 @@ var _ = Describe("HostDisk", func() {
 	BeforeEach(func() {
 		var err error
 		tempDir, err = ioutil.TempDir("", "host-disk-images")
+		setDiskDirectory(tempDir)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/config:go_default_library",
         "//pkg/container-disk:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/host-disk:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//pkg/util/types:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -31,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
+	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -391,7 +393,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	for _, volume := range vmi.Spec.Volumes {
 		volumeMount := k8sv1.VolumeMount{
 			Name:      volume.Name,
-			MountPath: filepath.Join("/var/run/kubevirt-private", "vmi-disks", volume.Name),
+			MountPath: hostdisk.GetMountedHostDiskDir(volume.Name),
 		}
 		if volume.PersistentVolumeClaim != nil {
 			logger := log.DefaultLogger()
@@ -446,7 +448,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 			volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 				Name:      volume.Name,
-				MountPath: filepath.Dir(volume.HostDisk.Path),
+				MountPath: hostdisk.GetMountedHostDiskDir(volume.Name),
 			})
 			volumes = append(volumes, k8sv1.Volume{
 				Name: volume.Name,

--- a/pkg/virt-launcher/virtwrap/api/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/api/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/container-disk:go_default_library",
         "//pkg/emptydisk:go_default_library",
         "//pkg/ephemeral-disk:go_default_library",
+        "//pkg/host-disk:go_default_library",
         "//pkg/ignition:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/net/dns:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -33,6 +33,8 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
@@ -230,7 +232,7 @@ func Convert_v1_Volume_To_api_Disk(source *v1.Volume, disk *Disk, c *ConverterCo
 	}
 
 	if source.HostDisk != nil {
-		return Convert_v1_HostDisk_To_api_Disk(source.HostDisk.Path, disk, c)
+		return Convert_v1_HostDisk_To_api_Disk(source.Name, source.HostDisk.Path, disk, c)
 	}
 
 	if source.PersistentVolumeClaim != nil {
@@ -310,10 +312,10 @@ func Convert_v1_BlockVolumeSource_To_api_Disk(volumeName string, disk *Disk, c *
 	return nil
 }
 
-func Convert_v1_HostDisk_To_api_Disk(path string, disk *Disk, c *ConverterContext) error {
+func Convert_v1_HostDisk_To_api_Disk(volumeName string, path string, disk *Disk, c *ConverterContext) error {
 	disk.Type = "file"
 	disk.Driver.Type = "raw"
-	disk.Source.File = path
+	disk.Source.File = hostdisk.GetMountedHostDiskPath(volumeName, path)
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -416,27 +416,27 @@ var _ = Describe("Converter", func() {
       <alias name="ua-cdrom_tray_unspecified"></alias>
     </disk>
     <disk device="cdrom" type="file">
-      <source file="/var/run/kubevirt-private/vmi-disks/volume1/disk.img"></source>
+      <source file="/var/run/kubevirt-private/vmi-disks/cdrom_tray_open/disk.img"></source>
       <target bus="sata" dev="sdb" tray="open"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
       <readonly></readonly>
       <alias name="ua-cdrom_tray_open"></alias>
     </disk>
     <disk device="floppy" type="file">
-      <source file="/var/run/kubevirt-private/vmi-disks/volume2/disk.img"></source>
+      <source file="/var/run/kubevirt-private/vmi-disks/floppy_tray_unspecified/disk.img"></source>
       <target bus="fdc" dev="fda" tray="closed"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-floppy_tray_unspecified"></alias>
     </disk>
     <disk device="floppy" type="file">
-      <source file="/var/run/kubevirt-private/vmi-disks/volume3/disk.img"></source>
+      <source file="/var/run/kubevirt-private/vmi-disks/floppy_tray_open/disk.img"></source>
       <target bus="fdc" dev="fdb" tray="open"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
       <readonly></readonly>
       <alias name="ua-floppy_tray_open"></alias>
     </disk>
     <disk device="disk" type="file">
-      <source file="/var/run/kubevirt-private/vmi-disks/volume4/disk.img"></source>
+      <source file="/var/run/kubevirt-private/vmi-disks/should_default_to_disk/disk.img"></source>
       <target bus="sata" dev="sdc"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-should_default_to_disk"></alias>

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -352,17 +352,27 @@ var _ = Describe("Storage", func() {
 						tests.AddHostDisk(vmi, filepath.Join(hostDiskDir, "another.img"), v1.HostDiskExistsOrCreate, "anotherdisk")
 						tests.RunVMIAndExpectLaunch(vmi, 30)
 
-						By("Checking if disk.img has been created")
+						By("Checking if another.img has been created")
 						vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
 						nodeName = vmiPod.Spec.NodeName
 						output, err := tests.ExecuteCommandOnPod(
 							virtClient,
 							vmiPod,
 							vmiPod.Spec.Containers[0].Name,
-							[]string{"find", hostdisk.GetMountedHostDiskDir("anotherdisk"), "-name", "another.img", "-size", "1G"},
+							[]string{"find", hostdisk.GetMountedHostDiskDir("anotherdisk"), "-size", "1G"},
 						)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(output).To(ContainSubstring(hostdisk.GetMountedHostDiskPath("anotherdisk", filepath.Join(hostDiskDir, "another.img"))))
+
+						By("Checking if disk.img has been created")
+						output, err = tests.ExecuteCommandOnPod(
+							virtClient,
+							vmiPod,
+							vmiPod.Spec.Containers[0].Name,
+							[]string{"find", hostdisk.GetMountedHostDiskDir("host-disk"), "-size", "1G"},
+						)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(output).To(ContainSubstring(hostdisk.GetMountedHostDiskPath("host-disk", diskPath)))
 					})
 
 				})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3218,7 +3218,7 @@ func CreateHostDiskImage(diskPath string) *k8sv1.Pod {
 func newDeleteHostDisksJob(diskPath string) *k8sv1.Pod {
 	hostPathType := k8sv1.HostPathDirectoryOrCreate
 
-	args := []string{fmt.Sprintf(`rm -f %s`, diskPath)}
+	args := []string{fmt.Sprintf(`rm -rf %s`, diskPath)}
 	job := RenderHostPathJob("hostdisk-delete-job", filepath.Dir(diskPath), hostPathType, k8sv1.MountPropagationNone, []string{"/bin/bash", "-c"}, args)
 
 	return job


### PR DESCRIPTION
**What this PR does / why we need it**:

If two disks are in the same host directory, don't mount the twho
resulting host directories in the same place in the container. Instead
every mount point for every disk is now unique, based on the volume
name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726766

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
