### PR TITLE
Make default VM IPv6 CIDR human-friendly

### DIFF
--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -40,9 +40,9 @@ spec:
       userData: |-
         #!/bin/bash
         echo "fedora" |passwd fedora --stdin
-        ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0
+        ip -6 addr add fd10:0:2::2/120 dev eth0
         sleep 5
-        ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2
+        ip -6 route add default via fd10:0:2::1 src fd10:0:2::2
         yum install -y nginx
         systemctl enable nginx
         systemctl start nginx

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -4,7 +4,7 @@ const (
 	resolvConf        = "/etc/resolv.conf"
 	DefaultProtocol   = "TCP"
 	DefaultVMCIDR     = "10.0.2.0/24"
-	DefaultVMIpv6CIDR = "fd2e:f1fe:9490:a8ff::/120"
+	DefaultVMIpv6CIDR = "fd10:0:2::/120"
 	DefaultBridgeName = "k6t-eth0"
 )
 

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -77,10 +77,10 @@ var _ = Describe("Common Methods", func() {
 		})
 		It("Should return 2 IPV6 addresses", func() {
 			networkHandler := NetworkUtilsHandler{}
-			gw, vm, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd2e:f1fe:9490:a8ff::/120")
+			gw, vm, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd10:0:2::/120")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(gw).To(Equal("fd2e:f1fe:9490:a8ff::1/120"))
-			Expect(vm).To(Equal("fd2e:f1fe:9490:a8ff::2/120"))
+			Expect(gw).To(Equal("fd10:0:2::1/120"))
+			Expect(vm).To(Equal("fd10:0:2::2/120"))
 		})
 		It("Should fail when the subnet is too small", func() {
 			networkHandler := NetworkUtilsHandler{}
@@ -89,7 +89,7 @@ var _ = Describe("Common Methods", func() {
 		})
 		It("Should fail when the IPV6 subnet is too small", func() {
 			networkHandler := NetworkUtilsHandler{}
-			_, _, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd2e:f1fe:9490:a8ff::/127")
+			_, _, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd10:0:2::/127")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -188,8 +188,8 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeGwAddr).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeIpv6GwAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
-		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return("10.0.2.1/30", "10.0.2.2/30", nil)
-		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return("fd10:0:2::1/120", "fd10:0:2::2/120", nil)
+		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return(masqueradeGwStr, masqueradeVmStr, nil)
+		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return(masqueradeIpv6GwStr, masqueradeIpv6VmStr, nil)
 		// Global nat rules using iptables
 		mockNetwork.EXPECT().ConfigureIpv6Forwarding().Return(nil)
 		mockNetwork.EXPECT().GetNFTIPString(iptables.ProtocolIPv4).Return("ip").AnyTimes()

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -112,10 +112,10 @@ var _ = Describe("Pod Network", func() {
 		masqueradeVmStr = "10.0.2.2/30"
 		masqueradeVmAddr, _ = netlink.ParseAddr(masqueradeVmStr)
 		masqueradeVmIp = masqueradeVmAddr.IP.String()
-		masqueradeIpv6GwStr = "fd2e:f1fe:9490:a8ff::1/120"
+		masqueradeIpv6GwStr = "fd10:0:2::1/120"
 		masqueradeIpv6GwAddr, _ = netlink.ParseAddr(masqueradeIpv6GwStr)
 		masqueradeGwIpv6 = masqueradeIpv6GwAddr.IP.String()
-		masqueradeIpv6VmStr = "fd2e:f1fe:9490:a8ff::2/120"
+		masqueradeIpv6VmStr = "fd10:0:2::2/120"
 		masqueradeIpv6VmAddr, _ = netlink.ParseAddr(masqueradeIpv6VmStr)
 		masqueradeVmIpv6 = masqueradeIpv6VmAddr.IP.String()
 		masqueradeDummyName = fmt.Sprintf("%s-nic", api.DefaultBridgeName)
@@ -189,7 +189,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeIpv6GwAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return("10.0.2.1/30", "10.0.2.2/30", nil)
-		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return("fd2e:f1fe:9490:a8ff::1/120", "fd2e:f1fe:9490:a8ff::2/120", nil)
+		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return("fd10:0:2::1/120", "fd10:0:2::2/120", nil)
 		// Global nat rules using iptables
 		mockNetwork.EXPECT().ConfigureIpv6Forwarding().Return(nil)
 		mockNetwork.EXPECT().GetNFTIPString(iptables.ProtocolIPv4).Return("ip").AnyTimes()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2027,8 +2027,8 @@ func GetGuestAgentUserData() string {
 
 	ipv6UserDataString := ""
 	if netutils.IsIPv6String(dnsServerIP) {
-		ipv6UserDataString = fmt.Sprintf(`sudo ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0
-                             sudo ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2
+		ipv6UserDataString = fmt.Sprintf(`sudo ip -6 addr add fd10:0:2::2/120 dev eth0
+                             sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2
                              echo "nameserver %s" >> /etc/resolv.conf`, dnsServerIP)
 	}
 	return fmt.Sprintf(`#!/bin/bash
@@ -2779,13 +2779,13 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 	ipv6Batch := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "sudo ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0\n"},
+		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: "0"},
 		&expect.BSnd{S: "sleep 5\n"},
 		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "sudo ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2\n"},
+		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: "0"},

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -385,7 +385,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{v1.Network{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vm.Spec)
-	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0\nsleep 5\nip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
+	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nip -6 addr add fd10:0:2::2/120 dev eth0\nsleep 5\nip -6 route add default via fd10:0:2::1 src fd10:0:2::2\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
 
 	masquerade := &v1.InterfaceMasquerade{}
 	ports := []v1.Port{v1.Port{Name: "http", Protocol: "TCP", Port: 80}}


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR changes the default VM's IPv6 CIDR to more comfortable to work with CIDR, which also similar to the default IPv4 CIDR
```
IPv4 default CIRD:    10.0.2.0/24 :    10.0.2.1,    10.0.2.2, ... 10.0.2.255
IPv6 default CIRD: fd10:0:2::/120 : fd10:0:2::1, fd10:0:2::2, ... fd10:0:2::ff
```
The Ipv6 CIDR that I chose `fd10:2::/120` is in the ULA (unique local addresses) range on the local which is `fc00::/7`. 
The ULA range has two parts: 
    `fc00::/8` reserved for allocation from global authority (ISP,domain  DHCP servers..) 
   **` fd00::/8`** reserved for local assignments

**Which issue(s) this PR fixes**  
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
