### PR TITLE
Improve prometheus functional tests

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Infrastructure", func() {
 
 			fmt.Fprintf(GinkgoWriter, "client: total errors #%d\n", errorCount) // troubleshooting helper
 			Expect(errorCount).To(BeNumerically(">", 0))
-		}, 300)
+		})
 
 		It("should include the metrics for a running VM", func() {
 			By("Scraping the Prometheus endpoint")
@@ -182,7 +182,7 @@ var _ = Describe("Infrastructure", func() {
 				lines := takeMetricsWithPrefix(out, "kubevirt")
 				return strings.Join(lines, "\n")
 			}, 30*time.Second, 2*time.Second).Should(ContainSubstring("kubevirt"))
-		}, 300)
+		})
 
 		It("should include the storage metrics for a running VM", func() {
 			By("Expecting the VirtualMachineInstance console")
@@ -217,7 +217,7 @@ var _ = Describe("Infrastructure", func() {
 					Expect(value).To(BeNumerically(">", float64(0.0)))
 				}
 			}
-		}, 300)
+		})
 
 		It("should include the network metrics for a running VM", func() {
 			By("Expecting the VirtualMachineInstance console")
@@ -242,7 +242,7 @@ var _ = Describe("Infrastructure", func() {
 					Expect(value).To(BeNumerically(">=", float64(0.0)))
 				}
 			}
-		}, 300)
+		})
 
 		It("should include the memory metrics for a running VM", func() {
 			out := getKubevirtVMMetrics(virtClient, pod, "virt-handler")
@@ -257,7 +257,7 @@ var _ = Describe("Infrastructure", func() {
 				// swap metrics may (and should) be actually zero
 				Expect(value).To(BeNumerically(">=", float64(0.0)))
 			}
-		}, 300)
+		})
 
 		It("should include VMI infos for a running VM", func() {
 			out := getKubevirtVMMetrics(virtClient, pod, "virt-handler")
@@ -282,7 +282,7 @@ var _ = Describe("Infrastructure", func() {
 					))
 				}
 			}
-		}, 300)
+		})
 
 		It("should include VMI phase metrics for few running VMs", func() {
 			// run another VM, we intentionally check with only 2 VMS as CI is resource-constrained
@@ -296,7 +296,7 @@ var _ = Describe("Infrastructure", func() {
 					Expect(value).To(Equal(float64(2)))
 				}
 			}
-		}, 300)
+		})
 	})
 
 	Describe("Start a VirtualMachineInstance", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Refactor the functional tests of the (prometheus based) metrics and reduce their execution time.
Specifically:
1. Most of the tests rely on having a running VMI. This PR changes the timing of when that VMI is started to be at the beginning (i.e., `BeforeAll`) rather than started at each of these tests.
2. Remove unused timeout parameter for synchronous tests.
3. Remove unused expecter in the test of memory metrics  - it used to serve as a sync point, ensuring that the VM completed the boot process. Alternatively, we now run the portion that writes to the disk using another expecter in the `BeforeAll` phase and so we don't need that expecter anymore.
4. Reduce the scope of functions that are intended for the prometheus metrics tests - this also enables them to access the "shared state" of the aforementioned running VMI, its pod and its metrics URL directly.
5. The functions mentioned above are split in a way they can be used in more places, reducing code duplication within the tests. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
