### PR TITLE
In multus tests, clean existings vms in BeforeEach instead of AfterEach

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Multus", func() {
 		},
 	}
 
-	AfterEach(func() {
+	BeforeEach(func() {
 		// Multus tests need to ensure that old VMIs are gone
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestDefault).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestAlternative).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
@@ -589,7 +589,7 @@ var _ = Describe("SRIOV", func() {
 		Expect(result.Error()).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	BeforeEach(func() {
 		// Multus tests need to ensure that old VMIs are gone
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestDefault).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestAlternative).Resource("virtualmachineinstances").Do().Error()).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Right now, in multus test we clean up vms when a test finishes, in order to free resources. The problem is, 
the reporter is not able to collect the logs of the launcher pod because its cleaned after the test execution.
With this pr, we move the cleaning in `BeforeEach` so that the reporter will find the launcher pod.



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
