### PR TITLE
RFC: limit utils.WaitForAllPodsReady to kubevirt's own namespace

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -478,7 +478,7 @@ func WaitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) 
 		virtClient, err := kubecli.GetKubevirtClient()
 		PanicOnError(err)
 
-		podsList, err := virtClient.CoreV1().Pods(k8sv1.NamespaceAll).List(listOptions)
+		podsList, err := virtClient.CoreV1().Pods(KubeVirtInstallNamespace).List(listOptions)
 		PanicOnError(err)
 		for _, pod := range podsList.Items {
 			for _, status := range pod.Status.ContainerStatuses {


### PR DESCRIPTION
WaitForAllPodsReady is used to validate that KubeVirt is properly
deployed before a test begins.

Recently, we noticed that if performance-addon-operator is installed on
the cluster, but is not deployed well, we cannot run our tests. This
patch ignores pods in unrelated namespaces; They are none of our
business.

This PR does have a downside: the tests make start, but then fail for
elaborate reasons, which would be harder to resolve.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
