### PR TITLE
Introduce the shasum switch for the tests, needed when testing on OKD 4+

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -40,6 +40,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
@@ -395,6 +396,11 @@ var _ = Describe("Operator", func() {
 	}
 
 	ensureShasums := func() {
+		if tests.SkipShasumCheck {
+			log.Log.Warning("Cannot use shasums, skipping")
+			return
+		}
+
 		for _, name := range []string{"virt-operator", "virt-api", "virt-controller"} {
 			deployment, err := virtClient.AppsV1().Deployments(tests.KubeVirtInstallNamespace).Get(name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -613,6 +619,10 @@ spec:
 
 	Describe("should start a VM", func() {
 		It("using virt-launcher with a shasum", func() {
+
+			if tests.SkipShasumCheck {
+				Skip("Cannot currently test shasums, skipping")
+			}
 
 			By("starting a VM")
 			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -99,6 +99,7 @@ var PreviousReleaseTag = ""
 var PreviousReleaseRegistry = ""
 var ConfigFile = ""
 var Config *KubeVirtTestsConfiguration
+var SkipShasumCheck bool
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -120,6 +121,7 @@ func init() {
 	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
+	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 }
 
 func FlagParse() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The tests requiering shasums are failing
on crio due to crio not supporting shasums.

This patch introduces the switch to let
the tests know that it shoould not test
shasums on crio.

The switch is used when running the tests
on OKD 4+ cluster using cri-o.

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
