### PR TITLE
Fix vmirs watcher, Controller can filter abnormal vmis related abnorm…

### DIFF
--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -351,7 +351,7 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 // filterActiveVMIs takes a list of VMIs and returns all VMIs which are not in a final state and not terminating
 func (c *VMIReplicaSet) filterActiveVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.VirtualMachineInstance {
 	return filter(vmis, func(vmi *virtv1.VirtualMachineInstance) bool {
-		return !vmi.IsFinal() && vmi.DeletionTimestamp == nil
+		return !vmi.IsFinal() && vmi.DeletionTimestamp == nil && !controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceConditionType(k8score.PodReady), k8score.ConditionFalse)
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: haemyung_yang <haemyung_yang@tmax.co.kr>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When node was failed and pod goes to deleting phase, vmi was not recreated by controller. Because controller not detected pod phase for related vmi,vmirs. So
I changed the filterActiveVmi method


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3332 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
