### PR TITLE
Remove @dshchedr from the list of test-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -37,6 +37,5 @@ aliases:
   test-reviewers:
       - jerry7z
       - ILpinto
-      - dshchedr
   ci-approvers:
       - dhiller


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove @dshchedr from the list of test-reviewers

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
