### PR TITLE
[WIP] Validate the presence of commands before using them

### DIFF
--- a/tests/probes_test.go
+++ b/tests/probes_test.go
@@ -63,6 +63,15 @@ var _ = Describe("[ref_id:1182]Probes", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmiReady(vmi)).To(Equal(v1.ConditionFalse))
 
+			expecter, err := tests.LoggedInCirrosExpecter(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			found := tests.IsCommandPresent(vmi, expecter, "screen")
+			if !found {
+				Skip("Skip test that requires GNU Screen to be present in Cirros VMI image")
+			}
+
 			By("Starting the server inside the VMI")
 			serverStarter(vmi, 1500)
 
@@ -136,6 +145,15 @@ var _ = Describe("[ref_id:1182]Probes", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// It may come to modify retries on the VMI because of the kubelet updating the pod, which can trigger controllers more often
 			tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
+
+			expecter, err := tests.LoggedInCirrosExpecter(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			found := tests.IsCommandPresent(vmi, expecter, "screen")
+			if !found {
+				Skip("Skip test that requires GNU Screen to be present in Cirros VMI image")
+			}
 
 			By("Starting the server inside the VMI")
 			serverStarter(vmi, 1500)


### PR DESCRIPTION
Our test suite makes various assumptions about the images used in the test environment. However, the content of those images does change over time. It's also possible to test against different images than our CI environment does.

This PR introduces a mechanism to address this by explicitly checking for various commands presumed to be present in our images and clearly stating which command is missing from which image.

**Release note**:
```release-note
NONE
```
