### PR TITLE
Annotation propagation

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -953,8 +953,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	}
 
 	for k, v := range vmi.Annotations {
-		if strings.Contains(k, "kubernetes.io") || strings.Contains(k, "kubevirt.io") {
-			// skip kubernetes and kubevirt internal annotations
+		// filtering so users will not see this on pod and in confusion
+		if strings.HasPrefix(k, "kubectl.kubernetes.io") ||
+			strings.HasPrefix(k, "kubevirt.io/storage-observed-api-version") ||
+			strings.HasPrefix(k, "kubevirt.io/latest-observed-api-version") {
 			continue
 		}
 		annotationsList[k] = v

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -22,7 +22,6 @@ package watch
 import (
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -709,15 +708,6 @@ func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.Virtual
 	vmi.Spec = vm.Spec.Template.Spec
 
 	setupStableFirmwareUUID(vm, vmi)
-
-	vmi.ObjectMeta.Annotations = map[string]string{}
-	for k, v := range vm.Annotations {
-		if strings.Contains(k, "kubernetes.io") || strings.Contains(k, "kubevirt.io") {
-			// skip kubernetes and kubevirt internal annotations
-			continue
-		}
-		vmi.ObjectMeta.Annotations[k] = v
-	}
 
 	// TODO check if vmi labels exist, and when make sure that they match. For now just override them
 	vmi.ObjectMeta.Labels = vm.Spec.Template.ObjectMeta.Labels

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -824,6 +824,48 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvents(recorder, FailedDeleteVirtualMachineReason)
 		})
 
+		It("should copy annotations from spec.template to vmi", func() {
+			vm, vmi := DefaultVirtualMachine(true)
+			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"test": "test"}
+			annotations := map[string]string{"test": "test"}
+
+			addVirtualMachine(vm)
+
+			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(obj interface{}) {
+				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+			}).Return(vmi, nil)
+
+			controller.Execute()
+		})
+
+		It("should copy kubevirt ignitiondata annotation from spec.template to vmi", func() {
+			vm, vmi := DefaultVirtualMachine(true)
+			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"kubevirt.io/ignitiondata": "test"}
+			annotations := map[string]string{"kubevirt.io/ignitiondata": "test"}
+
+			addVirtualMachine(vm)
+
+			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(obj interface{}) {
+				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+			}).Return(vmi, nil)
+
+			controller.Execute()
+		})
+
+		It("should copy kubernetes annotations from spec.template to vmi", func() {
+			vm, vmi := DefaultVirtualMachine(true)
+			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
+			annotations := map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}
+
+			addVirtualMachine(vm)
+
+			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(obj interface{}) {
+				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
+			}).Return(vmi, nil)
+
+			controller.Execute()
+		})
+
 		Context("VM rename", func() {
 			Context("source VM", func() {
 				var vm *v1.VirtualMachine

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -81,6 +81,7 @@ type EvictionStrategy string
 // ---
 // +k8s:openapi-gen=true
 type VirtualMachineInstanceSpec struct {
+
 	// If specified, indicates the pod's priority.
 	// If not specified, the pod priority will be default or zero if there is no
 	// default.

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -327,7 +327,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			err = tests.RetryWithMetadataIfModified(vm.ObjectMeta, func(meta v12.ObjectMeta) error {
 				vm, err = virtClient.VirtualMachine(meta.Namespace).Get(meta.Name, &v12.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				vm.Annotations = annotations
+				vm.Spec.Template.ObjectMeta.Annotations = annotations
 				vm, err = virtClient.VirtualMachine(meta.Namespace).Update(vm)
 				return err
 			})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -121,7 +121,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		It("[test_id:3195]should carry annotations to pod", func() {
 			vmi.Annotations = map[string]string{
-				"testannotation": "test",
+				"testannotation": "annotation from vmi",
 			}
 
 			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
@@ -131,10 +131,10 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).NotTo(BeNil())
 
-			Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "test"), "annotation should be carried to the pod")
+			Expect(pod.Annotations).To(HaveKeyWithValue("testannotation", "annotation from vmi"), "annotation should be carried to the pod")
 		})
 
-		It("[test_id:3196]should not carry kubernetes and kubevirt annotations to pod", func() {
+		It("[test_id:3196]should carry kubernetes and kubevirt annotations to pod", func() {
 			vmi.Annotations = map[string]string{
 				"kubevirt.io/test":   "test",
 				"kubernetes.io/test": "test",
@@ -147,8 +147,8 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(pod).NotTo(BeNil())
 
-			Expect(pod.Annotations).ToNot(HaveKey("kubevirt.io/test"), "kubevirt annotation should not be carried to the pod")
-			Expect(pod.Annotations).ToNot(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
+			Expect(pod.Annotations).To(HaveKey("kubevirt.io/test"), "kubevirt annotation should not be carried to the pod")
+			Expect(pod.Annotations).To(HaveKey("kubernetes.io/test"), "kubernetes annotation should not be carried to the pod")
 		})
 
 		It("[test_id:1622]should log libvirtd logs", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
1. PR is fixing issue where annotation is not passed from VMI template to VMI. 
2. Provide passing of annotations from VMI to Pod even when annotation start with kubvirt.io/ or kubernetes.io/ which is now not possible.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3009 
Fixes #3070

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
