### PR TITLE
Make operator readiness probe pass without KubeVirt CR present

### DIFF
--- a/pkg/certificates/bootstrap/BUILD.bazel
+++ b/pkg/certificates/bootstrap/BUILD.bazel
@@ -6,9 +6,11 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/certificates/bootstrap",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
+        "//vendor/k8s.io/client-go/util/certificate:go_default_library",
     ],
 )
 
@@ -22,8 +24,10 @@ go_test(
     deps = [
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -386,5 +386,5 @@ func (app *VirtOperatorApp) AddFlags() {
 }
 
 func (app *VirtOperatorApp) prepareCertManagers() {
-	app.operatorCertManager = bootstrap.NewFileCertificateManager("/etc/virt-operator/certificates")
+	app.operatorCertManager = bootstrap.NewFallbackCertificateManager(bootstrap.NewFileCertificateManager("/etc/virt-operator/certificates"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In case of no active KubeVirt installation, the certificates for the
operator-readiness probes are never generated. In this case, fall back
to a self signed certificate. As soon as an installation is present, use
the "official" certificate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
