### PR TITLE
Support setting custom schedulers on VMIs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6948,6 +6948,10 @@
       "description": "Periodic probe of VirtualMachineInstance service readiness.\nVirtualmachineInstances will be removed from service endpoints if the probe fails.\nCannot be updated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes\n+optional",
       "$ref": "#/definitions/v1.Probe"
      },
+     "schedulerName": {
+      "description": "If specified, the VMI will be dispatched by specified scheduler.\nIf not specified, the VMI will be dispatched by default scheduler.\n+optional",
+      "type": "string"
+     },
      "subdomain": {
       "description": "If specified, the fully qualified vmi hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\".\nIf not specified, the vmi will not have a domainname at all. The DNS entry will resolve to the vmi,\nno matter if the vmi itself can pick up a hostname.\n+optional",
       "type": "string"

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1031,6 +1031,8 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	pod.Spec.Tolerations = vmi.Spec.Tolerations
 
+	pod.Spec.SchedulerName = vmi.Spec.SchedulerName
+
 	if len(serviceAccountName) > 0 {
 		pod.Spec.ServiceAccountName = serviceAccountName
 		automount := true

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -819,6 +819,19 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Tolerations).To(BeEquivalentTo([]kubev1.Toleration{{Key: podToleration.Key, TolerationSeconds: &tolerationSeconds}}))
 			})
 
+			It("should add the scheduler name to the pod", func() {
+				vm := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: "testvm", Namespace: "default", UID: "1234"},
+					Spec: v1.VirtualMachineInstanceSpec{
+						SchedulerName: "test-scheduler",
+						Domain:        v1.DomainSpec{},
+					},
+				}
+				pod, err := svc.RenderLaunchManifest(&vm)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.SchedulerName).To(Equal("test-scheduler"))
+			})
+
 			It("should use the hostname and subdomain if specified on the vm", func() {
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{Name: "testvm",

--- a/staging/src/kubevirt.io/client-go/api/v1/defaults_test.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/defaults_test.go
@@ -7,6 +7,18 @@ import (
 
 var _ = Describe("Defaults", func() {
 
+	It("should leave the scheduler name unset by default", func() {
+		vmi := &VirtualMachineInstance{}
+		SetObjectDefaults_VirtualMachineInstance(vmi)
+		Expect(vmi.Spec.SchedulerName).To(BeEmpty())
+	})
+
+	It("should take a custom scheduler if specified", func() {
+		vmi := &VirtualMachineInstance{Spec: VirtualMachineInstanceSpec{SchedulerName: "custom-one"}}
+		SetObjectDefaults_VirtualMachineInstance(vmi)
+		Expect(vmi.Spec.SchedulerName).To(Equal("custom-one"))
+	})
+
 	It("should add ACPI feature if it is unspecified", func() {
 		vmi := &VirtualMachineInstance{}
 		SetObjectDefaults_VirtualMachineInstance(vmi)

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -3526,6 +3526,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceSpec(ref common.Re
 							Ref:         ref("k8s.io/api/core/v1.Affinity"),
 						},
 					},
+					"schedulerName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, the VMI will be dispatched by specified scheduler. If not specified, the VMI will be dispatched by default scheduler.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tolerations": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If toleration is specified, obey all the toleration rules.",

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_test.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_test.go
@@ -233,7 +233,9 @@ var exampleJSON = `{
       }
     ]
   },
-  "status": {}
+  "status": {
+    "guestOSInfo": {}
+  }
 }`
 
 var _ = Describe("Schema", func() {
@@ -395,6 +397,7 @@ var _ = Describe("Schema", func() {
 				},
 			},
 		}
+
 		policy := IOThreadsPolicyShared
 		exampleVMI.Spec.Domain.IOThreadsPolicy = &policy
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -96,6 +96,10 @@ type VirtualMachineInstanceSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// If affinity is specifies, obey all the affinity rules
 	Affinity *k8sv1.Affinity `json:"affinity,omitempty"`
+	// If specified, the VMI will be dispatched by specified scheduler.
+	// If not specified, the VMI will be dispatched by default scheduler.
+	// +optional
+	SchedulerName string `json:"schedulerName,omitempty"`
 	// If toleration is specified, obey all the toleration rules.
 	Tolerations []k8sv1.Toleration `json:"tolerations,omitempty"`
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -23,6 +23,7 @@ func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 		"domain":                        "Specification of the desired behavior of the VirtualMachineInstance on the host.",
 		"nodeSelector":                  "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",
 		"affinity":                      "If affinity is specifies, obey all the affinity rules",
+		"schedulerName":                 "If specified, the VMI will be dispatched by specified scheduler.\nIf not specified, the VMI will be dispatched by default scheduler.\n+optional",
 		"tolerations":                   "If toleration is specified, obey all the toleration rules.",
 		"evictionStrategy":              "EvictionStrategy can be set to \"LiveMigrate\" if the VirtualMachineInstance should be\nmigrated instead of shut-off in case of a node drain.",
 		"terminationGracePeriodSeconds": "Grace period observed after signalling a VirtualMachineInstance to stop after which the VirtualMachineInstance is force terminated.",

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1524,6 +1524,16 @@ var _ = Describe("Configurations", func() {
 		})
 	})
 
+	Context("with a custom scheduler", func() {
+		It("schould set the custom scheduler on the pod", func() {
+			vmi := tests.NewRandomVMI()
+			vmi.Spec.SchedulerName = "my-custom-scheduler"
+			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
+			launcherPod := tests.GetPodByVirtualMachineInstance(runningVMI, tests.NamespaceTestDefault)
+			Expect(launcherPod.Spec.SchedulerName).To(Equal("my-custom-scheduler"))
+		})
+	})
+
 	Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with CPU request settings", func() {
 		defaultCPURequestKey := "cpu-request"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some people have custom schedulers. We can support them by adding a `schedulerName` field in the VMI and passing it to the launcher pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #3041

**Special notes for your reviewer**:

**Release note**:
```release-note
Allow setting custom schedulers on VMI specs
```
