### PR TITLE
make examples/vmi-migratable.yaml migratable again!

### DIFF
--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -12,11 +12,17 @@ spec:
       - disk:
           bus: virtio
         name: containerdisk
+      interfaces:
+      - masquerade: {}
+        name: default
     machine:
       type: ""
     resources:
       requests:
         memory: 64M
+  networks:
+  - name: default
+    pod: {}
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -287,6 +287,10 @@ func addHostDisk(spec *v1.VirtualMachineInstanceSpec, path string, hostDiskType 
 
 func GetVMIMigratable() *v1.VirtualMachineInstance {
 	vmi := getBaseVMI(VmiMigratable)
+	// having no network leads to adding a default interface that may be of type bridge on
+	// the pod network and that would make the VMI non-migratable. Therefore, adding a network.
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 
 	addContainerDisk(&vmi.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageAlpine, DockerTag), busVirtio)
 	return vmi

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -131,28 +131,24 @@ func addRNG(spec *v1.VirtualMachineInstanceSpec) *v1.VirtualMachineInstanceSpec 
 }
 
 func addContainerDisk(spec *v1.VirtualMachineInstanceSpec, image string, bus string) *v1.VirtualMachineInstanceSpec {
-	spec.Domain.Devices = v1.Devices{
-		Disks: []v1.Disk{
-			{
-				Name: "containerdisk",
-				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{
-						Bus: bus,
-					},
-				},
+	disk := &v1.Disk{
+		Name: "containerdisk",
+		DiskDevice: v1.DiskDevice{
+			Disk: &v1.DiskTarget{
+				Bus: bus,
 			},
 		},
 	}
-	spec.Volumes = []v1.Volume{
-		{
-			Name: "containerdisk",
-			VolumeSource: v1.VolumeSource{
-				ContainerDisk: &v1.ContainerDiskSource{
-					Image: image,
-				},
+	spec.Domain.Devices.Disks = append(spec.Domain.Devices.Disks, *disk)
+	volume := &v1.Volume{
+		Name: "containerdisk",
+		VolumeSource: v1.VolumeSource{
+			ContainerDisk: &v1.ContainerDiskSource{
+				Image: image,
 			},
 		},
 	}
+	spec.Volumes = append(spec.Volumes, *volume)
 	return spec
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR introduces the minimal changes to make the VMI described
in examples/vmi-migratable.yaml migratable as VMIs with only bridged
pod network are not migratable anymore.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change the VMI `vmi-migratable` in the examples folder to be migratable.
```