### PR TITLE
Remove VMI ready condition when the pod is finalized

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -367,6 +367,9 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 			log.Log.V(3).Object(vmi).Infof("All pods have been deleted, removing finalizer")
 			controller.RemoveFinalizer(vmiCopy, virtv1.VirtualMachineInstanceFinalizer)
 		}
+
+		conditionManager.RemoveCondition(vmiCopy, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+
 	case vmi.IsRunning():
 		// Keep PodReady condition in sync with the VMI
 		if !podExists {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -885,6 +885,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			table.Entry("and in pending state", k8sv1.PodPending),
 		)
 
+		It("should remove ready condition when VMI is in a finalized state", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = v1.Succeeded
+
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{Type: v1.VirtualMachineInstanceReady}}
+			addVirtualMachine(vmi)
+
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Conditions)).To(Equal(0))
+			}).Return(vmi, nil)
+
+			controller.Execute()
+		})
+
 		It("should add a ready condition if it is present on the pod and the VMI is in running state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = v1.Running


### PR DESCRIPTION
**What this PR does / why we need it**:

A VMI with a guest that shutsdown gracefully will have the "Ready" condition equal "True" indefinitely because we aren't clearing that condition when the VMI is finalized. This has been overlooked because typically we shutdown VMIs by deleting the VMI object itself. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes clearing Ready condition for VMI in finalized state
```
