### PR TITLE
tests: Stabilize annotations tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4012,6 +4012,12 @@ func PodReady(pod *k8sv1.Pod) k8sv1.ConditionStatus {
 	return k8sv1.ConditionFalse
 }
 
+func RetryWithMetadataIfModified(objectMeta metav1.ObjectMeta, do func(objectMeta metav1.ObjectMeta) error) (err error) {
+	return RetryIfModified(func() error {
+		return do(objectMeta)
+	})
+}
+
 func RetryIfModified(do func() error) (err error) {
 	retries := 0
 	for err = do(); errors.IsConflict(err); err = do() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -193,14 +193,15 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		stopVM := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
 			By("Stopping the VirtualMachine")
 
-			Eventually(func() error {
-				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
+			err = tests.RetryWithMetadataIfModified(vm.ObjectMeta, func(meta v12.ObjectMeta) error {
+				updatedVM, err := virtClient.VirtualMachine(meta.Namespace).Get(meta.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				updatedVM.Spec.Running = nil
 				updatedVM.Spec.RunStrategy = &runStrategyHalted
-				_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(updatedVM)
+				_, err = virtClient.VirtualMachine(meta.Namespace).Update(updatedVM)
 				return err
-			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			})
+			Expect(err).ToNot(HaveOccurred())
 
 			updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -227,14 +228,15 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		startVMIDontWait := func(vm *v1.VirtualMachine) *v1.VirtualMachine {
 			By("Starting the VirtualMachineInstance")
 
-			Eventually(func() error {
-				updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
+			err := tests.RetryWithMetadataIfModified(vm.ObjectMeta, func(meta v12.ObjectMeta) error {
+				updatedVM, err := virtClient.VirtualMachine(meta.Namespace).Get(meta.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				updatedVM.Spec.Running = nil
 				updatedVM.Spec.RunStrategy = &runStrategyAlways
-				_, err = virtClient.VirtualMachine(updatedVM.Namespace).Update(updatedVM)
+				_, err = virtClient.VirtualMachine(meta.Namespace).Update(updatedVM)
 				return err
-			}, 300*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			})
+			Expect(err).ToNot(HaveOccurred())
 
 			updatedVM, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -249,11 +251,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			vm := newVirtualMachine(false)
 
-			vm, err := virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			vm.Annotations = annotations
-
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
+			err = tests.RetryWithMetadataIfModified(vm.ObjectMeta, func(meta v12.ObjectMeta) error {
+				vm, err = virtClient.VirtualMachine(meta.Namespace).Get(meta.Name, &v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				vm.Annotations = annotations
+				vm, err = virtClient.VirtualMachine(meta.Namespace).Update(vm)
+				return err
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			startVMIDontWait(vm)
@@ -276,11 +280,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			vm := newVirtualMachine(false)
 
-			err = tests.RetryIfModified(func() error {
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
+			err = tests.RetryWithMetadataIfModified(vm.ObjectMeta, func(meta v12.ObjectMeta) error {
+				vm, err = virtClient.VirtualMachine(meta.Namespace).Get(meta.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				vm.Annotations = annotations
-				vm, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
+				vm, err = virtClient.VirtualMachine(meta.Namespace).Update(vm)
 				return err
 			})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

One update call was not retrying and another update call was not
retrying correctly.

Now an improved `RetryWithMetadataIfNececcary` function exists, which should be easier to use correctly.

Fixes the two most failing tests of last week on `pull-kubevirt-e2e-k8s-1.15.1-ceph` and `pull-kubevirt-e2e-os-3.11.0-crio`: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/flakefinder-2019-10-15-168h.html

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
