### PR TITLE
Added New Column Definitions for wide output

### DIFF
--- a/manifests/generated/vm-resource.yaml
+++ b/manifests/generated/vm-resource.yaml
@@ -17,6 +17,10 @@ spec:
     description: Primary Volume
     name: Volume
     type: string
+  - JSONPath: .status.created
+    name: Created
+    priority: 1
+    type: boolean
   group: kubevirt.io
   names:
     categories:

--- a/manifests/generated/vmi-resource.yaml
+++ b/manifests/generated/vmi-resource.yaml
@@ -19,6 +19,10 @@ spec:
   - JSONPath: .status.nodeName
     name: NodeName
     type: string
+  - JSONPath: .status.conditions[?(@.type=='LiveMigratable')].status
+    name: Live-Migratable
+    priority: 1
+    type: string
   group: kubevirt.io
   names:
     categories:

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -66,6 +66,7 @@ func NewVirtualMachineInstanceCrd() *extv1beta1.CustomResourceDefinition {
 			{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
 			{Name: "IP", Type: "string", JSONPath: ".status.interfaces[0].ipAddress"},
 			{Name: "NodeName", Type: "string", JSONPath: ".status.nodeName"},
+			{Name: "Live-Migratable", Type: "string", JSONPath: ".status.conditions[?(@.type=='LiveMigratable')].status", Priority: 1},
 		},
 	}
 
@@ -95,6 +96,7 @@ func NewVirtualMachineCrd() *extv1beta1.CustomResourceDefinition {
 			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
 			{Name: "Running", Type: "boolean", JSONPath: ".spec.running"},
 			{Name: "Volume", Description: "Primary Volume", Type: "string", JSONPath: ".spec.volumes[0].name"},
+			{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1},
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added New Column Definitions with Priority for the CRDs to show in `-o wide` output
```
➜  kubevirt git:(wide-output-for-vm) ./cluster-up/kubectl.sh get vm        
NAME        AGE   RUNNING   VOLUME
vm-cirros   40s   true      
➜  kubevirt git:(wide-output-for-vm) ./cluster-up/kubectl.sh get vm -o wide
NAME        AGE   RUNNING   VOLUME   CREATED
vm-cirros   42s   true               true

➜  kubevirt git:(wide-output-for-vm) ✗ kg vmi        
NAME                    AGE   PHASE     IP            NODENAME
vm-cirros               1m    Running   10.244.0.40   node01
vmi-alpine-efi          50s   Running   10.244.0.41   node01
vmi-fedora              44s   Running   10.244.0.42   node01
vmi-flavor-small        39s   Running   10.244.0.43   node01                
➜  kubevirt git:(wide-output-for-vm) ✗ kg vmi -o wide
NAME                    AGE   PHASE     IP            NODENAME   LIVEMIGRATABLE
vm-cirros               1m    Running   10.244.0.40   node01     False
vmi-alpine-efi          57s   Running   10.244.0.41   node01     False
vmi-fedora              51s   Running   10.244.0.42   node01     False
vmi-flavor-small        46s   Running   10.244.0.43   node01     False

```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added new Column Definitions with Priority for the CRDs to show in `-o wide` output
```
