### PR TITLE
Add chmod to Dockerfile

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -120,4 +120,5 @@ ENV PATH="$PATH:/usr/local/go/bin/"
 COPY --from=builder /gimme /gimme
 RUN chmod 777 /gimme
 COPY --from=builder /tmp/kubevirt /go/src/kubevirt.io/kubevirt
+RUN chmod -R 777 /go/src/kubevirt.io/kubevirt
 COPY --from=builder /tmp/kubevirt/hack/builder/rsyncd.conf /etc/rsyncd.conf


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add a chmod to the Dockerfile for OpenShift-ci in order to enable write access in kubevirt repo directory (within Docker image).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @rmohr @danielBelenky this should be merged soon as it's required to make openshift-ci work (finally)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
