### PR TITLE
Fixing Getting Started Guide since it pointed to an older version of KUBEVIRT_PROVIDER

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ In additional it runs dnsmasq and docker registry containers.
 
 ### Compatibility
 
-The minimum compatible Kubernetes version is 1.11.0. Important features required
+The minimum compatible Kubernetes version is 1.15.0. Important features required
 for scheduling and memory are missing or incompatible with previous versions.
 
 ### Compile and run it
@@ -70,7 +70,7 @@ dockerizied environment, clone the KubeVirt repository, `cd` into it, and:
 
 ```bash
 # Build and deploy KubeVirt on Kubernetes in our vms inside containers
-export KUBEVIRT_PROVIDER=k8s-1.13.3 # this is also the default if no KUBEVIRT_PROVIDER is set
+export KUBEVIRT_PROVIDER=k8s-1.15 # this is also the default if no KUBEVIRT_PROVIDER is set
 make cluster-up
 make cluster-sync
 ```
@@ -121,14 +121,14 @@ You can get the names from following command:
 
 ```bash
 # cluster-up/kubectl.sh get nodes
-NAME                        STATUS   ROLES    AGE   VERSION
-kind-1.14.2-control-plane   Ready    master   11h   v1.14.2
+NAME    STATUS   ROLES    AGE   VERSION
+node01  Ready    master   11h   v1.15.1
 ```
 
 Then you can execute the following command to access the node:
 ```
-# ./cluster-up/ssh.sh kind-1.14.2-control-plane
-root@kind-1:/#
+# ./cluster-up/ssh.sh node01
+[vagrant@node01 ~]$
 ```
 
 ### Automatic Code Generation


### PR DESCRIPTION
What this PR does / why we need it:
Fixing Development guide since it was broken. KUBEVIRT_PROVIDER pointed to an
older version of k8s that didn't exist in the repo. Now it's pointing to the
1.15 version.

```release-note
NONE
```
Signed-off-by: Pedro Navarro Perez <pednape@gmail.com>
