### PR TITLE
Fix containerdisk doc

### DIFF
--- a/cmd/container-disk-v2alpha/README.md
+++ b/cmd/container-disk-v2alpha/README.md
@@ -15,9 +15,9 @@ registry.
 Example: Place a bootable VMI disk into a container image in the /disk directory
 and upload to the container registry.
 ```
-cat << END > Dockerfile 
+cat << END > Dockerfile
 FROM scratch
-ADD fedora25.qcow2 /disk
+ADD fedora25.qcow2 /disk/
 END
 
 docker build -t vmdisks/fedora25:latest .
@@ -62,7 +62,7 @@ END
 ```
 
 After creating the VMI definition, starting the VMI is as simple starting a pod.
- 
+
 ```
 kubectl create -f vm.yaml
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:

The Add command have to end with / to copy into directory.
When users follow the example in copy paste manner, it results
into broken container disk image.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2622)
<!-- Reviewable:end -->
