### PR TITLE
Sriov reporter

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -175,7 +175,9 @@ done
 set -e
 make bazel-build-images
 
+trap '{ echo "Dump kubevirt state:"; make dump; }' ERR
 make cluster-up
+trap - ERR
 
 # Wait for nodes to become ready
 set +e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The sr-iov kind provider is prone to failures; to help debug those,
the state of all sr-iov info on the cluster after deployment is stored.

This information is made available in the `$ARTIFACTS/sriov/ ` folder.

Furthermore a per-pod event list is also stored.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
