### PR TITLE
 Refactor Travis CI test script 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,6 @@ bazel-generate:
 bazel-build:
 	hack/dockerized "hack/bazel-fmt.sh && hack/bazel-build.sh"
 
-bazel-build-verify: TARGET_TO_RUN='make'
-bazel-build-verify: bazel-build check-git-tree-state build-verify bazel-test
-
 bazel-build-images:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} DOCKER_TAG_ALT=${DOCKER_TAG_ALT} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT} ./hack/bazel-build-images.sh"
 
@@ -25,14 +22,6 @@ bazel-push-images:
 
 push: bazel-push-images
 
-check-git-tree-state:
-ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
-	$(error git tree is not clean, you probably need to run '${TARGET_TO_RUN}' and commit the changes)
-endif
-
-check-for-binaries:
-	hack/check-for-binaries.sh
-
 bazel-test:
 	hack/dockerized "hack/bazel-fmt.sh && hack/bazel-test.sh"
 
@@ -40,9 +29,6 @@ generate:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"
 	SYNC_VENDOR=true hack/dockerized "./hack/bazel-generate.sh && hack/bazel-fmt.sh"
 	hack/sync-kubevirtci.sh
-
-generate-verify: TARGET_TO_RUN='make generate'
-generate-verify: generate check-for-binaries check-git-tree-state
 
 apidocs:
 	hack/dockerized "./hack/generate.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1 html"

--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -1,41 +1,110 @@
 #!/bin/bash -e
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2020 Red Hat, Inc.
+#
 
+last_running_func=""
+trap '{ [[ $last_running_func != "" ]] && echo "Last running function was:" $last_running_func; }' EXIT ERR
 
-make generate
-if [[ -n "$(git status --porcelain)" ]] ; then
-    echo "It seems like you need to run 'make generate'. Please run it and commit the changes"
-    git status --porcelain; false
-fi
+# For development you can change this list, but to revert it before merging.
+declare -a functions=( 
+    test_generate 
+    test_binaries
+    test_make 
+    test_goveralls_bazel_test 
+    test_apidocs 
+    test_client_python 
+    test_manifests 
+    test_olm_verify 
+    test_prom_rules_verify    
+)
 
-if diff <(git grep -c '') <(git grep -cI '') | egrep -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*' | grep '^<'; then
-    echo "Binary files are present in git repostory."; false
-fi
+function test_generate {
+    make generate
+    if [[ -n "$(git status --porcelain)" ]] ; then
+        echo "It seems like you need to run 'make generate'. Please run it and commit the changes"
+        git status --porcelain; false
+    fi
+}
 
-make
+function test_binaries {
+    if diff <(git grep -c '') <(git grep -cI '') | egrep -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*' | grep '^<'; then
+        echo "Binary files are present in git repostory."; false
+    fi
+}
 
-if [[ -n "$(git status --porcelain)" ]] ; then
-    echo "It seems like you need to run 'make'. Please run it and commit the changes"; git status --porcelain; false
-fi
+function test_make {
+    make
+    if [[ -n "$(git status --porcelain)" ]] ; then
+        echo "It seems like you need to run 'make'. Please run it and commit the changes"; git status --porcelain; false
+    fi
+    
+    make build-verify # verify that we set version on the packages built by bazel
+}
 
-make build-verify # verify that we set version on the packages built by bazel
+function test_goveralls_bazel_test {
+    if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then
+        echo "Running goveralls"
+        make goveralls
+    else
+        echo "Running bazel-test"
+        make bazel-test
+    fi
 
-# The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
-while sleep 9m; do echo "Long running job - keep alive"; done & LOOP_PID=$!
+    make build-verify # verify that we set version on the packages built by go (goveralls depends on go-build target)
+}
 
-if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then
-    make goveralls
-else
-    make bazel-test
-fi
+function test_apidocs {
+    make apidocs
+}
 
-kill $LOOP_PID
+function test_client_python {
+    make client-python
+}
 
-make build-verify # verify that we set version on the packages built by go(goveralls depends on go-build target)
-make apidocs
-make client-python
-make manifests DOCKER_PREFIX="docker.io/kubevirt" DOCKER_TAG=$TRAVIS_TAG # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
-make olm-verify
-if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then
-    make prom-rules-verify
-fi
+function test_manifests {
+    make manifests DOCKER_PREFIX="docker.io/kubevirt" DOCKER_TAG=$TRAVIS_TAG # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
+}
 
+function test_olm_verify {
+    make olm-verify
+}
+
+function test_prom_rules_verify {
+    if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then
+        make prom-rules-verify
+    fi
+}
+
+function main() {
+    FUNC_LIST="${functions[*]// /|}"
+    if [ $# -ne 0 ]; then
+        echo "Overriding function list from arguments"
+        FUNC_LIST="$@"
+    fi
+
+    echo "Running functions:" $FUNC_LIST
+
+    for f in ${functions[@]}; do
+        last_running_func=$(echo $f)
+        echo "*** Starting $f ***"
+        $f
+        echo "*** Ended $f ***"
+        last_running_func=""
+    done
+}
+
+main "$@"

--- a/hack/check-for-binaries.sh
+++ b/hack/check-for-binaries.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if diff <(git grep -c '') <(git grep -cI '') |
-    grep -E -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*' |
-    grep '^<'; then
-    echo "Binary files are present in git repostory."
-    exit 1
-fi


### PR DESCRIPTION
Separate bash script to functions.
Add prints to assist finding what is the actual failing command without
the need to scroll back.

Support providing list of functions via arguments,
in order to enable running parallel automation of the script.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
