### PR TITLE
Ensure each permissions test uses a random user account

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
 	k8sv1 "k8s.io/api/core/v1"
 	v13 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -1474,12 +1475,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		Context("as ordinary OCP user trough test service account", func() {
+			var testUser string
+			var token string
+
 			BeforeEach(func() {
 				tests.SkipIfNoCmd("oc")
+				testUser = "testuser-" + uuid.NewRandom().String()
 			})
-
-			const testUser = "testuser"
-			var token string
 
 			Context("should succeed with right rights", func() {
 				BeforeEach(func() {


### PR DESCRIPTION
In order to ensure there's no overlap between user account permissions/roles tests, use a different account name for each one.

**Release note**:
```release-note
None
```
