### PR TITLE
VM destruction should always result in Failed phase

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1875,13 +1875,7 @@ func (d *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 			case api.ReasonCrashed, api.ReasonPanicked:
 				return v1.Failed, nil
 			case api.ReasonDestroyed:
-				// When ACPI is available, the domain was tried to be shutdown,
-				// and destroyed means that the domain was destroyed after the graceperiod expired.
-				// Without ACPI a destroyed domain is ok.
-				if isACPIEnabled(vmi, domain) {
-					return v1.Failed, nil
-				}
-				return v1.Succeeded, nil
+				return v1.Failed, nil
 			case api.ReasonShutdown, api.ReasonSaved, api.ReasonFromSnapshot:
 				return v1.Succeeded, nil
 			case api.ReasonMigrated:


### PR DESCRIPTION
Lifecycle rules for VMI phases in virt-controller are written around the
assumption that graceful shutdown of a VMI should result in the
Succeeded phase and every form of involuntary shutdown should be
considered a Failure. If ACPI is not enabled, the VMI cannot have
succeeded by definition.

**Release note**:
```release-note
Fix a bug where VMI's without ACPI support incorrectly entered the "Succeeded" lifecycle phase.
```
