### PR TITLE
Added dmidecode tests for SMBios and Chassis

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -329,3 +329,11 @@ http_file(
         "https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/28/Everything/x86_64/Packages/e/e2fsprogs-1.44.2-0.fc28.x86_64.rpm",
     ],
 )
+
+http_file(
+    name = "dmidecode",
+    sha256 = "5694c041bcebc273cbf9a67f7210b2dd93c517aba55d93d20980b5bdf4be3751",
+    urls = [
+        "https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/d/dmidecode-3.1-5.fc28.x86_64.rpm",
+    ],
+)

--- a/images/cdi-http-import-server/BUILD.bazel
+++ b/images/cdi-http-import-server/BUILD.bazel
@@ -16,6 +16,7 @@ rpm_image(
         "@capstone//file",
         "@libaio//file",
         "@e2fsprogs//file",
+        "@dmidecode//file",
     ],
 )
 

--- a/images/cdi-http-import-server/entrypoint.sh
+++ b/images/cdi-http-import-server/entrypoint.sh
@@ -60,5 +60,6 @@ else
     # Expose qemu-guest-agent via nginx server
     cp /usr/bin/qemu-ga /usr/share/nginx/html/
     cp /usr/bin/stress /usr/share/nginx/html/
+    cp /usr/bin/dmidecode /usr/share/nginx/html/
     /usr/sbin/nginx
 fi

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -149,6 +149,7 @@ const (
 	FedoraHttpUrl     = "http://cdi-http-import-server.kubevirt/images/fedora.img"
 	GuestAgentHttpUrl = "http://cdi-http-import-server.kubevirt/qemu-ga"
 	StressHttpUrl     = "http://cdi-http-import-server.kubevirt/stress"
+	DmidecodeHttpUrl  = "http://cdi-http-import-server.kubevirt/dmidecode"
 )
 
 const (
@@ -1760,6 +1761,17 @@ func NewRandomFedoraVMIWitGuestAgent() *v1.VirtualMachineInstance {
 	agentVMI := NewRandomVMIWithEphemeralDiskAndUserdata(ContainerDiskFor(ContainerDiskFedora), GetGuestAgentUserData())
 	agentVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
 	return agentVMI
+}
+
+func NewRandomFedoraVMIWithDmidecode() *v1.VirtualMachineInstance {
+	dmidecodeUserData := fmt.Sprintf(`#!/bin/bash
+	    echo "fedora" |passwd fedora --stdin
+	    mkdir -p /usr/local/bin
+	    curl %s > /usr/local/bin/dmidecode
+	    chmod +x /usr/local/bin/dmidecode
+	`, DmidecodeHttpUrl)
+	vmi := NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(ContainerDiskFor(ContainerDiskFedora), dmidecodeUserData)
+	return vmi
 }
 
 func GetGuestAgentUserData() string {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -48,10 +48,6 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-const (
-	dmidecodePackageUrl = "http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/29/Everything/x86_64/os/Packages/d/dmidecode-3.2-1.fc29.x86_64.rpm"
-)
-
 var _ = Describe("Configurations", func() {
 
 	tests.FlagParse()

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -48,6 +48,10 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
+const (
+	dmidecodePackageUrl = "http://download-ib01.fedoraproject.org/pub/fedora/linux/releases/29/Everything/x86_64/os/Packages/d/dmidecode-3.2-1.fc29.x86_64.rpm"
+)
+
 var _ = Describe("Configurations", func() {
 
 	tests.FlagParse()
@@ -1861,13 +1865,9 @@ var _ = Describe("Configurations", func() {
 	})
 
 	Context("Check Chassis value", func() {
-		var vmi *v1.VirtualMachineInstance
-
-		BeforeEach(func() {
-			vmi = tests.NewRandomVMI()
-		})
 
 		It("[test_id:2927]Test Chassis value in a newly created VM", func() {
+			vmi := tests.NewRandomFedoraVMIWithDmidecode()
 			vmi.Spec.Domain.Chassis = &v1.Chassis{
 				Asset: "Test-123",
 			}
@@ -1877,9 +1877,24 @@ var _ = Describe("Configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
+			By("Check values on domain XML")
 			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<entry name='asset'>Test-123</entry>"))
+
+			By("Expecting console")
+			expecter, err := tests.LoggedInFedoraExpecter(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			By("Check value in VM with dmidecode")
+			// Check on the VM, if expected values are there with dmidecode
+			res, err := expecter.ExpectBatch([]expect.Batcher{
+				&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') -eq Test-123 ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+			}, 1*time.Second)
+			log.DefaultLogger().Object(vmi).Infof("%v", res)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
@@ -1888,24 +1903,44 @@ var _ = Describe("Configurations", func() {
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+			vmi = tests.NewRandomFedoraVMIWithDmidecode()
 		})
 
 		It("[test_id:2751]test default SMBios", func() {
+
 			By("Starting a VirtualMachineInstance")
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
 
+			By("Check values in domain XML")
 			domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domXml).To(ContainSubstring("<entry name='family'>KubeVirt</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='product'>None</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>KubeVirt</entry>"))
 
+			By("Expecting console")
+			expecter, err := tests.LoggedInFedoraExpecter(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			By("Check values in dmidecode")
+			// Check on the VM, if expected values are there with dmidecode
+			res, err := expecter.ExpectBatch([]expect.Batcher{
+				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') -eq KubeVirt ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') -eq None ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') -eq KubeVirt ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+			}, 1*time.Second)
+			log.DefaultLogger().Object(vmi).Infof("%v", res)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("[test_id:2752]test custom SMBios values", func() {
+
 			// Set a custom test SMBios
 			test_smbios := &cmdv1.SMBios{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
 			smbiosJson, err := json.Marshal(test_smbios)
@@ -1924,6 +1959,25 @@ var _ = Describe("Configurations", func() {
 			Expect(domXml).To(ContainSubstring("<entry name='manufacturer'>None</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='sku'>1.0</entry>"))
 			Expect(domXml).To(ContainSubstring("<entry name='version'>1.0</entry>"))
+
+			By("Expecting console")
+			expecter, err := tests.LoggedInFedoraExpecter(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			By("Check values in dmidecode")
+
+			// Check on the VM, if expected values are there with dmidecode
+			res, err := expecter.ExpectBatch([]expect.Batcher{
+				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') -eq test ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') -eq test ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') -eq None ] && echo 'pass' || echo 'fail'\n"},
+				&expect.BExp{R: "pass"},
+			}, 1*time.Second)
+			log.DefaultLogger().Object(vmi).Infof("%v", res)
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added dmidecode tests for SMBios and Chassis
Now we check these values inside the VMI also (apart from the domain XML)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added dmidecode tests for SMBios and Chassis
```
