### PR TITLE
Create PSP policies - fixes#2221

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -28,6 +28,7 @@ ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=kubevirt-rbac
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=cluster-rbac --namespace={{.Namespace}} >${KUBEVIRT_DIR}/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=operator-rbac --namespace={{.Namespace}} >${KUBEVIRT_DIR}/manifests/generated/rbac-operator.authorization.k8s.yaml.in
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=prometheus --namespace={{.Namespace}} >${KUBEVIRT_DIR}/manifests/generated/prometheus.yaml.in
+${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=psp >${KUBEVIRT_DIR}/manifests/generated/psp.yaml
 
 # used for Image fields in manifests
 function getVersion() {

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -485,6 +485,14 @@ spec:
           verbs:
           - create
         - apiGroups:
+          - policy
+          resourceNames:
+          - kubevirt-controller
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
+        - apiGroups:
           - kubevirt.io
           resources:
           - virtualmachineinstances
@@ -520,6 +528,14 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - policy
+          resourceNames:
+          - kubevirt-handler
+          resources:
+          - podsecuritypolicies
+          verbs:
+          - use
         - apiGroups:
           - ""
           resources:

--- a/manifests/generated/psp.yaml
+++ b/manifests/generated/psp.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  labels:
+    kubevirt.io: ""
+  name: kubevirt-controller
+spec:
+  allowedCapabilities:
+  - NET_ADMIAN
+  - SYS_NICE
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath
+---
+apiVersion: v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+  labels:
+    kubevirt.io: ""
+  name: kubevirt-handler
+spec:
+  fsGroup:
+    ranges:
+    - max: 65535
+      min: 1000
+    rule: MustRunAs
+  hostPID: true
+  privileged: true
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    ranges:
+    - max: 65535
+      min: 1000
+    rule: MustRunAs
+  volumes:
+  - configMap
+  - secret
+  - emptyDir
+  - downwardAPI
+  - persistentVolumeClaim
+  - hostPath

--- a/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
@@ -267,6 +267,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-controller
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -334,6 +342,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-handler
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -340,6 +340,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-controller
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachineinstances
@@ -375,6 +383,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - policy
+  resourceNames:
+  - kubevirt-handler
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 - apiGroups:
   - ""
   resources:

--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "crds.go",
         "deployments.go",
+        "psps.go",
         "scc.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator/creation/components",

--- a/pkg/virt-operator/creation/components/psps.go
+++ b/pkg/virt-operator/creation/components/psps.go
@@ -1,0 +1,131 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2019 Red Hat, Inc.
+ *
+ */
+package components
+
+import (
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	virtv1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/pkg/virt-operator/creation/rbac"
+)
+
+func NewControllerPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return &policyv1beta1.PodSecurityPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy/v1beta1",
+			Kind:       "PodSecurityPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rbac.ControllerServiceAccountName,
+			Labels: map[string]string{
+				virtv1.AppLabel: "",
+			},
+			Annotations: map[string]string{
+				"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "*",
+				"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+			},
+		},
+		Spec: policyv1beta1.PodSecurityPolicySpec{
+			AllowedCapabilities: []corev1.Capability{
+				"NET_ADMIAN",
+				"SYS_NICE",
+			},
+			FSGroup: policyv1beta1.FSGroupStrategyOptions{
+				Rule: policyv1beta1.FSGroupStrategyRunAsAny,
+			},
+			RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+				Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
+			},
+			SELinux: policyv1beta1.SELinuxStrategyOptions{
+				Rule: policyv1beta1.SELinuxStrategyRunAsAny,
+			},
+			SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+				Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
+			},
+			Volumes: []policyv1beta1.FSType{
+				policyv1beta1.ConfigMap,
+				policyv1beta1.Secret,
+				policyv1beta1.EmptyDir,
+				policyv1beta1.DownwardAPI,
+				policyv1beta1.PersistentVolumeClaim,
+				policyv1beta1.HostPath,
+			},
+		},
+	}
+}
+
+func NewHandlerPodSecurityPolicy() *policyv1beta1.PodSecurityPolicy {
+	return &policyv1beta1.PodSecurityPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy/v1beta1",
+			Kind:       "PodSecurityPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: rbac.HandlerServiceAccountName,
+			Labels: map[string]string{
+				virtv1.AppLabel: "",
+			},
+			Annotations: map[string]string{
+				"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "*",
+				"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "runtime/default",
+			},
+		},
+		Spec: policyv1beta1.PodSecurityPolicySpec{
+			HostPID:    true,
+			Privileged: true,
+			FSGroup: policyv1beta1.FSGroupStrategyOptions{
+				Rule: policyv1beta1.FSGroupStrategyMustRunAs,
+				Ranges: []policyv1beta1.IDRange{
+					policyv1beta1.IDRange{
+						Min: 1000,
+						Max: 65535,
+					},
+				},
+			},
+			RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+				Rule: policyv1beta1.RunAsUserStrategyMustRunAsNonRoot,
+			},
+			SELinux: policyv1beta1.SELinuxStrategyOptions{
+				Rule: policyv1beta1.SELinuxStrategyRunAsAny,
+			},
+			SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+				Rule: policyv1beta1.SupplementalGroupsStrategyMustRunAs,
+				Ranges: []policyv1beta1.IDRange{
+					policyv1beta1.IDRange{
+						Min: 1000,
+						Max: 65535,
+					},
+				},
+			},
+			Volumes: []policyv1beta1.FSType{
+				policyv1beta1.ConfigMap,
+				policyv1beta1.Secret,
+				policyv1beta1.EmptyDir,
+				policyv1beta1.DownwardAPI,
+				policyv1beta1.PersistentVolumeClaim,
+				policyv1beta1.HostPath,
+			},
+		},
+	}
+}

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -188,6 +188,20 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"create",
 				},
 			},
