### PR TITLE
virt-handler should only update guest-agent details if interface doesn't have masquerade binding

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2382,6 +2382,6 @@ var _ = Describe("Configurations", func() {
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Should successfully get VMI")
 			return vmi.Status.Interfaces[0].IP == vmiPod.Status.PodIP
-		}, 180*time.Second, 1*time.Second).Should(BeTrue(), "VMI status IP should match VMI Pod IP")
+		}, 30*time.Second, 1*time.Second).Should(BeTrue(), "VMI status IP should match VMI Pod IP")
 	})
 })


### PR DESCRIPTION
Signed-off-by: Vatsal Parekh <vparekh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently `virt-handler` updates the VMI status with the interface data `guest-agent` provides when it is present. But, for VMI with `Masquerade` binding, this would update VMI with link-local IP address, which would not be a reachable address.

This PR changes this behavior so virt-handler would only update details from `guest-agent` on VMI status if interface does not have masquerade binding

This also unblocks https://github.com/kubevirt/kubevirt/pull/2963/, because both `virt-handler` and `virt-controller` would try to update VMI status when guest-agent is present without these patch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
**Fixes** # https://bugzilla.redhat.com/show_bug.cgi?id=1795889

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-handler should only update guest-agent details if interface doesn't have masquerade binding
```
