### PR TITLE
skip tests which require more CPUs than available

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2722,6 +2722,21 @@ func SkipIfNotUseNetworkPolicy(virtClient kubecli.KubevirtClient) {
 	}
 }
 
+func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
+	var cpus int64
+
+	nodes, err := virtClient.Core().Nodes().List(metav1.ListOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	for _, node := range nodes.Items {
+		if v, ok := node.Status.Capacity[k8sv1.ResourceCPU]; ok && v.Value() > cpus {
+			cpus = v.Value()
+		}
+	}
+
+	return int(cpus)
+}
+
 func GetK8sCmdClient() string {
 	// use oc if it exists, otherwise use kubectl
 	if KubeVirtOcPath != "" {

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -54,6 +54,8 @@ var _ = Describe("IOThreads", func() {
 
 	Context("IOThreads Policies", func() {
 
+		availableCPUs := tests.GetHighestCPUNumberAmongNodes(virtClient)
+
 		It("Should honor shared ioThreadsPolicy for single disk", func() {
 			policy := v1.IOThreadsPolicyShared
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
@@ -131,6 +133,10 @@ var _ = Describe("IOThreads", func() {
 		})
 
 		table.DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", func(numCpus int, expectedIOThreads int) {
+			if numCpus > availableCPUs {
+				Skip(fmt.Sprintf("Testing environment does not contain a node with required %d CPUs number, the heighest detected number is %d", numCpus, availbleCores))
+			}
+
 			policy := v1.IOThreadsPolicyAuto
 			vmi.Spec.Domain.IOThreadsPolicy = &policy
 


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <mfranczy@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes some iothread tests which require more CPUs than available

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
