### PR TITLE
tests: add retry in prometheus config pickup test

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1306,15 +1306,19 @@ spec:
 		It("[test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints", func() {
 			coreClient := virtClient.CoreV1()
 
-			By("Obtaining Prometheus' configuration data")
-			secret, err := coreClient.Secrets("openshift-monitoring").Get("prometheus-k8s", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			data := secret.Data["prometheus.yaml"]
-			Expect(data).ToNot(BeNil())
+			// we don't know when the prometheus toolchain will pick up our config, so we retry plenty of times
+			// before to give up. TODO: there is a smarter way to wait?
+			Eventually(func() string {
+				By("Obtaining Prometheus' configuration data")
+				secret, err := coreClient.Secrets("openshift-monitoring").Get("prometheus-k8s", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-			By("Verifying that Prometheus is watching KubeVirt")
-			Expect(string(data)).To(ContainSubstring(tests.KubeVirtInstallNamespace), "Prometheus should be monitoring KubeVirt")
+				data := secret.Data["prometheus.yaml"]
+				Expect(data).ToNot(BeNil())
 
+				By("Verifying that Prometheus is watching KubeVirt")
+				return string(data)
+			}, 90*time.Second, 3*time.Second).Should(ContainSubstring(tests.KubeVirtInstallNamespace), "Prometheus should be monitoring KubeVirt")
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce (hopefully eliminate) the flakiness of test `Operator [rfe_id:2937][crit:medium][vendor:cnv-qe@redhat.com][level:component]With ServiceMonitor Enabled [test_id:2936]Should allow Prometheus to scrape KubeVirt endpoints`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
