### PR TITLE
libvirt: expose a way to enable the  debug logs

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -53,6 +53,8 @@ const KvmDevice = "devices.kubevirt.io/kvm"
 const TunDevice = "devices.kubevirt.io/tun"
 const VhostNetDevice = "devices.kubevirt.io/vhost-net"
 
+const debugLogs = "debugLogs"
+
 const MultusNetworksAnnotation = "k8s.v1.cni.cncf.io/networks"
 const GenieNetworksAnnotation = "cni"
 
@@ -75,6 +77,8 @@ const MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION = "v1.multus-cni.io/default-network"
 
 // Istio list of virtual interfaces whose inbound traffic (from VM) will be treated as outbound traffic in envoy
 const ISTIO_KUBEVIRT_ANNOTATION = "traffic.sidecar.istio.io/kubevirtInterfaces"
+
+const ENV_VAR_LIBVIRT_DEBUG_LOGS = "LIBVIRT_DEBUG_LOGS"
 
 type TemplateService interface {
 	RenderLaunchManifest(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
@@ -713,6 +717,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	for networkName, resourceName := range networkToResourceMap {
 		varName := fmt.Sprintf("KUBEVIRT_RESOURCE_NAME_%s", networkName)
 		container.Env = append(container.Env, k8sv1.EnvVar{Name: varName, Value: resourceName})
+	}
+
+	if _, ok := vmi.Labels[debugLogs]; ok {
+		container.Env = append(container.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_DEBUG_LOGS, Value: "1"})
 	}
 
 	containers = append(containers, container)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -168,6 +168,34 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Subdomain).To(BeEmpty())
 			})
 		})
+		Context("with debug log annotation", func() {
+			It("should add the corresponding environment variable", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+						Labels: map[string]string{
+							debugLogs: "true",
+						},
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Domain: v1.DomainSpec{},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(pod.Spec.Containers)).To(Equal(1))
+				debugLogsValue := ""
+				for _, ev := range pod.Spec.Containers[0].Env {
+					if ev.Name == ENV_VAR_LIBVIRT_DEBUG_LOGS {
+						debugLogsValue = ev.Value
+					}
+				}
+				Expect(debugLogsValue).To(Equal("1"))
+			})
+		})
 		Context("with multus annotation", func() {
 			It("should add multus networks in the pod annotation", func() {
 				vmi := v1.VirtualMachineInstance{

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -358,5 +358,13 @@ func SetupLibvirt() error {
 		return err
 	}
 
+	if _, ok := os.LookupEnv("LIBVIRT_DEBUG_LOGS"); ok {
+		// see https://wiki.libvirt.org/page/DebugLogs for details
+		_, err = libvirtConf.WriteString("log_filters=\"3:remote 4:event 3:util.json 3:rpc 1:*\"\n")
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a way to enable the libvirt debug logs, to make it easier to troubleshoot VM launch failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes N/A

**Special notes for your reviewer**:
Replaces/Obsoletes https://github.com/kubevirt/libvirt/pull/29

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for optional label `debugLogs`. If present, enable the libvirt debug logs in the virt-launcher pod. Caution is advised: debug logs are intentionally very, very verbose.
```
