### PR TITLE
Add prow KUBEVIRT_LANE_FOCUS support

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -33,6 +33,31 @@ readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
 
+# KUBEVIRT_LANE_FOCUS allows running only selected lanes.
+# Usage: Add lane names, seperated by space.
+# All the other lanes will fail immediately, saving CI resources,
+# but still guarding from getting the PR merged, until the line
+# is restored to an empty string.
+export KUBEVIRT_LANE_FOCUS=""
+
+if [[ $KUBEVIRT_LANE_FOCUS != "" ]]; then
+   FOCUS_ERROR=1
+else
+   FOCUS_ERROR=0
+fi
+
+for lane in ${KUBEVIRT_LANE_FOCUS[@]}; do
+    if [[ ${lane} == $TARGET ]]; then
+        echo "found $lane equal TARGET"
+        FOCUS_ERROR=0
+    fi
+done
+
+if [ $FOCUS_ERROR -eq 1 ]; then
+    echo "Focus detected, TARGET $TARGET not equal $KUBEVIRT_LANE_FOCUS, failing run"
+    exit 1
+fi
+
 if [[ $TARGET =~ windows.* ]]; then
   echo "picking the default provider for windows tests"
 elif [[ $TARGET =~ cnao ]]; then

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,19 @@
+# Continuous integration
+
+Kubevirt uses prow as its CI
+See [Project-infra](https://github.com/kubevirt/project-infra)
+
+## CI developer mode
+
+In order to save resources and run only selected lanes (i.e. for debugging),
+a developer can use KUBEVIRT_LANE_FOCUS environment variable (located at automation/test.sh).
+The variable can be set to a list of selected lanes TARGET names, separated by space.
+For example:
+`export KUBEVIRT_LANE_FOCUS="kind-k8s-1.17.0-ipv6"`
+Will run only kind IPv6 lane.
+See [prow presubmit](https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml)
+in order to select the needed TARGET name accoring the lane name.
+The other lanes will fail immediately, thus saving CI resources and allow developers to get the results faster as well.
+In addition, the PR won't be mergeable until this selection will be reverted (unset the KUBEVIRT_LANE_FOCUS),
+and all the lanes will run and succeed.
+


### PR DESCRIPTION
KUBEVIRT_LANE_FOCUS allows running only selected lanes.
Usage: Add lane names, seperated by space.

All the other lanes will fail immediately, saving CI resources,
but still guarding from getting the PR merged, until the line
is restored to an empty string.

As suggested at https://github.com/kubevirt/kubevirt/issues/3169

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
