### PR TITLE
Fix deletion of ServiceMonitor CR

### DIFF
--- a/pkg/virt-operator/install-strategy/delete.go
+++ b/pkg/virt-operator/install-strategy/delete.go
@@ -204,7 +204,7 @@ func DeleteAll(kv *v1.KubeVirt,
 			if key, err := controller.KeyFunc(serviceMonitor); err == nil {
 				expectations.ServiceMonitor.AddExpectedDeletion(kvkey, key)
 				err := prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.Namespace).Delete(serviceMonitor.Name, deleteOptions)
-				if false && err != nil {
+				if err != nil {
 					expectations.ServiceMonitor.DeletionObserved(kvkey, key)
 					log.Log.Errorf("Failed to delete serviceMonitor %+v: %v", serviceMonitor, err)
 					return err


### PR DESCRIPTION
We could never detect a failed deletion because the condition was
prefixed with a `false` boolean.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to properly handle the deletion of service monitors

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
