### PR TITLE
DRAFT: Replace critical-pod annotation with PriorityClass

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -160,6 +160,16 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - scheduling.k8s.io
+          resources:
+          - priorityclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+        - apiGroups:
           - kubevirt.io
           resources:
           - kubevirts
@@ -665,8 +675,6 @@ spec:
             type: RollingUpdate
           template:
             metadata:
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ""
               labels:
                 kubevirt.io: virt-operator
                 prometheus.kubevirt.io: ""

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -15,6 +15,16 @@ metadata:
   name: kubevirt-operator
 rules:
 - apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+- apiGroups:
   - kubevirt.io
   resources:
   - kubevirts

--- a/manifests/generated/virt-api.yaml.in
+++ b/manifests/generated/virt-api.yaml.in
@@ -30,8 +30,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         kubevirt.io: virt-api
         prometheus.kubevirt.io: ""
@@ -77,6 +75,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
         resources: {}
+      priorityClassName: kubevirt-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubevirt-apiserver

--- a/manifests/generated/virt-controller.yaml.in
+++ b/manifests/generated/virt-controller.yaml.in
@@ -14,8 +14,6 @@ spec:
   strategy: {}
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         kubevirt.io: virt-controller
         prometheus.kubevirt.io: ""
@@ -65,6 +63,7 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 10
         resources: {}
+      priorityClassName: kubevirt-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubevirt-controller

--- a/manifests/generated/virt-handler.yaml.in
+++ b/manifests/generated/virt-handler.yaml.in
@@ -12,8 +12,6 @@ spec:
       kubevirt.io: virt-handler
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         kubevirt.io: virt-handler
         prometheus.kubevirt.io: ""
@@ -66,6 +64,7 @@ spec:
         - mountPath: /var/lib/kubelet/device-plugins
           name: device-plugin
       hostPID: true
+      priorityClassName: kubevirt-cluster-critical
       serviceAccountName: kubevirt-handler
       tolerations:
       - key: CriticalAddonsOnly

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -102,6 +102,8 @@ type VirtControllerApp struct {
 	informerFactory controller.KubeInformerFactory
 	podInformer     cache.SharedIndexInformer
 
+	priorityClassInformer cache.SharedIndexInformer
+
 	nodeInformer   cache.SharedIndexInformer
 	nodeController *NodeController
 
@@ -239,6 +241,8 @@ func Execute() {
 		app.dataVolumeInformer = app.informerFactory.DummyDataVolume()
 		log.Log.Infof("CDI not detected, DataVolume integration disabled")
 	}
+
+	app.priorityClassInformer = app.informerFactory.PriorityClass()
 
 	app.initCommon()
 	app.initReplicaSet()

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -197,6 +197,7 @@ func Execute() {
 		InfrastructurePod:        app.informerFactory.OperatorPod(),
 		PodDisruptionBudget:      app.informerFactory.OperatorPodDisruptionBudget(),
 		Namespace:                app.informerFactory.Namespace(),
+		PriorityClass:            app.informerFactory.PriorityClass(),
 	}
 
 	app.stores = util.Stores{
@@ -217,6 +218,7 @@ func Execute() {
 		InfrastructurePodCache:        app.informerFactory.OperatorPod().GetStore(),
 		PodDisruptionBudgetCache:      app.informerFactory.OperatorPodDisruptionBudget().GetStore(),
 		NamespaceCache:                app.informerFactory.Namespace().GetStore(),
+		PriorityClassCache:            app.informerFactory.PriorityClass().GetStore(),
 	}
 
 	onOpenShift, err := clusterutil.IsOnOpenShift(app.clientSet)

--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/prometheus-operator/pkg/apis/monitoring"
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -34,6 +35,24 @@ import (
 const (
 	KUBEVIRT_PROMETHEUS_RULE_NAME = "prometheus-kubevirt-rules"
 )
+
+// NewVirtPriorityClass returns the priority class for all KubeVirt core components
+func NewVirtPriorityClass() *schedulingv1.PriorityClass {
+	return &schedulingv1.PriorityClass{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "scheduling.k8s.io/v1",
+			Kind:       "PriorityClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt-cluster-critical",
+		},
+		// 1 billion is the highest value we can set
+		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+		Value:         1000000000,
+		GlobalDefault: false,
+		Description:   "This priority class should be used for KubeVirt core components only.",
+	}
+}
 
 func newBlankCrd() *extv1beta1.CustomResourceDefinition {
 	return &extv1beta1.CustomResourceDefinition{

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -109,14 +109,12 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 				virtv1.AppLabel:          podName,
 				"prometheus.kubevirt.io": "",
 			},
-			Annotations: map[string]string{
-				"scheduler.alpha.kubernetes.io/critical-pod": "",
-			},
 			Name: podName,
 		},
 		Spec: corev1.PodSpec{
-			Affinity:    podAffinity,
-			Tolerations: criticalAddonsToleration(),
+			Affinity:          podAffinity,
+			PriorityClassName: "kubevirt-cluster-critical",
+			Tolerations:       criticalAddonsToleration(),
 			Containers: []corev1.Container{
 				{
 					Name:            podName,
@@ -463,9 +461,6 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 					Labels: map[string]string{
 						virtv1.AppLabel:          name,
 						"prometheus.kubevirt.io": "",
-					},
-					Annotations: map[string]string{
-						"scheduler.alpha.kubernetes.io/critical-pod": "",
 					},
 					Name: name,
 				},

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -71,6 +71,21 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{
+					"scheduling.k8s.io",
+				},
+				Resources: []string{
+					"priorityclasses",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+					"create",
+					"delete",
+				},
+			},
+			{
+				APIGroups: []string{
 					"kubevirt.io",
 				},
 				Resources: []string{

--- a/pkg/virt-operator/install-strategy/BUILD.bazel
+++ b/pkg/virt-operator/install-strategy/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -98,6 +98,7 @@ func NewKubeVirtController(
 			PodDisruptionBudget:      controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("PodDisruptionBudgets")),
 			ServiceMonitor:           controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("ServiceMonitor")),
 			PrometheusRule:           controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("PrometheusRule")),
+			PriorityClass:            controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectationsWithName("PriorityClass")),
 		},
 		installStrategyMap: make(map[string]*installstrategy.InstallStrategy),
 		operatorNamespace:  operatorNamespace,
@@ -187,6 +188,18 @@ func NewKubeVirtController(
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.genericUpdateHandler(oldObj, newObj, c.kubeVirtExpectations.Crd)
+		},
+	})
+
+	c.informers.PriorityClass.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			c.genericAddHandler(obj, c.kubeVirtExpectations.PriorityClass)
+		},
+		DeleteFunc: func(obj interface{}) {
+			c.genericDeleteHandler(obj, c.kubeVirtExpectations.PriorityClass)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			c.genericUpdateHandler(oldObj, newObj, c.kubeVirtExpectations.PriorityClass)
 		},
 	})
 
