### PR TITLE
Fix file access in docker build

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -1,6 +1,5 @@
 FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/kubevirt
-COPY ./hack/builder/rsyncd.conf /etc/rsyncd.conf
 COPY . .
 
 RUN source /etc/profile.d/gimme.sh && \

--- a/hack/ci/Dockerfile.ci-pr
+++ b/hack/ci/Dockerfile.ci-pr
@@ -1,6 +1,5 @@
 FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/kubevirt
-COPY ./hack/builder/rsyncd.conf /etc/rsyncd.conf
 COPY . .
 
 RUN source /etc/profile.d/gimme.sh && \

--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -16,6 +16,11 @@ bash -x ./hack/build-manifests.sh
 # build dump
 CMD_OUT_DIR="$(pwd)/_out/cmd"
 export CMD_OUT_DIR
-mkdir -p _out/cmd/dump/
+mkdir -p "$CMD_OUT_DIR/dump/"
 GOPROXY=off GOFLAGS=-mod=vendor go build -o "$CMD_OUT_DIR/dump/dump" ./cmd/dump
 bash -x ./hack/build-func-tests.sh
+
+rm -rf _ci-configs/
+
+# to avoid any permission problems we reset access rights recursively
+chmod -R 777 .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When running the tests the cluster-up writes configuration into _ci-configs/external, which it can't currently as somehow during the docker build the directory seems to be put in readonly mode for the user. To avoid this we reset access rights during image build.

See openshift/release#8545 for reference

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
