### PR TITLE
Check if the service monitor namespace exists

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -297,6 +297,12 @@ spec:
           verbs:
           - put
         - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -152,6 +152,12 @@ rules:
   verbs:
   - put
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -263,6 +263,17 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 					"put",
 				},
 			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"namespaces",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
 		},
 	}
 

--- a/pkg/virt-operator/install-strategy/BUILD.bazel
+++ b/pkg/virt-operator/install-strategy/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
+        "@com_github_golang_glog//:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -27,7 +27,9 @@ import (
 
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
 	secv1 "github.com/openshift/api/security/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -82,9 +84,9 @@ type InstallStrategy struct {
 	serviceMonitors []*promv1.ServiceMonitor
 }
 
-func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig) (*corev1.ConfigMap, error) {
+func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, addMonitorServiceResources bool) (*corev1.ConfigMap, error) {
 
-	strategy, err := GenerateCurrentInstallStrategy(config)
+	strategy, err := GenerateCurrentInstallStrategy(config, addMonitorServiceResources)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +119,13 @@ func DumpInstallStrategyToConfigMap(clientset kubecli.KubevirtClient) error {
 		return err
 	}
 
-	configMap, err := NewInstallStrategyConfigMap(config)
+	monitorNamespace := config.GetMonitorNamespace()
+	addMonitorServiceResources, err := isNamespaceExist(clientset, monitorNamespace)
+	if err != nil {
+		return err
+	}
+
+	configMap, err := NewInstallStrategyConfigMap(config, addMonitorServiceResources)
 	if err != nil {
 		return err
 	}
@@ -184,7 +192,7 @@ func dumpInstallStrategyToBytes(strategy *InstallStrategy) []byte {
 	return b.Bytes()
 }
 
-func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfig) (*InstallStrategy, error) {
+func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfig, addMonitorServiceResources bool) (*InstallStrategy, error) {
 
 	strategy := &InstallStrategy{}
 
@@ -201,8 +209,14 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	rbaclist = append(rbaclist, rbac.GetAllHandler(config.GetNamespace())...)
 
 	monitorNamespace := config.GetMonitorNamespace()
-	monitorServiceAccount := config.GetMonitorServiceAccount()
-	rbaclist = append(rbaclist, rbac.GetAllServiceMonitor(config.GetNamespace(), monitorNamespace, monitorServiceAccount)...)
+	if addMonitorServiceResources {
+		// TODO: we should check that monitor SA exists in the monitor namespace
+		monitorServiceAccount := config.GetMonitorServiceAccount()
+		rbaclist = append(rbaclist, rbac.GetAllServiceMonitor(config.GetNamespace(), monitorNamespace, monitorServiceAccount)...)
+		strategy.serviceMonitors = append(strategy.serviceMonitors, components.NewServiceMonitorCR(config.GetNamespace(), monitorNamespace, true))
+	} else {
+		glog.Warningf("failed to create service monitor resources because namespace %s does not exist", monitorNamespace)
+	}
 
 	for _, entry := range rbaclist {
 		cr, ok := entry.(*rbacv1.ClusterRole)
@@ -231,8 +245,6 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	}
 
 	strategy.services = append(strategy.services, components.NewPrometheusService(config.GetNamespace()))
-	strategy.serviceMonitors = append(strategy.serviceMonitors, components.NewServiceMonitorCR(config.GetNamespace(), monitorNamespace, true))
-
 	strategy.services = append(strategy.services, components.NewApiServerService(config.GetNamespace()))
 	apiDeployment, err := components.NewApiServerDeployment(config.GetNamespace(), config.GetImageRegistry(), config.GetApiVersion(), config.GetImagePullPolicy(), config.GetVerbosity())
 	if err != nil {
@@ -452,4 +464,17 @@ func contains(users []string, user string) bool {
 		}
 	}
 	return false
+}
+
+func isNamespaceExist(clientset kubecli.KubevirtClient, ns string) (bool, error) {
+	_, err := clientset.CoreV1().Namespaces().Get(ns, metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, err
 }

--- a/pkg/virt-operator/install-strategy/strategy_test.go
+++ b/pkg/virt-operator/install-strategy/strategy_test.go
@@ -43,13 +43,6 @@ import (
 var _ = Describe("Install Strategy", func() {
 	log.Log.SetIOWriter(GinkgoWriter)
 
-	BeforeEach(func() {
-
-	})
-
-	AfterEach(func() {
-	})
-
 	namespace := "fake-namespace"
 
 	getConfig := func(registry, version string) *util.KubeVirtDeploymentConfig {
@@ -68,8 +61,7 @@ var _ = Describe("Install Strategy", func() {
 
 	Context("should generate", func() {
 		It("latest install strategy with lossless byte conversion.", func() {
-
-			strategy, err := GenerateCurrentInstallStrategy(config)
+			strategy, err := GenerateCurrentInstallStrategy(config, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			strategyStr := string(dumpInstallStrategyToBytes(strategy))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Verify that service monitor namespace exists before the creation of the
ServiceMonitor resource.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2688

**Special notes for your reviewer**:
In general, it can be a good idea to create k8s cluster with Prometheus under our providers, just to verify such cases. But it can be done under the other PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Verify that service monitor namespace exists before the creation of the ServiceMonitor resource.
```
