### PR TITLE
Add a static label to virt-operator job podspec

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	virtOperatorJobAppLabel = "virt-operator"
+	virtOperatorJobAppLabel = "virt-operator-strategy-dumper"
 )
 
 type KubeVirtController struct {

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -44,6 +44,10 @@ import (
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
 
+const (
+	virtOperatorJobAppLabel = "virt-operator"
+)
+
 type KubeVirtController struct {
 	clientset            kubecli.KubevirtClient
 	queue                workqueue.RateLimitingInterface
@@ -678,7 +682,11 @@ func (c *KubeVirtController) generateInstallStrategyJob(config *operatorutil.Kub
 		},
 		Spec: batchv1.JobSpec{
 			Template: k8sv1.PodTemplateSpec{
-
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.AppLabel: virtOperatorJobAppLabel,
+					},
+				},
 				Spec: k8sv1.PodSpec{
 					ServiceAccountName: "kubevirt-operator",
 					RestartPolicy:      k8sv1.RestartPolicyNever,

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1745,6 +1745,24 @@ var _ = Describe("KubeVirt Operator", func() {
 
 		}, 15)
 
+		It("should label install strategy creation job", func(done Done) {
+			defer close(done)
+
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{util.KubeVirtFinalizer},
+				},
+				Status: v1.KubeVirtStatus{},
+			}
+
+			job, err := controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(job.Spec.Template.ObjectMeta.Labels).Should(HaveKeyWithValue(v1.AppLabel, virtOperatorJobAppLabel))
+		}, 15)
+
 		It("should delete install strategy creation job if job has failed", func(done Done) {
 			defer close(done)
 


### PR DESCRIPTION
This allows network policy to apply to job pod

Signed-off-by: Marcus Sorensen <marcus_sorensen@apple.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This adds a static label to the virt-operator job's pod, which in turn allows us to target it with network policy, pod presets, etc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3339 

**Special notes for your reviewer**:
See mailing list discussion: https://groups.google.com/forum/#!topic/kubevirt-dev/X0NjRDuoFWs

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```