### PR TITLE
Add kubevirt-builder/Dockerfile.ci

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -1,0 +1,129 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+
+# Install packages
+# dnf copr enable -y @virtmaint-sig/virt-preview with yum?
+# python3-pip-9.0.3-5.el7.noarch \
+RUN yum install -y yum-plugin-copr && \
+    yum copr enable -y vbatts/bazel epel-7 && \
+    yum -y install \
+        libvirt-devel \
+        bazel \
+        cpio \
+        patch \
+        make \
+        git \
+        mercurial \
+        sudo \
+        gcc \
+        gcc-c++ \
+        glibc-devel \
+        findutils \
+        qemu-img \
+        protobuf-compiler \
+        python3-devel \
+        python3-pip \
+        redhat-rpm-config \
+        jq \
+        unzip && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+ENV GIMME_GO_VERSION=1.12.8
+
+RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
+
+ENV GOPATH="/go" GOBIN="/usr/bin"
+
+# Install persistent go packages
+RUN \
+    mkdir -p /go && \
+    source /etc/profile.d/gimme.sh && \
+    # Install goimports
+    go get -u -d golang.org/x/tools/cmd/goimports && \
+    cd $GOPATH/src/golang.org/x/tools/cmd/goimports && \
+    git checkout release-branch.go1.12 && \
+    go install && \
+    # Install mvdan/sh
+    git clone https://github.com/mvdan/sh.git $GOPATH/src/mvdan.cc/sh && \
+    cd $GOPATH/src/mvdan.cc/sh/cmd/shfmt && \
+    git checkout v2.5.0 && \
+    go get mvdan.cc/sh/cmd/shfmt && \
+    go install && \
+    go get -u -d k8s.io/code-generator/cmd/deepcopy-gen && \
+    go get -u -d k8s.io/code-generator/cmd/defaulter-gen && \
+    go get -u -d k8s.io/kube-openapi/cmd/openapi-gen && \
+    go get -u -d github.com/golang/protobuf/protoc-gen-go && \
+    # Install deepcopy-gen
+    cd $GOPATH/src/k8s.io/code-generator/cmd/deepcopy-gen && \
+    git checkout kubernetes-1.13.4 && \
+    go install && \
+    # Install defaulter-gen
+    cd $GOPATH/src/k8s.io/code-generator/cmd/defaulter-gen && \
+    git checkout kubernetes-1.13.4 && \
+    go install && \
+    # Install openapi-gen
+    cd $GOPATH/src/k8s.io/kube-openapi/cmd/openapi-gen && \
+    git checkout c59034cc13d587f5ef4e85ca0ade0c1866ae8e1d && \
+    go install && \
+    # Install protoc-gen-go
+    cd $GOPATH/src/github.com/golang/protobuf/protoc-gen-go && \
+    git checkout 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9 && \
+    go install
+
+
+RUN \
+    source /etc/profile.d/gimme.sh && \
+    go get github.com/mattn/goveralls && \
+    go get -u github.com/golang/mock/gomock && \
+    go get -u github.com/rmohr/mock/mockgen && \
+    go get -u github.com/rmohr/go-swagger-utils/swagger-doc && \
+    go get -u github.com/onsi/ginkgo/ginkgo
+
+RUN pip3 install j2cli && pip3 install operator-courier==1.3.0
+
+WORKDIR /tmp/kubevirt
+COPY . .
+
+# update git
+COPY hack/ci/wandisco-git.repo /etc/yum.repos.d/wandisco-git.repo
+RUN yum remove -y git && \
+    rpm --import http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco && \
+    yum install -y git && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+RUN \
+    export DOCKER_PREFIX='dhiller' && \
+    export DOCKER_TAG="latest" && \
+    export KUBEVIRT_PROVIDER=external && \
+    export GIMME_GO_VERSION=1.12.8 && \
+    export GOPATH="/go" && \
+    export GOBIN="/usr/bin" && \
+    source /etc/profile.d/gimme.sh && \
+    curl -L -O -o cluster-up/cluster/external/provider.sh https://raw.githubusercontent.com/dhiller/kubevirtci/fix-external-provider/cluster-up/cluster/external/provider.sh && \
+    bash -x ./hack/build-manifests.sh && \
+    bash -x ./hack/build-func-tests.sh && \
+    curl -L -O -o kvm-ds.yaml https://raw.githubusercontent.com/kubevirt/kubernetes-device-plugins/master/manifests/kvm-ds.yml
+FROM centos:7
+
+COPY --from=builder /etc/profile.d/gimme.sh /etc/profile.d/gimme.sh
+# Install persistent go packages
+RUN yum install -y yum-plugin-copr && \
+    yum copr enable -y vbatts/bazel epel-7 && \
+    yum -y install \
+        git \
+        wget \
+        which \
+        gcc \
+        gcc-c++ \
+        jq \
+        glibc-devel && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+RUN wget https://dl.google.com/go/go1.12.8.linux-amd64.tar.gz && \
+    tar -zxvf go1.12.8.linux-amd64.tar.gz -C /usr/local
+ENV GIMME_GO_VERSION=1.12.8
+ENV GOPATH="/go" GOBIN="/usr/bin"
+ENV PATH="$PATH:/usr/local/go/bin/"
+COPY --from=builder /gimme /gimme
+RUN chmod 777 /gimme
+COPY --from=builder /tmp/kubevirt /go/src/kubevirt.io/kubevirt
+COPY --from=builder /tmp/kubevirt/hack/kubevirt-builder/rsyncd.conf /etc/rsyncd.conf

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export PATH=$PATH:/usr/local/go/bin/
+which kubectl
+which oc
+echo "checking nodes for cluster"
+# in CI, this cmd fails unless you provide a ns
+oc -n default get nodes
+echo "checking configuration"
+env | grep KUBE
+kubectl config view
+export DOCKER_PREFIX='dhiller'
+export DOCKER_TAG="latest"
+export KUBEVIRT_PROVIDER=external
+export GIMME_GO_VERSION=1.12.8
+export GOPATH="/go"
+export GOBIN="/usr/bin"
+source /etc/profile.d/gimme.sh
+echo "checking configuration location"
+echo "KUBECONFIG: ${KUBECONFIG}"
+# enable nested-virt
+oc get machineset -n openshift-machine-api -o json >/tmp/machinesets.json
+MACHINE_IMAGE=$(jq .items[0].spec.template.spec.providerSpec.value.disks[0].image /tmp/machinesets.json)
+NESTED_VIRT_IMAGE="sotest-rhcos-nested-virt"
+sed -i "s/$MACHINE_IMAGE/$NESTED_VIRT_IMAGE/g" /tmp/machinesets.json
+sed -i 's/sotest-rhcos-nested-virt/"sotest-rhcos-nested-virt"/g' /tmp/machinesets.json
+oc apply -f /tmp/machinesets.json
+oc scale --replicas=0 machineset --all -n openshift-machine-api
+oc get machines -n openshift-machine-api -o json >/tmp/machines.json
+num_machines=$(jq '.items | length' /tmp/machines.json)
+while [ "$num_machines" -ne "3" ]; do
+    oc get machines -n openshift-machine-api -o json >/tmp/machines.json
+    num_machines=$(jq '.items | length' /tmp/machines.json)
+done
+oc scale --replicas=1 machineset --all -n openshift-machine-api
+while [ "$num_machines" -ne "6" ]; do
+    oc get machines -n openshift-machine-api -o json >/tmp/machines.json
+    num_machines=$(jq '.items | length' /tmp/machines.json)
+done
+while [ $(oc get nodes | wc -l) -ne "7" ]; do oc get nodes; done
+nodes_ready=false
+while ! "$nodes_ready"; do sleep 5 && if ! oc get nodes | grep NotReady; then nodes_ready=true; fi; done
+oc project default
+oc apply -f /go/src/kubevirt.io/kubevirt/kvm-ds.yml
+workers=$(oc get nodes | grep worker | awk '{ print $1 }')
+workers_each=($workers)
+for i in {0..2}; do
+    if ! oc debug node/"${workers_each[i]}" -- ls /dev/kvm; then oc debug node/"${workers_each[i]}" -- ls /dev/kvm; fi
+done
+echo "calling cluster-up to prepare config and check whether cluster is reachable"
+bash -x ./cluster-up/up.sh
+echo "checking cluster configuration after config prep"
+kubectl config view
+echo "deploying"
+bash -x ./hack/cluster-deploy.sh
+echo "checking pods for kubevirt"
+oc get pods -n kubevirt
+echo "testing"
+bash -x ./hack/functests.sh

