### PR TITLE
Add alert rules for a healthy virt-operator

### DIFF
--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/util:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -477,6 +477,42 @@ func NewPrometheusRuleSpec(ns string) *promv1.PrometheusRuleSpec {
 							"summary": "More than 80% of the rest calls failed in virt-operator for the last 5 minutes",
 						},
 					},
+					{
+						Record: "num_of_ready_virt_operators",
+						Expr: intstr.FromString(
+							fmt.Sprintf("sum(ready_virt_operator{namespace='%s'})", ns),
+						),
+					},
+					{
+						Record: "num_of_leading_virt_operators",
+						Expr: intstr.FromString(
+							fmt.Sprintf("sum(ready_virt_operator{namespace='%s'})", ns),
+						),
+					},
+					{
+						Alert: "LowReadyVirtOperatorsCount",
+						Expr:  intstr.FromString("num_of_ready_virt_operators <  num_of_running_virt_operators"),
+						For:   "5m",
+						Annotations: map[string]string{
+							"summary": "Some virt-operators are running but not ready.",
+						},
+					},
+					{
+						Alert: "NoReadyVirtOperator",
+						Expr:  intstr.FromString("num_of_running_virt_operators == 0"),
+						For:   "5m",
+						Annotations: map[string]string{
+							"summary": "No ready virt-operator was detected for the last 5 min.",
+						},
+					},
+					{
+						Alert: "NoLeadingVirtOperator",
+						Expr:  intstr.FromString("num_of_leading_virt_operators == 0"),
+						For:   "5m",
+						Annotations: map[string]string{
+							"summary": "No leading virt-operator was detected for the last 5 min.",
+						},
+					},
 				},
 			},
 		},

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -216,6 +216,47 @@ var _ = Describe("Infrastructure", func() {
 			Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-controller")
 		})
 
+		It("should find one leading virt-operator and two ready", func() {
+			endpoint, err := virtClient.CoreV1().
+				Endpoints(tests.KubeVirtInstallNamespace).
+				Get("kubevirt-prometheus-metrics", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			foundMetrics := map[string]int{
+				"ready":   0,
+				"leading": 0,
+			}
+			By("scraping the metrics endpoint on virt-operator pods")
+			for _, ep := range endpoint.Subsets[0].Addresses {
+				if !strings.HasPrefix(ep.TargetRef.Name, "virt-operator") {
+					continue
+				}
+				stdout, _, err := tests.ExecuteCommandOnPodV2(
+					virtClient,
+					pod,
+					"virt-handler",
+					[]string{
+						"curl", "-L", "-k",
+						fmt.Sprintf("https://%s:8443/metrics", ep.IP),
+					})
+				Expect(err).ToNot(HaveOccurred())
+				scrapedData := strings.Split(stdout, "\n")
+				for _, data := range scrapedData {
+					if strings.HasPrefix(data, "#") {
+						continue
+					}
+					switch data {
+					case "leading_virt_operator 1":
+						foundMetrics["leading"]++
+					case "ready_virt_operator 1":
+						foundMetrics["ready"]++
+					}
+				}
+			}
+
+			Expect(foundMetrics["ready"]).To(Equal(2), "expected 2 ready virt-operators")
+			Expect(foundMetrics["leading"]).To(Equal(1), "expected 1 leading virt-operator")
+		})
+
 		It("should be exposed and registered on the metrics endpoint", func() {
 			endpoint, err := virtClient.CoreV1().Endpoints(tests.KubeVirtInstallNamespace).Get("kubevirt-prometheus-metrics", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
To allow cluster admins to monitor their kubevirt deployment, we provide a set of default
alert rules that indicate on the health status of the components.
This PR adds such rules for virt-operator.

```release-note
Added prometheus alert rules and metrics to monitor virt-operator
```
