### PR TITLE
Fix an erroneous comparison in CPUManager test

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1765,10 +1765,10 @@ var _ = Describe("Configurations", func() {
 		Context("with cpu pinning enabled", func() {
 			It("[test_id:1684]should set the cpumanager label to false when it's not running", func() {
 
-				By("adding a cpumanger=true lable to a node")
+				By("adding a cpumanger=true label to a node")
 				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(nodes.Items).To(HaveLen(1))
+				Expect(len(nodes.Items)).To(BeNumerically(">=", 1))
 
 				node := &nodes.Items[0]
 				node, err = virtClient.CoreV1().Nodes().Patch(node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, v1.CPUManager)))


### PR DESCRIPTION
This test previously assumed each cluster would have exactly one master
node.

**Release note**:
```release-note
None
```
