### PR TITLE
Use IPv6 bind address instead of IPv4 one

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -33,6 +33,26 @@ readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
 
+export KUBEVIRT_LANE_FOCUS="kind-k8s-1.17.0-ipv6"
+
+if [[ $KUBEVIRT_LANE_FOCUS != "" ]]; then
+   FOCUS_ERROR=1
+else
+   FOCUS_ERROR=0
+fi
+
+for aString in ${KUBEVIRT_LANE_FOCUS[@]}; do
+    if [[ ${aString} == $TARGET ]]; then
+        echo "found $aString equal TARGET"
+        FOCUS_ERROR=0
+    fi
+done
+
+if [ $FOCUS_ERROR -eq 1 ]; then
+    echo "Focus detected, TARGET $TARGET not equal $KUBEVIRT_LANE_FOCUS, failing run"
+    exit 1
+fi
+
 if [[ $TARGET =~ windows.* ]]; then
   echo "picking the default provider for windows tests"
 elif [[ $TARGET =~ cnao ]]; then
@@ -281,7 +301,7 @@ elif [[ $TARGET =~ gpu.* ]]; then
 elif [[ $TARGET =~ (okd|ocp).* ]]; then
   ginko_params="$ginko_params --ginkgo.skip=SRIOV|GPU"
 elif [[ $TARGET =~ ipv6.* ]]; then
-  ginko_params="$ginko_params --ginkgo.skip=Multus|SRIOV|GPU|.*slirp.*|.*bridge.*"
+  ginko_params="$ginko_params --ginkgo.skip=Multus|SRIOV|GPU|.*slirp.*|.*bridge.* --ginkgo.v --ginkgo.focus=test_id:1677"
 else
   ginko_params="$ginko_params --ginkgo.skip=Multus|SRIOV|GPU"
 fi

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -40,9 +40,9 @@ spec:
       userData: |-
         #!/bin/bash
         echo "fedora" |passwd fedora --stdin
-        ip -6 addr add fd10:0:2::2/120 dev eth0
+        ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0
         sleep 5
-        ip -6 route add default via fd10:0:2::1 src fd10:0:2::2
+        ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2
         yum install -y nginx
         systemctl enable nginx
         systemctl start nginx

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os/exec"
+
 	v1 "kubevirt.io/client-go/api/v1"
 )
 
@@ -28,4 +30,19 @@ func IsGPUVMI(vmi *v1.VirtualMachineInstance) bool {
 		return true
 	}
 	return false
