### PR TITLE
Remove modifications on the default privileged SCC.

### DIFF
--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -298,26 +298,9 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	if err != nil {
 		return nil, fmt.Errorf("error generating virt-handler deployment %v", err)
 	}
+
 	strategy.daemonSets = append(strategy.daemonSets, handler)
-
-	prefix := "system:serviceaccount"
-	typeMeta := metav1.TypeMeta{
-		Kind: customSCCPrivilegedAccountsType,
-	}
-
 	strategy.sccs = append(strategy.sccs, components.GetAllSCC(config.GetNamespace())...)
-
-	// deprecated, keep it for backwards compatibility
-	strategy.customSCCPrivileges = append(strategy.customSCCPrivileges, &customSCCPrivilegedAccounts{
-		TypeMeta:  typeMeta,
-		TargetSCC: "privileged",
-		ServiceAccounts: []string{
-			fmt.Sprintf("%s:%s:%s", prefix, config.GetNamespace(), rbac.HandlerServiceAccountName),
-			fmt.Sprintf("%s:%s:%s", prefix, config.GetNamespace(), rbac.ApiServiceAccountName),
-			fmt.Sprintf("%s:%s:%s", prefix, config.GetNamespace(), rbac.ControllerServiceAccountName),
-		},
-	})
-
 	strategy.apiServices = components.NewVirtAPIAPIServices(config.GetNamespace())
 	strategy.certificateSecrets = components.NewCertSecrets(config.GetNamespace(), operatorNamespace)
 	strategy.certificateSecrets = append(strategy.certificateSecrets, components.NewCACertSecret(operatorNamespace))


### PR DESCRIPTION
Since we already have dedicated SCC for each of the relevant components we don't need to modify the default privileged SCC anymore. 

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
We want to mitigate upgrade issues of the underlying provider such as OCP.
Further discussion can be found here:
http://post-office.corp.redhat.com/archives/cnv-devel/2020-April/msg00105.html

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=1831536

**Release note**:
```release-note
None
```
