### PR TITLE
Add missing SELinux permission for SR-IOV

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -4,4 +4,5 @@
     (typeattributeset mcs_constrained_type (process))
     (allow process self (tun_socket (relabelfrom relabelto attach_queue)))
     (allow process hugetlbfs_t (dir (add_name create write remove_name rmdir setattr)))
-    (allow process hugetlbfs_t (file (create unlink))))
+    (allow process hugetlbfs_t (file (create unlink)))
+    (allow process sysfs_t (file (write))))


### PR DESCRIPTION
**What this PR does / why we need it**:
This (re-)adds the minimum set of permissions required for virt-launcher to support SR-IOV

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```