### PR TITLE
fix wrong use SwapInSet when push Swap Out Metric

### DIFF
--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -192,7 +192,7 @@ func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats,
 		)
 		tryToPushMetric(swapTrafficDesc, mv, err, ch)
 	}
-	if vmStats.Memory.SwapInSet {
+	if vmStats.Memory.SwapOutSet {
 		mv, err := prometheus.NewConstMetric(
 			swapTrafficDesc, prometheus.GaugeValue,
 			// the libvirt value is in KiB


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Signed-off-by: YINChengfeng cfengyin@gmail.com

**What this PR does / why we need it**:
fix wrong use SwapInSet when push Swap Out Metric

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
