### PR TITLE
Allow mixing SATA & SCSI files

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -180,16 +180,19 @@ func SetDriverCacheMode(disk *Disk) error {
 
 func makeDeviceName(bus string, devicePerBus map[string]int) string {
 	index := devicePerBus[bus]
-	devicePerBus[bus] += 1
 
 	prefix := ""
 	switch bus {
 	case "virtio":
 		prefix = "vd"
+		devicePerBus[bus] += 1
 	case "sata", "scsi":
 		prefix = "sd"
+		devicePerBus["scsi"] += 1
+		devicePerBus["sata"] += 1
 	case "fdc":
 		prefix = "fd"
+		devicePerBus[bus] += 1
 	default:
 		log.Log.Errorf("Unrecognized bus '%s'", bus)
 		return ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR allows us to mix both sata & scsi devices.
It's useful when we need for example, to mount drivers in sata mode and install our OS on an scsi disk for performances purpose.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow mixing SCSI & SATA Devices
```
