### PR TITLE
Fix flaky comparison to VM phase

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -730,7 +730,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					return ""
 				}, 120*time.Second, 1*time.Second).Should(ContainSubstring("failed to find pod"))
 
-				waitForVMIScheduling(virtClient, newVMI)
+				waitForNewVMI(virtClient, newVMI)
 
 				By("Comparing the new CreationTimeStamp with the old one")
 				newVMI, err = virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &v12.GetOptions{})
@@ -1693,17 +1693,17 @@ func waitForVMIStart(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	}, 120*time.Second, 1*time.Second).Should(Equal(v1.Running), "New VMI was not created")
 }
 
-func waitForVMIScheduling(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	Eventually(func() v1.VirtualMachineInstancePhase {
+func waitForNewVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
+	Eventually(func() bool {
 		newVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.GetName(), &v12.GetOptions{})
 		if err != nil {
 			if !errors.IsNotFound(err) {
 				Expect(err).ToNot(HaveOccurred())
 			}
-			return v1.Unknown
+			return false
 		}
-		return newVMI.Status.Phase
-	}, 120*time.Second, 1*time.Second).Should(Equal(v1.Scheduling), "New VMI was not created")
+		return (newVMI.Status.Phase == v1.Scheduling) || (newVMI.Status.Phase == v1.Running)
+	}, 120*time.Second, 1*time.Second).Should(BeTrue(), "New VMI was not created")
 }
 
 func waitForResourceDeletion(k8sClient string, resourceType string, resourceName string) {


### PR DESCRIPTION
This test restarted a VMI, then waited for a re-spawned one to enter the
scheduling phase. This isn't reliable because the VMI can get past that
stage and be Running before the test starts watching for Scheduling.

**Release note**:
```release-note
None
```
