### PR TITLE
relabel the hostImages directory to container_file_t

### DIFF
--- a/images/disks-images-provider/entrypoint.sh
+++ b/images/disks-images-provider/entrypoint.sh
@@ -38,6 +38,7 @@ rm /images/fedora-cloud/disk.qcow2
 echo "copy all images to host mount directory"
 cp -R /images/* /hostImages/
 chmod -R 777 /hostImages
+chcon -Rt svirt_sandbox_file_t /hostImages
 
 # for some reason without sleep, container sometime fails to create the file
 sleep 10


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR re-labels the `/tmp/hostImages` directory on nodes to  `container_file_t`
to support testing the virt-launcher on SELinux enabled environment.

The code uses `svirt_sandbox_file_t` instead of exclicitly using `container_file_t`.
`container_file_t` is aliased to `svirt_sandbox_file_t`, however, it is missing from some platforms such as RHEL 7.4

```release-note
NONE
```
