### PR TITLE
Make longer timeouts for SyncVMI and MigrateVirtualMachine

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -277,7 +277,7 @@ func (app *virtHandlerApp) Run() {
 	factory.Start(stop)
 	cache.WaitForCacheSync(stop, factory.ConfigMap().HasSynced)
 
-	go vmController.Run(3, stop)
+	go vmController.Run(10, stop)
 
 	logger.V(1).Infof("metrics: max concurrent requests=%d", app.MaxRequestsInFlight)
 	http.Handle("/metrics", promvm.Handler(app.MaxRequestsInFlight))

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -180,7 +180,7 @@ func (c *VirtLauncherClient) genericSendVMICmd(cmdName string,
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	response, err := cmdFunc(ctx, request)
 

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -88,6 +88,11 @@ type VirtLauncherClient struct {
 	conn     *grpc.ClientConn
 }
 
+const (
+	shortTimeout time.Duration = 5 * time.Second
+	longTimeout  time.Duration = 20 * time.Second
+)
+
 func ListAllSockets(baseDir string) ([]string, error) {
 	var socketFiles []string
 
@@ -134,7 +139,7 @@ func NewClient(socketPath string) (LauncherClient, error) {
 }
 
 func NewClientWithInfoClient(infoClient info.CmdInfoClient, conn *grpc.ClientConn) (LauncherClient, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), shortTimeout)
 	info, err := infoClient.Info(ctx, &info.CmdInfoRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("could not check cmd server version: %v", err)
@@ -180,7 +185,7 @@ func (c *VirtLauncherClient) genericSendVMICmd(cmdName string,
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), longTimeout)
 	defer cancel()
 	response, err := cmdFunc(ctx, request)
 
@@ -269,7 +274,7 @@ func (c *VirtLauncherClient) MigrateVirtualMachine(vmi *v1.VirtualMachineInstanc
 		Options: optionsJson,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), longTimeout)
 	defer cancel()
 	response, err := c.v1client.MigrateVirtualMachine(ctx, request)
 
@@ -293,7 +298,7 @@ func (c *VirtLauncherClient) GetDomain() (*api.Domain, bool, error) {
 	exists := false
 
 	request := &cmdv1.EmptyRequest{}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 	defer cancel()
 	response, err := c.v1client.GetDomain(ctx, request)
 
@@ -316,7 +321,7 @@ func (c *VirtLauncherClient) GetDomainStats() (*stats.DomainStats, bool, error) 
 	exists := false
 
 	request := &cmdv1.EmptyRequest{}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 	defer cancel()
 	response, err := c.v1client.GetDomainStats(ctx, request)
 
@@ -336,7 +341,7 @@ func (c *VirtLauncherClient) GetDomainStats() (*stats.DomainStats, bool, error) 
 
 func (c *VirtLauncherClient) Ping() error {
 	request := &cmdv1.EmptyRequest{}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 	defer cancel()
 	response, err := c.v1client.Ping(ctx, request)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We found out that several tests are failing because the SyncVMI call takes longer than 5 seconds to execute. This causes a Warning event that makes tests fail.

In the sriov-ci experimental lane we found one case that took 16 seconds to execute.
This PR raises the timeout to 20 seconds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2471


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE
```