+			{
+				APIGroups: []string{
+					"policy",
+				},
+				Resources: []string{
+					"podsecuritypolicies",
+				},
+				Verbs: []string{
+					"use",
+				},
+				ResourceNames: []string{
+					ControllerServiceAccountName,
+				},
+			},
 		},
 	}
 }

--- a/pkg/virt-operator/creation/rbac/handler.go
+++ b/pkg/virt-operator/creation/rbac/handler.go
@@ -125,6 +125,20 @@ func newHandlerClusterRole() *rbacv1.ClusterRole {
 					"watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"policy",
+				},
+				Resources: []string{
+					"podsecuritypolicies",
+				},
+				Verbs: []string{
+					"use",
+				},
+				ResourceNames: []string{
+					HandlerServiceAccountName,
+				},
+			},
 		},
 	}
 }

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -755,6 +755,9 @@ var _ = Describe("KubeVirt Operator", func() {
 
 		all = append(all, rbac.GetAllServiceMonitor(NAMESPACE, config.GetMonitorNamespace(), config.GetMonitorServiceAccount())...)
 		all = append(all, components.NewServiceMonitorCR(NAMESPACE, config.GetMonitorNamespace(), true))
+		// pod security policies
+		all = append(all, components.NewControllerPodSecurityPolicy())
+		all = append(all, components.NewHandlerPodSecurityPolicy())
 
 		for _, obj := range all {
 			if resource, ok := obj.(runtime.Object); ok {

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -71,6 +71,13 @@ func main() {
 		for _, r := range all {
 			util.MarshallObject(r, os.Stdout)
 		}
+	case "psp":
+		all := make([]interface{}, 0)
+		all = append(all, components.NewControllerPodSecurityPolicy())
+		all = append(all, components.NewHandlerPodSecurityPolicy())
+		for _, r := range all {
+			util.MarshallObject(r, os.Stdout)
+		}
 	case "cluster-rbac":
 		all := rbac.GetAllCluster(*namespace)
 		for _, r := range all {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow the operator to create dedicated pod security policies for the virt-handler and virt-controller.

This ensures kubevirt can work on clusters where PSP are enabled and the default policy is not granting the privileges requested.

Fixes #2221

**Special notes for your reviewer**:

This is my first contribution to the project and is still a WIP I think. I hope I was able to identify all the places of the code to be touched.

I've still to update the `pkg/virt-operator/kubevirt_test.go` test, but I would like to have your feedback on this approach before proceeding.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Have operator create dedicated pod security policies for virt-handler and virt-controller. This allows usage of kubevirt on clusters where PSP is enabled and restrictive policies are in place.
```
