### PR TITLE
Carry annotations from VM down to the POD

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -858,6 +858,14 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		v1.DomainAnnotation: domain,
 	}
 
+	for k, v := range vmi.Annotations {
+		if strings.Contains(k, "kubernetes.io") || strings.Contains(k, "kubevirt.io") {
+			// skip kubernetes and kubevirt internal annotations
+			continue
+		}
+		annotationsList[k] = v
+	}
+
 	cniAnnotations, err := getCniAnnotations(vmi)
 	if err != nil {
 		return nil, err

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Template", func() {
 				trueVar := true
 				annotations := map[string]string{
 					hooks.HookSidecarListAnnotationName: `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
+					"test/test":                         "shouldwork",
 				}
 				pod, err := svc.RenderLaunchManifest(&v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "testns", UID: "1234", Annotations: annotations}, Spec: v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}})
 				Expect(err).ToNot(HaveOccurred())
@@ -134,6 +135,7 @@ var _ = Describe("Template", func() {
 				}))
 				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
 					v1.DomainAnnotation: "testvmi",
+					"test/test":         "shouldwork",
 				}))
 				Expect(pod.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{{
 					APIVersion:         v1.VirtualMachineInstanceGroupVersionKind.GroupVersion().String(),

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -689,6 +690,15 @@ func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.Virtual
 	vmi.Spec = vm.Spec.Template.Spec
 
 	setupStableFirmwareUUID(vm, vmi)
+
+	vmi.ObjectMeta.Annotations = map[string]string{}
+	for k, v := range vm.Annotations {
+		if strings.Contains(k, "kubernetes.io") || strings.Contains(k, "kubevirt.io") {
+			// skip kubernetes and kubevirt internal annotations
+			continue
+		}
+		vmi.ObjectMeta.Annotations[k] = v
+	}
 
 	// TODO check if vmi labels exist, and when make sure that they match. For now just override them
 	vmi.ObjectMeta.Labels = vm.Spec.Template.ObjectMeta.Labels

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -118,6 +118,38 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Should(ContainSubstring("Found PID for"))
 		})
 
+		It("should carry annotations to pod", func() {
+			vmi.Annotations = map[string]string{
+				"testannotation": "test",
+			}
+
+			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).To(BeNil(), "Create VMI successfully")
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			Expect(pod).NotTo(BeNil())
+
+			Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "test"), "annotation should be carried to the pod")
+		})
+
+		It("should not carry kubernetes and kubevirt annotations to pod", func() {
+			vmi.Annotations = map[string]string{
+				"kubevirt.io/test":   "test",
+				"kubernetes.io/test": "test",
+			}
+
+			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).To(BeNil(), "Create VMI successfully")
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+			Expect(pod).NotTo(BeNil())
+
+			Expect(pod.Annotations).ToNot(HaveKey("kubevirt.io/test"), "kubevirt annotation should not be carried to the pod")
+			Expect(pod.Annotations).ToNot(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
+		})
+
 		It("[test_id:1622]should log libvirtd logs", func() {
 			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).To(BeNil(), "Create VMI successfully")


### PR DESCRIPTION
**What this PR does / why we need it**:

Copies the annotations from the VM to the VMI and to the POD.
It ignores kubernetes annotations containing the `kubernetes.io` and
kubevirt annotations containing the `kubevirt.io`.

Possible enhancement: put it behind feature gate.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2527

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Copies the annotations from VM to the VMI and to the POD.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2627)
<!-- Reviewable:end -->
