### PR TITLE
Fix race condition when reporting migration abort status

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -615,7 +615,11 @@ monitorLoop:
 		case passedErr := <-migrationErr:
 			if passedErr != nil {
 				logger.Reason(passedErr).Error("Live migration failed")
-				l.setMigrationResult(vmi, true, fmt.Sprintf("Live migration failed %v", passedErr), "")
+				var abortStatus v1.MigrationAbortStatus
+				if strings.Contains(passedErr.Error(), "canceled by client") {
+					abortStatus = v1.MigrationAbortSucceeded
+				}
+				l.setMigrationResult(vmi, true, fmt.Sprintf("Live migration failed %v", passedErr), abortStatus)
 				break monitorLoop
 			}
 		default:


### PR DESCRIPTION
We've seen some flakiness in our migration abort related functional tests lately. This should specifically address the occasional failure of the following test.

 ```[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration Starting a VirtualMachineInstance live migration cancelation should be able to cancel a migration [test_id:2731] with OCS Disk```

This race condition is super minor. The aborted migration is correctly getting canceled and does in fact fail. The minor issue is that there's one situation that results in the abort status never being set to AbortSuccess. It's that specific value that our functional tests are waiting on to gurantee the abort was processed correctly, which causes some tests to time out occasionally.

The race condition is between our async monitor loop detecting that the abort has finished, and the processing of the completed migration client command. When the client request to migrate exits, it sends an error to the async monitor loop to indicate the migration exited with an error. This happens when migrations are aborted. If that error reaches the async monitor loop before the loop detects the job has been aborted, then the migration is marked as "Failed" **BUT** the abort status is never finalized.

This is pretty simple to fix. We can detect when the client exits due to migration being aborted by looking at the error, and finalize the abort status. Either path of the race now results in the migration being both failed and the abortstatus being finalized. 


```release-note
NONE
```
