### PR TITLE
Increase the amount of memory used by stress to delay migrations

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -328,7 +328,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	runStressTest := func(expecter expect.Expecter) {
 		By("Run a stress test to dirty some pages and slow down the migration")
 		_, err = expecter.ExpectBatch([]expect.Batcher{
-			&expect.BSnd{S: "stress --vm 1 --vm-bytes 600M --vm-keep --timeout 1600s&\n"},
+			&expect.BSnd{S: "stress --vm 1 --vm-bytes 800M --vm-keep --timeout 1600s&\n"},
 		}, 15*time.Second)
 		Expect(err).ToNot(HaveOccurred(), "should run a stress test")
 		// give stress tool some time to trash more memory pages before returning control to next steps


### PR DESCRIPTION
**What this PR does / why we need it**:
Some migrations related functional rests are failing randomly on the 1.17 lane. This is probably because stress doesn't have enough time to pollute the guest's memory. This change increases the amount of memory stress uses instead of increasing the time.

```release-note
NONE
```
