### PR TITLE
Disable ppc64 builds until we have it under control again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 arch:
 - amd64
-- ppc64le
+# - ppc64le # temporary disable until we have it under control again
 
 os: linux
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Diable ppc64 until we know why the builds running into timeouts and we can fix it. There are chances that ppc64 builder toolchain may break, but we don't have any specific unit-tests which only run on the ppc64 lane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
