### PR TITLE
Add Prometheus alert rules for virt-api

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -282,6 +282,7 @@ spec:
           - monitoring.coreos.com
           resources:
           - servicemonitors
+          - prometheusrules
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -137,6 +137,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - prometheusrules
   verbs:
   - get
   - list

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -214,6 +214,21 @@ func Execute() {
 		app.stores.ServiceMonitorCache = app.informerFactory.DummyOperatorServiceMonitor().GetStore()
 	}
 
+	prometheusRuleEnabled, err := util.IsPrometheusRuleEnabled(app.clientSet)
+	if err != nil {
+		golog.Fatalf("Error checking for PrometheusRule: %v", err)
+	}
+	if prometheusRuleEnabled {
+		log.Log.Info("prometheusrule is defined")
+		app.informers.PrometheusRule = app.informerFactory.OperatorPrometheusRule()
+		app.stores.PrometheusRuleCache = app.informerFactory.OperatorPrometheusRule().GetStore()
+		app.stores.PrometheusRulesEnabled = true
+	} else {
+		log.Log.Info("prometheusrule is not defined")
+		app.informers.PrometheusRule = app.informerFactory.DummyOperatorPrometheusRule()
+		app.stores.PrometheusRuleCache = app.informerFactory.DummyOperatorPrometheusRule().GetStore()
+	}
+
 	if err = app.getSelfSignedCert(); err != nil {
 		panic(err)
 	}

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -242,6 +242,7 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					"servicemonitors",
+					"prometheusrules",
 				},
 				Verbs: []string{
 					"get", "list", "watch", "create", "delete", "update", "patch",

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -91,6 +91,7 @@ func NewKubeVirtController(
 			InstallStrategyJob:       controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("Jobs")),
 			PodDisruptionBudget:      controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("PodDisruptionBudgets")),
 			ServiceMonitor:           controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("ServiceMonitor")),
+			PrometheusRule:           controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("PrometheusRule")),
 		},
 		installStrategyMap: make(map[string]*installstrategy.InstallStrategy),
 		operatorNamespace:  operatorNamespace,
@@ -303,6 +304,18 @@ func NewKubeVirtController(
 		},
 	})
 
+	c.informers.PrometheusRule.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.genericAddHandler(obj, c.kubeVirtExpectations.PrometheusRule)
+		},
+		DeleteFunc: func(obj interface{}) {
+			c.genericDeleteHandler(obj, c.kubeVirtExpectations.PrometheusRule)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.genericUpdateHandler(oldObj, newObj, c.kubeVirtExpectations.PrometheusRule)
+		},
+	})
+
 	return &c
 }
 
