### PR TITLE
Add 'migrate' command to virtctl

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3774,6 +3774,44 @@
      }
     }
    },
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/migrate": {
+    "put": {
+     "summary": "Migrate a running VirtualMachine to another node.",
+     "operationId": "migrate",
+     "parameters": [
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK"
+      },
+      "400": {
+       "description": "Bad Request"
+      },
+      "404": {
+       "description": "Not Found"
+      },
+      "default": {
+       "description": "OK"
+      }
+     }
+    }
+   },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachines/{name}/restart": {
     "put": {
      "summary": "Restart a VirtualMachine object.",

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -313,8 +313,17 @@ spec:
           resources:
           - virtualmachines
           - virtualmachineinstances
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - kubevirt.io
+          resources:
           - virtualmachineinstancemigrations
           verbs:
+          - create
           - get
           - list
           - watch

--- a/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
@@ -43,8 +43,17 @@ rules:
   resources:
   - virtualmachines
   - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachineinstancemigrations
   verbs:
+  - create
   - get
   - list
   - watch

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -168,8 +168,17 @@ rules:
   resources:
   - virtualmachines
   - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachineinstancemigrations
   verbs:
+  - create
   - get
   - list
   - watch

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -214,6 +214,15 @@ func (app *virtAPIApp) composeSubresources() {
 			Returns(http.StatusNotFound, "Not Found", nil).
 			Returns(http.StatusBadRequest, "Bad Request", nil))
 
+		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("migrate")).
+			To(subresourceApp.MigrateVMRequestHandler).
+			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
+			Operation("migrate").
+			Doc("Migrate a running VirtualMachine to another node.").
+			Returns(http.StatusOK, "OK", nil).
+			Returns(http.StatusNotFound, "Not Found", nil).
+			Returns(http.StatusBadRequest, "Bad Request", nil))
+
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("start")).
 			To(subresourceApp.StartVMRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
@@ -294,6 +303,10 @@ func (app *virtAPIApp) composeSubresources() {
 					},
 					{
 						Name:       "virtualmachines/stop",
+						Namespaced: true,
+					},
+					{
+						Name:       "virtualmachines/migrate",
 						Namespaced: true,
 					},
 					{

--- a/pkg/virt-operator/creation/rbac/apiserver.go
+++ b/pkg/virt-operator/creation/rbac/apiserver.go
@@ -107,10 +107,20 @@ func newApiServerClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"virtualmachines",
 					"virtualmachineinstances",
-					"virtualmachineinstancemigrations",
 				},
 				Verbs: []string{
 					"get", "list", "watch", "patch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachineinstancemigrations",
+				},
+				Verbs: []string{
+					"create", "get", "list", "watch", "patch",
 				},
 			},
 			{

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -70,6 +70,7 @@ func NewVirtctlCommand() *cobra.Command {
 		vm.NewStartCommand(clientConfig),
 		vm.NewStopCommand(clientConfig),
 		vm.NewRestartCommand(clientConfig),
+		vm.NewMigrateCommand(clientConfig),
 		expose.NewExposeCommand(clientConfig),
 		version.VersionCommand(clientConfig),
 		imageupload.NewImageUploadCommand(clientConfig),

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -34,6 +34,7 @@ const (
 	COMMAND_START   = "start"
 	COMMAND_STOP    = "stop"
 	COMMAND_RESTART = "restart"
+	COMMAND_MIGRATE = "migrate"
 )
 
 func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
@@ -74,6 +75,21 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
+			return c.Run(cmd, args)
+		},
+	}
+	cmd.SetUsageTemplate(templates.UsageTemplate())
+	return cmd
+}
+
+func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "migrate (VM)",
+		Short:   "Migrate a virtual machine.",
+		Example: usage(COMMAND_MIGRATE),
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := Command{command: COMMAND_MIGRATE, clientConfig: clientConfig}
 			return c.Run(cmd, args)
 		},
 	}
