### PR TITLE
Supply virt-launcher an unique UUID for Kind Ipv6 

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/settings/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -57,6 +57,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	settingsv1alpha1 "k8s.io/api/settings/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -763,6 +764,10 @@ func BeforeTestSuitSetup() {
 	CreatePVC(osWindows, defaultWindowsDiskSize, Config.StorageClassWindows)
 	CreatePVC(osRhel, defaultRhelDiskSize, Config.StorageClassRhel)
 
+	if IsRunningOnKindInfraIPv6() {
+		createPodPreset("fix-node-uuid", "fake-product-uuid", "virt-launcher", "/kind/product_uuid", "/sys/class/dmi/id/product_uuid")
+	}
+
 	EnsureKVMPresent()
 
 	SetDefaultEventuallyTimeout(defaultEventuallyTimeout)
@@ -1244,6 +1249,48 @@ func cleanupSubresourceServiceAccount() {
 
 	err = virtCli.RbacV1().ClusterRoleBindings().Delete(SubresourceServiceAccountName, nil)
 	if !errors.IsNotFound(err) {
+		PanicOnError(err)
+	}
+}
+
+func createPodPreset(podPresetName, volName, label, srcPath, dstPath string) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	hostPathType := k8sv1.HostPathFile
+	podPreset := settingsv1alpha1.PodPreset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podPresetName,
+			Namespace: NamespaceTestDefault,
+		},
+		Spec: settingsv1alpha1.PodPresetSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubevirt.io": label,
+				},
+			},
+			Volumes: []k8sv1.Volume{
+				{
+					Name: volName,
+					VolumeSource: k8sv1.VolumeSource{
+						HostPath: &k8sv1.HostPathVolumeSource{
+							Path: srcPath,
+							Type: &hostPathType,
+						},
+					},
+				},
+			},
+			VolumeMounts: []k8sv1.VolumeMount{
+				{
+					Name:      volName,
+					MountPath: dstPath,
+				},
+			},
+		},
+	}
+
+	_, err = virtCli.SettingsV1alpha1().PodPresets(NamespaceTestDefault).Create(&podPreset)
+	if !errors.IsAlreadyExists(err) {
 		PanicOnError(err)
 	}
 }
@@ -4582,6 +4629,11 @@ func getClusterDnsServiceIP(virtClient kubecli.KubevirtClient) (string, error) {
 func IsRunningOnKindInfra() bool {
 	provider := os.Getenv("KUBEVIRT_PROVIDER")
 	return strings.HasPrefix(provider, "kind")
+}
+
+func IsRunningOnKindInfraIPv6() bool {
+	provider := os.Getenv("KUBEVIRT_PROVIDER")
+	return strings.HasPrefix(provider, "kind-k8s-1.17.0-ipv6")
 }
 
 func SkipPVCTestIfRunnigOnKindInfra() {


### PR DESCRIPTION
Libvirt require Unique UUID for each virt-launcher pod,
in order for migration to start.
Since we are using Kind provider for IPv6,
all the containers inherit the same UUID from DMI which is shared
between all the containers.

We limit in this PR the change for IPv6 kind provider,
as the task is urgent, and doesnt present a regression for
the other kind providers.

See
kubevirt/kubevirtci#353
once its done, the limitation can be removed, and more tests
can be enabled, in case they can be.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
