### PR TITLE
Increase amount of memory allocated for container-disk container

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -126,14 +126,14 @@ func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, bi
 			if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("20M")
+				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("20M")
+				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("40M")
 			} else {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("100m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("20M")
+				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1M")


### PR DESCRIPTION
At least in some environments (e.g. when using sriov kind based
provider for kubevirt deployment), virt-launcher sometimes ends up in
OOMKilled state, and dmesg suggests that container-disk process is
killed:

Memory cgroup out of memory: Kill process 226667 (container-disk)
score 1001 or sacrifice child
Killed process 226431 (container-disk) total-vm:115804kB,
anon-rss:0kB, file-rss:3760kB, shmem-rss:0kB

With slight increase of memory allocated to the container, I no longer
get the launcher pod dying with OOMKilled state.

```release-note
NONE
```