### PR TITLE
Remove --deploy-testing-infra test flag.

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -45,4 +45,4 @@ if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* 
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry}

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,5 @@ docker run \
         --container-tag=latest \
         --container-prefix=docker.io/kubevirt \
         --test.timeout 180m \
-        --junit-output=data/results/junit.xml \
-        --deploy-testing-infra \
-        --path-to-testing-infra-manifests=data/manifests
+        --junit-output=data/results/junit.xml
 ```


### PR DESCRIPTION
This flag helps setup missing bits in the environment if they're not
already there, and remove them in the end.

The teardown code, in its current state, is quite dangerous to have.
If those resources were created in other methods, they will still
be removed.

As an alternative, don't have this flag and assume anyone testing
already has an environment setup. Anyone setting up a cluster using
this repository will apply all the manifests already: they are
applied in hack/cluster-deploy.sh.

**Release note**:
```release-note
Removed --deploy-testing-infra and --path-to-testing-infra-manifests flags to the testsuite
```
