### PR TITLE
Virtio transitional

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8543,6 +8543,10 @@
        "type": "string"
       }
      },
+     "preventPCIe": {
+      "description": "Use virtio-transitional instead of virtio, for compatibility with virtio-[0.9|1.0]. Defaults to false.",
+      "type": "boolean"
+     },
      "priorityClassName": {
       "description": "If specified, indicates the pod's priority. If not specified, the pod priority will be default or zero if there is no default.",
       "type": "string"

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1195,6 +1195,10 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			domain.Spec.Devices.HostDevices = append(domain.Spec.Devices.HostDevices, hostDev)
 		} else {
 			ifaceType := getInterfaceType(&iface)
+			if ifaceType == "virtio" && vmi.Spec.PreventPCIe {
+				ifaceType = "virtio-transitional"
+			}
+
 			domainIface := Interface{
 				Model: &Model{
 					Type: ifaceType,

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1240,6 +1240,19 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("e1000"))
 		})
 
+		It("should use virtio model when PCIe configuration is not explicitly set", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			domain := vmiToDomain(vmi, c)
+			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("virtio"))
+		})
+
+		It("should use virtio-transitional model when PCIe is explicitly disabled", func() {
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			vmi.Spec.PreventPCIe = true
+			domain := vmiToDomain(vmi, c)
+			Expect(domain.Spec.Devices.Interfaces[0].Model.Type).To(Equal("virtio-transitional"))
+		})
+
 		It("should set nic pci address when specified", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:81:01.0"

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -17361,6 +17361,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceSpec(ref common.Re
 							Ref:         ref("k8s.io/api/core/v1.PodDNSConfig"),
 						},
 					},
+					"preventPCIe": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Use virtio-transitional instead of virtio, for compatibility with virtio-[0.9|1.0]. Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"domain"},
 			},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -149,6 +149,9 @@ type VirtualMachineInstanceSpec struct {
 	// configuration based on DNSPolicy.
 	// +optional
 	DNSConfig *k8sv1.PodDNSConfig `json:"dnsConfig,omitempty" protobuf:"bytes,26,opt,name=dnsConfig"`
+	// Use virtio-transitional instead of virtio, for compatibility with virtio-[0.9|1.0]. Defaults to false.
+	// + optional
+	PreventPCIe bool `json:"preventPCIe,omitempty"`
 }
 
 // VirtualMachineInstanceStatus represents information about the status of a VirtualMachineInstance. Status may trail the actual

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -35,6 +35,7 @@ func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 		"networks":                      "List of networks that can be attached to a vm's virtual interface.",
 		"dnsPolicy":                     "Set DNS policy for the pod.\nDefaults to \"ClusterFirst\".\nValid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.\nDNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.\nTo have DNS options set along with hostNetwork, you have to specify DNS policy\nexplicitly to 'ClusterFirstWithHostNet'.\n+optional",
 		"dnsConfig":                     "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.\n+optional",
+		"preventPCIe":                   "Use virtio-transitional instead of virtio, for compatibility with virtio-[0.9|1.0]. Defaults to false.\n+ optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -17214,6 +17214,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceSpec(ref common.Re
 							Ref:         ref("k8s.io/api/core/v1.PodDNSConfig"),
 						},
 					},
+					"preventPCIe": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Use virtio-transitional instead of virtio, for compatibility with virtio-[0.9|1.0]. Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"domain"},
 			},

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -425,6 +425,24 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
+	Context("VirtualMachineInstance with virtio-transitional interface model", func() {
+		var legacyTypeVMI *v1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			tests.BeforeTestCleanup()
+			legacyTypeVMI = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+			tests.AddExplicitPodNetworkInterface(legacyTypeVMI)
+			legacyTypeVMI.Spec.PreventPCIe = true
+			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(legacyTypeVMI)
+			Expect(err).ToNot(HaveOccurred(), "Legacy VMI with `virtio-transitional` interface model type should be created")
+		})
+
+		It("should expose the virtio device type to the guest", func() {
+			tests.WaitUntilVMIReady(legacyTypeVMI, tests.LoggedInAlpineExpecter)
+			checkNetworkVendor(legacyTypeVMI, "0x1af4", "localhost:~#")
+		})
+	})
+
 	Context("VirtualMachineInstance with custom MAC address", func() {
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds support for virtio-transitional as an available model for`InterfaceModel`.

The `virtio-transitional` `InterfaceModel` is useful to support older OSs, which require virtio 0.9/1.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [Bugzilla 1794243](https://bugzilla.redhat.com/show_bug.cgi?id=1794243)

To Do:
  - functest w/ `virtio-transitional` iface model

**Special notes for your reviewer**:
Taking over PR https://github.com/kubevirt/kubevirt/pull/3218 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add virtio-transitional as a new InterfaceModel type.
```
