### PR TITLE
Move containerdisks to their own BUILD file to not download them when just building

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -212,12 +212,12 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)example-cloudinit-hook-sidecar:$(container_tag)": "//cmd/example-cloudinit-hook-sidecar:example-cloudinit-hook-sidecar-image",
         "$(container_prefix)/$(image_prefix)subresource-access-test:$(container_tag)": "//cmd/subresource-access-test:subresource-access-test-image",
         # container-disk images
-        "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//cmd/container-disk-v2alpha:alpine-container-disk-image",
-        "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//cmd/container-disk-v2alpha:cirros-container-disk-image",
-        "$(container_prefix)/$(image_prefix)cirros-custom-container-disk-demo:$(container_tag)": "//cmd/container-disk-v2alpha:cirros-custom-container-disk-image",
-        "$(container_prefix)/$(image_prefix)fedora-cloud-container-disk-demo:$(container_tag)": "//cmd/container-disk-v2alpha:fedora-cloud-container-disk-image",
-        "$(container_prefix)/$(image_prefix)fedora30-cloud-container-disk-demo:$(container_tag)": "//cmd/container-disk-v2alpha:fedora30-cloud-container-disk-image",
-        "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//cmd/container-disk-v2alpha:virtio-container-disk-image",
+        "$(container_prefix)/$(image_prefix)alpine-container-disk-demo:$(container_tag)": "//containerimages:alpine-container-disk-image",
+        "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",
+        "$(container_prefix)/$(image_prefix)cirros-custom-container-disk-demo:$(container_tag)": "//containerimages:cirros-custom-container-disk-image",
+        "$(container_prefix)/$(image_prefix)fedora-cloud-container-disk-demo:$(container_tag)": "//containerimages:fedora-cloud-container-disk-image",
+        "$(container_prefix)/$(image_prefix)fedora30-cloud-container-disk-demo:$(container_tag)": "//containerimages:fedora30-cloud-container-disk-image",
+        "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
         # testing images
         "$(container_prefix)/$(image_prefix)disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",
         "$(container_prefix)/$(image_prefix)cdi-http-import-server:$(container_tag)": "//images/cdi-http-import-server:cdi-http-import-server-image",

--- a/cmd/container-disk-v2alpha/BUILD.bazel
+++ b/cmd/container-disk-v2alpha/BUILD.bazel
@@ -1,49 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-
-container_image(
-    name = "alpine-container-disk-image",
-    directory = "/disk",
-    files = ["@alpine_image//file"],
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "cirros-container-disk-image",
-    directory = "/disk",
-    files = ["@cirros_image//file"],
-    visibility = ["//visibility:public"],
-)
-
-# used for e2e testing of custom base baths
-container_image(
-    name = "cirros-custom-container-disk-image",
-    directory = "/custom-disk",
-    files = ["@cirros_image//file"],
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "fedora-cloud-container-disk-image",
-    directory = "/disk",
-    files = ["@fedora_image//file"],
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "fedora30-cloud-container-disk-image",
-    directory = "/disk",
-    files = ["@fedora30_image//file"],
-    visibility = ["//visibility:public"],
-)
-
-container_image(
-    name = "virtio-container-disk-image",
-    directory = "/disk",
-    files = ["@virtio_win_image//file"],
-    visibility = ["//visibility:public"],
-)
 
 go_library(
     name = "go_default_library",

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+container_image(
+    name = "alpine-container-disk-image",
+    directory = "/disk",
+    files = ["@alpine_image//file"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "cirros-container-disk-image",
+    directory = "/disk",
+    files = ["@cirros_image//file"],
+    visibility = ["//visibility:public"],
+)
+
+# used for e2e testing of custom base baths
+container_image(
+    name = "cirros-custom-container-disk-image",
+    directory = "/custom-disk",
+    files = ["@cirros_image//file"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "fedora-cloud-container-disk-image",
+    directory = "/disk",
+    files = ["@fedora_image//file"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "fedora30-cloud-container-disk-image",
+    directory = "/disk",
+    files = ["@fedora30_image//file"],
+    visibility = ["//visibility:public"],
+)
+
+container_image(
+    name = "virtio-container-disk-image",
+    directory = "/disk",
+    files = ["@virtio_win_image//file"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid pulling in all testing and demo container dependencies if one just
wants to build kubevirt and run unittests.

Before we had the containerdisk definitions at the same location like
the containerdisk binary and  we were just pulling them in on every
"make build".

Now the containerdisks are only pulled in when we explicitliy want to
build and/or push containers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
