### PR TITLE
Skip test where the guest datetime is updated after migration on kind based providers

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -539,6 +539,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 		Context("with setting guest time", func() {
 			It("should set an updated time after a migration", func() {
+				tests.SkipMigrationTestIfRunnigOnKindInfra()
+
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR skips a test which right now can't pass on the IPv6 lane, since the `migration-proxy` does not accept IPv6 addresses.

PR #3221 addresses that issue, allowing this skip to be removed.

**Special notes for your reviewer**:
I'm afraid I do not know why this test is not skipped already - I don't see how can it have passed.

This PR would enable the IPv6 lane to be added as mandatory on CI, thus assuring that the IPv6 feature is not broken.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
