### PR TITLE
Test fixes - dmidecode file was missing on NGINX DL path of the HTTP CDI import server 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -561,6 +561,14 @@ http_file(
     ],
 )
 
+http_file(
+    name = "which",
+    sha256 = "a7557e0f91d7d710bb7cd939d4263ebbc84aeec9594d7dc4e062ace4b090e3b6",
+    urls = [
+        "https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/w/which-2.21-8.fc28.x86_64.rpm",
+    ],
+)
+
 # some repos which are not part of go_rules anymore
 go_repository(
     name = "com_github_golang_glog",

--- a/images/cdi-http-import-server/BUILD.bazel
+++ b/images/cdi-http-import-server/BUILD.bazel
@@ -31,6 +31,7 @@ rpm_image(
             "@libaio//file",
             "@e2fsprogs//file",
             "@dmidecode//file",
+            "@which//file",
         ],
     }),
 )

--- a/images/cdi-http-import-server/entrypoint.sh
+++ b/images/cdi-http-import-server/entrypoint.sh
@@ -57,9 +57,10 @@ elif [ -n "$AS_EMPTY" ]; then
     touch /tmp/healthy
     bash expose-as-iscsi.sh "${IMAGE_PATH}/disk.raw"
 else
-    # Expose qemu-guest-agent via nginx server
-    cp /usr/bin/qemu-ga /usr/share/nginx/html/
-    cp /usr/bin/stress /usr/share/nginx/html/
-    cp /usr/bin/dmidecode /usr/share/nginx/html/
+    # Expose binaries via nginx server
+    for executable in qemu-ga stress dmidecode; do
+        cp $(which $executable) /usr/share/nginx/html/
+    done
+
     /usr/sbin/nginx
 fi


### PR DESCRIPTION
The dmidecode utility is being downloaded from the CDI HTTP import server at the cloud-init stage.
We noticed that instead of a binary, 404 was returned. The issue was with incorrect source copy path in the entrypoint.sh script of the CDI HTTP container. Path is fixed using the which command.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Dmidecode is required is some tests in order to test various VMI configurations

**Which issue(s) this PR fixes** :
Fixes #
dmidecode related tests
**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
