### PR TITLE
Handle DataVolume volumes mistakenly used as PVC volumes

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "replicaset.go",
         "snapshot.go",
         "snapshot_base.go",
+        "util.go",
         "vm.go",
         "vmi.go",
     ],

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -404,7 +404,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.launcherSubGid,
 	)
 
-	vca.vmiController = NewVMIController(vca.templateService, vca.vmiInformer, vca.podInformer, vca.vmiRecorder, vca.clientSet, vca.dataVolumeInformer)
+	vca.vmiController = NewVMIController(vca.templateService, vca.vmiInformer, vca.podInformer, vca.persistentVolumeClaimInformer, vca.vmiRecorder, vca.clientSet, vca.dataVolumeInformer)
 	recorder := vca.getNewRecorder(k8sv1.NamespaceAll, "node-controller")
 	vca.nodeController = NewNodeController(vca.clientSet, vca.nodeInformer, vca.vmiInformer, recorder)
 	vca.migrationController = NewMigrationController(vca.templateService, vca.vmiInformer, vca.podInformer, vca.migrationInformer, vca.vmiRecorder, vca.clientSet, vca.clusterConfig)
@@ -422,6 +422,7 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.vmiInformer,
 		vca.vmInformer,
 		vca.dataVolumeInformer,
+		vca.persistentVolumeClaimInformer,
 		recorder,
 		vca.clientSet)
 }

--- a/pkg/virt-controller/watch/util.go
+++ b/pkg/virt-controller/watch/util.go
@@ -1,0 +1,95 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2017, 2018 Red Hat, Inc.
+ *
+ */
+
+package watch
+
+import (
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/log"
+)
+
+func handlePVCMisuseInVM(pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder, vm *v1.VirtualMachine) error {
+	logger := log.Log.Object(vm)
+
+	volumeName, err := handlePVCMisuse(pvcInformer, recorder, vm.Namespace, vm.Spec.Template.Spec.Volumes, logger)
+	if err != nil && volumeName != nil {
+		recorder.Eventf(vm,
+			k8sv1.EventTypeWarning,
+			FailedPVCVolumeSourceMisusedReason,
+			"PVC '%s' used as volume source where Data Volume should be used",
+			*volumeName)
+	}
+
+	return err
+}
+
+func handlePVCMisuseInVMI(pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder, vmi *v1.VirtualMachineInstance) error {
+	logger := log.Log.Object(vmi)
+
+	volumeName, err := handlePVCMisuse(pvcInformer, recorder, vmi.Namespace, vmi.Spec.Volumes, logger)
+	if err != nil && volumeName != nil {
+		recorder.Eventf(vmi,
+			k8sv1.EventTypeWarning,
+			FailedPVCVolumeSourceMisusedReason,
+			"PVC '%s' used as volume source where Data Volume should be used",
+			*volumeName)
+	}
+
+	return err
+}
+
+// Checks if PVC used in VolumeSource is owned by a DataVolume.
+// If so, the DV should be used instead and this is an error
+func handlePVCMisuse(pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder, namespace string, volumes []v1.Volume, logger *log.FilteredLogger) (*string, error) {
+
+	for _, volume := range volumes {
+		if volume.VolumeSource.PersistentVolumeClaim == nil {
+			continue
+		}
+
+		key := fmt.Sprintf("%s/%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName)
+		obj, exists, err := pvcInformer.GetStore().GetByKey(key)
+		if err != nil {
+			logger.Reason(err).Warning("failed to fetch PVC for namespace from cache")
+			return nil, err
+		} else if !exists {
+			continue
+		}
+
+		pvc := obj.(*k8sv1.PersistentVolumeClaim)
+		for _, or := range pvc.ObjectMeta.OwnerReferences {
+			if or.Kind != "DataVolume" {
+				continue
+			}
+
+			err := fmt.Errorf("PVC %v owned by DataVolume %v cannot be used as a volume source. Use DataVolume instead",
+				key, or.Name)
+			logger.Reason(err).Error("Invalid VM spec")
+			return &volume.VolumeSource.PersistentVolumeClaim.ClaimName, err
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -40,6 +40,7 @@ var _ = Describe("VirtualMachine", func() {
 		var vmInformer cache.SharedIndexInformer
 		var dataVolumeInformer cache.SharedIndexInformer
 		var dataVolumeSource *framework.FakeControllerSource
+		var pvcInformer cache.SharedIndexInformer
 		var stop chan struct{}
 		var controller *VMController
 		var recorder *record.FakeRecorder
@@ -65,9 +66,10 @@ var _ = Describe("VirtualMachine", func() {
 			dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmInformer, vmSource = testutils.NewFakeInformerFor(&v1.VirtualMachine{})
+			pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			recorder = record.NewFakeRecorder(100)
 
-			controller = NewVMController(vmiInformer, vmInformer, dataVolumeInformer, recorder, virtClient)
+			controller = NewVMController(vmiInformer, vmInformer, dataVolumeInformer, pvcInformer, recorder, virtClient)
 			// Wrap our workqueue to have a way to detect when we are done processing updates
 			mockQueue = testutils.NewMockWorkQueue(controller.Queue)
 			controller.Queue = mockQueue

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -169,6 +169,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			services.NewTemplateService("a", "b", "c", "d", "e", "f", pvcInformer.GetStore(), virtClient, config, qemuGid),
 			vmiInformer,
 			podInformer,
+			pvcInformer,
 			recorder,
 			virtClient,
 			dataVolumeInformer,
@@ -309,6 +310,55 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
+		})
+
+		It("should not start VMI if it mistakenly uses PVC instead of DV that owns it", func() {
+			vmi := v1.NewMinimalVMI("testvm")
+
+			annotations := map[string]string{}
+			annotations[v1.ControllerAPILatestVersionObservedAnnotation] = v1.ApiLatestVersion
+			annotations[v1.ControllerAPIStorageVersionObservedAnnotation] = v1.ApiStorageVersion
+			vmi.SetAnnotations(annotations)
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "dv1",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "dv1",
+					},
+				},
+			})
+
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vmi.Namespace,
+				},
+				Status: cdiv1.DataVolumeStatus{
+					Phase: cdiv1.Succeeded,
+				},
+			}
+
+			pvcInformer.GetStore().Add(&k8sv1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vmi.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						metav1.OwnerReference{
+							Name: "dv1",
+							Kind: "DataVolume",
+						},
+					},
+				},
+			})
+
+			addVirtualMachine(vmi)
+			dataVolumeInformer.GetStore().Add(dv)
+
+			vmiInterface.EXPECT().Update(gomock.Any()).Return(vmi, nil)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, FailedPVCVolumeSourceMisusedReason)
 		})
 	})
 

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -97,7 +97,7 @@ var _ = Describe("ImageUpload", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Start VM")
-			vmi := tests.NewRandomVMIWithPVC(dvName)
+			vmi := tests.NewRandomVMIWithDataVolume(dvName)
 			vmi, err = virtClient.VirtualMachineInstance(namespace).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)


### PR DESCRIPTION
When a PVC created by a DataVolume is used as volume source, it can
cause problems with VM startup (as the Data Volume may not be ready
yet). This commit adds a check to detect the erronous situation where a
PVC created by a Data Volume is used directly as Volume Source.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR improves usability of handling Data Volumes. If a DataVolume is to be used, the VM's yaml has to use the DV, not the underlying PVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If a PVC was created by a DataVolume, it cannot be used as a Volume Source for a VM. The owning DataVolume has to be used instead.
```
