### PR TITLE
fix syntax and semantic issues in vmi-webhook and config-test

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -554,19 +554,19 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			if cniTypesCount == 0 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: fmt.Sprintf("should have a network type"),
+					Message: "should have a network type",
 					Field:   field.Child("networks").Index(idx).String(),
 				})
 			} else if cniTypesCount > 1 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: fmt.Sprintf("should have only one network type"),
+					Message: "should have only one network type",
 					Field:   field.Child("networks").Index(idx).String(),
 				})
 			} else if genieExists && (podExists || multusExists) {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: fmt.Sprintf("cannot combine Genie with other CNIs across networks"),
+					Message: "cannot combine Genie with other CNIs across networks",
 					Field:   field.Child("networks").Index(idx).String(),
 				})
 			}
@@ -574,7 +574,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			if !networkNameExistsOrNotNeeded {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: fmt.Sprintf("CNI delegating plugin must have a networkName"),
+					Message: "CNI delegating plugin must have a networkName",
 					Field:   field.Child("networks").Index(idx).String(),
 				})
 			}
@@ -585,7 +585,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		if multusDefaultCount > 1 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Multus CNI should only have one default network"),
+				Message: "Multus CNI should only have one default network",
 				Field:   field.Child("networks").String(),
 			})
 		}
@@ -593,7 +593,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		if podExists && multusDefaultCount > 0 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Pod network cannot be defined when Multus default network is defined"),
+				Message: "Pod network cannot be defined when Multus default network is defined",
 				Field:   field.Child("networks").String(),
 			})
 		}
@@ -621,19 +621,19 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			} else if iface.Slirp != nil && networkData.Pod == nil {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("Slirp interface only implemented with pod network"),
+					Message: "Slirp interface only implemented with pod network",
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
 			} else if iface.Slirp != nil && networkData.Pod != nil && !config.IsSlirpInterfaceEnabled() {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("Slirp interface is not enabled in kubevirt-config"),
+					Message: "Slirp interface is not enabled in kubevirt-config",
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
 			} else if iface.Masquerade != nil && networkData.Pod == nil {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("Masquerade interface only implemented with pod network"),
+					Message: "Masquerade interface only implemented with pod network",
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
 			}
@@ -642,7 +642,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			if _, networkAlreadyUsed := networkInterfaceMap[iface.Name]; networkAlreadyUsed {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueDuplicate,
-					Message: fmt.Sprintf("Only one interface can be connected to one specific network"),
+					Message: "Only one interface can be connected to one specific network",
 					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
 				})
 			}
@@ -656,7 +656,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					if forwardPort.Port == 0 {
 						causes = append(causes, metav1.StatusCause{
 							Type:    metav1.CauseTypeFieldValueRequired,
-							Message: fmt.Sprintf("Port field is mandatory in every Port"),
+							Message: "Port field is mandatory.",
 							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).String(),
 						})
 					}
@@ -664,7 +664,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					if forwardPort.Port < 0 || forwardPort.Port > 65536 {
 						causes = append(causes, metav1.StatusCause{
 							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: fmt.Sprintf("Port field must be in range 0 < x < 65536."),
+							Message: "Port field must be in range 0 < x < 65536.",
 							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).String(),
 						})
 					}
@@ -673,7 +673,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 						if forwardPort.Protocol != "TCP" && forwardPort.Protocol != "UDP" {
 							causes = append(causes, metav1.StatusCause{
 								Type:    metav1.CauseTypeFieldValueInvalid,
-								Message: fmt.Sprintf("Unknown protocol, only TCP or UDP allowed"),
+								Message: "Unknown protocol, only TCP or UDP allowed",
 								Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("protocol").String(),
 							})
 						}
@@ -805,7 +805,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 					if net.ParseIP(ip).To4() == nil {
 						causes = append(causes, metav1.StatusCause{
 							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: fmt.Sprintf("NTP servers must be a valid IPv4 address."),
+							Message: "NTP servers must be a list of valid IPv4 addresses.",
 							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("dhcpOptions", "ntpServers").Index(index).String(),
 						})
 					}
