### PR TITLE
Preparing kubevirt to make the ipv6 lane mandatory

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -540,6 +540,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 		Context("with setting guest time", func() {
 			It("[test_id:4114]should set an updated time after a migration", func() {
+				tests.SkipMigrationTestIfRunnigOnKindInfra()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
@@ -970,6 +971,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1081,6 +1083,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -391,7 +391,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		}
 
 		It("[test_id:3090]should be continued after the VMI is unpaused", func() {
-
+			tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 			By("Starting a Fedora VMI")
 			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4651,6 +4651,12 @@ func SkipMigrationTestIfRunnigOnKindInfra() {
 	}
 }
 
+func SkipIpv6TestsFailingAfterVmImageUpgradeToFc32() {
+	if IsRunningOnKindInfraIPv6() {
+		Skip("Skip ipv6 tests started to fail after https://github.com/kubevirt/kubevirt/pull/3372 was merged (issue: https://github.com/kubevirt/kubevirt/issues/3421)")
+	}
+}
+
 func IsUsingBuiltinNodeDrainKey() bool {
 	return GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1108,7 +1108,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("[test_id:1677]VMI condition should signal agent presence", func() {
-
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 
@@ -1124,6 +1124,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should remove condition when agent is off", func() {
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 
@@ -1164,7 +1165,7 @@ var _ = Describe("Configurations", func() {
 				})
 
 				It("[test_id:]VMI condition should signal unsupported agent presence", func() {
-
+					tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 					agentVMI := prepareAgentVM()
 					getOptions := metav1.GetOptions{}
 
@@ -1186,6 +1187,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should have guestosinfo in status when agent is present", func() {
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 				var updatedVmi *v1.VirtualMachineInstance
@@ -1205,7 +1207,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should return the whole data when agent is present", func() {
-
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
@@ -1227,7 +1229,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should not return the whole data when agent is not present", func() {
-
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the VirtualMachineInstance console")
@@ -1253,6 +1255,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should return user list", func() {
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				expecter, err := tests.LoggedInFedoraExpecter(agentVMI)
@@ -1277,6 +1280,7 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should return filesystem list", func() {
+				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
@@ -2408,6 +2412,7 @@ var _ = Describe("Configurations", func() {
 	})
 
 	It("[test_id:4153]VMI with masquerade binding and guest agent should expose Pod IP as its public address", func() {
+		tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 		vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 
 		By("Starting a VirtualMachineInstance")


### PR DESCRIPTION
**What this PR does / why we need it**:
Since ipv6 support was merged to kubevirt there were servel PRs that broke
the ipv6 lane.
Since the lane is not mandaroty it is very hard to track and to catch
those failures on time.

To avoid this situation in the future. The current failing tests on the
ipv6 lane are skipped so the lane can become green.
Once this PR will be merged, the ipv6 lane can be moved to be
mandatory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
