### PR TITLE
build: remove unused variable in dockerized script

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -5,8 +5,6 @@ source $(dirname "$0")/common.sh
 
 KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:7585e27b5a5a019f5749eaa1ef29da3278878eefc862b45d6e1c2e343d9f8859"
 
-DOCKER_DIR=${KUBEVIRT_DIR}/hack/kubevirt-builder
-
 SYNC_OUT=${SYNC_OUT:-true}
 
 BUILDER=${job_prefix}


### PR DESCRIPTION
Commit 881a3cb583 removed the hack/kubevirt-builder directory but
missed a variable using that directory in hack/dockerized. The
variable is unused so remove it.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removes an unused variable in the dockerized script.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
