### PR TITLE
[release-0.26] Clear KubeVirt configmap after testing custom SMBIOS settings.

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4220,3 +4220,18 @@ func GetKubeVirtConfigMap() (*k8sv1.ConfigMap, error) {
 
 	return cfgMap, err
 }
+
+func ClearKubeVirtConfigMap(key string) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	cfgMap, err := GetKubeVirtConfigMap()
+	if err == nil {
+		if _, ok := cfgMap.Data[key]; ok {
+			data := fmt.Sprintf(`[{ "op": "remove", "path": "/data/%s"}]`, key)
+			_, err = virtClient.CoreV1().ConfigMaps(KubeVirtInstallNamespace).Patch(virtconfig.ConfigMapName, types.JSONPatchType, []byte(data))
+		}
+	}
+
+	return err
+}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2142,12 +2142,12 @@ var _ = Describe("Configurations", func() {
 		})
 
 		It("[test_id:2752]test custom SMBios values", func() {
-
 			// Set a custom test SMBios
 			test_smbios := &cmdv1.SMBios{Family: "test", Product: "test", Manufacturer: "None", Sku: "1.0", Version: "1.0"}
 			smbiosJson, err := json.Marshal(test_smbios)
 			Expect(err).ToNot(HaveOccurred())
-			tests.UpdateClusterConfigValueAndWait("smbios", string(smbiosJson))
+			tests.UpdateClusterConfigValueAndWait(virtconfig.SmbiosConfigKey, string(smbiosJson))
+			defer tests.ClearKubeVirtConfigMap(virtconfig.SmbiosConfigKey)
 
 			By("Starting a VirtualMachineInstance")
 			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/3292

-------

Using a new utility function to clear data on configmap.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**Release note**:
```release-note
NONE
```
