### PR TITLE
Enable sriov support by default

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -199,25 +199,7 @@ Finally, create a new SR-IOV network CRD that will use SR-IOV device plugin to a
 
 # Install kubevirt services
 
-The SR-IOV feature is gated, so you would need to enable the `SRIOV` gate
-feature using `kubevirt-config` map before deploying Kubevirt. For example,
-
-```
-cat <<EOF | ./cluster/kubectl.sh create -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kubevirt
-  labels:
-    kubevirt.io: ""
-data:
-  feature-gates: "SRIOV"
-EOF
-```
-
-After that, you are ready to deploy Kubevirt. As you can see, this particular
-step is not specific to SR-IOV.
+This particular step is not specific to SR-IOV.
 
 ```
 make cluster-sync

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -56,12 +56,6 @@ if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]] || [[ "$KUBEVIRT_PROVIDER" =~ okd-* ]]; th
     _kubectl adm policy add-scc-to-user privileged admin
 fi
 
-if [[ "$KUBEVIRT_PROVIDER" =~ .*sriov.* ]]; then
-    #enable feature gate
-    _kubectl patch configmap kubevirt-config -n kubevirt --patch "data: 
-  feature-gates: $(kubectl get configmap kubevirt-config -n kubevirt -o jsonpath='{.data.feature-gates}'), SRIOV"
-fi
-
 if [[ "$KUBEVIRT_PROVIDER" =~ kind.* ]]; then
     #removing it since it's crashing with dind because loopback devices are shared with the host
     _kubectl delete -n kubevirt ds disks-images-provider

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -636,14 +636,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 				})
 			}
 
-			if iface.SRIOV != nil && !config.SRIOVEnabled() {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("SRIOV feature gate is not enabled in kubevirt-config"),
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			}
-
 			// Check if the interface name is unique
 			if _, networkAlreadyUsed := networkInterfaceMap[iface.Name]; networkAlreadyUsed {
 				causes = append(causes, metav1.StatusCause{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1735,36 +1735,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(len(causes)).To(Equal(0))
 		})
 
-		It("should accept SRIOV interface when feature gate is disabled", func() {
-			vmi := v1.NewMinimalVMI("testvmi")
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-
-			vmi.Spec.Domain.Devices.Interfaces = append(
-				vmi.Spec.Domain.Devices.Interfaces,
-				v1.Interface{
-					Name: "sriov",
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						SRIOV: &v1.InterfaceSRIOV{},
-					},
-				},
-			)
-			vmi.Spec.Networks = append(
-				vmi.Spec.Networks,
-				v1.Network{
-					Name: "sriov",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{NetworkName: "sriov"},
-					},
-				},
-			)
-
-			disableFeatureGates()
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(0))
-		})
-
 		It("should allow valid ioThreadsPolicy", func() {
 			vmi := v1.NewMinimalVMI("testvm")
 			var ioThreadPolicy v1.IOThreadsPolicy

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1735,7 +1735,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(len(causes)).To(Equal(0))
 		})
 
-		It("should reject SRIOV interface when feature gate is disabled", func() {
+		It("should accept SRIOV interface when feature gate is disabled", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
@@ -1762,8 +1762,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			disableFeatureGates()
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces[1].name"))
+			Expect(len(causes)).To(Equal(0))
 		})
 
 		It("should allow valid ioThreadsPolicy", func() {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -32,7 +32,6 @@ const (
 	cpuManager            = "CPUManager"
 	IgnitionGate          = "ExperimentalIgnitionSupport"
 	liveMigrationGate     = "LiveMigration"
-	SRIOVGate             = "SRIOV"
 	CPUNodeDiscoveryGate  = "CPUNodeDiscovery"
 	HypervStrictCheckGate = "HypervStrictCheck"
 	SidecarGate           = "Sidecar"
@@ -52,10 +51,6 @@ func (config *ClusterConfig) IgnitionEnabled() bool {
 
 func (config *ClusterConfig) LiveMigrationEnabled() bool {
 	return config.isFeatureGateEnabled(liveMigrationGate)
-}
-
-func (config *ClusterConfig) SRIOVEnabled() bool {
-	return config.isFeatureGateEnabled(SRIOVGate)
 }
 
 func (config *ClusterConfig) HypervStrictCheckEnabled() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This pr makes the sr-iov support enabled by default by removing the need for feature gate. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

SR-IOV support enabled by default, removed feature gate.

```
