### PR TITLE
Qemu bug

### DIFF
--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -146,7 +146,9 @@ func (t *ConsoleHandler) getUnixSocketPath(vmi *v1.VirtualMachineInstance, socke
 	if _, err = os.Stat(socketPath); os.IsNotExist(err) {
 		return "", err
 	}
-	// See https://github.com/kubevirt/kubevirt/pull/2171
+	// This is a workaround preventing QEMU from deleting its sockets prematurely as described in a bug https://bugs.launchpad.net/qemu/+bug/1795100
+	// once the QEMU 4.0 is released the need for this workaround goes away
+	// Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1683964
 	if err = os.Chmod(socketDir, 0444); err != nil {
 		return "", err
 	}

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -108,26 +108,12 @@ func GracefulShutdownTriggerInitiate(triggerFile string) error {
 }
 
 func InitializePrivateDirectories(baseDir string) error {
-	unixPathVNC := filepath.Join(baseDir, "virt-vnc")
-	unixPathConsole := filepath.Join(baseDir, "virt-serial0")
-
-	err := os.MkdirAll(filepath.Dir(unixPathVNC), 0755)
-	if err != nil {
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return err
 	}
-	err = os.MkdirAll(filepath.Dir(unixPathConsole), 0755)
-	if err != nil {
+	if err := diskutils.SetFileOwnership("qemu", baseDir); err != nil {
 		return err
 	}
-	err = diskutils.SetFileOwnership("qemu", filepath.Dir(unixPathVNC))
-	if err != nil {
-		return err
-	}
-	err = diskutils.SetFileOwnership("qemu", filepath.Dir(unixPathConsole))
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Previously, the solution for the disappearing unix sockets for VNC (due
to a QEMU bug) was to have virt-launcher track when the unix socket for
VNC connection was created and then make its parent folder read-only.

In 944e019, we changed virt-handler to make the parent folder of
the unix socket for VNC read-only when a new connection request comes
and we find that the unix socket exists. This resolves a race in which
a VNC connection is established before virt-launcher manages to change
the parent folder of the unix socket read-only.

Here we remove the former solution as the latter renders it redundant.
Upgrade flow is covered since we assume upgrades from the previous
version where console connections are established through virt-handler.

**Special notes for your reviewer**:
That is cleanup for  #2519 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```