### PR TITLE
make template VMs to use networkInterfaceMultiqueue

### DIFF
--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -41,7 +41,9 @@ objects:
               name: cloudinitdisk
             interfaces:
             - masquerade: {}
+              model: virtio
               name: default
+            networkInterfaceMultiqueue: true
             rng: {}
           machine:
             type: ""

--- a/examples/vm-template-rhel7.yaml
+++ b/examples/vm-template-rhel7.yaml
@@ -38,7 +38,9 @@ objects:
               name: disk0
             interfaces:
             - masquerade: {}
+              model: virtio
               name: default
+            networkInterfaceMultiqueue: true
           machine:
             type: ""
           resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR changes the template VM- Fedora and RHEL7 to be with
`networkInterfaceMultiqueue`, in order
to receive better network performances.
benefits and reasoning behind `networkInterfaceMultiqueue`
can be found here:
https://www.linux-kvm.org/page/Multiqueue#Multiqueue_virtio-net
The Windows template is still **without** `networkInterfaceMultiqueue`
since the CPU model it uses is `e1000` which does not support `networkInterfaceMultiqueue`.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
template Fedora and RHEL7 VMs are now configured with network interface multiqueue
```
