### PR TITLE
Skip three flaky tests

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -507,7 +507,7 @@ var _ = Describe("Infrastructure", func() {
 			metricsURL = fmt.Sprintf("https://%s:%d/metrics", tests.FormatIPForURL(pod.Status.PodIP), 8443)
 		})
 
-		It("should find one leading virt-controller and two ready", func() {
+		PIt(" [flaky] should find one leading virt-controller and two ready", func() {
 			endpoint, err := virtClient.CoreV1().
 				Endpoints(tests.KubeVirtInstallNamespace).
 				Get("kubevirt-prometheus-metrics", metav1.GetOptions{})

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1224,7 +1224,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			},
 				table.Entry("[test_id:2226]with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
-				table.Entry("[test_id:2731]with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
+				table.PEntry("[test_id:2731] [flaky] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
 				tests.SkipMigrationTestIfRunnigOnKindInfra()

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -205,7 +205,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		tests.BeforeTestCleanup()
 	})
 
-	It("[test_id:3468]Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
+	PIt("[test_id:3468] [flaky] Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
 		By("Creating a new VM spec")
 		vm := tests.NewRandomVMWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 		Expect(vm).ToNot(BeNil())


### PR DESCRIPTION
**What this PR does / why we need it**:

Skipping three flaky tests which make merging almost impossible. We should fix them asap.

The tests are:

```
Infrastructure [rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com][level:component] Prometheus Endpoints should find one leading virt-controller and two ready
[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:component]VmWatch [test_id:3468]Should update vm status with the proper columns using 'kubectl get vm -w'
[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration Starting a VirtualMachineInstance live migration cancelation should be able to cancel a migration [test_id:2731]with OCS Disk
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
