### PR TITLE
Priority classes

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6644,6 +6644,10 @@
       "description": "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
       "type": "object"
      },
+     "priorityClassName": {
+      "description": "If specified, indicates the pod's priority.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.\n+optional",
+      "type": "string"
+     },
      "readinessProbe": {
       "description": "Periodic probe of VirtualMachineInstance service readiness.\nVirtualmachineInstances will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n+optional",
       "$ref": "#/definitions/v1.Probe"

--- a/examples/non-preemtible.yaml
+++ b/examples/non-preemtible.yaml
@@ -1,7 +1,7 @@
+---
 apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-globalDefault: false
 description: Priority class for VMs which should not be preemtited.
+kind: PriorityClass
 metadata:
   name: non-preemtible
 preemptionPolicy: Never

--- a/examples/non-preemtible.yaml
+++ b/examples/non-preemtible.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+globalDefault: false
+description: Priority class for VMs which should not be preemtited.
+metadata:
+  name: non-preemtible
+preemptionPolicy: Never
+value: 999999999

--- a/examples/preemtible.yaml
+++ b/examples/preemtible.yaml
@@ -1,7 +1,7 @@
+---
 apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-globalDefault: false
 description: Priority class for VMs which are allowed to be preemtited.
+kind: PriorityClass
 metadata:
   name: preemtible
 preemptionPolicy: PreemptLowerPriority

--- a/examples/preemtible.yaml
+++ b/examples/preemtible.yaml
@@ -1,0 +1,8 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+globalDefault: false
+description: Priority class for VMs which are allowed to be preemtited.
+metadata:
+  name: preemtible
+preemptionPolicy: PreemptLowerPriority
+value: 1000000

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-cirros
+  name: vm-non-preemtible
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-cirros
+    spec:
+    // deploy priorityClass first
+      priorityClassName: non-preemtible
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        machine:
+          type: ""
+        resources:
+          requests:
+            memory: 64M
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - containerDisk:
+          image: registry:5000/kubevirt/cirros-container-disk-demo:devel
+        name: containerdisk
+      - cloudInitNoCloud:
+          userData: |
+            #!/bin/sh
+
+            echo 'printed from cloud-init userdata'
+        name: cloudinitdisk

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -12,8 +12,6 @@ spec:
       labels:
         kubevirt.io/vm: vm-cirros
     spec:
-    // deploy priorityClass first
-      priorityClassName: non-preemtible
       domain:
         devices:
           disks:
@@ -28,6 +26,7 @@ spec:
         resources:
           requests:
             memory: 64M
+      priorityClassName: non-preemtible
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -991,6 +991,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		},
 	}
 
+	if vmi.Spec.PriorityClassName != "" {
+		pod.Spec.PriorityClassName = vmi.Spec.PriorityClassName
+	}
+
 	if vmi.Spec.Affinity != nil {
 		pod.Spec.Affinity = vmi.Spec.Affinity.DeepCopy()
 	}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1645,6 +1645,26 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Containers[0].Command).To(ContainElement("42"), "command arg value should be correct")
 		})
 
+		Context("with specified priorityClass", func() {
+			It("should add priorityClass", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "namespace",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						PriorityClassName: "test",
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.PriorityClassName).To(Equal("test"))
+			})
+
+		})
+
 	})
 
 	Describe("ServiceAccountName", func() {

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -3306,6 +3306,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceSpec(ref common.Re
 				Description: "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"priorityClassName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"domain": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the VirtualMachineInstance on the host.",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -81,6 +81,12 @@ type EvictionStrategy string
 // ---
 // +k8s:openapi-gen=true
 type VirtualMachineInstanceSpec struct {
+	// If specified, indicates the pod's priority.
+	// If not specified, the pod priority will be default or zero if there is no
+	// default.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+
 	// Specification of the desired behavior of the VirtualMachineInstance on the host.
 	Domain DomainSpec `json:"domain"`
 	// NodeSelector is a selector which must be true for the vmi to fit on a node.

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -19,6 +19,7 @@ func (VirtualMachineInstanceList) SwaggerDoc() map[string]string {
 func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                              "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
+		"priorityClassName":             "If specified, indicates the pod's priority.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.\n+optional",
 		"domain":                        "Specification of the desired behavior of the VirtualMachineInstance on the host.",
 		"nodeSelector":                  "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
 		"affinity":                      "If affinity is specifies, obey all the affinity rules",

--- a/tools/vms-generator/BUILD.bazel
+++ b/tools/vms-generator/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//tools/util:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],

--- a/tools/vms-generator/utils/BUILD.bazel
+++ b/tools/vms-generator/utils/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -28,6 +28,7 @@ import (
 	"kubevirt.io/kubevirt/tools/util"
 
 	k8sv1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -52,11 +53,16 @@ func main() {
 			virtconfig.PermitBridgeInterfaceOnPodNetwork: "true",
 		},
 	})
+	var priorityClasses = map[string]*schedulingv1.PriorityClass{
+		utils.Preemtible:    utils.GetPreemtible(),
+		utils.NonPreemtible: utils.GetNonPreemtible(),
+	}
 
 	var vms = map[string]*v1.VirtualMachine{
 		utils.VmCirros:           utils.GetVMCirros(),
 		utils.VmAlpineMultiPvc:   utils.GetVMMultiPvc(),
 		utils.VmAlpineDataVolume: utils.GetVMDataVolume(),
+		utils.VMPriorityClass:    utils.GetVMPriorityClass(),
 	}
 
 	var vmis = map[string]*v1.VirtualMachineInstance{
@@ -166,6 +172,10 @@ func main() {
 
 	// TODO:(ihar) how to validate templates?
 	for name, obj := range templates {
+		handleError(dumpObject(name, *obj))
+	}
+
+	for name, obj := range priorityClasses {
 		handleError(dumpObject(name, *obj))
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
PR introduce option to specify priorityClass for VMI. This allow virt-launcher pod to be scheduled in priority and kubelet also takes this into account(for example out-of-resource eviction) .

Proposal:
Kubevirt can include priorityClasses (included in examples) in installation process and add defaulting of VM/VMI according to evicationStrategy(non/preemptive).

Reasoning behind this is that VMs are still taking as pet and this feature can improve scheduling/running vm on top of kubernetes. 



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3089

**Special notes for your reviewer**:

**Release note**:
```release-note
It is now possible to use priorityClass for VMI.
```
