### PR TITLE
Use a properly SELinux-labelled location for the hostdisk in test 1681

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1598,7 +1598,7 @@ var _ = Describe("Configurations", func() {
 			tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 			tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
 			tests.AddPVCDisk(vmi, "block-pvc", "virtio", tests.BlockDiskForTest)
-			tests.AddHostDisk(vmi, "/run/kubevirt-private/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "hostdisk")
+			tests.AddHostDisk(vmi, "/run/kubevirt/vm-disks/test-disk.img", v1.HostDiskExistsOrCreate, "hostdisk")
 			tests.RunVMIAndExpectLaunch(vmi, 60)
 
 			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:
/run/kubevirt-private is labelled container_var_run_t, which containers (labelled container_t) can't write to.
/run/kubevirt is also a tmpfs location, but it has the label we want (container_file_t).
Switching to that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Should fix at least test 1681 on the 1.17 test lane.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
