### PR TITLE
fix(#2738): multiple hook sidecars on the same hook point

### DIFF
--- a/pkg/hooks/BUILD.bazel
+++ b/pkg/hooks/BUILD.bazel
@@ -30,10 +30,13 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/hooks/info:go_default_library",
+        "//pkg/hooks/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/pkg/hooks/BUILD.bazel
+++ b/pkg/hooks/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     srcs = [
         "hooks_suite_test.go",
         "hooks_test.go",
+        "manager_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -50,12 +50,12 @@ var manager *Manager
 var once sync.Once
 
 type Manager struct {
-	callbacksPerHookPoint map[string][]*callBackClient
+	CallbacksPerHookPoint map[string][]*callBackClient
 }
 
 func GetManager() *Manager {
 	once.Do(func() {
-		manager = &Manager{callbacksPerHookPoint: make(map[string][]*callBackClient)}
+		manager = &Manager{CallbacksPerHookPoint: make(map[string][]*callBackClient)}
 	})
 	return manager
 }
@@ -70,7 +70,7 @@ func (m *Manager) Collect(numberOfRequestedHookSidecars uint, timeout time.Durat
 	sortCallbacksPerHookPoint(callbacksPerHookPoint)
 	log.Log.Infof("Sorted all collected sidecar sockets per hook point based on their priority and name: %v", callbacksPerHookPoint)
 
-	m.callbacksPerHookPoint = callbacksPerHookPoint
+	m.CallbacksPerHookPoint = callbacksPerHookPoint
 
 	return nil
 }
@@ -163,7 +163,7 @@ func processSideCarSocket(socketPath string) (*callBackClient, bool, error) {
 func sortCallbacksPerHookPoint(callbacksPerHookPoint map[string][]*callBackClient) {
 	for _, callbacks := range callbacksPerHookPoint {
 		for _, callback := range callbacks {
-			sort.Slice(callbacks, func(i, j int) bool {
+			sort.Slice(callback.subsribedHookPoints, func(i, j int) bool {
 				if callback.subsribedHookPoints[i].Priority == callback.subsribedHookPoints[j].Priority {
 					return strings.Compare(callback.subsribedHookPoints[i].Name, callback.subsribedHookPoints[j].Name) < 0
 				} else {
@@ -179,7 +179,7 @@ func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.Vir
 	if err != nil {
 		return "", fmt.Errorf("Failed to marshal domain spec: %v", domainSpec)
 	}
-	if callbacks, found := m.callbacksPerHookPoint[hooksInfo.OnDefineDomainHookPointName]; found {
+	if callbacks, found := m.CallbacksPerHookPoint[hooksInfo.OnDefineDomainHookPointName]; found {
 		for _, callback := range callbacks {
 			if callback.Version == hooksV1alpha1.Version || callback.Version == hooksV1alpha2.Version {
 				vmiJSON, err := json.Marshal(vmi)
@@ -228,7 +228,7 @@ func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.Vir
 }
 
 func (m *Manager) PreCloudInitIso(vmi *v1.VirtualMachineInstance, cloudInitData *cloudinit.CloudInitData) (*cloudinit.CloudInitData, error) {
-	if callbacks, found := m.callbacksPerHookPoint[hooksInfo.PreCloudInitIsoHookPointName]; found {
+	if callbacks, found := m.CallbacksPerHookPoint[hooksInfo.PreCloudInitIsoHookPointName]; found {
 		for _, callback := range callbacks {
 			if callback.Version == hooksV1alpha2.Version {
 				var resultData *cloudinit.CloudInitData

--- a/pkg/hooks/manager_test.go
+++ b/pkg/hooks/manager_test.go
@@ -1,0 +1,158 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package hooks_test
+
+import (
+	"context"
+	"fmt"
+	"google.golang.org/grpc"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/hooks"
+	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
+	hooksV1alpha1 "kubevirt.io/kubevirt/pkg/hooks/v1alpha1"
+)
+
+type dynamicInfoServer struct {
+	hookName          string
+	hookPointName     string
+	hookPointPriority int32
+}
+
+func (s dynamicInfoServer) Info(ctx context.Context, params *hooksInfo.InfoParams) (*hooksInfo.InfoResult, error) {
+	fmt.Fprintf(GinkgoWriter, "Hook's Info method has been called")
+
+	return &hooksInfo.InfoResult{
+		Name: s.hookName,
+		Versions: []string{
+			hooksV1alpha1.Version,
+		},
+		HookPoints: []*hooksInfo.HookPoint{
+			&hooksInfo.HookPoint{
+				Name:     s.hookPointName,
+				Priority: s.hookPointPriority,
+			},
+		},
+	}, nil
+}
+
+func hookListenAndServe(socketPath string, hookName string, hookPointName string, hookPointPriority int32) (net.Listener, error) {
+	socket, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	server := grpc.NewServer([]grpc.ServerOption{}...)
+	hooksInfo.RegisterInfoServer(server, dynamicInfoServer{
+		hookName:          hookName,
+		hookPointName:     hookPointName,
+		hookPointPriority: hookPointPriority,
+	})
+	// hooksV1alpha1.RegisterCallbacksServer(server, v1alpha1Server{})
+	fmt.Fprintf(GinkgoWriter, "Starting hook server exposing 'info' and 'v1alpha1' services on socket %s", socketPath)
+	go func() {
+		server.Serve(socket)
+	}()
+	return socket, nil
+}
+
+var _ = Describe("HooksManager", func() {
+	Context("With existing sockets", func() {
+		socketDir := hooks.HookSocketsSharedDirectory
+
+		BeforeEach(func() {
+			os.MkdirAll(socketDir, os.ModePerm)
+		})
+
+		It("Should find sidecar", func() {
+			hookPointName := hooksInfo.OnDefineDomainHookPointName
+
+			socketPath := filepath.Join(socketDir, "hook1.sock")
+			socket, err := hookListenAndServe(socketPath, "hook1", hookPointName, 0)
+			Expect(err).ToNot(HaveOccurred())
+			defer socket.Close()
+			defer os.Remove(socketPath)
+
+			manager := hooks.GetManager()
+			err = manager.Collect(1, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			callbackMaps := manager.CallbacksPerHookPoint
+			Expect(callbackMaps).Should(HaveKey(hookPointName))
+			Expect(callbackMaps[hookPointName]).Should(HaveLen(1))
+		})
+
+		It("Should find multiple sidecars on the same hook point", func() {
+			hookPointName := hooksInfo.OnDefineDomainHookPointName
+			hookNames := []string{"hook1", "hook2"}
+
+			for _, hookName := range hookNames {
+				socketPath := filepath.Join(socketDir, fmt.Sprintf("%s.sock", hookName))
+				socket, err := hookListenAndServe(socketPath, hookName, hookPointName, 0)
+				Expect(err).ToNot(HaveOccurred())
+				defer socket.Close()
+				defer os.Remove(socketPath)
+			}
+
+			manager := hooks.GetManager()
+			err := manager.Collect(uint(len(hookNames)), 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			callbackMaps := manager.CallbacksPerHookPoint
+			Expect(callbackMaps).Should(HaveKey(hookPointName))
+			Expect(callbackMaps[hookPointName]).Should(HaveLen(len(hookNames)))
+		})
+
+		It("Should find multiple sidecars on differrnt hook points", func() {
+			hookNameMap := map[string]string{
+				"hook1": hooksInfo.OnDefineDomainHookPointName,
+				"hook2": hooksInfo.PreCloudInitIsoHookPointName,
+			}
+			for hookName, hookPointName := range hookNameMap {
+				socketPath := filepath.Join(socketDir, fmt.Sprintf("%s.sock", hookName))
+				socket, err := hookListenAndServe(socketPath, hookName, hookPointName, 0)
+				Expect(err).ToNot(HaveOccurred())
+				defer socket.Close()
+				defer os.Remove(socketPath)
+			}
+
+			manager := hooks.GetManager()
+			err := manager.Collect(uint(len(hookNameMap)), 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			callbackMaps := manager.CallbacksPerHookPoint
+
+			for _, hookPointName := range hookNameMap {
+				Expect(callbackMaps).Should(HaveKey(hookPointName))
+				Expect(callbackMaps[hookPointName]).Should(HaveLen(1))
+			}
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(socketDir)
+		})
+	})
+})

--- a/pkg/hooks/manager_test.go
+++ b/pkg/hooks/manager_test.go
@@ -126,7 +126,7 @@ var _ = Describe("HooksManager", func() {
 			Expect(callbackMaps[hookPointName]).Should(HaveLen(len(hookNames)))
 		})
 
-		It("Should find multiple sidecars on differrnt hook points", func() {
+		It("Should find multiple sidecars on different hook points", func() {
 			hookNameMap := map[string]string{
 				"hook1": hooksInfo.OnDefineDomainHookPointName,
 				"hook2": hooksInfo.PreCloudInitIsoHookPointName,

--- a/pkg/hooks/manager_test.go
+++ b/pkg/hooks/manager_test.go
@@ -22,11 +22,12 @@ package hooks_test
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc"
 	"net"
 	"os"
 	"path/filepath"
 	"time"
+
+	"google.golang.org/grpc"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -71,8 +72,7 @@ func hookListenAndServe(socketPath string, hookName string, hookPointName string
 		hookPointName:     hookPointName,
 		hookPointPriority: hookPointPriority,
 	})
-	// hooksV1alpha1.RegisterCallbacksServer(server, v1alpha1Server{})
-	fmt.Fprintf(GinkgoWriter, "Starting hook server exposing 'info' and 'v1alpha1' services on socket %s", socketPath)
+	fmt.Fprintf(GinkgoWriter, "Starting hook server exposing 'info' services on socket %s", socketPath)
 	go func() {
 		server.Serve(socket)
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** :
Fixes #2738

**Special notes for your reviewer**:
* fix mistake in `sortCallbacksPerHookPoint` function
* make `hooks.manager.CallbacksPerHookPoint` field public for testing.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix panic when more than one sidecar containers are added to a VMI
```
