### PR TITLE
Open and close /dev/net/tun on virt-handler startup

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -341,6 +341,13 @@ func (app *virtHandlerApp) Run() {
 		panic(fmt.Errorf("failed to detect the presence of selinux: %v", err))
 	}
 
+	// Make sure the tun module is loaded on the node
+	// Just opening and closing /dev/net/tun triggers a modprobe on the host if necessary
+	devnettun, err := os.Open("/dev/net/tun")
+	if err == nil {
+		devnettun.Close()
+	}
+
 	cache.WaitForCacheSync(stop, factory.ConfigMap().HasSynced, vmiInformer.HasSynced, factory.CRD().HasSynced)
 
 	go vmController.Run(10, stop)


### PR DESCRIPTION
**What this PR does / why we need it**:
Trying to access /dev/net/tun on a host which doesn't have the tun module loaded triggers a modprobe.
libvirtd in virt-launcher uses /dev/net/tun, which will trigger a modprobe if the module is not already loaded.
That won't work if/when virt-launcher runs under the SELinux type container_t.

In virt-handler, which runs as spc_t, access (open/close) /dev/net/tun and (potentially) trigger the modprobe.
That way the tun module will be loaded for sure when (libvirtd in) virt-launcher tries to access /dev/net/tun.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Hard to review with virt-launcher not running as container_t.
I will PR that next.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