+}
+
+// IsIpv6Disabled returns if IPv6 is disabled according sysctl
+func IsIpv6Disabled() bool {
+	ipv6Disabled, err := exec.Command("cat", "/proc/sys/net/ipv6/conf/default/disable_ipv6").Output()
+	return err != nil || string(ipv6Disabled) == "1"
+}
+
+// GetIPBindAddress returns IP bind address (either 0.0.0.0 or [::] according sysctl disable_ipv6)
+func GetIPBindAddress() string {
+	if IsIpv6Disabled() {
+		return "0.0.0.0"
+	}
+
+	return "[::]"
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -40,9 +40,11 @@ func IsIpv6Disabled() bool {
 
 // GetIPBindAddress returns IP bind address (either 0.0.0.0 or [::] according sysctl disable_ipv6)
 func GetIPBindAddress() string {
-	if IsIpv6Disabled() {
-		return "0.0.0.0"
-	}
+	//DBG
 
-	return "[::]"
+	//if IsIpv6Disabled() {
+	return "0.0.0.0"
+	//}
+
+	//return "[::]"
 }

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["migration-proxy.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/log:go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
     ],

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -33,6 +33,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -132,7 +133,7 @@ func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles 
 	proxiesList := []*migrationProxy{}
 	for _, targetUnixFile := range targetUnixFiles {
 		// 0 means random port is used
-		proxy := NewTargetProxy("0.0.0.0", 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
+		proxy := NewTargetProxy(util.GetIPBindAddress(), 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
 
 		err := proxy.StartListening()
 		if err != nil {

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"sync"
 
+	netutils "k8s.io/utils/net"
+
 	"kubevirt.io/client-go/log"
 )
 
@@ -213,6 +215,10 @@ func (m *migrationProxyManager) StopTargetListener(key string) {
 func (m *migrationProxyManager) StartSourceListener(key string, targetAddress string, destSrcPortMap map[string]int, baseDir string) error {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
+
+	if netutils.IsIPv6String(targetAddress) {
+		targetAddress = "[" + targetAddress + "]"
+	}
 
 	isExistingProxy := func(curProxies []*migrationProxy, targetAddress string, destSrcPortMap map[string]int) bool {
 		if len(curProxies) != len(destSrcPortMap) {

--- a/pkg/virt-launcher/virtwrap/api/defaults.go
+++ b/pkg/virt-launcher/virtwrap/api/defaults.go
@@ -4,7 +4,7 @@ const (
 	resolvConf        = "/etc/resolv.conf"
 	DefaultProtocol   = "TCP"
 	DefaultVMCIDR     = "10.0.2.0/24"
-	DefaultVMIpv6CIDR = "fd10:0:2::/120"
+	DefaultVMIpv6CIDR = "fd2e:f1fe:9490:a8ff::/120"
 	DefaultBridgeName = "k6t-eth0"
 )
 

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -77,10 +77,10 @@ var _ = Describe("Common Methods", func() {
 		})
 		It("Should return 2 IPV6 addresses", func() {
 			networkHandler := NetworkUtilsHandler{}
-			gw, vm, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd10:0:2::/120")
+			gw, vm, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd2e:f1fe:9490:a8ff::/120")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(gw).To(Equal("fd10:0:2::1/120"))
-			Expect(vm).To(Equal("fd10:0:2::2/120"))
+			Expect(gw).To(Equal("fd2e:f1fe:9490:a8ff::1/120"))
+			Expect(vm).To(Equal("fd2e:f1fe:9490:a8ff::2/120"))
 		})
 		It("Should fail when the subnet is too small", func() {
 			networkHandler := NetworkUtilsHandler{}
@@ -89,7 +89,7 @@ var _ = Describe("Common Methods", func() {
 		})
 		It("Should fail when the IPV6 subnet is too small", func() {
 			networkHandler := NetworkUtilsHandler{}
-			_, _, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd10:0:2::/127")
+			_, _, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd2e:f1fe:9490:a8ff::/127")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -112,10 +112,10 @@ var _ = Describe("Pod Network", func() {
 		masqueradeVmStr = "10.0.2.2/30"
 		masqueradeVmAddr, _ = netlink.ParseAddr(masqueradeVmStr)
 		masqueradeVmIp = masqueradeVmAddr.IP.String()
-		masqueradeIpv6GwStr = "fd10:0:2::1/120"
+		masqueradeIpv6GwStr = "fd2e:f1fe:9490:a8ff::1/120"
 		masqueradeIpv6GwAddr, _ = netlink.ParseAddr(masqueradeIpv6GwStr)
 		masqueradeGwIpv6 = masqueradeIpv6GwAddr.IP.String()
-		masqueradeIpv6VmStr = "fd10:0:2::2/120"
+		masqueradeIpv6VmStr = "fd2e:f1fe:9490:a8ff::2/120"
 		masqueradeIpv6VmAddr, _ = netlink.ParseAddr(masqueradeIpv6VmStr)
 		masqueradeVmIpv6 = masqueradeIpv6VmAddr.IP.String()
 		masqueradeDummyName = fmt.Sprintf("%s-nic", api.DefaultBridgeName)
@@ -188,8 +188,8 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeGwAddr).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeIpv6GwAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
-		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return(masqueradeGwStr, masqueradeVmStr, nil)
-		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return(masqueradeIpv6GwStr, masqueradeIpv6VmStr, nil)
+		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return("10.0.2.1/30", "10.0.2.2/30", nil)
+		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return("fd2e:f1fe:9490:a8ff::1/120", "fd2e:f1fe:9490:a8ff::2/120", nil)
 		// Global nat rules using iptables
 		mockNetwork.EXPECT().ConfigureIpv6Forwarding().Return(nil)
 		mockNetwork.EXPECT().GetNFTIPString(iptables.ProtocolIPv4).Return("ip").AnyTimes()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -406,8 +406,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 		Context("with a Cirros disk", func() {
 			It("[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				vmi.Annotations = map[string]string{
 					v1.PlacePCIDevicesOnRootComplex: "true",
@@ -450,8 +448,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
@@ -504,8 +500,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3237]should complete a migration", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -680,8 +674,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
@@ -873,7 +865,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var pvName string
 			var vmi *v1.VirtualMachineInstance
 			BeforeEach(func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
+				tests.SkipNFSTestIfRunnigOnKindInfra()
 				pvName = "test-nfs" + rand.String(48)
 				// Prepare a NFS backed PV
 				By("Starting an NFS POD")
@@ -1081,6 +1073,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
+				tests.SkipStressTestIfRunnigOnKindInfra()
+
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -1202,8 +1196,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			table.DescribeTable("should be able to cancel a migration", func(createVMI vmiBuilder) {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi, dv := createVMI()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				defer deleteDataVolume(dv)
@@ -1245,8 +1237,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				table.Entry("[test_id:2731] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1284,8 +1274,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	Context("with sata disks", func() {
 
 		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret", func() {
-			tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 			configMapName := "configmap-" + rand.String(5)
 			secretName := "secret-" + rand.String(5)
 
@@ -1375,8 +1363,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3244]should block the eviction api while a slow migration is in progress", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
@@ -1432,7 +1418,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			Context("with node tainted during node drain", func() {
 				It("[test_id:2221] should migrate a VMI under load to another node", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -1485,7 +1470,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 
 				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = cirrosVMIWithEvictionStrategy()
@@ -1540,7 +1524,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 400)
 
 				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi_evict1 := cirrosVMIWithEvictionStrategy()
@@ -1664,8 +1647,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with multiple VMIs with eviction policies set", func() {
 
 			It("[test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := cirrosVMIWithEvictionStrategy()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2075,8 +2075,8 @@ func GetGuestAgentUserData() string {
 
 	ipv6UserDataString := ""
 	if netutils.IsIPv6String(dnsServerIP) {
-		ipv6UserDataString = fmt.Sprintf(`sudo ip -6 addr add fd10:0:2::2/120 dev eth0
-                             sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2
+		ipv6UserDataString = fmt.Sprintf(`sudo ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0
+                             sudo ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2
                              echo "nameserver %s" >> /etc/resolv.conf`, dnsServerIP)
 	}
 	return fmt.Sprintf(`#!/bin/bash
@@ -2827,13 +2827,13 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 	ipv6Batch := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0\n"},
+		&expect.BSnd{S: "sudo ip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: "0"},
 		&expect.BSnd{S: "sleep 5\n"},
 		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2\n"},
+		&expect.BSnd{S: "sudo ip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: "0"},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4639,15 +4639,21 @@ func IsRunningOnKindInfraIPv6() bool {
 	return strings.HasPrefix(provider, "kind-k8s-1.17.0-ipv6")
 }
 
+func SkipStressTestIfRunnigOnKindInfra() {
+	if IsRunningOnKindInfra() {
+		Skip("Skip stress test till issue https://github.com/kubevirt/kubevirt/issues/3323 is fixed")
+	}
+}
+
 func SkipPVCTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
 		Skip("Skip PVC tests till PR https://github.com/kubevirt/kubevirt/pull/3171 is merged")
 	}
 }
 
-func SkipMigrationTestIfRunnigOnKindInfra() {
+func SkipNFSTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
-		Skip("Skip migration tests till PR https://github.com/kubevirt/kubevirt/pull/3221 is merged")
+		Skip("Skip NFS tests till issue https://github.com/kubevirt/kubevirt/issues/3322 is fixed")
 	}
 }
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -385,7 +385,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{v1.Network{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vm.Spec)
-	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nip -6 addr add fd10:0:2::2/120 dev eth0\nsleep 5\nip -6 route add default via fd10:0:2::1 src fd10:0:2::2\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
+	addNoCloudDiskWitUserData(&vm.Spec, "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nip -6 addr add fd2e:f1fe:9490:a8ff::2/120 dev eth0\nsleep 5\nip -6 route add default via fd2e:f1fe:9490:a8ff::1 src fd2e:f1fe:9490:a8ff::2\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx")
 
 	masquerade := &v1.InterfaceMasquerade{}
 	ports := []v1.Port{v1.Port{Name: "http", Protocol: "TCP", Port: 80}}


### PR DESCRIPTION
Use IPv6 bind address instead of IPv4 one
    
Change migration virt-handler to virt-handler socket to listen
on [::] instead of 0.0.0.0, unless IPv6 is disabled.
    
According to standard, listening on [::] will also allow
incoming IPv4 connections, but not vice versa.
It does work without it because Golang net library use implicity
an IPv6 socket, but its not readable and not maintainable.
    
This PR still considers IPv4 mapping is enabled.
    
Depends on: #3392

Signed-off-by: Or Shoval oshoval@redhat.com

```release-note
None
```
