### PR TITLE
Enable libvirt debug logs under our e2e tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1558,6 +1558,12 @@ func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	t := defaultTestGracePeriod
 	vmi.Spec.TerminationGracePeriodSeconds = &t
 
+	// Enable by default debug logs
+	// TODO: part of tests can override it
+	vmi.Labels = map[string]string{
+		"debugLogs": "true",
+	}
+
 	// To avoid mac address issue in the tests change the pod interface binding to masquerade
 	// https://github.com/kubevirt/kubevirt/issues/1494
 	vmi.Spec.Domain.Devices = v1.Devices{Interfaces: []v1.Interface{{Name: "default",


### PR DESCRIPTION
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
