### PR TITLE
docs: correct the links on the images README

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -5,9 +5,9 @@ Some of our testing images
 - `cdi-http-import-server`
 - `vm-killer`
 
-use base image `kubevirtci/kubevirt-testing` from the [KubeVirtCI repository](https://github.com/kubevirt/kubevirtci/tree/master/images).
+use base image `kubevirtci/kubevirt-testing` from the [KubeVirtCI repository](https://github.com/kubevirt/kubevirtci/blob/master/cluster-provision/images).
 
 To add new RPM's under this image:
 
-- follow instructions under [README.md](https://github.com/kubevirt/kubevirtci/blob/master/images/README.md)
+- follow instructions under [README.md](https://github.com/kubevirt/kubevirtci/blob/master/cluster-provision/images/README.md)
 - use the hash the you got from the above step to update `WORKSPACE` target `kubevirt-testing`


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The links on the `images` README file are outdated, and return 404 not found.

This PR corrects those links.

**Which issue(s) this PR fixes**: 
Fixes #3244

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
