### PR TITLE
Change to direct deployment from operator yaml

### DIFF
--- a/hack/ci/build.sh
+++ b/hack/ci/build.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-export DOCKER_PREFIX='kubevirtnightlybuilds'
-export DOCKER_TAG="latest"
-export KUBEVIRT_PROVIDER=external
-
-bash -x ./hack/build-manifests.sh
-
 # build dump
 CMD_OUT_DIR="$(pwd)/_out/cmd"
 export CMD_OUT_DIR

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -1,15 +1,33 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+release_base_url="https://gcsweb.apps.ovirt.org/gcs/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt"
+release_date=$(curl -L "${release_base_url}/latest")
+release_url="${release_base_url}/${release_date}"
+commit=$(curl -L "${release_url}/commit")
+
 export DOCKER_PREFIX='kubevirtnightlybuilds'
-export DOCKER_TAG="latest"
-export KUBEVIRT_PROVIDER=external
+DOCKER_TAG="${release_date}_$(echo ${commit} | cut -c 1-9)"
+export DOCKER_TAG
+
+echo "deploying kubevirt from nightly build"
+oc create -f "${release_url}/kubevirt-operator.yaml"
+oc create -f "${release_url}/kubevirt-cr.yaml"
+
+echo "Deploying test infrastructure"
+for testinfra_file in $(curl -L "${release_url}/testing/" | grep -oE 'https://[^"]*\.yaml'); do
+    oc create -f ${testinfra_file}
+done
+
+oc wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
+if [ $? -ne 0 ]; then
+    echo "Dumping KubeVirt state"
+    hack/dump.sh
+fi
 
 echo "calling cluster-up to prepare config and check whether cluster is reachable"
+export KUBEVIRT_PROVIDER=external
 bash -x ./cluster-up/up.sh
-
-echo "deploying"
-bash -x ./hack/cluster-deploy.sh
 
 echo "testing"
 mkdir -p "$ARTIFACT_DIR"

--- a/hack/ci/test.sh
+++ b/hack/ci/test.sh
@@ -19,10 +19,14 @@ for testinfra_file in $(curl -L "${release_url}/testing/" | grep -oE 'https://[^
     oc create -f ${testinfra_file}
 done
 
+set +e
 oc wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
-if [ $? -ne 0 ]; then
+return_code=$?
+set -e
+if [ ${return_code} -ne 0 ]; then
     echo "Dumping KubeVirt state"
     hack/dump.sh
+    exit ${return_code}
 fi
 
 echo "calling cluster-up to prepare config and check whether cluster is reachable"


### PR DESCRIPTION
Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Elaborates on [uploading the operator manifest](https://github.com/kubevirt/project-infra/pull/461), using that upload and directly deploying from the manifests in the gcs bucket.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
