### PR TITLE
Add a new reporter which collects cluster info into files

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -21,6 +21,7 @@ set -e
 
 DOCKER_TAG=${DOCKER_TAG:-devel}
 DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
+export ARTIFACTS=${ARTIFACTS:-_out/artifacts}
 
 source hack/common.sh
 source hack/config.sh

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -122,6 +122,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
+        "//tests/reporter:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/gorilla/websocket:go_default_library",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
-        "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["kubernetes.go"],
+    importpath = "kubevirt.io/kubevirt/tests/reporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/config:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/types:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -1,0 +1,115 @@
+package reporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+)
+
+type KubernetesReporter struct {
+	failureCount int
+	artifactsDir string
+}
+
+func NewKubernetesReporter(artifactsDir string) *KubernetesReporter {
+	return &KubernetesReporter{
+		failureCount: 0,
+		artifactsDir: artifactsDir,
+	}
+}
+
+func (r *KubernetesReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+
+}
+
+func (r *KubernetesReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
+	// clean up artifacts from previous run
+	if r.artifactsDir != "" {
+		os.RemoveAll(r.artifactsDir)
+	}
+}
+
+func (r *KubernetesReporter) SpecWillRun(specSummary *types.SpecSummary) {
+}
+
+func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+
+	if r.failureCount > 10 {
+		return
+	}
+	if specSummary.HasFailureState() {
+		r.failureCount++
+	} else {
+		return
+	}
+
+	virtCli, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get client: %v", err)
+		return
+	}
+
+	// If we got not directory, print to stderr
+	if r.artifactsDir == "" {
+		return
+	}
+	if err := os.MkdirAll(r.artifactsDir, 0777); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create directory: %v", err)
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, "events.log"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		return
+	}
+	defer f.Close()
+
+	startTime := time.Now().Add(-specSummary.RunTime).Add(-5 * time.Second)
+
+	events, err := virtCli.CoreV1().Events(v1.NamespaceAll).List(v12.ListOptions{})
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to fetch events")
+		return
+	}
+
+	e := events.Items
+	sort.Slice(e, func(i, j int) bool {
+		return e[i].LastTimestamp.After(e[j].LastTimestamp.Time)
+	})
+
+	fmt.Fprint(f, "===== snip =====\n")
+
+	for _, event := range e {
+		if event.LastTimestamp.Time.Before(startTime) {
+			continue
+		}
+
+		j, err := json.MarshalIndent(event, "", "    ")
+		if err != nil {
+			log.DefaultLogger().Reason(err).Errorf("Failed to fetch events")
+			return
+		}
+		fmt.Fprintln(f, string(j))
+	}
+	fmt.Fprintln(f, "")
+}
+
+func (r *KubernetesReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+
+}
+
+func (r *KubernetesReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -20,10 +20,13 @@
 package tests_test
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/tests/reporter"
 
 	"kubevirt.io/kubevirt/tests"
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
@@ -31,7 +34,7 @@ import (
 
 func TestTests(t *testing.T) {
 	RegisterFailHandler(tests.KubevirtFailHandler)
-	reporters := make([]Reporter, 0)
+	reporters := []Reporter{reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"))}
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)
 	}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/tests/reporter"
 
@@ -33,7 +32,6 @@ import (
 )
 
 func TestTests(t *testing.T) {
-	RegisterFailHandler(tests.KubevirtFailHandler)
 	reporters := []Reporter{reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"))}
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Configurations", func() {
 
 	Context("for CPU and memory limits should", func() {
 
-		FIt("lead to get the burstable QOS class assigned when limit and requests differ", func() {
+		It("lead to get the burstable QOS class assigned when limit and requests differ", func() {
 			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
@@ -72,7 +72,6 @@ var _ = Describe("Configurations", func() {
 				}
 				return *vmi.Status.QOSClass
 			}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSBurstable))
-			Expect(true).To(BeFalse())
 		})
 
 		It("lead to get the guaranteed QOS class assigned when limit and requests are identical", func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Configurations", func() {
 
 	Context("for CPU and memory limits should", func() {
 
-		It("lead to get the burstable QOS class assigned when limit and requests differ", func() {
+		FIt("lead to get the burstable QOS class assigned when limit and requests differ", func() {
 			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			vmi = tests.RunVMIAndExpectScheduling(vmi, 60)
 
@@ -72,6 +72,7 @@ var _ = Describe("Configurations", func() {
 				}
 				return *vmi.Status.QOSClass
 			}, 10*time.Second, 1*time.Second).Should(Equal(kubev1.PodQOSBurstable))
+			Expect(true).To(BeFalse())
 		})
 
 		It("lead to get the guaranteed QOS class assigned when limit and requests are identical", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Upload in CI all info into separate files, instead of printing huge traces on every test failure which are only only of limited use.

It logs the cluster state for the first 10 failing tests. Prow will upload the files and make it available for browsing.

For each failing test the the following things are logged:

 * Logs of all pods, including previous logs, starting from the start time of the test
 * Specs of all pods in the cluster
 * Specs of all vmis in the cluster
 * All events starting from the start time of the test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
