### PR TITLE
Add functional test to verify core tolerations

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -165,6 +165,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",


### PR DESCRIPTION
Core kubevirt apps should tolerate the CriticalAddonsOnly taint to
ensure we get a reserved spot in case of eviction and reschedule.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
-->
```release-note
NONE
```
