### PR TITLE
build: Only build container-disk as a static binary

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -77,15 +77,15 @@ if [ "${target}" = "install" ]; then
     # Delete all binaries which are not present in the binaries variable to avoid branch inconsistencies
     to_delete=$(comm -23 <(find ${CMD_OUT_DIR} -mindepth 1 -maxdepth 1 -type d | sort) <(echo $binaries | sed -e 's/cmd\///g' -e 's/ /\n/g' | sed -e "s#^#${CMD_OUT_DIR}/#" | sort))
     rm -rf ${to_delete}
-fi
 
-if [ "${target}" = "install" ]; then
     (
-        mkdir -p ${CMD_OUT_DIR}/container-disk-v2alpha
-        cd cmd/container-disk-v2alpha
-        # the containerdisk bianry needs to be static, as it runs in a scratch container
-        echo "building static binary container-disk"
-        gcc -static -o ${CMD_OUT_DIR}/container-disk-v2alpha/container-disk main.c
+        if [ -z "$BIN_NAME" ] || [[ $BIN_NAME == *"container-disk"* ]]; then
+            mkdir -p ${CMD_OUT_DIR}/container-disk-v2alpha
+            cd cmd/container-disk-v2alpha
+            # the containerdisk bianry needs to be static, as it runs in a scratch container
+            echo "building static binary container-disk"
+            gcc -static -o ${CMD_OUT_DIR}/container-disk-v2alpha/container-disk main.c
+        fi
     )
 fi
 


### PR DESCRIPTION
Commit 7b4deb2736 removed a check that verified the build target is
container-disk before building it statically, causing builds of other
targets which are not built statically to fail. Reinsert the check
so only container-disk is built statically.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>

**What this PR does / why we need it**:
It is needed to fix e.g. 'hack/build-go.sh install virt-controller'

**Special notes for your reviewer**:
Commit 7b4deb2736 also introduced another
  if [ "${target}" = "install" ]; then
conditional below an existing one. I can merge the contents of those conditionals if desired. It wasn't clear to me if that was intentional, e.g. binaries are deleted in the first instance and built in the second.

**Release note**:
```release-note
NONE
```
