### PR TITLE
Revert sriov to only one node setup

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -52,7 +52,11 @@ if [[ $TARGET =~ os-.* ]]; then
   export KUBEVIRT_MEMORY_SIZE=6144M
 fi
 
-export KUBEVIRT_NUM_NODES=2 
+if [[ "$TARGET" =~ .*sriov.* ]]; then
+  export KUBEVIRT_NUM_NODES=1 # to be sure the guest lands on the master node
+else
+  export KUBEVIRT_NUM_NODES=2 
+fi
 
 export RHEL_NFS_DIR=${RHEL_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/rhel7}
 export RHEL_LOCK_PATH=${RHEL_LOCK_PATH:-/var/lib/stdci/shared/download_rhel_image.lock}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Hoping this is temporary, we revert the sriov lane to use just one note to reduce the scope of changes in order to understand ci failures.


```release-note
NONE
```
