### PR TITLE
fail iothread tests when there is not enough cpu resources

### DIFF
--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -133,9 +133,10 @@ var _ = Describe("IOThreads", func() {
 		})
 
 		table.DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", func(numCpus int, expectedIOThreads int) {
-			if numCpus > availableCPUs {
-				Skip(fmt.Sprintf("Testing environment does not contain a node with required %d CPUs number, the highest detected number is %d", numCpus, availableCPUs))
-			}
+			Expect(
+				numCpus <= availableCPUs).To(BeTrue(),
+				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
+			)
 
 			policy := v1.IOThreadsPolicyAuto
 			vmi.Spec.Domain.IOThreadsPolicy = &policy

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -133,8 +133,7 @@ var _ = Describe("IOThreads", func() {
 		})
 
 		table.DescribeTable("[ref_id:2065] should honor auto ioThreadPolicy", func(numCpus int, expectedIOThreads int) {
-			Expect(
-				numCpus <= availableCPUs).To(BeTrue(),
+			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
 			)
 

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -52,8 +52,13 @@ var _ = Describe("MultiQueue", func() {
 
 	Context("MultiQueue Behavior", func() {
 
+		availableCPUs := tests.GetHighestCPUNumberAmongNodes(virtClient)
+
 		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {
 			numCpus := 3
+			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
+				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
+			)
 
 			multiQueue := true
 			vmi.Spec.Domain.Devices.BlockMultiQueue = &multiQueue


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <mfranczy@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It fails iothread tests in case there is not enough cpu resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
