### PR TITLE
Set kubevirt priority class on all core components

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -42,6 +42,7 @@ ${KUBEVIRT_DIR}/tools/openapispec/openapispec --dump-api-spec-path ${KUBEVIRT_DI
 (cd ${KUBEVIRT_DIR}/tools/csv-generator/ && go_build)
 rm -f ${KUBEVIRT_DIR}/manifests/generated/*
 rm -f ${KUBEVIRT_DIR}/examples/*
+${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=priorityclass >${KUBEVIRT_DIR}/manifests/generated/kubevirt-priority-class.yaml
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=vmi >${KUBEVIRT_DIR}/manifests/generated/vmi-resource.yaml
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=vmirs >${KUBEVIRT_DIR}/manifests/generated/vmirs-resource.yaml
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=vmipreset >${KUBEVIRT_DIR}/manifests/generated/vmipreset-resource.yaml

--- a/manifests/generated/kubevirt-priority-class.yaml
+++ b/manifests/generated/kubevirt-priority-class.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class should be used for KubeVirt core components only.
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+value: 1000000000

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -726,6 +726,7 @@ spec:
                   initialDelaySeconds: 5
                   timeoutSeconds: 10
                 resources: {}
+              priorityClassName: kubevirt-cluster-critical
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: kubevirt-operator

--- a/manifests/generated/virt-api.yaml.in
+++ b/manifests/generated/virt-api.yaml.in
@@ -77,6 +77,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
         resources: {}
+      priorityClassName: kubevirt-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubevirt-apiserver

--- a/manifests/generated/virt-controller.yaml.in
+++ b/manifests/generated/virt-controller.yaml.in
@@ -65,6 +65,7 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 10
         resources: {}
+      priorityClassName: kubevirt-cluster-critical
       securityContext:
         runAsNonRoot: true
       serviceAccountName: kubevirt-controller

--- a/manifests/generated/virt-handler.yaml.in
+++ b/manifests/generated/virt-handler.yaml.in
@@ -66,6 +66,7 @@ spec:
         - mountPath: /var/lib/kubelet/device-plugins
           name: device-plugin
       hostPID: true
+      priorityClassName: kubevirt-cluster-critical
       serviceAccountName: kubevirt-handler
       tolerations:
       - key: CriticalAddonsOnly

--- a/manifests/release/kubevirt-operator.yaml.in
+++ b/manifests/release/kubevirt-operator.yaml.in
@@ -7,6 +7,14 @@ metadata:
   name: {{.Namespace}}
 {{index .GeneratedManifests "kv-resource.yaml"}}
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kubevirt-cluster-critical
+value: 1000000000
+globalDefault: false
+description: "This priority class should be used for core kubevirt components only."
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/release/kubevirt.yaml.in
+++ b/manifests/release/kubevirt.yaml.in
@@ -16,3 +16,4 @@ metadata:
 {{index .GeneratedManifests "vmipreset-resource.yaml"}}
 {{index .GeneratedManifests "vm-resource.yaml"}}
 {{index .GeneratedManifests "vmim-resource.yaml"}}
+{{index .GeneratedManifests "kubevirt-cluster-critical.yaml"}}

--- a/manifests/release/olm/kubevirt-csv-preconditions.yaml.in
+++ b/manifests/release/olm/kubevirt-csv-preconditions.yaml.in
@@ -7,3 +7,4 @@ metadata:
   name: {{.Namespace}}
 {{index .GeneratedManifests "kv-resource.yaml"}}
 {{index .GeneratedManifests "rbac-operator.authorization.k8s.yaml.in"}}
+{{index .GeneratedManifests "kubevirt-cluster-critical.yaml"}}

--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/prometheus-operator/pkg/apis/monitoring"
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -594,5 +595,23 @@ func NewKubeVirtCR(namespace string, pullPolicy corev1.PullPolicy) *virtv1.KubeV
 		Spec: virtv1.KubeVirtSpec{
 			ImagePullPolicy: pullPolicy,
 		},
+	}
+}
+
+// NewKubeVirtPriorityClassCR is used for manifest generation
+func NewKubeVirtPriorityClassCR() *schedulingv1.PriorityClass {
+	return &schedulingv1.PriorityClass{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "scheduling.k8s.io/v1",
+			Kind:       "PriorityClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubevirt-cluster-critical",
+		},
+		// 1 billion is the highest value we can set
+		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+		Value:         1000000000,
+		GlobalDefault: false,
+		Description:   "This priority class should be used for KubeVirt core components only.",
 	}
 }

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -115,8 +115,9 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 			Name: podName,
 		},
 		Spec: corev1.PodSpec{
-			Affinity:    podAffinity,
-			Tolerations: criticalAddonsToleration(),
+			PriorityClassName: "kubevirt-cluster-critical",
+			Affinity:          podAffinity,
+			Tolerations:       criticalAddonsToleration(),
 			Containers: []corev1.Container{
 				{
 					Name:            podName,
@@ -470,6 +471,7 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 					Name: name,
 				},
 				Spec: corev1.PodSpec{
+					PriorityClassName:  "kubevirt-cluster-critical",
 					Tolerations:        criticalAddonsToleration(),
 					Affinity:           podAntiAffinity,
 					ServiceAccountName: "kubevirt-operator",

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -64,6 +64,7 @@ type templateData struct {
 	VirtControllerSha      string
 	VirtHandlerSha         string
 	VirtLauncherSha        string
+	PriorityClassSpec      string
 	GeneratedManifests     map[string]string
 }
 
@@ -125,6 +126,7 @@ func main() {
 		data.CreatedAt = getTimestamp()
 		data.ReplacesCsvVersion = ""
 		data.OperatorDeploymentSpec = getOperatorDeploymentSpec(data, 2)
+		data.PriorityClassSpec = getPriorityClassSpec(2)
 
 		// operator deployment differs a bit in normal manifest and CSV
 		if strings.Contains(*inputFile, ".clusterserviceversion.yaml") {
@@ -207,6 +209,16 @@ func getOperatorRules() string {
 		}
 	}
 	return fixResourceString(writer.String(), 14)
+}
+
+func getPriorityClassSpec(indentation int) string {
+	priorityClassSpec := components.NewKubeVirtPriorityClassCR()
+	writer := strings.Builder{}
+	err := util.MarshallObject(priorityClassSpec, &writer)
+	if err != nil {
+		panic(err)
+	}
+	return fixResourceString(writer.String(), indentation)
 }
 
 func getOperatorDeploymentSpec(data templateData, indentation int) string {

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-	resourceType := flag.String("type", "", "Type of resource to generate. vmi | vmipreset | vmirs | vm | vmim | kv | rbac")
+	resourceType := flag.String("type", "", "Type of resource to generate. vmi | vmipreset | vmirs | vm | vmim | kv | rbac | priorityclass")
 	namespace := flag.String("namespace", "kube-system", "Namespace to use.")
 	repository := flag.String("repository", "kubevirt", "Image Repository to use.")
 	imagePrefix := flag.String("imagePrefix", "", "Optional prefix for virt-* image names.")
@@ -107,6 +107,9 @@ func main() {
 			panic(fmt.Errorf("error generating virt-handler deployment %v", err))
 		}
 		util.MarshallObject(handler, os.Stdout)
+	case "priorityclass":
+		priorityClass := components.NewKubeVirtPriorityClassCR()
+		util.MarshallObject(priorityClass, os.Stdout)
 	default:
 		panic(fmt.Errorf("unknown resource type %s", *resourceType))
 	}


### PR DESCRIPTION
As of K8s 1.16, the `scheduler.alpha.kubernetes.io/critical-pod`
annotation is deprecated. As a result, we now deploy a priority class
for our core components. Since the operator is managing the cert
rotation for all of our components, we also consider it as a high
priority component and in result, the priority class must be deployed
before the operator is being deployed.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Special notes for your reviewer**:
/cc @rmohr implemented as we discussed offline.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt components now use a priority class.
```
