### PR TITLE
Fix tests which are related to cpu model / features

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1859,6 +1859,39 @@ func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 	return vmi
 }
 
+func GetSupportedCPUFeatures(node k8sv1.Node) []string {
+	var featureBlackList = map[string]bool{
+		"svm": true,
+	}
+	features := make([]string, 0)
+	for key := range node.Labels {
+		if strings.Contains(key, services.NFD_CPU_FEATURE_PREFIX) {
+			feature := strings.TrimPrefix(key, services.NFD_CPU_FEATURE_PREFIX)
+			if _, ok := featureBlackList[feature]; !ok {
+				features = append(features, feature)
+			}
+		}
+	}
+	return features
+}
+
+func GetSupportedCPUModels(node k8sv1.Node) []string {
+	var cpuBlackList = map[string]bool{
+		"qemu64":     true,
+		"Opteron_G2": true,
+	}
+	cpus := make([]string, 0)
+	for key := range node.Labels {
+		if strings.Contains(key, services.NFD_CPU_MODEL_PREFIX) {
+			cpu := strings.TrimPrefix(key, services.NFD_CPU_MODEL_PREFIX)
+			if _, ok := cpuBlackList[cpu]; !ok {
+				cpus = append(cpus, cpu)
+			}
+		}
+	}
+	return cpus
+}
+
 func NewRandomVMIWithDataVolume(dataVolumeName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Virsh reports some cpu models as supported, but libvirt refuses to run vms with that cpu model/feature.
This PR adds cpu model / feature black list to tests. These tests will not run with qemu64, Opteron_G2 cpu models and svm feature.

**Which issue(s) this PR fixes**
Fixes #3390

**Special notes for your reviewer**:

**Release note**:
```NONE

```
Signed-off-by: Karel Simon <ksimon@redhat.com>
