### PR TITLE
Test sriov over vlan

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2855,10 +2855,10 @@ func WaitForPodToDisappearWithTimeout(podName string, seconds int) {
 func WaitForVirtualMachineToDisappearWithTimeout(vmi *v1.VirtualMachineInstance, seconds int) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	EventuallyWithOffset(1, func() bool {
+	EventuallyWithOffset(1, func() error {
 		_, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-		return errors.IsNotFound(err)
-	}, seconds, 1*time.Second).Should(BeTrue())
+		return err
+	}, seconds, 1*time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
 }
 
 func WaitForMigrationToDisappearWithTimeout(migration *v1.VirtualMachineInstanceMigration, seconds int) {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -814,7 +814,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 		// Note: test case assumes interconnectivity between SR-IOV
 		// interfaces. It can be achieved either by configuring the external switch
 		// properly, or via in-PF switching for VFs (works for some NIC models)
-		createSriovVMs := func(cidrA, cidrB string) (*v1.VirtualMachineInstance, *v1.VirtualMachineInstance) {
+		createSriovVMs := func(networkNameA, networkNameB, cidrA, cidrB string) (*v1.VirtualMachineInstance, *v1.VirtualMachineInstance) {
 			// Explicitly choose different random mac addresses instead of relying on kubemacpool to do it:
 			// 1) we don't at the moment deploy kubemacpool in kind providers
 			// 2) even if we would do, it's probably a good idea to have the suite not depend on this fact
@@ -830,8 +830,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 			// start peer machines with sriov interfaces from the same resource pool
 			// manually configure IP/link on sriov interfaces because there is
 			// no DHCP server to serve the address to the guest
-			vmi1 := getSriovVmi([]string{sriovnet3}, cloudInitNetworkDataWithStaticIPsByMac(sriovnet3, mac1.String(), cidrA))
-			vmi2 := getSriovVmi([]string{sriovnet3}, cloudInitNetworkDataWithStaticIPsByMac(sriovnet3, mac2.String(), cidrB))
+			vmi1 := getSriovVmi([]string{networkNameA}, cloudInitNetworkDataWithStaticIPsByMac(networkNameA, mac1.String(), cidrA))
+			vmi2 := getSriovVmi([]string{networkNameB}, cloudInitNetworkDataWithStaticIPsByMac(networkNameB, mac2.String(), cidrB))
 
 			vmi1.Spec.Domain.Devices.Interfaces[1].MacAddress = mac1.String()
 			vmi2.Spec.Domain.Devices.Interfaces[1].MacAddress = mac2.String()
@@ -852,7 +852,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {
 			cidrA := "192.168.1.1/24"
 			cidrB := "192.168.1.2/24"
-			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
+			//create two vms on the smae sriov network
+			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, cidrA, cidrB)
 
 			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642")
 			Eventually(func() error {
@@ -866,7 +867,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 		It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
 			cidrA := "fc00::1/64"
 			cidrB := "fc00::2/64"
-			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
+			//create two vms on the smae sriov network
+			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, cidrA, cidrB)
 
 			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642")
 			Eventually(func() error {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -602,6 +602,14 @@ var _ = Describe("[Serial]SRIOV", func() {
 		sriovResourceName = "openshift.io/sriov_net"
 	}
 
+	createNetworkAttachementDefinition := func(networkName string, namespace string, networkAttachmentDefinition string) error {
+		return virtClient.RestClient().
+			Post().
+			RequestURI(fmt.Sprintf(postUrl, namespace, networkName)).
+			Body([]byte(fmt.Sprintf(networkAttachmentDefinition, networkName, namespace, sriovResourceName))).
+			Do().Error()
+	}
+
 	tests.BeforeAll(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		tests.PanicOnError(err)
@@ -613,25 +621,9 @@ var _ = Describe("[Serial]SRIOV", func() {
 			Skip("Sriov is not enabled in this environment. Skip these tests using - export FUNC_TEST_ARGS='--ginkgo.skip=SRIOV'")
 		}
 
-		// Create two sriov networks referring to the same resource name
-		result := virtClient.RestClient().
-			Post().
-			RequestURI(fmt.Sprintf(postUrl, tests.NamespaceTestDefault, sriovnet1)).
-			Body([]byte(fmt.Sprintf(sriovConfCRD, sriovnet1, tests.NamespaceTestDefault, sriovResourceName))).
-			Do()
-		Expect(result.Error()).NotTo(HaveOccurred())
-		result = virtClient.RestClient().
-			Post().
-			RequestURI(fmt.Sprintf(postUrl, tests.NamespaceTestDefault, sriovnet2)).
-			Body([]byte(fmt.Sprintf(sriovConfCRD, sriovnet2, tests.NamespaceTestDefault, sriovResourceName))).
-			Do()
-		Expect(result.Error()).NotTo(HaveOccurred())
-		result = virtClient.RestClient().
-			Post().
-			RequestURI(fmt.Sprintf(postUrl, tests.NamespaceTestDefault, sriovnet3)).
-			Body([]byte(fmt.Sprintf(sriovLinkEnableConfCRD, sriovnet3, tests.NamespaceTestDefault, sriovResourceName))).
-			Do()
-		Expect(result.Error()).NotTo(HaveOccurred())
+		Expect(createNetworkAttachementDefinition(sriovnet1, tests.NamespaceTestDefault, sriovConfCRD)).To((Succeed()), "should successfully create the network")
+		Expect(createNetworkAttachementDefinition(sriovnet2, tests.NamespaceTestDefault, sriovConfCRD)).To((Succeed()), "should successfully create the network")
+		Expect(createNetworkAttachementDefinition(sriovnet3, tests.NamespaceTestDefault, sriovLinkEnableConfCRD)).To((Succeed()), "should successfully create the network")
 	})
 
 	BeforeEach(func() {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -166,7 +166,6 @@ var _ = Describe("[Serial]Multus", func() {
 
 	Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance using different types of interfaces.", func() {
 		Context("VirtualMachineInstance with cni ptp plugin interface", func() {
-
 			It("[test_id:1751]should create a virtual machine with one interface", func() {
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
 				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
@@ -240,7 +239,6 @@ var _ = Describe("[Serial]Multus", func() {
 		})
 
 		Context("VirtualMachineInstance with multus network as default network", func() {
-
 			It("[test_id:1751]should create a virtual machine with one interface with multus default network definition", func() {
 				detachedVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				detachedVMI.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "ptp", InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}}
@@ -277,7 +275,6 @@ var _ = Describe("[Serial]Multus", func() {
 		})
 
 		Context("VirtualMachineInstance with cni ptp plugin interface with custom MAC address", func() {
-
 			It("[test_id:1705]should configure valid custom MAC address on ptp interface when using tuning plugin", func() {
 				customMacAddress := "50:00:00:00:90:0d"
 				ptpInterface := v1.Interface{
@@ -328,7 +325,6 @@ var _ = Describe("[Serial]Multus", func() {
 		})
 
 		Context("VirtualMachineInstance with Linux bridge plugin interface", func() {
-
 			It("[test_id:1577]should create two virtual machines with one interface", func() {
 				By("checking virtual machine instance can ping the secondary virtual machine instance using Linux bridge CNI plugin")
 				interfaces := []v1.Interface{linuxBridgeInterface}
@@ -384,7 +380,6 @@ var _ = Describe("[Serial]Multus", func() {
 
 		Context("VirtualMachineInstance with Linux bridge CNI plugin interface and custom MAC address.", func() {
 			customMacAddress := "50:00:00:00:90:0d"
-
 			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
 				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
 				vmiTwo := libvmi.NewFedora(
@@ -432,8 +427,8 @@ var _ = Describe("[Serial]Multus", func() {
 				Expect(libnet.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 		})
-		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
 
+		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
 			It("[test_id:1756]should report all interfaces in Status", func() {
 				interfaces := []v1.Interface{
 					defaultInterface,
@@ -768,7 +763,6 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 			By("checking virtual machine instance has two interfaces")
 			checkInterfacesInGuest(vmi, []string{"eth0", "eth1"})
-
 		})
 
 		It("[test_id:3985]should create a virtual machine with sriov interface with custom MAC address", func() {
@@ -1115,15 +1109,6 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 	}
 
 	return setInterfaceUp(vmi, interfaceName)
-}
-
-func configureInterfaceStaticIPByMAC(vmi *v1.VirtualMachineInstance, interfaceMac, interfaceAddress string) error {
-	interfaceName, err := getInterfaceNameByMAC(vmi, interfaceMac)
-	if err != nil {
-		return fmt.Errorf("could not configure address %s for interface with mac %s on VMI %s: %w", interfaceAddress, interfaceMac, vmi.Name, err)
-	}
-
-	return configInterface(vmi, interfaceName, interfaceAddress)
 }
 
 func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
we need to improve sriov testing.
so in this pr we:
1) Change pingVirtualMachine to return
a error and move the assertion outside of it's scope.
This is done so that we can assert that the ping failed as well.

2) warped the http requests for creating network function and deleting
network attachment definitions.  

3) Test  connectivity between two
VMs that share vlan over an SRIOV network.
A third vm without which do not share the
vlan should not get connected.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
1. second commit relies on the change in the first one, because as a part of the test we check that a ping to a vm which is not connected to vlan- fails.  
2. if this PR would be approved , we will add follow up PR to wrap all not pretty http requests in functions. I thought it was not related to this PR so I made it just in the SRIOV scope. 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
