### PR TITLE
Fix starting VMIs with DataVolume in Block mode

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -437,12 +437,31 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			})
 		}
 		if volume.DataVolume != nil {
-			volumeMounts = append(volumeMounts, volumeMount)
+			logger := log.DefaultLogger()
+			claimName := volume.DataVolume.Name
+			_, exists, isBlock, err := types.IsPVCBlockFromStore(t.persistentVolumeClaimStore, namespace, claimName)
+			if err != nil {
+				logger.Errorf("error getting PVC associated with DataVolume: %v", claimName)
+				return nil, err
+			} else if !exists {
+				logger.Errorf("didn't find PVC associated with DataVolume: %v", claimName)
+				return nil, PvcNotFoundError(fmt.Errorf("didn't find PVC associated with DataVolume: %v", claimName))
+			} else if isBlock {
+				devicePath := filepath.Join(string(filepath.Separator), "dev", volume.Name)
+				device := k8sv1.VolumeDevice{
+					Name:       volume.Name,
+					DevicePath: devicePath,
+				}
+				volumeDevices = append(volumeDevices, device)
+			} else {
+				volumeMounts = append(volumeMounts, volumeMount)
+			}
+
 			volumes = append(volumes, k8sv1.Volume{
 				Name: volume.Name,
 				VolumeSource: k8sv1.VolumeSource{
 					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-						ClaimName: volume.DataVolume.Name,
+						ClaimName: claimName,
 					},
 				},
 			})

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -63,6 +63,7 @@ type ConverterContext struct {
 	VirtualMachine *v1.VirtualMachineInstance
 	CPUSet         []int
 	IsBlockPVC     map[string]bool
+	IsBlockDV      map[string]bool
 	DiskType       map[string]*containerdisk.DiskInfo
 	SRIOVDevices   map[string][]string
 	SMBios         *cmdv1.SMBios
@@ -243,7 +244,7 @@ func Convert_v1_Volume_To_api_Disk(source *v1.Volume, disk *Disk, c *ConverterCo
 	}
 
 	if source.DataVolume != nil {
-		return Convert_v1_FilesystemVolumeSource_To_api_Disk(source.Name, disk, c)
+		return Convert_v1_DataVolume_To_api_Disk(source.Name, disk, c)
 	}
 
 	if source.Ephemeral != nil {
@@ -295,6 +296,13 @@ func GetBlockDeviceVolumePath(volumeName string) string {
 
 func Convert_v1_PersistentVolumeClaim_To_api_Disk(name string, disk *Disk, c *ConverterContext) error {
 	if c.IsBlockPVC[name] {
+		return Convert_v1_BlockVolumeSource_To_api_Disk(name, disk, c)
+	}
+	return Convert_v1_FilesystemVolumeSource_To_api_Disk(name, disk, c)
+}
+
+func Convert_v1_DataVolume_To_api_Disk(name string, disk *Disk, c *ConverterContext) error {
+	if c.IsBlockDV[name] {
 		return Convert_v1_BlockVolumeSource_To_api_Disk(name, disk, c)
 	}
 	return Convert_v1_FilesystemVolumeSource_To_api_Disk(name, disk, c)

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -237,6 +237,10 @@ var _ = Describe("Converter", func() {
 					Cache: "writethrough",
 				},
 				{
+					Name:  "dv_block_test",
+					Cache: "writethrough",
+				},
+				{
 					Name: "serviceaccount_test",
 				},
 			}
@@ -342,6 +346,14 @@ var _ = Describe("Converter", func() {
 					VolumeSource: v1.VolumeSource{
 						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
 							ClaimName: "testblock",
+						},
+					},
+				},
+				{
+					Name: "dv_block_test",
+					VolumeSource: v1.VolumeSource{
+						DataVolume: &v1.DataVolumeSource{
+							Name: "dv_block_test",
 						},
 					},
 				},
@@ -481,9 +493,15 @@ var _ = Describe("Converter", func() {
       <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-pvc_block_test"></alias>
     </disk>
+    <disk device="disk" type="block">
+      <source dev="/dev/dv_block_test"></source>
+      <target bus="sata" dev="sdh"></target>
+      <driver cache="writethrough" name="qemu" type="raw" iothread="1"></driver>
+      <alias name="ua-dv_block_test"></alias>
+    </disk>
     <disk device="disk" type="file">
       <source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
-      <target bus="sata" dev="sdh"></target>
+      <target bus="sata" dev="sdi"></target>
       <driver name="qemu" type="raw" iothread="1"></driver>
       <alias name="ua-serviceaccount_test"></alias>
     </disk>
@@ -551,6 +569,8 @@ var _ = Describe("Converter", func() {
 
 		isBlockPVCMap := make(map[string]bool)
 		isBlockPVCMap["pvc_block_test"] = true
+		isBlockDVMap := make(map[string]bool)
+		isBlockDVMap["dv_block_test"] = true
 		BeforeEach(func() {
 			c = &ConverterContext{
 				VirtualMachine: vmi,
@@ -563,6 +583,7 @@ var _ = Describe("Converter", func() {
 				},
 				UseEmulation: true,
 				IsBlockPVC:   isBlockPVCMap,
+				IsBlockDV:    isBlockDVMap,
 				SRIOVDevices: map[string][]string{},
 				SMBios:       TestSmbios,
 			}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1096,8 +1096,7 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulDataVolumeImport(dv, 600)
-				// workaround for: https://github.com/kubevirt/kubevirt/issues/2438
-				vmi := tests.NewRandomVMIWithPVC(dv.Name)
+				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
 				tests.AddUserData(vmi, "disk1", tests.GetGuestAgentUserData())
 				return vmi, dv
 			}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1454,14 +1454,7 @@ func NewRandomVirtualMachineInstanceWithOCSDisk(imageUrl, namespace string, acce
 	_, err = virtCli.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
 	Expect(err).ToNot(HaveOccurred())
 	WaitForSuccessfulDataVolumeImport(dv, 240)
-
-	switch volMode {
-	case k8sv1.PersistentVolumeBlock:
-		// workaround for: https://github.com/kubevirt/kubevirt/issues/2438
-		return NewRandomVMIWithPVC(dv.Name), dv
-	default:
-		return NewRandomVMIWithDataVolume(dv.Name), dv
-	}
+	return NewRandomVMIWithDataVolume(dv.Name), dv
 }
 
 func newRandomDataVolumeWithHttpImport(imageUrl, namespace, storageClass string, accessMode k8sv1.PersistentVolumeAccessMode) *cdiv1.DataVolume {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR comprises two fixes:
1. Block DataVolumes were added to the volumeMounts as if they were Filesystems. They are now added to volumeDevices instead.
2. Previously file disks were added to the libvirt domain also in case of block DataVolumes. Block disks are now added instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2438 

**Special notes for your reviewer:**:
The tests for OCS block mode volumes (added as part of #2617) serve as the functional tests for this PR once the workaround of referring to the underlying PVC is removed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix running VMIs with block DataVolumes.
```