### PR TITLE
Take minimum memory limit of cri-o into account

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -832,7 +832,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			Resources: k8sv1.ResourceRequirements{
 				Limits: map[k8sv1.ResourceName]resource.Quantity{
 					k8sv1.ResourceCPU:    resource.MustParse("1m"),
-					k8sv1.ResourceMemory: resource.MustParse("5Mi"),
+					k8sv1.ResourceMemory: resource.MustParse("12Mi"), // this is the minimum memory limit for cri-o!
 				},
 			},
 			Command:        []string{"/usr/bin/tail", "-f", "/dev/null"},


### PR DESCRIPTION
**What this PR does / why we need it**:
Newer versions of cri-o decline containers with less than 12Mi memory limit, see https://github.com/cri-o/cri-o/blob/73b260922d0aca54593ee31d56bd2fe4fb501301/server/container_create_linux.go#L40


**Release note**:
```release-note
Fixed virt-launcher on OKD 4.x by increasing memory limit to cri-o's minimum
```
