### PR TITLE
Preapre kubevirt for libvirt 5.6.0

### DIFF
--- a/pkg/emptydisk/BUILD.bazel
+++ b/pkg/emptydisk/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["emptydisk.go"],
     importpath = "kubevirt.io/kubevirt/pkg/emptydisk",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/api/v1:go_default_library"],
+    deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -7,9 +7,11 @@ import (
 	"strconv"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 var EmptyDiskBaseDir = "/var/run/libvirt/empty-disks/"
+var emptyDiskOwner = "qemu"
 
 func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
 
@@ -29,6 +31,9 @@ func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
 			} else if err != nil {
 				return err
 			}
+			if err := ephemeraldiskutils.SetFileOwnership(emptyDiskOwner, file); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -37,4 +42,9 @@ func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
 
 func FilePathForVolumeName(volumeName string) string {
 	return path.Join(EmptyDiskBaseDir, volumeName+".qcow2")
+}
+
+// Used by tests.
+func SetLocalDataOwner(user string) {
+	emptyDiskOwner = user
 }

--- a/pkg/emptydisk/emptydisk_test.go
+++ b/pkg/emptydisk/emptydisk_test.go
@@ -3,6 +3,7 @@ package emptydisk
 import (
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path"
 
 	. "github.com/onsi/ginkgo"
@@ -13,6 +14,10 @@ import (
 )
 
 var _ = Describe("EmptyDisk", func() {
+	owner, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
 
 	AppendEmptyDisk := func(vmi *v1.VirtualMachineInstance, diskName string) {
 		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
@@ -33,6 +38,7 @@ var _ = Describe("EmptyDisk", func() {
 
 	BeforeEach(func() {
 		var err error
+		SetLocalDataOwner(owner.Username)
 		EmptyDiskBaseDir, err = ioutil.TempDir("", "emptydisk-dir")
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -164,7 +164,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Eventually(logs,
 				2*time.Second,
 				500*time.Millisecond).
-				Should(And(ContainSubstring("internal error: Cannot probe for supported suspend types"), ContainSubstring(`"subcomponent":"libvirt"`)))
+				Should(And(ContainSubstring("internal error: Unable to get DBus system bus connection"), ContainSubstring(`"subcomponent":"libvirt"`)))
 		})
 
 		It("[test_id:3197]should log libvirtd debug logs when enabled", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Search for a new logline which exists in libvirt 5.6.0 and libvirt 5.0.0
* Set correct ownership on emptyDisks, since libvirt 5.6.0 seems to have issues with that.
  We should have set the ownership anyway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
