### PR TITLE
Outside via macvlan

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -115,6 +115,7 @@ type NetworkHandler interface {
 	CreateTapDevice(tapName string, isMultiqueue bool, launcherPID int) error
 	BindTapDeviceToBridge(tapName string, bridgeName string) error
 	DelBridgeFdb(link netlink.Link) error
+	LinkSetHardwareAddr(link netlink.Link, mac net.HardwareAddr) error
 }
 
 type NetworkUtilsHandler struct{}
@@ -346,6 +347,10 @@ func (h *NetworkUtilsHandler) DelBridgeFdb(link netlink.Link) error {
 	}
 
 	return nil
+}
+
+func (h *NetworkUtilsHandler) LinkSetHardwareAddr(link netlink.Link, mac net.HardwareAddr) error {
+	return netlink.LinkSetHardwareAddr(link, mac)
 }
 
 func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -334,3 +334,13 @@ func (_m *MockNetworkHandler) BindTapDeviceToBridge(tapName string, bridgeName s
 func (_mr *_MockNetworkHandlerRecorder) BindTapDeviceToBridge(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BindTapDeviceToBridge", arg0, arg1)
 }
+
+func (_m *MockNetworkHandler) DelBridgeFdb(link netlink.Link) error {
+	ret := _m.ctrl.Call(_m, "DelBridgeFdb", link)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) DelBridgeFdb(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DelBridgeFdb", arg0)
+}

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -344,3 +344,13 @@ func (_m *MockNetworkHandler) DelBridgeFdb(link netlink.Link) error {
 func (_mr *_MockNetworkHandlerRecorder) DelBridgeFdb(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DelBridgeFdb", arg0)
 }
+
+func (_m *MockNetworkHandler) LinkSetHardwareAddr(link netlink.Link, mac net.HardwareAddr) error {
+	ret := _m.ctrl.Call(_m, "LinkSetHardwareAddr", link, mac)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) LinkSetHardwareAddr(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetHardwareAddr", arg0, arg1)
+}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -419,21 +419,6 @@ func (b *BridgePodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
 }
 
 func (b *BridgePodInterface) preparePodNetworkInterfaces(isMultiqueue bool, launcherPID int) error {
-	// Set interface link to down to change its MAC address
-	if err := Handler.LinkSetDown(b.podNicLink); err != nil {
-		log.Log.Reason(err).Errorf("failed to bring link down for interface: %s", b.podInterfaceName)
-		return err
-	}
-
-	if _, err := Handler.SetRandomMac(b.podInterfaceName); err != nil {
-		return err
-	}
-
-	if err := Handler.LinkSetUp(b.podNicLink); err != nil {
-		log.Log.Reason(err).Errorf("failed to bring link up for interface: %s", b.podInterfaceName)
-		return err
-	}
-
 	if err := b.createBridge(); err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -452,6 +452,11 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(isMultiqueue bool, laun
 		Managed: "no",
 	}
 
+	if err := Handler.DelBridgeFdb(b.podNicLink); err != nil {
+		log.Log.Reason(err).Errorf("failed to delete fdb for requested pod interface %s", b.podInterfaceName)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -452,6 +452,11 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(isMultiqueue bool, laun
 		Managed: "no",
 	}
 
+	if err := Handler.LinkSetHardwareAddr(b.podNicLink, b.vif.MAC); err != nil {
+		log.Log.Reason(err).Errorf("failed to change macaddr %s for requested pod interface %s", b.vif.MAC.String(), b.podInterfaceName)
+		return err
+	}
+
 	if err := Handler.DelBridgeFdb(b.podNicLink); err != nil {
 		log.Log.Reason(err).Errorf("failed to delete fdb for requested pod interface %s", b.podInterfaceName)
 		return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -185,6 +185,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, isTapDeviceMultiqueued, pid).Return(nil)
 		mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
+		mockNetwork.EXPECT().DelBridgeFdb(dummy).Return(nil)
 
 		// For masquerade tests
 		mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
@@ -307,6 +308,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, isTapDeviceMultiqueued, pid).Return(nil)
 			mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
 			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
+			mockNetwork.EXPECT().DelBridgeFdb(dummy).Return(nil)
 
 			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(HaveOccurred(), "SetupPodNetworkPhase1 should return an error")

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -51,7 +51,6 @@ var _ = Describe("Pod Network", func() {
 	var routeAddr netlink.Route
 	var fakeMac net.HardwareAddr
 	var fakeAddr netlink.Addr
-	var updateFakeMac net.HardwareAddr
 	var bridgeTest *netlink.Bridge
 	var bridgeAddr *netlink.Addr
 	var testNic *VIF
@@ -86,12 +85,10 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork = NewMockNetworkHandler(ctrl)
 		Handler = mockNetwork
 		testMac := "12:34:56:78:9A:BC"
-		updateTestMac := "AF:B3:1F:78:2A:CA"
 		dummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 1, MTU: 1410}}
 		address := &net.IPNet{IP: net.IPv4(10, 35, 0, 6), Mask: net.CIDRMask(24, 32)}
 		gw := net.IPv4(10, 35, 0, 1)
 		fakeMac, _ = net.ParseMAC(testMac)
-		updateFakeMac, _ = net.ParseMAC(updateTestMac)
 		fakeAddr = netlink.Addr{IPNet: address}
 		addrList = []netlink.Addr{fakeAddr}
 		routeAddr = netlink.Route{Gw: gw}
@@ -177,7 +174,6 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
 		mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(nil)
 		mockNetwork.EXPECT().LinkSetDown(dummy).Return(nil)
-		mockNetwork.EXPECT().SetRandomMac(podInterface).Return(updateFakeMac, nil)
 		mockNetwork.EXPECT().LinkSetUp(dummy).Return(nil)
 		mockNetwork.EXPECT().LinkSetLearningOff(dummy).Return(nil)
 		mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
@@ -297,7 +293,6 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_ALL).Return(addrList, nil)
 			mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
 			mockNetwork.EXPECT().LinkSetDown(dummy).Return(nil)
-			mockNetwork.EXPECT().SetRandomMac(podInterface).Return(updateFakeMac, nil)
 			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_V4).Return(addrList, nil)
 			mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
 			mockNetwork.EXPECT().LinkByName(api.DefaultBridgeName).Return(bridgeTest, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
I have taken over this PR. If you have any problems, please tell me.
> https://github.com/kubevirt/kubevirt/pull/2192

When using multus to start a VM with macvlan, get an ip, but there is a problem that cannot communicate with the outside.
This happened because of a configuration issue with the linux bridge Forwarding Database.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubevirt/kubevirt/issues/2925

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Outside via macvlan
```
