### PR TITLE
Allow a manual adjustment of guest memory overhead

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -231,21 +231,8 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	}
 	// Validate hugepages
 	if spec.Domain.Memory != nil && spec.Domain.Memory.Guest != nil {
-		requests := spec.Domain.Resources.Requests.Memory().Value()
 		limits := spec.Domain.Resources.Limits.Memory().Value()
 		guest := spec.Domain.Memory.Guest.Value()
-		if requests > guest {
-			causes = append(causes, metav1.StatusCause{
-				Type: metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%s '%s' must be equal to or larger than the requested memory %s '%s'",
-					field.Child("domain", "memory", "guest").String(),
-					spec.Domain.Memory.Guest,
-					field.Child("domain", "resources", "requests", "memory").String(),
-					spec.Domain.Resources.Requests.Memory(),
-				),
-				Field: field.Child("domain", "memory", "guest").String(),
-			})
-		}
 		if limits < guest && limits != 0 {
 			causes = append(causes, metav1.StatusCause{
 				Type: metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -723,7 +723,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(len(causes)).To(Equal(1))
 			Expect(causes[0].Field).To(Equal("fake.domain.resources.requests.memory"))
 		})
-		It("should reject smaller guest memory than requested memory", func() {
+		It("should allow smaller guest memory than requested memory", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			guestMemory := resource.MustParse("1Mi")
 
@@ -733,8 +733,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Domain.Memory = &v1.Memory{Guest: &guestMemory}
 
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.memory.guest"))
+			Expect(len(causes)).To(Equal(0))
 		})
 		It("should reject bigger guest memory than the memory limit", func() {
 			vmi := v1.NewMinimalVMI("testvmi")


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases, manual adjustment of the calculated guest memory overhead is required.
However, until now this option was blocked.

This PR re-enables setting the guest's memory to a different value than the container requested memory. This will effectively allow the container to allocate more memory than the VMI and manually control the guest's memory overhead.

```
spec:
  domain:
    memory:
      guest: "2G"
    resources:
      requests:
        memory: "3G"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR also adjusts the memory overhead when huge pages are being requested.
Since until now, we didn't allow setting different values for `memory.guest` and `resources.requests.memory` we were requesting huge pages based on the `resources.requests.memory`. This PR requests huge pages based on guest memory (if present and different from requests.memory) and adds the difference to the containers `resources.requests.memory` in addition to the guest's memory overhead.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
