### PR TITLE
Adjust the SELinux context of /tmp/yyy before mounting it in storage tests

### DIFF
--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -518,7 +518,8 @@ var _ = Describe("Storage", func() {
 					tmpDir := "/tmp/kubevirt/" + rand.String(10)
 					mountDir = filepath.Join(tmpDir, "mount")
 					diskPath = filepath.Join(mountDir, "disk.img")
-					pod = tests.RenderHostPathJob("host-path-preparator", tmpDir, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationBidirectional, []string{"/usr/bin/bash", "-c"}, []string{fmt.Sprintf("mkdir -p %s && mkdir -p /tmp/yyy  && mount --bind /tmp/yyy %s && while true; do sleep 1; done", mountDir, mountDir)})
+					cmd := "mkdir -p " + mountDir + " && mkdir -p /tmp/yyy && chcon -t container_file_t /tmp/yyy && mount --bind /tmp/yyy " + mountDir + " && while true; do sleep 1; done"
+					pod = tests.RenderHostPathJob("host-path-preparator", tmpDir, k8sv1.HostPathDirectoryOrCreate, k8sv1.MountPropagationBidirectional, []string{"/usr/bin/bash", "-c"}, []string{cmd})
 					pod.Spec.Containers[0].Lifecycle = &k8sv1.Lifecycle{
 						PreStop: &k8sv1.Handler{
 							Exec: &k8sv1.ExecAction{


### PR DESCRIPTION
**What this PR does / why we need it**:
/tmp/yyy defaults to container_ro_file_t, which by definition can't be written to.
Since test 3109 actually writes to it, relabel it container_file_t.
Also re-factored that line that was really getting too long.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Should fix at least test 3109 on the 1.17 test lane.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
