### PR TITLE
Don't override virt-handler status updates in scheduled state

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -472,6 +472,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		return nil
 	case vmi.IsScheduled():
 		// Don't process states where the vmi is clearly owned by virt-handler
+		return nil
 	default:
 		return fmt.Errorf("unknown vmi phase %v", vmi.Status.Phase)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that virt-controller does not override sync errors from
virt-handler when the VMI is in Scheduled phase.

This error manifested itself for instance on the test

```
Configurations [rfe_id:898][crit:medium][vendor:cnv-qe@redhat.com][level:component]New VirtualMachineInstance with all supported drives [test_id:1020]should not create the VM with wrong PCI adress
```

The flakefinder restults relevant for this are: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2020-06-04-168h.html#row31

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix hot-looping on the  VMI sync-condition if errors happen during the Scheduled phase of a VMI
```
