### PR TITLE
Allow setting custom volume labels for configmap and secret volumes

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4549,6 +4549,10 @@
      "optional": {
       "description": "Specify whether the ConfigMap or it's keys must be defined\n+optional",
       "type": "boolean"
+     },
+     "volumeLabel": {
+      "description": "The volume label of the resulting disk inside the VMI.\nDifferent bootstrapping mechanisms require different values.\nTypical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).\n+optional",
+      "type": "string"
      }
     }
    },
@@ -5960,6 +5964,10 @@
      },
      "secretName": {
       "description": "Name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret\n+optional",
+      "type": "string"
+     },
+     "volumeLabel": {
+      "description": "The volume label of the resulting disk inside the VMI.\nDifferent bootstrapping mechanisms require different values.\nTypical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).\n+optional",
       "type": "string"
      }
     }

--- a/pkg/config/config-map.go
+++ b/pkg/config/config-map.go
@@ -47,7 +47,7 @@ func CreateConfigMapDisks(vmi *v1.VirtualMachineInstance) error {
 			}
 
 			disk := GetConfigMapDiskPath(volume.Name)
-			if err := createIsoConfigImage(disk, filesPath); err != nil {
+			if err := createIsoConfigImage(disk, volume.ConfigMap.VolumeLabel, filesPath); err != nil {
 				return err
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,7 +29,7 @@ type (
 	// Type represents allowed config types like ConfigMap or Secret
 	Type string
 
-	isoCreationFunc func(output string, files []string) error
+	isoCreationFunc func(output string, volID string, files []string) error
 )
 
 const (
@@ -84,12 +84,17 @@ func getFilesLayout(dirPath string) ([]string, error) {
 	return filesPath, nil
 }
 
-func defaultCreateIsoImage(output string, files []string) error {
+func defaultCreateIsoImage(output string, volID string, files []string) error {
+
+	if volID == "" {
+		volID = "cfgdata"
+	}
+
 	var args []string
 	args = append(args, "-output")
 	args = append(args, output)
 	args = append(args, "-volid")
-	args = append(args, "cfgdata")
+	args = append(args, volID)
 	args = append(args, "-joliet")
 	args = append(args, "-rock")
 	args = append(args, "-graft-points")
@@ -103,8 +108,8 @@ func defaultCreateIsoImage(output string, files []string) error {
 	return nil
 }
 
-func createIsoConfigImage(output string, files []string) error {
-	err := createISOImage(output, files)
+func createIsoConfigImage(output string, volID string, files []string) error {
+	err := createISOImage(output, volID, files)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func mockCreateISOImage(output string, files []string) error {
+func mockCreateISOImage(output string, volID string, files []string) error {
 	_, err := os.Create(output)
 	if err != nil {
 		panic(err)
@@ -73,7 +73,7 @@ var _ = Describe("Creating config images", func() {
 
 		It("Should create an iso image", func() {
 			imgPath := filepath.Join(tempISODir, "volume1.iso")
-			err := createIsoConfigImage(imgPath, expectedLayout)
+			err := createIsoConfigImage(imgPath, "", expectedLayout)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = os.Stat(imgPath)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/config/secret.go
+++ b/pkg/config/secret.go
@@ -48,7 +48,7 @@ func CreateSecretDisks(vmi *v1.VirtualMachineInstance) error {
 			}
 
 			disk := GetSecretDiskPath(volume.Name)
-			if err := createIsoConfigImage(disk, filesPath); err != nil {
+			if err := createIsoConfigImage(disk, volume.Secret.VolumeLabel, filesPath); err != nil {
 				return err
 			}
 

--- a/pkg/config/service-account.go
+++ b/pkg/config/service-account.go
@@ -42,7 +42,7 @@ func CreateServiceAccountDisk(vmi *v1.VirtualMachineInstance) error {
 			}
 
 			disk := GetServiceAccountDiskPath()
-			if err := createIsoConfigImage(disk, filesPath); err != nil {
+			if err := createIsoConfigImage(disk, "", filesPath); err != nil {
 				return err
 			}
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -549,6 +549,13 @@ func schema_kubevirtio_client_go_api_v1_ConfigMapVolumeSource(ref common.Referen
 							Format:      "",
 						},
 					},
+					"volumeLabel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -2411,6 +2418,13 @@ func schema_kubevirtio_client_go_api_v1_SecretVolumeSource(ref common.ReferenceC
 						SchemaProps: spec.SchemaProps{
 							Description: "Specify whether the Secret or it's keys must be defined",
 							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"volumeLabel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -66,6 +66,11 @@ type ConfigMapVolumeSource struct {
 	// Specify whether the ConfigMap or it's keys must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty"`
+	// The volume label of the resulting disk inside the VMI.
+	// Different bootstrapping mechanisms require different values.
+	// Typical values are "cidata" (cloud-init), "config-2" (cloud-init) or "OEMDRV" (kickstart).
+	// +optional
+	VolumeLabel string `json:"volumeLabel,omitempty"`
 }
 
 // SecretVolumeSource adapts a Secret into a volume.
@@ -79,6 +84,11 @@ type SecretVolumeSource struct {
 	// Specify whether the Secret or it's keys must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty"`
+	// The volume label of the resulting disk inside the VMI.
+	// Different bootstrapping mechanisms require different values.
+	// Typical values are "cidata" (cloud-init), "config-2" (cloud-init) or "OEMDRV" (kickstart).
+	// +optional
+	VolumeLabel string `json:"volumeLabel,omitempty"`
 }
 
 // ServiceAccountVolumeSource adapts a ServiceAccount into a volume.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -14,16 +14,18 @@ func (HostDisk) SwaggerDoc() map[string]string {
 
 func (ConfigMapVolumeSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":         "ConfigMapVolumeSource adapts a ConfigMap into a volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#configmap",
-		"optional": "Specify whether the ConfigMap or it's keys must be defined\n+optional",
+		"":            "ConfigMapVolumeSource adapts a ConfigMap into a volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes/#configmap",
+		"optional":    "Specify whether the ConfigMap or it's keys must be defined\n+optional",
+		"volumeLabel": "The volume label of the resulting disk inside the VMI.\nDifferent bootstrapping mechanisms require different values.\nTypical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).\n+optional",
 	}
 }
 
 func (SecretVolumeSource) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":           "SecretVolumeSource adapts a Secret into a volume.",
-		"secretName": "Name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret\n+optional",
-		"optional":   "Specify whether the Secret or it's keys must be defined\n+optional",
+		"":            "SecretVolumeSource adapts a Secret into a volume.",
+		"secretName":  "Name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret\n+optional",
+		"optional":    "Specify whether the Secret or it's keys must be defined\n+optional",
+		"volumeLabel": "The volume label of the resulting disk inside the VMI.\nDifferent bootstrapping mechanisms require different values.\nTypical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).\n+optional",
 	}
 }
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1287,8 +1287,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskFedora))
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 			tests.AddUserData(vmi, "cloud-init", "#cloud-config\npassword: fedora\nchpasswd: { expire: False }\n")
-			tests.AddConfigMapDisk(vmi, configMapName)
-			tests.AddSecretDisk(vmi, secretName)
+			tests.AddConfigMapDisk(vmi, configMapName, configMapName)
+			tests.AddSecretDisk(vmi, secretName, secretName)
 			tests.AddServiceAccountDisk(vmi, "default")
 			vmi.Spec.Domain.Devices = v1.Devices{Interfaces: []v1.Interface{{Name: "default", Tag: "testnic",
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2324,43 +2324,53 @@ func NewRandomVMIWithWatchdog() *v1.VirtualMachineInstance {
 
 func NewRandomVMIWithConfigMap(configMapName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMIWithPVC(DiskAlpineHostPath)
-	AddConfigMapDisk(vmi, configMapName)
+	AddConfigMapDisk(vmi, configMapName, configMapName)
 	return vmi
 }
 
-func AddConfigMapDisk(vmi *v1.VirtualMachineInstance, configMapName string) {
+func AddConfigMapDisk(vmi *v1.VirtualMachineInstance, configMapName string, volumeName string) {
+	AddConfigMapDiskWithCustomLabel(vmi, configMapName, volumeName, "")
+
+}
+func AddConfigMapDiskWithCustomLabel(vmi *v1.VirtualMachineInstance, configMapName string, volumeName string, volumeLabel string) {
 	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: configMapName + "-disk",
+		Name: volumeName,
 		VolumeSource: v1.VolumeSource{
 			ConfigMap: &v1.ConfigMapVolumeSource{
 				LocalObjectReference: k8sv1.LocalObjectReference{
 					Name: configMapName,
 				},
+				VolumeLabel: volumeLabel,
 			},
 		},
 	})
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name: configMapName + "-disk",
+		Name: volumeName,
 	})
 }
 
 func NewRandomVMIWithSecret(secretName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMIWithPVC(DiskAlpineHostPath)
-	AddSecretDisk(vmi, secretName)
+	AddSecretDisk(vmi, secretName, secretName)
 	return vmi
 }
 
-func AddSecretDisk(vmi *v1.VirtualMachineInstance, secretName string) {
+func AddSecretDisk(vmi *v1.VirtualMachineInstance, secretName string, volumeName string) {
+	AddSecretDiskWithCustomLabel(vmi, secretName, volumeName, "")
+}
+
+func AddSecretDiskWithCustomLabel(vmi *v1.VirtualMachineInstance, secretName string, volumeName string, volumeLabel string) {
 	vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-		Name: secretName + "-disk",
+		Name: volumeName,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
-				SecretName: secretName,
+				SecretName:  secretName,
+				VolumeLabel: volumeLabel,
 			},
 		},
 	})
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-		Name: secretName + "-disk",
+		Name: volumeName,
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows supporting different bootstrap solutions without having explicit support for them. For instance right now we don't have a special kickstart volume.
With this change people can just use configmaps and secrets right now without explicit support of the specific bootstrap mechanism.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3284 

**Special notes for your reviewer**:

**Release note**:

```release-note
Allow setting custom volume labels for configmap and secret volumes
```
