### PR TITLE
Fix test reviewer assignment

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,9 +6,6 @@ filters:
       - code-reviewers
     approvers:
       - approvers
-  "tests/.*":
-    reviewers:
-      - test-reviewers
   "pkg/virt-api/.*":
     reviewers:
       - ux-reviewers

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+  - test-reviewers


### PR DESCRIPTION
Previously test reviewers did not get assigned, this new owners file should fix it.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
