### PR TITLE
Live migration tests - Additions and fixes

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -54,7 +54,7 @@ const (
 	fedoraVMSize      = "256M"
 )
 
-var _ = Describe("[rfe_id:393][crit:high[vendor:cnv-qe@redhat.com][level:system] VM Live Migration", func() {
+var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration", func() {
 	tests.FlagParse()
 
 	virtClient, err := kubecli.GetKubevirtClient()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2437,6 +2437,15 @@ func WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi runtime.Object, seco
 	return waitForVMIStart(vmi, seconds, true)
 }
 
+func WaitForPodToDisappearWithTimeout(podName string, seconds int) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	EventuallyWithOffset(1, func() bool {
+		_, err := virtClient.CoreV1().Pods(NamespaceTestDefault).Get(podName, metav1.GetOptions{})
+		return errors.IsNotFound(err)
+	}, seconds, 1*time.Second).Should(BeTrue())
+}
+
 func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -175,6 +175,7 @@ const (
 	ViewServiceAccountName        = "kubevirt-view-test-sa"
 )
 
+
 const SubresourceTestLabel = "subresource-access-test-pod"
 const namespaceKubevirt = "kubevirt"
 const kubevirtConfig = "kubevirt-config"
@@ -2443,7 +2444,7 @@ func WaitForPodToDisappearWithTimeout(podName string, seconds int) {
 	EventuallyWithOffset(1, func() bool {
 		_, err := virtClient.CoreV1().Pods(NamespaceTestDefault).Get(podName, metav1.GetOptions{})
 		return errors.IsNotFound(err)
-	}, seconds, 1*time.Second).Should(BeTrue())
+	}, seconds*time.Second, 1*time.Second).Should(BeTrue())
 }
 
 func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -175,7 +175,6 @@ const (
 	ViewServiceAccountName        = "kubevirt-view-test-sa"
 )
 
-
 const SubresourceTestLabel = "subresource-access-test-pod"
 const namespaceKubevirt = "kubevirt"
 const kubevirtConfig = "kubevirt-config"
@@ -2444,7 +2443,7 @@ func WaitForPodToDisappearWithTimeout(podName string, seconds int) {
 	EventuallyWithOffset(1, func() bool {
 		_, err := virtClient.CoreV1().Pods(NamespaceTestDefault).Get(podName, metav1.GetOptions{})
 		return errors.IsNotFound(err)
-	}, seconds*time.Second, 1*time.Second).Should(BeTrue())
+	}, seconds, 1*time.Second).Should(BeTrue())
 }
 
 func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -188,6 +188,11 @@ const (
 	NamespaceTestOperator = "kubevirt-test-operator"
 )
 
+const (
+	NFSTargetName   = "test-nfs-target"
+	ISCSITargetName = "test-isci-target"
+)
+
 var testNamespaces = []string{NamespaceTestDefault, NamespaceTestAlternative, NamespaceTestOperator}
 var schedulableNode = ""
 
@@ -3226,16 +3231,16 @@ func CreateISCSITargetPOD(containerDiskName ContainerDisk) (iscsiTargetIP string
 	resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("256M")
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "test-iscsi-target",
+			GenerateName: ISCSITargetName,
 			Labels: map[string]string{
-				v1.AppLabel: "test-iscsi-target",
+				v1.AppLabel: ISCSITargetName,
 			},
 		},
 		Spec: k8sv1.PodSpec{
 			RestartPolicy: k8sv1.RestartPolicyNever,
 			Containers: []k8sv1.Container{
 				{
-					Name:      "test-iscsi-target",
+					Name:      ISCSITargetName,
 					Image:     image,
 					Resources: resources,
 				},
@@ -3352,9 +3357,9 @@ func CreateNFSTargetPOD(os string) (nfsTargetIP string) {
 	hostPathType := k8sv1.HostPathDirectory
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-nfs-target",
+			Name: NFSTargetName,
 			Labels: map[string]string{
-				v1.AppLabel: "test-nfs-target",
+				v1.AppLabel: NFSTargetName,
 			},
 		},
 		Spec: k8sv1.PodSpec{
@@ -3372,7 +3377,7 @@ func CreateNFSTargetPOD(os string) (nfsTargetIP string) {
 			},
 			Containers: []k8sv1.Container{
 				{
-					Name:            "test-nfs-target",
+					Name:            NFSTargetName,
 					Image:           image,
 					ImagePullPolicy: k8sv1.PullAlways,
 					Resources:       resources,


### PR DESCRIPTION
Signed-off-by: Igor Bezukh ibezukh@redhat.com

**What this PR does / why we need it**:
We need to test a live migration case where a Linux VM has guest agent inside. To be more specific, this test was already implemented but labeled incorrectly, so the PR fixes the labeling. In addition, some cosmetic changes were added while working on the PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Test IDs 2653

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
