### PR TITLE
Change to kubevirt builder

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -83,19 +83,16 @@ RUN pip3 install j2cli && pip3 install operator-courier==1.3.0
 WORKDIR /tmp/kubevirt
 COPY . .
 
-# TODO: remove patching of external provider, after kubevirtci#199 has been merged and kubevirt updates
 RUN \
-    export DOCKER_PREFIX='dhiller' && \
+    export DOCKER_PREFIX='kubevirtnightlybuilds' && \
     export DOCKER_TAG="latest" && \
     export KUBEVIRT_PROVIDER=external && \
     export GIMME_GO_VERSION=1.12.8 && \
     export GOPATH="/go" && \
     export GOBIN="/usr/bin" && \
     source /etc/profile.d/gimme.sh && \
-    (cd cluster-up/cluster/external && curl -L -O -o provider.sh https://raw.githubusercontent.com/dhiller/kubevirtci/fix-external-provider/cluster-up/cluster/external/provider.sh) && \
     bash -x ./hack/build-manifests.sh && \
-    bash -x ./hack/build-func-tests.sh && \
-    curl -L -O -o kvm-ds.yaml https://raw.githubusercontent.com/kubevirt/kubernetes-device-plugins/master/manifests/kvm-ds.yml
+    bash -x ./hack/build-func-tests.sh
 FROM centos:7
 
 COPY --from=builder /etc/profile.d/gimme.sh /etc/profile.d/gimme.sh

--- a/hack/ci/Dockerfile.ci-pr
+++ b/hack/ci/Dockerfile.ci-pr
@@ -1,0 +1,11 @@
+FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
+WORKDIR /go/src/github.com/kubevirt.io/kubevirt
+COPY ./hack/builder/rsyncd.conf /etc/rsyncd.conf
+COPY . .
+
+RUN source /etc/profile.d/gimme.sh && \
+    export GOPATH="/root/go" && \
+    ./hack/ci/build.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD ["./hack/ci/test.sh"]

--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# poor mans replacement for PULL_PULL_SHA provided by prow - use the second parent commit id from the merge commit
+mkdir -p _out/
+merge_commit=$(git --no-pager log -1 --merges --format=%H)
+git --no-pager show ${merge_commit} --format=%P | tr -d '\n' | cut -d ' ' -f 2 >_out/PULL_PULL_SHA
+PULL_PULL_SHA=$(cat _out/PULL_PULL_SHA)
+export PULL_PULL_SHA
+
+export DOCKER_PREFIX='kubevirtnightlybuilds'
+export DOCKER_TAG="latest"
+export KUBEVIRT_PROVIDER=external
+
+bash -x ./hack/build-manifests.sh
+
+# build dump
+CMD_OUT_DIR="$(pwd)/_out/cmd"
+export CMD_OUT_DIR
+mkdir -p _out/cmd/dump/
+GOPROXY=off GOFLAGS=-mod=vendor go build -o "$CMD_OUT_DIR/dump/dump" ./cmd/dump
+bash -x ./hack/build-func-tests.sh

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -1,60 +1,18 @@
 #!/usr/bin/env bash
+set -xeuo pipefail
 
-set -euo pipefail
-
-export PATH=$PATH:/usr/local/go/bin/
-which kubectl
-which oc
-echo "checking nodes for cluster"
-# in CI, this cmd fails unless you provide a ns
-oc -n default get nodes
-echo "checking configuration"
-env | grep KUBE
-kubectl config view
-export DOCKER_PREFIX='dhiller'
+export DOCKER_PREFIX='kubevirtnightlybuilds'
 export DOCKER_TAG="latest"
 export KUBEVIRT_PROVIDER=external
-export GIMME_GO_VERSION=1.12.8
-export GOPATH="/go"
-export GOBIN="/usr/bin"
-source /etc/profile.d/gimme.sh
-echo "checking configuration location"
-echo "KUBECONFIG: ${KUBECONFIG}"
-# enable nested-virt
-oc get machineset -n openshift-machine-api -o json >/tmp/machinesets.json
-MACHINE_IMAGE=$(jq -r .items[0].spec.template.spec.providerSpec.value.disks[0].image /tmp/machinesets.json)
-NESTED_VIRT_IMAGE="rhcos43-nested-virt"
-sed -i 's/'"$MACHINE_IMAGE"'/'"$NESTED_VIRT_IMAGE"'/g'
-oc apply -f /tmp/machinesets.json
-oc scale --replicas=0 machineset --all -n openshift-machine-api
-oc get machines -n openshift-machine-api -o json >/tmp/machines.json
-num_machines=$(jq '.items | length' /tmp/machines.json)
-while [ "$num_machines" -ne "3" ]; do
-    oc get machines -n openshift-machine-api -o json >/tmp/machines.json
-    num_machines=$(jq '.items | length' /tmp/machines.json)
-done
-oc scale --replicas=1 machineset --all -n openshift-machine-api
-while [ "$num_machines" -ne "6" ]; do
-    oc get machines -n openshift-machine-api -o json >/tmp/machines.json
-    num_machines=$(jq '.items | length' /tmp/machines.json)
-done
-while [ $(oc get nodes | wc -l) -ne "7" ]; do oc get nodes; done
-nodes_ready=false
-while ! "$nodes_ready"; do sleep 5 && if ! oc get nodes | grep NotReady; then nodes_ready=true; fi; done
-oc project default
-oc apply -f /go/src/kubevirt.io/kubevirt/kvm-ds.yml
-workers=$(oc get nodes | grep worker | awk '{ print $1 }')
-workers_each=($workers)
-for i in {0..2}; do
-    if ! oc debug node/"${workers_each[i]}" -- ls /dev/kvm; then oc debug node/"${workers_each[i]}" -- ls /dev/kvm; fi
-done
+
 echo "calling cluster-up to prepare config and check whether cluster is reachable"
 bash -x ./cluster-up/up.sh
-echo "checking cluster configuration after config prep"
-kubectl config view
+
 echo "deploying"
 bash -x ./hack/cluster-deploy.sh
-echo "checking pods for kubevirt"
-oc get pods -n kubevirt
+
 echo "testing"
-bash -x ./hack/functests.sh
+mkdir -p "$ARTIFACT_DIR"
+TESTS_TO_FOCUS=$(grep -E -o '\[crit\:high\]' tests/*_test.go | sort | uniq | sed -E 's/tests\/([a-z_]+)\.go\:.*/\1/' | tr '\n' '|' | sed 's/|$//')
+FUNC_TEST_ARGS='--ginkgo.noColor --ginkgo.focus='"$TESTS_TO_FOCUS"' --ginkgo.regexScansFilePath=true --junit-output='"$ARTIFACT_DIR"'/junit.functest.xml' \
+    bash -x ./hack/functests.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR reduces the duplication of hack/ci/Dockerfile.ci by reusing kubevirt builder. It goes together with [adding the kubevirt builder](https://github.com/openshift/release/pull/7579) as a supplemental ci image stream

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/cc @rmohr 