### PR TITLE
Do not set an SELinux type on virt-launcher by default

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -983,10 +983,10 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		annotationsList[ISTIO_KUBEVIRT_ANNOTATION] = "k6t-eth0"
 	}
 
-	// If an SELinux type was specified, use that--otherwise default to the one KubeVirt Defines
-	selinuxLauncherType := t.clusterConfig.GetSELinuxLauncherType()
-	if selinuxLauncherType == virtconfig.DefaultSELinuxLauncherType {
-		selinuxLauncherType = "virt_launcher.process"
+	// If an SELinux type was specified, use that--otherwise don't set an SELinux type
+	selinuxOptions := k8sv1.SELinuxOptions{}
+	if t.clusterConfig.GetSELinuxLauncherType() != virtconfig.DefaultSELinuxLauncherType {
+		selinuxOptions.Type = t.clusterConfig.GetSELinuxLauncherType()
 	}
 
 	// TODO use constants for podLabels
@@ -1004,9 +1004,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			Subdomain: vmi.Spec.Subdomain,
 			SecurityContext: &k8sv1.PodSecurityContext{
 				RunAsUser: &userId,
-				SELinuxOptions: &k8sv1.SELinuxOptions{
-					Type: selinuxLauncherType,
-				},
+				SELinuxOptions: &selinuxOptions,
 				FSGroup: &t.launcherSubGid,
 			},
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1003,9 +1003,9 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			Hostname:  hostName,
 			Subdomain: vmi.Spec.Subdomain,
 			SecurityContext: &k8sv1.PodSecurityContext{
-				RunAsUser: &userId,
+				RunAsUser:      &userId,
 				SELinuxOptions: &selinuxOptions,
-				FSGroup: &t.launcherSubGid,
+				FSGroup:        &t.launcherSubGid,
 			},
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,
 			RestartPolicy:                 k8sv1.RestartPolicyNever,

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -112,7 +112,7 @@ var _ = Describe("SecurityFeatures", func() {
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 			})
 
-			It("[test_id:2953]Ensure virt-launcher pod securityContext type is virt_launcher.process", func() {
+			It("[test_id:2953]Ensure virt-launcher pod securityContext type is not forced", func() {
 
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
@@ -121,7 +121,7 @@ var _ = Describe("SecurityFeatures", func() {
 
 				By("Check virt-launcher pod SecurityContext values")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-				Expect(vmiPod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal("virt_launcher.process"))
+				Expect(vmiPod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(""))
 			})
 
 			It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
virt-launcher will default to container_t, which is different than forcing it to container_t.
For example, container disks don't get relabelled when a type is forced.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
With this fix, virt-launcher pods should have an SELinux type of container_t by default.
VMs that use a container disk should not trigger SELinux denials.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
