### PR TITLE
Multus Tests: Get the image to use for the network config daemon from the virt operator pod

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -820,6 +820,7 @@ func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
 // TODO: Once kubernetes-nmstate is ready, we should use it instead
 func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
 
+	// Fetching the kubevirt-operator image from the pod makes this independent from the installation method / image used
 	pods, err := virtClient.CoreV1().Pods(tests.KubeVirtInstallNamespace).List(metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(pods.Items).ToNot(BeEmpty())

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -819,6 +819,13 @@ func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
 // both iptables and newer nftables.
 // TODO: Once kubernetes-nmstate is ready, we should use it instead
 func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
+
+	pods, err := virtClient.CoreV1().Pods(tests.KubeVirtInstallNamespace).List(metav1.ListOptions{LabelSelector: "kubevirt.io=virt-operator"})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(pods.Items).ToNot(BeEmpty())
+
+	virtOperatorImage := pods.Items[0].Spec.Containers[0].Image
+
 	// Privileged DaemonSet configuring host networking as needed
 	networkConfigDaemonSet := appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
@@ -843,7 +850,7 @@ func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
 							Name: "network-config",
 							// Reuse image which is already installed in the cluster. All we need is chroot.
 							// Local OKD cluster doesn't allow us to pull from the outside.
-							Image: "registry:5000/kubevirt/virt-operator:devel",
+							Image: virtOperatorImage,
 							Command: []string{
 								"sh",
 								"-c",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Right now the network setup is done via a daemon that uses the same image as the virt operator (hardcoded from the local registry). 
This won't work in case of external providers, where the local registry may not exist.

In this PR we fetch the image to use directly from the running pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```
