### PR TITLE
tests: Do not trigger tests for documents changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ bazel-push-images:
 push: bazel-push-images
 
 bazel-test:
-	hack/dockerized "hack/bazel-fmt.sh && hack/bazel-test.sh"
+	if git diff --name-only | grep -q -v -e "md$$"; then \
+	    hack/dockerized "hack/bazel-fmt.sh && hack/bazel-test.sh"; \
+	else \
+	    echo "No changes detected, skipping tests."; \
+	fi
 
 generate:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"
@@ -50,8 +54,12 @@ go-test: go-build
 test: bazel-test
 
 functest:
-	hack/dockerized "hack/build-func-tests.sh"
-	hack/functests.sh
+	if git diff --name-only | grep -q -v -e "md$$"; then \
+	    hack/dockerized "hack/build-func-tests.sh" && \
+	    hack/functests.sh; \
+	else \
+	    echo "No changes detected, skipping tests."; \
+	fi
 
 dump: bazel-build
 	hack/dump.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
In case there are no changes or the only changes introduced
are of *.md files, skip testing.

**Release note**:
```release-note
NONE
```
