### PR TITLE
Always have compute as the first container in the virt-launcher pod.

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -736,8 +736,8 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_DEBUG_LOGS, Value: "1"})
 	}
 
-	// Make sure the compute container is always the first since the cni mutating webhook will add the
-	// requested resources to the first container of the pod
+	// Make sure the compute container is always the first since the mutating webhook shipped with the sriov operator
+	// for adding the requested resources to the pod will add them to the first container of the list
 	containers := []k8sv1.Container{compute}
 	containersDisks := containerdisk.GenerateContainers(vmi, "container-disks", "virt-bin-share-dir")
 	containers = append(containers, containersDisks...)

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -678,7 +678,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	volumes = append(volumes, k8sv1.Volume{Name: "infra-ready-mount", VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}}})
 
-	containers := containerdisk.GenerateContainers(vmi, "container-disks", "virt-bin-share-dir")
+	containersDisks := containerdisk.GenerateContainers(vmi, "container-disks", "virt-bin-share-dir")
 
 	networkToResourceMap, err := getNetworkToResourceMap(t.virtClient, vmi)
 	if err != nil {
@@ -700,7 +700,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	}
 
 	// VirtualMachineInstance target container
-	container := k8sv1.Container{
+	compute := k8sv1.Container{
 		Name:            "compute",
 		Image:           t.launcherImage,
 		ImagePullPolicy: imagePullPolicy,
@@ -720,25 +720,28 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	}
 
 	if vmi.Spec.ReadinessProbe != nil {
-		container.ReadinessProbe = copyProbe(vmi.Spec.ReadinessProbe)
-		container.ReadinessProbe.InitialDelaySeconds = container.ReadinessProbe.InitialDelaySeconds + LibvirtStartupDelay
+		compute.ReadinessProbe = copyProbe(vmi.Spec.ReadinessProbe)
+		compute.ReadinessProbe.InitialDelaySeconds = compute.ReadinessProbe.InitialDelaySeconds + LibvirtStartupDelay
 	}
 
 	if vmi.Spec.LivenessProbe != nil {
-		container.LivenessProbe = copyProbe(vmi.Spec.LivenessProbe)
-		container.LivenessProbe.InitialDelaySeconds = container.LivenessProbe.InitialDelaySeconds + LibvirtStartupDelay
+		compute.LivenessProbe = copyProbe(vmi.Spec.LivenessProbe)
+		compute.LivenessProbe.InitialDelaySeconds = compute.LivenessProbe.InitialDelaySeconds + LibvirtStartupDelay
 	}
 
 	for networkName, resourceName := range networkToResourceMap {
 		varName := fmt.Sprintf("KUBEVIRT_RESOURCE_NAME_%s", networkName)
-		container.Env = append(container.Env, k8sv1.EnvVar{Name: varName, Value: resourceName})
+		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: varName, Value: resourceName})
 	}
 
 	if _, ok := vmi.Labels[debugLogs]; ok {
-		container.Env = append(container.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_DEBUG_LOGS, Value: "1"})
+		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_DEBUG_LOGS, Value: "1"})
 	}
 
-	containers = append(containers, container)
+	// Make sure the compute container is always the first since the cni mutating webhook will add the
+	// requested resources to the first container of the pod
+	containers := []k8sv1.Container{compute}
+	containers = append(containers, containersDisks...)
 
 	volumes = append(volumes,
 		k8sv1.Volume{

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -678,8 +678,6 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	volumes = append(volumes, k8sv1.Volume{Name: "infra-ready-mount", VolumeSource: k8sv1.VolumeSource{EmptyDir: &k8sv1.EmptyDirVolumeSource{}}})
 
-	containersDisks := containerdisk.GenerateContainers(vmi, "container-disks", "virt-bin-share-dir")
-
 	networkToResourceMap, err := getNetworkToResourceMap(t.virtClient, vmi)
 	if err != nil {
 		return nil, err
@@ -741,6 +739,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	// Make sure the compute container is always the first since the cni mutating webhook will add the
 	// requested resources to the first container of the pod
 	containers := []k8sv1.Container{compute}
+	containersDisks := containerdisk.GenerateContainers(vmi, "container-disks", "virt-bin-share-dir")
 	containers = append(containers, containersDisks...)
 
 	volumes = append(volumes,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1141,6 +1141,14 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("pull-secret-2"))
 				Expect(pod.Spec.ImagePullSecrets[1].Name).To(Equal("pull-secret-1"))
 			})
+
+			It("should have compute as first container in the pod", func() {
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.Containers[0].Image).To(Equal("kubevirt/virt-launcher"))
+				Expect(pod.Spec.Containers[0].Name).To(Equal("compute"))
+				Expect(pod.Spec.Containers[1].Name).To(Equal("volumecontainerdisk1"))
+			})
 		})
 
 		Context("with sriov interface", func() {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -339,7 +339,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				podOutputCfgMap, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
-					vmiPod.Spec.Containers[1].Name,
+					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
 						configMapPath + "/config1",
 						configMapPath + "/config2",
@@ -371,7 +371,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				podOutputSecret, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
-					vmiPod.Spec.Containers[1].Name,
+					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
 						secretPath + "/user",
 						secretPath + "/password",
@@ -440,7 +440,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				podOutput1, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
-					vmiPod.Spec.Containers[1].Name,
+					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
 						secretPath + "/ssh-privatekey",
 					},
@@ -451,7 +451,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				podOutput2, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,
-					vmiPod.Spec.Containers[1].Name,
+					vmiPod.Spec.Containers[0].Name,
 					[]string{"cat",
 						secretPath + "/ssh-publickey",
 					},

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -668,7 +668,7 @@ spec:
 			pods, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(metav1.ListOptions{LabelSelector: labelSelector})
 			Expect(err).ToNot(HaveOccurred(), "Should list pods")
 			Expect(len(pods.Items)).To(Equal(1))
-			Expect(usesSha(pods.Items[0].Spec.Containers[1].Image)).To(BeTrue(), "launcher pod should use shasum")
+			Expect(usesSha(pods.Items[0].Spec.Containers[0].Image)).To(BeTrue(), "launcher pod should use shasum")
 
 		})
 	})

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Slirp Networking", func() {
 		output, err := tests.ExecuteCommandOnPod(
 			virtClient,
 			vmiPod,
-			vmiPod.Spec.Containers[1].Name,
+			vmiPod.Spec.Containers[0].Name,
 			[]string{"cat", "/proc/net/tcp"},
 		)
 		log.Log.Infof("%v", output)
@@ -106,7 +106,7 @@ var _ = Describe("Slirp Networking", func() {
 		output, err = tests.ExecuteCommandOnPod(
 			virtClient,
 			vmiPod,
-			vmiPod.Spec.Containers[1].Name,
+			vmiPod.Spec.Containers[0].Name,
 			[]string{"curl", "-s", "--retry", "30", "--retry-delay", "30", "127.0.0.1"},
 		)
 		log.Log.Infof("%v", output)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When we have container disk volumes, those containers are put at the beginning of the container list of the launcher pod, before the compute container.
This may be a problem when using the sriov mutating webhook, which parses the requested network attachment definitions of the pod and modifies the pod adding the requested resources to the first container. If the first container is not the compute one, we are requesting resources for the wrong container (see https://github.com/openshift/ose-sriov-dp-admission-controller/blob/e65f11b5eb7da1918b439a60d7fcc814719b1433/pkg/webhook/webhook.go#L325).

In this PR we ensure the compute container is always the first one of the list.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

Change the virt-launcher pod to always have the computer container as the first of the pod.

```
