### PR TITLE
Build and test vs kubevirt pr

### DIFF
--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -2,6 +2,8 @@ FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/kubevirt
 COPY . .
 
+ENV KUBEVIRT_RUN_UNNESTED=true
+
 RUN source /etc/profile.d/gimme.sh && \
     export GOPATH="/root/go" && \
     ./hack/ci/build.sh

--- a/hack/ci/Dockerfile.ci
+++ b/hack/ci/Dockerfile.ci
@@ -1,6 +1,5 @@
 FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/kubevirt
-COPY ./hack/builder/rsyncd.conf /etc/rsyncd.conf
 COPY . .
 
 RUN source /etc/profile.d/gimme.sh && \

--- a/hack/ci/Dockerfile.ci-pr
+++ b/hack/ci/Dockerfile.ci-pr
@@ -2,9 +2,13 @@ FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/kubevirt
 COPY . .
 
+ARG PULL_PULL_SHA
+ENV KUBEVIRT_RUN_UNNESTED=true \
+    PULL_PULL_SHA=$PULL_PULL_SHA
+
 RUN source /etc/profile.d/gimme.sh && \
     export GOPATH="/root/go" && \
-    ./hack/ci/build.sh
+    ./hack/ci/build-pr.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
-CMD ["./hack/ci/test.sh"]
+CMD ["./hack/ci/test-pr.sh"]

--- a/hack/ci/Dockerfile.ci-pr
+++ b/hack/ci/Dockerfile.ci-pr
@@ -1,6 +1,5 @@
 FROM registry.svc.ci.openshift.org/ci/kubevirt-builder:30-5.8.1 AS builder
 WORKDIR /go/src/github.com/kubevirt.io/kubevirt
-COPY ./hack/builder/rsyncd.conf /etc/rsyncd.conf
 COPY . .
 
 RUN source /etc/profile.d/gimme.sh && \

--- a/hack/ci/build-pr.sh
+++ b/hack/ci/build-pr.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# bazel will fail if either HOME or USER are not set
+HOME=$(pwd)
+export HOME
+USER='kubeadmin'
+export USER
+
+mkdir -p _out/
+if [ -z ${PULL_PULL_SHA} ]; then
+    # poor mans replacement for PULL_PULL_SHA provided by prow - use the second parent commit id from the merge commit
+    merge_commit=$(git --no-pager log -1 --merges --format=%H)
+    PULL_PULL_SHA=$(git --no-pager show ${merge_commit} --format=%P | tr -d '\n' | cut -d ' ' -f 2)
+fi
+echo ${PULL_PULL_SHA} >_out/PULL_PULL_SHA
+export PULL_PULL_SHA
+
+# build dump
+CMD_OUT_DIR="$(pwd)/_out/cmd"
+export CMD_OUT_DIR
+mkdir -p "$CMD_OUT_DIR/dump/"
+GOPROXY=off GOFLAGS=-mod=vendor go build -o "$CMD_OUT_DIR/dump/dump" ./cmd/dump
+./hack/build-func-tests.sh
+
+rm -rf _ci-configs/
+
+# to avoid any permission problems we reset access rights recursively
+chmod -R 777 .

--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -16,6 +16,11 @@ bash -x ./hack/build-manifests.sh
 # build dump
 CMD_OUT_DIR="$(pwd)/_out/cmd"
 export CMD_OUT_DIR
-mkdir -p _out/cmd/dump/
+mkdir -p "$CMD_OUT_DIR/dump/"
 GOPROXY=off GOFLAGS=-mod=vendor go build -o "$CMD_OUT_DIR/dump/dump" ./cmd/dump
 bash -x ./hack/build-func-tests.sh
+
+rm -rf _ci-configs/
+
+# to avoid any permission problems we reset access rights recursively
+chmod -R 777 .

--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-# poor mans replacement for PULL_PULL_SHA provided by prow - use the second parent commit id from the merge commit
-mkdir -p _out/
-merge_commit=$(git --no-pager log -1 --merges --format=%H)
-git --no-pager show ${merge_commit} --format=%P | tr -d '\n' | cut -d ' ' -f 2 >_out/PULL_PULL_SHA
-PULL_PULL_SHA=$(cat _out/PULL_PULL_SHA)
-export PULL_PULL_SHA
-
 export DOCKER_PREFIX='kubevirtnightlybuilds'
 export DOCKER_TAG="latest"
 export KUBEVIRT_PROVIDER=external

