### PR TITLE
Report IPs list for pod network

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6777,7 +6777,7 @@
       "type": "string"
      },
      "ipAddress": {
-      "description": "IP address of a Virtual Machine interface",
+      "description": "IP address of a Virtual Machine interface. It is always the first item of IPs",
       "type": "string"
      },
      "ipAddresses": {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -366,7 +366,11 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 					interfaces := make([]virtv1.VirtualMachineInstanceNetworkInterface, 0)
 					for _, network := range vmi.Spec.Networks {
 						if network.NetworkSource.Pod != nil {
-							ifc := virtv1.VirtualMachineInstanceNetworkInterface{Name: network.Name, IP: pod.Status.PodIP}
+							ifc := virtv1.VirtualMachineInstanceNetworkInterface{
+								Name: network.Name,
+								IP:   pod.Status.PodIP,
+								IPs:  []string{pod.Status.PodIP},
+							}
 							interfaces = append(interfaces, ifc)
 						}
 					}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1017,6 +1017,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Interfaces)).To(Equal(1))
 				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].Name).To(Equal(networkName))
 				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IP).To(Equal(podIp))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IPs[0]).To(Equal(podIp))
 			}).Return(vmi, nil)
 			controller.Execute()
 		})

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -16831,7 +16831,7 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceNetworkInterface(r
 				Properties: map[string]spec.Schema{
 					"ipAddress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IP address of a Virtual Machine interface",
+							Description: "IP address of a Virtual Machine interface. It is always the first item of IPs",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -317,7 +317,8 @@ func (m *VirtualMachineInstanceMigration) TargetIsHandedOff() bool {
 //
 // +k8s:openapi-gen=true
 type VirtualMachineInstanceNetworkInterface struct {
-	// IP address of a Virtual Machine interface
+	// IP address of a Virtual Machine interface. It is always the first item of
+	// IPs
 	IP string `json:"ipAddress,omitempty"`
 	// Hardware address of a Virtual Machine interface
 	MAC string `json:"mac,omitempty"`

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -73,7 +73,7 @@ func (VirtualMachineInstanceMigrationCondition) SwaggerDoc() map[string]string {
 func (VirtualMachineInstanceNetworkInterface) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":              "+k8s:openapi-gen=true",
-		"ipAddress":     "IP address of a Virtual Machine interface",
+		"ipAddress":     "IP address of a Virtual Machine interface. It is always the first item of\nIPs",
 		"mac":           "Hardware address of a Virtual Machine interface",
 		"name":          "Name of the interface, corresponds to name of the network assigned to the interface",
 		"ipAddresses":   "List of all IP addresses of a Virtual Machine interface",

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -837,6 +837,28 @@ sockfd = None`})
 			Expect(err.Error()).To(ContainSubstring("Bridge interface is not enabled in kubevirt-config"))
 		})
 	})
+
+	Context("VirtualMachineInstance connected to the pod network", func() {
+		vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+		tests.AddExplicitPodNetworkInterface(vmi)
+
+		BeforeEach(func() {
+			tests.BeforeTestCleanup()
+
+			By("Starting tested VMI")
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).NotTo(HaveOccurred(), "VMI should be successfully created")
+			vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+		})
+
+		It("should report IP address matching the launcher PodIP in its status", func() {
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+
+			Expect(vmi.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP), "The address reported in VMI's IP should match the PodIP")
+			Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty(), "VMI should report a list of its IP addresses")
+			Expect(vmi.Status.Interfaces[0].IPs[0]).To(Equal(vmiPod.Status.PodIP), "The first address reported in VMI's IPs should match the PodIP")
+		})
+	})
 })
 
 func waitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory tests.VMIExpecterFactory) *v1.VirtualMachineInstance {


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This PR clarifies IP reporting documentation and fixes inconsistent behavior
in IP reporting.

Make it clear that IP reported in VMI status always reflects the first
address from IPs list. This is already the case, but has not been
documented. This behavior matches the logic seen in Kubernetes' PodIPs
that were recently introduced to support dual-stack.

Patch d5c5a81 introduced list of IPs to VMI interface status. This list
should deprecate the single IP report. IP report will be kept and always
report the first IP of the list. We used this entry to report IPs found
by guest agent. With this PR we enable it for pod network too, to keep
it consistent.
    
Example of the inconsistency:

```yaml
interfaces:
- interfaceName: eth0
  ipAddress: 10.244.196.180
  mac: 02:00:00:b4:21:69
  name: default
- interfaceName: eth1
  ipAddress: 192.168.66.36/24
  ipAddresses:
  - 192.168.66.36/24
  - fe80::454c:f566:baad:9107/64
  mac: 02:fb:9e:00:00:06
  name: secondary
```


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Report list of IPs for Pod interfaces
```
