### PR TITLE
WORKSPACE: Update libvirt container

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -258,10 +258,10 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:840d4502f48f567f9030e22ba8aa8294003f1ac20b6a0c06c01b0236a8964a3a",
+    digest = "sha256:be2976a5869fdd6cc5ab184f1bfee2345fcee22fa5fdad2db516e5d5de221ab2",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
-    #tag = "5.0.0-2.fc30",
+    #tag = "20191120.8b875d2",
 )
 
 # Pull kubevirt-testing image


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

libvirt provides many features, some of which are of no use to KubeVirt: this PR switches KubeVirt to using a new container that doesn't include any unnecessary libvirt components.

**Special notes for your reviewer**:

The container image tested is `andreabolognani/kubevirt-libvirt:20191117.b9c091d`.
    
This is only to validate that we're not missing any libvirt component: once CI has passed, [the corresponding `kubevirt/libvirt` PR](https://github.com/kubevirt/libvirt/pull/37) will be merged and I'll update this PR accordingly.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
