### PR TITLE
Avoid timeouts on test and generate in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install:
 - git reset --hard
 
 script:
-# adding a keep-alive to avoid timeouts if there is no output for 10 minutes
-- while sleep 9m; do echo "keep alive"; done & make generate
+# ppc64 has resource issues, only run `make generate` for amd64
+- if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then make generate; fi
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
 - if diff <(git grep -c '') <(git grep -cI '') | egrep -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*'
@@ -24,7 +24,7 @@ script:
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make`. Please run it and commit the changes"; git status --porcelain; false; fi
 - make build-verify # verify that we set version on the packages built by bazel
-# adding a keep-alive to avoid timeouts if there is no output for 10 minutes
+# adding a keep-alive to avoid timeouts if there is no output for 10 minutes on ppc64
 - while sleep 9m; do echo "keep alive"; done & if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then make goveralls; else make bazel-test; fi
 - make build-verify # verify that we set version on the packages built by go(goveralls depends on go-build target)
 - make apidocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ install:
 - git reset --hard
 
 script:
-- make generate
+# adding a keep-alive to avoid timeouts if there is no output for 10 minutes
+- while sleep 9m; do echo "keep alive"; done & make generate
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
 - if diff <(git grep -c '') <(git grep -cI '') | egrep -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*'
@@ -24,12 +25,8 @@ script:
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make`. Please run it and commit the changes"; git status --porcelain; false; fi
 - make build-verify # verify that we set version on the packages built by bazel
-# The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
-- |
-  while sleep 9m; do echo "Long running job - keep alive"; done &
-  LOOP_PID=$!
-- if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then make goveralls; else make bazel-test; fi
-- kill $LOOP_PID
+# adding a keep-alive to avoid timeouts if there is no output for 10 minutes
+- while sleep 9m; do echo "keep alive"; done & if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then make goveralls; else make bazel-test; fi
 - make build-verify # verify that we set version on the packages built by go(goveralls depends on go-build target)
 - make apidocs
 - make client-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: generic
-sudo: required
 dist: xenial
 
 services:
@@ -37,13 +36,13 @@ script:
 deploy:
 - provider: script
   script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt" DOCKER_TAG="latest" make bazel-push-images
-  skip_cleanup: true
+  cleanup: false
   on:
     branch: master
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
   script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt" DOCKER_TAG="latest" make functest-image-push
-  skip_cleanup: true
+  cleanup: false
   on:
     branch: master
     condition: $TRAVIS_CPU_ARCH = amd64
@@ -51,14 +50,14 @@ deploy:
   script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt"
     DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub"
     sh -c 'make bazel-push-images && make manifests'
-  skip_cleanup: true
+  cleanup: false
   file:
   on:
     tags: true
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: releases
-  skip_cleanup: true
-  api_key:
+  cleanup: false
+  token:
     secure: KD1d1EkvX5iY5pvKQbi6Aj6y49XXnQBxBMok9x2d9LVMbmzBQIHoTqUQz2Dv2TSpANshkIrLmR1eT/brCK382cIUVvA6kG8JB2yqAAE2hzJ8u49+CI4iyqpBWw1HCuH/4xPWZUPVBW0Yl9WsW0vencAeKK6cTDm4Z9K3esJf+iZMpJh7ZpK2ESn9d2RZsrpOKJpxYrvt14Wox+8YfqPRCTJoO/Q8vdXbyOrRVpK6daSe11HsmTZZpFzgLWGojpjH05wcENUaokpCIp8Hgx3rJmO9z5iReNG+2QuPCw0QyEIKGAvzlA5KbYFWBUurxz0XsnaovbJ7BKI070arxQKjKRnjSNE3kEValOwMIE8dA835A1nChm85NILQdWvlbexSxPpz0z62SGPjFthUj9VBx/RnUrd1itxWOi6ZW5k6PnWDUoKPr63+fYSAkp6bXO9ELexA19wUfQCicGRBEO3mJ6QvKKbiDAFKWcABlavxlNtFgw1mMPxxWEhKkW0PrCqOVu9fDDzJ48DCD5XHRT8HUVHDeKcscMTW675rlzo3SxTJdqnZSybpbMSmKbxNs0rM8kPXf1RQLsGDg4CC6Daxz255PV5Y/+p0AhZ2hWtfC3c/Ff8wOdDSdCaEcg5tGa/e1kJWAKuIATUGdZsFZUri8ePQcgcXzM4ihANn7gP8Cl4=
   file_glob: true
   file:
@@ -80,38 +79,38 @@ deploy:
     repo: kubevirt/kubevirt
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
-  skip_cleanup: true
+  cleanup: false
   script: bash hack/gen-swagger-doc/deploy.sh
   on:
     branch: master
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
-  skip_cleanup: true
+  cleanup: false
   script: bash hack/gen-swagger-doc/deploy.sh
   on:
     tags: true
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
-  skip_cleanup: true
+  cleanup: false
   script: bash hack/gen-client-python/deploy.sh
   on:
     branch: master
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
-  skip_cleanup: true
+  cleanup: false
   script: hack/publish-staging.sh
   on:
     tags: true
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
-  skip_cleanup: true
+  cleanup: false
   script: hack/publish-staging.sh
   on:
     branch: master
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
   script: DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub" make olm-push
-  skip_cleanup: true
+  cleanup: false
   file:
   on:
     tags: true


### PR DESCRIPTION
**What this PR does / why we need it**:

`make generate` , `make goverals` and `make test` can sometimes don't print anything for minutes if running on a weak system. Protect these commands with printing something every minute.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
