### PR TITLE
docs: fix ADD destination in container-register-disks

### DIFF
--- a/docs/container-register-disks.md
+++ b/docs/container-register-disks.md
@@ -63,7 +63,7 @@ Example:
 ```
 cat << END > Dockerfile
 FROM scratch
-ADD fedora25.qcow2 /disk
+ADD fedora25.qcow2 /disk/
 END
 docker build -t vmdisks/fedora25:latest .
 docker push vmdisks/fedora25:latest


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With destination set to /disk, it places the image to file /disk. We need to
change it to /disk/ instead, so the image is put under /disk directory.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed image destination folder in container register disk docs
```