--- a/hack/ci/resources/docker-registry.yaml
+++ b/hack/ci/resources/docker-registry.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  labels:
+    app: docker-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: docker-registry
+  template:
+    metadata:
+      labels:
+        app: docker-registry
+    spec:
+      containers:
+        - name: docker-registry
+          image: registry:2.7.1
+          ports:
+            - containerPort: 5000
+          volumeMounts:
+            - mountPath: "/var/lib/registry"
+              name: data
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5000
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-registry
+spec:
+  selector:
+    app: docker-registry
+  ports:
+    - protocol: TCP
+      port: 5000
+      targetPort: 5000

--- a/hack/ci/test-pr.sh
+++ b/hack/ci/test-pr.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# bazel will fail if either HOME or USER are not set
+HOME=$(pwd)
+export HOME
+USER='kubeadmin'
+export USER
+
+echo "setting up ephemeral image registry"
+oc create -f hack/ci/resources/docker-registry.yaml
+oc wait deployment registry --for condition=available --timeout=180s
+while ! oc get service docker-registry; do
+    echo 'waiting for service'
+    sleep 1
+done
+oc expose service docker-registry
+registry_host=$(oc get route docker-registry --template='{{ .spec.host }}')
+echo "Registry host will be $registry_host"
+# now enable the insecure registry
+oc patch image.config.openshift.io/cluster --type merge -p '{"spec":{"registrySources":{"insecureRegistries":["'"$registry_host"'"]}}}'
+
+# for some reason the entry point from dockerfile is overridden, so we source gimme go again
+source /etc/profile.d/gimme.sh && export GOPATH="/root/go" && go version
+
+# we can only build here, otherwise the image build would be OOMKilled
+echo "building images"
+./hack/bazel-build.sh
+./hack/bazel-build-images.sh
+
+registry_port=5000
+registry_pod=$(oc get pod -l app=docker-registry --no-headers -o custom-columns=:metadata.name)
+echo "Forwarding $registry_port to pod $registry_pod"
+oc port-forward $registry_pod $registry_port:$registry_port &
+
+echo "pushing images"
+export DOCKER_PREFIX="localhost:$registry_port"
+DOCKER_TAG=$(cat _out/PULL_PULL_SHA)
+export DOCKER_TAG
+./hack/bazel-push-images.sh
+
+echo "calling cluster-up to prepare config and check whether cluster is reachable"
+export KUBEVIRT_PROVIDER=external
+./cluster-up/up.sh
+
+echo "building manifests"
+export DOCKER_PREFIX="${registry_host}"
+./hack/build-manifests.sh
+
+echo "deploying"
+./hack/cluster-deploy.sh
+
+echo "testing"
+mkdir -p "$ARTIFACT_DIR"
+FUNC_TEST_ARGS='--ginkgo.noColor --ginkgo.focus=\[crit:high\] --junit-output='"$ARTIFACT_DIR"'/junit.functest.xml' \
+    ./hack/functests.sh

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -13,6 +13,5 @@ bash -x ./hack/cluster-deploy.sh
 
 echo "testing"
 mkdir -p "$ARTIFACT_DIR"
-TESTS_TO_FOCUS=$(grep -E -o '\[crit\:high\]' tests/*_test.go | sort | uniq | sed -E 's/tests\/([a-z_]+)\.go\:.*/\1/' | tr '\n' '|' | sed 's/|$//')
-FUNC_TEST_ARGS='--ginkgo.noColor --ginkgo.focus='"$TESTS_TO_FOCUS"' --ginkgo.regexScansFilePath=true --junit-output='"$ARTIFACT_DIR"'/junit.functest.xml' \
+FUNC_TEST_ARGS='--ginkgo.noColor --ginkgo.focus=\[crit:high\] --junit-output='"$ARTIFACT_DIR"'/junit.functest.xml' \
     bash -x ./hack/functests.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds the counterpart to [openshift/release configuration](https://github.com/openshift/release/pull/9483), there are now enhancements and fixes to scripts and Dockerfile s required to run presubmit jobs on openshift-ci from any PR created within kubevirt/kubevirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR can be merged regardless of test results as there are no direct effects on kubevirt/kubevirt. It's just required to be in here for openshift-ci to build images and run scripts from this repository.

Regarding `hack/ci/resources/docker-registry.yaml`: this is required to bootstrap an ephemeral registry on the cluster to be able to push images into, as the test cluster does not have one configured.

/cc @rmohr @jean-edouard @danielBelenky 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
