### PR TITLE
Use HCO conditions on KubeVirt CR

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -96,6 +96,6 @@ until _kubectl -n kubevirt get kv kubevirt; do
 done
 
 # wait until KubeVirt is ready
-_kubectl wait -n kubevirt kv kubevirt --for condition=Ready --timeout 6m || (echo "KubeVirt not ready in time" && dump_kubevirt && exit 1)
+_kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 6m || (echo "KubeVirt not ready in time" && dump_kubevirt && exit 1)
 
 echo "Done"

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1278,10 +1278,14 @@ const (
 	KubeVirtConditionSynchronized KubeVirtConditionType = "Synchronized"
 	// Whether all resources were created and up-to-date
 	KubeVirtConditionCreated KubeVirtConditionType = "Created"
-	// Whether all components were ready
-	KubeVirtConditionReady KubeVirtConditionType = "Ready"
-	// Whether we're in the process of updating previously deployed version
-	KubeVirtConditionUpdating KubeVirtConditionType = "Updating"
+
+	// Conditions for HCO, see https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md
+	// Whether KubeVirt is functional and available in the cluster.
+	KubeVirtConditionAvailable KubeVirtConditionType = "Available"
+	// Whether the operator is actively making changes to KubeVirt
+	KubeVirtConditionProgressing KubeVirtConditionType = "Progressing"
+	// Whether KubeVirt is not functioning completely
+	KubeVirtConditionDegraded KubeVirtConditionType = "Degraded"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Use HCO conditions on KubeVirt CR

**Special notes for your reviewer**:
See https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md
Needs userguide update and heads up via mail for renaming `Ready` condition to `Available`, which is being used while waiting for a sucessfull deployment of KubeVirt

**Release note**:
```release-note
Added and renamed some KubeVirt CR conditions for usage by HCO
```
