### PR TITLE
Use the correct DNS service name for OKD clusters

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4529,7 +4529,13 @@ func FormatIPForURL(ip string) string {
 }
 
 func getClusterDnsServiceIP(virtClient kubecli.KubevirtClient) (string, error) {
-	kubeDNSService, err := virtClient.CoreV1().Services("kube-system").Get("kube-dns", metav1.GetOptions{})
+	dnsServiceName := "kube-dns"
+	dnsNamespace := "kube-system"
+	if IsOpenShift() {
+		dnsServiceName = "dns-default"
+		dnsNamespace = "openshift-dns"
+	}
+	kubeDNSService, err := virtClient.CoreV1().Services(dnsNamespace).Get(dnsServiceName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On okd clusters, the DNS service is deployed in a different
namespace, and has a different name.

This patch addresses that difference, allowing the functional tests
to work both on k8s and okd clusters.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
