### PR TITLE
Explicitly fail on Multus if network-attachment-definitions are missing

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -133,6 +133,9 @@ var _ = Describe("Multus", func() {
 			RequestURI(fmt.Sprintf(postUrl, tests.NamespaceTestDefault, "linux-bridge-net-vlan100")).
 			Body([]byte(fmt.Sprintf(linuxBridgeConfCRD, "linux-bridge-net-vlan100", tests.NamespaceTestDefault))).
 			Do()
+		if result.Error() != nil && errors.IsNotFound(result.Error()) {
+			Expect(result.Error()).NotTo(HaveOccurred(), "Network attachment definition is missing. Install it or skip this suite.")
+		}
 		Expect(result.Error()).NotTo(HaveOccurred())
 
 		// Create ptp crds with tuning plugin enabled in two different namespaces


### PR DESCRIPTION
Signed-off-by: L. Pivarc <lpivarc@redhat.com>

**What this PR does / why we need it**:
Explicitly fail on Multus tests if network attachment definitions are missing. This will be less confusing for new contributors which runs tests locally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
