### PR TITLE
Avoid timeout with travis on ppc64 on "make generate"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
 - git reset --hard
 
 script:
+- |
+  while sleep 9m; do echo "Long running job - keep alive"; done &
+  LOOP_PID=$!
 - make generate
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
@@ -25,9 +28,6 @@ script:
   `make`. Please run it and commit the changes"; git status --porcelain; false; fi
 - make build-verify # verify that we set version on the packages built by bazel
 # The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
-- |
-  while sleep 9m; do echo "Long running job - keep alive"; done &
-  LOOP_PID=$!
 - if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then make goveralls; else make bazel-test; fi
 - kill $LOOP_PID
 - make build-verify # verify that we set version on the packages built by go(goveralls depends on go-build target)


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that we also print periodically a keep alive message already when
we do "make generate".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
