### PR TITLE
Fixed double "replaces: " in CSV

### DIFF
--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -137,7 +137,7 @@ func main() {
 					if strings.HasSuffix(latestVersion, *csvVersion) {
 						panic(fmt.Errorf("CSV version %s is already published!", *csvVersion))
 					}
-					data.ReplacesCsvVersion = fmt.Sprintf("  replaces: %v", latestVersion)
+					data.ReplacesCsvVersion = latestVersion
 					// also copy old manifests to out dir
 					bundleHelper.AddOldManifests(*bundleOutDir, *csvVersion)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed double "replaces: " in CSV

**Special notes for your reviewer**:
This slipped through because of  problem with the olm verification (without pushing):
- if you download old CSV manifests, like you will do when pushing a new CSV, verification fails on old CSVs because of new requirements / improved verification. So we don not download, and just verify the new CSV
- if you don't download old CSVs, the `replaces` will stay empty... so it was never verified. And this single field had a bug when filled.
  
**Release note**:
```release-note
NONE
```
