### PR TITLE
add configmap iso support for Windows (i.e. sysprep support)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,7 @@ func defaultCreateIsoImage(output string, files []string) error {
 	var args []string
 	args = append(args, "-output")
 	args = append(args, output)
+	args = append(args, "-follow-links")
 	args = append(args, "-volid")
 	args = append(args, "cfgdata")
 	args = append(args, "-joliet")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently all files coming via configMap are created as symlinks via an ISO file which works on Linux but shows 0 bytes on Windows. This PR adds '-follow-links' switch to iso generation so that the generated iso does not contain any symlink which enables use cases like providing Autounattended.xml for sysprep.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes 2902

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow windows picking up files in configmaps and secrets, by following symlinks when generating the corresponding ISOs.
```