### PR TITLE
Fix name handling of VMIs in VM templates

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -698,12 +698,11 @@ func (c *VMController) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMac
 
 // setupVMIfromVM creates a VirtualMachineInstance object from one VirtualMachine object.
 func (c *VMController) setupVMIFromVM(vm *virtv1.VirtualMachine) *virtv1.VirtualMachineInstance {
-	basename := c.getVirtualMachineBaseName(vm)
 
 	vmi := virtv1.NewVMIReferenceFromNameWithNS(vm.ObjectMeta.Namespace, "")
 	vmi.ObjectMeta = vm.Spec.Template.ObjectMeta
-	vmi.ObjectMeta.Name = basename
-	vmi.ObjectMeta.GenerateName = basename
+	vmi.ObjectMeta.Name = vm.ObjectMeta.Name
+	vmi.ObjectMeta.GenerateName = ""
 	vmi.ObjectMeta.Namespace = vm.ObjectMeta.Namespace
 	vmi.Spec = vm.Spec.Template.Spec
 
@@ -1230,18 +1229,6 @@ func copyConditionDetails(source *virtv1.VirtualMachineInstanceCondition, dest *
 	dest.LastTransitionTime = source.LastTransitionTime
 	dest.Reason = source.Reason
 	dest.Message = source.Message
-}
-
-func (c *VMController) getVirtualMachineBaseName(vm *virtv1.VirtualMachine) string {
-
-	// TODO defaulting should make sure that the right field is set, instead of doing this
-	if len(vm.Spec.Template.ObjectMeta.Name) > 0 {
-		return vm.Spec.Template.ObjectMeta.Name
-	}
-	if len(vm.Spec.Template.ObjectMeta.GenerateName) > 0 {
-		return vm.Spec.Template.ObjectMeta.GenerateName
-	}
-	return vm.ObjectMeta.Name
 }
 
 func (c *VMController) processFailure(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, createErr error) {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -545,6 +545,28 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
+		It("should ignore the name of a VirtualMachineInstance templates", func() {
+			vm, vmi := DefaultVirtualMachineWithNames(true, "vmname", "vminame")
+
+			addVirtualMachine(vm)
+
+			// expect creation called
+			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.Name).To(Equal("vmname"))
+				Expect(arg.(*v1.VirtualMachineInstance).ObjectMeta.GenerateName).To(Equal(""))
+			}).Return(vmi, nil)
+
+			// expect update status is called
+			vmInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*v1.VirtualMachine).Status.Created).To(BeFalse())
+				Expect(arg.(*v1.VirtualMachine).Status.Ready).To(BeFalse())
+			}).Return(nil, nil)
+
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
+		})
+
 		It("should update status to created if the vmi exists", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vmi.Status.Phase = v1.Scheduled
@@ -975,6 +997,7 @@ func VirtualMachineFromVMI(name string, vmi *v1.VirtualMachineInstance, started 
 
 func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
 	vmi := v1.NewMinimalVMI(vmiName)
+	vmi.GenerateName = "prettyrandom"
 	vmi.Status.Phase = v1.Running
 	vm := VirtualMachineFromVMI(vmName, vmi, started)
 	t := true

--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -119,9 +119,6 @@ func (vc *VirtCommand) Run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Error getting VirtualMachine %s: %v", resourceName, err)
 			}
 			vmiName := vm.Name
-			if vm.Spec.Template != nil && vm.Spec.Template.ObjectMeta.Name != "" {
-				vmiName = vm.Spec.Template.ObjectMeta.Name
-			}
 			err = virtClient.VirtualMachineInstance(namespace).Pause(vmiName)
 			if err != nil {
 				if errors.IsNotFound(err) {
@@ -153,9 +150,6 @@ func (vc *VirtCommand) Run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("Error getting VirtualMachine %s: %v", resourceName, err)
 			}
 			vmiName := vm.Name
-			if vm.Spec.Template != nil && vm.Spec.Template.ObjectMeta.Name != "" {
-				vmiName = vm.Spec.Template.ObjectMeta.Name
-			}
 			err = virtClient.VirtualMachineInstance(namespace).Unpause(vmiName)
 			if err != nil {
 				return fmt.Errorf("Error unpausing VirtualMachineInstance %s: %v", vmiName, err)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3951,7 +3951,7 @@ func NewRandomVirtualMachine(vmi *v1.VirtualMachineInstance, running bool) *v1.V
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:    labels,
-					Name:      name,
+					Name:      name + "makeitinteresting", // this name should have no effect
 					Namespace: namespace,
 				},
 				Spec: vmi.Spec,


### PR DESCRIPTION
**What this PR does / why we need it**:

VMIs have to have the same name as VMs. Remove traces of code where in
some cases `spec.template.metadata.name` was taken into account instead
of `metadata.name`. If `spec.template.metadata.name` was given, some
imperative commands did not work, since virt-api and virt-controller got
confused.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3140

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
