### PR TITLE
Print stderr from qemu-img if present

### DIFF
--- a/pkg/virt-handler/isolation/validation.go
+++ b/pkg/virt-handler/isolation/validation.go
@@ -19,6 +19,11 @@ func GetImageInfo(imagePath string, context IsolationResult) (*containerdisk.Dis
 		QEMUIMGPath, "info", imagePath, "--output", "json",
 	).Output()
 	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			if len(e.Stderr) > 0 {
+				return nil, fmt.Errorf("failed to invoke qemu-img: %v: '%v'", err, string(e.Stderr))
+			}
+		}
 		return nil, fmt.Errorf("failed to invoke qemu-img: %v", err)
 	}
 


### PR DESCRIPTION
Signed-off-by: Roman Mohr <rmohr@redhat.com>

**What this PR does / why we need it**:

Make visible why qemu-img failed with a non-zero return code when it fails the validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3360 

**Special notes for your reviewer**:

**Release note**:

```release-note
Report why qemu-img failed to validate an image if it returns a non-zero exit code
```
