### PR TITLE
Fix some network/interface mapping validation issues

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -138,7 +138,7 @@ func (mutator *VMIsMutator) setDefaultNetworkInterface(obj *v1.VirtualMachineIns
 	}
 
 	// Override only when nothing is specified
-	if len(obj.Spec.Networks) == 0 {
+	if len(obj.Spec.Networks) == 0 && len(obj.Spec.Domain.Devices.Interfaces) == 0 {
 		iface := v1.NetworkInterfaceType(mutator.ClusterConfig.GetDefaultNetworkInterface())
 		switch iface {
 		case v1.BridgeInterface:

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -358,7 +358,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		),
 	)
 
-	table.DescribeTable("should set default network interface",
+	table.DescribeTable("should add the default network interface",
 		func(iface string) {
 			expectedIface := "bridge"
 			switch iface {
@@ -390,7 +390,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		table.Entry("as slirp", "slirp"),
 	)
 
-	table.DescribeTable("should not default interfaces if", func(interfaces []v1.Interface, networks []v1.Network) {
+	table.DescribeTable("should not add the default interfaces if", func(interfaces []v1.Interface, networks []v1.Network) {
 		vmi.Spec.Domain.Devices.Interfaces = append([]v1.Interface{}, interfaces...)
 		vmi.Spec.Networks = append([]v1.Network{}, networks...)
 		vmiSpec, _ := getVMISpecMetaFromResponse()
@@ -664,5 +664,4 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		}
 		Expect(ok).To(BeTrue())
 	})
-
 })

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -389,6 +389,27 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		table.Entry("as masquerade", "masquerade"),
 		table.Entry("as slirp", "slirp"),
 	)
+
+	table.DescribeTable("should not default interfaces if", func(interfaces []v1.Interface, networks []v1.Network) {
+		vmi.Spec.Domain.Devices.Interfaces = append([]v1.Interface{}, interfaces...)
+		vmi.Spec.Networks = append([]v1.Network{}, networks...)
+		vmiSpec, _ := getVMISpecMetaFromResponse()
+		if len(interfaces) == 0 {
+			Expect(vmiSpec.Domain.Devices.Interfaces).To(BeNil())
+		} else {
+			Expect(vmiSpec.Domain.Devices.Interfaces).To(Equal(interfaces))
+		}
+		if len(networks) == 0 {
+			Expect(vmiSpec.Networks).To(BeNil())
+		} else {
+			Expect(vmiSpec.Networks).To(Equal(networks))
+		}
+	},
+		table.Entry("interfaces and networks are non-empty", []v1.Interface{{Name: "a"}}, []v1.Network{{Name: "b"}}),
+		table.Entry("interfaces is non-empty", []v1.Interface{{Name: "a"}}, []v1.Network{}),
+		table.Entry("networks is non-empty", []v1.Interface{}, []v1.Network{{Name: "b"}}),
+	)
+
 	It("should not override specified properties with defaults on VMI create", func() {
 		testutils.UpdateFakeClusterConfig(configMapInformer, &k8sv1.ConfigMap{
 			Data: map[string]string{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -519,322 +519,331 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		}
 	}
 
-	if len(spec.Networks) > 0 && len(spec.Domain.Devices.Interfaces) > 0 {
-		multusDefaultCount := 0
-		multusExists := false
-		genieExists := false
-		podExists := false
+	multusDefaultCount := 0
+	multusExists := false
+	genieExists := false
+	podExists := false
 
-		for idx, network := range spec.Networks {
+	for idx, network := range spec.Networks {
 
-			cniTypesCount := 0
-			// network name not needed by default
-			networkNameExistsOrNotNeeded := true
+		cniTypesCount := 0
+		// network name not needed by default
+		networkNameExistsOrNotNeeded := true
 
-			if network.Pod != nil {
-				cniTypesCount++
-				podExists = true
-			}
-
-			if network.NetworkSource.Multus != nil {
-				cniTypesCount++
-				multusExists = true
-				networkNameExistsOrNotNeeded = network.Multus.NetworkName != ""
-				if network.NetworkSource.Multus.Default {
-					multusDefaultCount++
-				}
-			}
-
-			if network.NetworkSource.Genie != nil {
-				cniTypesCount++
-				genieExists = true
-				networkNameExistsOrNotNeeded = network.Genie.NetworkName != ""
-			}
-
-			if cniTypesCount == 0 {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: "should have a network type",
-					Field:   field.Child("networks").Index(idx).String(),
-				})
-			} else if cniTypesCount > 1 {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: "should have only one network type",
-					Field:   field.Child("networks").Index(idx).String(),
-				})
-			} else if genieExists && (podExists || multusExists) {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: "cannot combine Genie with other CNIs across networks",
-					Field:   field.Child("networks").Index(idx).String(),
-				})
-			}
-
-			if !networkNameExistsOrNotNeeded {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueRequired,
-					Message: "CNI delegating plugin must have a networkName",
-					Field:   field.Child("networks").Index(idx).String(),
-				})
-			}
-
-			networkNameMap[spec.Networks[idx].Name] = &spec.Networks[idx]
+		if network.Pod != nil {
+			cniTypesCount++
+			podExists = true
 		}
 
