### PR TITLE
Let the operator remove virt-controller generated traces

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -278,7 +278,7 @@ func (app *virtHandlerApp) Run() {
 		glog.Fatalf("Error constructing migration tls config: %v", err)
 	}
 
-	factory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, app.namespace)
+	factory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, nil, app.namespace)
 
 	gracefulShutdownInformer := cache.NewSharedIndexInformer(
 		inotifyinformer.NewFileListWatchFromClient(

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -270,6 +270,19 @@ spec:
           - admissionregistration.k8s.io
           resources:
           - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+          - patch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -125,6 +125,19 @@ rules:
   - admissionregistration.k8s.io
   resources:
   - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - update
+  - patch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
   verbs:
   - get
   - list

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -44,6 +44,8 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
     ],
 )

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -95,7 +95,8 @@ var _ = Describe("Virt-api", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: virtWebhookMutator,
 				Labels: map[string]string{
-					v1.AppLabel: virtWebhookMutator,
+					v1.AppLabel:       virtWebhookMutator,
+					v1.ManagedByLabel: v1.ManagedByLabelOperatorValue,
 				},
 			},
 			Webhooks: app.mutatingWebhooks(),
@@ -109,7 +110,8 @@ var _ = Describe("Virt-api", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: virtWebhookValidator,
 				Labels: map[string]string{
-					v1.AppLabel: virtWebhookValidator,
+					v1.AppLabel:       virtWebhookValidator,
+					v1.ManagedByLabel: v1.ManagedByLabelOperatorValue,
 				},
 			},
 			Webhooks: app.validatingWebhooks(),
