### PR TITLE
Forward all in masquerade 0.17

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -548,6 +548,15 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables() error {
 		return err
 	}
 
+	if len(p.iface.Ports) == 0 {
+		err = Handler.IptablesAppendRule("nat", "KUBEVIRT_PREINBOUND",
+			"-j",
+			"DNAT",
+			"--to-destination", p.vif.IP.IP.String())
+
+		return err
+	}
+
 	for _, port := range p.iface.Ports {
 		if port.Protocol == "" {
 			port.Protocol = "tcp"


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick for https://github.com/kubevirt/kubevirt/pull/2331


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
forward all ports using masquerade
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2542)
<!-- Reviewable:end -->
