### PR TITLE
Cloud-Init network data referenced by NetworkDataSecretRef does not work

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -511,38 +511,82 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			serviceAccountName = volume.ServiceAccount.ServiceAccountName
 		}
 
-		if volume.CloudInitNoCloud != nil && volume.CloudInitNoCloud.UserDataSecretRef != nil {
-			// attach a secret referenced by the user
-			volumes = append(volumes, k8sv1.Volume{
-				Name: volume.Name,
-				VolumeSource: k8sv1.VolumeSource{
-					Secret: &k8sv1.SecretVolumeSource{
-						SecretName: volume.CloudInitNoCloud.UserDataSecretRef.Name,
+		if volume.CloudInitNoCloud != nil {
+			if volume.CloudInitNoCloud.UserDataSecretRef != nil {
+				// attach a secret referenced by the user
+				volumeName := volume.Name + "-udata"
+				volumes = append(volumes, k8sv1.Volume{
+					Name: volumeName,
+					VolumeSource: k8sv1.VolumeSource{
+						Secret: &k8sv1.SecretVolumeSource{
+							SecretName: volume.CloudInitNoCloud.UserDataSecretRef.Name,
+						},
 					},
-				},
-			})
-			volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
-				Name:      volume.Name,
-				MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
-				ReadOnly:  true,
-			})
+				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userdata"),
+					SubPath:   "userdata",
+					ReadOnly:  true,
+				})
+			}
+			if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
+				// attach a secret referenced by the networkdata
+				volumeName := volume.Name + "-ndata"
+				volumes = append(volumes, k8sv1.Volume{
+					Name: volumeName,
+					VolumeSource: k8sv1.VolumeSource{
+						Secret: &k8sv1.SecretVolumeSource{
+							SecretName: volume.CloudInitNoCloud.NetworkDataSecretRef.Name,
+						},
+					},
+				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkdata"),
+					SubPath:   "networkdata",
+					ReadOnly:  true,
+				})
+			}
 		}
 
-		if volume.CloudInitConfigDrive != nil && volume.CloudInitConfigDrive.UserDataSecretRef != nil {
-			// attach a secret referenced by the user
-			volumes = append(volumes, k8sv1.Volume{
-				Name: volume.Name,
-				VolumeSource: k8sv1.VolumeSource{
-					Secret: &k8sv1.SecretVolumeSource{
-						SecretName: volume.CloudInitConfigDrive.UserDataSecretRef.Name,
+		if volume.CloudInitConfigDrive != nil {
+			if volume.CloudInitConfigDrive.UserDataSecretRef != nil {
+				// attach a secret referenced by the user
+				volumeName := volume.Name + "-udata"
+				volumes = append(volumes, k8sv1.Volume{
+					Name: volumeName,
+					VolumeSource: k8sv1.VolumeSource{
+						Secret: &k8sv1.SecretVolumeSource{
+							SecretName: volume.CloudInitConfigDrive.UserDataSecretRef.Name,
+						},
 					},
-				},
-			})
-			volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
-				Name:      volume.Name,
-				MountPath: filepath.Join(config.SecretSourceDir, volume.Name),
-				ReadOnly:  true,
-			})
+				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userdata"),
+					SubPath:   "userdata",
+					ReadOnly:  true,
+				})
+			}
+			if volume.CloudInitConfigDrive.NetworkDataSecretRef != nil {
+				// attach a secret referenced by the networkdata
+				volumeName := volume.Name + "-ndata"
+				volumes = append(volumes, k8sv1.Volume{
+					Name: volumeName,
+					VolumeSource: k8sv1.VolumeSource{
+						Secret: &k8sv1.SecretVolumeSource{
+							SecretName: volume.CloudInitConfigDrive.NetworkDataSecretRef.Name,
+						},
+					},
+				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkdata"),
+					SubPath:   "networkdata",
+					ReadOnly:  true,
+				})
+			}
 		}
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Template", func() {
 				Expect(debugLogsValue).To(Equal("1"))
 			})
 		})
-		Context("with cloud-init secret", func() {
+		Context("with cloud-init user secret", func() {
 			It("should add volume with secret referenced by cloud-init user secret ref", func() {
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -261,19 +261,63 @@ var _ = Describe("Template", func() {
 
 				cloudInitVolumeFound := false
 				for _, volume := range pod.Spec.Volumes {
-					if volume.Name == "cloud-init-user-data-secret-ref" {
+					if volume.Name == "cloud-init-user-data-secret-ref-udata" {
 						cloudInitVolumeFound = true
 					}
 				}
-				Expect(cloudInitVolumeFound).To(BeTrue(), "could not find cloud init secret volume")
+				Expect(cloudInitVolumeFound).To(BeTrue(), "could not find cloud init user secret volume")
 
 				cloudInitVolumeMountFound := false
 				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
-					if volumeMount.Name == "cloud-init-user-data-secret-ref" {
+					if volumeMount.Name == "cloud-init-user-data-secret-ref-udata" {
 						cloudInitVolumeMountFound = true
 					}
 				}
-				Expect(cloudInitVolumeMountFound).To(BeTrue(), "could not find cloud init secret volume mount")
+				Expect(cloudInitVolumeMountFound).To(BeTrue(), "could not find cloud init user secret volume mount")
+			})
+		})
+		Context("with cloud-init network data secret", func() {
+			It("should add volume with secret referenced by cloud-init network data secret ref", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "default",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{
+						Volumes: []v1.Volume{
+							{
+								Name: "cloud-init-network-data-secret-ref",
+								VolumeSource: v1.VolumeSource{
+									CloudInitNoCloud: &v1.CloudInitNoCloudSource{
+										UserDataSecretRef: &kubev1.LocalObjectReference{
+											Name: "some-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				cloudInitVolumeFound := false
+				for _, volume := range pod.Spec.Volumes {
+					if volume.Name == "cloud-init-network-data-secret-ref-ndata" {
+						cloudInitVolumeFound = true
+					}
+				}
+				Expect(cloudInitVolumeFound).To(BeTrue(), "could not find cloud init network secret volume")
+
+				cloudInitVolumeMountFound := false
+				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
+					if volumeMount.Name == "cloud-init-network-data-secret-ref-ndata" {
+						cloudInitVolumeMountFound = true
+					}
+				}
+				Expect(cloudInitVolumeMountFound).To(BeTrue(), "could not find cloud init network secret volume mount")
 			})
 		})
 		Context("with multus annotation", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Template", func() {
 								Name: "cloud-init-network-data-secret-ref",
 								VolumeSource: v1.VolumeSource{
 									CloudInitNoCloud: &v1.CloudInitNoCloudSource{
-										UserDataSecretRef: &kubev1.LocalObjectReference{
+										NetworkDataSecretRef: &kubev1.LocalObjectReference{
 											Name: "some-secret",
 										},
 									},


### PR DESCRIPTION

**What this PR does / why we need it**:
Cloud-Init network data referenced by NetworkDataSecretRef does not get propagated into the guest VM and this PR fixes that bug. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cloud-Init network data referenced by NetworkDataSecretRef in CloudInit config of VM definition does not propagate into the guest VM
```
