### PR TITLE
Increase timeout values for expose tests further.

### DIFF
--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -80,7 +80,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for the pod to report a successful connection attempt")
-				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 300)
+				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 420)
 			})
 		})
 
@@ -170,7 +170,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Waiting for the pod to report a successful connection attempt")
-					waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 300)
+					waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 420)
 				}
 			})
 		})
@@ -207,7 +207,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for the pod to report a successful connection attempt")
-				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 300)
+				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 420)
 			})
 		})
 
@@ -250,7 +250,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					Expect(err).ToNot(HaveOccurred())
 
 					By("Waiting for the pod to report a successful connection attempt")
-					waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 300)
+					waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 420)
 				}
 			})
 		})
@@ -312,7 +312,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Waiting for the pod to report a successful connection attempt")
-				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 300)
+				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 420)
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Increases the time out values for expose tests from 5 to 7 minutes, as [one of them has again run into a timeout](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2019-12-12-168h.html).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
