### PR TITLE
Added a check to VMI validating webhook to not allow non-dns1123 comp…

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -61,6 +61,10 @@ var validInterfaceModels = []string{"e1000", "e1000e", "ne2k_pci", "pcnet", "rtl
 var validIOThreadsPolicies = []v1.IOThreadsPolicy{v1.IOThreadsPolicyShared, v1.IOThreadsPolicyAuto}
 var validCPUFeaturePolicies = []string{"", "force", "require", "optional", "disable", "forbid"}
 
+// taken from k8s.io/apimachinery/pkg/util/validation/validation.go since not exported
+const dns1123LabelErrMsg string = "a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+
 type VMICreateAdmitter struct {
 	ClusterConfig *virtconfig.ClusterConfig
 }
@@ -1622,6 +1626,17 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 				Field:   field.Index(idx).Child("cache").String(),
 			})
 		}
+
+		// Verify disk and volume name can be a valid container name since disk 
+		// name can become a container name which will fail to schedule if invalid
+		e := validation.IsDNS1123Subdomain(disk.Name)
+		if len(e) != 0 {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Invalid value: \"%s\": %s, regex used for validation is '%s'", disk.Name, dns1123LabelErrMsg, dns1123LabelFmt),
+			Field: field.Child("domain", "devices", "disks").Index(idx).Child("name").String(),
+		})
+	}
 	}
 
 	return causes

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1438,18 +1438,6 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 				})
 			}
 		}
-
-		// Verify disk and volume name can be a valid container name since disk
-		// name can become a container name which will fail to schedule if invalid
-		errs := validation.IsDNS1123Label(volume.Name)
-
-		for _, err := range errs {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: err,
-				Field:   field.Child("domain", "devices", "disks").Index(idx).Child("name").String(),
-			})
-		}
 	}
 
 	if serviceAccountVolumeCount > 1 {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1627,16 +1627,16 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 			})
 		}
 
-		// Verify disk and volume name can be a valid container name since disk 
+		// Verify disk and volume name can be a valid container name since disk
 		// name can become a container name which will fail to schedule if invalid
 		e := validation.IsDNS1123Subdomain(disk.Name)
 		if len(e) != 0 {
-		causes = append(causes, metav1.StatusCause{
-			Type: metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("Invalid value: \"%s\": %s, regex used for validation is '%s'", disk.Name, dns1123LabelErrMsg, dns1123LabelFmt),
-			Field: field.Child("domain", "devices", "disks").Index(idx).Child("name").String(),
-		})
-	}
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("Invalid value: \"%s\": %s, regex used for validation is '%s'", disk.Name, dns1123LabelErrMsg, dns1123LabelFmt),
+				Field:   field.Child("domain", "devices", "disks").Index(idx).Child("name").String(),
+			})
+		}
 	}
 
 	return causes

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2325,7 +2325,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(len(causes)).To(Equal(1))
-		}
+		})
 
 		It("should reject disk without a valid DNS-1123 name", func() {
 			vmi := v1.NewMinimalVMI("testvmi")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2329,9 +2329,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		FIt("should reject disk without a valid DNS-1123 name", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
-			
+
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name:      "TESTDISK2",
+				Name: "TESTDISK2",
 				DiskDevice: v1.DiskDevice{
 					Disk: &v1.DiskTarget{},
 				},

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2326,6 +2326,20 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(len(causes)).To(Equal(1))
 		})
+
+		FIt("should reject disk without a valid DNS-1123 name", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:      "TESTDISK2",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{},
+				},
+			})
+
+			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(1))
+		})
 	})
 })
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -423,7 +423,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 
 			for i := 0; i < arrayLenMax; i++ {
-				diskName := fmt.Sprintf("testDisk%d", i)
+				diskName := fmt.Sprintf("testdisk%d", i)
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: diskName,
 				})
@@ -2325,7 +2325,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(len(causes)).To(Equal(1))
-		})
+		}
 
 		It("should reject disk without a valid DNS-1123 name", func() {
 			vmi := v1.NewMinimalVMI("testvmi")

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2327,7 +2327,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(len(causes)).To(Equal(1))
 		})
 
-		FIt("should reject disk without a valid DNS-1123 name", func() {
+		It("should reject disk without a valid DNS-1123 name", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{


### PR DESCRIPTION
…liant names for disks as the name is used for a container inside of the VM pod. Fixes issue #2161

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Disk names can be used as container names inside the VMI pod. Without this validating webhook addition, the VMI will get created successfully but the pod will fail to get scheduled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2161 

**Special notes for your reviewer**:


**Release Notes**
```release-note
NONE
```