### PR TITLE
Fix race in operator test suite

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1222,6 +1222,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 	fakeNamespaceModificationEvent := func() {
 		// Add modification event for namespace w/o the labels we need
+		mockQueue.ExpectAdds(1)
 		namespaceSource.Modify(&k8sv1.Namespace{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "Namespace",
@@ -1230,6 +1231,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Name: NAMESPACE,
 			},
 		})
+		mockQueue.Wait()
 	}
 
 	shouldExpectNamespacePatch := func() {


### PR DESCRIPTION
When adding a dummy "modified" namespace, we should wait until the event
was actually added to the queue. Otherwise, we're facing a race where
we add a modified event to the source triggers addition to the mock
queue and it adds an event to the queue. This call to add reduces an
expectation from the work group of the queue and since nothing raised it
in first place, the test panics.

The reason we sometimes see it and sometimes we don't, is because if
another component is being added to the queue before the watch event is
being distributed thought the channel, we will be "ok".

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

```release-note
NONE
```
