### PR TITLE
Fix an EnvVar map equivalence test

### DIFF
--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -21,6 +21,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"reflect"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -175,7 +176,7 @@ var _ = Describe("Operator Config", func() {
 				{Name: key2, Value: val2},
 			}
 
-			Expect(*envObjects).To(BeEquivalentTo(expected))
+			Expect(reflect.DeepEqual(*envObjects, expected)).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A unit test compares maps as strings, which doesn't guarantee any specific order.
Fixing that by using `reflect.DeepEqual()`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
