### PR TITLE
Skip kubevirt-bot in release announcement

### DIFF
--- a/hack/release-announce.sh
+++ b/hack/release-announce.sh
@@ -41,7 +41,7 @@ EOF
 }
 
 shortlog() {
-    git shortlog -sne $RELSPANREF | sed "s/^/    /"
+    git shortlog -sne $RELSPANREF | sed "s/^/    /" | grep -v kubevirt-bot
 }
 
 functest() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip kubevirt-bot in release announcement's contributors list

**Release note**:
```release-note
NONE
```
