### PR TITLE
[fix] allow virt-launcher to write to sysfs

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -5,6 +5,7 @@
     (allow process mtrr_device_t (file (write)))
     (allow process self (tun_socket (relabelfrom)))
     (allow process self (tun_socket (relabelto)))
+    (allow process sysfs_t (file (write)))
     (allow process tmp_t (dir (write add_name open getattr setattr read link search remove_name reparent lock ioctl)))
     (allow process tmp_t (file (setattr open read write create getattr append ioctl lock)))
     (allow process container_share_t (dir (write add_name)))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates virt-launcher SELinux profile to allow it to assign SRIOV devices by writing to sysfs

Fixes #2887 

```release-note
NONE
```
