### PR TITLE
remove @ahadas from code-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,7 +26,6 @@ aliases:
       - dhiller
       - pkotas
       - vatsalparekh
-      - ahadas
       - danielBelenky
   ux-reviewers:
       - matthewcarleton


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove @ahadas  from the list of core reviewers.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
