### PR TITLE
Add make focus target to ease lane focusing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,9 @@ olm-push:
 bump-kubevirtci:
 	./hack/bump-kubevirtci.sh
 
+focus:
+	./hack/focus.sh "$(lanes)"
+
 .PHONY: \
 	build-verify \
 	go-build \
@@ -160,4 +163,5 @@ bump-kubevirtci:
 	cluster-deploy \
 	cluster-sync \
 	olm-verify \
-	olm-push
+	olm-push \
+	focus

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -17,3 +17,16 @@ The other lanes will fail immediately, thus saving CI resources and allow develo
 In addition, the PR won't be mergeable until this selection will be reverted (unset the KUBEVIRT_LANE_FOCUS),
 and all the lanes will run and succeed.
 
+## Using make targets to focus lanes
+
+Focus on one target
+`make focus lanes=target`
+or
+`make focus lanes="target"`
+
+Clear focus
+`make focus`
+
+Focus on multi targets
+`make focus lanes="target1 target2"`
+

--- a/hack/focus.sh
+++ b/hack/focus.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2020 Red Hat, Inc.
+#
+
+LANES=${1:-}
+
+function main() {
+    sed -i "s/export KUBEVIRT_LANE_FOCUS.*/export KUBEVIRT_LANE_FOCUS="\""$1"\""/" automation/test.sh
+}
+
+main "$@"


### PR DESCRIPTION
During development, we frequently need to iterate on a specific
lane (i.e only K8s-1.17) of Kubevirt CI.
This method allows us to do it easily and save time and resources,
without breaking the required gating.

See docs/ci.md for usage examples.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
