### PR TITLE
Move tolerations annotation to pod specs

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -667,7 +667,6 @@ spec:
             metadata:
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ""
-                scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
               labels:
                 kubevirt.io: virt-operator
                 prometheus.kubevirt.io: ""
@@ -730,6 +729,9 @@ spec:
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: kubevirt-operator
+              tolerations:
+              - key: CriticalAddonsOnly
+                operator: Exists
     strategy: deployment
   installModes:
   - supported: true

--- a/manifests/generated/virt-api.yaml.in
+++ b/manifests/generated/virt-api.yaml.in
@@ -32,7 +32,6 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
       labels:
         kubevirt.io: virt-api
         prometheus.kubevirt.io: ""
@@ -81,3 +80,6 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubevirt-apiserver
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists

--- a/manifests/generated/virt-controller.yaml.in
+++ b/manifests/generated/virt-controller.yaml.in
@@ -16,7 +16,6 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
       labels:
         kubevirt.io: virt-controller
         prometheus.kubevirt.io: ""
@@ -69,3 +68,6 @@ spec:
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubevirt-controller
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists

--- a/manifests/generated/virt-handler.yaml.in
+++ b/manifests/generated/virt-handler.yaml.in
@@ -14,7 +14,6 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly","operator":"Exists"}]'
       labels:
         kubevirt.io: virt-handler
         prometheus.kubevirt.io: ""
@@ -68,6 +67,9 @@ spec:
           name: device-plugin
       hostPID: true
       serviceAccountName: kubevirt-handler
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
       volumes:
       - hostPath:
           path: /var/run/kubevirt-libvirt-runtimes

--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -24,6 +24,5 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
     ],
 )


### PR DESCRIPTION
The `scheduler.alpha.kubernetes.io/tolerations` annotation is deprecated
as of K8s 1.6 and is replaced by spec.Tolerations.

Since the annotated value is ignored by the rescheduler, it can result
in evicted kubevrit components not being rescheduled.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
**Special notes for your reviewer**:
K8s 1.6 release notes: https://github.com/kubernetes/kubernetes/blob/release-1.6/CHANGELOG-1.6.md#scheduling

**Release note**:
```release-note
Move tolerations annotation to pod spec
```
