### PR TITLE
Remove www from links to kubevirt.io website

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and learn more about the major components by taking a look at
 
  * [Architecture](docs/architecture.md) - High-level view on the architecture
  * [Components](docs/components.md) - Detailed look at all components
- * [API Reference](https://www.kubevirt.io/api-reference/)
+ * [API Reference](https://kubevirt.io/api-reference/)
 
 
 # Community

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -136,7 +136,7 @@ spec:
 
       * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
       * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
-      * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+      * [API Reference](https://kubevirt.io/api-reference/)
 
     # Community
 

--- a/pkg/virt-operator/creation/csv/csv.go
+++ b/pkg/virt-operator/creation/csv/csv.go
@@ -111,7 +111,7 @@ and learn more about the major components by taking a look at our developer docu
 
   * [Architecture](https://github.com/kubevirt/kubevirt/blob/master/docs/architecture.md) - High-level view on the architecture
   * [Components](https://github.com/kubevirt/kubevirt/blob/master/docs/components.md) - Detailed look at all components
-  * [API Reference](https://github.com/kubevirt/kubevirt/blob/master/https://www.kubevirt.io/api-reference/)
+  * [API Reference](https://kubevirt.io/api-reference/)
 
 # Community
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The `www.kubevirt.io` DNS entry is not working at the moment (see kubevirt/kubevirt.github.io#346).

This PR updates the links to the web site to use just `kubevirt.io` instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes kubevirt/user-guide#298

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
