### PR TITLE
Configurable increase for test timeouts

### DIFF
--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -12,6 +12,7 @@ image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}
 verbosity=${VERBOSITY:-2}
 package_name=${PACKAGE_NAME:-kubevirt-dev}
 kubevirtci_git_hash="b334de7478cf7d80d6bfaa16bd0cd874282a71eb"
+test_timeout_multiplier=${TEST_TIMEOUT_MULTIPLIER:-1}
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -45,4 +45,4 @@ if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* 
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra}
+${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${previous_release_tag} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -timeout-multiplier=${test_timeout_multiplier}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1607,7 +1607,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("waiting until the VMIs are ready")
 				for _, vmi := range vmis {
-					tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 180)
+					tests.WaitForSuccessfulVMIStartWithTimeout(vmi, tests.GetVMIStartTimeoutSeconds())
 				}
 
 				By("selecting a  node as the target")
@@ -1625,7 +1625,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					runningMigrations := migrations.FilterRunningMigrations(migrationList.Items)
 
 					return len(runningMigrations)
-				}, 2*time.Minute, 1*time.Second).Should(BeNumerically(">", 0))
+				}, tests.GetVMIMigrationTimeoutSeconds(), 1*time.Second).Should(BeNumerically(">", 0))
 
 				By("checking that all VMIs were migrated, and we never see more than two running migrations in parallel")
 				Eventually(func() []string {
@@ -1642,7 +1642,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Expect(len(runningMigrations)).To(BeNumerically("<=", 2))
 
 					return nodes
-				}, 4*time.Minute, 1*time.Second).Should(ConsistOf(
+				}, tests.GetVMIMigrationTimeoutSeconds()*2, 1*time.Second).Should(ConsistOf(
 					targetNode.Name,
 					targetNode.Name,
 					targetNode.Name,

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -395,7 +395,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Starting a Fedora VMI")
 			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
-			vmi = tests.RunVMIAndExpectLaunch(vmi, 360)
+			vmi = tests.RunVMIAndExpectLaunch(vmi, tests.GetVMIStartTimeoutSeconds())
 			tests.WaitAgentConnected(virtClient, vmi)
 
 			expecter, expecterErr := tests.LoggedInFedoraExpecter(vmi)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Templates", func() {
 					vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})
 					ExpectWithOffset(1, err).ToNot(HaveOccurred(), "failed to fetch VirtualMachine %q: %v", vmName, err)
 					return vm.Status.Ready
-				}).Should(BeTrue(), "VirtualMachine %q still does not have status ready", vmName)
+				}, tests.GetVMIStartTimeoutSeconds()).Should(BeTrue(), "VirtualMachine %q still does not have status ready", vmName)
 
 				By("Checking if the VirtualMachineInstance specs match Template parameters")
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmName, &metav1.GetOptions{})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -107,6 +107,7 @@ var PreviousReleaseRegistry = ""
 var ConfigFile = ""
 var Config *KubeVirtTestsConfiguration
 var SkipShasumCheck bool
