### PR TITLE
Small fix of rename condition on VM

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -324,7 +324,7 @@ func (c *VMController) handleVMRenameRequest(vm *virtv1.VirtualMachine, newName 
 	newVM.Status.Conditions = []virtv1.VirtualMachineCondition{
 		{
 			Type:    virtv1.RenameConditionType,
-			Status:  "Success",
+			Status:  k8score.ConditionTrue,
 			Reason:  vm.Name,
 			Message: fmt.Sprintf("This VM was renamed, the old name was %s", vm.Name),
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -947,7 +947,7 @@ const (
 	VirtualMachinePaused VirtualMachineConditionType = "Paused"
 
 	// This condition indicates that the VM was renamed
-	RenameConditionType VirtualMachineConditionType = "Rename Operation"
+	RenameConditionType VirtualMachineConditionType = "RenameOperation"
 )
 
 // ---


### PR DESCRIPTION
**What this PR does / why we need it**:
The condition status should be `ConditionTrue`, instead of "Success"
The type should probably not contain space character.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The VM rename condition has now type 'RenameOperation'.
```
