### PR TITLE
Ipv6 config via cloud init network data

### DIFF
--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -49,6 +49,5 @@ spec:
         echo "fedora" |passwd fedora --stdin
         for i in {1..20}; do curl -I %s | grep "200 OK" && break || sleep 0.1; done
         yum install -y nginx
-        systemctl enable nginx
-        systemctl start nginx
+        systemctl enable --now nginx
     name: cloudinitdisk

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -37,12 +37,17 @@ spec:
       image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
     name: containerdisk
   - cloudInitNoCloud:
+      networkData: |
+        version: 2
+        ethernets:
+          eth0:
+            addresses: [ fd10:0:2::2/120 ]
+            dhcp4: true
+            gateway6: fd10:0:2::1
       userData: |-
         #!/bin/bash
         echo "fedora" |passwd fedora --stdin
-        ip -6 addr add fd10:0:2::2/120 dev eth0
-        sleep 5
-        ip -6 route add default via fd10:0:2::1 src fd10:0:2::2
+        for i in {1..20}; do curl -I %s | grep "200 OK" && break || sleep 0.1; done
         yum install -y nginx
         systemctl enable nginx
         systemctl start nginx

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -270,6 +270,11 @@ const (
 	tmpPath         = "/tmp/kubevirt.io/tests"
 )
 
+const (
+	ipv6MasqueradeAddress = "fd10:0:2::2/120"
+	ipv6MasqueradeGateway = "fd10:0:2::1"
+)
+
 type ProcessFunc func(event *k8sv1.Event) (done bool)
 
 type ObjectEventWatcher struct {
@@ -2140,6 +2145,25 @@ func GetGuestAgentUserData() string {
                 setenforce 0
                 systemd-run --unit=guestagent /usr/local/bin/qemu-ga
                 `, ipv6UserDataString, GetUrl(GuestAgentHttpUrl), GetUrl(StressHttpUrl))
+}
+
+func GetIPv6NetworkData(ipAddress string, gateway string, dnsServer string, searchDomains []string) string {
+	networkData := fmt.Sprintf(`
+version: 2
+ethernets:
+    eth0:
+        addresses: [ %s ]
+        dhcp4: true
+        gateway6: %s
+        nameservers:
+            addresses: [ %s ]
+            search: [ %s ]
+    `, ipAddress, gateway, dnsServer, strings.Join(searchDomains, " "))
+	return networkData
+}
+
+func getVMISeachDomains() []string {
+	return []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}
 }
 
 func NewRandomVMIWithEphemeralDiskAndUserdata(containerImage string, userData string) *v1.VirtualMachineInstance {

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -432,7 +432,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{v1.Network{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vm.Spec)
-	userData := "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nfor i in {1..20}; do curl -I %s | grep \"200 OK\" && break || sleep 0.1; done\nyum install -y nginx\nsystemctl enable nginx\nsystemctl start nginx"
+	userData := "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nfor i in {1..20}; do curl -I %s | grep \"200 OK\" && break || sleep 0.1; done\nyum install -y nginx\nsystemctl enable --now nginx"
 	networkData := "version: 2\nethernets:\n  eth0:\n    addresses: [ fd10:0:2::2/120 ]\n    dhcp4: true\n    gateway6: fd10:0:2::1\n"
 	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, userData, networkData)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR replaces the IPv6 address / route / DNS configuration for guest agent based tests from userData scripts to networkData, for fedora guests.

The `vmi-masquerade` example is also updated accordingly.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
