### PR TITLE
Open and close /dev/vhost-net on virt-handler startup

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -347,6 +347,11 @@ func (app *virtHandlerApp) Run() {
 	if err == nil {
 		devnettun.Close()
 	}
+	// Same for /dev/vhost-net
+	devvhostnet, err := os.Open("/dev/vhost-net")
+	if err == nil {
+		devvhostnet.Close()
+	}
 
 	cache.WaitForCacheSync(stop, factory.ConfigMap().HasSynced, vmiInformer.HasSynced, factory.CRD().HasSynced)
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -341,18 +341,6 @@ func (app *virtHandlerApp) Run() {
 		panic(fmt.Errorf("failed to detect the presence of selinux: %v", err))
 	}
 
-	// Make sure the tun module is loaded on the node
-	// Just opening and closing /dev/net/tun triggers a modprobe on the host if necessary
-	devnettun, err := os.Open("/dev/net/tun")
-	if err == nil {
-		devnettun.Close()
-	}
-	// Same for /dev/vhost-net
-	devvhostnet, err := os.Open("/dev/vhost-net")
-	if err == nil {
-		devvhostnet.Close()
-	}
-
 	cache.WaitForCacheSync(stop, factory.ConfigMap().HasSynced, vmiInformer.HasSynced, factory.CRD().HasSynced)
 
 	go vmController.Run(10, stop)

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -46,9 +46,9 @@ type DeviceController struct {
 func NewDeviceController(host string, maxDevices int) *DeviceController {
 	return &DeviceController{
 		devicePlugins: []GenericDevice{
-			NewGenericDevicePlugin(KVMName, KVMPath, maxDevices),
-			NewGenericDevicePlugin(TunName, TunPath, maxDevices),
-			NewGenericDevicePlugin(VhostNetName, VhostNetPath, maxDevices),
+			NewGenericDevicePlugin(KVMName, KVMPath, maxDevices, false),
+			NewGenericDevicePlugin(TunName, TunPath, maxDevices, true),
+			NewGenericDevicePlugin(VhostNetName, VhostNetPath, maxDevices, true),
 		},
 		host:       host,
 		maxDevices: maxDevices,

--- a/pkg/virt-handler/device-manager/generic_device_test.go
+++ b/pkg/virt-handler/device-manager/generic_device_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Generic Device", func() {
 		Expect(err).ToNot(HaveOccurred())
 		fileObj.Close()
 
-		dpi = NewGenericDevicePlugin("foo", devicePath, 1)
+		dpi = NewGenericDevicePlugin("foo", devicePath, 1, true)
 		dpi.socketPath = filepath.Join(workDir, "test.sock")
 		dpi.server = grpc.NewServer([]grpc.ServerOption{}...)
 		dpi.done = make(chan struct{})


### PR DESCRIPTION
**What this PR does / why we need it**:
Similarly to /dev/net/tun, opening vhost-net for the first time triggers a modprobe of the vhost_net module.
virt-launcher sometimes uses vhost-net, but is not allowed to modprobe since it runs under the SELinux type container_t.
In virt-handler, which runs as spc_t, access (open/close) /dev/vhost-net and (potentially) trigger the modprobe.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
