### PR TITLE
Fix Ipv6 Migration

### DIFF
--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 source hack/common.sh
 

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 ./hack/coverage.sh
 goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,25 +32,17 @@ func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
-func isIpv6Disabled() bool {
-	res, err := exec.Command("cat", "/proc/sys/net/ipv6/conf/default/disable_ipv6").Output()
-	return err != nil || string(res) == "1"
+// IsIpv6Disabled returns if IPv6 is disabled according sysctl
+func IsIpv6Disabled() bool {
+	ipv6Disabled, err := exec.Command("cat", "/proc/sys/net/ipv6/conf/default/disable_ipv6").Output()
+	return err != nil || string(ipv6Disabled) == "1"
 }
 
 // GetIPBindAddress returns IP bind address (either 0.0.0.0 or [::] according sysctl disable_ipv6)
 func GetIPBindAddress() string {
-	if isIpv6Disabled() {
+	if IsIpv6Disabled() {
 		return "0.0.0.0"
 	}
 
 	return "[::]"
-}
-
-// GetLoopbackAddress returns the loopback IP address (either 127.0.0.1 or [::1] according sysctl disable_ipv6)
-func GetLoopbackAddress() string {
-	if isIpv6Disabled() {
-		return "127.0.0.1"
-	}
-
-	return "[::1]"
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os/exec"
+
 	v1 "kubevirt.io/client-go/api/v1"
 )
 
@@ -28,4 +30,27 @@ func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
 		return true
 	}
 	return false
+}
+
+func isIpv6Disabled() bool {
+	res, err := exec.Command("cat", "/proc/sys/net/ipv6/conf/default/disable_ipv6").Output()
+	return err != nil || string(res) == "1"
+}
+
+// GetIPBindAddress returns IP bind address (either 0.0.0.0 or [::] according sysctl disable_ipv6)
+func GetIPBindAddress() string {
+	if isIpv6Disabled() {
+		return "0.0.0.0"
+	}
+
+	return "[::]"
+}
+
+// GetLoopbackAddress returns the loopback IP address (either 127.0.0.1 or [::1] according sysctl disable_ipv6)
+func GetLoopbackAddress() string {
+	if isIpv6Disabled() {
+		return "127.0.0.1"
+	}
+
+	return "[::1]"
 }

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["migration-proxy.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/log:go_default_library"],
+    deps = [
+        "//pkg/virt-launcher/virtwrap/network:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -32,7 +32,6 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
 )
 
 const (
@@ -97,7 +96,8 @@ func SourceUnixFile(baseDir string, key string) string {
 }
 
 func ipBindAddress() string {
-	if network.IsIpv6Enabled() {
+	podIP := os.Getenv("MY_POD_IP")
+	if netutils.IsIPv6String(podIP) {
 		return "[::]"
 	}
 

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -32,6 +32,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -95,15 +96,6 @@ func SourceUnixFile(baseDir string, key string) string {
 	return filepath.Join(baseDir, "migrationproxy", key+"-source.sock")
 }
 
-func ipBindAddress() string {
-	podIP := os.Getenv("MY_POD_IP")
-	if netutils.IsIPv6String(podIP) {
-		return "[::]"
-	}
-
-	return "0.0.0.0"
-}
-
 func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles []string) error {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
@@ -140,7 +132,7 @@ func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles 
 	proxiesList := []*migrationProxy{}
 	for _, targetUnixFile := range targetUnixFiles {
 		// 0 means random port is used
-		proxy := NewTargetProxy(ipBindAddress(), 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
+		proxy := NewTargetProxy(util.GetIPBindAddress(), 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
 
 		err := proxy.StartListening()
 		if err != nil {

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/hooks:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/ignition:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -199,3 +199,13 @@ func (_m *MockDomainManager) SetGuestTime(_param0 *v1.VirtualMachineInstance) er
 func (_mr *_MockDomainManagerRecorder) SetGuestTime(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetGuestTime", arg0)
 }
+
+func (_m *MockDomainManager) GetLoopbackAddress() string {
+	ret := _m.ctrl.Call(_m, "GetLoopbackAddress")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) GetLoopbackAddress() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLoopbackAddress")
+}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -407,12 +407,11 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 
 		isBlockMigration := (vmi.Status.MigrationMethod == v1.BlockMigration)
 		migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
-		loopbackAddress := network.GetLoopbackAddress()
 
 		// Create a tcp server for each direct connection proxy
 		for _, port := range migrationPortsRange {
 			key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-			migrationProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
+			migrationProxy := migrationproxy.NewTargetProxy("127.0.0.1", port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
 			defer migrationProxy.StopListening()
 			err := migrationProxy.StartListening()
 			if err != nil {
@@ -422,7 +421,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		}
 
 		//  proxy incoming migration requests on port 22222 to the vmi's existing libvirt connection
-		libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
+		libvirtConnectionProxy := migrationproxy.NewTargetProxy("127.0.0.1", LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
 		defer libvirtConnectionProxy.StopListening()
 		err := libvirtConnectionProxy.StartListening()
 		if err != nil {
@@ -431,8 +430,8 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		}
 
 		// For a tunnelled migration, this is always the uri
-		dstUri := fmt.Sprintf("qemu+tcp://%s:%d/system", loopbackAddress, LibvirtLocalConnectionPort)
-		migrUri := "tcp://" + loopbackAddress
+		dstUri := fmt.Sprintf("qemu+tcp://127.0.0.1:%d/system", LibvirtLocalConnectionPort)
+		migrUri := "tcp://127.0.0.1"
 
 		domName := api.VMINamespaceKeyFunc(vmi)
 		dom, err := l.virConn.LookupDomainByName(domName)
@@ -747,7 +746,7 @@ func (l *LibvirtDomainManager) MigrateVMI(vmi *v1.VirtualMachineInstance, option
 		return nil
 	}
 
-	if err := updateHostsFile(fmt.Sprintf("%s %s\n", network.GetLoopbackAddress(), vmi.Status.MigrationState.TargetPod)); err != nil {
+	if err := updateHostsFile(fmt.Sprintf("%s %s\n", "127.0.0.1", vmi.Status.MigrationState.TargetPod)); err != nil {
 		return fmt.Errorf("failed to update the hosts file: %v", err)
 	}
 	l.asyncMigrate(vmi, options)
@@ -855,8 +854,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		return fmt.Errorf("executing custom preStart hooks failed: %v", err)
 	}
 
-	loopbackAddress := network.GetLoopbackAddress()
-	if err := updateHostsFile(fmt.Sprintf("%s %s\n", loopbackAddress, vmi.Status.MigrationState.TargetPod)); err != nil {
+	if err := updateHostsFile(fmt.Sprintf("%s %s\n", "127.0.0.1", vmi.Status.MigrationState.TargetPod)); err != nil {
 		return fmt.Errorf("failed to update the hosts file: %v", err)
 	}
 
@@ -865,7 +863,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 	for _, port := range migrationPortsRange {
 		// Prepare the direct migration proxy
 		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-		curDirectAddress := fmt.Sprintf("%s:%d", loopbackAddress, port)
+		curDirectAddress := fmt.Sprintf("%s:%d", "127.0.0.1", port)
 		unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)
 		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil)
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -59,6 +59,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/hooks"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/ignition"
+	generalutil "kubevirt.io/kubevirt/pkg/util"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
 	agentpoller "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent-poller"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -408,10 +409,12 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		isBlockMigration := (vmi.Status.MigrationMethod == v1.BlockMigration)
 		migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
 
+		loopbackAddress := generalutil.GetLoopbackAddress()
+
 		// Create a tcp server for each direct connection proxy
 		for _, port := range migrationPortsRange {
 			key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-			migrationProxy := migrationproxy.NewTargetProxy("127.0.0.1", port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
+			migrationProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
 			defer migrationProxy.StopListening()
 			err := migrationProxy.StartListening()
 			if err != nil {
@@ -421,7 +424,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		}
 
 		//  proxy incoming migration requests on port 22222 to the vmi's existing libvirt connection
-		libvirtConnectionProxy := migrationproxy.NewTargetProxy("127.0.0.1", LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
+		libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
 		defer libvirtConnectionProxy.StopListening()
 		err := libvirtConnectionProxy.StartListening()
 		if err != nil {
@@ -430,8 +433,8 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		}
 
 		// For a tunnelled migration, this is always the uri
-		dstUri := fmt.Sprintf("qemu+tcp://127.0.0.1:%d/system", LibvirtLocalConnectionPort)
-		migrUri := "tcp://127.0.0.1"
+		dstUri := fmt.Sprintf("qemu+tcp://%s:%d/system", loopbackAddress, LibvirtLocalConnectionPort)
+		migrUri := "tcp://" + loopbackAddress
 
 		domName := api.VMINamespaceKeyFunc(vmi)
 		dom, err := l.virConn.LookupDomainByName(domName)
@@ -746,7 +749,7 @@ func (l *LibvirtDomainManager) MigrateVMI(vmi *v1.VirtualMachineInstance, option
 		return nil
 	}
 
-	if err := updateHostsFile(fmt.Sprintf("%s %s\n", "127.0.0.1", vmi.Status.MigrationState.TargetPod)); err != nil {
+	if err := updateHostsFile(fmt.Sprintf("%s %s\n", generalutil.GetLoopbackAddress(), vmi.Status.MigrationState.TargetPod)); err != nil {
 		return fmt.Errorf("failed to update the hosts file: %v", err)
 	}
 	l.asyncMigrate(vmi, options)
@@ -854,7 +857,8 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		return fmt.Errorf("executing custom preStart hooks failed: %v", err)
 	}
 
-	if err := updateHostsFile(fmt.Sprintf("%s %s\n", "127.0.0.1", vmi.Status.MigrationState.TargetPod)); err != nil {
+	loopbackAddress := generalutil.GetLoopbackAddress()
+	if err := updateHostsFile(fmt.Sprintf("%s %s\n", loopbackAddress, vmi.Status.MigrationState.TargetPod)); err != nil {
 		return fmt.Errorf("failed to update the hosts file: %v", err)
 	}
 
@@ -863,7 +867,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 	for _, port := range migrationPortsRange {
 		// Prepare the direct migration proxy
 		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-		curDirectAddress := fmt.Sprintf("%s:%d", "127.0.0.1", port)
+		curDirectAddress := fmt.Sprintf("%s:%d", loopbackAddress, port)
 		unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)
 		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil)
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -39,8 +39,6 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network/dhcp"
-
-	netutils "k8s.io/utils/net"
 )
 
 const randomMacGenerationAttempts = 10
@@ -88,7 +86,6 @@ type NetworkHandler interface {
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
 	HasNatIptables(proto iptables.Protocol) bool
-	IsIpv6Enabled() bool
 	ConfigureIpv6Forwarding() error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
 	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
@@ -152,15 +149,6 @@ func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 func (h *NetworkUtilsHandler) ConfigureIpv6Forwarding() error {
 	_, err := exec.Command("sysctl", "net.ipv6.conf.all.forwarding=1").CombinedOutput()
 	return err
-}
-
-func (h *NetworkUtilsHandler) IsIpv6Enabled() bool {
-	podIp := os.Getenv("MY_POD_IP")
-	if !netutils.IsIPv6String(podIp) {
-		log.Log.V(5).Info("Since the pod ip is non IPv6, IPv6 is disabled")
-		return false
-	}
-	return true
 }
 
 func (h *NetworkUtilsHandler) IptablesNewChain(proto iptables.Protocol, table, chain string) error {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -213,16 +213,6 @@ func (_mr *_MockNetworkHandlerRecorder) HasNatIptables(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasNatIptables", arg0)
 }
 
-func (_m *MockNetworkHandler) IsIpv6Enabled() bool {
-	ret := _m.ctrl.Call(_m, "IsIpv6Enabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled")
-}
-
 func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {
 	ret := _m.ctrl.Call(_m, "ConfigureIpv6Forwarding")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -27,9 +27,6 @@ package network
 
 import (
 	"fmt"
-	"os"
-
-	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -135,19 +132,4 @@ func getNetworkClass(network *v1.Network) (NetworkInterface, error) {
 		return new(PodInterface), nil
 	}
 	return nil, fmt.Errorf("Network not implemented")
-}
-
-// IsIpv6Enabled returns if IPv6 is enabled
-func IsIpv6Enabled() bool {
-	podIP := os.Getenv("MY_POD_IP")
-	return netutils.IsIPv6String(podIP)
-}
-
-// GetLoopbackAddress returns loopback address
-func GetLoopbackAddress() string {
-	if IsIpv6Enabled() {
-		return "[::1]"
-	}
-
-	return "127.0.0.1"
 }

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -27,6 +27,9 @@ package network
 
 import (
 	"fmt"
+	"os"
+
+	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -132,4 +135,19 @@ func getNetworkClass(network *v1.Network) (NetworkInterface, error) {
 		return new(PodInterface), nil
 	}
 	return nil, fmt.Errorf("Network not implemented")
+}
+
+// IsIpv6Enabled returns if IPv6 is enabled
+func IsIpv6Enabled() bool {
+	podIP := os.Getenv("MY_POD_IP")
+	return netutils.IsIPv6String(podIP)
+}
+
+// GetLoopbackAddress returns loopback address
+func GetLoopbackAddress() string {
+	if IsIpv6Enabled() {
+		return "[::1]"
+	}
+
+	return "127.0.0.1"
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -511,7 +511,7 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 		return err
 	}
 
-	if Handler.IsIpv6Enabled() {
+	if IsIpv6Enabled() {
 		err = configureVifV6Addresses(p, err)
 		if err != nil {
 			return err
@@ -620,7 +620,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 			return err
 		}
 	}
-	if Handler.IsIpv6Enabled() && (Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil) {
+	if IsIpv6Enabled() && (Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil) {
 		err = Handler.ConfigureIpv6Forwarding()
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to turn on net.ipv6.conf.all.forwarding")
@@ -733,7 +733,7 @@ func (p *MasqueradePodInterface) createBridge() error {
 		return err
 	}
 
-	if Handler.IsIpv6Enabled() {
+	if IsIpv6Enabled() {
 		if err := Handler.AddrAdd(bridge, p.gatewayIpv6Addr); err != nil {
 			log.Log.Reason(err).Errorf("failed to set bridge IPv6")
 			return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 
 	"github.com/vishvananda/netlink"
+	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
@@ -491,6 +492,11 @@ type MasqueradePodInterface struct {
 	gatewayIpv6Addr     *netlink.Addr
 }
 
+func isIpv6Enabled() bool {
+	podIP := os.Getenv("MY_POD_IP")
+	return netutils.IsIPv6String(podIP)
+}
+
 func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 	link, err := Handler.LinkByName(p.podInterfaceName)
 	if err != nil {
@@ -511,7 +517,7 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 		return err
 	}
 
-	if IsIpv6Enabled() {
+	if isIpv6Enabled() {
 		err = configureVifV6Addresses(p, err)
 		if err != nil {
 			return err
@@ -620,7 +626,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 			return err
 		}
 	}
-	if IsIpv6Enabled() && (Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil) {
+	if isIpv6Enabled() && (Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil) {
 		err = Handler.ConfigureIpv6Forwarding()
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to turn on net.ipv6.conf.all.forwarding")
@@ -733,7 +739,7 @@ func (p *MasqueradePodInterface) createBridge() error {
 		return err
 	}
 
-	if IsIpv6Enabled() {
+	if isIpv6Enabled() {
 		if err := Handler.AddrAdd(bridge, p.gatewayIpv6Addr); err != nil {
 			log.Log.Reason(err).Errorf("failed to set bridge IPv6")
 			return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -378,7 +378,6 @@ var _ = Describe("Pod Network", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -388,8 +387,6 @@ var _ = Describe("Pod Network", func() {
 			})
 			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
-
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 					mockNetwork.EXPECT().IptablesAppendRule(proto, "nat",
@@ -425,7 +422,6 @@ var _ = Describe("Pod Network", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -435,8 +431,6 @@ var _ = Describe("Pod Network", func() {
 			})
 			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
-
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(false).Times(2)
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/settings/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -404,9 +404,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 		Context("with a Cirros disk", func() {
-			It("should be successfully migrate with cloud-init disk with devices on the root bus", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
+			It("[test_id:3227]should be successfully migrate with cloud-init disk with devices on the root bus", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				vmi.Annotations = map[string]string{
 					v1.PlacePCIDevicesOnRootComplex: "true",
@@ -449,8 +447,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
@@ -503,8 +499,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3237]should complete a migration", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -679,8 +673,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
@@ -872,7 +864,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var pvName string
 			var vmi *v1.VirtualMachineInstance
 			BeforeEach(func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
+				tests.SkipNFSTestIfRunnigOnKindInfra()
 				pvName = "test-nfs" + rand.String(48)
 				// Prepare a NFS backed PV
 				By("Starting an NFS POD")
@@ -1079,6 +1071,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
+				tests.SkipStressTestIfRunnigOnKindInfraIPv6()
+
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -1200,8 +1194,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			table.DescribeTable("should be able to cancel a migration", func(createVMI vmiBuilder) {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi, dv := createVMI()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				defer deleteDataVolume(dv)
@@ -1243,8 +1235,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				table.Entry("[test_id:2731] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1282,8 +1272,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	Context("with sata disks", func() {
 
 		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret", func() {
-			tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 			configMapName := "configmap-" + rand.String(5)
 			secretName := "secret-" + rand.String(5)
 
@@ -1373,8 +1361,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3244]should block the eviction api while a slow migration is in progress", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
@@ -1430,7 +1416,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			Context("with node tainted during node drain", func() {
 				It("[test_id:2221] should migrate a VMI under load to another node", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -1483,7 +1468,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 
 				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = cirrosVMIWithEvictionStrategy()
@@ -1538,7 +1522,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 400)
 
 				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi_evict1 := cirrosVMIWithEvictionStrategy()
@@ -1662,8 +1645,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with multiple VMIs with eviction policies set", func() {
 
 			It("[test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := cirrosVMIWithEvictionStrategy()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4637,7 +4637,7 @@ func IsRunningOnKindInfraIPv6() bool {
 }
 
 func SkipStressTestIfRunnigOnKindInfraIPv6() {
-	if IsRunningOnKindInfraIPv6() {
+	if IsRunningOnKindInfra() {
 		Skip("Skip stress test till issue https://github.com/kubevirt/kubevirt/issues/3323 is fixed")
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -394,6 +394,7 @@ k8s.io/api/admission/v1beta1
 k8s.io/api/authorization/v1beta1
 k8s.io/api/scheduling/v1
 k8s.io/api/autoscaling/v1
+k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/apps/v1beta1
@@ -420,7 +421,6 @@ k8s.io/api/rbac/v1alpha1
 k8s.io/api/rbac/v1beta1
 k8s.io/api/scheduling/v1alpha1
 k8s.io/api/scheduling/v1beta1
-k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.16.4 => k8s.io/apiextensions-apiserver v0.16.4
@@ -435,14 +435,14 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake
 # k8s.io/apimachinery v0.16.4 => k8s.io/apimachinery v0.16.4
-k8s.io/apimachinery/pkg/api/errors
-k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/api/resource
+k8s.io/apimachinery/pkg/api/errors
+k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/util/clock
@@ -462,12 +462,12 @@ k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/util/net
-k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/cache
 k8s.io/apimachinery/pkg/util/diff
 k8s.io/apimachinery/pkg/util/naming
+k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/api/equality
@@ -482,8 +482,8 @@ k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
-k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/apis/meta/internalversion
+k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/pkg/util/framer
 # k8s.io/apiserver v0.16.4 => k8s.io/apiserver v0.16.4


### PR DESCRIPTION
Use IPv6 bind address and local address unless IPv6 is disabled,
Its done in order to support IPv6 only when will be available,
since at the moment it was using IPv4 0.0.0.0, and 127.0.0.1 as bind and localhost address.

Fix migration server to support IPv6, by using
well formatted IPv6 address in case IPv6 is enabled.

Move IsIpv6Enabled from common to network, in order to reuse it,
and make it independent on the handler at common (which isn't needed anyhow).

To remove this part once #3374 is merged.
Create a PodPreset in order to supply each virt-launcher with unique UUID,
this is mandatory for migration to pass, and since we are using Kind provider,
all the containers inherit the same UUID from DMI which is shared between the containers,
that act as cluster nodes.

Possible needed follow up changes:
1. Allow migration via the cli in kind providers (including ipv6) - for this we need to add for kubevirt, The script of Fabian, if its acceptable as part of kubevirt repository,
(The script creates the PodPreset which is created as part of the e2e tests, in the default name space, as the namespace of the vm in examples folder).

```release-note
NONE
```