### PR TITLE
Add unsupported GA condition to vmi

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -61,6 +61,7 @@ const (
 	NodeDrainTaintDefaultKey          = "kubevirt.io/drain"
 	SmbiosConfigKey                   = "smbios"
 	SELinuxLauncherTypeKey            = "selinuxLauncherType"
+	SupportedGuestAgentVersionsKey    = "supported-guest-agent"
 )
 
 type ConfigModifiedFn func()
@@ -190,6 +191,7 @@ func defaultClusterConfig() *Config {
 		Manufacturer: SmbiosConfigDefaultManufacturer,
 		Product:      SmbiosConfigDefaultProduct,
 	}
+	supportedQEMUGuestAgentVersions := strings.Split(strings.TrimRight(SupportedGuestAgentVersions, ","), ",")
 	return &Config{
 		ResourceVersion: "0",
 		ImagePullPolicy: DefaultImagePullPolicy,
@@ -215,6 +217,7 @@ func defaultClusterConfig() *Config {
 		PermitBridgeInterfaceOnPodNetwork: DefaultPermitBridgeInterfaceOnPodNetwork,
 		SmbiosConfig:                      SmbiosDefaultConfig,
 		SELinuxLauncherType:               DefaultSELinuxLauncherType,
+		SupportedGuestAgentVersions:       supportedQEMUGuestAgentVersions,
 	}
 }
 
@@ -236,6 +239,7 @@ type Config struct {
 	PermitBridgeInterfaceOnPodNetwork bool
 	SmbiosConfig                      *cmdv1.SMBios
 	SELinuxLauncherType               string
+	SupportedGuestAgentVersions       []string
 }
 
 type MigrationConfig struct {
@@ -410,6 +414,14 @@ func setConfig(config *Config, configMap *k8sv1.ConfigMap) error {
 
 	if selinuxLauncherType := strings.TrimSpace(configMap.Data[SELinuxLauncherTypeKey]); selinuxLauncherType != "" {
 		config.SELinuxLauncherType = selinuxLauncherType
+	}
+
+	if supportedGuestAgentVersions := strings.TrimSpace(configMap.Data[SupportedGuestAgentVersionsKey]); supportedGuestAgentVersions != "" {
+		vals := strings.Split(strings.TrimRight(supportedGuestAgentVersions, ","), ",")
+		for i := range vals {
+			vals[i] = strings.TrimSpace(vals[i])
+		}
+		config.SupportedGuestAgentVersions = vals
 	}
 
 	return nil

--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -170,6 +170,17 @@ var _ = Describe("ConfigMap", func() {
 		table.Entry("when unset, GetEmulatedMachines should return the defaults", "", strings.Split(virtconfig.DefaultEmulatedMachines, ",")),
 	)
 
+	table.DescribeTable(" when supportedGuestAgentVersions", func(value string, result []string) {
+		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{virtconfig.SupportedGuestAgentVersionsKey: value},
+		})
+		supportedGuestAgentVersions := clusterConfig.GetSupportedAgentVersions()
+		Expect(supportedGuestAgentVersions).To(ConsistOf(result))
+	},
+		table.Entry("when set, GetSupportedAgentVersions should return the value", "5.*,6.*", []string{"5.*", "6.*"}),
+		table.Entry("when unset, GetSupportedAgentVersions should return the defaults", "", strings.Split(virtconfig.SupportedGuestAgentVersions, ",")),
+	)
+
 	It("Should return migration config values if specified as json", func() {
 		clusterConfig, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
 			Data: map[string]string{virtconfig.MigrationsConfigKey: `{"parallelOutboundMigrationsPerNode" : 10, "parallelMigrationsPerCluster": 20, "bandwidthPerMigration": "110Mi", "progressTimeout" : 5, "completionTimeoutPerGiB": 5, "unsafeMigrationOverride": true, "allowAutoConverge": true}`},

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -57,6 +57,7 @@ const (
 	SmbiosConfigDefaultProduct                      = "None"
 	DefaultPermitBridgeInterfaceOnPodNetwork        = true
 	DefaultSELinuxLauncherType                      = ""
+	SupportedGuestAgentVersions                     = "3.*,4.*"
 )
 
 // Set default machine type and supported emulated machines based on architecture
@@ -127,4 +128,8 @@ func (c *ClusterConfig) IsBridgeInterfaceOnPodNetworkEnabled() bool {
 
 func (c *ClusterConfig) GetSELinuxLauncherType() string {
 	return c.getConfig().SELinuxLauncherType
+}
+
+func (c *ClusterConfig) GetSupportedAgentVersions() []string {
+	return c.getConfig().SupportedGuestAgentVersions
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -550,6 +551,35 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 		vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 	case !channelConnected:
 		condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceAgentConnected)
+	}
+
+	if condManager.HasCondition(vmi, v1.VirtualMachineInstanceAgentConnected) {
+		client, err := d.getLauncherClient(vmi)
+		if err != nil {
+			return err
+		}
+
+		guestInfo, err := client.GetGuestInfo()
+		if err != nil {
+			return err
+		}
+
+		var match = false
+		for _, version := range d.clusterConfig.GetSupportedAgentVersions() {
+			match = match || regexp.MustCompile(version).MatchString(guestInfo.GAVersion)
+		}
+
+		if !match && !condManager.HasCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent) {
+			agentCondition := v1.VirtualMachineInstanceCondition{
+				Type:          v1.VirtualMachineInstanceUnsupportedAgent,
+				LastProbeTime: v12.Now(),
+				Status:        k8sv1.ConditionTrue,
+			}
+			vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
+		} else {
+			condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent)
+		}
+
 	}
 
 	// Update paused condition in case VMI was paused / unpaused

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -460,6 +460,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 					LastProbeTime: metav1.Now(),
 					Status:        k8sv1.ConditionTrue,
 				},
