### PR TITLE
Changed the logic to only allow specific interface types for migrations

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1272,17 +1272,9 @@ func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.Vi
 		networks[network.Name] = network.DeepCopy()
 	}
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if networks[iface.Name].Pod != nil {
-			if iface.Masquerade != nil {
-				continue
-			}
+		if iface.Masquerade == nil && networks[iface.Name].Pod != nil {
+			return fmt.Errorf("cannot migrate VMI which does not use masquerade to connect to the pod network")
 		}
-		if networks[iface.Name].Multus != nil {
-			if iface.Bridge != nil {
-				continue
-			}
-		}
-		return fmt.Errorf("cannot migrate VMI with the given interface & network, only Masquerade with a Pod network allowed for migration")
 	}
 	return nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1272,9 +1272,13 @@ func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.Vi
 		networks[network.Name] = network.DeepCopy()
 	}
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Bridge != nil && networks[iface.Name].Pod != nil {
-			return fmt.Errorf("cannot migrate VMI with a bridge interface connected to a pod network")
+		if networks[iface.Name].Pod != nil {
+			if iface.Masquerade != nil {
+				continue
+			}
+			return fmt.Errorf("cannot migrate VMI with the given interface & network, only Masquerade with a Pod network allowed for migration")
 		}
+		return fmt.Errorf("cannot migrate VMI with the given interface & network, only Masquerade with a Pod network allowed for migration")
 	}
 	return nil
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1276,7 +1276,11 @@ func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.Vi
 			if iface.Masquerade != nil {
 				continue
 			}
-			return fmt.Errorf("cannot migrate VMI with the given interface & network, only Masquerade with a Pod network allowed for migration")
+		}
+		if networks[iface.Name].Multus != nil {
+			if iface.Bridge != nil {
+				continue
+			}
 		}
 		return fmt.Errorf("cannot migrate VMI with the given interface & network, only Masquerade with a Pod network allowed for migration")
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1152,7 +1152,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with non-shared HostDisk")))
 		})
 
-		It("should allow to migrate with adding default networks", func() {
+		It("should not allow to migrate with adding default network configuration", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			err := controller.checkNetworkInterfacesForMigration(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -1178,7 +1178,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}
 
 			err := controller.checkNetworkInterfacesForMigration(vmi)
-			Expect(err).ToNot(HaveOccurred(), "should block migration for bridging interface")
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 	Context("VirtualMachineInstance controller gets informed about interfaces in a Domain", func() {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1151,6 +1151,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(blockMigrate).To(BeTrue())
 			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with non-shared HostDisk")))
 		})
+
+		It("should allow to migrate with adding default networks", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			err := controller.checkNetworkInterfacesForMigration(vmi)
+			Expect(err).To(BeNil())
+		})
 	})
 	Context("VirtualMachineInstance controller gets informed about interfaces in a Domain", func() {
 		It("should update existing interface with MAC", func() {


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Changed the logic for which interfaces and networks should be allowed for migrations
From not allowing only bridge, changed it to allow only the types we support
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changed the logic for which interfaces and networks should be allowed for migrations
```