@@ -515,6 +528,7 @@ func (c *KubeVirtController) Run(threadiness int, stopCh <-chan struct{}) {
 	cache.WaitForCacheSync(stopCh, c.informers.ServiceMonitor.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.Namespace.HasSynced)
 	cache.WaitForCacheSync(stopCh, c.informers.PrometheusRule.HasSynced)
+	cache.WaitForCacheSync(stopCh, c.informers.PriorityClass.HasSynced)
 
 	// Start the actual work
 	for i := 0; i < threadiness; i++ {

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -47,6 +47,7 @@ type Stores struct {
 	ServiceMonitorCache           cache.Store
 	NamespaceCache                cache.Store
 	PrometheusRuleCache           cache.Store
+	PriorityClassCache            cache.Store
 	IsOnOpenshift                 bool
 	ServiceMonitorEnabled         bool
 	PrometheusRulesEnabled        bool
@@ -68,7 +69,8 @@ func (s *Stores) AllEmpty() bool {
 		IsStoreEmpty(s.PodDisruptionBudgetCache) &&
 		IsSCCStoreEmpty(s.SCCCache) &&
 		IsStoreEmpty(s.ServiceMonitorCache) &&
-		IsStoreEmpty(s.PrometheusRuleCache)
+		IsStoreEmpty(s.PrometheusRuleCache) &&
+		IsStoreEmpty(s.PriorityClassCache)
 
 	// Don't add InstallStrategyConfigMapCache to this list. The install
 	// strategies persist even after deletion and updates.
@@ -114,6 +116,7 @@ type Expectations struct {
 	PodDisruptionBudget      *controller.UIDTrackingControllerExpectations
 	ServiceMonitor           *controller.UIDTrackingControllerExpectations
 	PrometheusRule           *controller.UIDTrackingControllerExpectations
+	PriorityClass            *controller.UIDTrackingControllerExpectations
 }
 
 type Informers struct {
@@ -137,6 +140,7 @@ type Informers struct {
 	ServiceMonitor           cache.SharedIndexInformer
 	Namespace                cache.SharedIndexInformer
 	PrometheusRule           cache.SharedIndexInformer
+	PriorityClass            cache.SharedIndexInformer
 }
 
 func (e *Expectations) DeleteExpectations(key string) {
@@ -158,6 +162,7 @@ func (e *Expectations) DeleteExpectations(key string) {
 	e.PodDisruptionBudget.DeleteExpectations(key)
 	e.ServiceMonitor.DeleteExpectations(key)
 	e.PrometheusRule.DeleteExpectations(key)
+	e.PriorityClass.DeleteExpectations(key)
 }
 
 func (e *Expectations) ResetExpectations(key string) {
@@ -179,6 +184,7 @@ func (e *Expectations) ResetExpectations(key string) {
 	e.PodDisruptionBudget.SetExpectations(key, 0, 0)
 	e.ServiceMonitor.SetExpectations(key, 0, 0)
 	e.PrometheusRule.SetExpectations(key, 0, 0)
+	e.PriorityClass.SetExpectations(key, 0, 0)
 }
 
 func (e *Expectations) SatisfiedExpectations(key string) bool {
@@ -199,5 +205,6 @@ func (e *Expectations) SatisfiedExpectations(key string) bool {
 		e.InstallStrategyJob.SatisfiedExpectations(key) &&
 		e.PodDisruptionBudget.SatisfiedExpectations(key) &&
 		e.ServiceMonitor.SatisfiedExpectations(key) &&
-		e.PrometheusRule.SatisfiedExpectations(key)
+		e.PrometheusRule.SatisfiedExpectations(key) &&
+		e.PriorityClass.SatisfiedExpectations(key)
 }


### PR DESCRIPTION
The `scheduler.alpha.kubernetes.io/critical-pod` annotation is
deprecated as of K8s 1.16. It was replaced with PriorityClasses.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
So far, I've encountered an issue that even though operator's clsuter-role
is giving it permissions to act on `PriorityClasses`, it can't create them.
Since `PriorityClasses` were stable only in k8s 1.16, we still have time to
properly integrate it into KubeVirt.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use PriorityClasses instead of critical-pod annotation
```
