### PR TITLE
Do not consider SELinux in Permissive mode

### DIFF
--- a/pkg/virt-handler/selinux/BUILD.bazel
+++ b/pkg/virt-handler/selinux/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["labels.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/selinux",
     visibility = ["//visibility:public"],
+    deps = ["//staging/src/kubevirt.io/client-go/log:go_default_library"],
 )
 
 go_test(


### PR DESCRIPTION
From the application point-of-view, Permissive mode should be
the same as Disabled mode.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
So far there is a dependency for the `semanage` binary to be available on the host if SELinux is not `Disabled`. On CoreOS `semanage` is not available, and SELinux is in `Permissive` mode.
Since `Permissive` mode doesn't seem to have any effect on applications, this patch consider this mode just as if it was `Disabled`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2664 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed dependency on host semanage in SELinux Permissive mode
```
