### PR TITLE
[WIP]Expose permitBridge config through kubevirt-CR

### DIFF
--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -5,6 +5,8 @@ metadata:
   labels:
     kubevirt.io: ""
   name: {{.Namespace}}
+spec:
+  permitBridgeInterfaceOnPodNetwork: true
 {{index .GeneratedManifests "prometheus.yaml.in"}}
 {{index .GeneratedManifests "rbac-cluster.authorization.k8s.yaml.in"}}
 {{index .GeneratedManifests "rbac-kubevirt.authorization.k8s.yaml.in"}}

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -1896,6 +1896,13 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtSpec(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
+					"permitBridgeInterfaceOnPodNetwork": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether bridge is allowed on pod network",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1228,6 +1228,9 @@ type KubeVirtSpec struct {
 	// The name of the Prometheus service account that needs read-access to KubeVirt endpoints
 	// Defaults to prometheus-k8s
 	MonitorAccount string `json:"monitorAccount,omitempty"`
+
+	//Whether bridge is allowed on pod network
+	PermitBridgeInterfaceOnPodNetwork bool `json:"permitBridgeInterfaceOnPodNetwork,omitempty"`
 }
 
 // KubeVirtStatus represents information pertaining to a KubeVirt deployment.

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -257,11 +257,12 @@ func (KubeVirtList) SwaggerDoc() map[string]string {
 
 func (KubeVirtSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"imageTag":         "The image tag to use for the continer images installed.\nDefaults to the same tag as the operator's container image.",
-		"imageRegistry":    "The image registry to pull the container images from\nDefaults to the same registry the operator's container image is pulled from.",
-		"imagePullPolicy":  "The ImagePullPolicy to use.",
-		"monitorNamespace": "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
-		"monitorAccount":   "The name of the Prometheus service account that needs read-access to KubeVirt endpoints\nDefaults to prometheus-k8s",
+		"imageTag":                          "The image tag to use for the continer images installed.\nDefaults to the same tag as the operator's container image.",
+		"imageRegistry":                     "The image registry to pull the container images from\nDefaults to the same registry the operator's container image is pulled from.",
+		"imagePullPolicy":                   "The ImagePullPolicy to use.",
+		"monitorNamespace":                  "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
+		"monitorAccount":                    "The name of the Prometheus service account that needs read-access to KubeVirt endpoints\nDefaults to prometheus-k8s",
+		"permitBridgeInterfaceOnPodNetwork": "Whether bridge is allowed on pod network",
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR makes the permitBridgOnPodNetwork config
to be exposed on the kubevirt-CR. that way we can validate
the config before kubevirt is deployed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
