### PR TITLE
Add autoattachSerialConsole flag

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4543,6 +4543,10 @@
       "description": "Whether to attach a pod network interface. Defaults to true.",
       "type": "boolean"
      },
+     "autoattachSerialConsole": {
+      "description": "Whether to attach the default serial console or not.\nSerial console access will not be available if set to false. Defaults to true.",
+      "type": "boolean"
+     },
      "blockMultiQueue": {
       "description": "Whether or not to enable virtio multi-queue for block devices\n+optional",
       "type": "boolean"

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -293,6 +293,11 @@ func (app *SubresourceAPIApp) getVirtHandlerConnForVMI(vmi *v1.VirtualMachineIns
 
 func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, response *restful.Response) {
 	validate := func(vmi *v1.VirtualMachineInstance) *errors.StatusError {
+		if vmi.Spec.Domain.Devices.AutoattachSerialConsole != nil && *vmi.Spec.Domain.Devices.AutoattachSerialConsole == false {
+			err := fmt.Errorf("No serial consoles are present.")
+			log.Log.Object(vmi).Reason(err).Error("Can't establish a serial console connection.")
+			return errors.NewBadRequest(err.Error())
+		}
 		condManager := controller.NewVirtualMachineInstanceConditionManager()
 		if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
 			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("VMI is paused"))

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1011,30 +1011,32 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		domain.Spec.CPU.Mode = v1.CPUModeHostModel
 	}
 
-	// Add mandatory console device
-	var serialPort uint = 0
-	var serialType string = "serial"
-	domain.Spec.Devices.Consoles = []Console{
-		{
-			Type: "pty",
-			Target: &ConsoleTarget{
-				Type: &serialType,
-				Port: &serialPort,
+	if vmi.Spec.Domain.Devices.AutoattachSerialConsole == nil || *vmi.Spec.Domain.Devices.AutoattachSerialConsole == true {
+		// Add mandatory console device
+		var serialPort uint = 0
+		var serialType string = "serial"
+		domain.Spec.Devices.Consoles = []Console{
+			{
+				Type: "pty",
+				Target: &ConsoleTarget{
+					Type: &serialType,
+					Port: &serialPort,
+				},
 			},
-		},
-	}
+		}
 
-	domain.Spec.Devices.Serials = []Serial{
-		{
-			Type: "unix",
-			Target: &SerialTarget{
-				Port: &serialPort,
+		domain.Spec.Devices.Serials = []Serial{
+			{
+				Type: "unix",
+				Target: &SerialTarget{
+					Port: &serialPort,
+				},
+				Source: &SerialSource{
+					Mode: "bind",
+					Path: fmt.Sprintf("/var/run/kubevirt-private/%s/virt-serial%d", vmi.ObjectMeta.UID, serialPort),
+				},
 			},
-			Source: &SerialSource{
-				Mode: "bind",
-				Path: fmt.Sprintf("/var/run/kubevirt-private/%s/virt-serial%d", vmi.ObjectMeta.UID, serialPort),
-			},
-		},
+		}
 	}
 
 	if vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == nil || *vmi.Spec.Domain.Devices.AutoattachGraphicsDevice == true {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1271,6 +1271,42 @@ var _ = Describe("Converter", func() {
 		)
 	})
 
+	Context("serial console", func() {
+
+		table.DescribeTable("should check autoAttachSerialConsole", func(autoAttach *bool, devices int) {
+
+			vmi := v1.VirtualMachineInstance{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name:      "testvmi",
+					Namespace: "default",
+					UID:       "1234",
+				},
+				Spec: v1.VirtualMachineInstanceSpec{
+					Domain: v1.DomainSpec{
+						CPU: &v1.CPU{Cores: 3},
+						Resources: v1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								k8sv1.ResourceCPU:    resource.MustParse("1m"),
+								k8sv1.ResourceMemory: resource.MustParse("64M"),
+							},
+						},
+					},
+				},
+			}
+			vmi.Spec.Domain.Devices = v1.Devices{
+				AutoattachSerialConsole: autoAttach,
+			}
+			domain := vmiToDomain(&vmi, &ConverterContext{UseEmulation: true})
+			Expect(domain.Spec.Devices.Serials).To(HaveLen(devices))
+			Expect(domain.Spec.Devices.Consoles).To(HaveLen(devices))
+
+		},
+			table.Entry("and add the serial console if it is not set", nil, 1),
+			table.Entry("and add the serial console if it is set to true", True(), 1),
+			table.Entry("and not add the serial console if it is set to false", False(), 0),
+		)
+	})
+
 	Context("IOThreads", func() {
 		_false := false
 		_true := true

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -97,7 +97,7 @@ func (c *Console) Run(cmd *cobra.Command, args []string) error {
 	signal.Notify(waitInterrupt, os.Interrupt)
 
 	go func() {
-		con, err := virtCli.VirtualMachineInstance(namespace).SerialConsole(vmi, time.Duration(timeout)*time.Minute)
+		con, err := virtCli.VirtualMachineInstance(namespace).SerialConsole(vmi, &kubecli.SerialConsoleOptions{ConnectionTimeout: time.Duration(timeout) * time.Minute})
 		runningChan <- err
 
 		if err != nil {

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -399,6 +399,11 @@ func (in *Devices) DeepCopyInto(out *Devices) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AutoattachSerialConsole != nil {
+		in, out := &in.AutoattachSerialConsole, &out.AutoattachSerialConsole
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Rng != nil {
 		in, out := &in.Rng, &out.Rng
 		*out = new(Rng)

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -736,6 +736,13 @@ func schema_kubevirtio_client_go_api_v1_Devices(ref common.ReferenceCallback) co
 							Format:      "",
 						},
 					},
+					"autoattachSerialConsole": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"rng": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether to have random number generator from host",

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -336,6 +336,9 @@ type Devices struct {
 	// Whether to attach the default graphics device or not.
 	// VNC will not be available if set to false. Defaults to true.
 	AutoattachGraphicsDevice *bool `json:"autoattachGraphicsDevice,omitempty"`
+	// Whether to attach the default serial console or not.
+	// Serial console access will not be available if set to false. Defaults to true.
+	AutoattachSerialConsole *bool `json:"autoattachSerialConsole,omitempty"`
 	// Whether to have random number generator from host
 	// +optional
 	Rng *Rng `json:"rng,omitempty"`

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -165,6 +165,7 @@ func (Devices) SwaggerDoc() map[string]string {
 		"inputs":                     "Inputs describe input devices",
 		"autoattachPodInterface":     "Whether to attach a pod network interface. Defaults to true.",
 		"autoattachGraphicsDevice":   "Whether to attach the default graphics device or not.\nVNC will not be available if set to false. Defaults to true.",
+		"autoattachSerialConsole":    "Whether to attach the default serial console or not.\nSerial console access will not be available if set to false. Defaults to true.",
 		"rng":                        "Whether to have random number generator from host\n+optional",
 		"blockMultiQueue":            "Whether or not to enable virtio multi-queue for block devices\n+optional",
 		"networkInterfaceMultiqueue": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature\n+optional",

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -4,8 +4,6 @@
 package kubecli
 
 import (
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	v10 "k8s.io/api/autoscaling/v1"
@@ -742,8 +740,8 @@ func (_mr *_MockVirtualMachineInstanceInterfaceRecorder) Patch(arg0, arg1, arg2 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Patch", _s...)
 }
 
-func (_m *MockVirtualMachineInstanceInterface) SerialConsole(name string, timeout time.Duration) (StreamInterface, error) {
-	ret := _m.ctrl.Call(_m, "SerialConsole", name, timeout)
+func (_m *MockVirtualMachineInstanceInterface) SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error) {
+	ret := _m.ctrl.Call(_m, "SerialConsole", name, options)
 	ret0, _ := ret[0].(StreamInterface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -27,7 +27,6 @@ package kubecli
 
 import (
 	"io"
-	"time"
 
 	secv1 "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	autov1 "k8s.io/api/autoscaling/v1"
@@ -126,7 +125,7 @@ type VirtualMachineInstanceInterface interface {
 	Update(*v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 	Delete(name string, options *k8smetav1.DeleteOptions) error
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.VirtualMachineInstance, err error)
-	SerialConsole(name string, timeout time.Duration) (StreamInterface, error)
+	SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error)
 	VNC(name string) (StreamInterface, error)
 	Pause(name string) error
 	Unpause(name string) error

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -335,10 +335,9 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				tests.WaitForVMCondition(virtClient, vm, v1.VirtualMachinePaused, 30)
 
 				By("Trying to console into the VM")
-				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, 30*time.Second)
+				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("VMI is paused"))
-
 			})
 
 			It("[test_id:3084]should gracefully handle vnc connection", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2553,7 +2553,7 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	resCh := make(chan error)
 
 	startTime := time.Now()
-	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, timeout)
+	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout})
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
For completeness also allow opting out of the default serial console
device, like we allow for VNC.

For some usecases on some Operating Systems an unneeded device can have
unwanted side-effects. The most recent case we saw is Windows, where
every user in the Guest OS by default sees the serial console as an
unpluggable PCI device.

First this is confusing for the user and second the serial console does
not even serve any purpose on windows guests.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add "autoattachSerialConsole" flag to the devices section to opt out of having the default serial console added to a VMI.
```
