### PR TITLE
Convenient function to rename a stopped Virtual Machine

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -11,6 +11,3 @@ filters:
   "pkg/virt-api/.*":
     reviewers:
       - ux-reviewers
-  "cluster-up-sha.txt":
-    approvers:
-      - ci-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -36,5 +36,3 @@ aliases:
       - jerry7z
       - ILpinto
       - dshchedr
-  ci-approvers:
-      - dhiller

--- a/cluster-up/OWNERS
+++ b/cluster-up/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-filters:
-  ".*":
-    approvers:
-      - ci-approvers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR gives a new ability in kubevirt packages, virt-api and virtctl to rename a stopped VM (delete and recreate with a new name)

**Special notes for your reviewer**:
- At this moment, Finalizers and Initializers are not taken care of, will take care of them soon
- There are some commits here from a different feature im working on, will take care of it
- Also need to take care of related objects and resources that are owned by the original vm resource

**Release note**:
```release-note
A new feature to rename a stopped Virtual Machine:

`virtctl rename [vm_name] [new_vm_name]`

or, from the kubevirt packages:

`_, err = virtClient.VirtualMachine(namespace).Rename(vmName, newVMName)`
```
