### PR TITLE
Compile functests with go test -c

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -19,9 +19,9 @@ PYTHON_CLIENT_OUT_DIR=$OUT_DIR/client-python
 ARCHITECTURE=$(uname -m)
 
 function build_func_tests() {
-    mkdir -p ${TESTS_OUT_DIR}/
-    GOPROXY=off GOFLAGS=-mod=vendor ginkgo build ${KUBEVIRT_DIR}/tests
-    mv ${KUBEVIRT_DIR}/tests/tests.test ${TESTS_OUT_DIR}/
+    mkdir -p "${TESTS_OUT_DIR}/"
+    GOPROXY=off GOFLAGS=-mod=vendor \
+        go test -c "${KUBEVIRT_DIR}/tests" -o "${TESTS_OUT_DIR}/tests.test"
 }
 
 function build_func_tests_image() {


### PR DESCRIPTION
Instead of using ginkgo's wrapper around go test -c, use go test -c
directly. This allows us to compile the tests in environments where the
ginkgo binary does not exist.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
