### PR TITLE
add masquerade binding method to templates

### DIFF
--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -39,12 +39,18 @@ objects:
             - disk:
                 bus: virtio
               name: cloudinitdisk
+            interfaces:
+            - masquerade: {}
+              name: default
             rng: {}
           machine:
             type: ""
           resources:
             requests:
               memory: ${MEMORY}
+        networks:
+        - name: default
+          pod: {}
         terminationGracePeriodSeconds: 0
         volumes:
         - containerDisk:

--- a/examples/vm-template-rhel7.yaml
+++ b/examples/vm-template-rhel7.yaml
@@ -36,11 +36,17 @@ objects:
             - disk:
                 bus: virtio
               name: disk0
+            interfaces:
+            - masquerade: {}
+              name: default
           machine:
             type: ""
           resources:
             requests:
               memory: ${MEMORY}
+        networks:
+        - name: default
+          pod: {}
         terminationGracePeriodSeconds: 0
         volumes:
         - name: disk0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In this PR we added masquerade binding mehtod
to RHEL7 and Fedora templates, so that those
template VMs will be migratable.
(if no binding method is specified we use bridge
as a default)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fedora and RHEL7 template VMs were changed to use masquerade binding method
```
