### PR TITLE
Silence compilation warning on container-disk

### DIFF
--- a/cmd/container-disk-v2alpha/main.c
+++ b/cmd/container-disk-v2alpha/main.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
     */
     memset(&address, 0, sizeof(struct sockaddr_un));
     address.sun_family = AF_UNIX;
-    strncat(copy_path, ".sock", 5);
+    strcat(copy_path, ".sock");
     strncpy(address.sun_path, copy_path, sizeof(address.sun_path));
 
     int fd = socket(AF_UNIX, SOCK_STREAM, 0);


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes unnecessary use of strncat to silence the following compilation warning:
```
main.c: In function 'main':
main.c:172:5: warning: 'strncat' specified bound 5 equals source length [-Wstringop-overflow=]
  172 |     strncat(copy_path, ".sock", 5);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
