### PR TITLE
Fix annotations not being copied in data volume templates.

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -342,7 +342,7 @@ func createDataVolumeManifest(dataVolume *cdiv1.DataVolume, vm *virtv1.VirtualMa
 
 	labels[virtv1.CreatedByLabel] = string(vm.UID)
 
-	for k, v := range dataVolume.Labels {
+	for k, v := range dataVolume.Annotations {
 		annotations[k] = v
 	}
 	for k, v := range dataVolume.Labels {


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes data volume templates not properly copying annotations into the resulting DV.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2553 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: DataVolumeTemplate annotations are now copied properly.
```