@@ -471,6 +484,7 @@ func (c *KubeVirtController) Run(threadiness int, stopCh <-chan struct{}) {
 	cache.WaitForCacheSync(stopCh, c.informers.PodDisruptionBudget.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.ServiceMonitor.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.Namespace.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.informers.PrometheusRule.HasSynced)
 
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -209,3 +209,24 @@ func IsServiceMonitorEnabled(clientset kubecli.KubevirtClient) (bool, error) {
 
 	return false, nil
 }
+
+// IsPrometheusRuleEnabled returns true if prometheusrules cr is defined
+// and false otherwise.
+func IsPrometheusRuleEnabled(clientset kubecli.KubevirtClient) (bool, error) {
+	apis, err := clientset.DiscoveryClient().ServerResources()
+	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
+		return false, err
+	}
+
+	for _, api := range apis {
+		if api.GroupVersion == promv1.SchemeGroupVersion.String() {
+			for _, resource := range api.APIResources {
+				if resource.Name == "prometheusrules" {
+					return true, nil
+				}
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -44,8 +44,10 @@ type Stores struct {
 	PodDisruptionBudgetCache      cache.Store
 	ServiceMonitorCache           cache.Store
 	NamespaceCache                cache.Store
+	PrometheusRuleCache           cache.Store
 	IsOnOpenshift                 bool
 	ServiceMonitorEnabled         bool
+	PrometheusRulesEnabled        bool
 }
 
 func (s *Stores) AllEmpty() bool {
@@ -61,7 +63,8 @@ func (s *Stores) AllEmpty() bool {
 		IsStoreEmpty(s.ValidationWebhookCache) &&
 		IsStoreEmpty(s.PodDisruptionBudgetCache) &&
 		IsSCCStoreEmpty(s.SCCCache) &&
-		IsStoreEmpty(s.ServiceMonitorCache)
+		IsStoreEmpty(s.ServiceMonitorCache) &&
+		IsStoreEmpty(s.PrometheusRuleCache)
 
 	// Don't add InstallStrategyConfigMapCache to this list. The install
 	// strategies persist even after deletion and updates.
@@ -104,6 +107,7 @@ type Expectations struct {
 	InstallStrategyJob       *controller.UIDTrackingControllerExpectations
 	PodDisruptionBudget      *controller.UIDTrackingControllerExpectations
 	ServiceMonitor           *controller.UIDTrackingControllerExpectations
+	PrometheusRule           *controller.UIDTrackingControllerExpectations
 }
 
 type Informers struct {
@@ -124,6 +128,7 @@ type Informers struct {
 	PodDisruptionBudget      cache.SharedIndexInformer
 	ServiceMonitor           cache.SharedIndexInformer
 	Namespace                cache.SharedIndexInformer
+	PrometheusRule           cache.SharedIndexInformer
 }
 
 func (e *Expectations) DeleteExpectations(key string) {
@@ -142,6 +147,7 @@ func (e *Expectations) DeleteExpectations(key string) {
 	e.InstallStrategyJob.DeleteExpectations(key)
 	e.PodDisruptionBudget.DeleteExpectations(key)
 	e.ServiceMonitor.DeleteExpectations(key)
+	e.PrometheusRule.DeleteExpectations(key)
 }
 
 func (e *Expectations) ResetExpectations(key string) {
@@ -160,6 +166,7 @@ func (e *Expectations) ResetExpectations(key string) {
 	e.InstallStrategyJob.SetExpectations(key, 0, 0)
 	e.PodDisruptionBudget.SetExpectations(key, 0, 0)
 	e.ServiceMonitor.SetExpectations(key, 0, 0)
+	e.PrometheusRule.SetExpectations(key, 0, 0)
 }
 
 func (e *Expectations) SatisfiedExpectations(key string) bool {
@@ -177,5 +184,6 @@ func (e *Expectations) SatisfiedExpectations(key string) bool {
 		e.InstallStrategyConfigMap.SatisfiedExpectations(key) &&
 		e.InstallStrategyJob.SatisfiedExpectations(key) &&
 		e.PodDisruptionBudget.SatisfiedExpectations(key) &&
-		e.ServiceMonitor.SatisfiedExpectations(key)
+		e.ServiceMonitor.SatisfiedExpectations(key) &&
+		e.PrometheusRule.SatisfiedExpectations(key)
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1355,6 +1355,38 @@ spec:
 		})
 	})
 
+	Context("With PrometheusRule Enabled", func() {
+
+		BeforeEach(func() {
+			if !tests.PrometheusRuleEnabled() {
+				Skip("Test applies on when PrometheusRule is defined")
+			}
+		})
+
+		It("Checks if the kubevirt PrometheusRule cr exists and verify it's spec", func() {
+			monv1 := virtClient.PrometheusClient().MonitoringV1()
+			prometheusRule, err := monv1.PrometheusRules(tests.KubeVirtInstallNamespace).Get(components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			expectedPromRuleSpec := components.NewPrometheusRuleSpec(tests.KubeVirtInstallNamespace)
+			Expect(prometheusRule.Spec).To(Equal(*expectedPromRuleSpec))
+		})
+	})
+
+	Context("With PrometheusRule Disabled", func() {
+
+		BeforeEach(func() {
+			if tests.PrometheusRuleEnabled() {
+				Skip("Test applies on when PrometheusRule is not defined")
+			}
+		})
+
+		It("Checks that we do not deploy a PrometheusRule cr when not needed", func() {
+			monv1 := virtClient.PrometheusClient().MonitoringV1()
+			_, err := monv1.PrometheusRules(tests.KubeVirtInstallNamespace).Get(components.KUBEVIRT_PROMETHEUS_RULE_NAME, metav1.GetOptions{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("[rfe_id:2937][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Enabled", func() {
 
 		BeforeEach(func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1020,6 +1020,21 @@ func ServiceMonitorEnabled() bool {
 	return serviceMonitorEnabled
 }
 
+// PrometheusRuleEnabled returns true if the PrometheusRule CRD is enabled
+// and false otherwise.
+func PrometheusRuleEnabled() bool {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	prometheusRuleEnabled, err := util.IsPrometheusRuleEnabled(virtClient)
+	if err != nil {
+		fmt.Printf("ERROR: Can't verify PrometheusRule CRD %v\n", err)
+		panic(err)
+	}
+
+	return prometheusRuleEnabled
+}
+
 func composeResourceURI(object unstructured.Unstructured) string {
 	uri := "/api"
 	if object.GetAPIVersion() != "v1" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding basic pre-defined Prometheus alert rules with KubeVirt deployment will allow cluster admins to monitor their KubeVirt deployment using OpenShift's cluster monitoring solution.

This PR defines alert rules only for virt-api and only for the "up" condition, which means that the api-server is up (and in this case means it's also ready).

**Release note**:
Introducing basic Prometheus alert rules for virt-api.
```release-note
Add Prometheus alert rules for virt-api.
```
