### PR TITLE
Migration tests - use proper node drain key

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	configMapName                     = "kubevirt-config"
+	ConfigMapName                     = "kubevirt-config"
 	FeatureGatesKey                   = "feature-gates"
 	EmulatedMachinesKey               = "emulated-machines"
 	MachineTypeKey                    = "machine-type"
@@ -79,12 +79,12 @@ func getConfigMap() *k8sv1.ConfigMap {
 			return false, err
 		}
 
-		cfgMap, curErr = virtClient.CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
+		cfgMap, curErr = virtClient.CoreV1().ConfigMaps(namespace).Get(ConfigMapName, metav1.GetOptions{})
 
 		if curErr != nil {
 			if errors.IsNotFound(curErr) {
 				logger := log.DefaultLogger()
-				logger.Infof("%s ConfigMap does not exist. Using defaults.", configMapName)
+				logger.Infof("%s ConfigMap does not exist. Using defaults.", ConfigMapName)
 				cfgMap = &k8sv1.ConfigMap{}
 				return true, nil
 			}
@@ -423,7 +423,7 @@ func (c *ClusterConfig) getConfig() (config *Config) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if obj, exists, err := c.configMapInformer.GetStore().GetByKey(c.namespace + "/" + configMapName); err != nil {
+	if obj, exists, err := c.configMapInformer.GetStore().GetByKey(c.namespace + "/" + ConfigMapName); err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Error loading the cluster config from cache, falling back to last good resource version '%s'", c.lastValidConfig.ResourceVersion)
 		return c.lastValidConfig
 	} else if !exists {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	migrations "kubevirt.io/kubevirt/pkg/util/migrations"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -67,7 +68,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	tests.BeforeAll(func() {
 
-		originalKubeVirtConfig, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
+		originalKubeVirtConfig, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, metav1.GetOptions{})
 		if err != nil && !errors.IsNotFound(err) {
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -75,7 +76,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		if errors.IsNotFound(err) {
 			// create an empty kubevirt-config configmap if none exists.
 			cfgMap := &k8sv1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "kubevirt-config"},
+				ObjectMeta: metav1.ObjectMeta{Name: virtconfig.ConfigMapName},
 				Data: map[string]string{
 					"feature-gates": "",
 				},
@@ -104,7 +105,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	})
 
 	AfterEach(func() {
-		curKubeVirtConfig, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
+		curKubeVirtConfig, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, metav1.GetOptions{})
 		if err != nil {
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -116,7 +117,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			Expect(err).ToNot(HaveOccurred())
 			data := fmt.Sprintf(`[{ "op": "replace", "path": "/data", "value": %s }]`, string(newData))
 
-			newConfig, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Patch("kubevirt-config", types.JSONPatchType, []byte(data))
+			newConfig, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Patch(virtconfig.ConfigMapName, types.JSONPatchType, []byte(data))
 			Expect(err).ToNot(HaveOccurred())
 
 			// update the restored originalKubeVirtConfig
@@ -468,13 +469,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var options metav1.GetOptions
 			var cfgMap *k8sv1.ConfigMap
 			var originalMigrationConfig string
-			var kubevirtConfig = "kubevirt-config"
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 
 				// set autoconverge flag
 				options = metav1.GetOptions{}
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
 
@@ -524,7 +524,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var options metav1.GetOptions
 			var cfgMap *k8sv1.ConfigMap
 			var originalMigrationConfig string
-			var kubevirtConfig = "kubevirt-config"
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
 				if !tests.HasCDI() {
@@ -535,7 +534,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				// set unsafe migration flag
 				options = metav1.GetOptions{}
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
 				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": true}`)
@@ -879,12 +878,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var options metav1.GetOptions
 			var cfgMap *k8sv1.ConfigMap
 			var originalMigrationConfig string
-			var kubevirtConfig = "kubevirt-config"
 
 			BeforeEach(func() {
 				// update migration timeouts
 				options = metav1.GetOptions{}
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
 				tests.UpdateClusterConfigValueAndWait("migrations", `{"bandwidthPerMigration" : "1Mi"}`)
@@ -989,12 +987,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var options metav1.GetOptions
 			var cfgMap *k8sv1.ConfigMap
 			var originalMigrationConfig string
-			var kubevirtConfig = "kubevirt-config"
 
 			BeforeEach(func() {
 				// update migration timeouts
 				options = metav1.GetOptions{}
-				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(kubevirtConfig, options)
+				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
 				tests.UpdateClusterConfigValueAndWait("migrations", `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`)
@@ -1373,9 +1370,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					runStressTest(expecter)
 
 					// Taint Node.
-					By("Tainting node with kubevirt.io/drain=NoSchedule")
+					By("Tainting node with node drain key")
 					node := vmi.Status.NodeName
-					tests.Taint(node, "kubevirt.io/drain", k8sv1.TaintEffectNoSchedule)
+					tests.Taint(node, tests.GetNodeDrainKey(), k8sv1.TaintEffectNoSchedule)
 
 					// Drain Node using cli client
 					k8sClient := tests.GetK8sCmdClient()
@@ -1413,7 +1410,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					vmi = cirrosVMIWithEvictionStrategy()
 
 					By("Configuring a custom nodeDrainTaintKey in kubevirt-config")
-					cfg, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
+					cfg, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
 					// set a custom taint value
@@ -1423,7 +1420,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Expect(err).ToNot(HaveOccurred())
 					data := fmt.Sprintf(`[{ "op": "replace", "path": "/data", "value": %s }]`, string(newData))
 
-					_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Patch("kubevirt-config", types.JSONPatchType, []byte(data))
+					_, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Patch(virtconfig.ConfigMapName, types.JSONPatchType, []byte(data))
 					Expect(err).ToNot(HaveOccurred())
 					// this sleep is to allow the config to stick. The informers on virt-controller have to
 					// be notified of the config change.
@@ -1532,9 +1529,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Expect(vmi_evict1.Status.NodeName).To(Equal(vmi_noevict.Status.NodeName))
 
 					// Taint Node.
-					By("Tainting node with kubevirt.io/drain=NoSchedule")
+					By("Tainting node with the node drain key")
 					node := vmi_evict1.Status.NodeName
-					tests.Taint(node, "kubevirt.io/drain", k8sv1.TaintEffectNoSchedule)
+					tests.Taint(node, tests.GetNodeDrainKey(), k8sv1.TaintEffectNoSchedule)
 
 					// Drain Node using cli client
 					By("Draining using kubectl drain")
@@ -1615,7 +1612,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.AddLabelToNode(targetNode.Name, "tests.kubevirt.io", "target")
 
 				By("tainting the source node as non-schedulabele")
-				tests.Taint(sourceNode.Name, "kubevirt.io/drain", k8sv1.TaintEffectNoSchedule)
+				tests.Taint(sourceNode.Name, tests.GetNodeDrainKey(), k8sv1.TaintEffectNoSchedule)
 
 				By("waiting until migration kicks in")
 				Eventually(func() int {


### PR DESCRIPTION
In order to test a migration in case of node drain, the migration tests were using a hardcoded taint key "kubevirt.io/drain" for tainting the node and trigger VMI eviction. This taint key is configurable and is read from the KubeVirt configmap by the virt-handler evacuation controller. Thus, the tests also should read this key from the configmap and not assume a constant value.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
In some cases the node drain key is being customized (One good example is the HCO which builds the KV configmap and uses drain key "node.kubernetes.io/unschedulable"). This PR will fix potential issues with running functional tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Live migration tests

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
