### PR TITLE
Revoke permission to GET secrets from virt-launcher

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -503,7 +503,6 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - secrets
           - persistentvolumeclaims
           verbs:
           - get
@@ -542,6 +541,7 @@ spec:
           - secrets
           verbs:
           - create
+          - get
         - apiGroups:
           - subresources.kubevirt.io
           resources:

--- a/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-kubevirt.authorization.k8s.yaml.in
@@ -311,7 +311,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - persistentvolumeclaims
   verbs:
   - get
@@ -374,6 +373,7 @@ rules:
   - secrets
   verbs:
   - create
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -358,7 +358,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
   - persistentvolumeclaims
   verbs:
   - get
@@ -397,6 +396,7 @@ rules:
   - secrets
   verbs:
   - create
+  - get
 - apiGroups:
   - subresources.kubevirt.io
   resources:

--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -9,11 +9,8 @@ go_library(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )
 
@@ -27,14 +24,10 @@ go_test(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",
-        "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
     ],
 )

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -504,6 +504,40 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		if volume.ServiceAccount != nil {
 			serviceAccountName = volume.ServiceAccount.ServiceAccountName
 		}
+
+		if volume.CloudInitNoCloud != nil && volume.CloudInitNoCloud.UserDataSecretRef != nil {
+			// attach a secret referenced by the user
+			volumes = append(volumes, k8sv1.Volume{
+				Name: volume.Name,
+				VolumeSource: k8sv1.VolumeSource{
+					Secret: &k8sv1.SecretVolumeSource{
+						SecretName: volume.CloudInitNoCloud.UserDataSecretRef.Name,
+					},
+				},
+			})
+			volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+				Name:      volume.Name,
+				MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
+				ReadOnly:  true,
+			})
+		}
+
+		if volume.CloudInitConfigDrive != nil && volume.CloudInitConfigDrive.UserDataSecretRef != nil {
+			// attach a secret referenced by the user
+			volumes = append(volumes, k8sv1.Volume{
+				Name: volume.Name,
+				VolumeSource: k8sv1.VolumeSource{
+					Secret: &k8sv1.SecretVolumeSource{
+						SecretName: volume.CloudInitConfigDrive.UserDataSecretRef.Name,
+					},
+				},
+			})
+			volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+				Name:      volume.Name,
+				MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
+				ReadOnly:  true,
+			})
+		}
 	}
 
 	if t.imagePullSecret != "" {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -241,34 +241,6 @@ var _ = Describe("Template", func() {
 				}
 				Expect(cloudInitVolumeMountFound).To(BeTrue(), "could not find cloud init secret volume mount")
 			})
