### PR TITLE
Add ready condition flag to VM (#2864)

### DIFF
--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -69,6 +69,18 @@ func (d *VirtualMachineConditionManager) HasConditionWithStatus(vmi *v1.VirtualM
 	return false
 }
 
+func (d *VirtualMachineConditionManager) GetConditionWithStatus(vmi *v1.VirtualMachineInstance, cond v1.VirtualMachineInstanceConditionType, status k8sv1.ConditionStatus) *v1.VirtualMachineInstanceCondition {
+	for _, c := range vmi.Status.Conditions {
+		if c.Type == cond {
+			if c.Status == status {
+				return &c
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
 func (d *VirtualMachineConditionManager) RemoveCondition(vmi *v1.VirtualMachineInstance, cond v1.VirtualMachineInstanceConditionType) {
 	var conds []v1.VirtualMachineInstanceCondition
 	for _, c := range vmi.Status.Conditions {


### PR DESCRIPTION
Signed-off-by: Mason Prey <masonprey7@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Provides ready condition flag to the VM which enables
`$ kubectl wait --for=condition=Ready vm <vm>`

**Which issue(s) this PR fixes**
Fixes #2864 

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
