### PR TITLE
VMI configuration tests - Clear SMBIOS test data from configmap when the test ends

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4576,3 +4576,18 @@ func GetKubeVirtConfigMap() (*k8sv1.ConfigMap, error) {
 
 	return cfgMap, err
 }
+
+func ClearKubeVirtConfigMap(key string) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	cfgMap, err := GetKubeVirtConfigMap()
+	if err == nil {
+		if _, ok := cfgMap.Data[key]; ok {
+			data := fmt.Sprintf(`[{ "op": "remove", "path": "/data/%s"}]`, key)
+			_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Patch(virtconfig.ConfigMapName, types.JSONPatchType, []byte(data))
+		}
+	}
+
+	return err
+}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2295,12 +2295,12 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("[test_id:2752]test custom SMBios values", func() {
-
 			// Set a custom test SMBios
 			test_smbios := &cmdv1.SMBios{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
 			smbiosJson, err := json.Marshal(test_smbios)
 			Expect(err).ToNot(HaveOccurred())
-			tests.UpdateClusterConfigValueAndWait("smbios", string(smbiosJson))
+			tests.UpdateClusterConfigValueAndWait(virtconfig.SmbiosConfigKey, string(smbiosJson))
+			defer tests.ClearKubeVirtConfigMap(virtconfig.SmbiosConfigKey)
 
 			By("Starting a VirtualMachineInstance")
 			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
When testing custom SMBIOS settings we use KV configmap in order to propagate these settings. The issue was that the test does not clear these settings from the CM at the end. This PR fixes this issue.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Not cleaning the custom SMBIOS settings can lead to a failure of the default SMBIOS settings test. As it already happened on cluster that is frequently used to run functional tests on a nightly basis.

**Which issue(s) this PR fixes** 
Fixes #
Test 2752 - Custom SMBIOS settings
**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
