### PR TITLE
 Create loop devices on kubevirtci test nodes

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -61,11 +61,6 @@ if [[ "$KUBEVIRT_PROVIDER" =~ os-* ]] || [[ "$KUBEVIRT_PROVIDER" =~ (okd|ocp)-* 
     _kubectl adm policy add-scc-to-user privileged admin
 fi
 
-if [[ "$KUBEVIRT_PROVIDER" =~ kind.* ]]; then
-    #removing it since it's crashing with dind because loopback devices are shared with the host
-    _kubectl delete -n kubevirt ds disks-images-provider
-fi
-
 # Ensure the KubeVirt CRD is created
 count=0
 until _kubectl get crd kubevirts.kubevirt.io; do

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -114,6 +114,27 @@ spec:
               - /ready
             initialDelaySeconds: 10
             periodSeconds: 5
+        - name: loopdev
+          command:
+          - sh
+          - -c
+          - |
+            while true; do
+              for i in $(seq 0 5); do
+                  losetup -d /dev/loop$i
+                  rm -f /dev/loop$i
+                  mknod /dev/loop$i b 7 $i
+              done
+              sleep 100000000
+            done
+          image: {{.DockerPrefix}}/disks-images-provider:{{.DockerTag}}
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: dev
+            mountPath: /dev
       volumes:
         - name: images
           hostPath:
@@ -123,3 +144,6 @@ spec:
           hostPath:
             path: /mnt/local-storage
             type: DirectoryOrCreate
+        - name: dev
+          hostPath:
+            path: /dev

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -120,10 +120,10 @@ spec:
           - -c
           - |
             while true; do
-              for i in $(seq 0 5); do
-                  losetup -d /dev/loop$i
-                  rm -f /dev/loop$i
+              for i in $(seq 100); do
+                if ! [ -e /dev/loop$i ]; then
                   mknod /dev/loop$i b 7 $i
+                fi
               done
               sleep 100000000
             done

--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -120,11 +120,13 @@ spec:
           - -c
           - |
             while true; do
-              for i in $(seq 100); do
+              for i in $(seq 0 100); do
                 if ! [ -e /dev/loop$i ]; then
                   mknod /dev/loop$i b 7 $i
                 fi
               done
+              # XXX: we can't finish running because we're a DaemonSet
+              # Switch to being a Pod!
               sleep 100000000
             done
           image: {{.DockerPrefix}}/disks-images-provider:{{.DockerTag}}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -69,8 +69,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 
 			It("[test_id:782]Should be the fs layout the same for a pod and vmi", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				expectedOutput := "value1value2value3"
 
 				By("Running VMI")
@@ -164,7 +162,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			})
 
 			It("[test_id:779]Should be the fs layout the same for a pod and vmi", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
 
 				expectedOutput := "adminredhat"
 
@@ -243,8 +240,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		serviceAccountPath := config.ServiceAccountSourceDir
 
 		It("[test_id:998]Should be the namespace and token the same for a pod and vmi", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			By("Running VMI")
 			vmi := tests.NewRandomVMIWithServiceAccount("default")
 			tests.RunVMIAndExpectLaunch(vmi, 90)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -104,12 +104,11 @@ var _ = Describe("Storage", func() {
 		})
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]with Alpine PVC", func() {
 			table.DescribeTable("should be successfully started", func(newVMI VMICreationFunc, storageEngine string) {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				var ignoreWarnings bool
 				var pvName string
 				// Start the VirtualMachineInstance with the PVC attached
 				if storageEngine == "nfs" {
+					tests.SkipNFSTestIfRunnigOnKindInfra()
 					pvName = initNFS()
 					ignoreWarnings = true
 				} else {
@@ -129,8 +128,6 @@ var _ = Describe("Storage", func() {
 			)
 
 			table.DescribeTable("should be successfully started and stopped multiple times", func(newVMI VMICreationFunc) {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi = newVMI(tests.DiskAlpineHostPath)
 
 				num := 3
@@ -254,11 +251,11 @@ var _ = Describe("Storage", func() {
 
 			// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
 			table.DescribeTable("should be successfully started", func(newVMI VMICreationFunc, storageEngine string) {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
 				var ignoreWarnings bool
 				var pvName string
 				// Start the VirtualMachineInstance with the PVC attached
 				if storageEngine == "nfs" {
+					tests.SkipNFSTestIfRunnigOnKindInfra()
 					pvName = initNFS()
 					ignoreWarnings = true
 				} else {
@@ -278,8 +275,6 @@ var _ = Describe("Storage", func() {
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3137]should not persist data", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi = tests.NewRandomVMIWithEphemeralPVC(tests.DiskAlpineHostPath)
 
 				By("Starting the VirtualMachineInstance")
@@ -345,8 +340,6 @@ var _ = Describe("Storage", func() {
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3138]should start vmi multiple times", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi = tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 				tests.AddPVCDisk(vmi, "disk1", "virtio", tests.DiskCustomHostPath)
 
@@ -669,7 +662,6 @@ var _ = Describe("Storage", func() {
 
 			// Not a candidate for NFS because local volumes are used in test
 			It("[test_id:1015] should be successfully started", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi = tests.NewRandomVMIWithPVC(tests.BlockDiskForTest)
 				// Without userdata the hostname isn't set correctly and the login expecter fails...

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4723,12 +4723,6 @@ func SkipStressTestIfRunnigOnKindInfra() {
 	}
 }
 
-func SkipPVCTestIfRunnigOnKindInfra() {
-	if IsRunningOnKindInfra() {
-		Skip("Skip PVC tests till PR https://github.com/kubevirt/kubevirt/pull/3171 is merged")
-	}
-}
-
 func SkipNFSTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
 		Skip("Skip NFS tests till issue https://github.com/kubevirt/kubevirt/issues/3322 is fixed")

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1619,8 +1619,6 @@ var _ = Describe("Configurations", func() {
 		}, 60)
 
 		It("[test_id:1681]should set appropriate cache modes", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			vmi := tests.NewRandomVMI()
 			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
 


### PR DESCRIPTION
Create loop devices on kubevirtci test nodes
    
We cannot assume that loop devices will always exist on kubevirtci nodes.  For
example, the kind provider does not have them.  Instead we should create them
using a DaemonSet.  This fixes the disks-images-provider deployment on kind-*
providers so that we can run storage tests there.
    
A similar thing was done in k8s testing infrastructure which you can find here:
https://github.com/kubernetes/test-infra/pull/16230

Almost identical to #3171 except:
- It's a different PR so I can push code to it
- Checking for the existence of a loop device and creating if it doesn't exist, same as kubernetes/test-infra's latest code.
This should avoid the need for "rm" which feels like a risky operation (brought up by daniel belenky in the review for #3171)
- Re-enabled functional tests, they now pass
- Rebased on top of master

**Release note**:
```release-note
NONE
```
