### PR TITLE
Fix relabeling rules

### DIFF
--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -275,8 +275,8 @@ func NewServiceMonitorCR(namespace string, monitorNamespace string, insecureSkip
 					},
 					RelabelConfigs: []*promv1.RelabelConfig{
 						{
-							SourceLabels: []string{"namespace"},
-							Action:       "labeldrop",
+							Regex:  "namespace",
+							Action: "labeldrop",
 						},
 					},
 				},

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -115,6 +115,7 @@ go_test(
         "//pkg/host-disk:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/cluster:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/net/dns:go_default_library",


### PR DESCRIPTION
The `labeldrop` action requires only `regex` matcher to be set.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>


```release-note
Fix ServiceMonitor relabel rules
```
