### PR TITLE
Ensure labels on our metrics are not being overwritten

### DIFF
--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -273,6 +273,12 @@ func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkip
 					TLSConfig: &promv1.TLSConfig{
 						InsecureSkipVerify: insecureSkipVerify,
 					},
+					RelabelConfigs: []*promv1.RelabelConfig{
+						{
+							SourceLabels: []string{"namespace"},
+							Action:       "labeldrop",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Since OCP 4.3, the monitoring stack is featuring a Prometheus proxy
component (Thanos). One of the proxy components (prom-query-proxy) is modifying
the metrics on the fly: it changes our namespace label to exported_namespace.
In result, while virt-handler sets the namespace label to be the
namespace in which the VMI resides, it's being overwritten to the
namespace of virt-handler. Since virt-handler's namespace is privileged,
users without access to this namespace will not be able to view this
metric.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

** Related BZ **:
https://bugzilla.redhat.com/show_bug.cgi?id=1805044

** Related PR on openshift-console **:
https://github.com/openshift/console/pull/4623

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ensure Prometheus operator honors labels on kubevirt exported metrics
```
