### PR TITLE
Flaky test: [test_id:1536]Should expose a NodePort service on a VMI and connect to it

### DIFF
--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -234,6 +234,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := tests.NewHelloWorldJobUDP(serviceIP, servicePort)
 				job, err = virtClient.CoreV1().Pods(udpVM.Namespace).Create(job)
 				Expect(err).ToNot(HaveOccurred())
+				waitForJobToCompleteWithStatus(&virtClient, job, "success", 120)
 
 				By("Getting the node IP from all nodes")
 				nodes, err := virtClient.CoreV1().Nodes().List(k8smetav1.ListOptions{})

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -234,7 +234,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := tests.NewHelloWorldJobUDP(serviceIP, servicePort)
 				job, err = virtClient.CoreV1().Pods(udpVM.Namespace).Create(job)
 				Expect(err).ToNot(HaveOccurred())
-				waitForJobToCompleteWithStatus(&virtClient, job, "success", 120)
+				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 120)
 
 				By("Getting the node IP from all nodes")
 				nodes, err := virtClient.CoreV1().Nodes().List(k8smetav1.ListOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:

When we run the test, we start both a pod that tries to probe the udp server via the Cluster IP and a pod that tries to do the same thing via the Node Port:

See
https://github.com/kubevirt/kubevirt/blob/0796d46f95211d07d5eae7b627f5f582ab8b3560/tests/expose_test.go#L234
and 
https://github.com/kubevirt/kubevirt/blob/0796d46f95211d07d5eae7b627f5f582ab8b3560/tests/expose_test.go#L247

Apparently, nc is not able to handle concurrent udp connections (see also the comment [here](https://github.com/nmap/nmap/blob/d639a53088cda2d558b32e9176076c4975a7bb4c/ncat/ncat_listen.c#L893) ) so it might happen that the two pods hit the service at the same time and only one gets served.

I managed to reproduce this locally, and by ssh-ing into the stuck pod and sending an udp message it worked so NodePort issues are not probably involved.

With this PR we just wait for the ServiceIP probe pod to complete before starting the node one.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I did not manage to get failures locally, which do not mean that the test is fixed. Let's merge this and see if it fixes the flaky test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE


```
