### PR TITLE
Add dhiller to kubevirtci approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,3 +11,6 @@ filters:
   "pkg/virt-api/.*":
     reviewers:
       - ux-reviewers
+  "cluster-up-sha.txt":
+    approvers:
+      - ci-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,3 +33,5 @@ aliases:
       - jerry7z
       - ILpinto
       - dshchedr
+  ci-approvers:
+      - dhiller

--- a/cluster-up/OWNERS
+++ b/cluster-up/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    approvers:
+      - ci-approvers


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds user dhiller to the approvers for kubevirtci updates.

**Release note**:
```release-note
NONE
```
