### PR TITLE
Create loop devices on kubevirtci test nodes

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -61,11 +61,6 @@ if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]] || [[ "$KUBEVIRT_PROVIDER" =~ (okd|ocp)-* 
     _kubectl adm policy add-scc-to-user privileged admin
 fi
 
-if [[ "$KUBEVIRT_PROVIDER" =~ kind.* ]]; then
-    #removing it since it's crashing with dind because loopback devices are shared with the host
-    _kubectl delete -n kubevirt ds disks-images-provider
-fi
-
 # Ensure the KubeVirt CRD is created
 count=0
 until _kubectl get crd kubevirts.kubevirt.io; do

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -114,6 +114,27 @@ spec:
               - /ready
             initialDelaySeconds: 10
             periodSeconds: 5
+        - name: loopdev
+          command:
+          - sh
+          - -c
+          - |
+            while true; do
+              for i in $(seq 0 5); do
+                  losetup -d /dev/loop$i
+                  rm -f /dev/loop$i
+                  mknod /dev/loop$i b 7 $i
+              done
+              sleep 100000000
+            done
+          image: {{.DockerPrefix}}/disks-images-provider:{{.DockerTag}}
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: dev
+            mountPath: /dev
       volumes:
         - name: images
           hostPath:
@@ -123,3 +144,6 @@ spec:
           hostPath:
             path: /mnt/local-storage
             type: DirectoryOrCreate
+        - name: dev
+          hostPath:
+            path: /dev


### PR DESCRIPTION
We cannot assume that loop devices will always exist on kubevirtci nodes.  For
example, the kind provider does not have them.  Instead we should create them
using a DaemonSet.  This fixes the disks-images-provider deployment on kind-*
providers so that we can run storage tests there.

A similar thing was done in k8s testing infrastructure which you can find here:
https://github.com/kubernetes/test-infra/pull/16230

Signed-off-by: Adam Litke <alitke@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
