### PR TITLE
Add test id for kubevirt ready and available condition

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -659,6 +659,13 @@ spec:
 		ensureShasums()
 	})
 
+	It("[testid:1746]should have created and available condition", func() {
+		kv := getCurrentKv()
+
+		By("vyrifying that created and available condition is present")
+		waitForKv(kv)
+	})
+
 	Describe("should start a VM", func() {
 		It("using virt-launcher with a shasum", func() {
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add test for kubevirt ready and created condition.

**Special notes for your reviewer**:
Test was already present. Added simple test function to link the test to test id.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
