### PR TITLE
Skip tests requiring CPU manager if feature gate is disabled

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	cpuManager            = "CPUManager"
+	CPUManager            = "CPUManager"
 	IgnitionGate          = "ExperimentalIgnitionSupport"
 	liveMigrationGate     = "LiveMigration"
 	CPUNodeDiscoveryGate  = "CPUNodeDiscovery"
@@ -42,7 +42,7 @@ func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
 }
 
 func (config *ClusterConfig) CPUManagerEnabled() bool {
-	return config.isFeatureGateEnabled(cpuManager)
+	return config.isFeatureGateEnabled(CPUManager)
 }
 
 func (config *ClusterConfig) IgnitionEnabled() bool {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -46,6 +46,7 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	kubevirt_hooks_v1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	hw_utils "kubevirt.io/kubevirt/pkg/util/hardware"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -1747,6 +1748,9 @@ var _ = Describe("Configurations", func() {
 			tests.PanicOnError(err)
 			if len(nodes.Items) == 1 {
 				Skip("Skip cpu pinning test that requires multiple nodes when only one node is present.")
+			}
+			if !tests.HasFeature(virtconfig.CPUManager) {
+				Skip("Skip tests requiring CPUManager if feature gate is not enabled.")
 			}
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In environments where CPU manager feature gate is disabled, tests requiring it will fail.

**Release note**:
-->
```release-note
NONE
```
