### PR TITLE
Set proper architecture label in generated container images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,11 +48,10 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "dc97fccceacd4c6be14e800b2a00693d5e8d07f69ee187babfd04a80a9f8e250",
-    strip_prefix = "rules_docker-0.14.1",
+    sha256 = "3efbd23e195727a67f87b2a04fb4388cc7a11a0c0c2cf33eec225fb8ffbb27ea",
+    strip_prefix = "rules_docker-0.14.2",
     urls = [
-        "https://github.com/bazelbuild/rules_docker/releases/download/v0.14.1/rules_docker-v0.14.1.tar.gz",
-        "https://storage.googleapis.com/builddeps/dc97fccceacd4c6be14e800b2a00693d5e8d07f69ee187babfd04a80a9f8e250",
+        "https://github.com/bazelbuild/rules_docker/releases/download/v0.14.2/rules_docker-v0.14.2.tar.gz",
     ],
 )
 

--- a/cmd/example-cloudinit-hook-sidecar/BUILD.bazel
+++ b/cmd/example-cloudinit-hook-sidecar/BUILD.bazel
@@ -29,6 +29,10 @@ load(
 
 container_image(
     name = "example-cloudinit-hook-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@fedora_ppc64le//image",
         "//conditions:default": "@fedora//image",

--- a/cmd/example-hook-sidecar/BUILD.bazel
+++ b/cmd/example-hook-sidecar/BUILD.bazel
@@ -31,6 +31,10 @@ load(
 
 container_image(
     name = "example-hook-sidecar-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@fedora_ppc64le//image",
         "//conditions:default": "@fedora//image",

--- a/cmd/subresource-access-test/BUILD.bazel
+++ b/cmd/subresource-access-test/BUILD.bazel
@@ -24,6 +24,10 @@ load(
 
 container_image(
     name = "subresource-access-test-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = "//:passwd-image",
     directory = "/",
     entrypoint = ["/subresource-access-test"],

--- a/cmd/virt-api/BUILD.bazel
+++ b/cmd/virt-api/BUILD.bazel
@@ -38,6 +38,10 @@ container_image(
 
 container_image(
     name = "virt-api-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":version-container",
     directory = "/usr/bin/",
     entrypoint = ["/usr/bin/virt-api"],

--- a/cmd/virt-controller/BUILD.bazel
+++ b/cmd/virt-controller/BUILD.bazel
@@ -36,6 +36,10 @@ container_image(
 
 container_image(
     name = "virt-controller-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":version-container",
     directory = "/usr/bin/",
     entrypoint = ["/usr/bin/virt-controller"],

--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -74,6 +74,10 @@ container_image(
 
 container_image(
     name = "virt-handler-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":version-container",
     directory = "/usr/bin/",
     entrypoint = ["/usr/bin/virt-handler"],

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -57,6 +57,10 @@ container_image(
 
 container_image(
     name = "virt-launcher-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":version-container",
     directory = "/usr/bin",
     entrypoint = ["/usr/bin/virt-launcher"],

--- a/cmd/virt-operator/BUILD.bazel
+++ b/cmd/virt-operator/BUILD.bazel
@@ -33,6 +33,10 @@ container_image(
 
 container_image(
     name = "virt-operator-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":version-container",
     directory = "/usr/bin/",
     entrypoint = ["/usr/bin/virt-operator"],

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -2,6 +2,10 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 
 container_image(
     name = "alpine-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     directory = "/disk",
     files = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@alpine_image_ppc64le//file"],
@@ -12,6 +16,10 @@ container_image(
 
 container_image(
     name = "cirros-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     directory = "/disk",
     files = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@cirros_image_ppc64le//file"],
@@ -23,6 +31,10 @@ container_image(
 # used for e2e testing of custom base baths
 container_image(
     name = "cirros-custom-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     directory = "/custom-disk",
     files = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@cirros_image_ppc64le//file"],
@@ -33,6 +45,10 @@ container_image(
 
 container_image(
     name = "fedora-cloud-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     directory = "/disk",
     files = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@fedora_image_ppc64le//file"],
@@ -43,6 +59,10 @@ container_image(
 
 container_image(
     name = "virtio-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     directory = "/disk",
     files = ["@virtio_win_image//file"],
     visibility = ["//visibility:public"],

--- a/images/cdi-http-import-server/BUILD.bazel
+++ b/images/cdi-http-import-server/BUILD.bazel
@@ -109,6 +109,10 @@ pkg_tar(
 
 container_image(
     name = "cdi-http-import-server-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":cdi-http-import-server-base-image",
     directory = "/",
     entrypoint = ["/entrypoint.sh"],

--- a/images/disks-images-provider/BUILD.bazel
+++ b/images/disks-images-provider/BUILD.bazel
@@ -107,6 +107,10 @@ pkg_tar(
 
 container_image(
     name = "disks-images-provider-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = ":qemu-img-image",
     directory = "/",
     entrypoint = ["/entrypoint.sh"],

--- a/images/nfs-server/BUILD.bazel
+++ b/images/nfs-server/BUILD.bazel
@@ -5,6 +5,10 @@ load(
 
 container_image(
     name = "nfs-server-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@nfs-server_ppc64le//image",
         "//conditions:default": "@nfs-server//image",

--- a/images/vm-killer/BUILD.bazel
+++ b/images/vm-killer/BUILD.bazel
@@ -5,6 +5,10 @@ load(
 
 container_image(
     name = "vm-killer-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@kubevirt-testing_ppc64le//image",
         "//conditions:default": "@kubevirt-testing//image",

--- a/images/winrmcli/BUILD.bazel
+++ b/images/winrmcli/BUILD.bazel
@@ -9,6 +9,10 @@ load(
 
 container_image(
     name = "winrmcli-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
     base = select({
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@fedora_ppc64le//image",
         "//conditions:default": "@fedora//image",


### PR DESCRIPTION
With the 0.14.2 release of rules_docker a new attribute called
"architecture" has been exposed in the container_image rule. It allows
setting a custom architecture label, previously the images were always
labeled as amd64. So moving to this release and  adding a select in
order to properly label the architecture of the container images pushed
by Kubevirt.

Signed-off-by: Murilo Fossa Vicentini <muvic@linux.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This PR allows the container images built by Kubevirt to be properly labeled for the architecture they are built in

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3065

**Special notes for your reviewer**:
A nice follow up enhancement would be to add support for a manifest list that could be used as a pointer in a release for multi architecture support.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
