### PR TITLE
Increase timeout on PDB test for eviction strategies

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1224,7 +1224,7 @@ var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system]
 					Eventually(func() bool {
 						_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 						return errors.IsNotFound(err)
-					}, 30*time.Second, 500*time.Millisecond).Should(BeTrue())
+					}, 60*time.Second, 500*time.Millisecond).Should(BeTrue())
 				}
 			})
 


### PR DESCRIPTION
How long it takes until a deleted pod really disappears, which is scheduled but not quite
running yet, is very unpredictable. Even if there is no load on the node
it can vary greatly and can depend on kubelet internals of different k8s
versions.

This test:

```
[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system] VM Live Migration with a live-migrate eviction strategy set [ref_id:2293] with a VMI running with an eviction strategy set should recreate the PDB if VMIs with similar names are recreated
```

failed 6 times in the [last weekly report](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/flakefinder-2019-10-21-168h.html) because of unpredictable delete times.

Here some numbers which I collected to show how volatile the time-span already iss on a system without load:

```
10.099223228s
2.041562519s
1.51909842s
2.019970995s
514.620678ms
3.042363049s
2.028022876s
12.113562762s
```

Increasing the timeout to 60 seconds, to make the test more robust.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
