### PR TITLE
Add skip condition for CPUManager=false

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1811,7 +1811,9 @@ var _ = Describe("Configurations", func() {
 				By("adding a cpumanger=true label to a node")
 				nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: v1.CPUManager + "=" + "false"})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(nodes.Items)).To(BeNumerically(">=", 1))
+				if len(nodes.Items) == 0 {
+					Skip("Skip CPU manager test on clusters where CPU manager is running on all worker/compute nodes")
+				}
 
 				node := &nodes.Items[0]
 				node, err = virtClient.CoreV1().Nodes().Patch(node.Name, types.StrategicMergePatchType, []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, v1.CPUManager)))


### PR DESCRIPTION
Prior to this change, one CPUManager test assumed virt-handler would be
running on every node, including master nodes. In clusters where this
assumption is false, this test is invalid.

**Release note**:
```release-note
NONE
```
