### PR TITLE
Avoid setting SELinuxOptions on virt-launcher when no type is specified

### DIFF
--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -183,8 +183,8 @@ var _ = Describe("Template", func() {
 				}
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
-				if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SELinuxOptions != nil {
-					Expect(pod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(""))
+				if pod.Spec.SecurityContext != nil {
+					Expect(pod.Spec.SecurityContext.SELinuxOptions).To(BeNil())
 				}
 			})
 			It("should run under the corresponding SELinux type if specified", func() {

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -121,7 +121,7 @@ var _ = Describe("SecurityFeatures", func() {
 
 				By("Check virt-launcher pod SecurityContext values")
 				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-				Expect(vmiPod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(""))
+				Expect(vmiPod.Spec.SecurityContext.SELinuxOptions).To(BeNil())
 			})
 
 			It("[test_id:2895]Make sure the virt-launcher pod is not priviledged", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Setting SELinuxOptions to anything, including "{}", has implications.
It notably disables automatic relabelling of overlay2 mounts.
Avoid setting SELinuxOptions when no SELinux type is specified.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
