### PR TITLE
Ensure that tests pick the right VMI pod after migrations

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3321,9 +3321,15 @@ func UnfinishedVMIPodSelector(vmi *v1.VirtualMachineInstance) metav1.ListOptions
 	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
-	fieldSelector := fields.ParseSelectorOrDie(
-		"status.phase!=" + string(k8sv1.PodFailed) +
-			",status.phase!=" + string(k8sv1.PodSucceeded))
+	fieldSelectorStr := "status.phase!=" + string(k8sv1.PodFailed) +
+		",status.phase!=" + string(k8sv1.PodSucceeded)
+
+	if vmi.Status.NodeName != "" {
+		fieldSelectorStr = fieldSelectorStr +
+			",spec.nodeName=" + vmi.Status.NodeName
+	}
+
+	fieldSelector := fields.ParseSelectorOrDie(fieldSelectorStr)
 	labelSelector, err := labels.Parse(fmt.Sprintf(v1.AppLabel + "=virt-launcher," + v1.CreatedByLabel + "=" + string(vmi.GetUID())))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

The source pod of a migration can still be alive when the migration is
already over. Ensure that we pick the right one of the two alive pods
when selecting the VMI pod in tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Fixes flakes in 

```
[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration Starting a VirtualMachineInstance with setting guest time should set an updated time after a migration
```

where it selects sometimes the wrong pod.

**Release note**:

```release-note
NONE
```
