### PR TITLE
Make containerDisk work with different filesystem backends

### DIFF
--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -41,7 +41,7 @@ func (m *Mounter) Mount(vmi *v1.VirtualMachineInstance, verify bool) error {
 				if err != nil {
 					return fmt.Errorf("failed to detect root mount point of containerDisk %v on the node: %v", volume.Name, err)
 				}
-				sourceFile, err := containerdisk.GetImage(filepath.Join(nodeRes.MountRoot(), nodeMountInfo.MountPoint), volume.ContainerDisk.Path)
+				sourceFile, err := containerdisk.GetImage(filepath.Join(nodeRes.MountRoot(), nodeMountInfo.Root, nodeMountInfo.MountPoint), volume.ContainerDisk.Path)
 				if err != nil {
 					return fmt.Errorf("failed to find a sourceFile in containerDisk %v: %v", volume.Name, err)
 				}

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -296,7 +296,7 @@ func (r *realIsolationResult) MountInfoRoot() (*MountInfo, error) {
 			}
 		}
 
-		if record[3] == "/" && record[4] == "/" {
+		if record[4] == "/" {
 			return &MountInfo{
 				DeviceContainingFile: record[2],
 				Root:                 record[3],


### PR DESCRIPTION
Different container runtime filesystem backends display the root mount point for the container differenty.

On btrfs:

```
2545 1152 0:25 /@/var/lib/docker/btrfs/subvolumes/73f599843c89c363939d571c4750f75b306f88641186ccf64f8600f44cd2a48a / rw,relatime master:1 - btrfs [...]
```

On devicemapper:

```
1626 850 253:29 /rootfs / rw,relatime - ext4 /dev/mapper/docker-253:2- [...]
```

On overlay fs:

```
1863 1557 0:374 / / rw,relatime - overlay overlay [...]
```

Remove the check which was checking that row 4 has to be `/`, since it
only matters that row number 5 is `/`. Further add row 4 to the absolute
mount path, to match the real path.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3119, #3117 

**Special notes for your reviewer**:

**Release note**:
```release-note
Make containerDisk work with devicemapper and btrfs
```