-		if multusDefaultCount > 1 {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "Multus CNI should only have one default network",
-				Field:   field.Child("networks").String(),
-			})
-		}
-
-		if podExists && multusDefaultCount > 0 {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "Pod network cannot be defined when Multus default network is defined",
-				Field:   field.Child("networks").String(),
-			})
-		}
-
-		// Make sure interfaces and networks are 1to1 related
-		networkInterfaceMap := make(map[string]struct{})
-
-		// Make sure the port name is unique across all the interfaces
-		portForwardMap := make(map[string]struct{})
-
-		vifMQ := spec.Domain.Devices.NetworkInterfaceMultiQueue
-		isVirtioNicRequested := false
-
-		// Validate that each interface has a matching network
-		for idx, iface := range spec.Domain.Devices.Interfaces {
-
-			networkData, networkExists := networkNameMap[iface.Name]
-
-			if !networkExists {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("%s '%s' not found.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.Name),
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			} else if iface.Slirp != nil && networkData.Pod == nil {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "Slirp interface only implemented with pod network",
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			} else if iface.Slirp != nil && networkData.Pod != nil && !config.IsSlirpInterfaceEnabled() {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "Slirp interface is not enabled in kubevirt-config",
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			} else if iface.Masquerade != nil && networkData.Pod == nil {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "Masquerade interface only implemented with pod network",
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			} else if iface.InterfaceBindingMethod.Bridge != nil && networkData.NetworkSource.Pod != nil && !config.IsBridgeInterfaceOnPodNetworkEnabled() {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "Bridge on pod network configuration is not enabled under kubevirt-config",
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			}
-
-			// Check if the interface name is unique
-			if _, networkAlreadyUsed := networkInterfaceMap[iface.Name]; networkAlreadyUsed {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueDuplicate,
-					Message: "Only one interface can be connected to one specific network",
-					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
-				})
-			}
-
-			networkInterfaceMap[iface.Name] = struct{}{}
-
-			// Check only ports configured on interfaces connected to a pod network
-			if networkExists && networkData.Pod != nil && iface.Ports != nil {
-				for portIdx, forwardPort := range iface.Ports {
-
-					if forwardPort.Port == 0 {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueRequired,
-							Message: "Port field is mandatory.",
-							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).String(),
-						})
-					}
-
-					if forwardPort.Port < 0 || forwardPort.Port > 65536 {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: "Port field must be in range 0 < x < 65536.",
-							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).String(),
-						})
-					}
-
-					if forwardPort.Protocol != "" {
-						if forwardPort.Protocol != "TCP" && forwardPort.Protocol != "UDP" {
-							causes = append(causes, metav1.StatusCause{
-								Type:    metav1.CauseTypeFieldValueInvalid,
-								Message: "Unknown protocol, only TCP or UDP allowed",
-								Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("protocol").String(),
-							})
-						}
-					} else {
-						forwardPort.Protocol = "TCP"
-					}
-
-					if forwardPort.Name != "" {
-						if _, ok := portForwardMap[forwardPort.Name]; ok {
-							causes = append(causes, metav1.StatusCause{
-								Type:    metav1.CauseTypeFieldValueDuplicate,
-								Message: fmt.Sprintf("Duplicate name of the port: %s", forwardPort.Name),
-								Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("name").String(),
-							})
-						}
-
-						if msgs := validation.IsValidPortName(forwardPort.Name); len(msgs) != 0 {
-							causes = append(causes, metav1.StatusCause{
-								Type:    metav1.CauseTypeFieldValueInvalid,
-								Message: fmt.Sprintf("Invalid name of the port: %s", forwardPort.Name),
-								Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("name").String(),
-							})
-						}
-
-						portForwardMap[forwardPort.Name] = struct{}{}
-					}
-				}
-			}
-
-			// verify that selected model is supported
-			if iface.Model != "" {
-				isModelSupported := func(model string) bool {
-					for _, m := range validInterfaceModels {
-						if m == model {
-							return true
-						}
-					}
-					return false
-				}
-				if !isModelSupported(iface.Model) {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueNotSupported,
-						Message: fmt.Sprintf("interface %s uses model %s that is not supported.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.Model),
-						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("model").String(),
-					})
-				}
-			}
-
-			// verify that selected macAddress is valid
-			if iface.MacAddress != "" {
-				mac, err := net.ParseMAC(iface.MacAddress)
-				if err != nil {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("interface %s has malformed MAC address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
-						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
-					})
-				}
-				if len(mac) > 6 {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("interface %s has MAC address (%s) that is too long.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
-						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
-					})
-				}
-			}
-
-			if iface.BootOrder != nil {
-				order := *iface.BootOrder
-				// Verify boot order is greater than 0, if provided
-				if order < 1 {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("%s must have a boot order > 0, if supplied", field.Index(idx).String()),
-						Field:   field.Index(idx).Child("bootOrder").String(),
-					})
-				} else {
-					// verify that there are no duplicate boot orders
-					if bootOrderMap[order] {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: fmt.Sprintf("Boot order for %s already set for a different device.", field.Child("domain", "devices", "interfaces").Index(idx).Child("bootOrder").String()),
-							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("bootOrder").String(),
-						})
-					}
-					bootOrderMap[order] = true
-				}
-			}
-			// verify that the specified pci address is valid
-			if iface.PciAddress != "" {
-				_, err := util.ParsePciAddress(iface.PciAddress)
-				if err != nil {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("interface %s has malformed PCI address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.PciAddress),
-						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("pciAddress").String(),
-					})
-				}
-			}
-			// verify that the extra dhcp options are valid
-			if iface.DHCPOptions != nil {
-				PrivateOptions := iface.DHCPOptions.PrivateOptions
-				err := ValidateDuplicateDHCPPrivateOptions(PrivateOptions)
-				if err != nil {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("Found Duplicates: %v", err),
-						Field:   field.String(),
-					})
-					return causes
-				}
-				for _, DHCPPrivateOption := range PrivateOptions {
-					if !(DHCPPrivateOption.Option >= 224 && DHCPPrivateOption.Option <= 254) {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: "provided DHCPPrivateOptions are out of range, must be in range 224 to 254",
-							Field:   field.String(),
-						})
-					}
-				}
-			}
-
-			if iface.Model == "virtio" || iface.Model == "" {
-				isVirtioNicRequested = true
-			}
-
-			if iface.DHCPOptions != nil {
-				for index, ip := range iface.DHCPOptions.NTPServers {
-					if net.ParseIP(ip).To4() == nil {
-						causes = append(causes, metav1.StatusCause{
-							Type:    metav1.CauseTypeFieldValueInvalid,
-							Message: "NTP servers must be a list of valid IPv4 addresses.",
-							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("dhcpOptions", "ntpServers").Index(index).String(),
-						})
-					}
-				}
+		if network.NetworkSource.Multus != nil {
+			cniTypesCount++
+			multusExists = true
+			networkNameExistsOrNotNeeded = network.Multus.NetworkName != ""
+			if network.NetworkSource.Multus.Default {
+				multusDefaultCount++
 			}
 		}
-		// Network interface multiqueue can only be set for a virtio driver
-		if vifMQ != nil && *vifMQ && !isVirtioNicRequested {
 
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "virtio-net multiqueue request, but there are no virtio interfaces defined",
-				Field:   field.Child("domain", "devices", "networkInterfaceMultiqueue").String(),
-			})
-
+		if network.NetworkSource.Genie != nil {
+			cniTypesCount++
+			genieExists = true
+			networkNameExistsOrNotNeeded = network.Genie.NetworkName != ""
 		}
 
