### PR TITLE
Fixed typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Maintainers are:
  * @stu-gott
  * @vladikr
 
-### Becoming a memeber
+### Becoming a member
 
 Contributors that frequently contribute to the project may ask to join the
 kubevirt organization.


### PR DESCRIPTION
Signed-off-by: Kunal Kushwaha <kunalkushwaha453@gmail.com>

Getting started with contributing to the project and found a typo while going through the docs.
Fixed typo in CONTRIBUTING.md in line 95, **memeber -> member**

```release-note
NONE
```