### PR TITLE
change pod network with bridge interface examples

### DIFF
--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -16,7 +16,7 @@ spec:
           bus: virtio
         name: cloudinitdisk
       interfaces:
-      - bridge: {}
+      - masquerade: {}
         name: default
       - bridge: {}
         name: ptp

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -16,7 +16,7 @@ spec:
           bus: virtio
         name: cloudinitdisk
       interfaces:
-      - bridge: {}
+      - masquerade: {}
         name: default
       - name: sriov-net
         sriov: {}

--- a/examples/vmi-windows.yaml
+++ b/examples/vmi-windows.yaml
@@ -25,7 +25,7 @@ spec:
           bus: sata
         name: pvcdisk
       interfaces:
-      - bridge: {}
+      - masquerade: {}
         model: e1000
         name: default
     features:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
In this PR all examples from
 kubevirt/examples that included
pod network with bridge interface were changed to
masquerde.

thats regarding isseus discussed in detail here:
https://github.com/kubevirt/kubevirt/pull/2493

we would like the examples to be consistent with
the changes suggested in this PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
