### PR TITLE
bugfix: Resolve permission mismatch when system default mask is set more restrictive than 022

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -179,6 +179,10 @@ func initializeDirs(virtShareDir string,
 	containerDiskDir string,
 	uid string) {
 
+	// Resolve permission mismatch when system default mask is set more restrictive than 022.
+	mask := syscall.Umask(0)
+	defer syscall.Umask(mask)
+
 	err := virtlauncher.InitializeSharedDirectories(virtShareDir)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR resolve permission mismatch when system default mask is set more restrictive than 022.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3118 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
