### PR TITLE
tests: increase nc idle and wait timeouts

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3537,7 +3537,7 @@ func RenderHostPathJob(jobName string, dir string, hostPathType k8sv1.HostPathTy
 // NewHelloWorldJob takes a DNS entry or an IP and a port which it will use create a pod
 // which tries to contact the host on the provided port. It expects to receive "Hello World!" to succeed.
 func NewHelloWorldJob(host string, port string) *k8sv1.Pod {
-	check := []string{fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 1 -w 1))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)}
+	check := []string{fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)}
 	job := RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
 
 	return job
@@ -3556,7 +3556,7 @@ func NewHelloWorldJobUDP(host string, port string) *k8sv1.Pod {
 	// local port is used to catch the reply - any number can be used
 	// we make it different than the port to be safe if both are running on the same machine
 	localPort--
-	check := []string{fmt.Sprintf(`set -x; trap "kill 0" EXIT; x="$(head -n 1 < <(echo | nc -up %d %s %s -i 1 -w 1 & nc -ul %d))"; echo "$x" ; if [ "$x" = "Hello UDP World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`,
+	check := []string{fmt.Sprintf(`set -x; trap "kill 0" EXIT; x="$(head -n 1 < <(echo | nc -up %d %s %s -i 3 -w 3 & nc -ul %d))"; echo "$x" ; if [ "$x" = "Hello UDP World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`,
 		localPort, host, port, localPort)}
 	job := RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

On slower/busy clusters, netcat often times out with:

Ncat: Idle timeout expired (1000 ms).

In order to avoid this issue, we increase the idle and wait timeouts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
