### PR TITLE
Allow setting of custom SELinux type for virt-launcher

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -60,6 +60,7 @@ const (
 	PermitBridgeInterfaceOnPodNetwork = "permitBridgeInterfaceOnPodNetwork"
 	NodeDrainTaintDefaultKey          = "kubevirt.io/drain"
 	SmbiosConfigKey                   = "smbios"
+	SELinuxLauncherTypeKey            = "selinuxLauncherType"
 )
 
 type ConfigModifiedFn func()
@@ -213,6 +214,7 @@ func defaultClusterConfig() *Config {
 		PermitSlirpInterface:              DefaultPermitSlirpInterface,
 		PermitBridgeInterfaceOnPodNetwork: DefaultPermitBridgeInterfaceOnPodNetwork,
 		SmbiosConfig:                      SmbiosDefaultConfig,
+		SELinuxLauncherType:               DefaultSELinuxLauncherType,
 	}
 }
 
@@ -233,6 +235,7 @@ type Config struct {
 	PermitSlirpInterface              bool
 	PermitBridgeInterfaceOnPodNetwork bool
 	SmbiosConfig                      *cmdv1.SMBios
+	SELinuxLauncherType               string
 }
 
 type MigrationConfig struct {
@@ -265,7 +268,7 @@ func (c *ClusterConfig) SetConfigModifiedCallback(cb ConfigModifiedFn) {
 }
 
 // setConfig parses the provided config map and updates the provided config.
-// Default values in the provided config stay in tact.
+// Default values in the provided config stay intact.
 func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 
 	// set revision
@@ -404,6 +407,11 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 	default:
 		return fmt.Errorf("invalid default-network-interface in config: %v", iface)
 	}
+
+	if selinuxLauncherType := strings.TrimSpace(configMap.Data[SELinuxLauncherTypeKey]); selinuxLauncherType != "" {
+		config.SELinuxLauncherType = selinuxLauncherType
+	}
+
 	return nil
 }
 

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -288,4 +288,16 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when values set, should equal to result", `{"Family":"test","Product":"test", "Manufacturer":"None"}`, cmdv1.SMBios{Family: "test", Product: "test", Manufacturer: "None"}),
 		table.Entry("When an invalid smbios value is set, should return default values", `{"invalid":"invalid"}`, cmdv1.SMBios{Family: "KubeVirt", Product: "None", Manufacturer: "KubeVirt"}),
 	)
