### PR TITLE
adding flag to make the controller threads configurable

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -129,6 +129,7 @@ type VirtControllerApp struct {
 	// the channel used to trigger re-initialization.
 	reInitChan chan string
 
+	// number of threads for each controller
 	nodeControllerThreads             int
 	vmiControllerThreads              int
 	rsControllerThreads               int
@@ -440,6 +441,7 @@ func (vca *VirtControllerApp) AddFlags() {
 	flag.StringVar(&vca.containerDiskDir, "container-disk-dir", containerDiskDir,
 		"Base directory for container disk data")
 
+	// allows user-defined threads based on the underlying hardware in use
 	flag.IntVar(&vca.nodeControllerThreads, "node-controller-threads", defaultControllerThreads,
 		"Number of goroutines to run for node controller")
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -69,7 +69,7 @@ const (
 
 	ephemeralDiskDir = virtShareDir + "-ephemeral-disks"
 
-	controllerThreads = 3
+	defaultControllerThreads = 3
 )
 
 var (
@@ -128,6 +128,14 @@ type VirtControllerApp struct {
 	hasCDI bool
 	// the channel used to trigger re-initialization.
 	reInitChan chan string
+
+	nodeControllerThreads             int
+	vmiControllerThreads              int
+	rsControllerThreads               int
+	vmControllerThreads               int
+	migrationControllerThreads        int
+	evacuationControllerThreads       int
+	disruptionBudgetControllerThreads int
 }
 
 var _ service.Service = &VirtControllerApp{}
@@ -287,13 +295,20 @@ func (vca *VirtControllerApp) Run() {
 			Callbacks: leaderelection.LeaderCallbacks{
 				OnStartedLeading: func(ctx context.Context) {
 					vca.informerFactory.Start(stop)
-					go vca.evacuationController.Run(controllerThreads, stop)
-					go vca.disruptionBudgetController.Run(controllerThreads, stop)
-					go vca.nodeController.Run(controllerThreads, stop)
-					go vca.vmiController.Run(controllerThreads, stop)
-					go vca.rsController.Run(controllerThreads, stop)
-					go vca.vmController.Run(controllerThreads, stop)
-					go vca.migrationController.Run(controllerThreads, stop)
+
+					golog.Printf("STARTING controllers with following threads : "+
+						"node %d, vmi %d, replicaset %d, vm %d, migration %d, evacuation %d, disruptionBudget %d",
+						vca.nodeControllerThreads, vca.vmiControllerThreads, vca.rsControllerThreads,
+						vca.vmControllerThreads, vca.migrationControllerThreads, vca.evacuationControllerThreads,
+						vca.disruptionBudgetControllerThreads)
+
+					go vca.evacuationController.Run(vca.evacuationControllerThreads, stop)
+					go vca.disruptionBudgetController.Run(vca.disruptionBudgetControllerThreads, stop)
+					go vca.nodeController.Run(vca.nodeControllerThreads, stop)
+					go vca.vmiController.Run(vca.vmiControllerThreads, stop)
+					go vca.rsController.Run(vca.rsControllerThreads, stop)
+					go vca.vmController.Run(vca.vmControllerThreads, stop)
+					go vca.migrationController.Run(vca.migrationControllerThreads, stop)
 					cache.WaitForCacheSync(stop, vca.persistentVolumeClaimInformer.HasSynced)
 					close(vca.readyChan)
 				},
@@ -421,6 +436,28 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.StringVar(&vca.ephemeralDiskDir, "ephemeral-disk-dir", ephemeralDiskDir,
 		"Base directory for ephemeral disk data")
+
 	flag.StringVar(&vca.containerDiskDir, "container-disk-dir", containerDiskDir,
 		"Base directory for container disk data")
+
+	flag.IntVar(&vca.nodeControllerThreads, "node-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for node controller")
+
+	flag.IntVar(&vca.vmiControllerThreads, "vmi-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for vmi controller")
+
+	flag.IntVar(&vca.rsControllerThreads, "rs-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for replicaset controller")
+
+	flag.IntVar(&vca.vmControllerThreads, "vm-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for vm controller")
+
+	flag.IntVar(&vca.migrationControllerThreads, "migration-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for migration controller")
+
+	flag.IntVar(&vca.evacuationControllerThreads, "evacuation-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for evacuation controller")
+
+	flag.IntVar(&vca.disruptionBudgetControllerThreads, "disruption-budget-controller-threads", defaultControllerThreads,
+		"Number of goroutines to run for disruption budget controller")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a bottleneck with the number of threads when trying to create a big replica set of size 1000. The code was modified to increase the threads from 3 to 10 (or any other greater value) and the performance was improved. Opening this PR so that users can configure according to the underlying hardware they use.
 
**Release notes**:
```release-note
allow configurable threads in virt-controller
```
