### PR TITLE
virt-operator to enforce namespace labels

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -302,6 +302,9 @@ spec:
           - namespaces
           verbs:
           - get
+          - list
+          - watch
+          - patch
         - apiGroups:
           - admissionregistration.k8s.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -157,6 +157,9 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
+  - watch
+  - patch
 - apiGroups:
   - admissionregistration.k8s.io
   resources:

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -141,6 +141,7 @@ func Execute() {
 		InstallStrategyJob:       app.informerFactory.OperatorInstallStrategyJob(),
 		InfrastructurePod:        app.informerFactory.OperatorPod(),
 		PodDisruptionBudget:      app.informerFactory.OperatorPodDisruptionBudget(),
+		Namespace:                app.informerFactory.Namespace(),
 	}
 
 	app.stores = util.Stores{
@@ -158,6 +159,7 @@ func Execute() {
 		InstallStrategyJobCache:       app.informerFactory.OperatorInstallStrategyJob().GetStore(),
 		InfrastructurePodCache:        app.informerFactory.OperatorPod().GetStore(),
 		PodDisruptionBudgetCache:      app.informerFactory.OperatorPodDisruptionBudget().GetStore(),
+		NamespaceCache:                app.informerFactory.Namespace().GetStore(),
 	}
 
 	onOpenShift, err := clusterutil.IsOnOpenShift(app.clientSet)

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -272,6 +272,9 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 				},
 				Verbs: []string{
 					"get",
+					"list",
+					"watch",
+					"patch",
 				},
 			},
 		},

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -99,6 +99,14 @@ func NewKubeVirtController(
 		UpdateFunc: c.updateKubeVirt,
 	})
 
+	c.informers.Namespace.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.genericAddHandler(obj, nil)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.genericUpdateHandler(oldObj, newObj, nil)
+		},
+	})
 	c.informers.ServiceAccount.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.genericAddHandler(obj, c.kubeVirtExpectations.ServiceAccount)
@@ -458,6 +466,7 @@ func (c *KubeVirtController) Run(threadiness int, stopCh <-chan struct{}) {
 	cache.WaitForCacheSync(stopCh, c.informers.InfrastructurePod.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.PodDisruptionBudget.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.ServiceMonitor.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.informers.Namespace.HasSynced)
 
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -43,6 +43,7 @@ type Stores struct {
 	InfrastructurePodCache        cache.Store
 	PodDisruptionBudgetCache      cache.Store
 	ServiceMonitorCache           cache.Store
+	NamespaceCache                cache.Store
 	IsOnOpenshift                 bool
 	ServiceMonitorEnabled         bool
 }
@@ -122,6 +123,7 @@ type Informers struct {
 	InfrastructurePod        cache.SharedIndexInformer
 	PodDisruptionBudget      cache.SharedIndexInformer
 	ServiceMonitor           cache.SharedIndexInformer
+	Namespace                cache.SharedIndexInformer
 }
 
 func (e *Expectations) DeleteExpectations(key string) {

--- a/staging/src/kubevirt.io/client-go/go.mod
+++ b/staging/src/kubevirt.io/client-go/go.mod
@@ -40,3 +40,5 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
 	kubevirt.io/containerized-data-importer => kubevirt.io/containerized-data-importer v1.10.6
 )
+
+go 1.13

--- a/staging/src/kubevirt.io/client-go/go.sum
+++ b/staging/src/kubevirt.io/client-go/go.sum
@@ -471,6 +471,7 @@ gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1357,6 +1357,15 @@ spec:
 				return string(data)
 			}, 90*time.Second, 3*time.Second).Should(ContainSubstring(tests.KubeVirtInstallNamespace), "Prometheus should be monitoring KubeVirt")
 		})
+
+		It("Should patch our namespace labels with openshift.io/cluster-monitoring=true", func() {
+			By("Inspecting the labels on our namespace")
+			namespace, err := virtClient.CoreV1().Namespaces().Get(tests.KubeVirtInstallNamespace, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			monitoringLabel, exists := namespace.ObjectMeta.Labels["openshift.io/cluster-monitoring"]
+			Expect(exists).To(BeTrue())
+			Expect(monitoringLabel).To(Equal("true"))
+		})
 	})
 })
 


### PR DESCRIPTION
Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As part of the default KubeVirt installation, we deploy a set of alert rules for OpenShift's cluster-monitoring system to pick. This process requires a specific label on our namespace to be set.
This PR gives `virt-operator` the ability to patch our namespace and set the required labels.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-operator is now enforcing labels on the deployment namespace.
```