-		// Validate that every network was assign to an interface
-		if len(networkInterfaceMap) != len(networkNameMap) {
+		if cniTypesCount == 0 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueRequired,
-				Message: "every network must be mapped to an interface.",
-				Field:   field.Child("networks").String(),
+				Message: "should have a network type",
+				Field:   field.Child("networks").Index(idx).String(),
+			})
+		} else if cniTypesCount > 1 {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: "should have only one network type",
+				Field:   field.Child("networks").Index(idx).String(),
+			})
+		} else if genieExists && (podExists || multusExists) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: "cannot combine Genie with other CNIs across networks",
+				Field:   field.Child("networks").Index(idx).String(),
+			})
+		}
+
+		if !networkNameExistsOrNotNeeded {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: "CNI delegating plugin must have a networkName",
+				Field:   field.Child("networks").Index(idx).String(),
+			})
+		}
+
+		networkNameMap[spec.Networks[idx].Name] = &spec.Networks[idx]
+	}
+
+	if multusDefaultCount > 1 {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Multus CNI should only have one default network",
+			Field:   field.Child("networks").String(),
+		})
+	}
+
+	if podExists && multusDefaultCount > 0 {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "Pod network cannot be defined when Multus default network is defined",
+			Field:   field.Child("networks").String(),
+		})
+	}
+
+	// Make sure interfaces and networks are 1to1 related
+	networkInterfaceMap := make(map[string]struct{})
+
+	// Make sure the port name is unique across all the interfaces
+	portForwardMap := make(map[string]struct{})
+
+	vifMQ := spec.Domain.Devices.NetworkInterfaceMultiQueue
+	isVirtioNicRequested := false
+
+	// Validate that each interface has a matching network
+	for idx, iface := range spec.Domain.Devices.Interfaces {
+
+		networkData, networkExists := networkNameMap[iface.Name]
+
+		if !networkExists {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("%s '%s' not found.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.Name),
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		} else if iface.Slirp != nil && networkData.Pod == nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Slirp interface only implemented with pod network",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		} else if iface.Slirp != nil && networkData.Pod != nil && !config.IsSlirpInterfaceEnabled() {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Slirp interface is not enabled in kubevirt-config",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		} else if iface.Masquerade != nil && networkData.Pod == nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Masquerade interface only implemented with pod network",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		} else if iface.InterfaceBindingMethod.Bridge != nil && networkData.NetworkSource.Pod != nil && !config.IsBridgeInterfaceOnPodNetworkEnabled() {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Bridge on pod network configuration is not enabled under kubevirt-config",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		}
+
+		// Check if the interface name is unique
+		if _, networkAlreadyUsed := networkInterfaceMap[iface.Name]; networkAlreadyUsed {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueDuplicate,
+				Message: "Only one interface can be connected to one specific network",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		}
+
+		networkInterfaceMap[iface.Name] = struct{}{}
+
+		// Check only ports configured on interfaces connected to a pod network
+		if networkExists && networkData.Pod != nil && iface.Ports != nil {
+			for portIdx, forwardPort := range iface.Ports {
+
+				if forwardPort.Port == 0 {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueRequired,
+						Message: "Port field is mandatory.",
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).String(),
+					})
+				}
+
+				if forwardPort.Port < 0 || forwardPort.Port > 65536 {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: "Port field must be in range 0 < x < 65536.",
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).String(),
+					})
+				}
+
+				if forwardPort.Protocol != "" {
+					if forwardPort.Protocol != "TCP" && forwardPort.Protocol != "UDP" {
+						causes = append(causes, metav1.StatusCause{
+							Type:    metav1.CauseTypeFieldValueInvalid,
+							Message: "Unknown protocol, only TCP or UDP allowed",
+							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("protocol").String(),
+						})
+					}
+				} else {
+					forwardPort.Protocol = "TCP"
+				}
+
+				if forwardPort.Name != "" {
+					if _, ok := portForwardMap[forwardPort.Name]; ok {
+						causes = append(causes, metav1.StatusCause{
+							Type:    metav1.CauseTypeFieldValueDuplicate,
+							Message: fmt.Sprintf("Duplicate name of the port: %s", forwardPort.Name),
+							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("name").String(),
+						})
+					}
+
+					if msgs := validation.IsValidPortName(forwardPort.Name); len(msgs) != 0 {
+						causes = append(causes, metav1.StatusCause{
+							Type:    metav1.CauseTypeFieldValueInvalid,
+							Message: fmt.Sprintf("Invalid name of the port: %s", forwardPort.Name),
+							Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("name").String(),
+						})
+					}
+
+					portForwardMap[forwardPort.Name] = struct{}{}
+				}
+			}
+		}
+
+		// verify that selected model is supported
+		if iface.Model != "" {
+			isModelSupported := func(model string) bool {
+				for _, m := range validInterfaceModels {
+					if m == model {
+						return true
+					}
+				}
+				return false
+			}
+			if !isModelSupported(iface.Model) {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueNotSupported,
+					Message: fmt.Sprintf("interface %s uses model %s that is not supported.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.Model),
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("model").String(),
+				})
+			}
+		}
+
+		// verify that selected macAddress is valid
+		if iface.MacAddress != "" {
+			mac, err := net.ParseMAC(iface.MacAddress)
+			if err != nil {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("interface %s has malformed MAC address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
+				})
+			}
+			if len(mac) > 6 {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("interface %s has MAC address (%s) that is too long.", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.MacAddress),
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("macAddress").String(),
+				})
+			}
+		}
+
+		if iface.BootOrder != nil {
+			order := *iface.BootOrder
+			// Verify boot order is greater than 0, if provided
+			if order < 1 {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("%s must have a boot order > 0, if supplied", field.Index(idx).String()),
+					Field:   field.Index(idx).Child("bootOrder").String(),
+				})
+			} else {
+				// verify that there are no duplicate boot orders
+				if bootOrderMap[order] {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: fmt.Sprintf("Boot order for %s already set for a different device.", field.Child("domain", "devices", "interfaces").Index(idx).Child("bootOrder").String()),
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("bootOrder").String(),
+					})
+				}
+				bootOrderMap[order] = true
+			}
+		}
+		// verify that the specified pci address is valid
+		if iface.PciAddress != "" {
+			_, err := util.ParsePciAddress(iface.PciAddress)
+			if err != nil {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("interface %s has malformed PCI address (%s).", field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(), iface.PciAddress),
+					Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("pciAddress").String(),
+				})
+			}
+		}
+		// verify that the extra dhcp options are valid
+		if iface.DHCPOptions != nil {
+			PrivateOptions := iface.DHCPOptions.PrivateOptions
+			err := ValidateDuplicateDHCPPrivateOptions(PrivateOptions)
+			if err != nil {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("Found Duplicates: %v", err),
+					Field:   field.String(),
+				})
+				return causes
+			}
+			for _, DHCPPrivateOption := range PrivateOptions {
+				if !(DHCPPrivateOption.Option >= 224 && DHCPPrivateOption.Option <= 254) {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: "provided DHCPPrivateOptions are out of range, must be in range 224 to 254",
+						Field:   field.String(),
+					})
+				}
+			}
+		}
+
+		if iface.Model == "virtio" || iface.Model == "" {
+			isVirtioNicRequested = true
+		}
+
+		if iface.DHCPOptions != nil {
+			for index, ip := range iface.DHCPOptions.NTPServers {
+				if net.ParseIP(ip).To4() == nil {
+					causes = append(causes, metav1.StatusCause{
+						Type:    metav1.CauseTypeFieldValueInvalid,
+						Message: "NTP servers must be a list of valid IPv4 addresses.",
+						Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("dhcpOptions", "ntpServers").Index(index).String(),
+					})
+				}
+			}
+		}
+	}
+	// Network interface multiqueue can only be set for a virtio driver
+	if vifMQ != nil && *vifMQ && !isVirtioNicRequested {
+
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "virtio-net multiqueue request, but there are no virtio interfaces defined",
+			Field:   field.Child("domain", "devices", "networkInterfaceMultiqueue").String(),
+		})
+
+	}
+
+	// Validate that every network was assign to an interface
+	networkDuplicates := map[string]struct{}{}
+	for i, network := range spec.Networks {
+		if _, exists := networkDuplicates[network.Name]; exists {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueDuplicate,
+				Message: fmt.Sprintf("Network with name %q already exists, every network must have a unique name", network.Name),
+				Field:   field.Child("networks").Index(i).Child("name").String(),
+			})
+		}
+		networkDuplicates[network.Name] = struct{}{}
+		if _, exists := networkInterfaceMap[network.Name]; !exists {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueRequired,
+				Message: fmt.Sprintf("%s '%s' not found.", field.Child("networks").Index(i).Child("name").String(), network.Name),
+				Field:   field.Child("networks").Index(i).Child("name").String(),
 			})
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -988,7 +988,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
-			for _, model := range validInterfaceModels {
+			for model, _ := range validInterfaceModels {
 				vmi.Spec.Domain.Devices.Interfaces[0].Model = model
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				// if this is processed correctly, it should not result in any error
@@ -1759,10 +1759,13 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		It("should reject nic multi queue without CPU settings", func() {
 			_true := true
 			vmi := v1.NewMinimalVMI("testvm")
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(2))
+			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
 		})
 
@@ -1968,7 +1971,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 
-			for _, policy := range validCPUFeaturePolicies {
+			for policy, _ := range validCPUFeaturePolicies {
 				vmi.Spec.Domain.CPU.Features[0].Policy = policy
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				Expect(len(causes)).To(Equal(0))


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Don't add a default network if a single interface misses the network
configuration
 * Check for unique names in the network section
 * Explicitly say which network does not have an interface if it is
missing

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2577

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix some network defaulting and validation issues
```
