### PR TITLE
go build should always use vendor mode

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -96,10 +96,10 @@ for arg in $args; do
             # the containerdisk bianry needs to be static, as it runs in a scratch container
             if [[ $BIN_NAME == *"container-disk"* ]]; then
                 echo "building static binary $BIN_NAME"
-                CGO_ENABLED=0 GOPROXY=off GOFLAGS=-mod=vendor GOOS=linux GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -tags netgo -ldflags "-extldflags '-static' $(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
+                CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go_build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -tags netgo -ldflags "-extldflags '-static' $(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
             else
                 echo "building dynamic binary $BIN_NAME"
-                GOPROXY=off GOFLAGS=-mod=vendor GOOS=linux GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
+                GOOS=linux GOARCH=amd64 go_build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
             fi
 
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
@@ -109,8 +109,8 @@ for arg in $args; do
 
             # build virtctl also for darwin and windows
             if [ "${BIN_NAME}" = "virtctl" ]; then
-                GOPROXY=off GOFLAGS=-mod=vendor GOOS=darwin GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
-                GOPROXY=off GOFLAGS=-mod=vendor GOOS=windows GOARCH=amd64 go build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
+                GOOS=darwin GOARCH=amd64 go_build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-darwin-amd64 -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir darwin amd64)
+                GOOS=windows GOARCH=amd64 go_build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${ARCH_BASENAME}-windows-amd64.exe -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir windows amd64)
                 # Create symlinks to the latest binary of each architecture
                 (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-darwin-amd64 ${BIN_NAME}-darwin)
                 (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${ARCH_BASENAME}-windows-amd64.exe ${BIN_NAME}-windows.exe)

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -33,7 +33,7 @@ kubevirt_logo_path="assets/kubevirt_logo.png"
 rm -rf ${MANIFESTS_OUT_DIR}
 rm -rf ${MANIFEST_TEMPLATES_OUT_DIR}
 
-(cd ${KUBEVIRT_DIR}/tools/manifest-templator/ && go build)
+(cd ${KUBEVIRT_DIR}/tools/manifest-templator/ && go_build)
 
 # first process file includes only
 args=$(cd ${KUBEVIRT_DIR}/manifests && find . -type f -name "*.yaml.in" -not -path "./generated/*")

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -62,3 +62,7 @@ function kubevirt_version() {
     fi
 }
 KUBEVIRT_VERSION="$(kubevirt_version)"
+
+function go_build() {
+    GOPROXY=off GOFLAGS=-mod=vendor go build "$@"
+}

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -36,12 +36,12 @@ find ${KUBEVIRT_DIR}/pkg/ -name "*generated*.go" -exec rm {} -f \;
 
 ${KUBEVIRT_DIR}/hack/build-go.sh generate ${WHAT}
 /${KUBEVIRT_DIR}/hack/bootstrap-ginkgo.sh
-(cd ${KUBEVIRT_DIR}/tools/openapispec/ && go build)
+(cd ${KUBEVIRT_DIR}/tools/openapispec/ && go_build)
 
 ${KUBEVIRT_DIR}/tools/openapispec/openapispec --dump-api-spec-path ${KUBEVIRT_DIR}/api/openapi-spec/swagger.json
 
-(cd ${KUBEVIRT_DIR}/tools/resource-generator/ && go build)
-(cd ${KUBEVIRT_DIR}/tools/csv-generator/ && go build)
+(cd ${KUBEVIRT_DIR}/tools/resource-generator/ && go_build)
+(cd ${KUBEVIRT_DIR}/tools/csv-generator/ && go_build)
 rm -f ${KUBEVIRT_DIR}/manifests/generated/*
 rm -f ${KUBEVIRT_DIR}/examples/*
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=vmi >${KUBEVIRT_DIR}/manifests/generated/vmi-resource.yaml
@@ -100,7 +100,7 @@ ${KUBEVIRT_DIR}/tools/csv-generator/csv-generator --namespace={{.CSVNamespace}} 
 sed -i "s/$_fake_csv_version/{{.CsvVersion}}/g" ${KUBEVIRT_DIR}/manifests/generated/operator-csv.yaml.in
 sed -i "s/$_fake_replaces_csv_version/{{.ReplacesCsvVersion}}/g" ${KUBEVIRT_DIR}/manifests/generated/operator-csv.yaml.in
 
-(cd ${KUBEVIRT_DIR}/tools/vms-generator/ && go build)
+(cd ${KUBEVIRT_DIR}/tools/vms-generator/ && go_build)
 vms_docker_prefix=${DOCKER_PREFIX:-registry:5000/kubevirt}
 vms_docker_tag=${DOCKER_TAG:-devel}
 ${KUBEVIRT_DIR}/tools/vms-generator/vms-generator --container-prefix=${vms_docker_prefix} --container-tag=${vms_docker_tag} --generated-vms-dir=${KUBEVIRT_DIR}/examples


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Declare a function `go_build` in `hack/common.sh` and use it everywhere instead of directly using `go build` so vendoring is always used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
