### PR TITLE
Stabilize the OKD 4.1 lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -281,6 +281,8 @@ elif [[ $TARGET =~ sriov.* ]]; then
   ginko_params="$ginko_params --ginkgo.focus=SRIOV"
 elif [[ $TARGET =~ gpu.* ]]; then
   ginko_params="$ginko_params --ginkgo.focus=GPU" 
+elif [[ $TARGET =~ okd.* ]]; then
+  ginko_params="$ginko_params --ginkgo.skip=Genie|SRIOV|GPU"
 else
   ginko_params="$ginko_params --ginkgo.skip=Multus|Genie|SRIOV|GPU"
 fi

--- a/hack/cluster-build.sh
+++ b/hack/cluster-build.sh
@@ -69,8 +69,13 @@ else
 fi
 
 for node in ${nodes[@]}; do
-    ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container}\" | xargs \-\-max-args=1 sudo ${pull_command} pull"
-    ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container_alias}\" | xargs \-\-max-args=2 sudo ${pull_command} tag"
+    until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container}\" | xargs \-\-max-args=1 sudo ${pull_command} pull"; do
+        sleep 1
+    done
+
+    until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container_alias}\" | xargs \-\-max-args=2 sudo ${pull_command} tag"; do
+        sleep 1
+    done
 done
 
 echo "Done"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -45,4 +45,4 @@ if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} == okd-* ]]; th
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 360m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1183,11 +1183,6 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 	})
 
 	Context("with a live-migrate eviction strategy set", func() {
-
-		AfterEach(func() {
-			tests.CleanNodes()
-		})
-
 		Context("[ref_id:2293] with a VMI running with an eviction strategy set", func() {
 
 			var vmi *v1.VirtualMachineInstance

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -760,7 +760,7 @@ spec:
 						return true
 					}
 					return false
-				}, 90*time.Second, 1*time.Second).Should(BeTrue())
+				}, 180*time.Second, 1*time.Second).Should(BeTrue())
 			}
 
 			// Update KubeVirt from the previous release to the testing target release.
@@ -794,7 +794,7 @@ spec:
 					}
 
 					return true
-				}, 90*time.Second, 1*time.Second).Should(BeTrue())
+				}, 180*time.Second, 1*time.Second).Should(BeTrue())
 
 				By(fmt.Sprintf("Connecting to %s's console", vmYaml.vmName))
 				// This is in an eventually loop because it's possible for the

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -81,6 +81,8 @@ func (r *KubernetesReporter) Dump(since time.Duration) {
 
 	r.logEvents(virtCli, since)
 	r.logNodes(virtCli)
+	r.logPVCs(virtCli)
+	r.logPVs(virtCli)
 	r.logPods(virtCli)
 	r.logVMIs(virtCli)
 	r.logDomainXMLs(virtCli)
@@ -189,6 +191,54 @@ func (r *KubernetesReporter) logNodes(virtCli kubecli.KubevirtClient) {
 	j, err := json.MarshalIndent(nodes, "", "    ")
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Failed to marshal nodes")
+		return
+	}
+	fmt.Fprintln(f, string(j))
+}
+
+func (r *KubernetesReporter) logPVs(virtCli kubecli.KubevirtClient) {
+
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_pvs.log", r.failureCount)),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	pvs, err := virtCli.CoreV1().PersistentVolumes().List(v12.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch pvs: %v\n", err)
+		return
+	}
+
+	j, err := json.MarshalIndent(pvs, "", "    ")
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to marshal pvs")
+		return
+	}
+	fmt.Fprintln(f, string(j))
+}
+
+func (r *KubernetesReporter) logPVCs(virtCli kubecli.KubevirtClient) {
+
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_pvcs.log", r.failureCount)),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
+		return
+	}
+	defer f.Close()
+
+	pvcs, err := virtCli.CoreV1().PersistentVolumeClaims(v1.NamespaceAll).List(v12.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch pvcs: %v\n", err)
+		return
+	}
+
+	j, err := json.MarshalIndent(pvcs, "", "    ")
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to marshal pvcs")
 		return
 	}
 	fmt.Fprintln(f, string(j))

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -261,11 +261,6 @@ var _ = Describe("Storage", func() {
 				tests.CreateHostPathPVC(tests.CustomHostPath, "1Gi")
 			}, 120)
 
