### PR TITLE
Add a functional test and example VMI for EFI Secure Boot

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -239,6 +239,7 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)cirros-container-disk-demo:$(container_tag)": "//containerimages:cirros-container-disk-image",
         "$(container_prefix)/$(image_prefix)cirros-custom-container-disk-demo:$(container_tag)": "//containerimages:cirros-custom-container-disk-image",
         "$(container_prefix)/$(image_prefix)fedora-cloud-container-disk-demo:$(container_tag)": "//containerimages:fedora-cloud-container-disk-image",
+        "$(container_prefix)/$(image_prefix)microlivecd-container-disk-demo:$(container_tag)": "//containerimages:microlivecd-container-disk-image",
         "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
         # testing images
         "$(container_prefix)/$(image_prefix)disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -159,6 +159,24 @@ http_file(
 )
 
 http_file(
+    name = "microlivecd_image",
+    sha256 = "ae449ae8c0f73b1a7e2c394bc5385e7ab01d8fc000f5b074bc8b2aaabf931eac",
+    urls = [
+        "https://github.com/jean-edouard/microlivecd/releases/download/0.1/microlivecd_amd64.iso",
+        "https://storage.googleapis.com/builddeps/ae449ae8c0f73b1a7e2c394bc5385e7ab01d8fc000f5b074bc8b2aaabf931eac",
+    ],
+)
+
+http_file(
+    name = "microlivecd_image_ppc64el",
+    sha256 = "eae431d68b9dc5fab422f4b90d4204cbc28c39518780c4822970a4bef42f7c7f",
+    urls = [
+        "https://github.com/jean-edouard/microlivecd/releases/download/0.1/microlivecd_ppc64el.iso",
+        "https://storage.googleapis.com/builddeps/eae431d68b9dc5fab422f4b90d4204cbc28c39518780c4822970a4bef42f7c7f",
+    ],
+)
+
+http_file(
     name = "virtio_win_image",
     sha256 = "7bf7f53e30c69a360f89abb3d2cc19cc978f533766b1b2270c2d8344edf9b3ef",
     urls = [

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -42,6 +42,16 @@ container_image(
 )
 
 container_image(
+    name = "microlivecd-container-disk-image",
+    directory = "/disk",
+    files = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@microlivecd_image_ppc64le//file"],
+        "//conditions:default": ["@microlivecd_image//file"],
+    }),
+    visibility = ["//visibility:public"],
+)
+
+container_image(
     name = "virtio-container-disk-image",
     directory = "/disk",
     files = ["@virtio_win_image//file"],

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  labels:
+    special: vmi-secureboot
+  name: vmi-secureboot
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+    features:
+      acpi: {}
+      smm:
+        enabled: true
+    firmware:
+      bootloader:
+        efi:
+          secureBoot: true
+    machine:
+      type: ""
+    resources:
+      requests:
+        memory: 1Gi
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - containerDisk:
+      image: registry:5000/kubevirt/microlivecd-container-disk-demo:devel
+    name: containerdisk

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1949,6 +1949,28 @@ func NewRandomVMIWithEFIBootloader() *v1.VirtualMachineInstance {
 
 }
 
+func NewRandomVMIWithSecureBoot() *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithEphemeralDiskHighMemory(ContainerDiskFor(ContainerDiskMicroLiveCD))
+
+	// EFI needs more memory than other images
+	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+	vmi.Spec.Domain.Features = &v1.Features{
+		SMM: &v1.FeatureState{
+			Enabled: NewBool(true),
+		},
+	}
+	vmi.Spec.Domain.Firmware = &v1.Firmware{
+		Bootloader: &v1.Bootloader{
+			EFI: &v1.EFI{
+				SecureBoot: NewBool(true),
+			},
+		},
+	}
+
+	return vmi
+
+}
+
 func NewRandomMigration(vmiName string, namespace string) *v1.VirtualMachineInstanceMigration {
 	return &v1.VirtualMachineInstanceMigration{
 		TypeMeta: metav1.TypeMeta{
@@ -2770,6 +2792,7 @@ const (
 	ContainerDiskCirros               ContainerDisk = "cirros"
 	ContainerDiskAlpine               ContainerDisk = "alpine"
 	ContainerDiskFedora               ContainerDisk = "fedora-cloud"
+	ContainerDiskMicroLiveCD          ContainerDisk = "microlivecd"
 	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
 	ContainerDiskEmpty                ContainerDisk = "empty"
 )
@@ -2779,7 +2802,7 @@ const (
 // Supported values are: cirros, fedora, alpine, guest-agent
 func ContainerDiskFor(name ContainerDisk) string {
 	switch name {
-	case ContainerDiskCirros, ContainerDiskAlpine, ContainerDiskFedora, ContainerDiskCirrosCustomLocation:
+	case ContainerDiskCirros, ContainerDiskAlpine, ContainerDiskFedora, ContainerDiskMicroLiveCD, ContainerDiskCirrosCustomLocation:
 		return fmt.Sprintf("%s/%s-container-disk-demo:%s", KubeVirtUtilityRepoPrefix, name, KubeVirtUtilityVersionTag)
 	case ContainerDiskVirtio:
 		return fmt.Sprintf("%s/virtio-container-disk:%s", KubeVirtUtilityRepoPrefix, KubeVirtUtilityVersionTag)
@@ -2971,6 +2994,26 @@ func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expe
 		expecter.Close()
 		return expecter, err
 	}
+	return expecter, err
+}
+
+func SecureBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	b := append([]expect.Batcher{
+		&expect.BExp{R: "secureboot: Secure boot enabled"},
+	})
+	res, err := expecter.ExpectBatch(b, 180*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
+		expecter.Close()
+		return expecter, err
+	}
+
 	return expecter, err
 }
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -450,7 +450,23 @@ var _ = Describe("Configurations", func() {
 				By("Checking if UEFI is enabled")
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(ContainSubstring("OVMF_CODE"))
+				Expect(domXml).To(ContainSubstring("OVMF_CODE.fd"))
+			})
+
+			It("should enable EFI secure boot", func() {
+				vmi := tests.NewRandomVMIWithSecureBoot()
+
+				By("Starting a VirtualMachineInstance")
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking if SecureBoot is enabled in Linux")
+				tests.WaitUntilVMIReady(vmi, tests.SecureBootExpecter)
+
+				By("Checking if SecureBoot is enabled in the libvirt XML")
+				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(domXml).To(ContainSubstring("OVMF_CODE.secboot.fd"))
 			})
 		})
 

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -42,6 +42,7 @@ const (
 	VmiFlavorSmall       = "vmi-flavor-small"
 	VmiSata              = "vmi-sata"
 	VmiFedora            = "vmi-fedora"
+	VmiSecureBoot        = "vmi-secureboot"
 	VmiAlpineEFI         = "vmi-alpine-efi"
 	VmiNoCloud           = "vmi-nocloud"
 	VmiPVC               = "vmi-pvc"
@@ -84,9 +85,10 @@ const (
 )
 
 const (
-	imageAlpine = "alpine-container-disk-demo"
-	imageCirros = "cirros-container-disk-demo"
-	imageFedora = "fedora-cloud-container-disk-demo"
+	imageAlpine      = "alpine-container-disk-demo"
+	imageCirros      = "cirros-container-disk-demo"
+	imageFedora      = "fedora-cloud-container-disk-demo"
+	imageMicroLiveCD = "microlivecd-container-disk-demo"
 )
 const windowsFirmware = "5d307ca9-b3ef-428c-8861-06e72d69f223"
 const defaultInterfaceName = "default"
@@ -348,6 +350,29 @@ func GetVMIEphemeralFedora() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	initFedora(&vmi.Spec)
 	addNoCloudDiskWitUserData(&vmi.Spec, "#cloud-config\npassword: fedora\nchpasswd: { expire: False }")
+	return vmi
+}
+
+func GetVMISecureBoot() *v1.VirtualMachineInstance {
+	vmi := getBaseVMI(VmiSecureBoot)
+
+	addContainerDisk(&vmi.Spec, fmt.Sprintf("%s/%s:%s", DockerPrefix, imageMicroLiveCD, DockerTag), busVirtio)
+
+	_true := true
+	vmi.Spec.Domain.Features = &v1.Features{
+		SMM: &v1.FeatureState{
+			Enabled: &_true,
+		},
+	}
+	vmi.Spec.Domain.Firmware = &v1.Firmware{
+		Bootloader: &v1.Bootloader{
+			EFI: &v1.EFI{
+				SecureBoot: &_true,
+			},
+		},
+	}
+
+	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 	return vmi
 }
 

--- a/tools/vms-generator/vms-generator.go
+++ b/tools/vms-generator/vms-generator.go
@@ -71,6 +71,7 @@ func main() {
 		utils.VmiFlavorSmall:       utils.GetVMIFlavorSmall(),
 		utils.VmiSata:              utils.GetVMISata(),
 		utils.VmiFedora:            utils.GetVMIEphemeralFedora(),
+		utils.VmiSecureBoot:        utils.GetVMISecureBoot(),
 		utils.VmiAlpineEFI:         utils.GetVMIAlpineEFI(),
 		utils.VmiNoCloud:           utils.GetVMINoCloud(),
 		utils.VmiPVC:               utils.GetVMIPvc(),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the first secure boot functional test.
Since no demo containerdisk was able to boot with secure boot enabled, I created one.
I also added an example VMI for good measure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
