### PR TITLE
Update fedora img to fc32

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -239,7 +239,6 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-custom-container-disk-demo:$(container_tag)": "//containerimages:cirros-custom-container-disk-image",
         "$(container_prefix)/$(image_prefix)fedora-cloud-container-disk-demo:$(container_tag)": "//containerimages:fedora-cloud-container-disk-image",
-        "$(container_prefix)/$(image_prefix)fedora30-cloud-container-disk-demo:$(container_tag)": "//containerimages:fedora30-cloud-container-disk-image",
         "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
         # testing images
         "$(container_prefix)/$(image_prefix)disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,24 +159,6 @@ http_file(
 )
 
 http_file(
-    name = "fedora30_image",
-    sha256 = "72b6ae7b4ed09a4dccd6e966e1b3ac69bd97da419de9760b410e837ba00b4e26",
-    urls = [
-        "https://download.fedoraproject.org/pub/fedora/linux/releases/30/Cloud/x86_64/images/Fedora-Cloud-Base-30-1.2.x86_64.qcow2",
-        "https://storage.googleapis.com/builddeps/72b6ae7b4ed09a4dccd6e966e1b3ac69bd97da419de9760b410e837ba00b4e26",
-    ],
-)
-
-http_file(
-    name = "fedora30_image_ppc64le",
-    sha256 = "53384d8f0e3f1b40215f0e36dc895f10b7651b0d68eb8a5659530cd2c3747555",
-    urls = [
-        "https://kojipkgs.fedoraproject.org/compose/cloud/Fedora-Cloud-30-20200115.0/compose/Cloud/ppc64le/images/Fedora-Cloud-Base-30-20200115.0.ppc64le.qcow2",
-        "https://storage.googleapis.com/builddeps/53384d8f0e3f1b40215f0e36dc895f10b7651b0d68eb8a5659530cd2c3747555",
-    ],
-)
-
-http_file(
     name = "virtio_win_image",
     sha256 = "7bf7f53e30c69a360f89abb3d2cc19cc978f533766b1b2270c2d8344edf9b3ef",
     urls = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,19 +142,19 @@ http_file(
 
 http_file(
     name = "fedora_image",
-    sha256 = "a30549d620bf6bf41d30a9a58626e59dfa70bb011fd7d50f6c4511ad2e479a39",
+    sha256 = "423a4ce32fa32c50c11e3d3ff392db97a762533b81bef9d00599de518a7469c8",
     urls = [
-        "https://download.fedoraproject.org/pub/fedora/linux/releases/29/Cloud/x86_64/images/Fedora-Cloud-Base-29-1.2.x86_64.qcow2",
-        "https://storage.googleapis.com/builddeps/a30549d620bf6bf41d30a9a58626e59dfa70bb011fd7d50f6c4511ad2e479a39",
+        "https://download.fedoraproject.org/pub/fedora/linux/releases/32/Cloud/x86_64/images/Fedora-Cloud-Base-32-1.6.x86_64.qcow2",
+        "https://storage.googleapis.com/builddeps/423a4ce32fa32c50c11e3d3ff392db97a762533b81bef9d00599de518a7469c8",
     ],
 )
 
 http_file(
     name = "fedora_image_ppc64le",
-    sha256 = "e65ad30cd9724d18e669f9c58831ae81c85db733c74071e171583fb24ef750a9",
+    sha256 = "dd989a078d641713c55720ba3e4320b204ade6954e2bfe4570c8058dc36e2e5d",
     urls = [
-        "https://kojipkgs.fedoraproject.org/compose/29/Fedora-29-20180919.1/compose/Cloud/ppc64le/images/Fedora-Cloud-Base-29_Beta-1.5.ppc64le.qcow2",
-        "https://storage.googleapis.com/builddeps/e65ad30cd9724d18e669f9c58831ae81c85db733c74071e171583fb24ef750a9",
+        "https://kojipkgs.fedoraproject.org/compose/32/Fedora-32-20200422.0/compose/Cloud/ppc64le/images/Fedora-Cloud-Base-32-1.6.ppc64le.qcow2",
+        "https://storage.googleapis.com/builddeps/dd989a078d641713c55720ba3e4320b204ade6954e2bfe4570c8058dc36e2e5d",
     ],
 )
 

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -42,16 +42,6 @@ container_image(
 )
 
 container_image(
-    name = "fedora30-cloud-container-disk-image",
-    directory = "/disk",
-    files = select({
-        "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@fedora30_image_ppc64le//file"],
-        "//conditions:default": ["@fedora30_image//file"],
-    }),
-    visibility = ["//visibility:public"],
-)
-
-container_image(
     name = "virtio-container-disk-image",
     directory = "/disk",
     files = ["@virtio_win_image//file"],

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -530,7 +530,7 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance, dom 
 				currTime := time.Now()
 				secs := currTime.Unix()
 				nsecs := uint(currTime.Nanosecond())
-				err := dom.SetTime(secs, nsecs, libvirt.DOMAIN_TIME_SYNC)
+				err := dom.SetTime(secs, nsecs, 0)
 				if err != nil {
 					libvirtError, ok := err.(libvirt.Error)
 					if !ok {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the fedora VMI images from fc29 (which is unsupported) to fc32 (newly released).


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the VMI fedora image from fc29 to fc32.
```
