### PR TITLE
Adapt automation to run propertly cnao providers.

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -272,7 +272,7 @@ spec:
 EOF
   # Run only Windows tests
   ginko_params="$ginko_params --ginkgo.focus=Windows"
-elif [[ $TARGET =~ cnao ]]; then
+elif [[ $TARGET =~ (cnao|multus) ]]; then
   ginko_params="$ginko_params --ginkgo.focus=Multus|Networking|VMIlifecycle|Expose"
 elif [[ $TARGET =~ genie.* ]]; then
   ginko_params="$ginko_params --ginkgo.focus=Genie|Networking|VMIlifecycle|Expose"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -35,8 +35,11 @@ readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluste
 
 if [[ $TARGET =~ windows.* ]]; then
   echo "picking the default provider for windows tests"
+elif [[ $TARGET =~ cnao ]]; then
+  export KUBEVIRT_WITH_CNAO=true
+  export KUBEVIRT_PROVIDER=${TARGET/-cnao/}
 else
-  export KUBEVIRT_PROVIDER=$TARGET
+  export KUBEVIRT_PROVIDER=${TARGET}
 fi
 
 if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
@@ -269,14 +272,14 @@ spec:
 EOF
   # Run only Windows tests
   ginko_params="$ginko_params --ginkgo.focus=Windows"
-elif [[ $TARGET =~ multus.* ]]; then
+elif [[ $TARGET =~ cnao ]]; then
   ginko_params="$ginko_params --ginkgo.focus=Multus|Networking|VMIlifecycle|Expose"
 elif [[ $TARGET =~ genie.* ]]; then
   ginko_params="$ginko_params --ginkgo.focus=Genie|Networking|VMIlifecycle|Expose"
 elif [[ $TARGET =~ sriov.* ]]; then
   ginko_params="$ginko_params --ginkgo.focus=SRIOV"
 elif [[ $TARGET =~ gpu.* ]]; then
-  ginko_params="$ginko_params --ginkgo.focus=GPU" 
+  ginko_params="$ginko_params --ginkgo.focus=GPU"
 elif [[ $TARGET =~ (okd|ocp).* ]]; then
   ginko_params="$ginko_params --ginkgo.skip=Genie|SRIOV|GPU"
 else


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The multus lane at kubevirt is testing a very old version of cluster-network-addons-operator AKA CNAO, this PR bump kubevirtci and adapt automation to run cnao provider correctly and towards multus and networking tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The pull-kubevirt-e2e-k8s-cnao-1.17 job is still optional and run_always: false, it need to be exercised with pull-kubevirt-e2e-k8s-cnao-1.17, when this PR is merged we will do the replacement of lanes s/multus/cnao/.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
