### PR TITLE
Copy apache license to python-client

### DIFF
--- a/hack/gen-client-python/generate.sh
+++ b/hack/gen-client-python/generate.sh
@@ -46,3 +46,5 @@ echo "from .v1_interface_slirp import V1InterfaceSlirp" >>"${PYTHON_CLIENT_OUT_D
 
 echo "from .models.v1_interface_bridge import V1InterfaceBridge" >>"${PYTHON_CLIENT_OUT_DIR}"/kubevirt/__init__.py
 echo "from .models.v1_interface_slirp import V1InterfaceSlirp" >>"${PYTHON_CLIENT_OUT_DIR}"/kubevirt/__init__.py
+
+cp LICENSE ${PYTHON_CLIENT_OUT_DIR}/LICENSE


### PR DESCRIPTION
**What this PR does / why we need it**:

We forgot to add the license to the auto-generated python client.
Copying the LICENSE file now from the kubevirt root when generating the
client.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Make it clear that client-python is distributed under apache2.
```