-			AfterEach(func() {
-				tests.DeletePVC(tests.CustomHostPath)
-				tests.DeletePV(tests.CustomHostPath)
-			}, 120)
-
 			It("should start vmi multiple times", func() {
 				vmi := tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 				tests.AddPVCDisk(vmi, "disk1", "virtio", tests.DiskCustomHostPath)
@@ -565,22 +560,14 @@ var _ = Describe("Storage", func() {
 		})
 
 		Context("[rfe_id:2288][crit:high][vendor:cnv-qe@redhat.com][level:component] With Cirros BlockMode PVC", func() {
-
-			pvName := "block-pv-" + rand.String(48)
-
 			BeforeEach(func() {
 				// create a new PV and PVC (PVs can't be reused)
-				tests.CreateBlockVolumePvAndPvc(pvName, "1Gi")
-			})
-
-			AfterEach(func() {
-				// create a new PV and PVC (PVs can't be reused)
-				tests.DeletePvAndPvc(pvName)
+				tests.CreateBlockVolumePvAndPvc("1Gi")
 			})
 
 			It("[test_id:1015] should be successfully started", func() {
 				// Start the VirtualMachineInstance with the PVC attached
-				vmi := tests.NewRandomVMIWithPVC(pvName)
+				vmi := tests.NewRandomVMIWithPVC(tests.BlockDiskForTest)
 				// Without userdata the hostname isn't set correctly and the login expecter fails...
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -625,6 +625,14 @@ func BeforeTestSuitSetup() {
 		DeployTestingInfrastructure()
 	}
 
+	// Wait for schedulable nodes
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	Eventually(func() int {
+		nodes := GetAllSchedulableNodes(virtClient)
+		return len(nodes.Items)
+	}, 5*time.Minute, 10*time.Second).ShouldNot(BeZero(), "no schedulable nodes found")
+
 	CreateHostPathPv(osAlpineHostPath, HostPathAlpine)
 	CreateHostPathPVC(osAlpineHostPath, defaultDiskSize)
 

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -178,11 +178,17 @@ var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 		}
 
 		setSelectedNodeUnschedulable := func() {
-			selectedNode, err := getSelectedNode()
-			Expect(err).ToNot(HaveOccurred())
-			selectedNode.Spec.Unschedulable = true
-			_, err = virtCli.CoreV1().Nodes().Update(selectedNode)
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				selectedNode, err := getSelectedNode()
+				if err != nil {
+					return err
+				}
+				selectedNode.Spec.Unschedulable = true
+				if _, err = virtCli.CoreV1().Nodes().Update(selectedNode); err != nil {
+					return err
+				}
+				return nil
+			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
 		}
 
 		BeforeEach(func() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -1408,15 +1407,9 @@ var _ = Describe("Configurations", func() {
 	})
 
 	Context("[rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache settings", func() {
-		blockPVName := "block-pv-" + rand.String(48)
-
 		BeforeEach(func() {
 			// create a new PV and PVC (PVs can't be reused)
-			tests.CreateBlockVolumePvAndPvc(blockPVName, "1Gi")
-		}, 60)
-
-		AfterEach(func() {
-			tests.DeletePvAndPvc(blockPVName)
+			tests.CreateBlockVolumePvAndPvc("1Gi")
 		}, 60)
 
 		It("[test_id:1681]should set appropriate cache modes", func() {
@@ -1433,7 +1426,7 @@ var _ = Describe("Configurations", func() {
 			tests.AddEphemeralDisk(vmi, "ephemeral-disk3", "virtio", tests.ContainerDiskFor(tests.ContainerDiskCirros))
 			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 			tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
-			tests.AddPVCDisk(vmi, "block-pvc", "virtio", blockPVName)
+			tests.AddPVCDisk(vmi, "block-pvc", "virtio", tests.BlockDiskForTest)
 			tests.AddHostDisk(vmi, "/run/kubevirt-private/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "hostdisk")
 			tests.RunVMIAndExpectLaunch(vmi, 60)
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -444,15 +444,15 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				stopChan := make(chan struct{})
 				defer close(stopChan)
 
-				By(fmt.Sprintf("Waiting for %q %q event after the resource version %q", tests.WarningEvent, v1.Stopped, vmi.ResourceVersion))
-				tests.NewObjectEventWatcher(vmi).Timeout(120*time.Second).SinceWatchedObjectResourceVersion().WaitFor(stopChan, tests.WarningEvent, v1.Stopped)
-
 				By("Checking that VirtualMachineInstance has 'Failed' phase")
 				Eventually(func() v1.VirtualMachineInstancePhase {
 					vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI successfully")
 					return vmi.Status.Phase
-				}(), 10, 1).Should(Equal(v1.Failed), "VMI should be failed")
+				}, 240*time.Second, 1*time.Second).Should(Equal(v1.Failed), "VMI should be failed")
+
+				By(fmt.Sprintf("Waiting for %q %q event after the resource version %q", tests.WarningEvent, v1.Stopped, vmi.ResourceVersion))
+				tests.NewObjectEventWatcher(vmi).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(stopChan, tests.WarningEvent, v1.Stopped)
 
 				By("checking that it can still start VMIs")
 				newVMI := newCirrosVMI()

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -443,6 +443,8 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				// Give virt-handler some time. It can greatly vary when virt-handler will be ready again
 				stopChan := make(chan struct{})
 				defer close(stopChan)
+
+				By(fmt.Sprintf("Waiting for %q %q event after the resource version %q", tests.WarningEvent, v1.Stopped, vmi.ResourceVersion))
 				tests.NewObjectEventWatcher(vmi).Timeout(120*time.Second).SinceWatchedObjectResourceVersion().WaitFor(stopChan, tests.WarningEvent, v1.Stopped)
 
 				By("Checking that VirtualMachineInstance has 'Failed' phase")

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -166,6 +166,7 @@ var _ = Describe("Multus", func() {
 			})
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
+				tests.SkipIfOpenShift4("OpenShift 4 does not support usage of the network definition from the different namespace")
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
 				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes:
- before tests, wait until nodes will be tagged by virt-handler
- increase the total timeout for tests run
- use a newer OKD image, that includes local provisioner, master has more disk space and a worker has more disk space and more memory.
- try to pull images via ssh until it will succeed
- change `[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachine [rfe_id:273]with oc/kubectl as ordinary OCP user trough test service account should fail without right rights [It] [test_id:2914]should create VM via command line` error message
- skip one multus tests that not supported under the OKD
- create tests PV's always on the same schedulable node to avoid the situation when we create PV's on different nodes and trying to start VMI with both of them
- increase timeout for the operator test and virt-handler crash test

**Release note**:
```release-note
Stabilize the OKD 4.1 lane
```
