### PR TITLE
DNM: bisect ipv6 PR to discover ipv4 lanes error

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -249,7 +249,7 @@ kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"
 
-ginko_params="--ginkgo.noColor --junit-output=$ARTIFACTS_PATH/junit.functest.xml"
+ginko_params="--ginkgo.failFast --ginkgo.noColor --junit-output=$ARTIFACTS_PATH/junit.functest.xml"
 
 # Prepare PV for Windows testing
 if [[ $TARGET =~ windows.* ]]; then

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -8,6 +8,7 @@ const (
 	resolvConf        = "/etc/resolv.conf"
 	DefaultProtocol   = "TCP"
 	DefaultVMCIDR     = "10.0.2.0/24"
+	DefaultVMIpv6CIDR = "fd2e:f1fe:9490:a8ff::/120"
 	DefaultBridgeName = "k6t-eth0"
 )
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -29,6 +29,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
 
@@ -46,8 +47,10 @@ const randomMacGenerationAttempts = 10
 type VIF struct {
 	Name         string
 	IP           netlink.Addr
+	IPv6         netlink.Addr
 	MAC          net.HardwareAddr
 	Gateway      net.IP
+	GatewayIpv6  net.IP
 	Routes       *[]netlink.Route
 	Mtu          uint16
 	IPAMDisabled bool
@@ -84,8 +87,11 @@ type NetworkHandler interface {
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
 	UseIptables() bool
-	IptablesNewChain(table, chain string) error
-	IptablesAppendRule(table, chain string, rulespec ...string) error
+	Ipv4NatEnabled() bool
+	Ipv6NatEnabled() bool
+	ConfigureIpv6Forwarding() error
+	IptablesNewChain(proto iptables.Protocol, table, chain string) error
+	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
 	NftablesNewChain(table, chain string) error
 	NftablesAppendRule(table, chain string, rulespec ...string) error
 	NftablesNewTable(table string) error
@@ -142,22 +148,50 @@ func (h *NetworkUtilsHandler) UseIptables() bool {
 
 	return true
 }
-func (h *NetworkUtilsHandler) IptablesNewChain(table, chain string) error {
-	iptablesObject, err := iptables.New()
+
+func (h *NetworkUtilsHandler) ConfigureIpv6Forwarding() error {
+	_, err := exec.Command("sysctl", "net.ipv6.conf.all.forwarding=1").CombinedOutput()
+	return err
+}
+
+func (h *NetworkUtilsHandler) Ipv4NatEnabled() bool {
+	lsmod, _ := exec.Command("lsmod").CombinedOutput()
+	lsmodString := string(lsmod)
+	if !strings.Contains(lsmodString, "iptable_nat") && !strings.Contains(lsmodString, "nf_nat_ipv4") {
+		log.Log.Errorf("no ipv4 support")
+		return false
+	}
+	return true
+}
+
+func (h *NetworkUtilsHandler) Ipv6NatEnabled() bool {
+	lsmod, _ := exec.Command("lsmod").CombinedOutput()
+	lsmodString := string(lsmod)
+	if !strings.Contains(lsmodString, "iptable_nat") && !strings.Contains(lsmodString, "nf_nat_ipv6") {
+		log.Log.Errorf("no ipv6 support")
+		return false
+	}
+	return true
+}
+
+func (h *NetworkUtilsHandler) IptablesNewChain(proto iptables.Protocol, table, chain string) error {
+	iptablesObject, err := iptables.NewWithProtocol(proto)
 	if err != nil {
 		return err
 	}
 
 	return iptablesObject.NewChain(table, chain)
 }
-func (h *NetworkUtilsHandler) IptablesAppendRule(table, chain string, rulespec ...string) error {
-	iptablesObject, err := iptables.New()
+
+func (h *NetworkUtilsHandler) IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error {
+	iptablesObject, err := iptables.NewWithProtocol(proto)
 	if err != nil {
 		return err
 	}
 
 	return iptablesObject.Append(table, chain, rulespec...)
 }
+
 func (h *NetworkUtilsHandler) NftablesNewChain(table, chain string) error {
 	output, err := exec.Command("nft", "add", "chain", "ip", table, chain).CombinedOutput()
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -103,12 +103,12 @@ func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string
 func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error {
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		vif, err := getNetworkInterfaceFactory(networks, iface.Name)
+		networkInterfaceFactory, err := getNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err
 		}
 		podInterfaceName = getPodInterfaceName(networks, cniNetworks, iface.Name)
-		err = NetworkInterface.PlugPhase1(vif, vmi, &iface, networks[iface.Name], podInterfaceName, pid)
+		err = NetworkInterface.PlugPhase1(networkInterfaceFactory, vmi, &iface, networks[iface.Name], podInterfaceName, pid)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -520,9 +520,11 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 		return err
 	}
 
-	err = configureVifV6Addresses(p, err)
-	if err != nil {
-		return err
+	if Handler.IsIpv6Enabled(p.podNicLink) {
+		err = configureVifV6Addresses(p, err)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -627,8 +629,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 			return err
 		}
 	}
-
-	if Handler.Ipv6NatEnabled() {
+	if Handler.IsIpv6Enabled(p.podNicLink) && Handler.Ipv6NatEnabled() {
 		err = Handler.ConfigureIpv6Forwarding()
 		if err != nil {
 			log.Log.Errorf("failed to turn on net.ipv6.conf.all.forwarding")
@@ -741,11 +742,12 @@ func (p *MasqueradePodInterface) createBridge() error {
 		return err
 	}
 
-	if err := Handler.AddrAdd(bridge, p.gatewayIpv6Addr); err != nil {
-		log.Log.Reason(err).Errorf("failed to set bridge IPv6")
-		return err
+	if Handler.IsIpv6Enabled(p.podNicLink) {
+		if err := Handler.AddrAdd(bridge, p.gatewayIpv6Addr); err != nil {
+			log.Log.Reason(err).Errorf("failed to set bridge IPv6")
+			return err
+		}
 	}
-
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -805,7 +805,7 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables(protocol iptables.P
 			strconv.Itoa(int(port.Port)),
 			"-j",
 			"SNAT",
-			"--to-source", getVifIpByProtocol(p, protocol))
+			"--to-source", getGatewayByProtocol(p, protocol))
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -31,6 +31,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/coreos/go-iptables/iptables"
+
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -234,6 +236,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 			domain:              domain,
 			podInterfaceName:    podInterfaceName,
 			vmNetworkCIDR:       network.Pod.VMNetworkCIDR,
+			vmIpv6NetworkCIDR:   "", // TODO add ipv6 cidr to PodNetwork schema
 			bridgeInterfaceName: fmt.Sprintf("k6t-%s", podInterfaceName)}, nil
 	}
 	if iface.Slirp != nil {
@@ -492,7 +495,9 @@ type MasqueradePodInterface struct {
 	podInterfaceName    string
 	bridgeInterfaceName string
 	vmNetworkCIDR       string
+	vmIpv6NetworkCIDR   string
 	gatewayAddr         *netlink.Addr
+	gatewayIpv6Addr     *netlink.Addr
 }
 
 func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
@@ -508,8 +513,21 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 	}
 
 	// Get interface MTU
-	p.vif.Mtu = uint16(p.podNicLink.Attrs().MTU)
+	p.vif.Mtu = uint16(p.podNicLink.Attrs().MTU) // TODO - why do we override the mtu that was specified in the yaml - iface.MacAddress
 
+	err = configureVifV4Addresses(p, err)
+	if err != nil {
+		return err
+	}
+
+	err = configureVifV6Addresses(p, err)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func configureVifV4Addresses(p *MasqueradePodInterface, err error) error {
 	if p.vmNetworkCIDR == "" {
 		p.vmNetworkCIDR = api.DefaultVMCIDR
 	}
@@ -532,7 +550,32 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 		return fmt.Errorf("failed to parse vm ip address %s", vm)
 	}
 	p.vif.IP = *vmAddr
+	return nil
+}
 
+func configureVifV6Addresses(p *MasqueradePodInterface, err error) error {
+	if p.vmIpv6NetworkCIDR == "" {
+		p.vmIpv6NetworkCIDR = api.DefaultVMIpv6CIDR
+	}
+
+	defaultGatewayIpv6, vmIpv6, err := Handler.GetHostAndGwAddressesFromCIDR(p.vmIpv6NetworkCIDR)
+	if err != nil {
+		log.Log.Errorf("failed to get gw and vm available ipv6 addresses from CIDR %s", p.vmIpv6NetworkCIDR)
+		return err
+	}
+
+	gatewayIpv6Addr, err := Handler.ParseAddr(defaultGatewayIpv6)
+	if err != nil {
+		return fmt.Errorf("failed to parse gateway ipv6 address %s", gatewayIpv6Addr)
+	}
+	p.vif.GatewayIpv6 = gatewayIpv6Addr.IP.To16()
+	p.gatewayIpv6Addr = gatewayIpv6Addr
+
+	vmAddr, err := Handler.ParseAddr(vmIpv6)
+	if err != nil {
+		return fmt.Errorf("failed to parse vm ipv6 address %s", vmIpv6)
+	}
+	p.vif.IPv6 = *vmAddr
 	return nil
 }
 
@@ -577,10 +620,26 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 		return err
 	}
 
-	err = p.createNatRules()
-	if err != nil {
-		log.Log.Errorf("failed to create nat rules for vm error: %v", err)
-		return err
+	if Handler.Ipv4NatEnabled() {
+		err = p.createNatRules(iptables.ProtocolIPv4)
+		if err != nil {
+			log.Log.Errorf("failed to create ipv4 nat rules for vm error: %v", err)
+			return err
+		}
+	}
+
+	if Handler.Ipv6NatEnabled() {
+		err = Handler.ConfigureIpv6Forwarding()
+		if err != nil {
+			log.Log.Errorf("failed to turn on net.ipv6.conf.all.forwarding")
+			return err
+		}
+
+		err = p.createNatRules(iptables.ProtocolIPv6)
+		if err != nil {
+			log.Log.Errorf("failed to create ipv6 nat rules for vm error: %v", err)
+			return err
+		}
 	}
 
 	p.virtIface.MTU = &api.MTU{Size: strconv.Itoa(p.podNicLink.Attrs().MTU)}
@@ -632,6 +691,7 @@ func (p *MasqueradePodInterface) loadCachedVIF(pid, name string) (bool, error) {
 		return false, err
 	}
 	p.vif.Gateway = p.vif.Gateway.To4()
+	p.vif.GatewayIpv6 = p.vif.GatewayIpv6.To16()
 	return true, nil
 }
 
@@ -681,47 +741,52 @@ func (p *MasqueradePodInterface) createBridge() error {
 		return err
 	}
 
+	if err := Handler.AddrAdd(bridge, p.gatewayIpv6Addr); err != nil {
+		log.Log.Reason(err).Errorf("failed to set bridge IPv6")
+		return err
+	}
+
 	return nil
 }
 
-func (p *MasqueradePodInterface) createNatRules() error {
+func (p *MasqueradePodInterface) createNatRules(protocol iptables.Protocol) error {
 	if Handler.UseIptables() {
-		return p.createNatRulesUsingIptables()
+		return p.createNatRulesUsingIptables(protocol)
 	}
 	return p.createNatRulesUsingNftables()
 }
 
-func (p *MasqueradePodInterface) createNatRulesUsingIptables() error {
-	err := Handler.IptablesNewChain("nat", "KUBEVIRT_PREINBOUND")
+func (p *MasqueradePodInterface) createNatRulesUsingIptables(protocol iptables.Protocol) error {
+	err := Handler.IptablesNewChain(protocol, "nat", "KUBEVIRT_PREINBOUND")
 	if err != nil {
 		return err
 	}
 
-	err = Handler.IptablesNewChain("nat", "KUBEVIRT_POSTINBOUND")
+	err = Handler.IptablesNewChain(protocol, "nat", "KUBEVIRT_POSTINBOUND")
 	if err != nil {
 		return err
 	}
 
-	err = Handler.IptablesAppendRule("nat", "POSTROUTING", "-s", p.vif.IP.IP.String(), "-j", "MASQUERADE")
+	err = Handler.IptablesAppendRule(protocol, "nat", "POSTROUTING", "-s", getVifIpByProtocol(p, protocol), "-j", "MASQUERADE")
 	if err != nil {
 		return err
 	}
 
-	err = Handler.IptablesAppendRule("nat", "PREROUTING", "-i", p.podInterfaceName, "-j", "KUBEVIRT_PREINBOUND")
+	err = Handler.IptablesAppendRule(protocol, "nat", "PREROUTING", "-i", p.podInterfaceName, "-j", "KUBEVIRT_PREINBOUND")
 	if err != nil {
 		return err
 	}
 
-	err = Handler.IptablesAppendRule("nat", "POSTROUTING", "-o", p.bridgeInterfaceName, "-j", "KUBEVIRT_POSTINBOUND")
+	err = Handler.IptablesAppendRule(protocol, "nat", "POSTROUTING", "-o", p.bridgeInterfaceName, "-j", "KUBEVIRT_POSTINBOUND")
 	if err != nil {
 		return err
 	}
 
 	if len(p.iface.Ports) == 0 {
-		err = Handler.IptablesAppendRule("nat", "KUBEVIRT_PREINBOUND",
+		err = Handler.IptablesAppendRule(protocol, "nat", "KUBEVIRT_PREINBOUND",
 			"-j",
 			"DNAT",
-			"--to-destination", p.vif.IP.IP.String())
+			"--to-destination", getVifIpByProtocol(p, protocol))
 
 		return err
 	}
@@ -731,45 +796,69 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables() error {
 			port.Protocol = "tcp"
 		}
 
-		err = Handler.IptablesAppendRule("nat", "KUBEVIRT_POSTINBOUND",
+		err = Handler.IptablesAppendRule(protocol, "nat", "KUBEVIRT_POSTINBOUND",
 			"-p",
 			strings.ToLower(port.Protocol),
 			"--dport",
 			strconv.Itoa(int(port.Port)),
 			"-j",
 			"SNAT",
-			"--to-source", p.gatewayAddr.IP.String())
+			"--to-source", getVifIpByProtocol(p, protocol))
 		if err != nil {
 			return err
 		}
 
-		err = Handler.IptablesAppendRule("nat", "KUBEVIRT_PREINBOUND",
+		err = Handler.IptablesAppendRule(protocol, "nat", "KUBEVIRT_PREINBOUND",
 			"-p",
 			strings.ToLower(port.Protocol),
 			"--dport",
 			strconv.Itoa(int(port.Port)),
 			"-j",
 			"DNAT",
-			"--to-destination", p.vif.IP.IP.String())
+			"--to-destination", getVifIpByProtocol(p, protocol))
 		if err != nil {
 			return err
 		}
 
-		err = Handler.IptablesAppendRule("nat", "OUTPUT",
+		err = Handler.IptablesAppendRule(protocol, "nat", "OUTPUT",
 			"-p",
 			strings.ToLower(port.Protocol),
 			"--dport",
 			strconv.Itoa(int(port.Port)),
-			"--destination", "127.0.0.1",
+			"--destination", getLoopbackAdrress(protocol),
 			"-j",
 			"DNAT",
-			"--to-destination", p.vif.IP.IP.String())
+			"--to-destination", getVifIpByProtocol(p, protocol))
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func getGatewayByProtocol(p *MasqueradePodInterface, proto iptables.Protocol) string {
+	if proto == iptables.ProtocolIPv4 {
+		return p.gatewayAddr.IP.String()
+	} else {
+		return p.gatewayIpv6Addr.IP.String()
+	}
+}
+
+func getVifIpByProtocol(p *MasqueradePodInterface, proto iptables.Protocol) string {
+	if proto == iptables.ProtocolIPv4 {
+		return p.vif.IP.IP.String()
+	} else {
+		return p.vif.IPv6.IP.String()
+	}
+}
+
+func getLoopbackAdrress(proto iptables.Protocol) string {
+	if proto == iptables.ProtocolIPv4 {
+		return "127.0.0.1"
+	} else {
+		return "::1"
+	}
 }
 
 func (p *MasqueradePodInterface) createNatRulesUsingNftables() error {


### PR DESCRIPTION
The commit contains -
- Adding masquarade and dnat rule to ip6tables.
- Giving ipv6 address to k6t-eth0 bridge.
- Turning on 'net.ipv6.conf.all.forwarding' on the virt-launcher pod
(done via the virt-handler).

The commit doesn't contain -
- Adding masquarade and dnat rule to nftable.
- ipv6 support to bind methods other than masquarade.

Further changes needed-
- DHCP server support for ipv6 or deciding on another method to set
the ip + default gateway on the vm.

The change was tested by specifying manully on the vm-
$ sudo ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0
$ sudo ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2


Signed-off-by: Alona Kaplan <alkaplan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
