### PR TITLE
Ensure that the target pod of a migration is prepared by virt-handler only once

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -642,6 +642,25 @@ func (d *VirtualMachineController) migrationOrphanedSourceNodeExecute(key string
 	return nil
 }
 
+func isMigrating(vmi *v1.VirtualMachineInstance) bool {
+
+	now := v12.Now()
+
+	running := false
+	if vmi.Status.MigrationState != nil {
+		start := vmi.Status.MigrationState.StartTimestamp
+		stop := vmi.Status.MigrationState.EndTimestamp
+		if start != nil && (now.After(start.Time) || now.Equal(start)) {
+			running = true
+		}
+
+		if stop != nil && (now.After(stop.Time) || now.Equal(stop)) {
+			running = false
+		}
+	}
+	return running
+}
+
 func (d *VirtualMachineController) migrationTargetExecute(key string,
 	vmi *v1.VirtualMachineInstance,
 	vmiExists bool,
@@ -1362,21 +1381,23 @@ func (d *VirtualMachineController) processVmUpdate(origVMI *v1.VirtualMachineIns
 	}
 
 	if d.isPreMigrationTarget(vmi) {
+		if !isMigrating(vmi) {
 
-		// Mount container disks
-		if err := d.containerDiskMounter.Mount(vmi, false); err != nil {
-			return err
-		}
+			// Mount container disks
+			if err := d.containerDiskMounter.Mount(vmi, false); err != nil {
+				return err
+			}
 
-		if err := client.SyncMigrationTarget(vmi); err != nil {
-			return fmt.Errorf("syncing migration target failed: %v", err)
+			if err := client.SyncMigrationTarget(vmi); err != nil {
+				return fmt.Errorf("syncing migration target failed: %v", err)
 
-		}
-		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), "VirtualMachineInstance Migration Target Prepared.")
+			}
+			d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), "VirtualMachineInstance Migration Target Prepared.")
 
-		err := d.handlePostSyncMigrationProxy(vmi)
-		if err != nil {
-			return fmt.Errorf("failed to handle post sync migration proxy: %v", err)
+			err := d.handlePostSyncMigrationProxy(vmi)
+			if err != nil {
+				return fmt.Errorf("failed to handle post sync migration proxy: %v", err)
+			}
 		}
 	} else if d.isMigrationSource(vmi) {
 		if vmi.Status.MigrationState.AbortRequested {


### PR DESCRIPTION
**What this PR does / why we need it**:

On of the reasons for migration to fail is that
the test fails due to GRPC timout error while
starting VM.

This PR fixes it by ignoring warings and still
veryfying running VM.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't try to prepare the migration target again if the migration is already running. This could happen sometimes on the source pod.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2582)
<!-- Reviewable:end -->
