### PR TITLE
Add missing roles to csv-generator

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -733,6 +733,31 @@ spec:
                 secret:
                   optional: true
                   secretName: kubevirt-operator-certs
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - patch
+          - delete
+        serviceAccountName: kubevirt-operator
     strategy: deployment
   installModes:
   - supported: true

--- a/pkg/virt-operator/creation/csv/csv.go
+++ b/pkg/virt-operator/creation/csv/csv.go
@@ -55,6 +55,12 @@ type csvClusterPermissions struct {
 	ServiceAccountName string              `json:"serviceAccountName"`
 	Rules              []rbacv1.PolicyRule `json:"rules"`
 }
+
+type csvPermissions struct {
+	ServiceAccountName string              `json:"serviceAccountName"`
+	Rules              []rbacv1.PolicyRule `json:"rules"`
+}
+
 type csvDeployments struct {
 	Name string                `json:"name"`
 	Spec appsv1.DeploymentSpec `json:"spec,omitempty"`
@@ -62,6 +68,7 @@ type csvDeployments struct {
 
 type csvStrategySpec struct {
 	ClusterPermissions []csvClusterPermissions `json:"clusterPermissions"`
+	Permissions        []csvPermissions        `json:"permissions"`
 	Deployments        []csvDeployments        `json:"deployments"`
 }
 
@@ -153,10 +160,17 @@ func NewClusterServiceVersion(data *NewClusterServiceVersionData) (*csvv1.Cluste
 		deployment.Spec.Replicas = &replicas
 	}
 
-	rules := rbac.NewOperatorClusterRole().Rules
+	clusterRules := rbac.NewOperatorClusterRole().Rules
+	rules := rbac.NewOperatorRole(data.Namespace).Rules
 
 	strategySpec := csvStrategySpec{
 		ClusterPermissions: []csvClusterPermissions{
+			{
+				ServiceAccountName: "kubevirt-operator",
+				Rules:              clusterRules,
+			},
+		},
+		Permissions: []csvPermissions{
 			{
 				ServiceAccountName: "kubevirt-operator",
 				Rules:              rules,

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -30,7 +30,7 @@ import (
 func GetAllOperator(namespace string) []interface{} {
 	return []interface{}{
 		newOperatorServiceAccount(namespace),
-		newOperatorRole(namespace),
+		NewOperatorRole(namespace),
 		newOperatorRoleBinding(namespace),
 		NewOperatorClusterRole(),
 		newOperatorClusterRoleBinding(namespace),
@@ -436,7 +436,8 @@ func newOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
 	}
 }
 
-func newOperatorRole(namespace string) *rbacv1.Role {
+// NewOperatorRole creates a Role object for kubevirt-operator.
+func NewOperatorRole(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "rbac.authorization.k8s.io/v1",


### PR DESCRIPTION
With recent changes, we now require extra roles to properly operator
virt-operator. Some of the roles are namespaced. This commit syncs the
namespaced roles to the generated CSV.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

```release-note
NONE
```
