### PR TITLE
Fix the calculation of queues for virtio interefaces and disks

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -849,24 +849,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			})
 		}
 	}
-	_, requestOk := spec.Domain.Resources.Requests[k8sv1.ResourceCPU]
-	_, limitOK := spec.Domain.Resources.Limits[k8sv1.ResourceCPU]
-	isCPUResourcesSet := (requestOk == true) || (limitOK == true)
-	if !isCPUResourcesSet && (spec.Domain.Devices.BlockMultiQueue != nil) && (*spec.Domain.Devices.BlockMultiQueue == true) {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "MultiQueue for block devices can't be used without specifying CPU requests or limits.",
-			Field:   field.Child("domain", "devices", "blockMultiQueue").String(),
-		})
-	}
-	if !isCPUResourcesSet && (spec.Domain.Devices.NetworkInterfaceMultiQueue != nil) && (*spec.Domain.Devices.NetworkInterfaceMultiQueue == true) {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "MultiQueue for network interfaces can't be used without specifying CPU requests or limits.",
-			Field:   field.Child("domain", "devices", "networkInterfaceMultiqueue").String(),
-		})
-	}
-
 	if spec.Domain.IOThreadsPolicy != nil {
 		isValidPolicy := func(policy v1.IOThreadsPolicy) bool {
 			for _, p := range validIOThreadsPolicies {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1752,31 +1752,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(2))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
-		})
-
-		It("should reject nic multi queue without CPU settings", func() {
-			_true := true
-			vmi := v1.NewMinimalVMI("testvm")
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-
-			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
-		})
-
-		It("should reject BlockMultiQueue without CPU settings", func() {
-			_true := true
-			vmi := v1.NewMinimalVMI("testvm")
-			vmi.Spec.Domain.Devices.BlockMultiQueue = &_true
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.blockMultiQueue"))
 		})
 
 		It("should allow BlockMultiQueue with CPU settings", func() {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1621,7 +1621,19 @@ var _ = Describe("Converter", func() {
 
 			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
 			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(expectedQueues),
-				"expected number of queues to equal number of requested CPUs")
+				"expected number of queues to equal number of requested vCPUs")
+		})
+		It("should assign queues to a device if requested based on vcpus", func() {
+			var expectedQueues uint = 4
+
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores:   2,
+				Sockets: 1,
+				Threads: 2,
+			}
+			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(expectedQueues),
+				"expected number of queues to equal number of requested vCPUs")
 		})
 
 		It("should not assign queues to a non-virtio devices", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes how virtio queues are being calculated. The amount of virtio queues should be bases on the number of virtual CPUs the VM has described in [1]

[1] https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/interfaces-and-networks.html#virtio-net-multiqueue

Fixes #2782 
```release-note
NONE
```
