### PR TITLE
Fixed release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ deploy:
 - provider: script
   script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt"
     DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub"
-    sh -c 'make bazel-push-images && make manifests && make olm-push'
+    sh -c 'make bazel-push-images && make manifests'
   skip_cleanup: true
   file:
   on:
@@ -101,6 +101,12 @@ deploy:
   script: hack/publish-staging.sh
   on:
     branch: master
+- provider: script
+  script: DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub" make olm-push
+  skip_cleanup: true
+  file:
+  on:
+    tags: true
 
 env:
   global:

--- a/hack/publish-staging.sh
+++ b/hack/publish-staging.sh
@@ -23,7 +23,7 @@ git clone \
     "https://${API_REFERENCE_PUSH_TOKEN}@${GITHUB_FQDN}/${API_REF_REPO}.git" \
     "${API_REF_DIR}" >/dev/null 2>&1
 pushd ${API_REF_DIR}
-git checkout -B ${TARGET_BRANCH}
+git checkout -B ${TARGET_BRANCH}-local
 git rm -rf .
 git clean -fxd
 popd


### PR DESCRIPTION
**What this PR does / why we need it**:
- fixed pushing of client-go by using a local branch name that is
different from the tag, they can't be the same (but TRAVIS_TAG and
TRAVIS_BRANCH are the same on a tag)
- moved pushing of CSV manifest after the github release, so it can't
break the release anymore.

**Release note**:
```release-note
NONE
```
