### PR TITLE
Allow as many scrapes on the VMI, like we allow parallel prom scrapes

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -328,7 +328,7 @@ func (app *virtHandlerApp) Run() {
 		glog.Fatalf("unable to generate certificates: %v", err)
 	}
 
-	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride)
+	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight)
 
 	// Bootstrapping. From here on the startup order matters
 	stop := make(chan struct{})

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -391,13 +391,13 @@ type Collector struct {
 	concCollector *concurrentCollector
 }
 
-func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string) *Collector {
+func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int) *Collector {
 	log.Log.Infof("Starting collector: node name=%v", nodeName)
 	co := &Collector{
 		virtCli:       virtCli,
 		virtShareDir:  virtShareDir,
 		nodeName:      nodeName,
-		concCollector: NewConcurrentCollector(),
+		concCollector: NewConcurrentCollector(MaxRequestsInFlight),
 	}
 	prometheus.MustRegister(co)
 	return co


### PR DESCRIPTION
**What this PR does / why we need it**:

Tie the allowed number of metric scrapes on individual qemu processes to
the amount of parallel prometheus scrapes on the API.

This avoids errors when more than one scrape goes on in parallel, and a
VMI is currently being scraped by more than one call. In this case, no
metrics were collected, which lead to missing metrics in prometheus.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2826 

**Special notes for your reviewer**:

**Release note**:

```release-note
Allow parallel metric scrapes on individual VMIs to allow multiple prometheus instances to scrape in parallel.
```
