### PR TITLE
Fix IPv6 migration

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os/exec"
+
 	v1 "kubevirt.io/client-go/api/v1"
 )
 
@@ -28,4 +30,19 @@ func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
 		return true
 	}
 	return false
+}
+
+// IsIpv6Disabled returns if IPv6 is disabled according sysctl
+func IsIpv6Disabled() bool {
+	ipv6Disabled, err := exec.Command("cat", "/proc/sys/net/ipv6/conf/default/disable_ipv6").Output()
+	return err != nil || string(ipv6Disabled) == "1"
+}
+
+// GetIPBindAddress returns IP bind address (either 0.0.0.0 or [::] according sysctl disable_ipv6)
+func GetIPBindAddress() string {
+	if IsIpv6Disabled() {
+		return "0.0.0.0"
+	}
+
+	return "[::]"
 }

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -5,7 +5,11 @@ go_library(
     srcs = ["migration-proxy.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/log:go_default_library"],
+    deps = [
+        "//pkg/util:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -29,7 +29,10 @@ import (
 	"strings"
 	"sync"
 
+	netutils "k8s.io/utils/net"
+
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -129,7 +132,7 @@ func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles 
 	proxiesList := []*migrationProxy{}
 	for _, targetUnixFile := range targetUnixFiles {
 		// 0 means random port is used
-		proxy := NewTargetProxy("0.0.0.0", 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
+		proxy := NewTargetProxy(util.GetIPBindAddress(), 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
 
 		err := proxy.StartListening()
 		if err != nil {
@@ -211,6 +214,10 @@ func (m *migrationProxyManager) StopTargetListener(key string) {
 func (m *migrationProxyManager) StartSourceListener(key string, targetAddress string, destSrcPortMap map[int]int, baseDir string) error {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
+
+	if netutils.IsIPv6String(targetAddress) {
+		targetAddress = "[" + targetAddress + "]"
+	}
 
 	isExistingProxy := func(curProxies []*migrationProxy, targetAddress string, destSrcPortMap map[int]int) bool {
 		if len(curProxies) != len(destSrcPortMap) {
@@ -315,12 +322,16 @@ func NewTargetProxy(tcpBindAddress string, tcpBindPort int, serverTLSConfig *tls
 
 }
 
+func isLoopbackAddress(ipAddress string) bool {
+	return (strings.Contains(ipAddress, "127.0.0.1") || strings.Contains(ipAddress, "[::1]"))
+}
+
 func (m *migrationProxy) createTcpListener() error {
 	var listener net.Listener
 	var err error
 	if m.serverTLSConfig != nil {
 		listener, err = tls.Listen("tcp", fmt.Sprintf("%s:%d", m.tcpBindAddress, m.tcpBindPort), m.serverTLSConfig)
-	} else if strings.Contains(m.tcpBindAddress, "127.0.0.1") {
+	} else if isLoopbackAddress(m.tcpBindAddress) {
 		listener, err = net.Listen("tcp", fmt.Sprintf("%s:%d", m.tcpBindAddress, m.tcpBindPort))
 	} else {
 		return fmt.Errorf("Unsecured tcp migration proxy listeners are not permitted")

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/hooks:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/ignition:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -199,3 +199,13 @@ func (_m *MockDomainManager) SetGuestTime(_param0 *v1.VirtualMachineInstance) er
 func (_mr *_MockDomainManagerRecorder) SetGuestTime(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetGuestTime", arg0)
 }
+
+func (_m *MockDomainManager) GetLoopbackAddress() string {
+	ret := _m.ctrl.Call(_m, "GetLoopbackAddress")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) GetLoopbackAddress() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLoopbackAddress")
+}

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -39,8 +39,6 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network/dhcp"
-
-	netutils "k8s.io/utils/net"
 )
 
 const randomMacGenerationAttempts = 10
@@ -88,7 +86,6 @@ type NetworkHandler interface {
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
 	HasNatIptables(proto iptables.Protocol) bool
-	IsIpv6Enabled() bool
 	ConfigureIpv6Forwarding() error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
 	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
@@ -152,15 +149,6 @@ func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 func (h *NetworkUtilsHandler) ConfigureIpv6Forwarding() error {
 	_, err := exec.Command("sysctl", "net.ipv6.conf.all.forwarding=1").CombinedOutput()
 	return err
-}
-
-func (h *NetworkUtilsHandler) IsIpv6Enabled() bool {
-	podIp := os.Getenv("MY_POD_IP")
-	if !netutils.IsIPv6String(podIp) {
-		log.Log.V(5).Info("Since the pod ip is non IPv6, IPv6 is disabled")
-		return false
-	}
-	return true
 }
 
 func (h *NetworkUtilsHandler) IptablesNewChain(proto iptables.Protocol, table, chain string) error {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -213,16 +213,6 @@ func (_mr *_MockNetworkHandlerRecorder) HasNatIptables(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasNatIptables", arg0)
 }
 
-func (_m *MockNetworkHandler) IsIpv6Enabled() bool {
-	ret := _m.ctrl.Call(_m, "IsIpv6Enabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled")
-}
-
 func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {
 	ret := _m.ctrl.Call(_m, "ConfigureIpv6Forwarding")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -378,7 +378,6 @@ var _ = Describe("Pod Network", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -388,8 +387,6 @@ var _ = Describe("Pod Network", func() {
 			})
 			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
-
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 					mockNetwork.EXPECT().IptablesAppendRule(proto, "nat",
@@ -425,7 +422,6 @@ var _ = Describe("Pod Network", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -435,8 +431,6 @@ var _ = Describe("Pod Network", func() {
 			})
 			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
-
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(false).Times(2)
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/api/settings/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -404,9 +404,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 		})
 		Context("with a Cirros disk", func() {
-			It("should be successfully migrate with cloud-init disk with devices on the root bus", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
+			It("[test_id:3227]should be successfully migrate with cloud-init disk with devices on the root bus", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				vmi.Annotations = map[string]string{
 					v1.PlacePCIDevicesOnRootComplex: "true",
@@ -449,8 +447,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
@@ -503,8 +499,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3237]should complete a migration", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -679,8 +673,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
@@ -872,7 +864,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var pvName string
 			var vmi *v1.VirtualMachineInstance
 			BeforeEach(func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
+				tests.SkipNFSTestIfRunnigOnKindInfra()
 				pvName = "test-nfs" + rand.String(48)
 				// Prepare a NFS backed PV
 				By("Starting an NFS POD")
@@ -1079,6 +1071,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
+				tests.SkipStressTestIfRunnigOnKindInfraIPv6()
+
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -1200,8 +1194,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			table.DescribeTable("should be able to cancel a migration", func(createVMI vmiBuilder) {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi, dv := createVMI()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				defer deleteDataVolume(dv)
@@ -1243,8 +1235,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				table.Entry("[test_id:2731] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1282,8 +1272,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	Context("with sata disks", func() {
 
 		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret", func() {
-			tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 			configMapName := "configmap-" + rand.String(5)
 			secretName := "secret-" + rand.String(5)
 
@@ -1373,8 +1361,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3244]should block the eviction api while a slow migration is in progress", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
@@ -1430,7 +1416,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			Context("with node tainted during node drain", func() {
 				It("[test_id:2221] should migrate a VMI under load to another node", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -1483,7 +1468,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 
 				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = cirrosVMIWithEvictionStrategy()
@@ -1538,7 +1522,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 400)
 
 				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi_evict1 := cirrosVMIWithEvictionStrategy()
@@ -1662,8 +1645,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with multiple VMIs with eviction policies set", func() {
 
 			It("[test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := cirrosVMIWithEvictionStrategy()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4636,15 +4636,21 @@ func IsRunningOnKindInfraIPv6() bool {
 	return strings.HasPrefix(provider, "kind-k8s-1.17.0-ipv6")
 }
 
+func SkipStressTestIfRunnigOnKindInfraIPv6() {
+	if IsRunningOnKindInfra() {
+		Skip("Skip stress test till issue https://github.com/kubevirt/kubevirt/issues/3323 is fixed")
+	}
+}
+
 func SkipPVCTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
 		Skip("Skip PVC tests till PR https://github.com/kubevirt/kubevirt/pull/3171 is merged")
 	}
 }
 
-func SkipMigrationTestIfRunnigOnKindInfra() {
-	if IsRunningOnKindInfra() {
-		Skip("Skip migration tests till PR https://github.com/kubevirt/kubevirt/pull/3221 is merged")
+func SkipNFSTestIfRunnigOnKindInfra() {
+	if IsRunningOnKindInfraIPv6() {
+		Skip("Skip PVC tests till issue https://github.com/kubevirt/kubevirt/issues/3322 is fixed")
 	}
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -57,6 +57,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	settingsv1alpha1 "k8s.io/api/settings/v1alpha1"
 	storagev1 "k8s.io/api/storage/v1"
 	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -763,6 +764,10 @@ func BeforeTestSuitSetup() {
 	CreatePVC(osWindows, defaultWindowsDiskSize, Config.StorageClassWindows)
 	CreatePVC(osRhel, defaultRhelDiskSize, Config.StorageClassRhel)
 
+	if IsRunningOnKindInfraIPv6() {
+		createPodPreset("fix-node-uuid", "fake-product-uuid", "virt-launcher", "/kind/product_uuid", "/sys/class/dmi/id/product_uuid")
+	}
+
 	EnsureKVMPresent()
 
 	SetDefaultEventuallyTimeout(defaultEventuallyTimeout)
@@ -1244,6 +1249,48 @@ func cleanupSubresourceServiceAccount() {
 
 	err = virtCli.RbacV1().ClusterRoleBindings().Delete(SubresourceServiceAccountName, nil)
 	if !errors.IsNotFound(err) {
+		PanicOnError(err)
+	}
+}
+
+func createPodPreset(podPresetName, volName, label, srcPath, dstPath string) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	hostPathType := k8sv1.HostPathFile
+	pp := settingsv1alpha1.PodPreset{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podPresetName,
+			Namespace: NamespaceTestDefault,
+		},
+		Spec: settingsv1alpha1.PodPresetSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubevirt.io": label,
+				},
+			},
+			Volumes: []k8sv1.Volume{
+				{
+					Name: volName,
+					VolumeSource: k8sv1.VolumeSource{
+						HostPath: &k8sv1.HostPathVolumeSource{
+							Path: srcPath,
+							Type: &hostPathType,
+						},
+					},
+				},
+			},
+			VolumeMounts: []k8sv1.VolumeMount{
+				{
+					Name:      volName,
+					MountPath: dstPath,
+				},
+			},
+		},
+	}
+
+	_, err = virtCli.SettingsV1alpha1().PodPresets(NamespaceTestDefault).Create(&pp)
+	if !errors.IsAlreadyExists(err) {
 		PanicOnError(err)
 	}
 }
@@ -4582,6 +4629,11 @@ func getClusterDnsServiceIP(virtClient kubecli.KubevirtClient) (string, error) {
 func IsRunningOnKindInfra() bool {
 	provider := os.Getenv("KUBEVIRT_PROVIDER")
 	return strings.HasPrefix(provider, "kind")
+}
+
+func IsRunningOnKindInfraIPv6() bool {
+	provider := os.Getenv("KUBEVIRT_PROVIDER")
+	return strings.HasPrefix(provider, "kind-k8s-1.17.0-ipv6")
 }
 
 func SkipPVCTestIfRunnigOnKindInfra() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -394,6 +394,7 @@ k8s.io/api/admission/v1beta1
 k8s.io/api/authorization/v1beta1
 k8s.io/api/scheduling/v1
 k8s.io/api/autoscaling/v1
+k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/apps/v1beta1
@@ -420,7 +421,6 @@ k8s.io/api/rbac/v1alpha1
 k8s.io/api/rbac/v1beta1
 k8s.io/api/scheduling/v1alpha1
 k8s.io/api/scheduling/v1beta1
-k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.16.4 => k8s.io/apiextensions-apiserver v0.16.4
@@ -435,14 +435,14 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake
 # k8s.io/apimachinery v0.16.4 => k8s.io/apimachinery v0.16.4
-k8s.io/apimachinery/pkg/api/errors
-k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/api/resource
+k8s.io/apimachinery/pkg/api/errors
+k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/util/clock
@@ -462,12 +462,12 @@ k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/util/net
-k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/cache
 k8s.io/apimachinery/pkg/util/diff
 k8s.io/apimachinery/pkg/util/naming
+k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/uuid
 k8s.io/apimachinery/pkg/api/equality
@@ -482,8 +482,8 @@ k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
-k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/apis/meta/internalversion
+k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/pkg/util/framer
 # k8s.io/apiserver v0.16.4 => k8s.io/apiserver v0.16.4


### PR DESCRIPTION
DRAFT ONE 

Fix IPv6 migration
    
IPv6 address needs to be formatted as [ip]:port.
    
Support migration also in the following cases:
- IPv6 is disabled (sysfs disable_ipv6)
- bindv6only is enabled

Make createTcpListener to support IPv6 local address.
    
To support IPv6 migration on kind PR #3374 is mandatory,
Once its merged, i will rebase this one.
    
Signed-off-by: Or Shoval <oshoval@redhat.com>

This is a clean version of 
https://github.com/kubevirt/kubevirt/pull/3221
with little cosmetics that were requested there.

```release-note
None
```