### PR TITLE
Ensure that we can handle transient selinux errors

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -196,14 +196,13 @@ func (app *virtHandlerApp) Run() {
 		for _, dir := range []string{app.VirtShareDir, app.VirtLibDir} {
 			if labeled, err := se.IsLabeled(dir); err != nil {
 				panic(err)
-			} else if labeled {
-				continue
+			} else if !labeled {
+				err := se.Label("container_file_t", dir)
+				if err != nil {
+					panic(err)
+				}
 			}
-			err := se.Label("container_file_t", dir)
-			if err != nil {
-				panic(err)
-			}
-			err = se.Restore(dir)
+			err := se.Restore(dir)
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

In case that setting the fcontext succeeded but calling restorecon
failed, it was possible that we continue with the handler startup,
although the directory is not correctly labeled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
