### PR TITLE
Add logs to troubleshoot event handling issues.

### DIFF
--- a/pkg/inotify-informer/inotify.go
+++ b/pkg/inotify-informer/inotify.go
@@ -131,7 +131,11 @@ func (d *DirectoryListWatcher) startBackground() error {
 						log.Log.Reason(err).Error("Invalid content detected, ignoring and continuing.")
 						continue
 					}
-					d.eventChan <- watch.Event{Type: e, Object: api.NewMinimalDomainWithNS(namespace, name)}
+					domain := api.NewMinimalDomainWithNS(namespace, name)
+					if e == watch.Deleted {
+						log.Log.Object(domain).Warning("watchdog file removed for domain")
+					}
+					d.eventChan <- watch.Event{Type: e, Object: domain}
 				}
 			case err := <-d.watcher.Errors:
 				d.eventChan <- watch.Event{

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -111,7 +111,7 @@ func (d *DomainWatcher) handleStaleWatchdogFiles() error {
 	}
 
 	for _, domain := range domains {
-		log.Log.Object(domain).Warning("detected expire watchdog for domain")
+		log.Log.Object(domain).Warning("detected expired watchdog for domain")
 		d.eventChan <- watch.Event{Type: watch.Deleted, Object: domain}
 	}
 	return nil

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -111,6 +111,7 @@ func (d *DomainWatcher) handleStaleWatchdogFiles() error {
 	}
 
 	for _, domain := range domains {
+		log.Log.Object(domain).Warning("detected expire watchdog for domain")
 		d.eventChan <- watch.Event{Type: watch.Deleted, Object: domain}
 	}
 	return nil

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -74,7 +74,7 @@ func (n *Notify) HandleDomainEvent(ctx context.Context, request *notifyv1.Domain
 		}
 	}
 
-	log.Log.Infof("Received Domain Event of type %s", request.EventType)
+	log.Log.Object(domain).Infof("Received Domain Event of type %s", request.EventType)
 	switch request.EventType {
 	case string(watch.Added):
 		n.EventChan <- watch.Event{Type: watch.Added, Object: domain}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -758,14 +758,14 @@ func (d *VirtualMachineController) defaultExecute(key string,
 
 	log.Log.Infof("Processing event %v", key)
 	if vmiExists {
-		log.Log.Infof("Vmi %s in phase %v", vmi.Name, vmi.Status.Phase)
+		log.Log.Object(vmi).Infof("VMI is in phase: %v\n", vmi.Status.Phase)
 	} else {
-		log.Log.Info("Vmi does not exist")
+		log.Log.Info("VMI does not exist")
 	}
 	if domainExists {
-		log.Log.Infof("Domain %s in status %v, reason: %v", domain.ObjectMeta.Name, domain.Status.Status, domain.Status.Reason)
+		log.Log.Object(domain).Infof("Domain status: %v, reason: %v\n", domain.Status.Status, domain.Status.Reason)
 	} else {
-		log.Log.Info("Vmi does not exist")
+		log.Log.Info("Domain does not exist")
 	}
 
 	domainAlive := domainExists &&

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -756,14 +756,16 @@ func (d *VirtualMachineController) defaultExecute(key string,
 	// set true to ensure that no updates to the current VirtualMachineInstance state will occur
 	forceIgnoreSync := false
 
-	log.Log.V(3).Infof("Processing vmi %v, existing: %v\n", vmi.Name, vmiExists)
+	log.Log.Infof("Processing event %v", key)
 	if vmiExists {
-		log.Log.V(3).Infof("vmi is in phase: %v\n", vmi.Status.Phase)
+		log.Log.Infof("Vmi %s in phase %v", vmi.Name, vmi.Status.Phase)
+	} else {
+		log.Log.Info("Vmi does not exist")
 	}
-
-	log.Log.V(3).Infof("Domain: existing: %v\n", domainExists)
 	if domainExists {
-		log.Log.V(3).Infof("Domain status: %v, reason: %v\n", domain.Status.Status, domain.Status.Reason)
+		log.Log.Infof("Domain %s in status %v, reason: %v", domain.ObjectMeta.Name, domain.Status.Status, domain.Status.Reason)
+	} else {
+		log.Log.Info("Vmi does not exist")
 	}
 
 	domainAlive := domainExists &&


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

While investigating the issues described in https://github.com/kubevirt/kubevirt/issues/2672 , I found really hard to understand what the problem was. 

What seemed to happen there was that a domain running event reached the virt-handler but (ironically :-) ) it was not handled. for some reason.

This pr adds / extends logs to simplify the troubleshooting, in particular for:
- expired / missed watchdog events (which are supposed to be exceptional and have an high impact)
- When a domain event was received we already had a log in place, but it did not say what domain it was referring to making it harder to troubleshoot when more vmis are on the same node
- every time a worker processes an event it dumps the current phase of the vmi / domain, which are the main drivers to the evolution of the vmi



```release-note

NONE

```
