### PR TITLE
Fix IPv6 migration

### DIFF
--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["migration-proxy.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/log:go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"sync"
 
+	netutils "k8s.io/utils/net"
+
 	"kubevirt.io/client-go/log"
 )
 
@@ -213,6 +215,10 @@ func (m *migrationProxyManager) StopTargetListener(key string) {
 func (m *migrationProxyManager) StartSourceListener(key string, targetAddress string, destSrcPortMap map[string]int, baseDir string) error {
 	m.managerLock.Lock()
 	defer m.managerLock.Unlock()
+
+	if netutils.IsIPv6String(targetAddress) {
+		targetAddress = "[" + targetAddress + "]"
+	}
 
 	isExistingProxy := func(curProxies []*migrationProxy, targetAddress string, destSrcPortMap map[string]int) bool {
 		if len(curProxies) != len(destSrcPortMap) {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -406,8 +406,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 		Context("with a Cirros disk", func() {
 			It("[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				vmi.Annotations = map[string]string{
 					v1.PlacePCIDevicesOnRootComplex: "true",
@@ -450,8 +448,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:1783]should be successfully migrated multiple times with cloud-init disk", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskCirros))
 				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
 
@@ -504,8 +500,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3237]should complete a migration", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -540,7 +534,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 		Context("with setting guest time", func() {
 			It("[test_id:4114]should set an updated time after a migration", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
@@ -681,8 +674,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}
 			})
 			It("[test_id:3239]should reject a migration of a vmi with a non-shared data volume", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 				vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
 
@@ -874,7 +865,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			var pvName string
 			var vmi *v1.VirtualMachineInstance
 			BeforeEach(func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
+				tests.SkipNFSTestIfRunnigOnKindInfra()
 				pvName = "test-nfs" + rand.String(48)
 				// Prepare a NFS backed PV
 				By("Starting an NFS POD")
@@ -1082,6 +1073,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
+				tests.SkipStressTestIfRunnigOnKindInfra()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
@@ -1203,8 +1195,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			}
 
 			table.DescribeTable("should be able to cancel a migration", func(createVMI vmiBuilder) {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi, dv := createVMI()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				defer deleteDataVolume(dv)
@@ -1246,8 +1236,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				table.Entry("[test_id:2731] with OCS Disk", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1285,8 +1273,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	Context("with sata disks", func() {
 
 		It("[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret", func() {
-			tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 			configMapName := "configmap-" + rand.String(5)
 			secretName := "secret-" + rand.String(5)
 
@@ -1376,8 +1362,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It("[test_id:3244]should block the eviction api while a slow migration is in progress", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				vmi = fedoraVMIWithEvictionStrategy()
 
 				By("Starting the VirtualMachineInstance")
@@ -1433,7 +1417,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 			Context("with node tainted during node drain", func() {
 				It("[test_id:2221] should migrate a VMI under load to another node", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = fedoraVMIWithEvictionStrategy()
@@ -1486,7 +1469,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				})
 
 				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi = cirrosVMIWithEvictionStrategy()
@@ -1541,7 +1523,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 400)
 
 				It("[test_id:2224] should handle mixture of VMs with different eviction strategies.", func() {
-					tests.SkipMigrationTestIfRunnigOnKindInfra()
 					tests.SkipIfVersionBelow("Eviction of completed pods requires v1.13 and above", "1.13")
 
 					vmi_evict1 := cirrosVMIWithEvictionStrategy()
@@ -1665,8 +1646,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with multiple VMIs with eviction policies set", func() {
 
 			It("[test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
-				tests.SkipMigrationTestIfRunnigOnKindInfra()
-
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := cirrosVMIWithEvictionStrategy()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4663,15 +4663,21 @@ func IsRunningOnKindInfraIPv6() bool {
 	return strings.HasPrefix(provider, "kind-k8s-1.17.0-ipv6")
 }
 
+func SkipStressTestIfRunnigOnKindInfra() {
+	if IsRunningOnKindInfra() {
+		Skip("Skip stress test till issue https://github.com/kubevirt/kubevirt/issues/3323 is fixed")
+	}
+}
+
 func SkipPVCTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
 		Skip("Skip PVC tests till PR https://github.com/kubevirt/kubevirt/pull/3171 is merged")
 	}
 }
 
-func SkipMigrationTestIfRunnigOnKindInfra() {
+func SkipNFSTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
-		Skip("Skip migration tests till PR https://github.com/kubevirt/kubevirt/pull/3221 is merged")
+		Skip("Skip NFS tests till issue https://github.com/kubevirt/kubevirt/issues/3322 is fixed")
 	}
 }
 


### PR DESCRIPTION
When dealing with IPv6 addresses, the standard net package
is expecting an IPv6 address format that includes
square brackets (e.g [::1]).
By normalizing the IPv6 address, the whole migration flow succeeds
and the currently skipped functional tests are therefore run normally.

No unit test was added for the IPv6 scenario because
the existing tests are dependent on OS capabilities and the travis-ci
is not supporting IPv6 at the moment [1].
We are still safe as the IPv6 code is covered by the functional tests.

1. https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
