### PR TITLE
Make the reporter number of failures to dump log for configurable.

### DIFF
--- a/cmd/dump/BUILD.bazel
+++ b/cmd/dump/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/reporter:go_default_library",
-        "//vendor/github.com/onsi/ginkgo/types:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/onsi/ginkgo/types"
 	"github.com/spf13/pflag"
 
 	"kubevirt.io/client-go/kubecli"
@@ -16,13 +15,10 @@ func main() {
 	var duration time.Duration
 	pflag.CommandLine.AddGoFlagSet(kubecli.FlagSet())
 	pflag.DurationVarP(&duration, "since", "s", 10*time.Minute, "collection window, defaults to 10 minutes")
-	maxFails := pflag.Int("maxfails", 10, "max failed tests to report, defaults to 10")
 	pflag.Parse()
 
-	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), *maxFails)
-	reporter.BeforeSuiteDidRun(nil)
-	reporter.SpecDidComplete(&types.SpecSummary{
-		State:   types.SpecStateFailed,
-		RunTime: duration,
-	})
+	// Hardcoding maxFails to 1 since the purpouse here is just to dump the state once
+	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), 1)
+	reporter.Cleanup()
+	reporter.Dump(duration)
 }

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -16,9 +16,10 @@ func main() {
 	var duration time.Duration
 	pflag.CommandLine.AddGoFlagSet(kubecli.FlagSet())
 	pflag.DurationVarP(&duration, "since", "s", 10*time.Minute, "collection window, defaults to 10 minutes")
+	maxFails := pflag.Int("maxfails", 10, "max failed tests to report, defaults to 10")
 	pflag.Parse()
 
-	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"))
+	reporter := reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), *maxFails)
 	reporter.BeforeSuiteDidRun(nil)
 	reporter.SpecDidComplete(&types.SpecSummary{
 		State:   types.SpecStateFailed,

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -23,13 +23,15 @@ import (
 type KubernetesReporter struct {
 	failureCount int
 	artifactsDir string
+	maxFails     int
 	mux          sync.Mutex
 }
 
-func NewKubernetesReporter(artifactsDir string) *KubernetesReporter {
+func NewKubernetesReporter(artifactsDir string, maxFailures int) *KubernetesReporter {
 	return &KubernetesReporter{
 		failureCount: 0,
 		artifactsDir: artifactsDir,
+		maxFails:     maxFailures,
 	}
 }
 
@@ -50,7 +52,7 @@ func (r *KubernetesReporter) SpecWillRun(specSummary *types.SpecSummary) {
 func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	r.mux.Lock()
 	defer r.mux.Unlock()
-	if r.failureCount > 10 {
+	if r.failureCount > r.maxFails {
 		return
 	}
 	if specSummary.HasFailureState() {

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -40,10 +40,7 @@ func (r *KubernetesReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, 
 }
 
 func (r *KubernetesReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {
-	// clean up artifacts from previous run
-	if r.artifactsDir != "" {
-		os.RemoveAll(r.artifactsDir)
-	}
+	r.Cleanup()
 }
 
 func (r *KubernetesReporter) SpecWillRun(specSummary *types.SpecSummary) {
@@ -65,7 +62,12 @@ func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 	if r.artifactsDir == "" {
 		return
 	}
+	r.Dump(specSummary.RunTime)
+}
 
+// Dump dumps the current state of the cluster. The relevant logs are collected starting
+// from the since parameter.
+func (r *KubernetesReporter) Dump(since time.Duration) {
 	virtCli, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get client: %v\n", err)
@@ -77,15 +79,23 @@ func (r *KubernetesReporter) SpecDidComplete(specSummary *types.SpecSummary) {
 		return
 	}
 
-	r.logEvents(virtCli, specSummary)
-	r.logNodes(virtCli, specSummary)
-	r.logPods(virtCli, specSummary)
-	r.logVMIs(virtCli, specSummary)
-	r.logDomainXMLs(virtCli, specSummary)
-	r.logLogs(virtCli, specSummary)
+	r.logEvents(virtCli, since)
+	r.logNodes(virtCli)
+	r.logPods(virtCli)
+	r.logVMIs(virtCli)
+	r.logDomainXMLs(virtCli)
+	r.logLogs(virtCli, since)
 }
 
-func (r *KubernetesReporter) logDomainXMLs(virtCli kubecli.KubevirtClient, specSummary *types.SpecSummary) {
+// Cleanup cleans up the current content of the artifactsDir
+func (r *KubernetesReporter) Cleanup() {
+	// clean up artifacts from previous run
+	if r.artifactsDir != "" {
+		os.RemoveAll(r.artifactsDir)
+	}
+}
+
+func (r *KubernetesReporter) logDomainXMLs(virtCli kubecli.KubevirtClient) {
 
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_domains.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -112,7 +122,7 @@ func (r *KubernetesReporter) logDomainXMLs(virtCli kubecli.KubevirtClient, specS
 	}
 }
 
-func (r *KubernetesReporter) logVMIs(virtCli kubecli.KubevirtClient, specSummary *types.SpecSummary) {
+func (r *KubernetesReporter) logVMIs(virtCli kubecli.KubevirtClient) {
 
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_vmis.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -136,7 +146,7 @@ func (r *KubernetesReporter) logVMIs(virtCli kubecli.KubevirtClient, specSummary
 	fmt.Fprintln(f, string(j))
 }
 
-func (r *KubernetesReporter) logPods(virtCli kubecli.KubevirtClient, specSummary *types.SpecSummary) {
+func (r *KubernetesReporter) logPods(virtCli kubecli.KubevirtClient) {
 
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_pods.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -160,7 +170,7 @@ func (r *KubernetesReporter) logPods(virtCli kubecli.KubevirtClient, specSummary
 	fmt.Fprintln(f, string(j))
 }
 
-func (r *KubernetesReporter) logNodes(virtCli kubecli.KubevirtClient, specSummary *types.SpecSummary) {
+func (r *KubernetesReporter) logNodes(virtCli kubecli.KubevirtClient) {
 
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_nodes.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -184,7 +194,7 @@ func (r *KubernetesReporter) logNodes(virtCli kubecli.KubevirtClient, specSummar
 	fmt.Fprintln(f, string(j))
 }
 
-func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, specSummary *types.SpecSummary) {
+func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, since time.Duration) {
 
 	logsdir := filepath.Join(r.artifactsDir, "pods")
 
@@ -193,7 +203,7 @@ func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, specSummary
 		return
 	}
 
-	startTime := time.Now().Add(-specSummary.RunTime).Add(-5 * time.Second)
+	startTime := time.Now().Add(-since).Add(-5 * time.Second)
 
 	pods, err := virtCli.CoreV1().Pods(v1.NamespaceAll).List(v12.ListOptions{})
 	if err != nil {
@@ -231,7 +241,7 @@ func (r *KubernetesReporter) logLogs(virtCli kubecli.KubevirtClient, specSummary
 	}
 }
 
-func (r *KubernetesReporter) logEvents(virtCli kubecli.KubevirtClient, specSummary *types.SpecSummary) {
+func (r *KubernetesReporter) logEvents(virtCli kubecli.KubevirtClient, since time.Duration) {
 
 	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_events.log", r.failureCount)),
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -241,7 +251,7 @@ func (r *KubernetesReporter) logEvents(virtCli kubecli.KubevirtClient, specSumma
 	}
 	defer f.Close()
 
-	startTime := time.Now().Add(-specSummary.RunTime).Add(-5 * time.Second)
+	startTime := time.Now().Add(-since).Add(-5 * time.Second)
 
 	events, err := virtCli.CoreV1().Events(v1.NamespaceAll).List(v12.ListOptions{})
 	if err != nil {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -20,7 +20,9 @@
 package tests_test
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -32,7 +34,8 @@ import (
 )
 
 func TestTests(t *testing.T) {
-	reporters := []Reporter{reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"))}
+	maxFails := getMaxFailsFromEnv()
+	reporters := []Reporter{reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), maxFails)}
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)
 	}
@@ -49,3 +52,18 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	tests.AfterTestSuitCleanup()
 })
+
+func getMaxFailsFromEnv() int {
+	maxFailsEnv := os.Getenv("REPORTER_MAX_FAILS")
+	if maxFailsEnv == "" {
+		return 10
+	}
+
+	maxFails, err := strconv.Atoi(maxFailsEnv)
+	if err != nil { // if the variable is set with a non int value
+		fmt.Println("Invalid REPORTER_MAX_FAILS variable, defaulting to 10")
+		return 10
+	}
+
+	return maxFails
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently the kubernetes test reporter dumps the information related to the first 10 failing tests. 

With this PR we make that number configurable, so we can investigate a higher number of failures, especially for new lanes where some misconfiguration can cause different errors in different areas we want to tackle concurrently.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

NONE

```
