### PR TITLE
Handle update conflicts in annotation tests

### DIFF
--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -74,16 +74,13 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		// Status updates can conflict with our desire to change the spec
 		By(fmt.Sprintf("Scaling to %d", scale))
 		var s *autov1.Scale
-		for {
+		err = tests.RetryIfModified(func() error {
 			s, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).GetScale(name, v12.GetOptions{})
 			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 			s.Spec.Replicas = scale
 			s, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).UpdateScale(name, s)
-			if errors.IsConflict(err) {
-				continue
-			}
-			break
-		}
+			return err
+		})
 
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -276,11 +276,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			vm := newVirtualMachine(false)
 
-			vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vm.Annotations = annotations
-
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
+			err = tests.RetryIfModified(func() error {
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vm.Annotations = annotations
+				vm, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
+				return err
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			startVMIDontWait(vm)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a flaky annotation test, which sometimes fails because of
conflicting UPDATE calls.

This test shows up multiple times in the flakefinder because of update conflicts.

Here a report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/flakefinder-2019-09-16-024h.html

Here some logs:

https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/2696/pull-kubevirt-e2e-os-3.11.0-crio/1174158093026594816

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
