### PR TITLE
RFC: automation: use a constant ginkgo seed

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -248,7 +248,7 @@ kubectl version
 
 mkdir -p "$ARTIFACTS_PATH"
 
-ginko_params="--ginkgo.noColor --junit-output=$ARTIFACTS_PATH/junit.functest.xml"
+ginko_params="--ginkgo.noColor --junit-output=$ARTIFACTS_PATH/junit.functest.xml --ginkgo.seed=42"
 
 # Prepare PV for Windows testing
 if [[ $TARGET =~ windows.* ]]; then


### PR DESCRIPTION
Our tests are too fragile. Our CI fails to often and people do not take
failures seriously enough, as following execution may pass.

I suspect that some of the problem is due to the randomization of tests.
In this patch I suggest to stabilize the test order, so we have more
predictability. Once all flakiness is removed, we should try few other
constant seeds. When we are certain that none of them trigger flakiness
we can consider reintroducing random seed, to increase our coverage.
Issue #3450 tracks the reintroduction of a random seed.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
