### PR TITLE
Removes superfluous calls to res.WriteHeader()

### DIFF
--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -58,5 +58,4 @@ func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	resp.WriteHeader(http.StatusOK)
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -278,9 +278,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Doc("Open a websocket connection to connect to VNC on the specified VirtualMachineInstance."))
 
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("test")).
-			To(func(request *restful.Request, response *restful.Response) {
-				response.WriteHeader(http.StatusOK)
-			}).
+			To(func(request *restful.Request, response *restful.Response) {}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Operation("test").
 			Doc("Test endpoint verifying apiserver connectivity."))

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -277,6 +277,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation("vnc").
 			Doc("Open a websocket connection to connect to VNC on the specified VirtualMachineInstance."))
 
+		// An empty handler function would respond with HTTP OK by default
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("test")).
 			To(func(request *restful.Request, response *restful.Response) {}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -167,9 +167,7 @@ func (app *SubresourceAPIApp) streamRequestHandler(request *restful.Request, res
 	}()
 
 	// wait for copy to finish and check the result
-	if err = <-copyErr; err == nil || err == io.EOF {
-		response.WriteHeader(http.StatusOK)
-	} else {
+	if err = <-copyErr; err != nil && err != io.EOF {
 		log.Log.Object(vmi).Reason(err).Error("Error in websocket proxy")
 		writeError(errors.NewInternalError(err), response)
 		return

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -65,7 +65,6 @@ func serve(resp http.ResponseWriter, req *http.Request, m mutator) {
 		resp.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	resp.WriteHeader(http.StatusOK)
 }
 
 func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -182,14 +182,13 @@ func (t *ConsoleHandler) stream(vmi *v1.VirtualMachineInstance, request *restful
 
 	select {
 	case <-stopCh:
-		response.WriteHeader(http.StatusOK)
+		break
 	case err := <-errCh:
 		if err != nil && err != io.EOF {
 			log.Log.Object(vmi).Reason(err).Error("Error in proxing websocket and unix socket")
 			response.WriteHeader(http.StatusInternalServerError)
-		} else {
-			response.WriteHeader(http.StatusOK)
 		}
+
 		cleanup()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Omer Yahud <oyahud@redhat.com>

**What this PR does / why we need it**:
Removes the unnecessary calls to `response.WriteHeader()` to make `virt-api` and `virt-handler` logs cleaner.
The `net/http` package returns `http.StatusOK` as a default if a different status code was not explicitly 
written, this means that every call to `res.WriteHeader(http.StatusOK)` writes an info log like the two below and floods the logs for `virt-api` and `virt-handler`.

**Which issue(s) this PR fixes**
`virt-api` and `virt-handler` logs are being flooded because of unnecessary calls to `response.WriteHeader()` 

**Notes for the reviewer**
The logs that are flooding `virt-api`:
```
`{"component":"virt-api","level":"info","msg":"http: superfluous response.WriteHeader call from kubevirt.io/kubevirt/pkg/virt-api/webhooks/mutating-webhook.serve (mutating-webhook.go:68)\n","pos":"server.go:3012","timestamp":"2020-02-05T12:43:31.454691Z"}
{"component":"virt-api","level":"info","msg":"http: superfluous response.WriteHeader call from kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks.Serve (validating-webhook.go:61)\n","pos":"server.go:3012","timestamp":"2020-02-05T12:43:31.458961Z"}`
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
