### PR TITLE
Adding support to specify app armor profile for virt-launcher pod

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -888,6 +888,11 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	}
 
 	for k, v := range vmi.Annotations {
+		if strings.Contains(k, "container.apparmor.security.beta.kubernetes.io") {
+			annotationsList[k] = v
+			continue
+		}
+
 		if strings.Contains(k, "kubernetes.io") || strings.Contains(k, "kubevirt.io") {
 			// skip kubernetes and kubevirt internal annotations
 			continue

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1589,7 +1589,26 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Containers[0].Command).To(ContainElement("--less-pvc-space-toleration"), "command arg key should be correct")
 			Expect(pod.Spec.Containers[0].Command).To(ContainElement("42"), "command arg value should be correct")
 		})
+		Context("App armor annotation", func() {
+			It("should pass the app armor annotation to pod spec", func() {
+				annotations := map[string]string{
+					"container.apparmor.security.beta.kubernetes.io": "localhost/test-profile",
+				}
+				pod, err := svc.RenderLaunchManifest(&v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "testvmi",
+						Namespace:   "testns",
+						UID:         "1234",
+						Annotations: annotations},
+					Spec: v1.VirtualMachineInstanceSpec{Domain: v1.DomainSpec{}}})
 
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(pod.Spec.Containers)).To(Equal(1))
+				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
+					"kubevirt.io/domain":                             "testvmi",
+					"container.apparmor.security.beta.kubernetes.io": "localhost/test-profile",
+				}))
+			})
+		})
 	})
 
 	Describe("ServiceAccountName", func() {


### PR DESCRIPTION
Signed-off-by: Vishesh Tanksale <vtanksale@nvidia.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
These changes add ability to run virt-launcher pod under specific app armor profile. It leverages the existing support for app armor profile on k8s
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
AppArmor profiles can be applied to compute container in virt-launcher. 
```
