### PR TITLE
virt-launcher: lookup qemu gid

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"reflect"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -316,7 +318,15 @@ func SetupLibvirt() error {
 		if !ok {
 			return fmt.Errorf("can't convert file stats to unix/linux stats")
 		}
-		err := os.Chown("/dev/kvm", int(s.Uid), 107)
+		g, err := user.LookupGroup("qemu")
+		if err != nil {
+			return err
+		}
+		gid, err := strconv.Atoi(g.Gid)
+		if err != nil {
+			return err
+		}
+		err = os.Chown("/dev/kvm", int(s.Uid), gid)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When setting ownership of /dev/kvm, avoid hardcoding a gid of 107
and lookup qemu gid instead.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Allows dynamically setting group ownership of /dev/kvm

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
NONE
```release-note

```
