### PR TITLE
not check failed status when doing live migration hook

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -88,8 +88,7 @@ func (admitter *MigrationCreateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1b
 	// are already in flight.
 	if vmi.Status.MigrationState != nil &&
 		string(vmi.Status.MigrationState.MigrationUID) != "" &&
-		!vmi.Status.MigrationState.Completed &&
-		!vmi.Status.MigrationState.Failed {
+		!vmi.Status.MigrationState.Completed {
 
 		return webhooks.ToAdmissionResponseError(fmt.Errorf("in-flight migration detected. Active migration job (%s) is currently already in progress for VMI %s.", string(vmi.Status.MigrationState.MigrationUID), vmi.Name))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
the live migration hook check should only check completed status , not the failed statue which just indicate a error, sometimes a good live migratino only mark complete but no failed status
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to #2652 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
