### PR TITLE
Fix CRD scheme registration

### DIFF
--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -114,6 +114,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 			&KubeVirt{},
 			&KubeVirtList{},
 		)
+		metav1.AddToGroupVersion(scheme, groupVersion)
 	}
 	scheme.AddKnownTypes(metav1.Unversioned,
 		&metav1.Status{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When using the kubevirt types in a codebase that uses Kubenetes 1.15 dependencies, `Create` will fail with a `v1.CreateOptions is not suitable for converting to "kubevirt.io/v1alpha3" in scheme "k8s.io/client-go/kubernetes/scheme/register.go:65"`. This PR fixes that.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
