### PR TITLE
Fix nil exception when agent polling can't reach libvirt

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -190,7 +190,13 @@ func (l *LibvirtConnection) ListAllDomains(flags libvirt.ConnectListAllDomainsFl
 // command - the qemu command, for example this gets the interfaces: {"execute":"guest-network-get-interfaces"}
 // domainName -  the qemu domain name
 func (l *LibvirtConnection) QemuAgentCommand(command string, domainName string) (string, error) {
+	if err := l.reconnectIfNecessary(); err != nil {
+		return "", err
+	}
 	domain, err := l.Connect.LookupDomainByName(domainName)
+	if err != nil {
+		return "", err
+	}
 	result, err := domain.QemuAgentCommand(command, libvirt.DOMAIN_QEMU_AGENT_COMMAND_DEFAULT, uint32(0))
 	return result, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

If libvirt is not reachable, instead of returning with an error and retrying later again, it was possible that virt-launcher crashes when polling for the guest agent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
