### PR TITLE
Use masquerade for tests with explicit pod interface

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2161,7 +2161,7 @@ func NewRandomVMIWithMasqueradeInterfaceEphemeralDiskAndUserdata(containerImage 
 }
 
 func AddExplicitPodNetworkInterface(vmi *v1.VirtualMachineInstance) {
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 }
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 			Expect(output).Should(ContainSubstring(strings.ToUpper(windowsFirmware)))
 		}, 360)
 
-		It("should have pod IP", func() {
+		It("should have default masquerade IP", func() {
 			command := append(cli, "ipconfig /all")
 			By(fmt.Sprintf("Running \"%s\" command via winrm-cli", command))
 			Eventually(func() error {
@@ -218,7 +218,7 @@ var _ = Describe("Windows VirtualMachineInstance", func() {
 			}, time.Minute*5, time.Second*15).ShouldNot(HaveOccurred())
 
 			By("Checking that the Windows VirtualMachineInstance has expected IP address")
-			Expect(output).Should(ContainSubstring(vmiIp))
+			Expect(output).Should(ContainSubstring("10.0.2.2"))
 		}, 360)
 		It("should have the domain set properly", func() {
 			command := append(cli, "wmic nicconfig get dnsdomain")


### PR DESCRIPTION
Bridge has issues with fe: MAC address prefix, so unless a test
case depends on bridge type used, we should avoid it.

```release-note
NONE
```