### PR TITLE
vmi_configuration_test 3 cores - add check for cpu cores, skip if less than expected

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -140,11 +140,17 @@ var _ = Describe("Configurations", func() {
 
 	Describe("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance definition", func() {
 		Context("with 3 CPU cores", func() {
+			availableNumberOfCPUs := tests.GetHighestCPUNumberAmongNodes(virtClient)
+
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
+				requiredNumberOfCpus := 3
+				Expect(availableNumberOfCPUs).ToNot(BeNumerically("<", requiredNumberOfCpus),
+					fmt.Sprintf("Test requires %d cpus, but only %d available!", requiredNumberOfCpus, availableNumberOfCPUs))
 				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			})
+
 			It("[test_id:1659]should report 3 cpu cores under guest OS", func() {
 				vmi.Spec.Domain.CPU = &v1.CPU{
 					Cores: 3,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The test series "with 3 cores" within `tests/vmi_configuration_test.go` expects to have three cores but never checks it. This is done now in the `BeforeEach`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I couldn't test this as I don't have free resources locally. Please advise whether this approach could work and how to check for negative and positive.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
