### PR TITLE
Don't add default client flags in client-go to pflags

### DIFF
--- a/pkg/service/BUILD.bazel
+++ b/pkg/service/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["service.go"],
     importpath = "kubevirt.io/kubevirt/pkg/service",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
 )

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -25,7 +25,13 @@ import (
 	"strconv"
 
 	flag "github.com/spf13/pflag"
+
+	"kubevirt.io/client-go/kubecli"
 )
+
+func init() {
+	kubecli.Init()
+}
 
 type Service interface {
 	Run()

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -49,6 +49,8 @@ import (
 )
 
 var _ = Describe("VirtualMachineInstance Subresources", func() {
+	kubecli.Init()
+
 	var server *ghttp.Server
 	var backend *ghttp.Server
 	var request *restful.Request

--- a/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
@@ -54,8 +54,12 @@ var once sync.Once
 // Init adds the default `kubeconfig` and `master` flags. It is not added by default to allow integration into
 // the different controller generators which normally add these flags too.
 func Init() {
-	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
-	flag.StringVar(&master, "master", "", "master url")
+	if flag.CommandLine.Lookup("kubeconfig") == nil {
+		flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	if flag.CommandLine.Lookup("master") == nil {
+		flag.StringVar(&master, "master", "", "master url")
+	}
 }
 
 func GetKubevirtSubresourceClientFromFlags(master string, kubeconfig string) (KubevirtClient, error) {

--- a/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
@@ -51,7 +51,9 @@ var (
 var virtclient KubevirtClient
 var once sync.Once
 
-func init() {
+// Init adds the default `kubeconfig` and `master` flags. It is not added by default to allow integration into
+// the different controller generators which normally add these flags too.
+func Init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.StringVar(&master, "master", "", "master url")
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -105,6 +105,7 @@ var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
 
 func init() {
+	kubecli.Init()
 	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtVersionTag, "container-tag", "latest", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtVersionTagAlt, "container-tag-alt", "", "An alternate tag that can be used to test operator deployments")


### PR DESCRIPTION

**What this PR does / why we need it**:

Controller SDKs add the master and kubeconfig flags very often by
default. Our client added it too by default. Stop doing this, to avoid
flag conflicts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2368

**Special notes for your reviewer**:

**Release note**:

```release-note
Don't add default pflags in kubevirt.io/client-go to allow integration with operator sdks which add it too.
```
