### PR TITLE
Improve metrics tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -132,6 +132,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Infrastructure", func() {
 		tests.BeforeAll(func() {
 			tests.BeforeTestCleanup()
 
-			// The initial testd for the metrics subsystem used only a single VM for the sake of the simplicity.
+			// The initial test for the metrics subsystem used only a single VM for the sake of simplicity.
 			// However, testing a single entity is a corner case (do we test handling sequences? potential clashes
 			// in maps? and so on).
 			// Thus, we run now two VMIs per testcase. A more realistic test would use a random number of VMIs >= 3,

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -126,8 +126,10 @@ var _ = Describe("Infrastructure", func() {
 			// block device?
 			vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			tests.AppendEmptyDisk(vmi, "testdisk", "virtio", "1Gi")
-			pinVMIOnNode(vmi, preferredNodeName)
 
+			if preferredNodeName != "" {
+				pinVMIOnNode(vmi, preferredNodeName)
+			}
 			nodeName := startVMI(vmi)
 			if preferredNodeName != "" {
 				Expect(nodeName).To(Equal(preferredNodeName), "Should run VMIs on the same node")
@@ -155,7 +157,9 @@ var _ = Describe("Infrastructure", func() {
 		tests.BeforeAll(func() {
 			tests.BeforeTestCleanup()
 
+			// to avoid testing a corner case, we use 2+ VMIs
 			nodeName := prepareVMIForTests("")
+			prepareVMIForTests(nodeName)
 
 			By("Finding the prometheus endpoint")
 			pod, err = kubecli.NewVirtHandlerClient(virtClient).ForNode(nodeName).Pod()

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -157,8 +157,14 @@ var _ = Describe("Infrastructure", func() {
 		tests.BeforeAll(func() {
 			tests.BeforeTestCleanup()
 
-			// to avoid testing a corner case, we use 2+ VMIs
+			// The initial testd for the metrics subsystem used only a single VM for the sake of the simplicity.
+			// However, testing a single entity is a corner case (do we test handling sequences? potential clashes
+			// in maps? and so on).
+			// Thus, we run now two VMIs per testcase. A more realistic test would use a random number of VMIs >= 3,
+			// but we don't do now to make test run quickly and (more important) because lack of resources on CI.
+
 			nodeName := prepareVMIForTests("")
+			// any node is fine, we don't really care, as long as we run all VMIs on it.
 			prepareVMIForTests(nodeName)
 
 			By("Finding the prometheus endpoint")


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve the prometheus metrics tests using more than one VMI instance in the tests.

**Special notes for your reviewer**:
Originated from review of https://github.com/kubevirt/kubevirt/pull/2501
Followup of https://github.com/kubevirt/kubevirt/pull/2512 - a big refactoring happened in between

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
