### PR TITLE
Provide debug info in case of kubevirt missed start

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -25,13 +25,13 @@ source hack/common.sh
 source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
 source hack/config.sh
 
-function dump_kubevirt {
-  echo "Dump kubevirt state:"
-  _kubectl get all -n kubevirt
-  for operator in $(kubectl -n kubevirt get pods | grep operator | awk '{print $1}'); do
-    echo "Logs for operator $operator"
-    _kubectl logs -n kubevirt $operator
-  done
+function dump_kubevirt() {
+    echo "Dump kubevirt state:"
+    _kubectl get all -n kubevirt
+    for operator in $(kubectl -n kubevirt get pods | grep operator | awk '{print $1}'); do
+        echo "Logs for operator $operator"
+        _kubectl logs -n kubevirt $operator
+    done
 }
 
 echo "Deploying ..."

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -25,6 +25,15 @@ source hack/common.sh
 source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
 source hack/config.sh
 
+function dump_kubevirt {
+  echo "Dump kubevirt state:"
+  _kubectl get all -n kubevirt
+  for operator in $(kubectl -n kubevirt get pods | grep operator | awk '{print $1}'); do
+    echo "Logs for operator $operator"
+    _kubectl logs -n kubevirt $operator
+  done
+}
+
 echo "Deploying ..."
 
 # Create the installation namespace if it does not exist already
@@ -87,6 +96,6 @@ until _kubectl -n kubevirt get kv kubevirt; do
 done
 
 # wait until KubeVirt is ready
-_kubectl wait -n kubevirt kv kubevirt --for condition=Ready --timeout 6m || (echo "KubeVirt not ready in time" && exit 1)
+_kubectl wait -n kubevirt kv kubevirt --for condition=Ready --timeout 6m || (echo "KubeVirt not ready in time" && dump_kubevirt && exit 1)
 
 echo "Done"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
While running sriov ci tests, a few runs failed for timed out waiting for the condition on kubevirts/kubevirt during cluster-deploy. This PR provides debug information in case the deadline is missed. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```
