### PR TITLE
calculate guest memory overhead base on topology and not just cores

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1084,7 +1084,8 @@ func getMemoryOverhead(domain v1.DomainSpec) *resource.Quantity {
 	// overhead per vcpu in MiB
 	coresMemory := resource.MustParse("8Mi")
 	if domain.CPU != nil {
-		value := coresMemory.Value() * int64(domain.CPU.Cores)
+		vcpus := hardware.GetNumberOfVCPUs(domain.CPU)
+		value := coresMemory.Value() * vcpus
 		coresMemory = *resource.NewQuantity(value, coresMemory.Format)
 	}
 	overhead.Add(coresMemory)


### PR DESCRIPTION
**What this PR does / why we need it**:
So far we were calculating the vcpus memory overhead based only on the guest cores.
This PR calculates the overhead based on guest topology.

**Release note**:
```release-note
NONE
```