--- a/hack/ci/wandisco-git.repo
+++ b/hack/ci/wandisco-git.repo
@@ -1,0 +1,6 @@
+[wandisco-git]
+name=Wandisco GIT Repository
+baseurl=http://opensource.wandisco.com/centos/7/git/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -23,6 +23,8 @@ DOCKER_TAG=${DOCKER_TAG:-devel}
 DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
 
 export ARTIFACTS=${ARTIFACTS:-_out/artifacts}
+# without this the tests fail because kubeconfig is not set
+export KUBECONFIG=${KUBECONFIG}
 
 source hack/common.sh
 source hack/config.sh
@@ -45,4 +47,4 @@ if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} == okd-* ]]; th
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${KUBECONFIG} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra}


### PR DESCRIPTION
Dockerfile that will work for CI builds
@dhiller 
This PR needs to merge before https://github.com/dhiller/release/pull/2

I recommend merging this then the release PR (that I set the job to `always_run: false` so that to run it you'd `/test e2e` from a test PR here, then once the tests are passing you can submit a PR to release to change to `always_run: true`. 

This is pretty close to what you'll need to run the kubevirt hack/functests.sh in CI
The Dockerfile creates an image that has the tests built, src code - in CI it will be built w/ the PR's src code.  The CI job will use a stock CI template `openshift/release/ci-operator/templates/openshift/installer/cluster-launch-installer-custom-test-image.yaml` where the test image is the image built by this added Dockerfile.  

To Test This:
```console
$ podman pull quay.io/sallyom/kubevirt-test:test  
$ podman run --rm -it -v /path/to/a/local/kubeconfig:/tmp/kubeconfig:Z quay.io/sallyom/kubevirt-test:test sh
then in container:
# export KUBECONFIG=/tmp/kubeconfig
// have to install oc here, but in CI oc,kubectl are installed in the test container
# mkdir /tmp/oc; cd /tmp/oc
# curl -L -O https://mirror.openshift.com/pub/openshift-v4/clients/oc/4.2/linux/oc.tar.gz
# tar xzvf oc.tar.gz
# ln -s /tmp/oc/oc kubectl
# export PATH=$PATH:/tmp/oc/
# cd /go/src/kubevirt.io/kubevirt
# ./hack/ci/test.sh
```
**NOTE:** the image is huge, so after you're done remove it w/ something like: 
podman volume prune
podman system-prune -a 

```release-note
NONE
```