### PR TITLE
virtctl: If we have global flags, display them in usage

### DIFF
--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -18,7 +18,8 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-Use "{{ProgramName}} options" for a list of global command-line options (applies to all commands).{{end}}
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 `
 }
 


### PR DESCRIPTION
Rather than suggesting another command that the user could run
(it's more work)

**Release note**:
```release-note
Improve virtctl usage message
```
