### PR TITLE
Add NET_RAW to virt-launcher template

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -60,6 +60,7 @@ const debugLogs = "debugLogs"
 const MultusNetworksAnnotation = "k8s.v1.cni.cncf.io/networks"
 
 const CAP_NET_ADMIN = "NET_ADMIN"
+const CAP_NET_RAW = "NET_RAW"
 const CAP_SYS_NICE = "SYS_NICE"
 
 // LibvirtStartupDelay is added to custom liveness and readiness probes initial delay value.
@@ -1084,6 +1085,10 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability 
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
 		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true) {
 		res = append(res, CAP_NET_ADMIN)
+		// The DHCP server needs the ability to use raw sockets. This
+		// capability is available by default in some clusters, but not
+		// a given.
+		res = append(res, CAP_NET_RAW)
 	}
 	// add a CAP_SYS_NICE capability to allow setting cpu affinity
 	res = append(res, CAP_SYS_NICE)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1517,14 +1517,10 @@ var _ = Describe("Template", func() {
 				Expect(ok).To(BeTrue())
 				Expect(int(tun.Value())).To(Equal(1))
 
-				found := false
 				caps := pod.Spec.Containers[0].SecurityContext.Capabilities
-				for _, cap := range caps.Add {
-					if cap == CAP_NET_ADMIN {
-						found = true
-					}
-				}
-				Expect(found).To(BeTrue(), "Expected compute container to be granted NET_ADMIN capability")
+
+				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_ADMIN)), "Expected compute container to be granted NET_ADMIN capability")
+				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to be granted NET_RAW capability")
 			})
 
 			It("Should require tun device if explicitly requested", func() {
@@ -1545,14 +1541,10 @@ var _ = Describe("Template", func() {
 				Expect(ok).To(BeTrue())
 				Expect(int(tun.Value())).To(Equal(1))
 
-				found := false
 				caps := pod.Spec.Containers[0].SecurityContext.Capabilities
-				for _, cap := range caps.Add {
-					if cap == CAP_NET_ADMIN {
-						found = true
-					}
-				}
-				Expect(found).To(BeTrue(), "Expected compute container to be granted NET_ADMIN capability")
+
+				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_ADMIN)), "Expected compute container to be granted NET_ADMIN capability")
+				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to be granted NET_RAW capability")
 			})
 
 			It("Should not require tun device if explicitly rejected", func() {
@@ -1572,14 +1564,10 @@ var _ = Describe("Template", func() {
 				_, ok := pod.Spec.Containers[0].Resources.Limits[TunDevice]
 				Expect(ok).To(BeFalse())
 
-				found := false
 				caps := pod.Spec.Containers[0].SecurityContext.Capabilities
-				for _, cap := range caps.Add {
-					if cap == CAP_NET_ADMIN {
-						found = true
-					}
-				}
-				Expect(found).To(BeFalse(), "Expected compute container to not be granted NET_ADMIN capability")
+
+				Expect(caps.Add).To(Not(ContainElement(kubev1.Capability(CAP_NET_ADMIN))), "Expected compute container not to be granted NET_ADMIN capability")
+				Expect(caps.Add).To(Not(ContainElement(kubev1.Capability(CAP_NET_RAW))), "Expected compute container not to be granted NET_RAW capability")
 			})
 		})
 

--- a/pkg/virt-operator/creation/components/scc.go
+++ b/pkg/virt-operator/creation/components/scc.go
@@ -74,7 +74,7 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyRunAsAny,
 	}
-	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE"}
+	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "NET_RAW", "SYS_NICE"}
 	scc.AllowHostDirVolumePlugin = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -553,14 +553,10 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					_, ok = container.Resources.Limits[services.TunDevice]
 					Expect(ok).To(BeFalse())
 
-					netAdminCap := false
 					caps := container.SecurityContext.Capabilities
-					for _, cap := range caps.Add {
-						if cap == "NET_ADMIN" {
-							netAdminCap = true
-						}
-					}
-					Expect(netAdminCap).To(BeFalse(), "Compute container should not have NET_ADMIN capability")
+
+					Expect(caps).To(Not(ContainElement(k8sv1.Capability("NET_ADMIN"))), "Compute container should not have NET_ADMIN capability")
+					Expect(caps).To(Not(ContainElement(k8sv1.Capability("NET_RAW"))), "Compute container should not have NET_RAW capability")
 				}
 			}
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -555,8 +555,8 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 					caps := container.SecurityContext.Capabilities
 
-					Expect(caps).To(Not(ContainElement(k8sv1.Capability("NET_ADMIN"))), "Compute container should not have NET_ADMIN capability")
-					Expect(caps).To(Not(ContainElement(k8sv1.Capability("NET_RAW"))), "Compute container should not have NET_RAW capability")
+					Expect(caps.Add).To(Not(ContainElement(k8sv1.Capability("NET_ADMIN"))), "Compute container should not have NET_ADMIN capability")
+					Expect(caps.Add).To(Not(ContainElement(k8sv1.Capability("NET_RAW"))), "Compute container should not have NET_RAW capability")
 				}
 			}
 


### PR DESCRIPTION
Signed-off-by: Marcus Sorensen <marcus_sorensen@apple.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Some clusters are locking down default capabilities, and NET_RAW is a common target. The virt-launcher requires/assumes NET_RAW to create a userspace DHCP server. This makes the requirement explicit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3337

**Special notes for your reviewer**:

See mailing list discussion: https://groups.google.com/forum/#!topic/kubevirt-dev/8X3U-yIGNMM

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
