### PR TITLE
remove unused const value

### DIFF
--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -65,7 +65,6 @@ var (
 )
 
 const StandardLauncherSocketFileName = "launcher-sock"
-const StandardLauncherInfoFileName = "launcher-info"
 const StandardLauncherUnresponsiveFileName = "launcher-unresponsive"
 
 type MigrationOptions struct {


### PR DESCRIPTION
This const value was left over from a previous feature that has been removed. 

```release-note
NONE
```
