### PR TITLE
Prepare kubevirt for libvirt 5.6.0 without switching

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -325,7 +325,7 @@ func main() {
 	log.InitializeLogging("virt-launcher")
 
 	if !*noFork {
-		exitCode, err := ForkAndMonitor("qemu-system", *ephemeralDiskDir, *containerDiskDir)
+		exitCode, err := ForkAndMonitor("qemu-kvm", *ephemeralDiskDir, *containerDiskDir)
 		if err != nil {
 			log.Log.Reason(err).Error("monitoring virt-launcher failed")
 			os.Exit(1)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -512,7 +512,13 @@ func ForkAndMonitor(qemuProcessCommandPrefix string, ephemeralDiskDir string, co
 
 	}
 	// give qemu some time to shut down in case it survived virt-handler
-	pid, _ := virtlauncher.FindPid(qemuProcessCommandPrefix)
+	// Most of the time we call `qemu-system=* binaries, but qemu-system-* packages
+	// are not everywhere available where libvirt and qemu are. There we usually call qemu-kvm
+	// which resides in /usr/libexec/qemu-kvm
+	pid, _ := virtlauncher.FindPid("qemu-system")
+	if pid <= 0 {
+		pid, _ = virtlauncher.FindPid("qemu-kvm")
+	}
 	if pid > 0 {
 		p, err := os.FindProcess(pid)
 		if err != nil {

--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -41,7 +41,6 @@ import (
 type IsoCreationFunc func(isoOutFile, volumeID string, inDir string) error
 
 var cloudInitLocalDir = "/var/run/libvirt/cloud-init-dir"
-var cloudInitOwner = "qemu"
 var cloudInitIsoFunc = defaultIsoFunc
 
 // Locations of data source disk files
@@ -201,11 +200,6 @@ func defaultIsoFunc(isoOutFile, volumeID string, inDir string) error {
 // The unit test suite uses this function
 func SetIsoCreationFunction(isoFunc IsoCreationFunc) {
 	cloudInitIsoFunc = isoFunc
-}
-
-// The unit test suite uses this function
-func SetLocalDataOwner(user string) {
-	cloudInitOwner = user
 }
 
 func SetLocalDirectory(dir string) error {
@@ -425,8 +419,7 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 	diskutils.RemoveFile(userFile)
 	diskutils.RemoveFile(networkFile)
 
-	err = diskutils.SetFileOwnership(cloudInitOwner, isoStaging)
-	if err != nil {
+	if err := diskutils.DefaultOwnershipManager.SetFileOwnership(isoStaging); err != nil {
 		return err
 	}
 

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -51,17 +50,11 @@ var _ = Describe("CloudInit", func() {
 
 	tmpDir, _ := ioutil.TempDir("", "cloudinittest")
 
-	owner, err := user.Current()
-	if err != nil {
-		panic(err)
-	}
-
 	BeforeSuite(func() {
 		err := SetLocalDirectory(tmpDir)
 		if err != nil {
 			panic(err)
 		}
-		SetLocalDataOwner(owner.Username)
 	})
 
 	BeforeEach(func() {
@@ -143,7 +136,7 @@ var _ = Describe("CloudInit", func() {
 				It("should fail to remove local data", func() {
 					namespace := "fake-namespace"
 					domain := "fake-domain"
-					err = removeLocalData(domain, namespace)
+					err := removeLocalData(domain, namespace)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})

--- a/pkg/cloud-init/cloudinit_suite_test.go
+++ b/pkg/cloud-init/cloudinit_suite_test.go
@@ -25,11 +25,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
 	"kubevirt.io/client-go/log"
 )
 
 func TestCloudInit(t *testing.T) {
 	log.Log.SetIOWriter(GinkgoWriter)
 	RegisterFailHandler(Fail)
+	ephemeraldiskutils.MockDefaultOwnershipManager()
 	RunSpecs(t, "CloudInit Test Suite")
 }

--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "kubevirt.io/kubevirt/pkg/config",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/api/v1:go_default_library"],
+    deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+    ],
 )
 
 go_test(
@@ -24,6 +27,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/config/config-map.go
+++ b/pkg/config/config-map.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 // GetConfigMapSourcePath returns a path to ConfigMap mounted on a pod
@@ -45,8 +46,12 @@ func CreateConfigMapDisks(vmi *v1.VirtualMachineInstance) error {
 				return err
 			}
 
-			err = createIsoConfigImage(GetConfigMapDiskPath(volume.Name), filesPath)
-			if err != nil {
+			disk := GetConfigMapDiskPath(volume.Name)
+			if err := createIsoConfigImage(disk, filesPath); err != nil {
+				return err
+			}
+
+			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(disk); err != nil {
 				return err
 			}
 		}

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -6,11 +6,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
 	"kubevirt.io/client-go/log"
 )
 
 func TestConfig(t *testing.T) {
 	log.Log.SetIOWriter(GinkgoWriter)
+	ephemeraldiskutils.MockDefaultOwnershipManager()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 // GetSecretSourcePath returns a path to Secret mounted on a pod
@@ -46,8 +47,12 @@ func CreateSecretDisks(vmi *v1.VirtualMachineInstance) error {
 				return err
 			}
 
-			err = createIsoConfigImage(GetSecretDiskPath(volume.Name), filesPath)
-			if err != nil {
+			disk := GetSecretDiskPath(volume.Name)
+			if err := createIsoConfigImage(disk, filesPath); err != nil {
+				return err
+			}
+
+			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(disk); err != nil {
 				return err
 			}
 		}

--- a/pkg/config/service-account.go
+++ b/pkg/config/service-account.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 // GetServiceAccountDiskPath returns a path to the ServiceAccount iso image
@@ -40,8 +41,12 @@ func CreateServiceAccountDisk(vmi *v1.VirtualMachineInstance) error {
 				return err
 			}
 
-			err = createIsoConfigImage(GetServiceAccountDiskPath(), filesPath)
-			if err != nil {
+			disk := GetServiceAccountDiskPath()
+			if err := createIsoConfigImage(disk, filesPath); err != nil {
+				return err
+			}
+
+			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(disk); err != nil {
 				return err
 			}
 		}

--- a/pkg/emptydisk/BUILD.bazel
+++ b/pkg/emptydisk/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["emptydisk.go"],
     importpath = "kubevirt.io/kubevirt/pkg/emptydisk",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/api/v1:go_default_library"],
+    deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+    ],
 )
 
 go_test(
@@ -16,6 +19,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 )
 
 var EmptyDiskBaseDir = "/var/run/libvirt/empty-disks/"
@@ -27,6 +28,9 @@ func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
 					return err
 				}
 			} else if err != nil {
+				return err
+			}
+			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(file); err != nil {
 				return err
 			}
 		}

--- a/pkg/emptydisk/emptydisk_suite_test.go
+++ b/pkg/emptydisk/emptydisk_suite_test.go
@@ -6,11 +6,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
 	"kubevirt.io/client-go/log"
 )
 
 func TestEmptydisk(t *testing.T) {
 	log.Log.SetIOWriter(GinkgoWriter)
 	RegisterFailHandler(Fail)
+	ephemeraldiskutils.MockDefaultOwnershipManager()
 	RunSpecs(t, "Emptydisk Suite")
 }

--- a/pkg/ephemeral-disk/BUILD.bazel
+++ b/pkg/ephemeral-disk/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/ephemeral-disk/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/ephemeral-disk.go
@@ -31,7 +31,6 @@ import (
 
 var mountBaseDir = "/var/run/libvirt/kubevirt-ephemeral-disk"
 var pvcBaseDir = "/var/run/kubevirt-private/vmi-disks"
-var ephemeralImageDiskOwner = "qemu"
 
 func generateBaseDir() string {
 	return fmt.Sprintf("%s", mountBaseDir)
@@ -54,11 +53,6 @@ func SetLocalDirectory(dir string) error {
 func setBackingDirectory(dir string) error {
 	pvcBaseDir = dir
 	return os.MkdirAll(dir, 0755)
-}
-
-// Used by tests.
-func SetLocalDataOwner(user string) {
-	ephemeralImageDiskOwner = user
 }
 
 func createVolumeDirectory(volumeName string) error {
@@ -109,7 +103,7 @@ func CreateBackedImageForVolume(volume v1.Volume, backingFile string) error {
 	}
 
 	// We need to ensure that the permissions are setup correctly.
-	err = diskutils.SetFileOwnership(ephemeralImageDiskOwner, imagePath)
+	err = diskutils.DefaultOwnershipManager.SetFileOwnership(imagePath)
 	return err
 }
 

--- a/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
@@ -25,11 +25,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
 	"kubevirt.io/client-go/log"
 )
 
 func TestContainerDisk(t *testing.T) {
 	log.Log.SetIOWriter(GinkgoWriter)
 	RegisterFailHandler(Fail)
+	ephemeraldiskutils.MockDefaultOwnershipManager()
 	RunSpecs(t, "EphemeralDisk Suite")
 }

--- a/pkg/ephemeral-disk/ephemeral-disk_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_test.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -36,11 +35,6 @@ import (
 var _ = Describe("ContainerDisk", func() {
 	var imageTempDirPath string
 	var backingTempDirPath string
-
-	owner, err := user.Current()
-	if err != nil {
-		panic(err)
-	}
 
 	createBackingImageForPVC := func(volumeName string) {
 		// Note that this is within our tmpdir -- cleanup is done after tests.
@@ -87,7 +81,6 @@ var _ = Describe("ContainerDisk", func() {
 	}
 
 	BeforeEach(func() {
-		SetLocalDataOwner(owner.Username)
 
 		backingTempDirPath, err := ioutil.TempDir("", "ephemeraldisk-backing")
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/host-disk/BUILD.bazel
+++ b/pkg/host-disk/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/host-disk",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util/types:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -22,6 +23,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/host-disk/host_disk_suite_test.go
+++ b/pkg/host-disk/host_disk_suite_test.go
@@ -6,11 +6,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+
 	"kubevirt.io/client-go/log"
 )
 
 func TestHostDisk(t *testing.T) {
 	log.Log.SetIOWriter(GinkgoWriter)
 	RegisterFailHandler(Fail)
+	ephemeraldiskutils.MockDefaultOwnershipManager()
 	RunSpecs(t, "HostDisk Suite")
 }

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -111,7 +111,7 @@ func InitializePrivateDirectories(baseDir string) error {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		return err
 	}
-	if err := diskutils.SetFileOwnership("qemu", baseDir); err != nil {
+	if err := diskutils.DefaultOwnershipManager.SetFileOwnership(baseDir); err != nil {
 		return err
 	}
 	return nil
@@ -127,7 +127,7 @@ func InitializeDisksDirectories(baseDir string) error {
 	if err != nil {
 		return err
 	}
-	err = diskutils.SetFileOwnership("qemu", baseDir)
+	err = diskutils.DefaultOwnershipManager.SetFileOwnership(baseDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/cloud-init:go_default_library",
+        "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -164,7 +164,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Eventually(logs,
 				2*time.Second,
 				500*time.Millisecond).
-				Should(And(ContainSubstring("internal error: Cannot probe for supported suspend types"), ContainSubstring(`"subcomponent":"libvirt"`)))
+				Should(And(ContainSubstring("internal error: Unable to get DBus system bus connection"), ContainSubstring(`"subcomponent":"libvirt"`)))
 		})
 
 		It("[test_id:3197]should log libvirtd debug logs when enabled", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prepare kubevirt for libvirt 5.6.0 without actually switching.

* Libvirt 5.6.0 wants to set XATTRS when `remember_owner` is set to 1. Since we don't want to grant SYS_CAP_ADMIN privileges, disable `remember_owner`.
 * There is an issue with `dynamic_ownership`. It stopped working for us. Taking this as an opportuinity to clean up the code and set the ownership in a consistent fashion for all disks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

`dynamic_ownership` should work in dependent of XATTRS. We will investigate this further, but for now just set the ownership of disks ourselves in a consistent way.

 https://github.com/kubevirt/libvirt/pull/39 prepared kubevirt/libvirt.

#2893 actually switches to libvirt 5.6.0. This switch is done separately, since the 5.6 version there has slirp disabled. This can be sorted out separtely.

**Release note**:
<!--  Write your release note:

```release-note
NONE
```