### PR TITLE
Expand sriov docs with brief architecture notes

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -1,4 +1,75 @@
-# Enable SR-IOV on the host
+# Architecture
+
+There are multiple components involved to provide SR-IOV support in KubeVirt
+environment.
+
+* [SR-IOV device plugin](https://github.com/intel/sriov-network-device-plugin)
+  discovers available SR-IOV resources, advertises them to Kubernetes resource
+  manager, and allocates them as needed to pods and VMIs. This component
+  doesn't modify host resources, only discovers, advertises and allocates them.
+  When resources are advertized, they are registered in `capacity` section of
+  each node, that is then used for scheduling purposes.  For VMIs, it allocates
+  `vfio` device nodes to pods; it also sets environment variables with PCI IDs
+  of allocated devices. These variables are later used by KubeVirt to configure
+  libvirt domain.
+* [SR-IOV CNI plugin](https://github.com/intel/sriov-cni) configures allocated
+  SR-IOV resources before a pod or VMI is started. This component modifies host
+  resources to prepare them to be used inside a pod / VMI. Executed in root
+  network namespace context. Uses netlink and other commands to configure and
+  move SR-IOV VF / PF resources into pod namespaces.
+* [Multus](https://github.com/intel/multus-cni) is a meta-plugin. It will call
+  to SR-IOV CNI plugin when VMI is attached to an SR-IOV interface. It is
+  configured through `NetworkAttachmentDefinition` CRD objects. For SR-IOV, the
+  object annotations should refer to the resource name configured inside device
+  plugin `config.json` configuration file. This reference is used by KubeVirt
+  to automatically fill in `requests` and `limits` sections of `virt-launcher`
+  pods. (The same mechanism is used by other plugins, for example, `bridge`.)
+  If used alone, SR-IOV CNI plugin would need the PCI address of the device we
+  want to use inside the pod (and then, inside the VM). By using it in
+  combination with the device plugin and Multus, thanks to `resourceName`
+  annotation, the pod will receive a device from the pool allocated by the
+  device plugin, which allows to avoid manually passing the required PCI
+  address.
+* [OpenShift SR-IOV operator](https://github.com/openshift/sriov-network-operator)
+  configures kernel for SR-IOV, drains resources and reboots the kernel as
+  needed, deploys components listed above, and, based on values in policy CRD
+  resources managed by admin, configures the above listed components and the
+  host.
+* KubeVirt, based on values of environment variables set by SR-IOV device
+  plugin, configures libvirt domain for SR-IOV attached VMIs to use the right
+  PCI IDs. Also, fills in `requests` and `limits` sections of `virt-launcher`
+  pod spec as per attached NetworkAttachmentDefinition CRD.
+
+# Configuration
+
+> NOTE: steps to configure SR-IOV on a host are only applicable if you don't
+> use OpenShift SR-IOV operator to deploy SR-IOV components. Despite the name,
+> the operator supports installation on a plain Kubernetes cluster. The
+> operator handles most of the steps discussed below, including configuring
+> kernel parameters. The only step that cannot be handled by the operator is
+> BIOS setup, which should be handled by other means (either manually or
+> through some kind of IPMI driven automation).
+>
+> Documentation on how to use the operator
+> [is located](https://github.com/openshift/sriov-network-operator/blob/master/README.md)
+> [elsewhere](https://github.com/openshift/sriov-network-operator/blob/master/doc/quickstart.md).
+> Just remember to set `SriovNetworkNodePolicy` to use `deviceType: vfio-pci`
+> when configuring the operator.
+>
+> For local development purposes, one should be able to (re)use the same
+> [kind](https://kind.sigs.k8s.io/) based provider that the official upstream
+> SR-IOV CI relies on, for example:
+>
+> $ export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.14.2
+>
+> $ make cluster-up
+>
+> Assuming you run these commands on a SR-IOV enabled host, they should bring
+> up a dockerized cluster with all SR-IOV components and resources set up and
+> ready to use.
+>
+> If you know what you are doing and still would like to follow the manual
+> configuration path, keep reading.
 
 Before you deploy your cluster, make sure your host has a SR-IOV capable NIC
 plugged in, and that it supports it. You may need to adjust BIOS settings to
@@ -32,8 +103,15 @@ $ find /sys -name *vfs*
 /sys/devices/pci0000:00/0000:00:09.0/0000:05:00.1/sriov_totalvfs
 ```
 
-Kubevirt will use `vfio` userspace driver to pass through PCI devices into
-`qemu`. For this to work, load the following driver:
+KubeVirt will use [vfio](https://www.kernel.org/doc/Documentation/vfio.txt)
+userspace driver to pass through PCI devices into `qemu`. VFIO is an
+established way to pass raw devices into running virtual machines, in contrast
+to using the regular `netdevice` device plugin mode used to attach regular pods
+to `netlink` interfaces registered with corresponding Linux kernel network
+drivers. More information on VFIO can also be found
+[here](https://www.linux-kvm.org/images/b/b4/2012-forum-VFIO.pdf).
+
+For this to work, load the following driver:
 
 ```
 $ modprobe vfio-pci
@@ -52,18 +130,22 @@ Now you are ready to set up your cluster.
 # Set up kubernetes cluster
 
 You can use your preferred mechanism to deploy your kubernetes cluster as long
-as you deploy on bare metal.
+as you deploy on bare metal. Note that using virtualized environment is
+problematic with SR-IOV because to use SR-IOV PFs in such environment, one
+would first need to pass through PF devices from hypervisor level into the
+virtual machines. That's why right now it's impossible to use regular providers
+that use qemu machines for SR-IOV development.
 
-Current recommendation is to use ```kubevirt-ansible``` to deploy the cluster.
-Ansible playbooks will also deploy all the relevant SR-IOV components
-for you. See [here](https://github.com/kubevirt/kubevirt-ansible/).
+Current recommendation is to use the official KubeVirt operator to deploy
+clusters.
 
 You may still want to deploy software using `local` provider if you'd like to
-deploy from Kubevirt sources though.
+deploy from KubeVirt sources though.
 
 In the following example, we configure the cluster using `local` provider which
-is part of kubevirt/kubevirt repo. Please consult cluster/local/README.md for
-general information on setting up a host using the `local` provider.
+is part of kubevirt/kubevirt repo. Please consult
+[documentation](https://github.com/kubevirt/kubevirt/blob/master/cluster-up/cluster/local/README.md)
+for general information on setting up a host using the `local` provider.
 
 The `local` provider does not install default CNI plugins like `loopback`. So
 first, install default CNI plugins:
@@ -123,29 +205,59 @@ Once the cluster is deployed, we can move to SR-IOV specific components.
 
 # Deploy SR-IOV services
 
-First, deploy latest Multus with default Flannel backend. We will need to use
-the latest code from their tree, hence using `snapshot` image tag instead of
-`latest`. The `snapshot` image adds support for reading IDs of devices
-allocated by device plugins from "checkpoint" files, which is needed to make
-the whole setup work.
+> NOTE: as stated above, manual deployment of SR-IOV components is not
+> recommended. Please consider using SR-IOV operator instead. But if you know
+> what you are doing, keep reading.
+
+First, deploy latest Multus with default Flannel backend.
 
 ```
 $ go get -u -d github.com/intel/multus-cni
 $ cd $GOPATH/src/github.com/intel/multus-cni/
-$ vi images/multus-daemonset.yml # change to refer to nfvpe/multus:snapshot
 $ mkdir -p /etc/cni/net.d
 $ cp images/70-multus.conf /etc/cni/net.d/
 $ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/images/multus-daemonset.yml
 $ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/images/flannel-daemonset.yml
 ```
 
-The best way to configure your SR-IOV devices is by using the [OpenShift SR-IOV operator](https://github.com/openshift/sriov-network-operator).
+Now, deploy SR-IOV device plugin. Adjust config.json file for your particular
+setup. More information about configuration file format:
+https://github.com/intel/sriov-network-device-plugin/blob/master/README.md#configurations
 
-It will setup the devices according to the configuration provided and it will deploy the components needed to make SR-IOV work in your cluster (in particular, the [SR-IOV CNI plugin](https://github.com/intel/sriov-cni) and the [SR-IOV device plugin](https://github.com/intel/sriov-network-device-plugin)).
+```
+$ go get -u -d github.com/intel/sriov-network-device-plugin/
+$ cat <<EOF > /etc/pcidp/config.json
+{
+    "resourceList":
+    [
+        {
+            "resourceName": "sriov",
+            "rootDevices": ["05:00.0", "05:00.1"],
+            "sriovMode": true,
+            "deviceType": "vfio"
+        }
+    ]
+}
+EOF
+$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-network-device-plugin/images/sriovdp-daemonset.yaml
+```
 
-The OpenShift SR-IOV quickstart guide can be found [here](https://github.com/openshift/sriov-network-operator/blob/master/doc/quickstart.md). They provide instructions to run the operator both on Kubernetes and OpenShift.
+Deploy SR-IOV CNI plugin.
 
-Just remember to set the `SriovNetworkNodePolicy` to use `deviceType: vfio-pci`.
+```
+$ go get -u -d github.com/intel/sriov-cni/
+$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-cni/images/sriov-cni-daemonset.yaml
+```
+
+Finally, create a new SR-IOV network CRD that will use SR-IOV device plugin to allocate devices.
+
+```
+./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-network-device-plugin/deployments/sriov-crd.yaml
+```
+
+Just make sure that the network spec refers to the right resource name for
+SR-IOV resources configured in SR-IOV device plugin configuration file
+(config.json).
 
 # Install kubevirt services
 
@@ -155,6 +267,25 @@ This particular step is not specific to SR-IOV.
 make cluster-sync
 ```
 
+# Usage
+
 If all goes well, you should be able to post a VMI spec referring to the SR-IOV
 multus network and get a PCI device allocated to virt-launcher and passed
-through into qemu. Please consult cluster/examples/vmi-sriov.yaml for example.
+through into qemu. Please consult
+[the VMI spec example](https://github.com/kubevirt/kubevirt/blob/master/examples/vmi-sriov.yaml).
+
+As long as the VMI spec `networks` section refers to the proper
+`NetworkAttachmentDefinition` that describes a SR-IOV network, you should be
+able to post it and get a machine attached to an SR-IOV device via VFIO. Note
+that the `NetworkAttachmentDefinition` resource should also refer, in its
+annotations, to a correct resource name as reported by SR-IOV device plugin for
+all this to work. More details on usage can be found in
+[KubeVirt](https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/interfaces-and-networks.html#sriov)
+and [SR-IOV operator](https://github.com/openshift/sriov-network-operator/blob/master/doc/quickstart.md)
+user documentation.
+
+# External resources
+
+* [User guide section on SR-IOV](https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/interfaces-and-networks.html#sriov)
+* [OpenShift user docs on SR-IOV](https://docs.openshift.com/container-platform/4.2/networking/multiple-networks/configuring-sr-iov.html)
+* [Doug Smith's blog post on deploying and testing SR-IOV](https://dougbtv.com/nfvpe/2019/05/15/kubevirt-sriov/)


### PR DESCRIPTION
KubeVirt documentation is not the right place to expand too much on how
all components fit, but the brief notes should hopefully be a good start
for an interested reader to dive in if needed.

Also, be more explicit SR-IOV should be deployed with operator.

Plus, restored some documentation that was unintentionally removed in
a previous patch that still belongs in the document as part of
description of manual deployment of relevant SR-IOV components if an
admin / developer decides to not follow the operator path.

Finally, added some external links to relevant docs / blogs.

```release-note
Expanded in-tree SR-IOV documentation
```