### PR TITLE
Copy 'Ready' condition from VMI to VM

### DIFF
--- a/pkg/controller/conditions_test.go
+++ b/pkg/controller/conditions_test.go
@@ -30,7 +30,7 @@ import (
 var _ = Describe("VirtualMachineInstance ConditionManager", func() {
 
 	var vmi *v1.VirtualMachineInstance
-	var cm *VirtualMachineConditionManager
+	var cm *VirtualMachineInstanceConditionManager
 	var pc1 *v12.PodCondition
 	var pc2 *v12.PodCondition
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -953,6 +953,9 @@ const (
 	// etc. or deleted due to kubelet being down or finalizers are failing.
 	VirtualMachineFailure VirtualMachineConditionType = "Failure"
 
+	// VirtualMachineReady is copied to the virtual machine from its vmi
+	VirtualMachineReady VirtualMachineConditionType = "Ready"
+
 	// VirtualMachinePaused is added in a virtual machine when its vmi
 	// signals with its own condition that it is paused.
 	VirtualMachinePaused VirtualMachineConditionType = "Paused"


### PR DESCRIPTION
When 'Ready' condition is added the VMI resource,
the virt-controller copies it to the VM resource.

Signed-off-by: Andrej Krejcir <akrejcir@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Users will be able to wait for the VM start using `kubectl wait --for=condition=Ready vm ${NAME}`

**Which issue(s) this PR fixes**
Fixes #2864

**Release note**:
```release-note
Added a new 'Ready' condition to the VirtualMachine resource.
The condition is copied from the associated VMI resource.

This makes it possible to wait while the VM starts on the VM resource:
$ kubectl wait --for=condition=Ready vm ${NAME}
```