-			It("should not add volume with secret referenced by cloud-init user secret ref when it's not specified", func() {
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "testvmi",
-						Namespace: "default",
-						UID:       "1234",
-					},
-				}
-
-				pod, err := svc.RenderLaunchManifest(&vmi)
-				Expect(err).ToNot(HaveOccurred())
-				found := false
-				for _, volume := range pod.Spec.Volumes {
-					if volume.Name == "cloud-init-user-data-secret-ref" {
-						found = true
-					}
-				}
-				Expect(found).To(BeFalse(), "found cloud init secret volume when it should not exist")
-
-				cloudInitVolumeMountFound := false
-				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
-					if volumeMount.Name == "cloud-init-user-data-secret-ref" {
-						cloudInitVolumeMountFound = true
-					}
-				}
-				Expect(cloudInitVolumeMountFound).To(BeFalse(),
-					"found cloud init secret volume mount when it should not exist")
-			})
 		})
 		Context("with multus annotation", func() {
 			It("should add multus networks in the pod annotation", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -198,6 +198,78 @@ var _ = Describe("Template", func() {
 				Expect(debugLogsValue).To(Equal("1"))
 			})
 		})
+		Context("with cloud-init secret", func() {
+			It("should add volume with secret referenced by cloud-init user secret ref", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Volumes: []v1.Volume{
+							{
+								Name: "cloud-init-user-data-secret-ref",
+								VolumeSource: v1.VolumeSource{
+									CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+										UserDataSecretRef: &kubev1.LocalObjectReference{
+											Name: "some-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				cloudInitVolumeFound := false
+				for _, volume := range pod.Spec.Volumes {
+					if volume.Name == "cloud-init-user-data-secret-ref" {
+						cloudInitVolumeFound = true
+					}
+				}
+				Expect(cloudInitVolumeFound).To(BeTrue(), "could not find cloud init secret volume")
+
+				cloudInitVolumeMountFound := false
+				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
+					if volumeMount.Name == "cloud-init-user-data-secret-ref" {
+						cloudInitVolumeMountFound = true
+					}
+				}
+				Expect(cloudInitVolumeMountFound).To(BeTrue(), "could not find cloud init secret volume mount")
+			})
+			It("should not add volume with secret referenced by cloud-init user secret ref when it's not specified", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				found := false
+				for _, volume := range pod.Spec.Volumes {
+					if volume.Name == "cloud-init-user-data-secret-ref" {
+						found = true
+					}
+				}
+				Expect(found).To(BeFalse(), "found cloud init secret volume when it should not exist")
+
+				cloudInitVolumeMountFound := false
+				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
+					if volumeMount.Name == "cloud-init-user-data-secret-ref" {
+						cloudInitVolumeMountFound = true
+					}
+				}
+				Expect(cloudInitVolumeMountFound).To(BeFalse(),
+					"found cloud init secret volume mount when it should not exist")
+			})
+		})
 		Context("with multus annotation", func() {
 			It("should add multus networks in the pod annotation", func() {
 				vmi := v1.VirtualMachineInstance{

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/cloud-init:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/host-disk:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -46,7 +46,6 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
-	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/controller"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
@@ -1392,11 +1391,6 @@ func (d *VirtualMachineController) processVmUpdate(origVMI *v1.VirtualMachineIns
 	}
 
 	err = hostdisk.ReplacePVCByHostDisk(vmi, d.clientset)
-	if err != nil {
-		return err
-	}
-
-	err = cloudinit.InjectCloudInitSecrets(vmi, d.clientset)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -774,6 +774,16 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 
 	logger.Info("Executing PreStartHook on VMI pod environment")
 
+	err := cloudinit.ResolveNoCloudSecrets(vmi, config.SecretSourceDir)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cloudinit.ResolveConfigDriveSecrets(vmi, config.SecretSourceDir)
+	if err != nil {
+		return nil, err
+	}
+
 	// generate cloud-init data
 	cloudInitData, err := cloudinit.ReadCloudInitVolumeDataSource(vmi)
 	if err != nil {

--- a/pkg/virt-operator/creation/rbac/handler.go
+++ b/pkg/virt-operator/creation/rbac/handler.go
@@ -84,7 +84,7 @@ func newHandlerClusterRole() *rbacv1.ClusterRole {
 					"",
 				},
 				Resources: []string{
-					"secrets", "persistentvolumeclaims",
+					"persistentvolumeclaims",
 				},
 				Verbs: []string{
 					"get",
@@ -190,6 +190,7 @@ func newHandlerRole(namespace string) *rbacv1.Role {
 				},
 				Verbs: []string{
 					"create",
+					"get",
 				},
 			},
 		},


### PR DESCRIPTION
In order to avoid giving virt-handler permission to GET all secrets
across all namespaces, virt-controller will now renders an additional
secret volume mount to virt-launcher's pod. This allows virt-launcher
to read the secret directly from the disk instead of having virt-launcher
to GET it.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2967 

**Special notes for your reviewer**:
You don't see any functional test changes in this PR because those already exists from the previous implementation :)
Unit tests were adjusted to the new implementation...

**Release note**:
```release-note
Revoke permission to GET secrets from virt-launcher
```
