### PR TITLE
nit: fix typo in failure message

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -479,7 +479,7 @@ func WaitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) 
 		}
 		return podsNotReady
 	}
-	Eventually(checkForPodsToBeReady, timeout, 2*time.Second).Should(BeEmpty(), "The are pods in system which are not ready.")
+	Eventually(checkForPodsToBeReady, timeout, 2*time.Second).Should(BeEmpty(), "There are pods in system which are not ready.")
 }
 
 func GenerateRESTReport() error {


### PR DESCRIPTION
tiny typo fixed.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
