### PR TITLE
Address travis CI stalls in ppc64le

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,6 @@ build:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo
 run:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo
 test:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo
 
-build:ppc64le --platforms=@io_bazel_rules_go//go/toolchain:linux_ppc64le_cgo
+build:ppc64le --platforms=@io_bazel_rules_go//go/toolchain:linux_ppc64le_cgo --host_javabase=@local_jdk//:jdk
 run:ppc64le --platforms=@io_bazel_rules_go//go/toolchain:linux_ppc64le_cgo
 test:ppc64le --platforms=@io_bazel_rules_go//go/toolchain:linux_ppc64le_cgo --host_javabase=@local_jdk//:jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 arch:
 - amd64
-# - ppc64le # temporary disable until we have it under control again
+- ppc64le
 
 os: linux
 
@@ -15,6 +15,10 @@ install:
 - git reset --hard
 
 script:
+- |
+  if [[ $TRAVIS_CPU_ARCH == "ppc64le" ]]; then
+  while sleep 9m; do echo "Long running job - keep alive"; done & LOOP_PID=$!
+  fi
 - make generate
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
@@ -25,17 +29,14 @@ script:
   `make`. Please run it and commit the changes"; git status --porcelain; false; fi
 - make build-verify # verify that we set version on the packages built by bazel
 # The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
-- |
-  while sleep 9m; do echo "Long running job - keep alive"; done &
-  LOOP_PID=$!
 - if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then make goveralls; else make bazel-test; fi
-- kill $LOOP_PID
 - make build-verify # verify that we set version on the packages built by go(goveralls depends on go-build target)
 - make apidocs
 - make client-python
 - make manifests DOCKER_PREFIX="docker.io/kubevirt" DOCKER_TAG=$TRAVIS_TAG # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
 - make olm-verify
 - if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then make prom-rules-verify; fi
+- if [[ $TRAVIS_CPU_ARCH == "ppc64le" ]]; then kill $LOOP_PID; fi
 
 deploy:
 - provider: script

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -23,8 +23,8 @@ TEMPFILE=".rsynctemp"
 if [ -n "${TRAVIS_JOB_ID}" ]; then
     cat >ci.bazelrc <<EOF
 common --noshow_progress --noshow_loading_progress
-build:ppc64le --jobs=1
-run:ppc64le --jobs=1
+build:ppc64le --jobs=2
+run:ppc64le --jobs=2
 EOF
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR addresses the build failures seen in Travis for ppc64le due to no output being generated, the following error is seen in these cases:
"No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself."

It does so by moving the keep alive mechanism to run through the whole job. The patch also increases the number of jobs in bazel to 2 given it provides some performance benefit and so far it has not caused the issue of bazel server being abruptly ended.

**Special notes for your reviewer**:
We can ignore the first patch ("Add --host_javabase to fix ppc64le build") in the series and pick it up from PR #3225, I am just sending it along given it hasn't been incorporated in the upstream code yet and without it the build process in ppc64le is broken. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