@@ -151,7 +153,8 @@ var _ = Describe("Virt-api", func() {
 					Name:      virtApiCertSecretName,
 					Namespace: namespaceKubevirt,
 					Labels: map[string]string{
-						v1.AppLabel: "virt-api-aggregator",
+						v1.AppLabel:       "virt-api-aggregator",
+						v1.ManagedByLabel: v1.ManagedByLabelOperatorValue,
 					},
 				},
 				Type: "Opaque",

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -103,7 +103,7 @@ func newInformers() *Informers {
 	if err != nil {
 		glog.Fatalf("Error searching for namespace: %v", err)
 	}
-	kubeInformerFactory := controller.NewKubeInformerFactory(kubeClient.RestClient(), kubeClient, namespace)
+	kubeInformerFactory := controller.NewKubeInformerFactory(kubeClient.RestClient(), kubeClient, nil, namespace)
 	return &Informers{
 		VMIInformer:             kubeInformerFactory.VMI(),
 		VMIPresetInformer:       kubeInformerFactory.VirtualMachinePreset(),

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -175,7 +175,7 @@ func Execute() {
 	stopChan := ctx.Done()
 	app.ctx = ctx
 
-	app.informerFactory = controller.NewKubeInformerFactory(app.restClient, app.clientSet, app.kubevirtNamespace)
+	app.informerFactory = controller.NewKubeInformerFactory(app.restClient, app.clientSet, nil, app.kubevirtNamespace)
 
 	configMapInformer := app.informerFactory.ConfigMap()
 	crdInformer := app.informerFactory.CRD()

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
     ],
 )
 
@@ -87,5 +88,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
     ],
 )

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -231,6 +231,18 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 				},
 				Resources: []string{
 					"validatingwebhookconfigurations",
+					"mutatingwebhookconfigurations",
+				},
+				Verbs: []string{
+					"get", "list", "watch", "create", "delete", "update", "patch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"apiregistration.k8s.io",
+				},
+				Resources: []string{
+					"apiservices",
 				},
 				Verbs: []string{
 					"get", "list", "watch", "create", "delete", "update", "patch",

--- a/pkg/virt-operator/install-strategy/BUILD.bazel
+++ b/pkg/virt-operator/install-strategy/BUILD.bazel
@@ -34,6 +34,8 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/install-strategy/create.go
+++ b/pkg/virt-operator/install-strategy/create.go
@@ -2079,7 +2079,8 @@ func SyncAll(kv *v1.KubeVirt,
 	for _, obj := range objects {
 		if webhook, ok := obj.(*admissionregistrationv1beta1.ValidatingWebhookConfiguration); ok && webhook.DeletionTimestamp == nil {
 			found := false
-			if strings.HasPrefix(webhook.Name, "virt-operator-tmp-webhook") {
+			// XXX virt-api-validator is right now only half managed and not in the manifest, skip it right now on updates
+			if strings.HasPrefix(webhook.Name, "virt-operator-tmp-webhook") || webhook.Name == "virt-api-validator" {
 				continue
 			}
 			for _, targetWebhook := range targetStrategy.validatingWebhookConfigurations {

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -37,6 +37,8 @@ type Stores struct {
 	DeploymentCache               cache.Store
 	DaemonSetCache                cache.Store
 	ValidationWebhookCache        cache.Store
+	MutatingWebhookCache          cache.Store
+	APIServiceCache               cache.Store
 	SCCCache                      cache.Store
 	InstallStrategyConfigMapCache cache.Store
 	InstallStrategyJobCache       cache.Store
@@ -61,6 +63,8 @@ func (s *Stores) AllEmpty() bool {
 		IsStoreEmpty(s.DeploymentCache) &&
 		IsStoreEmpty(s.DaemonSetCache) &&
 		IsStoreEmpty(s.ValidationWebhookCache) &&
+		IsStoreEmpty(s.MutatingWebhookCache) &&
+		IsStoreEmpty(s.APIServiceCache) &&
 		IsStoreEmpty(s.PodDisruptionBudgetCache) &&
 		IsSCCStoreEmpty(s.SCCCache) &&
 		IsStoreEmpty(s.ServiceMonitorCache) &&
@@ -102,6 +106,8 @@ type Expectations struct {
 	Deployment               *controller.UIDTrackingControllerExpectations
 	DaemonSet                *controller.UIDTrackingControllerExpectations
 	ValidationWebhook        *controller.UIDTrackingControllerExpectations
+	MutatingWebhook          *controller.UIDTrackingControllerExpectations
+	APIService               *controller.UIDTrackingControllerExpectations
 	SCC                      *controller.UIDTrackingControllerExpectations
 	InstallStrategyConfigMap *controller.UIDTrackingControllerExpectations
 	InstallStrategyJob       *controller.UIDTrackingControllerExpectations
@@ -121,6 +127,8 @@ type Informers struct {
 	Deployment               cache.SharedIndexInformer
 	DaemonSet                cache.SharedIndexInformer
 	ValidationWebhook        cache.SharedIndexInformer
+	MutatingWebhook          cache.SharedIndexInformer
+	APIService               cache.SharedIndexInformer
 	SCC                      cache.SharedIndexInformer
 	InstallStrategyConfigMap cache.SharedIndexInformer
 	InstallStrategyJob       cache.SharedIndexInformer
@@ -142,6 +150,8 @@ func (e *Expectations) DeleteExpectations(key string) {
 	e.Deployment.DeleteExpectations(key)
 	e.DaemonSet.DeleteExpectations(key)
 	e.ValidationWebhook.DeleteExpectations(key)
+	e.MutatingWebhook.DeleteExpectations(key)
+	e.APIService.DeleteExpectations(key)
 	e.SCC.DeleteExpectations(key)
 	e.InstallStrategyConfigMap.DeleteExpectations(key)
 	e.InstallStrategyJob.DeleteExpectations(key)
@@ -161,6 +171,8 @@ func (e *Expectations) ResetExpectations(key string) {
 	e.Deployment.SetExpectations(key, 0, 0)
 	e.DaemonSet.SetExpectations(key, 0, 0)
 	e.ValidationWebhook.SetExpectations(key, 0, 0)
+	e.MutatingWebhook.SetExpectations(key, 0, 0)
+	e.APIService.SetExpectations(key, 0, 0)
 	e.SCC.SetExpectations(key, 0, 0)
 	e.InstallStrategyConfigMap.SetExpectations(key, 0, 0)
 	e.InstallStrategyJob.SetExpectations(key, 0, 0)
@@ -180,6 +192,8 @@ func (e *Expectations) SatisfiedExpectations(key string) bool {
 		e.Deployment.SatisfiedExpectations(key) &&
 		e.DaemonSet.SatisfiedExpectations(key) &&
 		e.ValidationWebhook.SatisfiedExpectations(key) &&
+		e.MutatingWebhook.SatisfiedExpectations(key) &&
+		e.APIService.SatisfiedExpectations(key) &&
 		e.SCC.SatisfiedExpectations(key) &&
 		e.InstallStrategyConfigMap.SatisfiedExpectations(key) &&
 		e.InstallStrategyJob.SatisfiedExpectations(key) &&

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -183,9 +183,11 @@ const (
 	NamespaceTestDefault = "kubevirt-test-default"
 	// NamespaceTestAlternative is used to test controller-namespace independency.
 	NamespaceTestAlternative = "kubevirt-test-alternative"
+	// NamespaceTestOperator is used to test if namespaces can still be deleted when kubevirt is uninstalled
+	NamespaceTestOperator = "kubevirt-test-operator"
 )
 
-var testNamespaces = []string{NamespaceTestDefault, NamespaceTestAlternative}
+var testNamespaces = []string{NamespaceTestDefault, NamespaceTestAlternative, NamespaceTestOperator}
 var schedulableNode = ""
 
 type startType string


### PR DESCRIPTION
**What this PR does / why we need it**:

virt-api registers apiservices and webhooks which it does not delete. On
uninstall during the operator this lead to incomplete uninstalls which
could block future namespace deletions.

While letting still virt-api creating all these objects, let
virt-operator now manage their removal. The control is still not fully
handed over to virt-operator since there are still people using the
manifest-only installation path without the operator.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1491 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Uninstall via the operator catches now all artifacts. Deleted namespaces should no longer be stuck forever after uninstalling kubevirt correctly.
```
