### PR TITLE
[release 0.20] Change emulated types in tests to pc

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -434,13 +434,12 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"allowAutoConverge": true}`
 
-				tests.UpdateClusterConfigValueAndWait("migrations", `{"allowAutoConverge": true}`)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"allowAutoConverge": true}`, 5*time.Second)
 			})
 
 			AfterEach(func() {
-				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig, 2*time.Second)
 			}, 60)
 
 			It("should complete a migration", func() {
@@ -494,11 +493,11 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": true}`)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": true}`, 5*time.Second)
 			})
 
 			AfterEach(func() {
-				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig, 2*time.Second)
 			}, 60)
 
 			It("should migrate a vmi with UNSAFE_MIGRATION flag set", func() {
@@ -833,10 +832,10 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				tests.UpdateClusterConfigValueAndWait("migrations", `{"bandwidthPerMigration" : "1Mi"}`)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"bandwidthPerMigration" : "1Mi"}`, 5*time.Second)
 			})
 			AfterEach(func() {
-				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig, 2*time.Second)
 			})
 			It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
@@ -943,10 +942,10 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				tests.UpdateClusterConfigValueAndWait("migrations", `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`, 5*time.Second)
 			})
 			AfterEach(func() {
-				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig, 5*time.Second)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -436,17 +436,11 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				originalMigrationConfig = cfgMap.Data["migrations"]
 				cfgMap.Data["migrations"] = `{"allowAutoConverge": true}`
 
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"allowAutoConverge": true}`)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			}, 60)
 
 			It("should complete a migration", func() {
@@ -500,19 +494,11 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"unsafeMigrationOverride": true}`
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": true}`)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			}, 60)
 
 			It("should migrate a vmi with UNSAFE_MIGRATION flag set", func() {
@@ -847,18 +833,10 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"bandwidthPerMigration" : "1Mi"}`
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"bandwidthPerMigration" : "1Mi"}`)
 			})
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
@@ -965,18 +943,10 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`)
 			})
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -525,7 +525,7 @@ var _ = Describe("Storage", func() {
 
 				configureToleration := func(toleration int) {
 					By("By configuring toleration")
-					tests.UpdateClusterConfigValueAndWait(virtconfig.LessPVCSpaceTolerationKey, strconv.Itoa(toleration))
+					tests.UpdateClusterConfigValueAndWait(virtconfig.LessPVCSpaceTolerationKey, strconv.Itoa(toleration), 2*time.Second)
 				}
 
 				It("Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", func() {

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -525,12 +525,7 @@ var _ = Describe("Storage", func() {
 
 				configureToleration := func(toleration int) {
 					By("By configuring toleration")
-					config, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-					config.Data[virtconfig.LessPVCSpaceTolerationKey] = strconv.Itoa(toleration)
-					_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(config)
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+					tests.UpdateClusterConfigValueAndWait(virtconfig.LessPVCSpaceTolerationKey, strconv.Itoa(toleration))
 				}
 
 				It("Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3869,14 +3869,18 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func UpdateClusterConfigValue(key string, value string) {
+// UpdateClusterConfigValueAndWait updates the given configuration in the kubevirt config map and then waits
+// to allow the configuration events to be propagated to the consumers.
+func UpdateClusterConfigValueAndWait(key string, value string) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 	cfgMap, err := virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 	cfgMap.Data[key] = value
 	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Update(cfgMap)
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	time.Sleep(2 * time.Second)
 }
 
 func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3870,17 +3870,17 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 }
 
 // UpdateClusterConfigValueAndWait updates the given configuration in the kubevirt config map and then waits
-// to allow the configuration events to be propagated to the consumers.
-func UpdateClusterConfigValueAndWait(key string, value string) {
+// for the given duration, to allow the configuration events to be propagated to the consumers.
+func UpdateClusterConfigValueAndWait(key string, value string, howLong time.Duration) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 	cfgMap, err := virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	cfgMap.Data[key] = value
 	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Update(cfgMap)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(howLong)
 }
 
 func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -381,11 +381,11 @@ var _ = Describe("Configurations", func() {
 
 		Context("with cluster memory overcommit being applied", func() {
 			BeforeEach(func() {
-				tests.UpdateClusterConfigValueAndWait("memory-overcommit", "200")
+				tests.UpdateClusterConfigValueAndWait("memory-overcommit", "200", 2*time.Second)
 			})
 
 			AfterEach(func() {
-				tests.UpdateClusterConfigValueAndWait("memory-overcommit", "")
+				tests.UpdateClusterConfigValueAndWait("memory-overcommit", "", 2*time.Second)
 			})
 
 			It("should set requested amount of memory according to the specified virtual memory", func() {
@@ -1281,7 +1281,7 @@ var _ = Describe("Configurations", func() {
 		defaultMachineTypeKey := "machine-type"
 
 		AfterEach(func() {
-			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "")
+			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "", 2*time.Second)
 		})
 
 		It("should set machine type from VMI spec", func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set machine type from kubevirt-config", func() {
-			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "pc-q35-3.0")
+			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "pc-q35-3.0", 2*time.Second)
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Machine.Type = ""
@@ -1321,7 +1321,7 @@ var _ = Describe("Configurations", func() {
 		defaultCPURequestKey := "cpu-request"
 
 		AfterEach(func() {
-			tests.UpdateClusterConfigValueAndWait(defaultCPURequestKey, "")
+			tests.UpdateClusterConfigValueAndWait(defaultCPURequestKey, "", 2*time.Second)
 		})
 
 		It("should set CPU request from VMI spec", func() {
@@ -1351,7 +1351,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set CPU request from kubevirt-config", func() {
-			tests.UpdateClusterConfigValueAndWait(defaultCPURequestKey, "800m")
+			tests.UpdateClusterConfigValueAndWait(defaultCPURequestKey, "800m", 2*time.Second)
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
@@ -1908,7 +1908,7 @@ var _ = Describe("Configurations", func() {
 			test_smbios := &cmdv1.SMBios{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
 			smbiosJson, err := json.Marshal(test_smbios)
 			Expect(err).ToNot(HaveOccurred())
-			tests.UpdateClusterConfigValueAndWait("smbios", string(smbiosJson))
+			tests.UpdateClusterConfigValueAndWait("smbios", string(smbiosJson), 2*time.Second)
 
 			By("Starting a VirtualMachineInstance")
 			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1279,6 +1279,11 @@ var _ = Describe("Configurations", func() {
 
 	Context("with machine type settings", func() {
 		defaultMachineTypeKey := "machine-type"
+		defaultEmulatedMachineType := "emulated-machines"
+
+		BeforeEach(func() {
+			tests.UpdateClusterConfigValueAndWait(defaultEmulatedMachineType, "q35*,pc-q35*,pc*")
+		})
 
 		AfterEach(func() {
 			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "", 2*time.Second)
@@ -1286,12 +1291,12 @@ var _ = Describe("Configurations", func() {
 
 		It("should set machine type from VMI spec", func() {
 			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Machine.Type = "pc-q35-3.0"
+			vmi.Spec.Domain.Machine.Type = "pc"
 			tests.RunVMIAndExpectLaunch(vmi, 30)
 			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(Equal("pc-q35-3.0"))
+			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
 		})
 
 		It("should set default machine type when it is not provided", func() {
@@ -1305,7 +1310,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set machine type from kubevirt-config", func() {
-			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "pc-q35-3.0", 2*time.Second)
+			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "pc")
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Machine.Type = ""
@@ -1313,7 +1318,7 @@ var _ = Describe("Configurations", func() {
 			runningVMISpec, err := tests.GetRunningVMISpec(vmi)
 
 			Expect(err).ToNot(HaveOccurred())
-			Expect(runningVMISpec.OS.Type.Machine).To(Equal("pc-q35-3.0"))
+			Expect(runningVMISpec.OS.Type.Machine).To(ContainSubstring("pc-i440"))
 		})
 	})
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -721,14 +721,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("should set default cpu model when vmi doesn't have it set", func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be loaded without error")
-
-				cfgMap.Data[defaultCPUModelKey] = defaultCPUModel
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be updated without error")
-
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel)
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 
@@ -743,15 +736,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("should not set default cpu model when vmi has it set", func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be loaded without error")
-
-				cfgMap.Data[defaultCPUModelKey] = defaultCPUModel
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be updated without error")
-
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel)
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Domain.CPU = &v1.CPU{
@@ -798,18 +783,12 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalFeatureGates = cfgMap.Data[virtconfig.FeatureGatesKey]
-				cfgMap.Data[virtconfig.FeatureGatesKey] = virtconfig.CPUNodeDiscoveryGate
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+
+				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, virtconfig.CPUNodeDiscoveryGate)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data[virtconfig.FeatureGatesKey] = originalFeatureGates
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, originalFeatureGates)
 
 				n, err := virtClient.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -721,7 +721,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("should set default cpu model when vmi doesn't have it set", func() {
-				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel)
+				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel, 5*time.Second)
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 
@@ -736,7 +736,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("should not set default cpu model when vmi has it set", func() {
-				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel)
+				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel, 5*time.Second)
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Domain.CPU = &v1.CPU{
@@ -784,11 +784,11 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred())
 				originalFeatureGates = cfgMap.Data[virtconfig.FeatureGatesKey]
 
-				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, virtconfig.CPUNodeDiscoveryGate)
+				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, virtconfig.CPUNodeDiscoveryGate, 5*time.Second)
 			})
 
 			AfterEach(func() {
-				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, originalFeatureGates)
+				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, originalFeatureGates, 2*time.Second)
 
 				n, err := virtClient.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -479,10 +479,10 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
-			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "true")
+			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "true", 2*time.Second)
 		})
 		AfterEach(func() {
-			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "false")
+			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "false", 2*time.Second)
 		})
 
 		It("[test_id:1773]should configure custom MAC address", func() {

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -479,10 +479,10 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
-			tests.UpdateClusterConfigValue("permitSlirpInterface", "true")
+			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "true")
 		})
 		AfterEach(func() {
-			tests.UpdateClusterConfigValue("permitSlirpInterface", "false")
+			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "false")
 		})
 
 		It("[test_id:1773]should configure custom MAC address", func() {

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Slirp Networking", func() {
 	var deadbeafVmi *v1.VirtualMachineInstance
 	var container k8sv1.Container
 	setSlirpEnabled := func(enable bool) {
-		tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", fmt.Sprintf("%t", enable))
+		tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", fmt.Sprintf("%t", enable), 2*time.Second)
 	}
 
 	setDefaultNetworkInterface := func(iface string) {
-		tests.UpdateClusterConfigValueAndWait("default-network-interface", fmt.Sprintf("%s", iface))
+		tests.UpdateClusterConfigValueAndWait("default-network-interface", fmt.Sprintf("%s", iface), 2*time.Second)
 	}
 
 	tests.BeforeAll(func() {

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Slirp Networking", func() {
 	var deadbeafVmi *v1.VirtualMachineInstance
 	var container k8sv1.Container
 	setSlirpEnabled := func(enable bool) {
-		tests.UpdateClusterConfigValue("permitSlirpInterface", fmt.Sprintf("%t", enable))
+		tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", fmt.Sprintf("%t", enable))
 	}
 
 	setDefaultNetworkInterface := func(iface string) {
-		tests.UpdateClusterConfigValue("default-network-interface", fmt.Sprintf("%s", iface))
+		tests.UpdateClusterConfigValueAndWait("default-network-interface", fmt.Sprintf("%s", iface))
 	}
 
 	tests.BeforeAll(func() {


### PR DESCRIPTION
Backports the #2719

Upstream and downstream machine types
differ:
  upstream   - pc-q35-3.0
  downstream - pc-q35-rhel7.4.0

To cover different machine types,
the tests for emulated types are
now testing specificaly the older
type and verifies that it indeed
changed.

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
