### PR TITLE
docs: clarify what will be reported in VMI status IPs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8284,11 +8284,11 @@
       "type": "string"
      },
      "ipAddress": {
-      "description": "IP address of a Virtual Machine interface. It is always the first item of IPs",
+      "description": "(deprecated) IP address of a Virtual Machine interface. This will show the first IP from IPs list.",
       "type": "string"
      },
      "ipAddresses": {
-      "description": "List of all IP addresses of a Virtual Machine interface",
+      "description": "List of all IP addresses of a Virtual Machine interface accessible on given network. For L2 binding mechanisms (bridge, sriov), this would be addresses assigned by CNI IPAM. In case IPAM was not set, this would be addresses reported by guest agent (if the guest agent is available in the guest). For forwarding binding mechanisms (masquerade, slirp), this would be always addresses assigned by CNI IPAM.",
       "type": "array",
       "items": {
        "type": "string"

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -17090,7 +17090,7 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceNetworkInterface(r
 				Properties: map[string]spec.Schema{
 					"ipAddress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IP address of a Virtual Machine interface. It is always the first item of IPs",
+							Description: "(deprecated) IP address of a Virtual Machine interface. This will show the first IP from IPs list.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -17111,7 +17111,7 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceNetworkInterface(r
 					},
 					"ipAddresses": {
 						SchemaProps: spec.SchemaProps{
-							Description: "List of all IP addresses of a Virtual Machine interface",
+							Description: "List of all IP addresses of a Virtual Machine interface accessible on given network. For L2 binding mechanisms (bridge, sriov), this would be addresses assigned by CNI IPAM. In case IPAM was not set, this would be addresses reported by guest agent (if the guest agent is available in the guest). For forwarding binding mechanisms (masquerade, slirp), this would be always addresses assigned by CNI IPAM.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -318,15 +318,21 @@ func (m *VirtualMachineInstanceMigration) TargetIsHandedOff() bool {
 //
 // +k8s:openapi-gen=true
 type VirtualMachineInstanceNetworkInterface struct {
-	// IP address of a Virtual Machine interface. It is always the first item of
-	// IPs
+	// (deprecated) IP address of a Virtual Machine interface. This will show
+	// the first IP from IPs list.
 	IP string `json:"ipAddress,omitempty"`
 	// Hardware address of a Virtual Machine interface
 	MAC string `json:"mac,omitempty"`
 	// Name of the interface, corresponds to name of the network assigned to the interface
 	// TODO: remove omitempty, when api breaking changes are allowed
 	Name string `json:"name,omitempty"`
-	// List of all IP addresses of a Virtual Machine interface
+	// List of all IP addresses of a Virtual Machine interface accessible on
+	// given network.
+	// For L2 binding mechanisms (bridge, sriov), this would be addresses
+	// assigned by CNI IPAM. In case IPAM was not set, this would be addresses
+	// reported by guest agent (if the guest agent is available in the guest).
+	// For forwarding binding mechanisms (masquerade, slirp), this would be
+	// always addresses assigned by CNI IPAM.
 	IPs []string `json:"ipAddresses,omitempty"`
 	// The interface name inside the Virtual Machine
 	InterfaceName string `json:"interfaceName,omitempty"`

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -73,10 +73,10 @@ func (VirtualMachineInstanceMigrationCondition) SwaggerDoc() map[string]string {
 func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":              "+k8s:openapi-gen=true",
-		"ipAddress":     "IP address of a Virtual Machine interface. It is always the first item of\nIPs",
+		"ipAddress":     "(deprecated) IP address of a Virtual Machine interface. This will show\nthe first IP from IPs list.",
 		"mac":           "Hardware address of a Virtual Machine interface",
 		"name":          "Name of the interface, corresponds to name of the network assigned to the interface",
-		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface",
+		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface accessible on\ngiven network.\nFor L2 binding mechanisms (bridge, sriov), this would be addresses\nassigned by CNI IPAM. In case IPAM was not set, this would be addresses\nreported by guest agent (if the guest agent is available in the guest).\nFor forwarding binding mechanisms (masquerade, slirp), this would be\nalways addresses assigned by CNI IPAM.",
 		"interfaceName": "The interface name inside the Virtual Machine",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -16943,7 +16943,7 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceNetworkInterface(r
 				Properties: map[string]spec.Schema{
 					"ipAddress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IP address of a Virtual Machine interface. It is always the first item of IPs",
+							Description: "(deprecated) IP address of a Virtual Machine interface. This will show the first IP from IPs list.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16964,7 +16964,7 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceNetworkInterface(r
 					},
 					"ipAddresses": {
 						SchemaProps: spec.SchemaProps{
-							Description: "List of all IP addresses of a Virtual Machine interface",
+							Description: "List of all IP addresses of a Virtual Machine interface accessible on given network. For L2 binding mechanisms (bridge, sriov), this would be addresses assigned by CNI IPAM. In case IPAM was not set, this would be addresses reported by guest agent (if the guest agent is available in the guest). For forwarding binding mechanisms (masquerade, slirp), this would be always addresses assigned by CNI IPAM.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

It was not clear which IPs should be reported in the status. This doc change
should make it clear and we should be able to adjust the existing code to follow
this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This should unblock @vatsalparekh on #3063

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