+
+	table.DescribeTable(" when SELinuxLauncherType", func(value string, result string) {
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{virtconfig.SELinuxLauncherTypeKey: value},
+		})
+		selinuxLauncherType := clusterConfig.GetSELinuxLauncherType()
+		Expect(selinuxLauncherType).To(Equal(result))
+	},
+		table.Entry("when set, GetSELinuxLauncherType should return the value", "spc_t", "spc_t"),
+		table.Entry("when unset, GetSELinuxLauncherType should return the default", "", ""),
+	)
+
 })

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -297,7 +297,7 @@ var _ = Describe("ConfigMap", func() {
 		Expect(selinuxLauncherType).To(Equal(result))
 	},
 		table.Entry("when set, GetSELinuxLauncherType should return the value", "spc_t", "spc_t"),
-		table.Entry("when unset, GetSELinuxLauncherType should return the default", "", ""),
+		table.Entry("when unset, GetSELinuxLauncherType should return the default", virtconfig.DefaultSELinuxLauncherType, virtconfig.DefaultSELinuxLauncherType),
 	)
 
 })

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -52,6 +52,7 @@ const (
 	SmbiosConfigDefaultManufacturer                 = "KubeVirt"
 	SmbiosConfigDefaultProduct                      = "None"
 	DefaultPermitBridgeInterfaceOnPodNetwork        = true
+	DefaultSELinuxLauncherType                      = ""
 )
 
 func (c *ClusterConfig) IsUseEmulation() bool {
@@ -108,4 +109,8 @@ func (c *ClusterConfig) GetSMBIOS() *cmdv1.SMBios {
 
 func (c *ClusterConfig) IsBridgeInterfaceOnPodNetworkEnabled() bool {
 	return c.getConfig().PermitBridgeInterfaceOnPodNetwork
+}
+
+func (c *ClusterConfig) GetSELinuxLauncherType() string {
+	return c.getConfig().SELinuxLauncherType
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -947,6 +947,12 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		annotationsList[ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
 	}
 
+	// If an SELinux type was specified, use that--otherwise default to the one KubeVirt Defines
+	selinuxLauncherType := t.clusterConfig.GetSELinuxLauncherType()
+	if selinuxLauncherType == "" {
+		selinuxLauncherType = "virt_launcher.process"
+	}
+
 	// TODO use constants for podLabels
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -963,7 +969,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			SecurityContext: &k8sv1.PodSecurityContext{
 				RunAsUser: &userId,
 				SELinuxOptions: &k8sv1.SELinuxOptions{
-					Type: "virt_launcher.process",
+					Type: selinuxLauncherType,
 				},
 			},
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -949,7 +949,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	// If an SELinux type was specified, use that--otherwise default to the one KubeVirt Defines
 	selinuxLauncherType := t.clusterConfig.GetSELinuxLauncherType()
-	if selinuxLauncherType == "" {
+	if selinuxLauncherType == virtconfig.DefaultSELinuxLauncherType {
 		selinuxLauncherType = "virt_launcher.process"
 	}
 

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -47,6 +47,7 @@ import (
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/controller"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 	"kubevirt.io/kubevirt/tests"
@@ -1432,6 +1433,66 @@ spec:
 			monitoringLabel, exists := namespace.ObjectMeta.Labels["openshift.io/cluster-monitoring"]
 			Expect(exists).To(BeTrue())
 			Expect(monitoringLabel).To(Equal("true"))
+		})
+	})
+
+	// This test isn't technically testing anything with virt-operator, but all the framework
+	// is in place to tear down and re-set the environment when it's been modified,
+	// and this test does modify significant components.
+	Context("With selinuxLauncherType defined", func() {
+		It("Should honor custom SELinux type for virt-launcher", func() {
+			cfgMap, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
+			// Update KubeVirt's ConfigMap
+			if err != nil && !errors.IsNotFound(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+			superPrivilegedType := "spc_t"
+
+			By("Starting a VMI")
+			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Fetching virt-launcher Pod")
+			pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+
+			By("Verifying SELinux context contains default type")
+			Expect(pod.Spec.SecurityContext.SELinuxOptions.Type).ToNot(Equal(superPrivilegedType))
+
+			By("Deleting the VMI")
+			err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Updating ConfigMap")
+			cfgMap.Data[virtconfig.SELinuxLauncherTypeKey] = superPrivilegedType
+
+			newData, err := json.Marshal(cfgMap.Data)
+			Expect(err).ToNot(HaveOccurred())
+			data := fmt.Sprintf(`[{ "op": "replace", "path": "/data", "value": %s }]`, string(newData))
+
+			cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Patch("kubevirt-config", types.JSONPatchType, []byte(data))
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Deleting virt-controller deployment")
+			err = virtClient.AppsV1().Deployments(tests.KubeVirtInstallNamespace).Delete("virt-controller", &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Starting a New VMI")
+			vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Fetching virt-launcher Pod")
+			pod = tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+
+			By("Verifying SELinux context contains custom type")
+			Expect(pod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(superPrivilegedType))
+
+			By("Deleting the VMI")
+			err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1449,10 +1449,13 @@ spec:
 			superPrivilegedType := "spc_t"
 
 			By("Starting a VMI")
-			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
+			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Ensuring VMI is running by logging in")
+			tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
 
 			By("Fetching virt-launcher Pod")
 			pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -1479,10 +1482,13 @@ spec:
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Starting a New VMI")
-			vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
+			vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
+
+			By("Ensuring VMI is running by logging in")
+			tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
 
 			By("Fetching virt-launcher Pod")
 			pod = tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)


### PR DESCRIPTION
This PR introduces a ConfigMap entry (`selinuxLauncherType`) that overrides the built in SELinux type for KubeVirt.

This can be used to cause virt-launcher to run as `spc_t` or any other custom type the cluster admin might define.

**Release note**:
```release-note
Allow setting a custom SELinux type for virt-launcher.
```
