### PR TITLE
Automate things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ distclean: clean
 	hack/dockerized "rm -rf vendor/ && rm -f go.sum && GO111MODULE=on go clean -modcache"
 	rm -rf vendor/
 
+deps-update-patch:
+	SYNC_VENDOR=true hack/dockerized " ./hack/dep-update.sh -u=patch && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
+
 deps-update:
 	SYNC_VENDOR=true hack/dockerized " ./hack/dep-update.sh && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
 

--- a/hack/autobump-generic.sh
+++ b/hack/autobump-generic.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Taken from https://github.com/kubernetes/test-infra/blob/4d7f26e59a5e186eef3a7de55486b7a40bbd79d7/hack/autodeps.sh
+# and modified for kubevirt.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+cd $(git rev-parse --show-toplevel)
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $(basename "$0") <github-login> </path/to/github/token> [git-name] [git-email] [target]" >&2
+    exit 1
+fi
+user=$1
+token=$2
+shift 2
+if [[ $# -ge 2 ]]; then
+    echo "git config user.name=$1 user.email=$2..." >&2
+    git config user.name "$1"
+    git config user.email "$2"
+    shift 2
+fi
+if ! git config user.name &>/dev/null && git config user.email &>/dev/null; then
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    exit 1
+fi
+
+make $@
+
+git add -A
+if git diff --name-only --exit-code HEAD; then
+    echo "Nothing changed" >&2
+    exit 0
+fi
+
+make test
+
+title="Run make $@"
+git commit -m "${title}"
+git push -f "https://${user}@github.com/kubevirt/kubevirt.git" HEAD:autoupdate-$@
+
+echo "Creating PR to merge ${user}:autoupdate into master..." >&2
+/pr-creator -- \
+    --github-token-path="${token}" \
+    --org=kubevirt --repo=kubevirt --branch=master \
+    --title="${title}" --match-title="${title}" \
+    --body="Automatic run of \"$@\". Please review" \
+    --source="${user}":autoupdate \
+    --confirm

--- a/hack/autobump-kubevirtci.sh
+++ b/hack/autobump-kubevirtci.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Taken from https://github.com/kubernetes/test-infra/blob/4d7f26e59a5e186eef3a7de55486b7a40bbd79d7/hack/autodeps.sh
+# and modified for kubevirt.
+
+set -o errexit
+set -o pipefail
+
+source $(dirname "$0")/common.sh
+source $(dirname "$0")/config.sh
+
+cd $(git rev-parse --show-toplevel)
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $(basename "$0") <github-login> </path/to/github/token> [git-name] [git-email]" >&2
+    exit 1
+fi
+user=$1
+token=$2
+shift 2
+if [[ $# -ge 2 ]]; then
+    echo "git config user.name=$1 user.email=$2..." >&2
+    git config user.name "$1"
+    git config user.email "$2"
+    shift 2
+fi
+if ! git config user.name &>/dev/null && git config user.email &>/dev/null; then
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    exit 1
+fi
+
+hack/bump-kubevirtci.sh
+
+git add -A
+if git diff --name-only --exit-code HEAD; then
+    echo "Nothing changed" >&2
+    exit 0
+fi
+
+title="Run hack/bump-kubevirtci.sh, updating to ${kubevirtci_git_hash:0:8}..."
+git commit -m "${title}"
+git push -f "https://${user}@github.com/kubevirt/kubevirt.git" HEAD:kubevirtci
+
+echo "Creating PR to merge ${user}:kubevirtci into master..." >&2
+/pr-creator -- \
+    --github-token-path="${token}" \
+    --org=kubevirt --repo=kubevirt --branch=master \
+    --title="${title}" --match-title="Run hack/bump-kubevirtci.sh" \
+    --body="Automatic kubevirtci update to ${kubevirtci_git_hash}. Please review" \
+    --source="${user}":kubevirtci \
+    --confirm

--- a/hack/bump-kubevirtci.sh
+++ b/hack/bump-kubevirtci.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+
+set -ex
+
+source $(dirname "$0")/common.sh
+source $(dirname "$0")/config.sh
+
 val=$(git ls-remote https://github.com/kubevirt/kubevirtci | grep HEAD | awk '{print $1}')
 sed -i "/^[[:blank:]]*kubevirtci_git_hash[[:blank:]]*=/s/=.*/=\"${val}\"/" hack/config-default.sh
-git --no-pager diff hack/config-default.sh | grep "kubevirtci_git_hash"
+
+hack/sync-kubevirtci.sh

--- a/hack/dep-update.sh
+++ b/hack/dep-update.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 export GO111MODULE=on
 
 (
     cd staging/src/kubevirt.io/client-go
+    go get $@ ./...
     go mod tidy
 )
 
 (
     cd staging/src/github.com/golang/glog
+    go get $@ ./...
     go mod tidy
 )
 
 (
     cd staging/src/kubevirt.io/client-go/examples/listvms
+    go get $@ ./...
     go mod tidy
 )
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -4,7 +4,7 @@ set -e
 source $(dirname "$0")/common.sh
 
 if [ "${KUBEVIRT_RUN_UNNESTED}" == "true" ]; then
-    $@
+    /bin/bash -c "$@"
     exit $?
 fi
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -3,6 +3,11 @@ set -e
 
 source $(dirname "$0")/common.sh
 
+if [ "${KUBEVIRT_RUN_UNNESTED}" == "true" ]; then
+    $@
+    exit $?
+fi
+
 KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:7585e27b5a5a019f5749eaa1ef29da3278878eefc862b45d6e1c2e343d9f8859"
 
 DOCKER_DIR=${KUBEVIRT_DIR}/hack/kubevirt-builder

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -114,32 +114,4 @@ protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/cmd/info/info.proto
 mockgen -source pkg/handler-launcher-com/notify/info/info.pb.go -package=info -destination=pkg/handler-launcher-com/notify/info/generated_mock_info.go
 mockgen -source pkg/handler-launcher-com/cmd/info/info.pb.go -package=info -destination=pkg/handler-launcher-com/cmd/info/generated_mock_info.go
 
-# update cluster-up if needed
-version_file="cluster-up/version.txt"
-sha_file="cluster-up-sha.txt"
-download_cluster_up=true
-function getClusterUpShasum() {
-    find ${KUBEVIRT_DIR}/cluster-up -type f | sort | xargs sha1sum | sha1sum | awk '{print $1}'
-}
-# check if we got a new cluster-up git commit hash
-if [[ -f "${version_file}" ]] && [[ $(cat ${version_file}) == ${kubevirtci_git_hash} ]]; then
-    # check if files are modified
-    current_sha=$(getClusterUpShasum)
-    if [[ -f "${sha_file}" ]] && [[ $(cat ${sha_file}) == ${current_sha} ]]; then
-        echo "cluster-up is up to date and not modified"
-        download_cluster_up=false
-    else
-        echo "cluster-up was modified"
-    fi
-else
-    echo "cluster-up git commit hash was updated"
-fi
-if [[ "$download_cluster_up" == true ]]; then
-    echo "downloading cluster-up"
-    rm -rf cluster-up
-    curl -L https://github.com/kubevirt/kubevirtci/archive/${kubevirtci_git_hash}/kubevirtci.tar.gz | tar xz kubevirtci-${kubevirtci_git_hash}/cluster-up --strip-component 1
-
-    echo ${kubevirtci_git_hash} >${version_file}
-    new_sha=$(getClusterUpShasum)
-    echo ${new_sha} >${sha_file}
-fi
+hack/sync-kubevirtci.sh

--- a/hack/sync-kubevirtci.sh
+++ b/hack/sync-kubevirtci.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -ex
+
+source $(dirname "$0")/common.sh
+source $(dirname "$0")/config.sh
+
+# update cluster-up if needed
+version_file="cluster-up/version.txt"
+sha_file="cluster-up-sha.txt"
+download_cluster_up=true
+function getClusterUpShasum() {
+    find ${KUBEVIRT_DIR}/cluster-up -type f | sort | xargs sha1sum | sha1sum | awk '{print $1}'
+}
+
+# check if we got a new cluster-up git commit hash
+if [[ -f "${version_file}" ]] && [[ $(cat ${version_file}) == ${kubevirtci_git_hash} ]]; then
+    # check if files are modified
+    current_sha=$(getClusterUpShasum)
+    if [[ -f "${sha_file}" ]] && [[ $(cat ${sha_file}) == ${current_sha} ]]; then
+        echo "cluster-up is up to date and not modified"
+        download_cluster_up=false
+    else
+        echo "cluster-up was modified"
+    fi
+else
+    echo "cluster-up git commit hash was updated"
+fi
+if [[ "$download_cluster_up" == true ]]; then
+    echo "downloading cluster-up"
+    rm -rf cluster-up
+    curl -L https://github.com/kubevirt/kubevirtci/archive/${kubevirtci_git_hash}/kubevirtci.tar.gz | tar xz kubevirtci-${kubevirtci_git_hash}/cluster-up --strip-component 1
+
+    echo ${kubevirtci_git_hash} >${version_file}
+    new_sha=$(getClusterUpShasum)
+    echo ${new_sha} >${sha_file}
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Add scripts which can be used to do the following automatic code bumps:

 * Bump to latest kubevirtci version
 * Update patch or minor versions of vendor dependencies

Further a KUBEVIRT_RUN_UNNUESTED environment variable is added, which
allows to execute all Makefile targets without nested docker. That is
useful when already running inside a builder image in e.g. a prow job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Follow up of #3071 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
