### PR TITLE
Minimalist example of validation failure

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3716,6 +3716,44 @@
      }
     }
    },
+   "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/guestosinfo": {
+    "get": {
+     "summary": "Get guest agent os information",
+     "operationId": "guestosinfo",
+     "parameters": [
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Object name and auth scope, such as for teams and projects",
+       "name": "namespace",
+       "in": "path",
+       "required": true
+      },
+      {
+       "pattern": "[a-z0-9][a-z0-9\\-]*",
+       "type": "string",
+       "description": "Name of the resource",
+       "name": "name",
+       "in": "path",
+       "required": true
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.VirtualMachineInstance"
+       }
+      },
+      "default": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.VirtualMachineInstance"
+       }
+      }
+     }
+    }
+   },
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace}/virtualmachineinstances/{name}/pause": {
     "put": {
      "summary": "Pause a VirtualMachineInstance object.",
@@ -4030,7 +4068,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "func7",
+     "operationId": "func8",
      "responses": {
       "200": {
        "description": "OK"

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -569,6 +569,7 @@ spec:
           - virtualmachineinstances/vnc
           - virtualmachineinstances/pause
           - virtualmachineinstances/unpause
+          - virtualmachineinstances/guestosinfo
           verbs:
           - get
         - apiGroups:
@@ -603,6 +604,7 @@ spec:
           - virtualmachineinstances/vnc
           - virtualmachineinstances/pause
           - virtualmachineinstances/unpause
+          - virtualmachineinstances/guestosinfo
           verbs:
           - get
         - apiGroups:

--- a/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-cluster.authorization.k8s.yaml.in
@@ -52,6 +52,7 @@ rules:
   - virtualmachineinstances/vnc
   - virtualmachineinstances/pause
   - virtualmachineinstances/unpause
+  - virtualmachineinstances/guestosinfo
   verbs:
   - get
 - apiGroups:
@@ -95,6 +96,7 @@ rules:
   - virtualmachineinstances/vnc
   - virtualmachineinstances/pause
   - virtualmachineinstances/unpause
+  - virtualmachineinstances/guestosinfo
   verbs:
   - get
 - apiGroups:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -424,6 +424,7 @@ rules:
   - virtualmachineinstances/vnc
   - virtualmachineinstances/pause
   - virtualmachineinstances/unpause
+  - virtualmachineinstances/guestosinfo
   verbs:
   - get
 - apiGroups:
@@ -458,6 +459,7 @@ rules:
   - virtualmachineinstances/vnc
   - virtualmachineinstances/pause
   - virtualmachineinstances/unpause
+  - virtualmachineinstances/guestosinfo
   verbs:
   - get
 - apiGroups:

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -298,6 +298,13 @@ func (app *virtAPIApp) composeSubresources() {
 			Returns(http.StatusOK, "OK", nil).
 			Returns(http.StatusInternalServerError, "Unhealthy", nil))
 
+		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("guestosinfo")).
+			To(func(request *restful.Request, response *restful.Response) {}).
+			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
+			Operation("guestosinfo").
+			Doc("Get guest agent os information").
+			Returns(http.StatusOK, "OK", v1.VirtualMachineInstance{}))
+
 		// Return empty api resource list.
 		// K8s expects to be able to retrieve a resource list for each aggregated
 		// app in order to discover what resources it provides. Without returning
@@ -342,6 +349,10 @@ func (app *virtAPIApp) composeSubresources() {
 					},
 					{
 						Name:       "virtualmachines/migrate",
+						Namespaced: true,
+					},
+					{
+						Name:       "virtualmachineinstances/guestosinfo",
 						Namespaced: true,
 					},
 				}

--- a/pkg/virt-operator/creation/rbac/cluster.go
+++ b/pkg/virt-operator/creation/rbac/cluster.go
@@ -125,6 +125,7 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstances/vnc",
 					"virtualmachineinstances/pause",
 					"virtualmachineinstances/unpause",
+					"virtualmachineinstances/guestosinfo",
 				},
 				Verbs: []string{
 					"get",
@@ -185,6 +186,7 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstances/vnc",
 					"virtualmachineinstances/pause",
 					"virtualmachineinstances/unpause",
+					"virtualmachineinstances/guestosinfo",
 				},
 				Verbs: []string{
 					"get",


### PR DESCRIPTION
**What this PR does / why we need it**:
Minimalist example of API validation failure.

When adding new API subresource with return value containing Kubernetes metadata, validation fails due to multiple types in creationTimestamp field.

Without adding the object with problematic fields, the validation is correct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Confirms #3059 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
