### PR TITLE
Wait for the KubeVirt API to be available before creating the KubeVirt CR

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -74,6 +74,14 @@ until _kubectl get crd kubevirts.kubevirt.io; do
     sleep 1
 done
 
+# Ensure the KubeVirt API is available
+count=0
+until _kubectl api-resources --api-group=kubevirt.io | grep kubevirts; do
+    ((count++)) && ((count == 30)) && echo "KubeVirt API not found" && exit 1
+    echo "waiting for KubeVirt API"
+    sleep 1
+done
+
 # Deploy KubeVirt
 _kubectl create -n ${namespace} -f ${MANIFESTS_OUT_DIR}/release/kubevirt-cr.yaml
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a timing issue which causes the following creation failure for kubevirt-cr.yaml:
`no matches for kind "KubeVirt" in version "kubevirt.io/v1alpha3"`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The issue is random and might never reproduce on some hardware.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