@@ -817,7 +817,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("virtio-net multiqueue request, but there are no virtio interfaces defined"),
+				Message: "virtio-net multiqueue request, but there are no virtio interfaces defined",
 				Field:   field.Child("domain", "devices", "networkInterfaceMultiqueue").String(),
 			})
 
@@ -827,7 +827,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		if len(networkInterfaceMap) != len(networkNameMap) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: fmt.Sprintf("every network must be mapped to an interface."),
+				Message: "every network must be mapped to an interface.",
 				Field:   field.Child("networks").String(),
 			})
 		}
@@ -837,7 +837,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		if input.Bus != "virtio" && input.Bus != "usb" && input.Bus != "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Input device can have only virtio or usb bus."),
+				Message: "Input device can have only virtio or usb bus.",
 				Field:   field.Child("domain", "devices", "inputs").Index(idx).Child("bus").String(),
 			})
 		}
@@ -845,7 +845,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		if input.Type != "tablet" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("Input device can have only tablet type."),
+				Message: "Input device can have only tablet type.",
 				Field:   field.Child("domain", "devices", "inputs").Index(idx).Child("type").String(),
 			})
 		}
@@ -856,14 +856,14 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	if !isCPUResourcesSet && (spec.Domain.Devices.BlockMultiQueue != nil) && (*spec.Domain.Devices.BlockMultiQueue == true) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("MultiQueue for block devices can't be used without specifying CPU requests or limits."),
+			Message: "MultiQueue for block devices can't be used without specifying CPU requests or limits.",
 			Field:   field.Child("domain", "devices", "blockMultiQueue").String(),
 		})
 	}
 	if !isCPUResourcesSet && (spec.Domain.Devices.NetworkInterfaceMultiQueue != nil) && (*spec.Domain.Devices.NetworkInterfaceMultiQueue == true) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("MultiQueue for network interfaces can't be used without specifying CPU requests or limits."),
+			Message: "MultiQueue for network interfaces can't be used without specifying CPU requests or limits.",
 			Field:   field.Child("domain", "devices", "networkInterfaceMultiqueue").String(),
 		})
 	}
@@ -1497,7 +1497,7 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 		if disk.Floppy != nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: fmt.Sprintf("Floppy disks are deprecated and will be removed from the API soon."),
+				Message: "Floppy disks are deprecated and will be removed from the API soon.",
 				Field:   field.Index(idx).Child("name").String(),
 			})
 		}

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -35,10 +35,10 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.IsUseEmulation()).To(Equal(result))
 	},
-		table.Entry("is true, it should return true", "true", true),
-		table.Entry("is false, it should return false", "false", false),
-		table.Entry("when unset, it should return false", "", false),
-		table.Entry("when invalid, it should return the default", "invalid", false),
+		table.Entry("is true, IsUseEmulation should return true", "true", true),
+		table.Entry("is false, IsUseEmulation should return false", "false", false),
+		table.Entry("when unset, IsUseEmulation should return false", "", false),
+		table.Entry("when invalid, IsUseEmulation should return the default", "invalid", false),
 	)
 
 	table.DescribeTable(" when permitSlirpInterface", func(value string, result bool) {
@@ -47,10 +47,10 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.IsSlirpInterfaceEnabled()).To(Equal(result))
 	},
-		table.Entry("is true, it should return true", "true", true),
-		table.Entry("is false, it should return false", "false", false),
-		table.Entry("when unset, it should return false", "", false),
-		table.Entry("when invalid, it should return the default", "invalid", false),
+		table.Entry("is true, IsSlirpInterfaceEnabled should return true", "true", true),
+		table.Entry("is false, IsSlirpInterfaceEnabled should return false", "false", false),
+		table.Entry("when unset, IsSlirpInterfaceEnabled should return false", "", false),
+		table.Entry("when invalid, IsSlirpInterfaceEnabled should return the default", "invalid", false),
 	)
 
 	table.DescribeTable(" when imagePullPolicy", func(value string, result kubev1.PullPolicy) {
@@ -59,11 +59,11 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetImagePullPolicy()).To(Equal(result))
 	},