+var TimeoutMultiplier float64
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -131,6 +132,7 @@ func init() {
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
+	flag.Float64Var(&TimeoutMultiplier, "timeout-multiplier", 1, "Scalar multiplier to apply to test timeouts")
 }
 
 func FlagParse() {
@@ -153,6 +155,9 @@ const TempDirPrefix = "kubevirt-test"
 const (
 	defaultEventuallyTimeout         = 5 * time.Second
 	defaultEventuallyPollingInterval = 1 * time.Second
+	defualtVMIStartTimeout           = 180
+	defualtVMIMigrationTimeout       = 180
+	defualtVMIDeletionTimeout        = 120
 )
 
 const (
@@ -268,6 +273,30 @@ type ObjectEventWatcher struct {
 
 func NewObjectEventWatcher(object runtime.Object) *ObjectEventWatcher {
 	return &ObjectEventWatcher{object: object, startType: invalidWatch}
+}
+
+func GetVMIStartTimeoutSeconds() int {
+	return int(GetVMIStartTimeout().Seconds())
+}
+
+func GetVMIStartTimeout() time.Duration {
+	return time.Duration(defualtVMIStartTimeout * TimeoutMultiplier * float64(time.Second))
+}
+
+func GetVMIMigrationTimeoutSeconds() int {
+	return int(GetVMIMigrationTimeout().Seconds())
+}
+
+func GetVMIMigrationTimeout() time.Duration {
+	return time.Duration(defualtVMIMigrationTimeout * TimeoutMultiplier * float64(time.Second))
+}
+
+func GetVMIDeletionTimeoutSeconds() int {
+	return int(GetVMIDeletionTimeout().Seconds())
+}
+
+func GetVMIDeletionTimeout() time.Duration {
+	return time.Duration(defualtVMIDeletionTimeout * TimeoutMultiplier * float64(time.Second))
 }
 
 func (w *ObjectEventWatcher) Timeout(duration time.Duration) *ObjectEventWatcher {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1694,7 +1694,7 @@ func waitForVMIStart(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 			return v1.Unknown
 		}
 		return newVMI.Status.Phase
-	}, 120*time.Second, 1*time.Second).Should(Equal(v1.Running), "New VMI was not created")
+	}, tests.GetVMIStartTimeout(), 1*time.Second).Should(Equal(v1.Running), "New VMI was not created")
 }
 
 func waitForVMIScheduling(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
@@ -1707,7 +1707,7 @@ func waitForVMIScheduling(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMach
 			return v1.Unknown
 		}
 		return newVMI.Status.Phase
-	}, 120*time.Second, 1*time.Second).Should(Equal(v1.Scheduling), "New VMI was not created")
+	}, tests.GetVMIStartTimeout(), 1*time.Second).Should(Equal(v1.Scheduling), "New VMI was not created")
 }
 
 func waitForResourceDeletion(k8sClient string, resourceType string, resourceName string) {
@@ -1715,5 +1715,5 @@ func waitForResourceDeletion(k8sClient string, resourceType string, resourceName
 		stdout, _, err := tests.RunCommand(k8sClient, "get", resourceType)
 		Expect(err).ToNot(HaveOccurred())
 		return strings.Contains(stdout, resourceName)
-	}, 120*time.Second, 1*time.Second).Should(BeFalse(), "VM was not deleted")
+	}, tests.GetVMIDeletionTimeout(), 1*time.Second).Should(BeFalse(), "VM was not deleted")
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1856,7 +1856,7 @@ var _ = Describe("Configurations", func() {
 				log.DefaultLogger().Object(cpuVmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
 			})
-			It("should be able to start a vm with guest memory different from requested and keed guaranteed qos", func() {
+			It("should be able to start a vm with guest memory different from requested and keep guaranteed qos", func() {
 				cpuVmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					Sockets:               2,

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -353,7 +353,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					launcher := findLauncherForVMI(vmi)
 					tests.NewObjectEventWatcher(launcher).
 						SinceWatchedObjectResourceVersion().
-						Timeout(60*time.Second).
+						Timeout(tests.GetVMIStartTimeout()).
 						Watch(stopChan, func(event *k8sv1.Event) bool {
 							if event.Type == "Warning" && event.Reason == "FailedMount" {
 								return true
@@ -385,7 +385,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					By("Checking that VirtualMachineInstance start failed")
 					stopChan := make(chan struct{})
 					defer close(stopChan)
-					event := tests.NewObjectEventWatcher(launcher).Timeout(60*time.Second).SinceWatchedObjectResourceVersion().WaitFor(stopChan, tests.WarningEvent, "FailedMount")
+					event := tests.NewObjectEventWatcher(launcher).Timeout(tests.GetVMIStartTimeout()).SinceWatchedObjectResourceVersion().WaitFor(stopChan, tests.WarningEvent, "FailedMount")
 					Expect(event.Message).To(SatisfyAny(
 						ContainSubstring(`secret "nonexistent" not found`),
 						ContainSubstring(`secrets "nonexistent" not found`), // for k8s 1.11.x
@@ -411,7 +411,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 					// Wait for the VirtualMachineInstance to be started, allow warning events to occur
 					By("Checking that VirtualMachineInstance start succeeded")
-					tests.NewObjectEventWatcher(createdVMI).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).WaitFor(stopChan, tests.NormalEvent, v1.Started)
+					tests.NewObjectEventWatcher(createdVMI).SinceWatchedObjectResourceVersion().Timeout(tests.GetVMIStartTimeout()).WaitFor(stopChan, tests.NormalEvent, v1.Started)
 				})
 			})
 		})


### PR DESCRIPTION
This introduces a configurable timeout for the test suite. This is useful in slow environments--our tests have hard coded timeouts, and there's always a counterexample.
**Release note**:
```release-note
NONE
```
