### PR TITLE
Add check which checks requested cpu model in vmi

### DIFF
--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virt-handler/device-manager:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -14,7 +14,7 @@ var domCapabilitiesFilePath = nodeLabellerVolumePath + "/virsh_domcapabilities.x
 // getCPUInfo retrieves xml data from file and parse them.
 // Output of this function is slice of usable cpu models and features.
 // Only models with tag usable yes will be used.
-func (n *NodeLabeller) getCPUInfo() ([]string, map[string]bool, error) {
+func (n *NodeLabeller) getCPUInfo() (map[string]bool, map[string]bool, error) {
 	hostDomCapabilities := HostDomCapabilities{}
 	err := getStructureFromXMLFile(domCapabilitiesFilePath, &hostDomCapabilities)
 	if err != nil {
@@ -30,7 +30,7 @@ func (n *NodeLabeller) getCPUInfo() ([]string, map[string]bool, error) {
 	obsoleteCPUsx86 := c.getObsoleteCPUMap()
 
 	basicFeaturesMap := make(map[string]bool)
-	cpus := make([]string, 0)
+	cpus := make(map[string]bool)
 	features := make(map[string]bool)
 	var newFeatures map[string]bool
 
@@ -56,7 +56,7 @@ func (n *NodeLabeller) getCPUInfo() ([]string, map[string]bool, error) {
 
 			features = unionMap(features, newFeatures)
 
-			cpus = append(cpus, model.Name)
+			cpus[model.Name] = true
 		}
 	}
 	return cpus, features, nil

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -994,6 +994,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			} else {
 				domain.Spec.CPU.Mode = "custom"
 				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+				domain.Spec.CPU.Check = "none" // TODO https://bugzilla.redhat.com/show_bug.cgi?id=1834714
 			}
 		}
 
@@ -1005,6 +1006,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 					Policy: feature.Policy,
 				})
 			}
+
+			domain.Spec.CPU.Check = "none" // TODO https://bugzilla.redhat.com/show_bug.cgi?id=1834714
 		}
 
 		// Adjust guest vcpu config. Currenty will handle vCPUs to pCPUs pinning

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1135,6 +1135,33 @@ var _ = Describe("Converter", func() {
 				table.Entry(v1.CPUModeHostPassthrough, v1.CPUModeHostPassthrough),
 				table.Entry(v1.CPUModeHostModel, v1.CPUModeHostModel),
 			)
+
+			table.DescribeTable("should set check CPU", func(model, result string) {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Model: model,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Check).To(Equal(result), "Expect check")
+			},
+				table.Entry(" to empty string when host-passthrough is set", v1.CPUModeHostPassthrough, ""),
+				table.Entry(" to empty string when host-model is set", v1.CPUModeHostModel, ""),
+				table.Entry(" to none string when cpu-model is set", "Conroe", "none"),
+			)
+
+			table.DescribeTable("should set check CPU", func(features []v1.CPUFeature, result string) {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = &v1.CPU{
+					Features: features,
+				}
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Check).To(Equal(result), "Expect check")
+			},
+				table.Entry(" to empty string when no features are set", nil, ""),
+				table.Entry(" to none string when cpu features are set", []v1.CPUFeature{{Name: "svm"}}, "none"),
+			)
 		})
 
 		Context("when CPU spec defined and model not", func() {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -218,6 +218,7 @@ type VCPU struct {
 type CPU struct {
 	Mode     string       `xml:"mode,attr,omitempty"`
 	Model    string       `xml:"model,omitempty"`
+	Check    string       `xml:"check,attr,omitempty"`
 	Features []CPUFeature `xml:"feature"`
 	Topology *CPUTopology `xml:"topology"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Virsh reports some cpu models as supported, but libvirt refuses to run vm with that cpu model.
This commit adds new functionality, which checks requested cpu model against supported models reported by virsh.

Added attribute `check=none` to vmi cpu converter when VM requested cpu mode or cpu features. This `check=none` allows to run vms with cpu model, which before didn't run.

**Which issue(s) this PR fixes**:
Fixes #3390

**Release note**:
```release-note
NONE
```
 
Signed-off-by: Karel Simon <ksimon@redhat.com>