### PR TITLE
Missing pod anti-affinity rule in virt-operator fixed

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -673,6 +673,18 @@ spec:
                 prometheus.kubevirt.io: ""
               name: virt-operator
             spec:
+              affinity:
+                podAntiAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                        - key: kubevirt.io
+                          operator: In
+                          values:
+                          - virt-operator
+                      topologyKey: kubernetes.io/hostname
+                    weight: 1
               containers:
               - command:
                 - virt-operator

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -437,6 +437,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 	kubeVirtVersionEnv string, virtApiShaEnv string, virtControllerShaEnv string,
 	virtHandlerShaEnv string, virtLauncherShaEnv string) (*appsv1.Deployment, error) {
 
+	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-operator"})
 	name := "virt-operator"
 	version = AddVersionSeparatorPrefix(version)
 	image := fmt.Sprintf("%s/%s%s%s", repository, imagePrefix, name, version)
@@ -481,27 +482,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 					Name: name,
 				},
 				Spec: corev1.PodSpec{
-					Affinity: &corev1.Affinity{
-						PodAntiAffinity: &corev1.PodAntiAffinity{
-							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-								{
-									Weight: 1,
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										LabelSelector: &metav1.LabelSelector{
-											MatchExpressions: []metav1.LabelSelectorRequirement{
-												{
-													Key:      virtv1.AppLabel,
-													Operator: metav1.LabelSelectorOpIn,
-													Values:   []string{name},
-												},
-											},
-										},
-										TopologyKey: "kubernetes.io/hostname",
-									},
-								},
-							},
-						},
-					},
+					Affinity:           podAntiAffinity,
 					ServiceAccountName: "kubevirt-operator",
 					Containers: []corev1.Container{
 						{

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -481,6 +481,27 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 					Name: name,
 				},
 				Spec: corev1.PodSpec{
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 1,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      virtv1.AppLabel,
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{name},
+												},
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+					},
 					ServiceAccountName: "kubevirt-operator",
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
Signed-off-by: Alberto Losada <alosadag@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently reviewing some advancing scheduling options in KubeVirt (affinity and antiaffinity rules basically). I've found that the deployment object of virt-operator, which is configured as replica 2 by default does not have any antiaffinity rules. `virt-controller` and `virt-api` already do have, which basically says that if it is possible (preferredDuringSchedulingIgnoredDuringExecution:) do not run both replicas together (same node). 

This PR fixes this missing pod anti-affinity rule in `virt-operator` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Thanks to @slintes for showing me the right place to write the fix.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing pod anti-affinity rule in virt-operator
```
