### PR TITLE
Change default binding method to bridge

### DIFF
--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -86,8 +86,8 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("is bridge, it should return bridge", "bridge", "bridge"),
 		table.Entry("is slirp, it should return slirp", "slirp", "slirp"),
 		table.Entry("is masquerade, it should return masquerade", "masquerade", "masquerade"),
-		table.Entry("when unset, it should return the default", "", "bridge"),
-		table.Entry("when invalid, it should return the default", "invalid", "bridge"),
+		table.Entry("when unset, it should return the default", "", "masquerade"),
+		table.Entry("when invalid, it should return the default", "invalid", "masquerade"),
 	)
 
 	nodeSelectorsStr := "kubernetes.io/hostname=node02\nnode-role.kubernetes.io/compute=true\n"

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -43,7 +43,7 @@ const (
 	DefaultEmulatedMachines                         = "q35*,pc-q35*"
 	DefaultLessPVCSpaceToleration                   = 10
 	DefaultNodeSelectors                            = ""
-	DefaultNetworkInterface                         = "bridge"
+	DefaultNetworkInterface                         = "masquerade"
 	DefaultImagePullPolicy                          = k8sv1.PullIfNotPresent
 	DefaultUseEmulation                             = false
 	DefaultUnsafeMigrationOverride                  = false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In this PR we change the default binding method from bridge to masquerade,
both in the code and the examples.
 
We would prefer masquerade as our default binding method, since live migration
is not allowed with bridge (see @vladikr 's merged PR regarding this: 
https://github.com/kubevirt/kubevirt/pull/2405) ,which means live migration is not possible by default.

Furthermore, it is not possible networking with sidecars when using bridge, which restricts, for example, the use of Istio.  

In order for the examples to be consistent with this implementation , and to avoid the situation of 
a random user copy-pasting the examples and unexpectedly not receiving support
for live migration and Istio, we changed the examples as well from bridge masquerade.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
default binding method was changed from bridge to masquerade
```
