### PR TITLE
add support to detect block mode on a CDI Datavolume

### DIFF
--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -150,7 +150,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmiInformer.HasSynced,
 			podInformer.HasSynced,
 			dataVolumeInformer.HasSynced,
-		        pvcInformer.HasSynced)).To(BeTrue())
+			pvcInformer.HasSynced)).To(BeTrue())
 	}
 
 	BeforeEach(func() {
@@ -221,12 +221,12 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta:   metav1.TypeMeta{
-					Kind: "PersistentVolumeClaim",
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolumeClaim",
 					APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: vmi.Namespace,
-					Name: "test1"},
+					Name:      "test1"},
 			}
 			pvcSource.Add(dvPVC)
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -67,7 +67,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var kubeClient *fake.Clientset
 	var networkClient *fakenetworkclient.Clientset
 	var pvcInformer cache.SharedIndexInformer
-	var pvcSource *framework.FakeControllerSource
 
 	var dataVolumeSource *framework.FakeControllerSource
 	var dataVolumeInformer cache.SharedIndexInformer
@@ -165,7 +164,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		recorder = record.NewFakeRecorder(100)
 
 		config, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
-		pvcInformer, pvcSource = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
+		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 		controller = NewVMIController(
 			services.NewTemplateService("a", "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config),
 			vmiInformer,
@@ -228,7 +227,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					Namespace: vmi.Namespace,
 					Name:      "test1"},
 			}
-			pvcSource.Add(dvPVC)
+			// we are mocking a successful DataVolume. we expect the PVC to
+			// be available in the store if DV is successful.
+			pvcInformer.GetIndexer().Add(dvPVC)
 
 			dataVolume := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -236,12 +236,8 @@ func Convert_v1_Volume_To_api_Disk(source *v1.Volume, disk *Disk, c *ConverterCo
 		return Convert_v1_HostDisk_To_api_Disk(source.Name, source.HostDisk.Path, disk, c)
 	}
 
-	if source.PersistentVolumeClaim != nil {
+	if source.PersistentVolumeClaim != nil || source.DataVolume != nil {
 		return Convert_v1_PersistentVolumeClaim_To_api_Disk(source.Name, disk, c)
-	}
-
-	if source.DataVolume != nil {
-		return Convert_v1_FilesystemVolumeSource_To_api_Disk(source.Name, disk, c)
 	}
 
 	if source.Ephemeral != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -234,6 +234,10 @@ var _ = Describe("Converter", func() {
 					Cache: "writethrough",
 				},
 				{
+					Name:  "dv_block_test",
+					Cache: "writethrough",
+				},
+				{
 					Name: "serviceaccount_test",
 				},
 			}
@@ -339,6 +343,14 @@ var _ = Describe("Converter", func() {
 					VolumeSource: v1.VolumeSource{
 						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "testblock",
+						},
+					},
+				},
+				{
+					Name: "dv_block_test",
+					VolumeSource: v1.VolumeSource{
+						DataVolume: &v1.DataVolumeSource{
+							Name: "dv_block_test",
 						},
 					},
 				},
@@ -471,9 +483,15 @@ var _ = Describe("Converter", func() {
       <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
+    <disk device="disk" type="block">
+      <source dev="/dev/dv_block_test"></source>
+      <target bus="sata" dev="sdh"></target>
+      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <alias name="ua-dv_block_test"></alias>
+    </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
-      <target bus="sata" dev="sdh"></target>
+      <target bus="sata" dev="sdi"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
@@ -541,6 +559,7 @@ var _ = Describe("Converter", func() {
 
 		isBlockPVCMap := make(map[string]bool)
 		isBlockPVCMap["pvc_block_test"] = true
+		isBlockPVCMap["dv_block_test"] = true
 		BeforeEach(func() {
 			c = &ConverterContext{
 				VirtualMachine: vmi,

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -876,7 +876,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 	isBlockPVCMap := make(map[string]bool)
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
-		if volume.VolumeSource.PersistentVolumeClaim != nil {
+		if volume.VolumeSource.PersistentVolumeClaim != nil || volume.VolumeSource.DataVolume != nil {
 			isBlockPVC, err := isBlockDeviceVolume(volume.Name)
 			if err != nil {
 				logger.Reason(err).Errorf("failed to detect volume mode for Volume %v and PVC %v.",


### PR DESCRIPTION
Signed-off-by: Prashanth Buddhala <pbudds@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently Kubevirt virt-controller and virt-launcher code are assuming CDI DataVolume to be backed by filesystem PVC only. As a result when block mode is turned ON on the CDI DV, the block device does not get properly appended to "VolumeDevices" of the virt-launcher pod. Add support to check Block mode on the DV and handle it accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Block mode on a Containerized Data Importer DataVolume does not get detected correctly and as a result VM fails to run.
```
