### PR TITLE
Adjust the record of allocatable nodes

### DIFF
--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -327,7 +327,9 @@ func NewPrometheusRuleSpec(ns string) *promv1.PrometheusRuleSpec {
 					},
 					{
 						Record: "num_of_allocatable_nodes",
-						Expr:   intstr.FromString("count(count (kube_node_status_allocatable) by (node))"),
+						// Since we don't set any specific node label selector, any node with at least 1 NoSchedule
+						// effect will prevent our workloads from being scheduled on that node.
+						Expr: intstr.FromString("count(count (kube_node_status_allocatable) by (node)) - count(kube_node_spec_taint{effect='NoSchedule'})"),
 					},
 					{
 						Alert: "LowVirtAPICount",


### PR DESCRIPTION
We can't rely just on the # of allocatable nodes because taint
configurations can also affect the schedulability of our workloads. This
commit adjusts the record to also consider taint configurations on nodes to
produce a more accurate record.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Node records now considers taint configs to calculate allocatable nodes  
```
