### PR TITLE
Ipv6 fix http readiness probe

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2049,6 +2049,14 @@ func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus string, 
 	return vmi
 }
 
+func NewRandomFedora32VMIWithFedoraUser() *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithEphemeralDiskAndUserdata(ContainerDiskFor(ContainerDiskFedora), `#!/bin/bash
+	    echo "fedora" |passwd fedora --stdin
+        echo `)
+	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
+	return vmi
+}
+
 func NewRandomFedoraVMIWitGuestAgent() *v1.VirtualMachineInstance {
 	agentVMI := NewRandomVMIWithEphemeralDiskAndUserdata(ContainerDiskFor(ContainerDiskFedora), GetGuestAgentUserData())
 	agentVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
@@ -4121,16 +4129,30 @@ func StartTCPServer(vmi *v1.VirtualMachineInstance, port int) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int) {
-	expecter, err := LoggedInCirrosExpecter(vmi)
-	Expect(err).ToNot(HaveOccurred())
+func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, isFedoraVM bool) {
+	var err error
+	var expecter expect.Expecter
+	var httpServerMaker string
+	var prompt string
+
+	if isFedoraVM {
+		expecter, err = LoggedInFedoraExpecter(vmi)
+		Expect(err).NotTo(HaveOccurred())
+		httpServerMaker = fmt.Sprintf("python3 -m http.server %d --bind ::0 &\n", port)
+		prompt = "#"
+	} else {
+		expecter, err = LoggedInCirrosExpecter(vmi)
+		Expect(err).NotTo(HaveOccurred())
+		httpServerMaker = fmt.Sprintf("screen -d -m nc -klp %d -e echo -e \"HTTP/1.1 200 OK\\n\\nHello World!\"\n", port)
+		prompt = "\\$"
+	}
 	defer expecter.Close()
 
 	resp, err := expecter.ExpectBatch([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: "\\$ "},
-		&expect.BSnd{S: fmt.Sprintf("screen -d -m nc -klp %d -e echo -e \"HTTP/1.1 200 OK\\n\\nHello World!\"\n", port)},
-		&expect.BExp{R: "\\$ "},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: httpServerMaker},
+		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: "0"},
 	}, 60*time.Second)
@@ -4702,4 +4724,9 @@ func ClearKubeVirtConfigMap(key string) error {
 
 func RandTmpDir() string {
 	return tmpPath + "/" + rand.String(10)
+}
+
+func IsIPv6Cluster(virtClient kubecli.KubevirtClient) bool {
+	clusterDnsIP, _ := getClusterDnsServiceIP(virtClient)
+	return netutils.IsIPv6String(clusterDnsIP)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
By avoiding the `nc` HTTP webserver provided in the cirros images we're currently using, HTTP readiness probes can work (`nc` replied w/ an extra RST TCP datagram).

**Which issue(s) this PR fixes** :
Fixes #3247 

**Special notes for your reviewer**:
Depends on: #3112, #3372

As indicated in #3247, `nc` software has a bug when binding to ipv6 addresses. Since that is the only resource we have available in cirrOS to build an http server, it was needed to update the type of VM to fedora, where a python webserver will be used.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
