### PR TITLE
Avoid unusable taints in test suite

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -604,6 +604,8 @@ func CleanNodes() {
 	PanicOnError(err)
 	nodes := GetAllSchedulableNodes(virtCli).Items
 
+	clusterDrainKey := GetNodeDrainKey()
+
 	for _, node := range nodes {
 
 		old, err := json.Marshal(node)
@@ -614,7 +616,11 @@ func CleanNodes() {
 		taints := []k8sv1.Taint{}
 		for _, taint := range node.Spec.Taints {
 
+			if taint.Key == clusterDrainKey && taint.Effect == k8sv1.TaintEffectNoSchedule {
+				found = true
+			}
 			if taint.Key == "kubevirt.io/drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
+				// this key is used as a fallback if the original drain key is built-in
 				found = true
 			} else if taint.Key == "kubevirt.io/alt-drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				// this key is used in testing as a custom alternate drain key

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4570,6 +4570,10 @@ func SkipMigrationTestIfRunnigOnKindInfra() {
 	}
 }
 
+func IsUsingBuiltinNodeDrainKey() bool {
+	return GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
+}
+
 func GetNodeDrainKey() string {
 	var data map[string]string
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -618,8 +618,7 @@ func CleanNodes() {
 
 			if taint.Key == clusterDrainKey && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				found = true
-			}
-			if taint.Key == "kubevirt.io/drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
+			} else if taint.Key == "kubevirt.io/drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {
 				// this key is used as a fallback if the original drain key is built-in
 				found = true
 			} else if taint.Key == "kubevirt.io/alt-drain" && taint.Effect == k8sv1.TaintEffectNoSchedule {


### PR DESCRIPTION
Some tests in our test suite use taints to trigger a migration. This is normally fine. However, in deployments where the node maintenance operator is installed, the `node.kubernetes.io/unschedulable` built-in taint is used. This taint cannot be applied manually. If this is the case, we can simply use another key.

**Release note**:
```release-note
NONE
```
