### PR TITLE
Avoid panic under GetDomain method

### DIFF
--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -237,7 +237,7 @@ func (l *Launcher) GetDomain(ctx context.Context, request *cmdv1.EmptyRequest) (
 		return response, nil
 	}
 
-	if len(list) >= 0 {
+	if len(list) > 0 {
 		if domain, err := json.Marshal(list[0]); err != nil {
 			log.Log.Reason(err).Errorf("Failed to marshal domain")
 			response.Response.Success = false

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -119,6 +119,17 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(domain.ObjectMeta.Name).To(Equal("testvmi1"))
 		})
 
+		It("should list no domain if no domain is there yet", func() {
+			var list []*api.Domain
+
+			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domain, exists, err := client.GetDomain()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(exists).To(BeFalse())
+			Expect(domain).ToNot(Equal(nil))
+		})
+
 		It("client should return disconnected after server stops", func() {
 			err := client.Ping()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Should fix
```
goroutine 88 [running]:
kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server.(*Launcher).GetDomain(0xc00020d1c0, 0x16daba0, 0xc0002a4390, 0xc000728260, 0xc00020d1c0, 0xc0002a4300, 0x13a4c80)
	pkg/virt-launcher/virtwrap/cmd-server/server.go:241 +0x310
kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1._Cmd_GetDomain_Handler(0x1471de0, 0xc00020d1c0, 0x16daba0, 0xc0002a4390, 0xc00072c3c0, 0x0, 0x0, 0x0, 0x0, 0x0)
	bazel-out/k8-fastbuild/bin/pkg/handler-launcher-com/cmd/v1/linux_amd64_stripped/kubevirt_cmd_go_proto%/kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1/cmd.pb.go:768 +0x23e
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000498d80, 0x16e6a60, 0xc000714300, 0xc000766000, 0xc000335200, 0x2274aa8, 0x0, 0x0, 0x0)
	external/org_golang_google_grpc/server.go:971 +0x4a2
google.golang.org/grpc.(*Server).handleStream(0xc000498d80, 0x16e6a60, 0xc000714300, 0xc000766000, 0x0)
	external/org_golang_google_grpc/server.go:1250 +0xd61
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000756020, 0xc000498d80, 0x16e6a60, 0xc000714300, 0xc000766000)
	external/org_golang_google_grpc/server.go:690 +0x9f
created by google.golang.org/grpc.(*Server).serveStreams.func1
	external/org_golang_google_grpc/server.go:688 +0xa1
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix GetDomain panic
```
