### PR TITLE
Add hostdisk test for sata driver

### DIFF
--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -326,10 +326,12 @@ var _ = Describe("Storage", func() {
 					diskName := "disk-" + uuid.NewRandom().String() + ".img"
 					diskPath := filepath.Join(hostDiskDir, diskName)
 
-					It("[test_id:851]Should create a disk image and start", func() {
+					table.DescribeTable("Should create a disk image and start", func(driver string) {
 						By("Starting VirtualMachineInstance")
 						// do not choose a specific node to run the test
 						vmi := tests.NewRandomVMIWithHostDisk(diskPath, v1.HostDiskExistsOrCreate, "")
+						vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = driver
+
 						tests.RunVMIAndExpectLaunch(vmi, 30)
 
 						By("Checking if disk.img has been created")
@@ -343,7 +345,10 @@ var _ = Describe("Storage", func() {
 						)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(output).To(ContainSubstring(hostdisk.GetMountedHostDiskPath("host-disk", diskPath)))
-					})
+					},
+						table.Entry("[test_id:851]with virtio driver", "virtio"),
+						table.Entry("[test_id:3057]with sata driver", "sata"),
+					)
 
 					It("should start with multiple hostdisks in the same directory", func() {
 						By("Starting VirtualMachineInstance")


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing sata driver to verify whether we are missing functionality for sata and hostdisk.

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Verifies #2705 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
