### PR TITLE
Add bump kubevirtci script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -148,6 +148,9 @@ Typical cases where code regeneration should be triggered are:
 
  We have a check in our CI system, so that you don't miss when `make generate` needs to be called.
 
+ * Another case is when kubevirtci is updated, in order to vendor cluster-up run `hack/bump-kubevirtci.sh` and then
+   `make generate`
+
 ### Testing
 
 After a successful build you can run the *unit tests*:

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,0 +1,4 @@
+#/bin/bash
+val=$(git ls-remote https://github.com/kubevirt/kubevirtci | grep HEAD | awk '{print $1}')
+sed -i "/^[[:blank:]]*kubevirtci_git_hash[[:blank:]]*=/s/=.*/=\"${val}\"/" hack/config-default.sh
+git --no-pager diff hack/config-default.sh | grep "kubevirtci_git_hash"


### PR DESCRIPTION
Script would update hack/config-default.sh,
and then its possible to run make generate in order to fetch
newest kubevirtci cluster-up folder

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
NONE
```