@@ -125,6 +141,11 @@ func (o *Command) Run(cmd *cobra.Command, args []string) error {
 		err = virtClient.VirtualMachine(namespace).Restart(vmiName)
 		if err != nil {
 			return fmt.Errorf("Error restarting VirtualMachine %v", err)
+		}
+	case COMMAND_MIGRATE:
+		err = virtClient.VirtualMachine(namespace).Migrate(vmiName)
+		if err != nil {
+			return fmt.Errorf("Error migrating VirtualMachine %v", err)
 		}
 	}
 

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -103,6 +103,18 @@ var _ = Describe("VirtualMachine", func() {
 
 	})
 
+	Context("with migrate VM cmd", func() {
+		It("should migrate vm", func() {
+			vm := kubecli.NewMinimalVM(vmName)
+
+			kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachine(k8smetav1.NamespaceDefault).Return(vmInterface).Times(1)
+			vmInterface.EXPECT().Migrate(vm.Name).Return(nil).Times(1)
+
+			cmd := tests.NewVirtctlCommand("migrate", vmName)
+			Expect(cmd.Execute()).To(BeNil())
+		})
+	})
+
 	Context("with restart VM cmd", func() {
 		It("should restart vm", func() {
 			vm := kubecli.NewMinimalVM(vmName)

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1192,6 +1192,16 @@ func (_mr *_MockVirtualMachineInterfaceRecorder) Stop(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop", arg0)
 }
 
+func (_m *MockVirtualMachineInterface) Migrate(name string) error {
+	ret := _m.ctrl.Call(_m, "Migrate", name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirtualMachineInterfaceRecorder) Migrate(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Migrate", arg0)
+}
+
 // Mock of VirtualMachineInstanceMigrationInterface interface
 type MockVirtualMachineInstanceMigrationInterface struct {
 	ctrl     *gomock.Controller

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -155,6 +155,7 @@ type VirtualMachineInterface interface {
 	Restart(name string) error
 	Start(name string) error
 	Stop(name string) error
+	Migrate(name string) error
 }
 
 type VirtualMachineInstanceMigrationInterface interface {

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -150,3 +150,8 @@ func (v *vm) Stop(name string) error {
 	uri := fmt.Sprintf(vmSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "stop")
 	return v.restClient.Put().RequestURI(uri).Do().Error()
 }
+
+func (v *vm) Migrate(name string) error {
+	uri := fmt.Sprintf(vmSubresourceURL, v1.ApiStorageVersion, v.namespace, name, "migrate")
+	return v.restClient.Put().RequestURI(uri).Do().Error()
+}

--- a/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm_test.go
@@ -176,6 +176,17 @@ var _ = Describe("Kubevirt VirtualMachine Client", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("should migrate a VirtualMachine", func() {
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("PUT", subVMIPath+"/migrate"),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, nil),
+		))
+		err := client.VirtualMachine(k8sv1.NamespaceDefault).Migrate("testvm")
+
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	AfterEach(func() {
 		server.Close()
 	})

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -706,9 +706,8 @@ spec:
 				// NOTE: we are using virtctl explicitly here because we want to start the VM
 				// using the subresource endpoint in the same way virtctl performs this.
 				By("Starting VM with virtctl")
-				startFn := tests.NewRepeatableVirtctlCommand("start", "--namespace", tests.NamespaceTestDefault, vmYaml.vmName)
-				err = startFn()
-				Expect(err).ToNot(HaveOccurred())
+				startCommand := tests.NewRepeatableVirtctlCommand("start", "--namespace", tests.NamespaceTestDefault, vmYaml.vmName)
+				Expect(startCommand()).To(Succeed())
 
 				By(fmt.Sprintf("Waiting for VM with %s api to become ready", vmYaml.apiVersion))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR enables migrating a VMI using `virtctl` by executing: `virtctl migrate <vm>`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable triggering live-migration through virtctl
```
