### PR TITLE
Adjust testing code to take proper URL of the files located at the HTTP import server.

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -118,11 +118,11 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				}
 
 				newVirtualMachineInstanceWithAlpineOCSFileDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-					return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.AlpineHttpUrl, tests.NamespaceTestDefault, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
+					return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeFilesystem)
 				}
 
 				newVirtualMachineInstanceWithAlpineOCSBlockDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-					return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.AlpineHttpUrl, tests.NamespaceTestDefault, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeBlock)
+					return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce, k8sv1.PersistentVolumeBlock)
 				}
 
 				table.DescribeTable("[test_id:2706] should return that we are running alpine", func(createVMI vmiBuilder) {

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -78,7 +78,7 @@ var _ = Describe("DataVolume Integration", func() {
 		Context("using Alpine import", func() {
 			It("[test_id:3189]should be successfully started and stopped multiple times", func() {
 
-				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.AlpineHttpUrl, tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
 				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Create(dataVolume)
@@ -150,7 +150,7 @@ var _ = Describe("DataVolume Integration", func() {
 		BeforeEach(func() {
 			running := true
 
-			vm = tests.NewRandomVMWithDataVolume(tests.AlpineHttpUrl, tests.NamespaceTestDefault)
+			vm = tests.NewRandomVMWithDataVolume(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault)
 			vm.Spec.Running = &running
 
 			dataVolumeName = vm.Spec.DataVolumeTemplates[0].Name
@@ -413,7 +413,7 @@ var _ = Describe("DataVolume Integration", func() {
 	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume", func() {
 		Context("using Alpine import", func() {
 			It("[test_id:3191]should be successfully started and stopped multiple times", func() {
-				vm := tests.NewRandomVMWithDataVolume(tests.AlpineHttpUrl, tests.NamespaceTestDefault)
+				vm := tests.NewRandomVMWithDataVolume(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault)
 				vm, err = virtClient.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 				num := 2
@@ -440,7 +440,7 @@ var _ = Describe("DataVolume Integration", func() {
 				// Cascade=false delete fails in ocp 3.11 with CRDs that contain multiple versions.
 				tests.SkipIfOpenShiftAndBelowOrEqualVersion("cascade=false delete does not work with CRD multi version support in ocp 3.11", "1.11.0")
 
-				vm := tests.NewRandomVMWithDataVolume(tests.AlpineHttpUrl, tests.NamespaceTestDefault)
+				vm := tests.NewRandomVMWithDataVolume(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault)
 				vm, err = virtClient.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -483,7 +483,7 @@ var _ = Describe("DataVolume Integration", func() {
 
 			BeforeEach(func() {
 				var err error
-				dv := tests.NewRandomDataVolumeWithHttpImport(tests.AlpineHttpUrl, tests.NamespaceTestAlternative, k8sv1.ReadWriteOnce)
+				dv := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestAlternative, k8sv1.ReadWriteOnce)
 				dataVolume, err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -552,7 +552,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				iscsiIP := tests.CreateISCSITargetPOD(tests.ContainerDiskEmpty)
 				_, err = virtClient.CoreV1().PersistentVolumes().Create(tests.NewISCSIPV(pvName, "2Gi", iscsiIP, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeFilesystem))
 				Expect(err).ToNot(HaveOccurred())
-				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.AlpineHttpUrl, tests.NamespaceTestDefault, k8sv1.ReadWriteMany)
+				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteMany)
 				volMode := k8sv1.PersistentVolumeFilesystem
 				dataVolume.Spec.PVC.VolumeMode = &volMode
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
@@ -597,7 +597,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
-				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.AlpineHttpUrl, tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
 				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Create(dataVolume)
@@ -638,7 +638,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Delete(dataVolume.Name, &metav1.DeleteOptions{})).To(Succeed())
 			})
 			It("[test_id:1479] should migrate a vmi with a shared OCS disk", func() {
-				vmi, dv := tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.AlpineHttpUrl, tests.NamespaceTestDefault, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeBlock)
+				vmi, dv := tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteMany, k8sv1.PersistentVolumeBlock)
 				defer deleteDataVolume(dv)
 
 				By("Starting the VirtualMachineInstance")

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1291,7 +1291,7 @@ spec:
 			tests.SkipIfVersionBelow("Skipping dynamic cdi test in versions below 1.13 because crd garbage collection is broken", "1.13")
 
 			// This tests starting infrastructure with and without the DataVolumes feature gate
-			vm = tests.NewRandomVMWithDataVolume(tests.AlpineHttpUrl, tests.NamespaceTestDefault)
+			vm = tests.NewRandomVMWithDataVolume(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault)
 			running := false
 			vm.Spec.Running = &running
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -155,7 +155,6 @@ const (
 
 const (
 	AlpineHttpUrl = iota
-	FedoraHttpUrl
 	GuestAgentHttpUrl
 	StressHttpUrl
 	DmidecodeHttpUrl
@@ -4203,8 +4202,6 @@ func GetUrl(urlIndex int) string {
 	switch urlIndex {
 	case AlpineHttpUrl:
 		str = fmt.sprintf("http://cdi-http-import-server.%s/images/alpine.iso", KubeVirtInstallNamespace)
-	case FedoraHttpUrl:
-		str = fmt.sprintf("http://cdi-http-import-server.%s/images/fedora.img", KubeVirtInstallNamespace)
 	case GuestAgentHttpUrl:
 		str = fmt.sprintf("http://cdi-http-import-server.%s/qemu-ga", KubeVirtInstallNamespace)
 	case StressHttpUrl:

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -154,11 +154,11 @@ const (
 )
 
 const (
-	AlpineHttpUrl     = "http://cdi-http-import-server.kubevirt/images/alpine.iso"
-	FedoraHttpUrl     = "http://cdi-http-import-server.kubevirt/images/fedora.img"
-	GuestAgentHttpUrl = "http://cdi-http-import-server.kubevirt/qemu-ga"
-	StressHttpUrl     = "http://cdi-http-import-server.kubevirt/stress"
-	DmidecodeHttpUrl  = "http://cdi-http-import-server.kubevirt/dmidecode"
+	AlpineHttpUrl = iota
+	FedoraHttpUrl
+	GuestAgentHttpUrl
+	StressHttpUrl
+	DmidecodeHttpUrl
 )
 
 const (
@@ -4196,4 +4196,24 @@ func GenerateRandomMac() (net.HardwareAddr, error) {
 		return nil, err
 	}
 	return net.HardwareAddr(append(prefix, suffix...)), nil
+}
+func GetUrl(urlIndex int) string {
+	var str string
+
+	switch urlIndex {
+	case AlpineHttpUrl:
+		str = fmt.sprintf("http://cdi-http-import-server.%s/images/alpine.iso", KubeVirtInstallNamespace)
+	case FedoraHttpUrl:
+		str = fmt.sprintf("http://cdi-http-import-server.%s/images/fedora.img", KubeVirtInstallNamespace)
+	case GuestAgentHttpUrl:
+		str = fmt.sprintf("http://cdi-http-import-server.%s/qemu-ga", KubeVirtInstallNamespace)
+	case StressHttpUrl:
+		str = fmt.sprintf("http://cdi-http-import-server.%s/stress", KubeVirtInstallNamespace)
+	case DmidecodeHttpUrl:
+		str = fmt.sprintf("http://cdi-http-import-server.%s/dmidecode", KubeVirtInstallNamespace)
+	default:
+		str = ""
+	}
+
+	return str
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1931,7 +1931,7 @@ func NewRandomFedoraVMIWithDmidecode() *v1.VirtualMachineInstance {
 	    mkdir -p /usr/local/bin
 	    curl %s > /usr/local/bin/dmidecode
 	    chmod +x /usr/local/bin/dmidecode
-	`, DmidecodeHttpUrl)
+	`, GetUrl(DmidecodeHttpUrl))
 	vmi := NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(ContainerDiskFor(ContainerDiskFedora), dmidecodeUserData)
 	return vmi
 }
@@ -1946,7 +1946,7 @@ func GetGuestAgentUserData() string {
                 chmod +x /usr/local/bin/stress
                 setenforce 0
                 systemd-run --unit=guestagent /usr/local/bin/qemu-ga
-                `, GuestAgentHttpUrl, StressHttpUrl)
+                `, GetUrl(GuestAgentHttpUrl), GetUrl(StressHttpUrl))
 }
 
 func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {
@@ -4201,13 +4201,13 @@ func GetUrl(urlIndex int) string {
 
 	switch urlIndex {
 	case AlpineHttpUrl:
-		str = fmt.sprintf("http://cdi-http-import-server.%s/images/alpine.iso", KubeVirtInstallNamespace)
+		str = fmt.Sprintf("http://cdi-http-import-server.%s/images/alpine.iso", KubeVirtInstallNamespace)
 	case GuestAgentHttpUrl:
-		str = fmt.sprintf("http://cdi-http-import-server.%s/qemu-ga", KubeVirtInstallNamespace)
+		str = fmt.Sprintf("http://cdi-http-import-server.%s/qemu-ga", KubeVirtInstallNamespace)
 	case StressHttpUrl:
-		str = fmt.sprintf("http://cdi-http-import-server.%s/stress", KubeVirtInstallNamespace)
+		str = fmt.Sprintf("http://cdi-http-import-server.%s/stress", KubeVirtInstallNamespace)
 	case DmidecodeHttpUrl:
-		str = fmt.sprintf("http://cdi-http-import-server.%s/dmidecode", KubeVirtInstallNamespace)
+		str = fmt.Sprintf("http://cdi-http-import-server.%s/dmidecode", KubeVirtInstallNamespace)
 	default:
 		str = ""
 	}

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -188,11 +188,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		}
 
 		newVirtualMachineInstanceWithOCSFileDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-			return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.AlpineHttpUrl, tests.NamespaceTestDefault, v13.ReadWriteOnce, v13.PersistentVolumeFilesystem)
+			return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, v13.ReadWriteOnce, v13.PersistentVolumeFilesystem)
 		}
 
 		newVirtualMachineInstanceWithOCSBlockDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-			return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.AlpineHttpUrl, tests.NamespaceTestDefault, v13.ReadWriteOnce, v13.PersistentVolumeBlock)
+			return tests.NewRandomVirtualMachineInstanceWithOCSDisk(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, v13.ReadWriteOnce, v13.PersistentVolumeBlock)
 		}
 
 		deleteDataVolume := func(dv *cdiv1.DataVolume) {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Multus", func() {
                     curl %s > /usr/local/bin/qemu-ga
                     chmod +x /usr/local/bin/qemu-ga
                     systemd-run --unit=guestagent /usr/local/bin/qemu-ga
-                `, ep1Ip, ep2Ip, ep1IpV6, ep2IpV6, tests.GuestAgentHttpUrl)
+                `, ep1Ip, ep2Ip, ep1IpV6, ep2IpV6, tests.GetUrl(tests.GuestAgentHttpUrl))
 				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userdata)
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
@@ -624,7 +624,7 @@ var _ = Describe("SRIOV", func() {
 			    mkdir -p /usr/local/bin
 			    curl %s > /usr/local/bin/qemu-ga
 			    chmod +x /usr/local/bin/qemu-ga
-			    systemd-run --unit=guestagent /usr/local/bin/qemu-ga`, tests.GuestAgentHttpUrl)
+			    systemd-run --unit=guestagent /usr/local/bin/qemu-ga`, tests.GetUrl(tests.GuestAgentHttpUrl))
 
 			ports := []v1.Port{}
 			vmi = tests.NewRandomVMIWithMasqueradeInterfaceEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskFedora), userData, ports)


### PR DESCRIPTION
Introduce a new test utility function called `GetUrl` which will be used in order to take proper URL of testing files located at the HTTP import server. That is because the HTTP server can be deployed to a configurable namespace and it's FQDN will be affected by that.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Functional tests are using testing infrastructure pods. These pods can be deployed to a namespace other then the traditional "kubevirt" namespace. Therefore The FQDN of the HTTP server cannot be determined in compile time using constants. The suggested PR introduces the changes required to invoke the correct URL according to run-time parameters.

Fixes #
Test automation

**Special notes for your reviewer**:

**Release note**:

```release-note
Improvement of testing infrastructure code. Calculate FQDN of HTTP import server in run-time.
```
