### PR TITLE
Fix potentially infinite loop in build scripts

### DIFF
--- a/hack/cluster-build.sh
+++ b/hack/cluster-build.sh
@@ -76,11 +76,23 @@ else
 fi
 
 for node in ${nodes[@]}; do
+    count=0
     until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container}\" | xargs \-\-max-args=1 sudo ${pull_command} pull"; do
+        count=$((count + 1))
+        if [ $count -eq 10 ]; then
+            echo "Failed to '${pull_command} pull' in ${node}" >&2
+            exit 1
+        fi
         sleep 1
     done
 
+    count=0
     until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container_alias}\" | xargs \-\-max-args=2 sudo ${pull_command} tag"; do
+        count=$((count + 1))
+        if [ $count -eq 10 ]; then
+            echo "Failed to '${pull_command} tag' in ${node}" >&2
+            exit 1
+        fi
         sleep 1
     done
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent 2 `until` loops in the build scripts to run, and fail, forever.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
