### PR TITLE
Fix fedora container-disk in template tests

### DIFF
--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -35,10 +35,10 @@ objects:
             disks:
             - disk:
                 bus: virtio
-              name: containerdisk
+              name: cloudinitdisk
             - disk:
                 bus: virtio
-              name: cloudinitdisk
+              name: containerdisk
             interfaces:
             - masquerade: {}
               model: virtio
@@ -55,15 +55,15 @@ objects:
           pod: {}
         terminationGracePeriodSeconds: 0
         volumes:
-        - containerDisk:
-            image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
-          name: containerdisk
         - cloudInitNoCloud:
             userData: |-
               #cloud-config
               password: fedora
               chpasswd: { expire: False }
           name: cloudinitdisk
+        - containerDisk:
+            image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
+          name: containerdisk
   status: {}
 parameters:
 - description: Name for the new VM

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -258,7 +258,7 @@ var _ = Describe("Templates", func() {
 
 		AfterEach(AssertTestCleanupSuccess())
 
-		FContext("with Fedora Template", func() {
+		Context("with Fedora Template", func() {
 			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTemplateFedoraWithContainerDisk(tests.ContainerDiskFor(tests.ContainerDiskFedora)), nil))
 
 			AssertTemplateTestSuccess()

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -258,8 +258,8 @@ var _ = Describe("Templates", func() {
 
 		AfterEach(AssertTestCleanupSuccess())
 
-		Context("with Fedora Template", func() {
-			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTemplateFedora(), nil))
+		FContext("with Fedora Template", func() {
+			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTemplateFedoraWithContainerDisk(tests.ContainerDiskFor(tests.ContainerDiskFedora)), nil))
 
 			AssertTemplateTestSuccess()
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a test that was using a container-disk image from a default registry that doesn't exist downstream.

**Special notes for your reviewer**:
The reason for the test failure was the package `kubevirt.io/kubevirt/tools/vms-generator/utils` is imported in the test, but because it is an internal package of the binary `vms-generator`, the flags the binary accepts are never parsed, specifically the image registry flag, and makes the package embed a default container-disk image to the returned vm template in the function `GetTemplateFedora()`.
This test adds a function that allows the tests to provide a container-disk image to embed in the template.