### PR TITLE
change pod+bridge examples to pod+masquerade

### DIFF
--- a/examples/vm-template-windows2012r2.yaml
+++ b/examples/vm-template-windows2012r2.yaml
@@ -50,7 +50,7 @@ objects:
                 bus: virtio
               name: disk0
             interfaces:
-            - bridge: {}
+            - masquerade: {}
               model: e1000
               name: default
           features:

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -16,7 +16,7 @@ spec:
           bus: virtio
         name: cloudinitdisk
       interfaces:
-      - bridge: {}
+      - masquerade: {}
         name: default
       - bridge: {}
         name: ptp

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -16,7 +16,7 @@ spec:
           bus: virtio
         name: cloudinitdisk
       interfaces:
-      - bridge: {}
+      - masquerade: {}
         name: default
       - name: sriov-net
         sriov: {}

--- a/examples/vmi-windows.yaml
+++ b/examples/vmi-windows.yaml
@@ -25,7 +25,7 @@ spec:
           bus: sata
         name: pvcdisk
       interfaces:
-      - bridge: {}
+      - masquerade: {}
         model: e1000
         name: default
     features:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -369,7 +369,7 @@ func GetVMISRIOV() *v1.VirtualMachineInstance {
 	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
 
-	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "sriov-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}}
 
 	return vm
@@ -394,7 +394,7 @@ func GetVMIMultusMultipleNet() *v1.VirtualMachineInstance {
 	initFedora(&vm.Spec)
 	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\ndhclient eth1\n")
 
-	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+	vm.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 		{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
 
 	return vm
@@ -509,7 +509,7 @@ func GetVMIWindows() *v1.VirtualMachineInstance {
 				},
 			},
 			Devices: v1.Devices{
-				Interfaces: []v1.Interface{*v1.DefaultBridgeNetworkInterface()},
+				Interfaces: []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()},
 			},
 		},
 		Networks: []v1.Network{*v1.DefaultPodNetwork()},


### PR DESCRIPTION
In this PR we changed example-generators
which included a VMI with a
pod network and a bridge interface combination,
to masquerade interface.

that's regarding the isseus discussed in detail here:
https://github.com/kubevirt/kubevirt/pull/2493

we would like the examples to be consistent with
the changes suggested in this PR, and to avoid the situation
where a random user copy-pasting the provided 
examples and receives a non-recommended network
behavior.  

Release note:

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
example-generators were changed to yield a VMI spec with masquerade interface instead of bridge. 
```
