### PR TITLE
Enable mod-vendor on test build, fix dockerfile ci image build

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -83,13 +83,6 @@ RUN pip3 install j2cli && pip3 install operator-courier==1.3.0
 WORKDIR /tmp/kubevirt
 COPY . .
 
-# update git
-# COPY hack/ci/wandisco-git.repo /etc/yum.repos.d/wandisco-git.repo
-#RUN yum remove -y git && \
-#    rpm --import http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco && \
-#    yum install -y git && \
-#    yum clean all && rm -rf /var/cache/yum/*
-
 # TODO: remove patching of external provider, after kubevirtci#199 has been merged and kubevirt updates
 RUN \
     export DOCKER_PREFIX='dhiller' && \

--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -84,11 +84,11 @@ WORKDIR /tmp/kubevirt
 COPY . .
 
 # update git
-COPY hack/ci/wandisco-git.repo /etc/yum.repos.d/wandisco-git.repo
-RUN yum remove -y git && \
-    rpm --import http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco && \
-    yum install -y git && \
-    yum clean all && rm -rf /var/cache/yum/*
+# COPY hack/ci/wandisco-git.repo /etc/yum.repos.d/wandisco-git.repo
+#RUN yum remove -y git && \
+#    rpm --import http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco && \
+#    yum install -y git && \
+#    yum clean all && rm -rf /var/cache/yum/*
 
 # TODO: remove patching of external provider, after kubevirtci#199 has been merged and kubevirt updates
 RUN \
@@ -127,4 +127,4 @@ ENV PATH="$PATH:/usr/local/go/bin/"
 COPY --from=builder /gimme /gimme
 RUN chmod 777 /gimme
 COPY --from=builder /tmp/kubevirt /go/src/kubevirt.io/kubevirt
-COPY --from=builder /tmp/kubevirt/hack/kubevirt-builder/rsyncd.conf /etc/rsyncd.conf
+COPY --from=builder /tmp/kubevirt/hack/builder/rsyncd.conf /etc/rsyncd.conf

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -22,10 +22,9 @@ echo "checking configuration location"
 echo "KUBECONFIG: ${KUBECONFIG}"
 # enable nested-virt
 oc get machineset -n openshift-machine-api -o json >/tmp/machinesets.json
-MACHINE_IMAGE=$(jq .items[0].spec.template.spec.providerSpec.value.disks[0].image /tmp/machinesets.json)
-NESTED_VIRT_IMAGE="sotest-rhcos-nested-virt"
-sed -i "s/$MACHINE_IMAGE/$NESTED_VIRT_IMAGE/g" /tmp/machinesets.json
-sed -i 's/sotest-rhcos-nested-virt/"sotest-rhcos-nested-virt"/g' /tmp/machinesets.json
+MACHINE_IMAGE=$(jq -r .items[0].spec.template.spec.providerSpec.value.disks[0].image /tmp/machinesets.json)
+NESTED_VIRT_IMAGE="rhcos43-nested-virt"
+sed -i 's/'"$MACHINE_IMAGE"'/'"$NESTED_VIRT_IMAGE"'/g'
 oc apply -f /tmp/machinesets.json
 oc scale --replicas=0 machineset --all -n openshift-machine-api
 oc get machines -n openshift-machine-api -o json >/tmp/machines.json

--- a/hack/ci/wandisco-git.repo
+++ b/hack/ci/wandisco-git.repo
@@ -1,6 +1,0 @@
-[wandisco-git]
-name=Wandisco GIT Repository
-baseurl=http://opensource.wandisco.com/centos/7/git/$basearch/
-enabled=1
-gpgcheck=1
-gpgkey=http://opensource.wandisco.com/RPM-GPG-KEY-WANdisco

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -19,7 +19,7 @@ PYTHON_CLIENT_OUT_DIR=$OUT_DIR/client-python
 
 function build_func_tests() {
     mkdir -p ${TESTS_OUT_DIR}/
-    ginkgo build ${KUBEVIRT_DIR}/tests
+    GOPROXY=off GOFLAGS=-mod=vendor ginkgo build ${KUBEVIRT_DIR}/tests
     mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fixes for openshift-ci onboarding:

* enable mod vendor for test build
* Fix couple of build failures when building the Dockerfile for OpenShift CI:
  * fix `rsyncd.conf` path
  * remove wandisco repo, as we now have vendoring enabled
* switch image to `rhcos43-nested-virt`

Image can now be built: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/6146/rehearse-6146-pull-ci-dhiller-kubevirt-kubevirt-os-ci-onboarding-images/3

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

**Special notes for your reviewer**:
See openshift/release#6146 for context

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
