### PR TITLE
introduce a flag to enable/disable  managing sc

### DIFF
--- a/tests/config.go
+++ b/tests/config.go
@@ -37,6 +37,8 @@ type KubeVirtTestsConfiguration struct {
 	StorageClassRhel string `json:"storageClassRhel"`
 	// StorageClass to use to create windows PVCs
 	StorageClassWindows string `json:"storageClassWindows"`
+	// Flag if true the storageclasses are managed, false otherwise
+	ManageStorageClasses bool `json:"manageStorageClasses"`
 }
 
 func loadConfig() (*KubeVirtTestsConfiguration, error) {

--- a/tests/default-config.json
+++ b/tests/default-config.json
@@ -3,6 +3,7 @@
     "storageClassHostPath":    "host-path",
     "storageClassBlockVolume": "block-volume",
     "storageClassRhel":        "rhel",
-    "storageClassWindows":     "windows"
+    "storageClassWindows":     "windows",
+    "manageStorageClasses":     true
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -553,8 +553,10 @@ func AfterTestSuitCleanup() {
 	DeletePVC(osAlpineHostPath)
 	DeletePV(osAlpineHostPath)
 
-	deleteStorageClass(Config.StorageClassHostPath)
-	deleteStorageClass(Config.StorageClassBlockVolume)
+	if Config.ManageStorageClasses {
+		deleteStorageClass(Config.StorageClassHostPath)
+		deleteStorageClass(Config.StorageClassBlockVolume)
+	}
 
 	if DeployTestingInfrastructureFlag {
 		WipeTestingInfrastructure()
@@ -725,8 +727,10 @@ func BeforeTestSuitSetup() {
 		return len(nodes.Items)
 	}, 5*time.Minute, 10*time.Second).ShouldNot(BeZero(), "no schedulable nodes found")
 
-	createStorageClass(Config.StorageClassHostPath)
-	createStorageClass(Config.StorageClassBlockVolume)
+	if Config.ManageStorageClasses {
+		createStorageClass(Config.StorageClassHostPath)
+		createStorageClass(Config.StorageClassBlockVolume)
+	}
 
 	CreateHostPathPv(osAlpineHostPath, HostPathAlpine)
 	CreateHostPathPVC(osAlpineHostPath, defaultDiskSize)


### PR DESCRIPTION
This PR introduces a flag which enables/disable managing the storage classes within the tests.
With this PR we can disable the creation and deletion of storage class in a case we have storage classes defined beforehand. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
