### PR TITLE
Guest agent requires more time to sync ntp

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -535,7 +535,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(expecterErr).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				// Need to wait for cloud init to finnish and start the agent inside the vmi.
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Set wrong time on the guest")
@@ -567,7 +567,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					// get current time on the node
 					output := tests.RunCommandOnVmiPod(vmi, []string{"date", "+%H:%M"})
 					expectedTime := strings.TrimSpace(output)
-					log.DefaultLogger().Infof("expoected time: %v", expectedTime)
+					log.DefaultLogger().Infof("expected time: %v", expectedTime)
 
 					By("Checking that the guest has an updated time")
 					resp, err := expecterNew.ExpectBatch([]expect.Batcher{

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -579,7 +579,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						return false
 					}
 					return true
-				}, 240*time.Second, 1*time.Second).Should(BeTrue())
+				}, 320*time.Second, 1*time.Second).Should(BeTrue())
 			})
 		})
 		Context("with a shared ISCSI Filesystem PVC", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Give more time for the guest agent to update the VMs time
    
The test where the QEMU guest agent updates the VMs time to the
time of the host where the VM runs is misbehaving lately, causing
it to randomly fail (more often then not), as can be seen in the
flake finder, at [0].
    
Adjusting the test, giving more time to the guest agent to fulfill
its task seems to help stabilize the test, enabling it to give
deterministic results.

https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2020-04-22-168h.html

**Special notes for your reviewer**:
I know just giving more breathing room to each test is not an option, but right now, it's the simplest thing I can do.

Let me know if you feel more time should be spent here trying to understand why synching ntp on the guest suddenly takes more time.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
