### PR TITLE
increase cpu-manager test timeout to 3 minutes

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1602,7 +1602,7 @@ var _ = Describe("Configurations", func() {
 					n, err := virtClient.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return n.Labels[v1.CPUManager]
-				}, 2*time.Minute, 2*time.Second).Should(Equal("false"))
+				}, 3*time.Minute, 2*time.Second).Should(Equal("false"))
 			})
 			It("[test_id:1685]non master node should have a cpumanager label", func() {
 				cpuManagerEnabled := false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It increases the cpu-manager test timeout to 3 minutes, the heartbeat is the place where we update a cpu-manager label and it happens that between calls we have 2 minutes break, as a result we have a flaky test.  The reason why it takes so long is under investigation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
