### PR TITLE
Make cluster-deploy issues better diagnosable

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -242,3 +242,13 @@ genrule(
     cmd = "echo '#!/bin/sh\n\ncp $(SRCS) $$1' > \"$@\"",
     executable = 1,
 )
+
+genrule(
+    name = "build-dump",
+    srcs = [
+        "//cmd/dump",
+    ],
+    outs = ["dump-copier"],
+    cmd = "echo '#!/bin/sh\n\ncp $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ test: go-test
 functest:
 	hack/dockerized "hack/build-func-tests.sh"
 	hack/functests.sh
+dump: bazel-build
+	hack/dump.sh
 
 functest-image-build:
 	hack/func-tests-image.sh build

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -225,6 +225,8 @@ for i in ${namespaces[@]}; do
 
     current_time=$((current_time + sample))
     if [ $current_time -gt $timeout ]; then
+      echo "Dump kubevirt state:"
+      make dump
       exit 1
     fi
   done
@@ -238,6 +240,8 @@ for i in ${namespaces[@]}; do
 
     current_time=$((current_time + sample))
     if [ $current_time -gt $timeout ]; then
+      echo "Dump kubevirt state:"
+      make dump
       exit 1
     fi
   done

--- a/cmd/dump/BUILD.bazel
+++ b/cmd/dump/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dump.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/dump",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/reporter:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/types:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "dump",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/onsi/ginkgo/types"
+	"github.com/spf13/pflag"
+
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/reporter"
+)
+
+func main() {
+	var duration time.Duration
+	pflag.CommandLine.AddGoFlagSet(kubecli.FlagSet())
+	pflag.DurationVarP(&duration, "since", "s", 10*time.Minute, "collection window, defaults to 10 minutes")
+	pflag.Parse()
+
+	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"))
+	reporter.BeforeSuiteDidRun(nil)
+	reporter.SpecDidComplete(&types.SpecSummary{
+		State:   types.SpecStateFailed,
+		RunTime: duration,
+	})
+}

--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -24,12 +24,18 @@ source hack/config.sh
 
 rm -rf ${CMD_OUT_DIR}
 mkdir -p ${CMD_OUT_DIR}/virtctl
+mkdir -p ${CMD_OUT_DIR}/dump
 
 # Build all binaries for amd64
 bazel build \
     --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
     --workspace_status_command=./hack/print-workspace-status.sh \
     //tools/csv-generator/... //cmd/... //staging/src/kubevirt.io/client-go/examples/...
+
+# Copy dump binary to a reachable place outside of the build container
+bazel run \
+    --workspace_status_command=./hack/print-workspace-status.sh \
+    :build-dump -- ${CMD_OUT_DIR}/dump/dump
 
 # build platform native virtctl explicitly
 bazel run \

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -27,11 +27,7 @@ source hack/config.sh
 
 function dump_kubevirt() {
     echo "Dump kubevirt state:"
-    _kubectl get all -n kubevirt
-    for operator in $(_kubectl -n kubevirt get pods | grep operator | awk '{print $1}'); do
-        echo "Logs for operator $operator"
-        _kubectl logs -n kubevirt $operator
-    done
+    hack/dump.sh
 }
 
 echo "Deploying ..."

--- a/hack/dump.sh
+++ b/hack/dump.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2017 Red Hat, Inc.
+#
+
+set -ex
+
+export ARTIFACTS=${ARTIFACTS:-_out/artifacts}
+
+source hack/common.sh
+source hack/config.sh
+
+${CMD_OUT_DIR}/dump/dump --kubeconfig=${kubeconfig}

--- a/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
@@ -64,6 +64,13 @@ func Init() {
 	}
 }
 
+func FlagSet() *flag.FlagSet {
+	set := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	set.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	set.StringVar(&master, "master", "", "master url")
+	return set
+}
+
 func GetKubevirtSubresourceClientFromFlags(master string, kubeconfig string) (KubevirtClient, error) {
 	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
 	if err != nil {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -66,12 +66,12 @@ func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get client: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to get client: %v\n", err)
 		return
 	}
 
 	if err := os.MkdirAll(r.artifactsDir, 0777); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create directory: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to create directory: %v\n", err)
 		return
 	}
 
@@ -88,14 +88,14 @@ func (r *KubernetesReporter) logDomainXMLs(virtCli kubecli.KubevirtClient, specS
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_domains.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
 		return
 	}
 	defer f.Close()
 
 	vmis, err := virtCli.VirtualMachineInstance(v1.NamespaceAll).List(&v12.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch vmis: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to fetch vmis, can't collect domain XMLs: %v\n", err)
 		return
 	}
 
@@ -115,14 +115,14 @@ func (r *KubernetesReporter) logVMIs(virtCli kubecli.KubevirtClient, specSummary
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_vmis.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
 		return
 	}
 	defer f.Close()
 
 	vmis, err := virtCli.VirtualMachineInstance(v1.NamespaceAll).List(&v12.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch vmis: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to fetch vmis: %v\n", err)
 		return
 	}
 
@@ -146,7 +146,7 @@ func (r *KubernetesReporter) logPods(virtCli kubecli.KubevirtClient, specSummary
 
 	pods, err := virtCli.CoreV1().Pods(v1.NamespaceAll).List(v12.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch pods: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to fetch pods: %v\n", err)
 		return
 	}
 
@@ -163,14 +163,14 @@ func (r *KubernetesReporter) logNodes(virtCli kubecli.KubevirtClient, specSummar
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_nodes.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
 		return
 	}
 	defer f.Close()
 
 	nodes, err := virtCli.CoreV1().Nodes().List(v12.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch nodes: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to fetch nodes: %v\n", err)
 		return
 	}
 
@@ -187,7 +187,7 @@ func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, specSummary
 	logsdir := filepath.Join(r.artifactsDir, "pods")
 
 	if err := os.MkdirAll(logsdir, 0777); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to create directory: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to create directory: %v\n", err)
 		return
 	}
 
@@ -195,7 +195,7 @@ func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, specSummary
 
 	pods, err := virtCli.CoreV1().Pods(v1.NamespaceAll).List(v12.ListOptions{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch pods: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to fetch pods: %v\n", err)
 		return
 	}
 
@@ -203,14 +203,14 @@ func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, specSummary
 		for _, container := range pod.Spec.Containers {
 			current, err := os.OpenFile(filepath.Join(logsdir, fmt.Sprintf("%d_%s_%s-%s.log", r.failureCount, pod.Namespace, pod.Name, container.Name)), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+				fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
 				return
 			}
 			defer current.Close()
 
 			previous, err := os.OpenFile(filepath.Join(logsdir, fmt.Sprintf("%d_%s_%s-%s_previous.log", r.failureCount, pod.Namespace, pod.Name, container.Name)), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+				fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
 				return
 			}
 			defer previous.Close()
@@ -234,7 +234,7 @@ func (r *KubernetesReporter) logEvents(virtCli kubecli.KubevirtClient, specSumma
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_events.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v\n", err)
 		return
 	}
 	defer f.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the test-failure-collector also when deploying kubevirt fails in CI, to collect cluster info. This makes debugging the following scenarios easier:

 * Code-changes lead to a situation where only on some test lanes the kubevirt installation succeeds (allows diagnose without having to rerun locally)
 * The cluster comes up and we can successfully install kubevirt, but some cluster- or test-infra pods never get ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
