### PR TITLE
Added root go file for client-go for dep dependency manager

### DIFF
--- a/staging/src/kubevirt.io/client-go/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "kubevirt.io/client-go",
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/kubevirt.io/client-go/doc.go
+++ b/staging/src/kubevirt.io/client-go/doc.go
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+package root
+
+// This file only exists for the "dep" dependency manager, which needs a go file on the project root


### PR DESCRIPTION
**What this PR does / why we need it**:
Added root go file for client-go for `dep` dependency manager

**Special notes for your reviewer**:
Just the same as we already have for kubevirt's root dir.
Already done on client-go v0.19.0 and tested on HCO

**Release note**:
```release-note
NONE
```
