### PR TITLE
Run virt-launcher as spc_t for failing multiqueue tests

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -360,6 +360,11 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("[test_id:1665]should map cores to virtio net queues", func() {
+				// HACK: run virt-launcher as spc_t for this test.
+				// This should be removed once multiqueue works with container_t
+				// Note: It's ok for the value associated with SELinuxLauncherTypeKey to go from not present to "" since "" is its default value.
+				originalContext := tests.UpdateClusterConfigValueAndWait(virtconfig.SELinuxLauncherTypeKey, "spc_t")
+				defer tests.UpdateClusterConfigValueAndWait(virtconfig.SELinuxLauncherTypeKey, originalContext)
 				if shouldUseEmulation(virtClient) {
 					Skip("Software emulation should not be enabled for this test to run")
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
This should fix test 1665 on the k8s-1.17 lane.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
