### PR TITLE
Added test for checking wide output for vm/vmi with kubectl/oc

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "expose_test.go",
         "imageupload_test.go",
         "infra_test.go",
+        "kubectl_test.go",
         "migration_test.go",
         "networkpolicy_test.go",
         "operator_test.go",

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -1,0 +1,69 @@
+package tests_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+)
+
+var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", func() {
+	tests.FlagParse()
+
+	var k8sClient string
+
+	virtCli, err := kubecli.GetKubevirtClient()
+	tests.PanicOnError(err)
+
+	BeforeEach(func() {
+		k8sClient = tests.GetK8sCmdClient()
+		tests.SkipIfNoCmd(k8sClient)
+		tests.BeforeTestCleanup()
+	})
+
+	table.DescribeTable("should verify set of columns for", func(verb, resource string, expectedHeader []string) {
+		vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+		vm, err := virtCli.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
+		Expect(err).NotTo(HaveOccurred())
+
+		tests.StartVirtualMachine(vm)
+
+		result, _, _ := tests.RunCommand(k8sClient, verb, resource)
+		Expect(result).ToNot(BeNil())
+		resultFields := strings.Fields(result)
+		columnHeaders := resultFields[:len(expectedHeader)]
+		// Verify the generated header is same as expected
+		Expect(columnHeaders).To(Equal(expectedHeader))
+		// Name will be there in all the cases, so verify name
+		Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
+	},
+		table.Entry("virtualmachine", "get", "vm", []string{"NAME", "AGE", "RUNNING", "VOLUME"}),
+		table.Entry("virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
+	)
+
+	table.DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
+		vm := tests.NewRandomVirtualMachine(tests.NewRandomVMI(), false)
+		vm, err := virtCli.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
+		Expect(err).NotTo(HaveOccurred())
+
+		tests.StartVirtualMachine(vm)
+
+		result, _, _ := tests.RunCommand(k8sClient, verb, resource, "-o", option)
+
+		Expect(result).ToNot(BeNil())
+		resultFields := strings.Fields(result)
+		columnHeaders := resultFields[:len(expectedHeader)]
+		// Verify the generated header is same as expected
+		Expect(columnHeaders).To(Equal(expectedHeader))
+		// Name will be there in all the cases, so verify name
+		Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
+		// Verify one of the wide column output field
+		Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
+	},
+		table.Entry("[test_id:3421]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "RUNNING", "VOLUME", "CREATED"}, 1, "true"),
+		table.Entry("[test_id:3422]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE"}, 1, "True"),
+	)
+})

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -12,7 +12,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = FDescribe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", func() {
+var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", func() {
 	tests.FlagParse()
 
 	var k8sClient string

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 )

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -41,8 +41,8 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 		// Name will be there in all the cases, so verify name
 		Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 	},
-		table.Entry("virtualmachine", "get", "vm", []string{"NAME", "AGE", "RUNNING", "VOLUME"}),
-		table.Entry("virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
+		table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "RUNNING", "VOLUME"}),
+		table.Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
 	)
 
 	table.DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -419,4 +419,22 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(vmis.Items)).Should(Equal(2))
 	})
+
+	It("should create and verify kubectl/oc output for vm replicaset", func() {
+		k8sClient := tests.GetK8sCmdClient()
+		tests.SkipIfNoCmd(k8sClient)
+
+		newRS := newReplicaSet()
+		doScale(newRS.ObjectMeta.Name, 2)
+
+		result, _, _ := tests.RunCommand(k8sClient, "get", "virtualmachineinstancereplicaset")
+		Expect(result).ToNot(BeNil())
+		resultFields := strings.Fields(result)
+		expectedHeader := []string{"NAME", "DESIRED", "CURRENT", "READY", "AGE"}
+		columnHeaders := resultFields[:len(expectedHeader)]
+		// Verify the generated header is same as expected
+		Expect(columnHeaders).To(Equal(expectedHeader))
+		// Name will be there in all the cases, so verify name
+		Expect(resultFields[len(expectedHeader)]).To(Equal(newRS.Name))
+	})
 })


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added test for checking wide output for vm/vmi with kubectl/oc
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added test for checking wide output for vm/vmi with kubectl/oc
```
