### PR TITLE
Some improvements for client-go:

### DIFF
--- a/hack/publish-staging.sh
+++ b/hack/publish-staging.sh
@@ -29,15 +29,13 @@ git clean -fxd
 popd
 cp -rf staging/src/kubevirt.io/client-go/. "${API_REF_DIR}/"
 
+# copy files which are the same on both repos
+cp -f LICENSE "${API_REF_DIR}/"
+cp -f SECURITY.md "${API_REF_DIR}/"
+
 cd "${API_REF_DIR}"
 
-# Generate README.md file
-cat >README.md <<__EOF__
-# client-go
-
-Go clients for talking to kubevirt.
-__EOF__
-
+# Generate .gitignore file. We want to keep bazel files in kubevirt/kubevirt, but not in kubevirt/client-go
 cat >.gitignore <<__EOF__
 BUILD
 BUILD.bazel

--- a/staging/src/kubevirt.io/client-go/README.md
+++ b/staging/src/kubevirt.io/client-go/README.md
@@ -1,0 +1,25 @@
+# KubeVirt client-go
+
+Go clients for talking to [KubeVirt](https://github.com/kubevirt/kubevirt).
+
+KubeVirt client-go is maintained at https://github.com/kubevirt/kubevirt/tree/master/staging/src/kubevirt.io/client-go.  
+The master branch of this repository is updated on every PR merge, release tags are pushed on every release of KubeVirt.
+
+## License
+
+KubeVirt client-go is distributed under the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
+
+    Copyright 2019
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
- copy LICENSE and SECURITY.md from kubevirt to client-go
- maintain README.md in staging dir instead of generating it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/client-go/issues/4

**Release note**:
```release-note
NONE
```