-		table.Entry("is PullAlways, it should return PullAlways", "Always", kubev1.PullAlways),
-		table.Entry("is Never, it should return Never", "Never", kubev1.PullNever),
-		table.Entry("is IsNotPresent, it should return IsNotPresent", "IfNotPresent", kubev1.PullIfNotPresent),
-		table.Entry("when unset, it should return PullIfNotPresent", "", kubev1.PullIfNotPresent),
-		table.Entry("when invalid, it should return the default", "invalid", kubev1.PullIfNotPresent),
+		table.Entry("is PullAlways, GetImagePullPolicy should return PullAlways", "Always", kubev1.PullAlways),
+		table.Entry("is Never, GetImagePullPolicy should return Never", "Never", kubev1.PullNever),
+		table.Entry("is IsNotPresent, GetImagePullPolicy should return IsNotPresent", "IfNotPresent", kubev1.PullIfNotPresent),
+		table.Entry("when unset, GetImagePullPolicy should return PullIfNotPresent", "", kubev1.PullIfNotPresent),
+		table.Entry("when invalid, GetImagePullPolicy should return the default", "invalid", kubev1.PullIfNotPresent),
 	)
 
 	table.DescribeTable(" when lessPVCSpaceToleration", func(value string, result int) {
@@ -72,9 +72,9 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetLessPVCSpaceToleration()).To(Equal(result))
 	},
-		table.Entry("is set, it should return correct value", "5", 5),
-		table.Entry("is unset, it should return the default", "", virtconfig.DefaultLessPVCSpaceToleration),
-		table.Entry("is invalid, it should return the default", "-1", virtconfig.DefaultLessPVCSpaceToleration),
+		table.Entry("is set, GetLessPVCSpaceToleration should return correct value", "5", 5),
+		table.Entry("is unset, GetLessPVCSpaceToleration should return the default", "", virtconfig.DefaultLessPVCSpaceToleration),
+		table.Entry("is invalid, GetLessPVCSpaceToleration should return the default", "-1", virtconfig.DefaultLessPVCSpaceToleration),
 	)
 
 	table.DescribeTable(" when defaultNetworkInterface", func(value string, result string) {
@@ -83,11 +83,11 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetDefaultNetworkInterface()).To(Equal(result))
 	},
-		table.Entry("is bridge, it should return bridge", "bridge", "bridge"),
-		table.Entry("is slirp, it should return slirp", "slirp", "slirp"),
-		table.Entry("is masquerade, it should return masquerade", "masquerade", "masquerade"),
-		table.Entry("when unset, it should return the default", "", "bridge"),
-		table.Entry("when invalid, it should return the default", "invalid", "bridge"),
+		table.Entry("is bridge, GetDefaultNetworkInterface should return bridge", "bridge", "bridge"),
+		table.Entry("is slirp, GetDefaultNetworkInterface should return slirp", "slirp", "slirp"),
+		table.Entry("is masquerade, GetDefaultNetworkInterface should return masquerade", "masquerade", "masquerade"),
+		table.Entry("when unset, GetDefaultNetworkInterface should return the default", "", "bridge"),
+		table.Entry("when invalid, GetDefaultNetworkInterface should return the default", "invalid", "bridge"),
 	)
 
 	nodeSelectorsStr := "kubernetes.io/hostname=node02\nnode-role.kubernetes.io/compute=true\n"
@@ -101,9 +101,9 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetNodeSelectors()).To(Equal(result))
 	},
