### PR TITLE
tests: Use patch on node updates in the cpu model tests

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -851,11 +851,13 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			AfterEach(func() {
 				tests.UpdateClusterConfigValueAndWait(virtconfig.FeatureGatesKey, originalFeatureGates)
 
-				n, err := virtClient.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				n.SetLabels(originalLabels)
-				_, err = virtClient.CoreV1().Nodes().Update(n)
+				labelBytes, err := json.Marshal(originalLabels)
 				Expect(err).ToNot(HaveOccurred())
+
+				node, err = virtClient.CoreV1().Nodes().Patch(node.Name, types.StrategicMergePatchType,
+					[]byte(fmt.Sprintf(`{"metadata": { "labels": %s}}`, labelBytes)))
+				Expect(err).ToNot(HaveOccurred(), "Should patch node successfully")
 
 				time.Sleep(5 * time.Second)
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up of #2816. These cpu model tests fail pretty often on an update conflict in the AfterEach. Now it will use `patch`, which should not fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
