### PR TITLE
tests: Wait for feature-gate changes to be propagated

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3702,14 +3702,7 @@ func DisableFeatureGate(feature string) {
 	newVal := strings.Replace(val, feature+",", "", 1)
 	newVal = strings.Replace(newVal, feature, "", 1)
 
-	cfg.Data["feature-gates"] = newVal
-
-	newData, err := json.Marshal(cfg.Data)
-	Expect(err).ToNot(HaveOccurred())
-
-	data := fmt.Sprintf(`[{ "op": "replace", "path": "/data", "value": %s }]`, string(newData))
-	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Patch("kubevirt-config", types.JSONPatchType, []byte(data))
-	Expect(err).ToNot(HaveOccurred())
+	UpdateClusterConfigValueAndWait("feature-gates", newVal)
 }
 
 func EnableFeatureGate(feature string) {
@@ -3724,15 +3717,7 @@ func EnableFeatureGate(feature string) {
 	val, _ := cfg.Data["feature-gates"]
 	newVal := fmt.Sprintf("%s,%s", val, feature)
 
-	cfg.Data["feature-gates"] = newVal
-
-	newData, err := json.Marshal(cfg.Data)
-	Expect(err).ToNot(HaveOccurred())
-
-	data := fmt.Sprintf(`[{ "op": "replace", "path": "/data", "value": %s }]`, string(newData))
-
-	_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Patch("kubevirt-config", types.JSONPatchType, []byte(data))
-	Expect(err).ToNot(HaveOccurred())
+	UpdateClusterConfigValueAndWait("feature-gates", newVal)
 }
 
 func HasDataVolumeCRD() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Give feature-gate changes some time to be propagated in this test:

```
HookSidecars [rfe_id:2667][crit:medium][vendor:cnv-qe@redhat.com][level:component] VMI definition with sidecar feature gate disabled [test_id:2666]should not start with hook sidecar annotation
```

We had in [this weekly report](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/flakefinder-2019-10-21-168h.html) three failures, all because the changes were not yet propagated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