-		table.Entry("is set, it should return correct value", nodeSelectorsStr, nodeSelectors),
-		table.Entry("is unset, it should return the default", "", nil),
-		table.Entry("is invalid, it should return the default", "-1", nil),
+		table.Entry("is set, GetNodeSelectors should return correct value", nodeSelectorsStr, nodeSelectors),
+		table.Entry("is unset, GetNodeSelectors should return the default", "", nil),
+		table.Entry("is invalid, GetNodeSelectors should return the default", "-1", nil),
 	)
 
 	table.DescribeTable(" when machineType", func(value string, result string) {
@@ -112,8 +112,8 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetMachineType()).To(Equal(result))
 	},
-		table.Entry("when set, it should return the value", "pc-q35-3.0", "pc-q35-3.0"),
-		table.Entry("when unset, it should return the default", "", virtconfig.DefaultMachineType),
+		table.Entry("when set, GetMachineType should return the value", "pc-q35-3.0", "pc-q35-3.0"),
+		table.Entry("when unset, GetMachineType should return the default", "", virtconfig.DefaultMachineType),
 	)
 
 	table.DescribeTable(" when cpuModel", func(value string, result string) {
@@ -122,8 +122,8 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetCPUModel()).To(Equal(result))
 	},
-		table.Entry("when set, it should return the value", "Haswell", "Haswell"),
-		table.Entry("when unset, it should return empty string", "", ""),
+		table.Entry("when set, GetCPUModel should return the value", "Haswell", "Haswell"),
+		table.Entry("when unset, GetCPUModel should return empty string", "", ""),
 	)
 
 	table.DescribeTable(" when cpuRequest", func(value string, result string) {
@@ -133,8 +133,8 @@ var _ = Describe("ConfigMap", func() {
 		cpuRequest := clusterConfig.GetCPURequest()
 		Expect(cpuRequest.String()).To(Equal(result))
 	},
-		table.Entry("when set, it should return the value", "400m", "400m"),
-		table.Entry("when unset, it should return the default", "", virtconfig.DefaultCPURequest),
+		table.Entry("when set, GetCPURequest should return the value", "400m", "400m"),
+		table.Entry("when unset, GetCPURequest should return the default", "", virtconfig.DefaultCPURequest),
 	)
 
 	table.DescribeTable(" when memoryOvercommit", func(value string, result int) {
@@ -143,8 +143,8 @@ var _ = Describe("ConfigMap", func() {
 		})
 		Expect(clusterConfig.GetMemoryOvercommit()).To(Equal(result))
 	},
-		table.Entry("when set, it should return the value", "150", 150),
-		table.Entry("when unset, it should return the default", "", virtconfig.DefaultMemoryOvercommit),
+		table.Entry("when set, GetMemoryOvercommit should return the value", "150", 150),
+		table.Entry("when unset, GetMemoryOvercommit should return the default", "", virtconfig.DefaultMemoryOvercommit),
 	)
 
 	table.DescribeTable(" when emulatedMachines", func(value string, result []string) {
@@ -154,8 +154,8 @@ var _ = Describe("ConfigMap", func() {
 		emulatedMachines := clusterConfig.GetEmulatedMachines()
 		Expect(emulatedMachines).To(ConsistOf(result))
 	},
-		table.Entry("when set, it should return the value", "q35, i440*", []string{"q35", "i440*"}),
-		table.Entry("when unset, it should return the defaults", "", strings.Split(virtconfig.DefaultEmulatedMachines, ",")),
+		table.Entry("when set, GetEmulatedMachines should return the value", "q35, i440*", []string{"q35", "i440*"}),
+		table.Entry("when unset, GetEmulatedMachines should return the defaults", "", strings.Split(virtconfig.DefaultEmulatedMachines, ",")),
 	)
 
 	It("Should return migration config values if specified as json", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes some typo/syntax/semntical issues in the vmi
addmition webhook and configuration test raised here:
https://github.com/kubevirt/kubevirt/pull/2493

**Special notes for your reviewer**:
The changes were suggested in the attached PR 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
