### PR TITLE
Change Targetdirectmigrationnodeports to map[string]int to have valid openapi

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -958,10 +958,10 @@ func (d *VirtualMachineController) migrationTargetExecute(key string,
 				hostAddress = vmi.Status.MigrationState.TargetNodeAddress
 			}
 			if hostAddress != d.ipAddress {
-				portsList := make([]int, 0, len(destSrcPortsMap))
+				portsList := make([]string, 0, len(destSrcPortsMap))
 
-				for value, _ := range destSrcPortsMap {
-					portsList = append(portsList, value)
+				for k := range destSrcPortsMap {
+					portsList = append(portsList, k)
 				}
 				portsStrList := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(portsList)), ","), "[]")
 				d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.PreparingTarget.String(), fmt.Sprintf("Migration Target is listening at %s, on ports: %s", d.ipAddress, portsStrList))

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -932,7 +932,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				TargetNodeAddress:              "127.0.0.1:12345",
 				SourceNode:                     host,
 				MigrationUID:                   "123",
-				TargetDirectMigrationNodePorts: map[int]int{49152: 12132},
+				TargetDirectMigrationNodePorts: map[string]int{"49152": 12132},
 			}
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{
@@ -971,7 +971,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				TargetNodeAddress:              "127.0.0.1:12345",
 				SourceNode:                     host,
 				MigrationUID:                   "123",
-				TargetDirectMigrationNodePorts: map[int]int{49152: 12132},
+				TargetDirectMigrationNodePorts: map[string]int{"49152": 12132},
 			}
 			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
 				{

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -2134,7 +2134,7 @@ func (in *VirtualMachineInstanceMigrationState) DeepCopyInto(out *VirtualMachine
 	}
 	if in.TargetDirectMigrationNodePorts != nil {
 		in, out := &in.TargetDirectMigrationNodePorts, &out.TargetDirectMigrationNodePorts
-		*out = make(map[int]int, len(*in))
+		*out = make(map[string]int, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -355,7 +355,7 @@ type VirtualMachineInstanceMigrationState struct {
 	// The address of the target node to use for the migration
 	TargetNodeAddress string `json:"targetNodeAddress,omitempty"`
 	// The list of ports opened for live migration on the destination node
-	TargetDirectMigrationNodePorts map[int]int `json:"targetDirectMigrationNodePorts,omitempty"`
+	TargetDirectMigrationNodePorts map[string]int `json:"targetDirectMigrationNodePorts,omitempty"`
 	// The target node that the VMI is moving to
 	TargetNode string `json:"targetNode,omitempty"`
 	// The target pod that the VMI is moving to

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"crypto/tls"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -1034,6 +1035,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				i := 0
 				errors := make(chan error, len(vmi.Status.MigrationState.TargetDirectMigrationNodePorts))
 				for port, _ := range vmi.Status.MigrationState.TargetDirectMigrationNodePorts {
+					portI, _ := strconv.Atoi(port)
 					go func(i int, port int) {
 						defer GinkgoRecover()
 						defer wg.Done()
@@ -1043,7 +1045,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 						_, err = tls.Dial("tcp", fmt.Sprintf("localhost:4321%d", i), tlsConfig)
 						Expect(err).To(HaveOccurred())
 						errors <- err
-					}(i, port)
+					}(i, portI)
 					i++
 				}
 				wg.Wait()


### PR DESCRIPTION
**What this PR does / why we need it**:
Map with non-string keys are not supported by OpenAPI. Therefor changing it to map[string]int

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
