### PR TITLE
Fix inconsistency in VM CRD CLI output

### DIFF
--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1319,7 +1319,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			res, err := getChangeRequestJson(vm, stopRequest)
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"stateChangeRequests":[{"action":"Stop","uid":"%s"}]}}]`, uid)
+			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"created":false,"ready":false,"stateChangeRequests":[{"action":"Stop","uid":"%s"}]}}]`, uid)
 			Expect(res).To(Equal(ref))
 		})
 
@@ -1356,7 +1356,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			res, err := getChangeRequestJson(vm, stopRequest, startRequest)
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"stateChangeRequests":[{"action":"Stop","uid":"%s"},{"action":"Start"}]}}]`, uid)
+			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"created":false,"ready":false,"stateChangeRequests":[{"action":"Stop","uid":"%s"},{"action":"Start"}]}}]`, uid)
 			Expect(res).To(Equal(ref))
 		})
 
@@ -1385,7 +1385,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			res, err := getChangeRequestJson(vm, startRequest)
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"stateChangeRequests":[{"action":"Start"}]}}]`)
+			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"created":false,"ready":false,"stateChangeRequests":[{"action":"Start"}]}}]`)
 			Expect(res).To(Equal(ref))
 		})
 

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -1319,7 +1319,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			res, err := getChangeRequestJson(vm, stopRequest)
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"created":false,"ready":false,"stateChangeRequests":[{"action":"Stop","uid":"%s"}]}}]`, uid)
+			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"stateChangeRequests":[{"action":"Stop","uid":"%s"}]}}]`, uid)
 			Expect(res).To(Equal(ref))
 		})
 
@@ -1356,7 +1356,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			res, err := getChangeRequestJson(vm, stopRequest, startRequest)
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"created":false,"ready":false,"stateChangeRequests":[{"action":"Stop","uid":"%s"},{"action":"Start"}]}}]`, uid)
+			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"stateChangeRequests":[{"action":"Stop","uid":"%s"},{"action":"Start"}]}}]`, uid)
 			Expect(res).To(Equal(ref))
 		})
 
@@ -1385,7 +1385,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			res, err := getChangeRequestJson(vm, startRequest)
 			Expect(err).ToNot(HaveOccurred())
 
-			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"created":false,"ready":false,"stateChangeRequests":[{"action":"Start"}]}}]`)
+			ref := fmt.Sprintf(`[{ "op": "add", "path": "/status", "value": {"stateChangeRequests":[{"action":"Start"}]}}]`)
 			Expect(res).To(Equal(ref))
 		})
 

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -102,7 +102,6 @@ func NewVirtualMachineCrd() *extv1beta1.CustomResourceDefinition {
 		},
 		AdditionalPrinterColumns: []extv1beta1.CustomResourceColumnDefinition{
 			{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
-			{Name: "Running", Type: "boolean", JSONPath: ".spec.running"},
 			{Name: "Volume", Description: "Primary Volume", Type: "string", JSONPath: ".spec.volumes[0].name"},
 			{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1},
 		},

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -55,7 +55,7 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 		// Name will be there in all the cases, so verify name
 		Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 	},
-		table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "RUNNING", "VOLUME"}),
+		table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "VOLUME", "STRATEGY", "READY"}),
 		table.Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
 	)
 
@@ -79,7 +79,7 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 		// Verify one of the wide column output field
 		Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 	},
-		table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "RUNNING", "VOLUME", "CREATED"}, 1, "true"),
+		table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "STRATEGY", "READY", "CREATED"}, 1, "true"),
 		table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE"}, 1, "True"),
 	)
 })

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -55,7 +55,7 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 		// Name will be there in all the cases, so verify name
 		Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 	},
-		table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "VOLUME", "STRATEGY", "READY"}),
+		table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "VOLUME"}),
 		table.Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
 	)
 
@@ -79,7 +79,7 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 		// Verify one of the wide column output field
 		Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 	},
-		table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "STRATEGY", "READY", "CREATED"}, 1, "true"),
+		table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED"}, 1, "true"),
 		table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE"}, 1, "True"),
 	)
 })

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -208,39 +208,8 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		// Read column titles
 		titles, err := readNewStatus(stdout, nil, readTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(titles).To(Equal([]string{"NAME", "AGE", "VOLUME", "STRATEGY", "READY"}),
+		Expect(titles).To(Equal([]string{"NAME", "AGE", "VOLUME"}),
 			"Output should have the proper columns")
-
-		// Read first status of the vm
-		vmStatus, err := readNewStatus(stdout, titles, readTimeout)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), "false"),
-			"VM should not be running")
-
-		By("Starting the VM")
-		vm = tests.StartVirtualMachine(vm)
-
-		vmStatus, err = readNewStatus(stdout, vmStatus, readTimeout)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), "true"),
-			"VM should be running")
-
-		By("Restarting the VM")
-		err = virtCli.VirtualMachine(vm.ObjectMeta.Namespace).Restart(vm.ObjectMeta.Name)
-		Expect(err).ToNot(HaveOccurred(), "VM should have been restarted")
-
-		vmStatus, err = readNewStatus(stdout, nil, readTimeout)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), "true"),
-			"VM should be running")
-
-		By("Stopping the VM")
-		vm = tests.StopVirtualMachine(vm)
-
-		vmStatus, err = readNewStatus(stdout, vmStatus, readTimeout)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), "false"),
-			"VM should be running")
 	})
 
 	It("[test_id:3466]Should update vmi status with the proper columns using 'kubectl get vmi -w'", func() {

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -208,7 +208,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		// Read column titles
 		titles, err := readNewStatus(stdout, nil, readTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(titles).To(Equal([]string{"NAME", "AGE", "RUNNING", "VOLUME"}),
+		Expect(titles).To(Equal([]string{"NAME", "AGE", "VOLUME", "STRATEGY", "READY"}),
 			"Output should have the proper columns")
 
 		// Read first status of the vm


### PR DESCRIPTION
In the current state the output of ```kubectl get vm``` looks like this:
```
NAME        AGE   RUNNING  VOLUME
vm-cirros   29m                       
```
the RUNNING column is confusing because of its name and it is inaccurate because it can be either empty or true. It was thought as an indicator to the VM status while actually that column reflected the ```spec.running``` configuration. 

This PR suggests to remove the inaccurate column. A new output will look like this:
```
NAME        AGE   VOLUME
vm-cirros   29m
```

**What this PR does / why we need it**:
It is required for consistency and accuracy in the information that is provided to the user that consumes the CLI tools.

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=1832179

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
