### PR TITLE
schema: Introduce an IPv6 CIDR for the vm network

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10765,6 +10765,10 @@
     "description": "Represents the stock pod network interface.",
     "type": "object",
     "properties": {
+     "vmIPv6NetworkCIDR": {
+      "description": "IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.",
+      "type": "string"
+     },
      "vmNetworkCIDR": {
       "description": "CIDR for vm network. Default 10.0.2.0/24 if not specified.",
       "type": "string"

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -351,7 +351,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 			domain:              domain,
 			podInterfaceName:    podInterfaceName,
 			vmNetworkCIDR:       network.Pod.VMNetworkCIDR,
-			vmIpv6NetworkCIDR:   "", // TODO add ipv6 cidr to PodNetwork schema
+			vmIPv6NetworkCIDR:   network.Pod.VMIPv6NetworkCIDR,
 			bridgeInterfaceName: fmt.Sprintf("k6t-%s", podInterfaceName),
 			storeFactory:        storeFactory,
 		}, nil
@@ -704,7 +704,7 @@ type MasqueradeBindMechanism struct {
 	podInterfaceName    string
 	bridgeInterfaceName string
 	vmNetworkCIDR       string
-	vmIpv6NetworkCIDR   string
+	vmIPv6NetworkCIDR   string
 	gatewayAddr         *netlink.Addr
 	gatewayIpv6Addr     *netlink.Addr
 	storeFactory        cache.InterfaceCacheFactory
@@ -771,13 +771,13 @@ func configureVifV4Addresses(b *MasqueradeBindMechanism, err error) error {
 }
 
 func configureVifV6Addresses(b *MasqueradeBindMechanism, err error) error {
-	if b.vmIpv6NetworkCIDR == "" {
-		b.vmIpv6NetworkCIDR = api.DefaultVMIpv6CIDR
+	if b.vmIPv6NetworkCIDR == "" {
+		b.vmIPv6NetworkCIDR = api.DefaultVMIpv6CIDR
 	}
 
-	defaultGatewayIpv6, vmIpv6, err := Handler.GetHostAndGwAddressesFromCIDR(b.vmIpv6NetworkCIDR)
+	defaultGatewayIpv6, vmIpv6, err := Handler.GetHostAndGwAddressesFromCIDR(b.vmIPv6NetworkCIDR)
 	if err != nil {
-		log.Log.Reason(err).Errorf("failed to get gw and vm available ipv6 addresses from CIDR %s", b.vmIpv6NetworkCIDR)
+		log.Log.Reason(err).Errorf("failed to get gw and vm available ipv6 addresses from CIDR %s", b.vmIPv6NetworkCIDR)
 		return err
 	}
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -2807,6 +2807,9 @@ var CRDsValidation map[string]string = map[string]string{
                       pod:
                         description: Represents the stock pod network interface.
                         properties:
+                          vmIPv6NetworkCIDR:
+                            description: IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.
+                            type: string
                           vmNetworkCIDR:
                             description: CIDR for vm network. Default 10.0.2.0/24 if not specified.
                             type: string
@@ -4612,6 +4615,9 @@ var CRDsValidation map[string]string = map[string]string{
               pod:
                 description: Represents the stock pod network interface.
                 properties:
+                  vmIPv6NetworkCIDR:
+                    description: IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.
+                    type: string
                   vmNetworkCIDR:
                     description: CIDR for vm network. Default 10.0.2.0/24 if not specified.
                     type: string
@@ -7191,6 +7197,9 @@ var CRDsValidation map[string]string = map[string]string{
                       pod:
                         description: Represents the stock pod network interface.
                         properties:
+                          vmIPv6NetworkCIDR:
+                            description: IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.
+                            type: string
                           vmNetworkCIDR:
                             description: CIDR for vm network. Default 10.0.2.0/24 if not specified.
                             type: string
@@ -9306,6 +9315,9 @@ var CRDsValidation map[string]string = map[string]string{
                                   pod:
                                     description: Represents the stock pod network interface.
                                     properties:
+                                      vmIPv6NetworkCIDR:
+                                        description: IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.
+                                        type: string
                                       vmNetworkCIDR:
                                         description: CIDR for vm network. Default 10.0.2.0/24 if not specified.
                                         type: string

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -22013,6 +22013,13 @@ func schema_kubevirtio_client_go_api_v1_PodNetwork(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
+					"vmIPv6NetworkCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -1348,6 +1348,10 @@ type PodNetwork struct {
 	// CIDR for vm network.
 	// Default 10.0.2.0/24 if not specified.
 	VMNetworkCIDR string `json:"vmNetworkCIDR,omitempty"`
+
+	// IPv6 CIDR for the vm network.
+	// Defaults to fd10:0:2::/120 if not specified.
+	VMIPv6NetworkCIDR string `json:"vmIPv6NetworkCIDR,omitempty"`
 }
 
 // Rng represents the random device passed from host

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -709,8 +709,9 @@ func (NetworkSource) SwaggerDoc() map[string]string {
 
 func (PodNetwork) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":              "Represents the stock pod network interface.\n\n+k8s:openapi-gen=true",
-		"vmNetworkCIDR": "CIDR for vm network.\nDefault 10.0.2.0/24 if not specified.",
+		"":                  "Represents the stock pod network interface.\n\n+k8s:openapi-gen=true",
+		"vmNetworkCIDR":     "CIDR for vm network.\nDefault 10.0.2.0/24 if not specified.",
+		"vmIPv6NetworkCIDR": "IPv6 CIDR for the vm network.\nDefaults to fd10:0:2::/120 if not specified.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -17097,6 +17097,13 @@ func schema_kubevirtio_client_go_api_v1_PodNetwork(ref common.ReferenceCallback)
 							Format:      "",
 						},
 					},
+					"vmIPv6NetworkCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IPv6 CIDR for the vm network. Defaults to fd10:0:2::/120 if not specified.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

When using the masquerade binding method, an internal IPv6 network is used
for the pod-vm communication.
This change introduces the ability to customize this network address in
scenarios where the default one cannot be used.

**Special notes for your reviewer**:

~~Tests are missing for both CIDR 4 and 6.~~

**Release note**:
```release-note
Add `vmIPv6NetworkCIDR` under `NetworkSource.pod` to support custom IPv6 CIDR for the vm network when using masquerade binding.
```
