### PR TITLE
Add missing cleanup to certificate tests

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -67,6 +67,10 @@ var _ = Describe("Infrastructure", func() {
 
 	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
 
+		BeforeEach(func() {
+			tests.BeforeTestCleanup()
+		})
+
 		It("[test_id:4099]should be rotated when a new CA is created", func() {
 			By("checking that the config-map gets the new CA bundle attached")
 			Eventually(func() int {


### PR DESCRIPTION
The certificate tests were missing the cleanup call after each test.  As
a result VMIs piled up on one of the test nodes. When we then scheduled
additional VMIs to this node, the tests timed out because of no
available resources.

A typical example can be found here: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/3364/pull-kubevirt-e2e-k8s-1.16/1255825501826584576.

When looking at the dumped VMIs in https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/3364/pull-kubevirt-e2e-k8s-1.16/1255825501826584576 one can see 2 VMIs running from previous tests and a third one tries to get started.

Signed-off-by: Roman Mohr <rmohr@redhat.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
