### PR TITLE
Add Security Feature tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -68,6 +68,7 @@ go_test(
         "operator_test.go",
         "probes_test.go",
         "replicaset_test.go",
+        "security_features_test.go",
         "stability_test.go",
         "storage_test.go",
         "subresource_api_test.go",

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+
+package tests_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("SecurityFeatures", func() {
+	tests.FlagParse()
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	tests.PanicOnError(err)
+
+	Context("Check virt-launcher securityContext", func() {
+
+		var container k8sv1.Container
+		var vmi *v1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+		})
+
+		It("[test_id:2953]Ensure virt-launcher pod securityContext type is virt_launcher.process", func() {
+
+			By("Starting a VirtualMachineInstance")
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Check virt-launcher pod SecurityContext values")
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			Expect(vmiPod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal("virt_launcher.process"))
+		})
+
+		It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", func() {
+
+			By("Starting a VirtualMachineInstance")
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Check virt-launcher pod SecurityContext values")
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			for _, containerSpec := range vmiPod.Spec.Containers {
+				if containerSpec.Name == "compute" {
+					container = containerSpec
+					break
+				}
+			}
+			Expect(*container.SecurityContext.Privileged).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
a) Ensure virt-launcher pod securityContext type is
virt_launcher.process

b) Make sure the virt-launcher pod is not priviledged.

Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: `Add test-cases related to security-features`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
