### PR TITLE
Clean up host mounts for sriov

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -341,21 +341,6 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	})
 
 	if isSRIOVVmi(vmi) {
-		// libvirt needs this volume to unbind the device from kernel
-		// driver, and register it with vfio userspace driver
-		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
-			Name:      "pci-bus",
-			MountPath: "/sys/bus/pci/",
-		})
-		volumes = append(volumes, k8sv1.Volume{
-			Name: "pci-bus",
-			VolumeSource: k8sv1.VolumeSource{
-				HostPath: &k8sv1.HostPathVolumeSource{
-					Path: "/sys/bus/pci/",
-				},
-			},
-		})
-
 		// libvirt needs this volume to determine iommu group assigned
 		// to the device
 		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -341,8 +341,9 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	})
 
 	if isSRIOVVmi(vmi) {
-		// libvirt needs this volume to determine iommu group assigned
-		// to the device
+		// libvirt needs this volume to access PCI device config;
+		// note that the volume should not be read-only because libvirt
+		// opens the config for writing
 		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
 			Name:      "pci-devices",
 			MountPath: "/sys/devices/",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -370,20 +370,6 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 				},
 			},
 		})
-
-		// libvirt uses vfio-pci to pass host devices through
-		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
-			Name:      "dev-vfio",
-			MountPath: "/dev/vfio/",
-		})
-		volumes = append(volumes, k8sv1.Volume{
-			Name: "dev-vfio",
-			VolumeSource: k8sv1.VolumeSource{
-				HostPath: &k8sv1.HostPathVolumeSource{
-					Path: "/dev/vfio/",
-				},
-			},
-		})
 	}
 
 	serviceAccountName := ""

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1143,12 +1143,8 @@ var _ = Describe("Template", func() {
 
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
 				// Skip first three mounts that are generic for all launcher pods
-				Expect(pod.Spec.Containers[0].VolumeMounts[3].MountPath).To(Equal("/sys/bus/pci/"))
-				Expect(pod.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/sys/devices/"))
-				Expect(pod.Spec.Containers[0].VolumeMounts[5].MountPath).To(Equal("/dev/vfio/"))
-				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/sys/bus/pci/"))
-				Expect(pod.Spec.Volumes[1].HostPath.Path).To(Equal("/sys/devices/"))
-				Expect(pod.Spec.Volumes[2].HostPath.Path).To(Equal("/dev/vfio/"))
+				Expect(pod.Spec.Containers[0].VolumeMounts[3].MountPath).To(Equal("/sys/devices/"))
+				Expect(pod.Spec.Volumes[0].HostPath.Path).To(Equal("/sys/devices/"))
 			})
 		})
 		Context("with slirp interface", func() {


### PR DESCRIPTION
**What this PR does / why we need it**: update (reduce) list of host mounts needed for SR-IOV launcher pods

```release-note
Reduced host exposure of SR-IOV VMIs by removing unneeded mounts from their launcher pods
```
