### PR TITLE
Minimize the scope of KUBEVIRT_POSTINBOUND chain

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -794,6 +794,7 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables(protocol iptables.P
 			strings.ToLower(port.Protocol),
 			"--dport",
 			strconv.Itoa(int(port.Port)),
+			"--source", getLoopbackAdrress(protocol),
 			"-j",
 			"SNAT",
 			"--to-source", p.getGatewayByProtocol(protocol))
@@ -896,6 +897,7 @@ func (p *MasqueradePodInterface) createNatRulesUsingNftables(proto iptables.Prot
 			strings.ToLower(port.Protocol),
 			"dport",
 			strconv.Itoa(int(port.Port)),
+			Handler.GetNFTIPString(proto), "saddr", getLoopbackAdrress(proto),
 			"counter", "snat", "to", p.getGatewayByProtocol(proto))
 		if err != nil {
 			return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -397,7 +397,9 @@ var _ = Describe("Pod Network", func() {
 						"-p",
 						"tcp",
 						"--dport",
-						"80", "-j", "SNAT", "--to-source", GetMasqueradeGwIp(proto)).Return(nil).AnyTimes()
+						"80",
+						"--source", getLoopbackAdrress(proto),
+						"-j", "SNAT", "--to-source", GetMasqueradeGwIp(proto)).Return(nil).AnyTimes()
 					mockNetwork.EXPECT().IptablesAppendRule(proto, "nat",
 						"KUBEVIRT_PREINBOUND",
 						"-p",
@@ -445,6 +447,7 @@ var _ = Describe("Pod Network", func() {
 						"tcp",
 						"dport",
 						"80",
+						GetNFTIPString(proto), "saddr", getLoopbackAdrress(proto),
 						"counter", "snat", "to", GetMasqueradeGwIp(proto)).Return(nil).AnyTimes()
 					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
 						"KUBEVIRT_PREINBOUND",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:\
Currently, in case the vm has a list of supported ports, the source
address of the incoming traffic to the vm is substituted by the address of
k6t-eth0 bridge (relevant for both ipv4 and ipv6).

The only reason for this behaviour I could find is for connecting to the vm
using localhost address as the destination (from an app inside the
virt-launcher pod).
In this case the source address would probably be also localhost.
The vm will try to reply to local host but of course won't succeed since the reply will stay
inside the vm and won't reach the default route.
 So in this specific case, the substitution of the source address (localhost) to the bridge address is indeed needed.

However, couldn't find any other use case for this substitution.
More over, the behaviour may be harmful since the vm thinks all its
clients have the same ip address.

The PR minimizes the rules to do the substitution only in case the source address is localhost.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
A follow-up PR will update the [documentation](https://github.com/kubevirt/kubevirt/pull/3395/commits/1d2295fcd9804db0f4965c3900d41934259bec84#diff-971521d7f1fea6eeaa462181948819a9R304) 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
