### PR TITLE
Update workspace libvirt5.6.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -258,10 +258,10 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:be2976a5869fdd6cc5ab184f1bfee2345fcee22fa5fdad2db516e5d5de221ab2",
+    digest = "sha256:cfff1e8729a7466581ba71d953b132beaef28f61b330f52caef6d0184e5f9af0",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
-    #tag = "20191120.8b875d2",
+    #tag = "tmp.20191126.748bd4d.x86_64",
 )
 
 # Pull kubevirt-testing image

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -101,13 +101,12 @@ var _ = Describe("Slirp Networking", func() {
 		Expect(err).ToNot(HaveOccurred())
 		// :0050 is port 80, 0A is listening
 		Expect(strings.Contains(output, "0: 00000000:0050 00000000:0000 0A")).To(BeTrue())
-
 		By("return \"Hello World!\" when connecting to localhost on port 80")
 		output, err = tests.ExecuteCommandOnPod(
 			virtClient,
 			vmiPod,
 			vmiPod.Spec.Containers[0].Name,
-			[]string{"curl", "-s", "--retry", "30", "--retry-delay", "30", "127.0.0.1"},
+			[]string{"nc", "127.0.0.1", "80", "--recv-only"},
 		)
 		log.Log.Infof("%v", output)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR change the bazel WORKSPACE to point to libvirt  5.6.0 and also fix the slirp test it does not work with fedora31 containers https://github.com/kubevirt/kubevirt/pull/2893#issuecomment-559466752

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update to libvirt 5.6
```
