### PR TITLE
Fix unsupported agent condition flapping and resolve source of flaky tests.

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -649,13 +649,15 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 			match = match || regexp.MustCompile(version).MatchString(guestInfo.GAVersion)
 		}
 
-		if !match && !condManager.HasCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent) {
-			agentCondition := v1.VirtualMachineInstanceCondition{
-				Type:          v1.VirtualMachineInstanceUnsupportedAgent,
-				LastProbeTime: v12.Now(),
-				Status:        k8sv1.ConditionTrue,
+		if !match {
+			if !condManager.HasCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent) {
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceUnsupportedAgent,
+					LastProbeTime: v12.Now(),
+					Status:        k8sv1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 			}
-			vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 		} else {
 			condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceUnsupportedAgent)
 		}

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1224,7 +1224,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			},
 				table.Entry("[test_id:2226]with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
-				table.PEntry("[test_id:2731] [flaky] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
+				table.Entry("[test_id:2731] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
 				tests.SkipMigrationTestIfRunnigOnKindInfra()

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -205,7 +205,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		tests.BeforeTestCleanup()
 	})
 
-	PIt("[test_id:3468] [flaky] Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
+	It("[test_id:3468] Should update vm status with the proper columns using 'kubectl get vm -w'", func() {
 		By("Creating a new VM spec")
 		vm := tests.NewRandomVMWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 		Expect(vm).ToNot(BeNil())


### PR DESCRIPTION
A but was introduced in pr #3209 that caused some chaos in our functional test suite that was difficult to track down. What was happening is that every time the unsupported user agent condition was set, it would immediately trigger unsetting it, which would then immediately trigger setting it again... which resulted in an infinite tight reconcile loop. each loop would result in a write to etcd. So it created a storm of database writes as well.

This fixes condition setting issue and likely resolves many of our flaky tests in the process. During the process of investigating this, i noticed that we were comparing the conditions slice in a way that didn't account for ordering differences, so I resolved that as well.

Luckily we didn't have a release with this bug. We need to find a way to detect this sort of error in the future. Perhaps something that can detect how many reconcile loops our controllers invoke during the functional tests. For example, if a 60 second test has > 1000 writes to an object, something is probably wrong. 

```release-note
NONE
```
