### PR TITLE
Network Setup Optimization 

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -310,6 +310,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			mockWatchdog.CreateFile(oldVMI)
 			// the domain is dead because the watchdog is expired
 			mockWatchdog.Expire(oldVMI)
+			controller.phase1NetworkSetupCache[oldVMI.UID] = 1
 			vmiFeeder.Add(vmi)
 			domainFeeder.Add(domain)
 
@@ -318,6 +319,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 			_, err := os.Stat(mockWatchdog.File(oldVMI))
 			Expect(os.IsNotExist(err)).To(BeTrue())
+			Expect(len(controller.phase1NetworkSetupCache)).To(Equal(0))
 		}, 3)
 
 		It("should attempt force terminate Domain if grace period expires", func() {
@@ -384,6 +386,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Expect(options.VirtualMachineSMBios.Manufacturer).To(Equal(virtconfig.SmbiosConfigDefaultManufacturer))
 			})
 			controller.Execute()
+			Expect(len(controller.phase1NetworkSetupCache)).To(Equal(1))
 		})
 
 		It("should update from Scheduled to Running, if it sees a running Domain", func() {


### PR DESCRIPTION

This optimization prevents attempting to setup phase1 of a vmi multiple times. Phase1 involves reaching into the VMI pods namespace and performing some tasks. The namespace switch involves killing a POSIX thread, which is expensive. We'd rather only do this when it's absolutely necessary.

```release-note
NONE
```
