### PR TITLE
Use new libvirt version which can handle 0xFE MAC prefixes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -228,10 +228,10 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:71d10b2ae0af286e4ff0674a7ecfb86ac2455e529fafc97810101f5700b4a416",
+    digest = "sha256:840d4502f48f567f9030e22ba8aa8294003f1ac20b6a0c06c01b0236a8964a3a",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
-    #tag = "5.0.0",
+    #tag = "5.0.0-2.fc30",
 )
 
 # Pull kubevirt-testing image


### PR DESCRIPTION
**What this PR does / why we need it**:

Use new libvirt version which can handle 0xFE MAC prefixes on tap devices.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
The VMI can now successfully start if it gets a 0xfe prefixed MAC address assigned from the pod network
```
