### PR TITLE
Relaxes the wait for pods in entrire cluster

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -437,7 +437,7 @@ func WaitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) 
 		virtClient, err := kubecli.GetKubevirtClient()
 		PanicOnError(err)
 
-		podsList, err := virtClient.CoreV1().Pods(k8sv1.NamespaceAll).List(listOptions)
+		podsList, err := virtClient.CoreV1().Pods(KubeVirtInstallNamespace).List(listOptions)
 		PanicOnError(err)
 		for _, pod := range podsList.Items {
 			for _, status := range pod.Status.ContainerStatuses {


### PR DESCRIPTION
**What this PR does / why we need it**:
Our test infrastructure waits for the entrire
cluster to become ready. This can create unreasonable
timeout due to large number of pods in OpenShift clusters.

More reasonable approach is to wait only for KubeVirt related
infrastructure.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=1747945

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/kubevirt/2653)
<!-- Reviewable:end -->