+				{
+					Type:          v1.VirtualMachineInstanceUnsupportedAgent,
+					LastProbeTime: metav1.Now(),
+					Status:        k8sv1.ConditionTrue,
+				},
 			}
 
 			vmiFeeder.Add(vmi)
@@ -471,6 +476,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Expect(options.VirtualMachineSMBios.Manufacturer).To(Equal(virtconfig.SmbiosConfigDefaultManufacturer))
 			})
 			vmiInterface.EXPECT().Update(NewVMICondMatcher(*updatedVMI))
+			client.EXPECT().GetGuestInfo().Return(&v1.VirtualMachineInstanceGuestAgentInfo{}, nil)
 
 			controller.Execute()
 		})

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -233,6 +233,9 @@ const (
 	// Reflects whether the QEMU guest agent is connected through the channel
 	VirtualMachineInstanceAgentConnected VirtualMachineInstanceConditionType = "AgentConnected"
 
+	// Reflects whether the QEMU guest agent is connected through the channel
+	VirtualMachineInstanceUnsupportedAgent VirtualMachineInstanceConditionType = "AgentVersionNotSupported"
+
 	// Indicates whether the VMI is live migratable
 	VirtualMachineInstanceIsMigratable VirtualMachineInstanceConditionType = "LiveMigratable"
 	// Reason means that VMI is not live migratioable because of it's disks collection

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1144,6 +1144,39 @@ var _ = Describe("Configurations", func() {
 					"Agent condition should be gone")
 			})
 
+			Context("with cluster config changes", func() {
+				supportedGuestAgentKey := "supported-guest-agent"
+
+				BeforeEach(func() {
+					tests.UpdateClusterConfigValueAndWait(supportedGuestAgentKey, "X.*")
+				})
+
+				AfterEach(func() {
+					tests.UpdateClusterConfigValueAndWait(supportedGuestAgentKey, "3.*,4.*")
+				})
+
+				It("[test_id:]VMI condition should signal unsupported agent presence", func() {
+
+					agentVMI := prepareAgentVM()
+					getOptions := metav1.GetOptions{}
+
+					freshVMI, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+					Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+
+					Eventually(func() []v1.VirtualMachineInstanceCondition {
+						freshVMI, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(agentVMI.Name, &getOptions)
+						Expect(err).ToNot(HaveOccurred(), "Should get VMI ")
+						return freshVMI.Status.Conditions
+					}, 240*time.Second, 2).Should(
+						ContainElement(
+							MatchFields(
+								IgnoreExtras,
+								Fields{"Type": Equal(v1.VirtualMachineInstanceUnsupportedAgent)})),
+						"Should have unsupported agent connected condition")
+
+				})
+			})
+
 			It("should have guestosinfo in status when agent is present", func() {
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}


### PR DESCRIPTION
**What this PR does / why we need it**:

When unsupported guest agent version is
installed in the guest VM, condition is
added to the VMI status.

This condition signals that the Guest agent feature
might not work as expected. 

Signed-off-by: Petr Kotas <petr.kotas@gmail.com>




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add unsupported guest agent vmi status condition
```
