### PR TITLE
KubeVirt v1 GA api

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -92,13 +92,13 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/": {
+   "/apis/kubevirt.io/v1/": {
     "get": {
      "description": "Get KubeVirt API Resources",
      "produces": [
       "application/json"
      ],
-     "operationId": "getAPIResources-kubevirt.io-v1alpha3",
+     "operationId": "getAPIResources-kubevirt.io-v1",
      "responses": {
       "200": {
        "description": "OK",
@@ -118,7 +118,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/kubevirt": {
+   "/apis/kubevirt.io/v1/kubevirt": {
     "get": {
      "description": "Get a list of all KubeVirt objects.",
      "produces": [
@@ -201,7 +201,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt": {
     "get": {
      "description": "Get a list of KubeVirt objects.",
      "produces": [
@@ -428,7 +428,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt/{name:[a-z0-9][a-z0-9\\-]*}": {
     "get": {
      "description": "Get a KubeVirt object.",
      "produces": [
@@ -621,7 +621,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations": {
     "get": {
      "description": "Get a list of VirtualMachineInstanceMigration objects.",
      "produces": [
@@ -848,7 +848,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations/{name:[a-z0-9][a-z0-9\\-]*}": {
     "get": {
      "description": "Get a VirtualMachineInstanceMigration object.",
      "produces": [
@@ -1041,7 +1041,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets": {
     "get": {
      "description": "Get a list of VirtualMachineInstancePreset objects.",
      "produces": [
@@ -1268,7 +1268,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets/{name:[a-z0-9][a-z0-9\\-]*}": {
     "get": {
      "description": "Get a VirtualMachineInstancePreset object.",
      "produces": [
@@ -1461,7 +1461,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets": {
     "get": {
      "description": "Get a list of VirtualMachineInstanceReplicaSet objects.",
      "produces": [
@@ -1688,7 +1688,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets/{name:[a-z0-9][a-z0-9\\-]*}": {
     "get": {
      "description": "Get a VirtualMachineInstanceReplicaSet object.",
      "produces": [
@@ -1881,7 +1881,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances": {
     "get": {
      "description": "Get a list of VirtualMachineInstance objects.",
      "produces": [
@@ -2108,7 +2108,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}": {
     "get": {
      "description": "Get a VirtualMachineInstance object.",
      "produces": [
@@ -2301,7 +2301,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines": {
     "get": {
      "description": "Get a list of VirtualMachine objects.",
      "produces": [
@@ -2528,7 +2528,7 @@
      }
     }
    },
-   "/apis/kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}": {
+   "/apis/kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}": {
     "get": {
      "description": "Get a VirtualMachine object.",
      "produces": [
@@ -2721,7 +2721,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/virtualmachineinstancemigrations": {
+   "/apis/kubevirt.io/v1/virtualmachineinstancemigrations": {
     "get": {
      "description": "Get a list of all VirtualMachineInstanceMigration objects.",
      "produces": [
@@ -2804,7 +2804,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/virtualmachineinstancepresets": {
+   "/apis/kubevirt.io/v1/virtualmachineinstancepresets": {
     "get": {
      "description": "Get a list of all VirtualMachineInstancePreset objects.",
      "produces": [
@@ -2887,7 +2887,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/virtualmachineinstancereplicasets": {
+   "/apis/kubevirt.io/v1/virtualmachineinstancereplicasets": {
     "get": {
      "description": "Get a list of all VirtualMachineInstanceReplicaSet objects.",
      "produces": [
@@ -2970,7 +2970,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/virtualmachineinstances": {
+   "/apis/kubevirt.io/v1/virtualmachineinstances": {
     "get": {
      "description": "Get a list of all VirtualMachineInstance objects.",
      "produces": [
@@ -3053,7 +3053,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/virtualmachines": {
+   "/apis/kubevirt.io/v1/virtualmachines": {
     "get": {
      "description": "Get a list of all VirtualMachine objects.",
      "produces": [
@@ -3136,7 +3136,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/kubevirt": {
+   "/apis/kubevirt.io/v1/watch/kubevirt": {
     "get": {
      "description": "Watch a KubeVirtList object.",
      "produces": [
@@ -3217,7 +3217,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/kubevirt": {
     "get": {
      "description": "Watch a KubeVirt object.",
      "produces": [
@@ -3306,7 +3306,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancemigrations": {
     "get": {
      "description": "Watch a VirtualMachineInstanceMigration object.",
      "produces": [
@@ -3395,7 +3395,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancepresets": {
     "get": {
      "description": "Watch a VirtualMachineInstancePreset object.",
      "produces": [
@@ -3484,7 +3484,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstancereplicasets": {
     "get": {
      "description": "Watch a VirtualMachineInstanceReplicaSet object.",
      "produces": [
@@ -3573,7 +3573,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances": {
     "get": {
      "description": "Watch a VirtualMachineInstance object.",
      "produces": [
@@ -3662,7 +3662,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines": {
+   "/apis/kubevirt.io/v1/watch/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines": {
     "get": {
      "description": "Watch a VirtualMachine object.",
      "produces": [
@@ -3751,7 +3751,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/virtualmachineinstancemigrations": {
+   "/apis/kubevirt.io/v1/watch/virtualmachineinstancemigrations": {
     "get": {
      "description": "Watch a VirtualMachineInstanceMigrationList object.",
      "produces": [
@@ -3832,7 +3832,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/virtualmachineinstancepresets": {
+   "/apis/kubevirt.io/v1/watch/virtualmachineinstancepresets": {
     "get": {
      "description": "Watch a VirtualMachineInstancePresetList object.",
      "produces": [
@@ -3913,7 +3913,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/virtualmachineinstancereplicasets": {
+   "/apis/kubevirt.io/v1/watch/virtualmachineinstancereplicasets": {
     "get": {
      "description": "Watch a VirtualMachineInstanceReplicaSetList object.",
      "produces": [
@@ -3994,7 +3994,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/virtualmachineinstances": {
+   "/apis/kubevirt.io/v1/watch/virtualmachineinstances": {
     "get": {
      "description": "Watch a VirtualMachineInstanceList object.",
      "produces": [
@@ -4075,7 +4075,7 @@
      }
     ]
    },
-   "/apis/kubevirt.io/v1alpha3/watch/virtualmachines": {
+   "/apis/kubevirt.io/v1/watch/virtualmachines": {
     "get": {
      "description": "Watch a VirtualMachineList object.",
      "produces": [
@@ -6233,7 +6233,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "getSubAPIGroup",
+     "operationId": "v1alpha3GetSubAPIGroup",
      "responses": {
       "200": {
        "description": "OK",
@@ -6253,13 +6253,763 @@
      }
     }
    },
+   "/apis/subresources.kubevirt.io/v1/": {
+    "get": {
+     "description": "Get a KubeVirt API resources",
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1getAPISubResources",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResourceList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1/healthz": {
+    "get": {
+     "description": "Health endpoint",
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1CheckHealth",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "500": {
+       "description": "Unhealthy",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
+    "put": {
+     "description": "Add a volume and disk to a running Virtual Machine Instance",
+     "operationId": "v1vmi-addvolume",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/console": {
+    "get": {
+     "description": "Open a websocket connection to a serial console on the specified VirtualMachineInstance.",
+     "operationId": "v1Console",
+     "responses": {
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/filesystemlist": {
+    "get": {
+     "description": "Get list of active filesystems on guest machine via guest agent",
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1Filesystemlist",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.VirtualMachineInstanceFileSystemList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/guestosinfo": {
+    "get": {
+     "description": "Get guest agent os information",
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1Guestosinfo",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.VirtualMachineInstanceGuestAgentInfo"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/pause": {
+    "put": {
+     "description": "Pause a VirtualMachineInstance object.",
+     "operationId": "v1Pause",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
+    "put": {
+     "description": "Removes a volume and disk from a running Virtual Machine Instance",
+     "operationId": "v1vmi-removevolume",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/test": {
+    "get": {
+     "description": "Test endpoint verifying apiserver connectivity.",
+     "operationId": "v1Test",
+     "responses": {
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unpause": {
+    "put": {
+     "description": "Unpause a VirtualMachineInstance object.",
+     "operationId": "v1Unpause",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/userlist": {
+    "get": {
+     "description": "Get list of active users via guest agent",
+     "consumes": [
+      "application/json"
+     ],
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1Userlist",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "$ref": "#/definitions/v1.VirtualMachineInstanceGuestOSUserList"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    }
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vnc": {
+    "get": {
+     "description": "Open a websocket connection to connect to VNC on the specified VirtualMachineInstance.",
+     "operationId": "v1VNC",
+     "responses": {
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
+    "put": {
+     "description": "Add a volume and disk to a running Virtual Machine.",
+     "operationId": "v1vm-addvolume",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/migrate": {
+    "put": {
+     "description": "Migrate a running VirtualMachine to another node.",
+     "operationId": "v1Migrate",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
+    "put": {
+     "description": "Removes a volume and disk from a running Virtual Machine.",
+     "operationId": "v1vm-removevolume",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/rename": {
+    "put": {
+     "description": "Rename a stopped VirtualMachine object.",
+     "operationId": "v1Rename",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "202": {
+       "description": "Accepted",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/restart": {
+    "put": {
+     "description": "Restart a VirtualMachine object.",
+     "operationId": "v1Restart",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "schema": {
+        "$ref": "#/definitions/v1.RestartOptions"
+       }
+      }
+     ],
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/start": {
+    "put": {
+     "description": "Start a VirtualMachine object.",
+     "operationId": "v1Start",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/stop": {
+    "put": {
+     "description": "Stop a VirtualMachine object.",
+     "operationId": "v1Stop",
+     "responses": {
+      "200": {
+       "description": "OK",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "400": {
+       "description": "Bad Request",
+       "schema": {
+        "type": "string"
+       }
+      },
+      "401": {
+       "description": "Unauthorized"
+      },
+      "404": {
+       "description": "Not Found",
+       "schema": {
+        "type": "string"
+       }
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Name of the resource",
+      "name": "name",
+      "in": "path",
+      "required": true
+     },
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "Object name and auth scope, such as for teams and projects",
+      "name": "namespace",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
+   "/apis/subresources.kubevirt.io/v1/version": {
+    "get": {
+     "produces": [
+      "application/json"
+     ],
+     "operationId": "v1Version",
+     "responses": {
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    }
+   },
    "/apis/subresources.kubevirt.io/v1alpha3/": {
     "get": {
      "description": "Get a KubeVirt API resources",
      "produces": [
       "application/json"
      ],
-     "operationId": "getAPISubResources",
+     "operationId": "v1alpha3getAPISubResources",
      "responses": {
       "200": {
        "description": "OK",
@@ -6288,7 +7038,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "checkHealth",
+     "operationId": "v1alpha3CheckHealth",
      "responses": {
       "200": {
        "description": "OK",
@@ -6311,7 +7061,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
-     "operationId": "vmi-addvolume",
+     "operationId": "v1alpha3vmi-addvolume",
      "responses": {
       "200": {
        "description": "OK",
@@ -6352,7 +7102,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/console": {
     "get": {
      "description": "Open a websocket connection to a serial console on the specified VirtualMachineInstance.",
-     "operationId": "console",
+     "operationId": "v1alpha3Console",
      "responses": {
       "401": {
        "description": "Unauthorized"
@@ -6387,7 +7137,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "filesystemlist",
+     "operationId": "v1alpha3Filesystemlist",
      "responses": {
       "200": {
        "description": "OK",
@@ -6410,7 +7160,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "guestosinfo",
+     "operationId": "v1alpha3Guestosinfo",
      "responses": {
       "200": {
        "description": "OK",
@@ -6445,7 +7195,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/pause": {
     "put": {
      "description": "Pause a VirtualMachineInstance object.",
-     "operationId": "pause",
+     "operationId": "v1alpha3Pause",
      "responses": {
       "200": {
        "description": "OK",
@@ -6492,7 +7242,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
-     "operationId": "vmi-removevolume",
+     "operationId": "v1alpha3vmi-removevolume",
      "responses": {
       "200": {
        "description": "OK",
@@ -6533,7 +7283,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/test": {
     "get": {
      "description": "Test endpoint verifying apiserver connectivity.",
-     "operationId": "test",
+     "operationId": "v1alpha3Test",
      "responses": {
       "401": {
        "description": "Unauthorized"
@@ -6562,7 +7312,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/unpause": {
     "put": {
      "description": "Unpause a VirtualMachineInstance object.",
-     "operationId": "unpause",
+     "operationId": "v1alpha3Unpause",
      "responses": {
       "200": {
        "description": "OK",
@@ -6615,7 +7365,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "userlist",
+     "operationId": "v1alpha3Userlist",
      "responses": {
       "200": {
        "description": "OK",
@@ -6632,7 +7382,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachineinstances/{name:[a-z0-9][a-z0-9\\-]*}/vnc": {
     "get": {
      "description": "Open a websocket connection to connect to VNC on the specified VirtualMachineInstance.",
-     "operationId": "vnc",
+     "operationId": "v1alpha3VNC",
      "responses": {
       "401": {
        "description": "Unauthorized"
@@ -6661,7 +7411,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/addvolume": {
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
-     "operationId": "vm-addvolume",
+     "operationId": "v1alpha3vm-addvolume",
      "responses": {
       "200": {
        "description": "OK",
@@ -6702,7 +7452,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/migrate": {
     "put": {
      "description": "Migrate a running VirtualMachine to another node.",
-     "operationId": "migrate",
+     "operationId": "v1alpha3Migrate",
      "responses": {
       "200": {
        "description": "OK",
@@ -6749,7 +7499,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/removevolume": {
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
-     "operationId": "vm-removevolume",
+     "operationId": "v1alpha3vm-removevolume",
      "responses": {
       "200": {
        "description": "OK",
@@ -6790,7 +7540,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/rename": {
     "put": {
      "description": "Rename a stopped VirtualMachine object.",
-     "operationId": "rename",
+     "operationId": "v1alpha3Rename",
      "responses": {
       "200": {
        "description": "OK",
@@ -6843,7 +7593,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/restart": {
     "put": {
      "description": "Restart a VirtualMachine object.",
-     "operationId": "restart",
+     "operationId": "v1alpha3Restart",
      "parameters": [
       {
        "name": "body",
@@ -6899,7 +7649,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/start": {
     "put": {
      "description": "Start a VirtualMachine object.",
-     "operationId": "start",
+     "operationId": "v1alpha3Start",
      "responses": {
       "200": {
        "description": "OK",
@@ -6946,7 +7696,7 @@
    "/apis/subresources.kubevirt.io/v1alpha3/namespaces/{namespace:[a-z0-9][a-z0-9\\-]*}/virtualmachines/{name:[a-z0-9][a-z0-9\\-]*}/stop": {
     "put": {
      "description": "Stop a VirtualMachine object.",
-     "operationId": "stop",
+     "operationId": "v1alpha3Stop",
      "responses": {
       "200": {
        "description": "OK",
@@ -6995,7 +7745,7 @@
      "produces": [
       "application/json"
      ],
-     "operationId": "version",
+     "operationId": "v1alpha3Version",
      "responses": {
       "401": {
        "description": "Unauthorized"

--- a/examples/migration-job.yaml
+++ b/examples/migration-job.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstanceMigration
 metadata:
   name: migration-job

--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:

--- a/examples/vm-alpine-multipvc.yaml
+++ b/examples/vm-alpine-multipvc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:

--- a/examples/vm-template-fedora.yaml
+++ b/examples/vm-template-fedora.yaml
@@ -11,7 +11,7 @@ metadata:
     miq.github.io/kubevirt-is-vm-template: "true"
   name: vm-template-fedora
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     creationTimestamp: null

--- a/examples/vm-template-rhel7.yaml
+++ b/examples/vm-template-rhel7.yaml
@@ -11,7 +11,7 @@ metadata:
     miq.github.io/kubevirt-is-vm-template: "true"
   name: vm-template-rhel7
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     creationTimestamp: null

--- a/examples/vm-template-windows2012r2.yaml
+++ b/examples/vm-template-windows2012r2.yaml
@@ -11,7 +11,7 @@ metadata:
     miq.github.io/kubevirt-is-vm-template: "true"
   name: vm-template-windows2012r2
 objects:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   kind: VirtualMachine
   metadata:
     creationTimestamp: null

--- a/examples/vmi-alpine-efi.yaml
+++ b/examples/vmi-alpine-efi.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-block-pvc.yaml
+++ b/examples/vmi-block-pvc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-flavor-small.yaml
+++ b/examples/vmi-flavor-small.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-gpu.yaml
+++ b/examples/vmi-gpu.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-host-disk.yaml
+++ b/examples/vmi-host-disk.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-macvtap.yaml
+++ b/examples/vmi-macvtap.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-nocloud.yaml
+++ b/examples/vmi-nocloud.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-preset-small.yaml
+++ b/examples/vmi-preset-small.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstancePreset
 metadata:
   name: vmi-preset-small

--- a/examples/vmi-pvc.yaml
+++ b/examples/vmi-pvc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-replicaset-cirros.yaml
+++ b/examples/vmi-replicaset-cirros.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstanceReplicaSet
 metadata:
   name: vmi-replicaset-cirros

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-slirp.yaml
+++ b/examples/vmi-slirp.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-windows.yaml
+++ b/examples/vmi-windows.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/examples/vmi-with-sidecar-hook.yaml
+++ b/examples/vmi-with-sidecar-hook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   annotations:

--- a/manifests/generated/kubevirt-cr.yaml.in
+++ b/manifests/generated/kubevirt-cr.yaml.in
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: KubeVirt
 metadata:
   name: kubevirt

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1041,8 +1041,11 @@ spec:
       required:
       - spec
       type: object
-  version: v1alpha3
+  version: v1
   versions:
+  - name: v1
+    served: true
+    storage: false
   - name: v1alpha3
     served: true
     storage: true

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -7,7 +7,7 @@ metadata:
 
             [
               {
-                "apiVersion":"kubevirt.io/v1alpha3",
+                "apiVersion":"kubevirt.io/v1",
                 "kind":"KubeVirt",
                 "metadata": {
                   "name":"kubevirt",
@@ -88,7 +88,7 @@ spec:
         path: operatorVersion
         x-descriptors:
         - urn:alm:descriptor:text
-      version: v1alpha3
+      version: v1
   description: |2
 
     **KubeVirt** is a virtual machine management add-on for Kubernetes.

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -195,7 +195,7 @@ func (app *virtAPIApp) composeSubresources() {
 			To(subresourceApp.RestartVMRequestHandler).
 			Reads(v1.RestartOptions{}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("restart").
+			Operation(version.Version+"Restart").
 			Doc("Restart a VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusNotFound, "Not Found", "").
@@ -206,7 +206,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("migrate")).
 			To(subresourceApp.MigrateVMRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("migrate").
+			Operation(version.Version+"Migrate").
 			Doc("Migrate a running VirtualMachine to another node.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusNotFound, "Not Found", "").
@@ -215,7 +215,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("start")).
 			To(subresourceApp.StartVMRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("start").
+			Operation(version.Version+"Start").
 			Doc("Start a VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusNotFound, "Not Found", "").
@@ -224,7 +224,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("stop")).
 			To(subresourceApp.StopVMRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("stop").
+			Operation(version.Version+"Stop").
 			Doc("Stop a VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusNotFound, "Not Found", "").
@@ -233,7 +233,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("pause")).
 			To(subresourceApp.PauseVMIRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("pause").
+			Operation(version.Version+"Pause").
 			Doc("Pause a VirtualMachineInstance object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusNotFound, "Not Found", "").
@@ -242,7 +242,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("unpause")).
 			To(subresourceApp.UnpauseVMIRequestHandler). // handles VMIs as well
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("unpause").
+			Operation(version.Version+"Unpause").
 			Doc("Unpause a VirtualMachineInstance object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusNotFound, "Not Found", "").
@@ -251,31 +251,31 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("console")).
 			To(subresourceApp.ConsoleRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("console").
+			Operation(version.Version + "Console").
 			Doc("Open a websocket connection to a serial console on the specified VirtualMachineInstance."))
 
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("vnc")).
 			To(subresourceApp.VNCRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("vnc").
+			Operation(version.Version + "VNC").
 			Doc("Open a websocket connection to connect to VNC on the specified VirtualMachineInstance."))
 
 		// An empty handler function would respond with HTTP OK by default
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("test")).
 			To(func(request *restful.Request, response *restful.Response) {}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("test").
+			Operation(version.Version + "Test").
 			Doc("Test endpoint verifying apiserver connectivity."))
 
 		subws.Route(subws.GET(rest.SubResourcePath("version")).Produces(restful.MIME_JSON).
 			To(func(request *restful.Request, response *restful.Response) {
 				response.WriteAsJson(virtversion.Get())
-			}).Operation("version"))
+			}).Operation(version.Version + "Version"))
 		subws.Route(subws.GET(rest.SubResourcePath("healthz")).
 			To(healthz.KubeConnectionHealthzFuncFactory(app.clusterConfig)).
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
-			Operation("checkHealth").
+			Operation(version.Version+"CheckHealth").
 			Doc("Health endpoint").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusInternalServerError, "Unhealthy", ""))
@@ -284,7 +284,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
-			Operation("guestosinfo").
+			Operation(version.Version+"Guestosinfo").
 			Doc("Get guest agent os information").
 			Writes(v1.VirtualMachineInstanceGuestAgentInfo{}).
 			Returns(http.StatusOK, "OK", v1.VirtualMachineInstanceGuestAgentInfo{}))
@@ -292,7 +292,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("rename")).
 			To(subresourceApp.RenameVMRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("rename").
+			Operation(version.Version+"Rename").
 			Doc("Rename a stopped VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusAccepted, "Accepted", "").
@@ -303,7 +303,7 @@ func (app *virtAPIApp) composeSubresources() {
 			To(subresourceApp.UserList).
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
-			Operation("userlist").
+			Operation(version.Version+"Userlist").
 			Doc("Get list of active users via guest agent").
 			Writes(v1.VirtualMachineInstanceGuestOSUserList{}).
 			Returns(http.StatusOK, "OK", v1.VirtualMachineInstanceGuestOSUserList{}))
@@ -312,7 +312,7 @@ func (app *virtAPIApp) composeSubresources() {
 			To(subresourceApp.FilesystemList).
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
-			Operation("filesystemlist").
+			Operation(version.Version+"Filesystemlist").
 			Doc("Get list of active filesystems on guest machine via guest agent").
 			Writes(v1.VirtualMachineInstanceFileSystemList{}).
 			Returns(http.StatusOK, "OK", v1.VirtualMachineInstanceFileSystemList{}))
@@ -320,7 +320,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("addvolume")).
 			To(subresourceApp.VMIAddVolumeRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("vmi-addvolume").
+			Operation(version.Version+"vmi-addvolume").
 			Doc("Add a volume and disk to a running Virtual Machine Instance").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusBadRequest, "Bad Request", ""))
@@ -328,7 +328,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("removevolume")).
 			To(subresourceApp.VMIRemoveVolumeRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("vmi-removevolume").
+			Operation(version.Version+"vmi-removevolume").
 			Doc("Removes a volume and disk from a running Virtual Machine Instance").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusBadRequest, "Bad Request", ""))
@@ -336,7 +336,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("addvolume")).
 			To(subresourceApp.VMAddVolumeRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("vm-addvolume").
+			Operation(version.Version+"vm-addvolume").
 			Doc("Add a volume and disk to a running Virtual Machine.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusBadRequest, "Bad Request", ""))
@@ -344,7 +344,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("removevolume")).
 			To(subresourceApp.VMRemoveVolumeRequestHandler).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
-			Operation("vm-removevolume").
+			Operation(version.Version+"vm-removevolume").
 			Doc("Removes a volume and disk from a running Virtual Machine.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusBadRequest, "Bad Request", ""))
@@ -423,7 +423,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 				response.WriteAsJson(list)
 			}).
-			Operation("getAPISubResources").
+			Operation(version.Version+"getAPISubResources").
 			Doc("Get a KubeVirt API resources").
 			Returns(http.StatusOK, "OK", metav1.APIResourceList{}).
 			Returns(http.StatusNotFound, "Not Found", ""))
@@ -463,7 +463,7 @@ func (app *virtAPIApp) composeSubresources() {
 			To(func(request *restful.Request, response *restful.Response) {
 				response.WriteAsJson(subresourceAPIGroup())
 			}).
-			Operation("getSubAPIGroup").
+			Operation(version.Version+"GetSubAPIGroup").
 			Doc("Get a KubeVirt API Group").
 			Returns(http.StatusOK, "OK", metav1.APIGroup{}).
 			Returns(http.StatusNotFound, "Not Found", ""))

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/preset_test.go
@@ -497,15 +497,15 @@ var _ = Describe("Mutating Webhook Presets", func() {
 
 			By("checking annotations were applied")
 			annotation, ok := vmi.Annotations["virtualmachinepreset.kubevirt.io/memory-64"]
-			Expect(annotation).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(annotation).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 			Expect(ok).To(BeTrue())
 
 			annotation, ok = vmi.Annotations["virtualmachinepreset.kubevirt.io/cpu-4"]
-			Expect(annotation).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(annotation).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 			Expect(ok).To(BeTrue())
 
 			annotation, ok = vmi.Annotations["virtualmachinepreset.kubevirt.io/duplicate-mem"]
-			Expect(annotation).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(annotation).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 			Expect(ok).To(BeTrue())
 
 			By("checking settings were applied")
@@ -554,7 +554,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 
 			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil())
 			Expect(vmi.Spec.Domain.CPU.Cores).To(Equal(uint32(4)))
-			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 
 		})
 
@@ -567,7 +567,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			applyPresets(&vmi, presetInformer)
 
 			Expect(vmi.Spec.Domain.Resources.Requests["memory"]).To(Equal(memory))
-			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 		})
 
 		It("Should apply Firmware settings", func() {
@@ -579,7 +579,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 
 			Expect(vmi.Spec.Domain.Firmware).ToNot(BeNil())
 			Expect(vmi.Spec.Domain.Firmware.UUID).To(Equal(uuid))
-			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 		})
 
 		It("Should apply Clock settings", func() {
@@ -592,7 +592,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			applyPresets(&vmi, presetInformer)
 
 			Expect(vmi.Spec.Domain.Clock).To(Equal(clock))
-			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 		})
 
 		It("Should apply Feature settings", func() {
@@ -607,7 +607,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			applyPresets(&vmi, presetInformer)
 
 			Expect(vmi.Spec.Domain.Features).To(Equal(features))
-			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 		})
 
 		It("Should apply Watchdog settings", func() {
@@ -619,7 +619,7 @@ var _ = Describe("Mutating Webhook Presets", func() {
 			applyPresets(&vmi, presetInformer)
 
 			Expect(vmi.Spec.Domain.Devices.Watchdog).To(Equal(watchdog))
-			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(vmi.Annotations["virtualmachinepreset.kubevirt.io/test-preset"]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 		})
 
 		It("Should apply IOThreads settings", func() {

--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     deps = [
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-operator/creation/components/apiservices_test.go
+++ b/pkg/virt-operator/creation/components/apiservices_test.go
@@ -3,13 +3,17 @@ package components
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/client-go/api/v1"
 )
 
 var _ = Describe("APIServices", func() {
 
 	It("should load one APIService with the correct namespace", func() {
 		services := NewVirtAPIAPIServices("mynamespace")
-		Expect(services).To(HaveLen(1))
+		// a subresource aggregated api endpoint should be registered for
+		// each vm/vmi api version
+		Expect(services).To(HaveLen(len(v1.SubresourceGroupVersions)))
 		Expect(services[0].Spec.Service.Namespace).To(Equal("mynamespace"))
 	})
 })

--- a/pkg/virt-operator/creation/components/webhooks.go
+++ b/pkg/virt-operator/creation/components/webhooks.go
@@ -476,7 +476,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 					},
 					Rule: v1beta1.Rule{
 						APIGroups:   []string{virtv1.GroupName},
-						APIVersions: []string{virtv1.VirtualMachineInstanceGroupVersionKind.Version},
+						APIVersions: virtv1.ApiSupportedWebhookVersions,
 						Resources:   []string{"*/status"},
 					},
 				}},

--- a/pkg/virt-operator/creation/csv/BUILD.bazel
+++ b/pkg/virt-operator/creation/csv/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/virt-operator/creation/components:go_default_library",
         "//pkg/virt-operator/creation/rbac:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//vendor/github.com/coreos/go-semver/semver:go_default_library",
         "//vendor/github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",

--- a/pkg/virt-operator/creation/csv/csv.go
+++ b/pkg/virt-operator/creation/csv/csv.go
@@ -20,6 +20,7 @@ package csv
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/coreos/go-semver/semver"
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -28,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	virtv1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/rbac"
 )
@@ -189,6 +191,23 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		return nil, err
 	}
 
+	almExampleFmt := `
+      [
+        {
+          "apiVersion":"kubevirt.io/%s",
+          "kind":"KubeVirt",
+          "metadata": {
+            "name":"kubevirt",
+            "namespace":"kubevirt"
+          },
+          "spec": {
+            "imagePullPolicy":"Always"
+          }
+        }
+      ]`
+
+	almExample := fmt.Sprintf(almExampleFmt, virtv1.ApiLatestVersion)
+
 	return &csvv1.ClusterServiceVersion{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterServiceVersion",
@@ -206,21 +225,8 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 				"repository":     "https://github.com/kubevirt/kubevirt",
 				"certified":      "false",
 				"support":        "KubeVirt",
-				"alm-examples": `
-      [
-        {
-          "apiVersion":"kubevirt.io/v1alpha3",
-          "kind":"KubeVirt",
-          "metadata": {
-            "name":"kubevirt",
-            "namespace":"kubevirt"
-          },
-          "spec": {
-            "imagePullPolicy":"Always"
-          }
-        }
-      ]`,
-				"description": "Creates and maintains KubeVirt deployments",
+				"alm-examples":   almExample,
+				"description":    "Creates and maintains KubeVirt deployments",
 			},
 		},
 
@@ -289,7 +295,7 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 				Owned: []csvv1.CRDDescription{
 					{
 						Name:        "kubevirts.kubevirt.io",
-						Version:     "v1alpha3",
+						Version:     virtv1.ApiLatestVersion,
 						Kind:        "KubeVirt",
 						DisplayName: "KubeVirt deployment",
 						Description: "Represents a KubeVirt deployment",

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -142,8 +142,8 @@ var _ = Describe("KubeVirt Operator", func() {
 	var totalDeletions int
 	var resourceChanges map[string]map[string]int
 
-	resourceCount := 52
-	patchCount := 33
+	resourceCount := 53
+	patchCount := 34
 	updateCount := 20
 
 	deleteFromCache := true

--- a/staging/src/kubevirt.io/client-go/api/v1/register.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/register.go
@@ -32,10 +32,15 @@ const GroupName = "kubevirt.io"
 const SubresourceGroupName = "subresources.kubevirt.io"
 
 var (
-	ApiLatestVersion            = "v1alpha3"
-	ApiSupportedWebhookVersions = []string{"v1alpha3"}
+	ApiLatestVersion            = "v1"
+	ApiSupportedWebhookVersions = []string{"v1alpha3", "v1"}
 	ApiStorageVersion           = "v1alpha3"
 	ApiSupportedVersions        = []extv1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:    "v1",
+			Served:  true,
+			Storage: false,
+		},
 		{
 			Name:    "v1alpha3",
 			Served:  true,
@@ -53,11 +58,11 @@ var (
 
 	// GroupVersions is group version list used to register these objects
 	// The preferred group version is the first item in the list.
-	GroupVersions = []schema.GroupVersion{GroupVersion}
+	GroupVersions = []schema.GroupVersion{GroupVersion, StorageGroupVersion}
 
 	// SubresourceGroupVersions is group version list used to register these objects
 	// The preferred group version is the first item in the list.
-	SubresourceGroupVersions = []schema.GroupVersion{{Group: SubresourceGroupName, Version: "v1alpha3"}}
+	SubresourceGroupVersions = []schema.GroupVersion{{Group: SubresourceGroupName, Version: ApiLatestVersion}, {Group: SubresourceGroupName, Version: ApiStorageVersion}}
 
 	// SubresourceStorageGroupVersion is the group version our api is persistented internally as
 	SubresourceStorageGroupVersion = schema.GroupVersion{Group: SubresourceGroupName, Version: ApiStorageVersion}

--- a/staging/src/kubevirt.io/client-go/api/v1/register.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/register.go
@@ -58,7 +58,7 @@ var (
 
 	// GroupVersions is group version list used to register these objects
 	// The preferred group version is the first item in the list.
-	GroupVersions = []schema.GroupVersion{GroupVersion, StorageGroupVersion}
+	GroupVersions = []schema.GroupVersion{{Group: GroupName, Version: "v1"}, {Group: GroupName, Version: "v1alpha3"}}
 
 	// SubresourceGroupVersions is group version list used to register these objects
 	// The preferred group version is the first item in the list.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_test.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_test.go
@@ -22,6 +22,7 @@ package v1
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"text/template"
 
 	. "github.com/onsi/ginkgo"
@@ -33,13 +34,13 @@ type NetworkTemplateConfig struct {
 	InterfaceConfig string
 }
 
-var exampleJSON = `{
+var exampleJSONFmt = `{
   "kind": "VirtualMachineInstance",
-  "apiVersion": "kubevirt.io/v1alpha3",
+  "apiVersion": "kubevirt.io/%s",
   "metadata": {
     "name": "testvmi",
     "namespace": "default",
-    "selfLink": "/apis/kubevirt.io/v1alpha3/namespaces/default/virtualmachineinstances/testvmi",
+    "selfLink": "/apis/kubevirt.io/%s/namespaces/default/virtualmachineinstances/testvmi",
     "creationTimestamp": null
   },
   "spec": {
@@ -240,6 +241,8 @@ var exampleJSON = `{
     "guestOSInfo": {}
   }
 }`
+
+var exampleJSON = fmt.Sprintf(exampleJSONFmt, ApiLatestVersion, ApiLatestVersion)
 
 var _ = Describe("Schema", func() {
 	//The example domain should stay in sync to the json above

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -165,7 +165,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 
 			By("checking that the ca bundle gets propagated to the apiservice")
 			Eventually(func() bool {
-				apiService, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Get("v1alpha3.subresources.kubevirt.io", metav1.GetOptions{})
+				apiService, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Get(fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return tests.ContainsCrt(apiService.Spec.CABundle, newCA)
 			}, 10*time.Second, 1*time.Second).Should(BeTrue())

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1636,7 +1636,7 @@ spec:
 		patchData := []byte(fmt.Sprint(`[{ "op": "replace", "path": "/metadata/labels", "value": {} }]`))
 		_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Patch(components.VirtApiCertSecretName, types.JSONPatchType, patchData)
 		Expect(err).ToNot(HaveOccurred())
-		_, err = aggregatorClient.ApiregistrationV1beta1().APIServices().Patch("v1alpha3.subresources.kubevirt.io", types.JSONPatchType, patchData)
+		_, err = aggregatorClient.ApiregistrationV1beta1().APIServices().Patch(fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), types.JSONPatchType, patchData)
 		Expect(err).ToNot(HaveOccurred())
 		_, err = virtClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Patch(components.VirtAPIValidatingWebhookName, types.JSONPatchType, patchData)
 		Expect(err).ToNot(HaveOccurred())
@@ -1650,7 +1650,7 @@ spec:
 			return secret.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 		Eventually(func() map[string]string {
-			apiService, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Get("v1alpha3.subresources.kubevirt.io", metav1.GetOptions{})
+			apiService, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Get(fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return apiService.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -260,7 +260,7 @@ var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][le
 
 		By("checking the output of server-side table printing")
 		rawTable, err := virtClient.RestClient().Get().
-			RequestURI(fmt.Sprintf("/apis/kubevirt.io/v1alpha3/namespaces/%s/virtualmachineinstancereplicasets/%s", tests.NamespaceTestDefault, newRS.ObjectMeta.Name)).
+			RequestURI(fmt.Sprintf("/apis/kubevirt.io/%s/namespaces/%s/virtualmachineinstancereplicasets/%s", v1.ApiLatestVersion, tests.NamespaceTestDefault, newRS.ObjectMeta.Name)).
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io, application/json").
 			DoRaw()
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1505,9 +1505,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(strings.HasPrefix(stdErr, "Error from server (AlreadyExists): error when creating")).To(BeTrue(), "command should error when creating VM second time")
 		})
 
-		It("[test_id:299]should create VM via command line", func() {
+		table.DescribeTable("[test_id:299]should create VM via command line using all supported API versions", func(version string) {
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			vm := tests.NewRandomVirtualMachine(vmi, true)
+
+			vm.APIVersion = version
 
 			vmJson, err = tests.GenerateVMJson(vm, workDir)
 			Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
@@ -1535,7 +1537,10 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(vmRunningRe.FindString(stdout)).ToNot(Equal(""), "VMI is not Running")
-		})
+		},
+			table.Entry("with v1 api", "kubevirt.io/v1"),
+			table.Entry("with v1alpha3 api", "kubevirt.io/v1alpha3"),
+		)
 
 		It("[test_id:264]should create and delete via command line", func() {
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -75,6 +75,9 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			vmiImage := cd.ContainerDiskFor(cd.ContainerDiskCirros)
 			template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmiImage, "echo Hi\n")
 			newVM := tests.NewRandomVirtualMachine(template, false)
+			// because we're marshaling this ourselves, we have to make sure
+			// we're using the same version the virtClient is using.
+			newVM.APIVersion = "kubevirt.io/" + v1.ApiStorageVersion
 
 			jsonBytes, err := json.Marshal(newVM)
 			Expect(err).To(BeNil())

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -250,7 +250,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(err).To(BeNil(), "Send POST successfully")
 
 			// Add a disk without a volume reference (this is in valid)
-			patchStr := "{\"apiVersion\":\"kubevirt.io/v1alpha3\",\"kind\":\"VirtualMachineInstance\",\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"fakedisk\"}]}}}}"
+			patchStr := fmt.Sprintf("{\"apiVersion\":\"kubevirt.io/%s\",\"kind\":\"VirtualMachineInstance\",\"spec\":{\"domain\":{\"devices\":{\"disks\":[{\"disk\":{\"bus\":\"virtio\"},\"name\":\"fakedisk\"}]}}}}", v1.ApiLatestVersion)
 
 			result := virtClient.RestClient().Patch(types.MergePatchType).Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Name(vmi.Name).Body([]byte(patchStr)).Do()
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -207,7 +207,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			// check the annotations
 			annotationKey := fmt.Sprintf("virtualmachinepreset.%s/%s", v1.GroupName, newPreset.Name)
-			Expect(newVMI.Annotations[annotationKey]).To(Equal("kubevirt.io/v1alpha3"))
+			Expect(newVMI.Annotations[annotationKey]).To(Equal(fmt.Sprintf("kubevirt.io/%s", v1.ApiLatestVersion)))
 
 			// check a setting from the preset itself to show it was applied
 			Expect(int(newVMI.Spec.Domain.CPU.Cores)).To(Equal(cores))


### PR DESCRIPTION
We nearly GA'd our api [last year](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/kubevirt-dev/WZJVnWyM5lo/V9MWQeoKBgAJ), but felt held back by a kubernetes [bug related to multiversion support ](https://github.com/kubernetes/kubernetes/pull/79495). That bug impacted kubernetes v1.13, which falls outside of the range of supported kubernetes versions KubeVirt master is tracking now.

We should be in the clear now to GA our api. The previous `kubevirt.io/v1alpha3` api will continue to be supported for the foreseeable future for all objects as well as it is just an alias for the new `kubevirt.io/v1` api.

Functionally, this shouldn't break anyone's existing deployments of KubeVirt. This means updating KubeVirt with the new `v1` api isn't expected to impact anyone's existing `v1alpha3` workloads. We have functional tests that specifically target this exact scenario to ensure no disruption of previous workloads occurs. After the update, both v1 and v1alpha3 will remain usable. 

**Release note**:
```release-note
KubeVirt v1 GA api
```
