### PR TITLE
Better timeout expired message for ObjectEventWatcher

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -378,7 +378,7 @@ func (w *ObjectEventWatcher) WaitFor(stopChan chan struct{}, eventType EventType
 			return true
 		}
 		return false
-	}, fmt.Sprintf("Waiting for %s == %s", string(eventType), reflect.ValueOf(reason).String()))
+	}, fmt.Sprintf("event type %s, reason = %s", string(eventType), reflect.ValueOf(reason).String()))
 	return
 }
 
@@ -391,7 +391,7 @@ func (w *ObjectEventWatcher) WaitNotFor(stopChan chan struct{}, eventType EventT
 			return true
 		}
 		return false
-	}, fmt.Sprintf("Not waiting for %s == %s", string(eventType), reflect.ValueOf(reason).String()))
+	}, fmt.Sprintf("not happen event type %s, reason = %s", string(eventType), reflect.ValueOf(reason).String()))
 	return
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -287,7 +287,7 @@ func (w *ObjectEventWatcher) SinceResourceVersion(rv string) *ObjectEventWatcher
 	return w
 }
 
-func (w *ObjectEventWatcher) Watch(abortChan chan struct{}, processFunc ProcessFunc) {
+func (w *ObjectEventWatcher) Watch(abortChan chan struct{}, processFunc ProcessFunc, watchedDescription string) {
 	Expect(w.startType).ToNot(Equal(invalidWatch))
 	resourceVersion := ""
 
@@ -360,7 +360,7 @@ func (w *ObjectEventWatcher) Watch(abortChan chan struct{}, processFunc ProcessF
 		case <-abortChan:
 		case <-time.After(*w.timeout):
 			if !w.dontFailOnMissingEvent {
-				Fail(fmt.Sprintf("Waited for %v seconds on the event stream to match a specific event", w.timeout.Seconds()), 1)
+				Fail(fmt.Sprintf("Waited for %v seconds on the event stream to match a specific event: %s", w.timeout.Seconds(), watchedDescription), 1)
 			}
 		}
 	} else {
@@ -378,7 +378,7 @@ func (w *ObjectEventWatcher) WaitFor(stopChan chan struct{}, eventType EventType
 			return true
 		}
 		return false
-	})
+	}, fmt.Sprintf("Waiting for %s == %s", string(eventType), reflect.ValueOf(reason).String()))
 	return
 }
 
@@ -391,7 +391,7 @@ func (w *ObjectEventWatcher) WaitNotFor(stopChan chan struct{}, eventType EventT
 			return true
 		}
 		return false
-	})
+	}, fmt.Sprintf("Not waiting for %s == %s", string(eventType), reflect.ValueOf(reason).String()))
 	return
 }
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -280,7 +280,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							}
 						}
 						return false
-					}, fmt.Sprintf("Waiting for two attempts of %s", v1.SyncFailed.String()))
+					}, fmt.Sprintf("two events of type Warning, reason = %s", v1.SyncFailed.String()))
 				})
 
 				It("[test_id:1630]should log warning and proceed once the secret is there", func() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -280,7 +280,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 							}
 						}
 						return false
-					})
+					}, fmt.Sprintf("Waiting for two attempts of %s", v1.SyncFailed.String()))
 				})
 
 				It("[test_id:1630]should log warning and proceed once the secret is there", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When a `ObjectEventWatcher` fails watching for a timeout (https://github.com/kubevirt/kubevirt/blob/master/tests/utils.go#L361) it gives back a very generic error message. 

What we see on the output is something along the line of:
```
/root/go/src/kubevirt.io/kubevirt/tests/vmi_multus_test.go:700
Waited for 182 seconds on the event stream to match a specific event
```

Which does not give much hint of what it is failing.

This PR adds a bit more context specifying the event type and the message we are waiting for while trying to be not too invasive.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```
