### PR TITLE
Make the kubevirt rising timeout longer in cluster-deploy.sh

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -87,6 +87,6 @@ until _kubectl -n kubevirt get kv kubevirt; do
 done
 
 # wait until KubeVirt is ready
-_kubectl wait -n kubevirt kv kubevirt --for condition=Ready --timeout 6m || (echo "KubeVirt not ready in time" && exit 1)
+_kubectl wait -n kubevirt kv kubevirt --for condition=Ready --timeout 12m || (echo "KubeVirt not ready in time" && exit 1)
 
 echo "Done"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

While running sriov ci tests, a few runs failed for `timed out waiting for the condition on kubevirts/kubevirt`  during cluster-deploy. This PR makes the timeout longer in order to see if it was just a matter of short time.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```
