### PR TITLE
Bump libvirt to 6.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -323,15 +323,16 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:cfff1e8729a7466581ba71d953b132beaef28f61b330f52caef6d0184e5f9af0",
+    digest = "sha256:584c7b49f1615e3f229668d530a79945ebf7f3afbab4ec554187e9ba2b754008",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
-    #tag = "tmp.20191126.748bd4d.x86_64",
+    #tag = "av-8.2-20200514-cc2bc34",
 )
 
+# TODO: Update this once we have PPC builds of the base image available
 container_pull(
     name = "libvirt_ppc64le",
-    digest = "sha256:9a24e6e9269c395e226b1dc949adce2076aaf5f20f882047116b3614b740294b",
+    digest = "sha256:NOT_AVAILABLE",  # Make sure we don't use outdated image by mistake
     puller_linux = "@go_puller_linux_ppc64le//file:downloaded",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -165,7 +165,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Eventually(logs,
 				2*time.Second,
 				500*time.Millisecond).
-				Should(And(ContainSubstring("internal error: Unable to get DBus system bus connection"), ContainSubstring(`"subcomponent":"libvirt"`)))
+				Should(And(ContainSubstring("At least one cgroup controller is required: No such device or address"), ContainSubstring(`"subcomponent":"libvirt"`)))
 		})
 
 		It("[test_id:3197]should log libvirtd debug logs when enabled", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In order to get latest bug fixes and features of libvirt, we should bump from
5.0 to 6.0. It would allow us to offload some of the tasks that are done in
virt-launcher to virt-handler and improve the overall security.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

* This is WIP testing changes made in https://github.com/kubevirt/libvirt/pull/48

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade to libvirt 6.0.0.
```
