### PR TITLE
Fix virt-handler restart issue

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -423,6 +423,9 @@ func main() {
 
 func copy(sourceFile string, targetFile string) error {
 
+	if err := os.RemoveAll(targetFile); err != nil {
+		return fmt.Errorf("failed to remove target file: %v", err)
+	}
 	target, err := os.Create(targetFile)
 	if err != nil {
 		return fmt.Errorf("failed to crate target file: %v", err)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -194,6 +194,11 @@ func (app *virtHandlerApp) Run() {
 	se, exists, err := selinux.NewSELinux()
 	if err == nil && exists {
 		for _, dir := range []string{app.VirtShareDir, app.VirtLibDir} {
+			if labeled, err := se.IsLabeled(dir); err != nil {
+				panic(err)
+			} else if labeled {
+				continue
+			}
 			err := se.Label("container_file_t", dir)
 			if err != nil {
 				panic(err)

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -93,6 +93,18 @@ func (se *SELinuxImpl) Label(label string, dir string) (err error) {
 	return nil
 }
 
+func (se *SELinuxImpl) IsLabeled(dir string) (labeled bool, err error) {
+	dir = strings.TrimRight(dir, "/") + "(/.*)?"
+	out, err := se.execute("semanage", se.Paths, "fcontext", "-l")
+	if err != nil {
+		return false, fmt.Errorf("failed to list labels: %v ", string(out))
+	}
+	if strings.Contains(string(out), dir) {
+		return true, nil
+	}
+	return false, nil
+}
+
 func (se *SELinuxImpl) Restore(dir string) (err error) {
 	dir = strings.TrimRight(dir, "/") + "/"
 	out, err := se.execute("restorecon", se.Paths, "-r", "-v", dir)
@@ -104,5 +116,6 @@ func (se *SELinuxImpl) Restore(dir string) (err error) {
 
 type SELinux interface {
 	Label(dir string, label string) (err error)
+	IsLabeled(dir string) (labeled bool, err error)
 	Restore(dir string) (err error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

First selinux does not like if a fcontext is redefined. Check if we already
added our labels and skip adding the label if we did. The issue fixed looks like this:

```
panic: failed to set label for directory /var/run/kubevirt(/.*)?: ValueError: File context for /var/run/kubevirt(/.*)? already defined
```

Second, don't truncate the container-disk binary on virt-handler restarts. Instead of that delete it. This allows running VMIs to continue using the containerDisk binary, while virt-handler can already copy over the new version. The issue fixed looks like this:

```
panic: failed to crate target file: open /var/lib/kubevirt/init/usr/bin/container-disk: text file busy
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
