### PR TITLE
travis-ci: Fail on first error in script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 - git reset --hard
 
 script:
+- set -e
 - make generate
 - if [[ -n "$(git status --porcelain)" ]] ; then echo "It seems like you need to run
   `make generate`. Please run it and commit the changes"; git status --porcelain; false; fi
@@ -36,6 +37,7 @@ script:
 - make manifests DOCKER_PREFIX="docker.io/kubevirt" DOCKER_TAG=$TRAVIS_TAG # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
 - make olm-verify
 - if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then make prom-rules-verify; fi
+- set +e
 
 deploy:
 - provider: script


### PR DESCRIPTION
**What this PR does / why we need it**:

The CI is passing several scripts of tests where each may fail.
When a script line fails, travis-ci is not existing but continues with the
next one.

This behavior makes the error hard to detect, wastes time and
resources.
Therefore, the scripts are wrapped with `set {-,+}e` for early exit on
failure.

**Release note**:
```release-note
NONE
```
