### PR TITLE
[release-0.20] Backport of #2646: Flaky tests: Wait for configmaps updated values to be consolidated

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -434,19 +434,12 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"allowAutoConverge": true}`
 
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"allowAutoConverge": true}`)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			}, 60)
 
 			It("should complete a migration", func() {
@@ -500,19 +493,11 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"unsafeMigrationOverride": true}`
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": true}`)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			}, 60)
 
 			It("should migrate a vmi with UNSAFE_MIGRATION flag set", func() {
@@ -847,18 +832,10 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"bandwidthPerMigration" : "1Mi"}`
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"bandwidthPerMigration" : "1Mi"}`)
 			})
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
@@ -965,18 +942,10 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				cfgMap.Data["migrations"] = `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`)
 			})
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data["migrations"] = originalMigrationConfig
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -525,12 +525,7 @@ var _ = Describe("Storage", func() {
 
 				configureToleration := func(toleration int) {
 					By("By configuring toleration")
-					config, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-					config.Data[virtconfig.LessPVCSpaceTolerationKey] = strconv.Itoa(toleration)
-					_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(config)
-					ExpectWithOffset(1, err).ToNot(HaveOccurred())
+					tests.UpdateClusterConfigValueAndWait(virtconfig.LessPVCSpaceTolerationKey, strconv.Itoa(toleration))
 				}
 
 				It("Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3869,14 +3869,18 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func UpdateClusterConfigValue(key string, value string) {
+// UpdateClusterConfigValueAndWait updates the given configuration in the kubevirt config map and then waits
+// to allow the configuration events to be propagated to the consumers.
+func UpdateClusterConfigValueAndWait(key string, value string) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 	cfgMap, err := virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Get(kubevirtConfig, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	cfgMap.Data[key] = value
 	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Update(cfgMap)
-	Expect(err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	time.Sleep(2 * time.Second)
 }
 
 func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -381,11 +381,11 @@ var _ = Describe("Configurations", func() {
 
 		Context("with cluster memory overcommit being applied", func() {
 			BeforeEach(func() {
-				tests.UpdateClusterConfigValue("memory-overcommit", "200")
+				tests.UpdateClusterConfigValueAndWait("memory-overcommit", "200")
 			})
 
 			AfterEach(func() {
-				tests.UpdateClusterConfigValue("memory-overcommit", "")
+				tests.UpdateClusterConfigValueAndWait("memory-overcommit", "")
 			})
 
 			It("should set requested amount of memory according to the specified virtual memory", func() {
@@ -1281,7 +1281,7 @@ var _ = Describe("Configurations", func() {
 		defaultMachineTypeKey := "machine-type"
 
 		AfterEach(func() {
-			tests.UpdateClusterConfigValue(defaultMachineTypeKey, "")
+			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "")
 		})
 
 		It("should set machine type from VMI spec", func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set machine type from kubevirt-config", func() {
-			tests.UpdateClusterConfigValue(defaultMachineTypeKey, "pc-q35-3.0")
+			tests.UpdateClusterConfigValueAndWait(defaultMachineTypeKey, "pc-q35-3.0")
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Machine.Type = ""
@@ -1321,7 +1321,7 @@ var _ = Describe("Configurations", func() {
 		defaultCPURequestKey := "cpu-request"
 
 		AfterEach(func() {
-			tests.UpdateClusterConfigValue(defaultCPURequestKey, "")
+			tests.UpdateClusterConfigValueAndWait(defaultCPURequestKey, "")
 		})
 
 		It("should set CPU request from VMI spec", func() {
@@ -1351,7 +1351,7 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("should set CPU request from kubevirt-config", func() {
-			tests.UpdateClusterConfigValue(defaultCPURequestKey, "800m")
+			tests.UpdateClusterConfigValueAndWait(defaultCPURequestKey, "800m")
 
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Resources = v1.ResourceRequirements{

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -721,14 +721,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("should set default cpu model when vmi doesn't have it set", func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be loaded without error")
-
-				cfgMap.Data[defaultCPUModelKey] = defaultCPUModel
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be updated without error")
-
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel)
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 
@@ -743,15 +736,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("should not set default cpu model when vmi has it set", func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be loaded without error")
-
-				cfgMap.Data[defaultCPUModelKey] = defaultCPUModel
-
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred(), "Expect config map to be updated without error")
-
-				time.Sleep(5 * time.Second)
+				tests.UpdateClusterConfigValueAndWait(defaultCPUModelKey, defaultCPUModel)
 
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				vmi.Spec.Domain.CPU = &v1.CPU{
@@ -798,18 +783,12 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalFeatureGates = cfgMap.Data[virtconfig.FeatureGatesKey]
-				cfgMap.Data[virtconfig.FeatureGatesKey] = virtconfig.CPUNodeDiscoveryGate
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
-				time.Sleep(5 * time.Second)
+
+				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, virtconfig.CPUNodeDiscoveryGate)
 			})
 
 			AfterEach(func() {
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
-				Expect(err).ToNot(HaveOccurred())
-				cfgMap.Data[virtconfig.FeatureGatesKey] = originalFeatureGates
-				_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Update(cfgMap)
-				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, originalFeatureGates)
 
 				n, err := virtClient.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -479,10 +479,10 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Context("VirtualMachineInstance with custom MAC address and slirp interface", func() {
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
-			tests.UpdateClusterConfigValue("permitSlirpInterface", "true")
+			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "true")
 		})
 		AfterEach(func() {
-			tests.UpdateClusterConfigValue("permitSlirpInterface", "false")
+			tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", "false")
 		})
 
 		It("[test_id:1773]should configure custom MAC address", func() {

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Slirp Networking", func() {
 	var deadbeafVmi *v1.VirtualMachineInstance
 	var container k8sv1.Container
 	setSlirpEnabled := func(enable bool) {
-		tests.UpdateClusterConfigValue("permitSlirpInterface", fmt.Sprintf("%t", enable))
+		tests.UpdateClusterConfigValueAndWait("permitSlirpInterface", fmt.Sprintf("%t", enable))
 	}
 
 	setDefaultNetworkInterface := func(iface string) {
-		tests.UpdateClusterConfigValue("default-network-interface", fmt.Sprintf("%s", iface))
+		tests.UpdateClusterConfigValueAndWait("default-network-interface", fmt.Sprintf("%s", iface))
 	}
 
 	tests.BeforeAll(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of #2646: Flaky tests: Wait for configmaps updated values to be consolidated

**Release note**:
```release-note
NONE
```
