### PR TITLE
[fix] input device without bus

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -790,7 +790,21 @@ var _ = Describe("Converter", func() {
 			disabled := false
 			for _, controller := range domain.Spec.Devices.Controllers {
 				if controller.Type == "usb" && controller.Model == "none" {
-					disabled = !disabled
+					disabled = true
+				}
+			}
+
+			Expect(disabled).To(BeFalse(), "Expect controller not to be disabled")
+		})
+
+		It("should not disable usb controller when device with no bus is present", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.Domain.Devices.Inputs[0].Bus = ""
+			domain := vmiToDomain(vmi, c)
+			disabled := false
+			for _, controller := range domain.Spec.Devices.Controllers {
+				if controller.Type == "usb" && controller.Model == "none" {
+					disabled = true
 				}
 			}
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -579,6 +579,32 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
 			})
 
+			It("should start the VMI with usb controller when input device doesn't have bus", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
+					{
+						Name: "tablet0",
+						Type: "tablet",
+					},
+				}
+				By("Starting a VirtualMachineInstance")
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred(), "should start vmi")
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				By("Expecting the VirtualMachineInstance console")
+				expecter, err := tests.LoggedInAlpineExpecter(vmi)
+				Expect(err).ToNot(HaveOccurred(), "should get console")
+				defer expecter.Close()
+
+				By("Checking the number of usb under guest OS")
+				_, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
+					&expect.BExp{R: "2"},
+				}, 60*time.Second)
+				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
+			})
+
 			It("should start the VMI without usb controller", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 				By("Starting a VirtualMachineInstance")


### PR DESCRIPTION
**What this PR does / why we need it**:
When input device bus is not defined, default value is usb. But enabling of usb controller is done before checking input devices, so usb controller is never enabled. This PR fixes it.

Signed-off-by: ksimon1 <ksimon@redhat.com>

**Release note**:

```release-note
 fix issue, when input device doesn't have bus specified and usb controller is not enabled.
```
