### PR TITLE
Allow bazel to have custom CA certs

### DIFF
--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -26,6 +26,8 @@ rm -rf ${CMD_OUT_DIR}
 mkdir -p ${CMD_OUT_DIR}/virtctl
 mkdir -p ${CMD_OUT_DIR}/dump
 
+check_update_trust
+
 # Build all binaries for amd64
 bazel build \
     --config=${ARCHITECTURE} \

--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -26,8 +26,6 @@ rm -rf ${CMD_OUT_DIR}
 mkdir -p ${CMD_OUT_DIR}/virtctl
 mkdir -p ${CMD_OUT_DIR}/dump
 
-check_update_trust
-
 # Build all binaries for amd64
 bazel build \
     --config=${ARCHITECTURE} \

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -68,9 +68,3 @@ function go_build() {
 
 DOCKER_CA_CERT_FILE="${DOCKER_CA_CERT_FILE:-}"
 DOCKERIZED_CUSTOM_CA_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
-
-function check_update_trust() {
-    if [ -f "$DOCKERIZED_CUSTOM_CA_PATH" ]; then
-        /usr/bin/update-ca-trust
-    fi
-}

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -61,3 +61,16 @@ KUBEVIRT_VERSION="$(kubevirt_version)"
 function go_build() {
     GOPROXY=off GOFLAGS=-mod=vendor go build "$@"
 }
+
+# Use this environment variable to set a local path to a custom CA certificate for
+# a private HTTPS docker registry. The intention is that this will be merged with the trust
+# store in the build environment.
+
+DOCKER_CA_CERT_FILE="${DOCKER_CA_CERT_FILE:-}"
+DOCKERIZED_CUSTOM_CA_PATH="/etc/pki/ca-trust/source/anchors/custom-ca.crt"
+
+function check_update_trust() {
+    if [ -f "$DOCKERIZED_CUSTOM_CA_PATH" ]; then
+        /usr/bin/update-ca-trust
+    fi
+}

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -93,6 +93,11 @@ volumes="-v ${BUILDER}:/root:rw,z"
 mkdir -p "${HOME}/.docker"
 volumes="$volumes -v ${HOME}/.docker:/root/.docker:ro,z"
 
+# add custom docker certs, if needed
+if [ -n "$DOCKER_CA_CERT_FILE" ] && [ -f "$DOCKER_CA_CERT_FILE" ]; then
+    volumes="$volumes -v ${DOCKER_CA_CERT_FILE}:${DOCKERIZED_CUSTOM_CA_PATH}:ro,z"
+fi
+
 # Ensure that a bazel server which is running is the correct one
 if [ -n "$(docker ps --format '{{.Names}}' | grep ${BUILDER}-bazel-server)" ]; then
     # check if the image is correct

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -114,6 +114,11 @@ if [ -z "$(docker ps --format '{{.Names}}' | grep ${BUILDER}-bazel-server)" ]; t
     docker run --network host -d ${volumes} --security-opt label:disable --name ${BUILDER}-bazel-server -w "/root/go/src/kubevirt.io/kubevirt" --rm ${KUBEVIRT_BUILDER_IMAGE} hack/bazel-server.sh
 fi
 
+# Update cert trust, if custom is provided
+if [ -n "$DOCKER_CA_CERT_FILE" ] && [ -f "$DOCKER_CA_CERT_FILE" ]; then
+    docker exec ${BUILDER}-bazel-server /entrypoint.sh "/usr/bin/update-ca-trust"
+fi
+
 # Run the command
 test -t 1 && USE_TTY="-it"
 docker exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows developers and CI systems to pull from and publish to private HTTPS docker registries by passing in a custom CA PEM file in the DOCKER_CA_CERT_FILE environment variable.  This then gets mounted into the build container and integrated into the container's system certs.

It seems necessary to do it this way since Bazel uses go-containerregistry package, and doesn't support the /etc/docker/certs.d functionality.

**Which issue(s) this PR fixes** :
Fixes #3194 

**Reviewer Notes**:

There seem to be a lot of configurations/adjustable variables for the development process that aren't explicitly documented, I'm not certain if this needs further documentation or not. Please let me know if you want to see something added in the way of documenting this feature, and where.

```release-note
NONE
```