### PR TITLE
Added check in virt-controller to update podNetwork IPs on VMI status interface

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1708,6 +1708,21 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					targetNode.Name,
 					targetNode.Name,
 				))
+
+				By("Checking that all migrated VMIs have the new pod IP address on VMI status")
+				for _, vmi := range vmis {
+					Eventually(func() error {
+						newvmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred(), "Should successfully get new VMI")
+						vmiPod := tests.GetRunningPodByVirtualMachineInstance(newvmi, tests.NamespaceTestDefault)
+
+						if newvmi.Status.Interfaces[0].IP == vmiPod.Status.PodIP {
+							return nil
+						}
+
+						return fmt.Errorf("interface not updated with latest IP")
+					}, 1*time.Minute, 1*time.Second).Should(BeNil(), "Should match PodIP with latest VMI Status after migration")
+				}
 			})
 		})
 


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added check in virt-controller to update podNetwork IPs on VMI status interface

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
**Fixes** # https://bugzilla.redhat.com/show_bug.cgi?id=1686208

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added check in virt-controller to update podNetwork interface IPs
```
