### PR TITLE
Increase memory limit for kubevirt-infra pod

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -870,7 +870,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			Resources: k8sv1.ResourceRequirements{
 				Limits: map[k8sv1.ResourceName]resource.Quantity{
 					k8sv1.ResourceCPU:    resource.MustParse("1m"),
-					k8sv1.ResourceMemory: resource.MustParse("12Mi"), // this is the minimum memory limit for cri-o!
+					k8sv1.ResourceMemory: resource.MustParse("40Mi"),
 				},
 			},
 			Command:        []string{"/usr/bin/tail", "-f", "/dev/null"},


### PR DESCRIPTION
**What this PR does / why we need it**:

The OOM Killer on Azure is occasionally killing the kubevirt-infra sidecar, causing VMIs to shutdown without warning at random intervals. This fix resolves that problem by increasing the memory limit.

**Which issue(s) this PR fixes** 
Fixes #3029

**Special notes for your reviewer**:
I have manually tested on an Azure platform that I am testing with, and this appears to completely resolve the issue (random shutdowns reduced from every hour or two to none in a couple of days, and still running).

**Release note**:
NONE
