### PR TITLE
limit cloudinit network data also to 2K and add info to error

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -43,13 +43,15 @@ import (
 )
 
 const (
-	cloudInitUserMaxLen = 2048
-	arrayLenMax         = 256
-	maxStrLen           = 256
+	arrayLenMax = 256
+	maxStrLen   = 256
 
-	// cloudInitNetworkMaxLen size is an arbitrary limit. It was selected to
-	// accommodate a reasonable number of interfaces and routes.
-	cloudInitNetworkMaxLen = 16384
+	// cloudInitNetworkMaxLen and CloudInitUserMaxLen are being limited
+	// to 2K to allow scaling of config as edits will cause entire object
+	// to be distributed to large no of nodes. For larger than 2K, user should
+	// use NetworkDataSecretRef and UserDataSecretRef
+	cloudInitUserMaxLen    = 2048
+	cloudInitNetworkMaxLen = 2048
 
 	// Copied from kubernetes/pkg/apis/core/validation/validation.go
 	maxDNSNameservers     = 3
@@ -1331,7 +1333,7 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 			if userDataLen > cloudInitUserMaxLen {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("%s userdata exceeds %d byte limit", field.Index(idx).Child(dataSourceType).String(), cloudInitUserMaxLen),
+					Message: fmt.Sprintf("%s userdata exceeds %d byte limit. Should use UserDataSecretRef for larger data.", field.Index(idx).Child(dataSourceType).String(), cloudInitUserMaxLen),
 					Field:   field.Index(idx).Child(dataSourceType).String(),
 				})
 			}
@@ -1367,7 +1369,7 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 			if networkDataLen > cloudInitNetworkMaxLen {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("%s networkdata exceeds %d byte limit", field.Index(idx).Child(dataSourceType).String(), cloudInitNetworkMaxLen),
+					Message: fmt.Sprintf("%s networkdata exceeds %d byte limit. Should use NetworkDataSecretRef for larger data.", field.Index(idx).Child(dataSourceType).String(), cloudInitNetworkMaxLen),
 					Field:   field.Index(idx).Child(dataSourceType).String(),
 				})
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Max network data len should also be limited to 2K to avoid scaling issues with vm updates.
The error message on exceeding the limit could be more informational.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is followup on the discussion of earlier pull request: https://github.com/kubevirt/kubevirt/pull/2559

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
UserDataMaxLen and NetworkDataMaxLen for Cloud init config will be limited to 2K. Larger data should use secretRef way of configuration.
```
