### PR TITLE
Add guest agent check after migration

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -798,6 +798,9 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 				// check VMI, confirm migration state
 				confirmVMIPostMigration(vmi, migrationUID)
 
+				// Is agent connected after migration
+				tests.WaitAgentConnected(virtClient, vmi)
+
 				By("Checking that the migrated VirtualMachineInstance console has expected output")
 				expecter, err = tests.ReLoggedInFedoraExpecter(vmi, 60)
 				defer expecter.Close()


### PR DESCRIPTION
**What this PR does / why we need it**:
Verifies that the guest agent stays up after successful migration.

Fixes: https://jira.coreos.com/browse/CNV-2532

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
