### PR TITLE
Add support of parallel clean in cluster-sync target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,13 @@ cluster-clean:
 cluster-deploy: cluster-clean
 	./hack/cluster-deploy.sh
 
-cluster-sync: cluster-build cluster-deploy
+cluster-sync:
+ifeq ($(PARALLEL_CLEANUP), 1)
+	./hack/parallel.sh
+else
+	make cluster-build
+	make cluster-deploy
+endif
 
 builder-build:
 	./hack/builder/build.sh

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -29,6 +29,7 @@
 set -ex
 
 export WORKSPACE="${WORKSPACE:-$PWD}"
+export PARALLEL_CLEANUP="${PARALLEL_CLEANUP:-1}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
@@ -204,14 +205,7 @@ set -e
 echo "Nodes are ready:"
 kubectl get nodes
 
-make cluster-build
-
-# I do not have good indication that OKD API server ready to serve requests, so I will just
-# repeat cluster-deploy until it succeeds
-until make cluster-deploy; do
-    sleep 1
-done
-
+make cluster-sync PARALLEL_CLEANUP=$PARALLEL_CLEANUP
 hack/dockerized bazel shutdown
 
 # OpenShift is running important containers under default namespace

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,4 +36,9 @@ to libvirt domains based on the state of those resources.
  * `make cluster-sync`: After deploying a fresh environment, or after making
    changes to code in this tree, this command will sync the Pods and DaemonSets
    in the running KubeVirt environment with the state of this tree.
+   Note: Use make cluster-sync PARALLEL_CLEANUP=1, for a faster deploy.
+   Usable for healthy clusters and for first deploy only.
+   It will skip cleaning in case kubevirt namespace doesnt exists, and if
+   it does exists, it will run the cluster-clean in parallel to the cluster-build,
+   once both are finished it would run cluster-deploy.
  * `make cluster-down`: This will tear down a running KubeVirt enviornment.

--- a/hack/parallel.sh
+++ b/hack/parallel.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2020 Red Hat, Inc.
+#
+
+# This script is meant for faster cluster-sync.
+# It checks if the kubevirt namespace exists, skipping cleaning of the cluster if it doesn't.
+# If the ns does exists, it would run the clean parallel to the build, and once both
+# are finished it will deploy the cluster.
+
+NAMESPACE=${KUBEVIRT_INSTALLED_NAMESPACE:-kubevirt}
+TEMP_FILE=$(mktemp -p /tmp -t kubevirt.deploy.XXXX)
+
+trap 'rm -f $TEMP_FILE' EXIT SIGINT SIGTERM
+
+function _kubectl() {
+    cluster-up/kubectl.sh "$@"
+}
+
+function clean_and_build() {
+    echo "Kubevirt namespace found, cleaning"
+    ./hack/cluster-clean.sh >$TEMP_FILE 2>&1 &
+    CLEAN_PID=$!
+
+    ./hack/cluster-build.sh
+
+    wait $CLEAN_PID
+    if [ $? -ne 0 ]; then
+        echo "Clean failed, output was:"
+        cat $TEMP_FILE
+        exit 1
+    fi
+}
+
+function build() {
+    echo "Kubevirt namespace not found, skipping clean"
+    ./hack/cluster-build.sh
+}
+
+function main() {
+    if ! _kubectl get nodes >/dev/null 2>&1; then
+        echo "Cluster not found, exiting"
+        exit 1
+    fi
+
+    _kubectl get ns $NAMESPACE >/dev/null 2>&1 && clean_and_build || build
+    ./hack/cluster-deploy.sh
+}
+
+main "$@"


### PR DESCRIPTION

In order to reduce deployment time and omit unneeded operations,
this PR adds the PARALLEL_CLEANUP `make cluster-sync` flag.

The feature determines if a cluster exists,
skipping the cleaning of it if not.

In case the cluster exists, it clean it parallel of the build stage.
It saves time on first deploy and on the other as well,
because it use parallel processes.

It saves around 1 - 1.5 minute out of 4.5 minutes in some cases,
comparing to cluster-sync.

Adapt automation to use PARALLEL_CLEANUP
Since CI runs each lane on a new cluster,
no need to run make cluster-clean as part of the
deploying.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
