### PR TITLE
Fix the testid for Should honor custom SELinux type for virt-launcher

### DIFF
--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -167,7 +167,7 @@ var _ = Describe("SecurityFeatures", func() {
 				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 			})
 
-			It("[test_id:3738]Should honor custom SELinux type for virt-launcher", func() {
+			It("[test_id:3787]Should honor custom SELinux type for virt-launcher", func() {
 				By("Starting a New VMI")
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: `Fix the testid for Should honor custom SELinux type for virt-launcher`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:  `Fix the testid for Should honor custom SELinux type for virt-launcher`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
