### PR TITLE
Explicitly test packages in case of error

### DIFF
--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -5,5 +5,23 @@ set -e
 path=${1:-./pkg/...}
 profile=.coverprofile
 
-go test -cover -v -coverprofile=$profile $(go list ${path})
+packages=$(go list ${path})
+
+# in rare cases go test with coverage seems to swallow test
+# failure output, so we keep the exit code
+set +e
+go test -cover -v -coverprofile=$profile ${packages}
+return_value=$?
+
+# in case of exit code we explicitly test
+# each package again to have the output of all
+# failing tests
+if [[ $return_value -ne 0 ]]; then
+    for package in ${packages}; do
+        go test ${package}
+    done
+    exit $return_value
+fi
+
+set -e
 go tool cover -html=$profile -o coverage.html


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We found out that `go test -cover` seems to swallow the error output (in this case it was 
`FAIL    kubevirt.io/kubevirt/pkg/virt-api/webhooks/validating-webhook/admitters [build failed]`
). In order to keep the output still helpful we test each package again in case of error to have at least a hint for the user what to do about this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @rmohr @phoracek mind taking a look whether you find is helpful? Alternative ideas welcome :)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
