### PR TITLE
fixing broken links pointing to the kubevirt doc about the sriov

### DIFF
--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -280,12 +280,12 @@ able to post it and get a machine attached to an SR-IOV device via VFIO. Note
 that the `NetworkAttachmentDefinition` resource should also refer, in its
 annotations, to a correct resource name as reported by SR-IOV device plugin for
 all this to work. More details on usage can be found in
-[KubeVirt](https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/interfaces-and-networks.html#sriov)
+[KubeVirt](https://kubevirt.io/user-guide/#/creation/interfaces-and-networks?id=sriov)
 and [SR-IOV operator](https://github.com/openshift/sriov-network-operator/blob/master/doc/quickstart.md)
 user documentation.
 
 # External resources
 
-* [User guide section on SR-IOV](https://kubevirt.io/user-guide/docs/latest/creating-virtual-machines/interfaces-and-networks.html#sriov)
+* [User guide section on SR-IOV](https://kubevirt.io/user-guide/#/creation/interfaces-and-networks?id=sriov)
 * [OpenShift user docs on SR-IOV](https://docs.openshift.com/container-platform/4.2/networking/multiple-networks/configuring-sr-iov.html)
 * [Doug Smith's blog post on deploying and testing SR-IOV](https://dougbtv.com/nfvpe/2019/05/15/kubevirt-sriov/)


### PR DESCRIPTION
Signed-off-by: Pedro Ibáñez <pedro@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: fixes a couple of broken links pointing to the kubevirt user-guide page.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fixed a couple of broken links to the user-guide kubevirt page
```
