### PR TITLE
functest: Fix VMI IPv6 configuration

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -971,7 +971,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
@@ -1083,7 +1082,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			It("[test_id:2227]should abort a vmi migration without progress", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -391,7 +391,6 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		}
 
 		It("[test_id:3090]should be continued after the VMI is unpaused", func() {
-			tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 			By("Starting a Fedora VMI")
 			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4675,12 +4675,6 @@ func SkipMigrationTestIfRunnigOnKindInfra() {
 	}
 }
 
-func SkipIpv6TestsFailingAfterVmImageUpgradeToFc32() {
-	if IsRunningOnKindInfraIPv6() {
-		Skip("Skip ipv6 tests started to fail after https://github.com/kubevirt/kubevirt/pull/3372 was merged (issue: https://github.com/kubevirt/kubevirt/issues/3421)")
-	}
-}
-
 func IsUsingBuiltinNodeDrainKey() bool {
 	return GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2084,12 +2084,14 @@ func GetGuestAgentUserData() string {
 	ipv6UserDataString := ""
 	if netutils.IsIPv6String(dnsServerIP) {
 		ipv6UserDataString = fmt.Sprintf(`sudo ip -6 addr add fd10:0:2::2/120 dev eth0
-                             sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2
+                             for i in {1..20}; do sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2 && break || sleep 0.1; done
                              echo "nameserver %s" >> /etc/resolv.conf`, dnsServerIP)
 	}
 	return fmt.Sprintf(`#!/bin/bash
                 echo "fedora" |passwd fedora --stdin
-				%s
+                systemctl disable NetworkManager
+                systemctl stop NetworkManager
+                %s
                 mkdir -p /usr/local/bin
                 curl %s > /usr/local/bin/qemu-ga
                 chmod +x /usr/local/bin/qemu-ga

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1108,7 +1108,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("[test_id:1677]VMI condition should signal agent presence", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 
@@ -1124,7 +1123,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should remove condition when agent is off", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 
@@ -1165,7 +1163,6 @@ var _ = Describe("Configurations", func() {
 				})
 
 				It("[test_id:]VMI condition should signal unsupported agent presence", func() {
-					tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 					agentVMI := prepareAgentVM()
 					getOptions := metav1.GetOptions{}
 
@@ -1187,7 +1184,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should have guestosinfo in status when agent is present", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 				getOptions := metav1.GetOptions{}
 				var updatedVmi *v1.VirtualMachineInstance
@@ -1207,7 +1203,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should return the whole data when agent is present", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
@@ -1229,7 +1224,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should not return the whole data when agent is not present", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the VirtualMachineInstance console")
@@ -1255,7 +1249,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should return user list", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				expecter, err := tests.LoggedInFedoraExpecter(agentVMI)
@@ -1280,7 +1273,6 @@ var _ = Describe("Configurations", func() {
 			})
 
 			It("should return filesystem list", func() {
-				tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 				agentVMI := prepareAgentVM()
 
 				By("Expecting the Guest VM information")
@@ -2412,7 +2404,6 @@ var _ = Describe("Configurations", func() {
 	})
 
 	It("[test_id:4153]VMI with masquerade binding and guest agent should expose Pod IP as its public address", func() {
-		tests.SkipIpv6TestsFailingAfterVmImageUpgradeToFc32()
 		vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 
 		By("Starting a VirtualMachineInstance")


### PR DESCRIPTION
**What this PR does / why we need it**:

On an IPv6 deployment, IPv6 configuration is set on boot through
(injected) scripts in order to enable the VM connectivity.
The configuration includes an IP address, default route and DNS.
Implemented through the `ip` tool.

The IP configuration failed frequently due to the async behavior of
the IP addition operation. There is a need to give it time before
proceeding to add the route (which cannot be added if the previous
action has not completed).

This change adds a small sleep between the addition of the IP address
and the route.
In addition, in order to avoid NetworkManager to overtake and overwrite
the IP configuration, disable it.

**Fixes** #3421

**Special notes for your reviewer**:
The IPv6 lane (pull-kubevirt-e2e-kind-k8s-1.17.0-ipv6) should pass.

**Release note**:
```release-note
NONE
```