### PR TITLE
Cleanup finalized vmi once domain is down. 

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -928,6 +928,9 @@ func (d *VirtualMachineController) defaultExecute(key string,
 	if domainExists && vmiExists && vmi.IsFinal() {
 		log.Log.Object(vmi).V(3).Info("Removing domain and ephemeral data for finalized vmi.")
 		shouldDelete = true
+	} else if !domainExists && vmiExists && vmi.IsFinal() {
+		log.Log.Object(vmi).V(3).Info("Cleaning up local data for finalized vmi.")
+		shouldCleanUp = true
 	}
 
 	// Determine if an active (or about to be active) VirtualMachineInstance should be updated.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If a vmi gracefully shuts down, we were not cleaning up the local data related to the vmi until the vmi object itself is deleted. This causes the watchdog to timeout and create a bunch of noise in virt-handler's logs.

So, a vmi's guest can gracefully terminate and leave the vmi object around in a finalized state. When this happens we need to clean up the local data related to that vmi or else we'll get a bunch of error messages in the logs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
