### PR TITLE
Add unit tests to cover the migration blocking for bridge network.

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -835,7 +835,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 		}, 3)
 	})
 
-	Context("check VMI disks for migration", func() {
+	Context("check if migratable", func() {
+
 		var testBlockPvc *k8sv1.PersistentVolumeClaim
 
 		BeforeEach(func() {
@@ -1152,50 +1153,77 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with non-shared HostDisk")))
 		})
 
-		It("should block migrations if the pod network is connected via a binding method different than masquerade", func() {
-			vmi := v1.NewMinimalVMI("testvmi")
-			interfaceName := "interface_name"
+		Context("with network configuration", func() {
+			It("should block migration for bridge binding assigned to the pod network", func() {
+				vmi := v1.NewMinimalVMI("testvmi")
+				interface_name := "interface_name"
 
-			vmi.Spec.Networks = []v1.Network{
-				v1.Network{
-					Name:          interfaceName,
-					NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-				},
-			}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				v1.Interface{
-					Name: interfaceName,
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Bridge: &v1.InterfaceBridge{},
+				vmi.Spec.Networks = []v1.Network{
+					v1.Network{
+						Name:          interface_name,
+						NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 					},
-				},
-			}
-			err := controller.checkNetworkInterfacesForMigration(vmi)
-			Expect(err).To(HaveOccurred())
+				}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					v1.Interface{
+						Name: interface_name,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{},
+						},
+					},
+				}
+
+				err := controller.checkNetworkInterfacesForMigration(vmi)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should not block migration for masquerade binding assigned to the pod network", func() {
+				vmi := v1.NewMinimalVMI("testvmi")
+				interface_name := "interface_name"
+
+				vmi.Spec.Networks = []v1.Network{
+					v1.Network{
+						Name:          interface_name,
+						NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+					},
+				}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					v1.Interface{
+						Name: interface_name,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Masquerade: &v1.InterfaceMasquerade{},
+						},
+					},
+				}
+
+				err := controller.checkNetworkInterfacesForMigration(vmi)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not block migration for bridge binding assigned to a multus network", func() {
+				vmi := v1.NewMinimalVMI("testvmi")
+				interface_name := "interface_name"
+
+				vmi.Spec.Networks = []v1.Network{
+					v1.Network{
+						Name:          interface_name,
+						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
+					},
+				}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					v1.Interface{
+						Name: interface_name,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{},
+						},
+					},
+				}
+
+				err := controller.checkNetworkInterfacesForMigration(vmi)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
-		It("should not block migration for bridge interface assigned to multus network", func() {
-			vmi := v1.NewMinimalVMI("testvmi")
-			interfaceName := "interface_name"
-
-			vmi.Spec.Networks = []v1.Network{
-				v1.Network{
-					Name:          interfaceName,
-					NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
-				},
-			}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				v1.Interface{
-					Name: interfaceName,
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Bridge: &v1.InterfaceBridge{},
-					},
-				},
-			}
-
-			err := controller.checkNetworkInterfacesForMigration(vmi)
-			Expect(err).ToNot(HaveOccurred())
-		})
 	})
 	Context("VirtualMachineInstance controller gets informed about interfaces in a Domain", func() {
 		It("should update existing interface with MAC", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add unit tests to cover the migration blocking for bridge network.

/cc @dhiller @danielBelenky 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
