### PR TITLE
Virt controller alerts

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/util:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to allow our users to monitor their kubevirt deployment,
we add a set of default alert rules which will be picked by the
monitoring operator in OKD (supported in 4.x and up).
    
Because it's not enough to have virt-controller up but we need
one of them to win the leader election, we expose a dedicated
metric that marks the controller that won the election and
another metric that indicates that the controller is ready to
step in and replace the current leader.

**Special notes for your reviewer**:
This PR is rebased on top of #2780 , so you see unrelated files in this PR. #2780 should be merged first as it adds support for alert rules.

**Release note**:
```release-note
NONE
```