### PR TITLE
WIP: temporary test for CI to see if the kind lane gets back

### DIFF
--- a/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
+++ b/cluster-up/cluster/kind-k8s-sriov-1.14.2/config_sriov.sh
@@ -31,6 +31,7 @@ function deploy_sriov_operator {
     # https://github.com/intel/sriov-cni/pull/88 available. This can be removed once the feature will
     # be merged in openshift sriov operator. We need latest since that feature was not tagged yet
     sed -i '/SRIOV_CNI_IMAGE/!b;n;c\              value: nfvpe\/sriov-cni' ./deploy/operator.yaml
+    sed -i 's#image: quay.io/openshift/origin-sriov-network-operator$#image: quay.io/openshift/origin-sriov-network-operator:4.2#' ./deploy/operator.yaml
 
     # on prow nodes the default shell is dash and some commands are not working
     make deploy-setup-k8s SHELL=/bin/bash OPERATOR_EXEC="${KUBECTL}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is to test the change on CI before having to commit to kubevirtci + generate

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
