### PR TITLE
Docs: Masquerade docs correction

### DIFF
--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -215,10 +215,10 @@ a
 in the project's examples folder.
 
 The masquerade bind mechanism has plenty in common with bridge binding; both
-have virt-handler create an in-pod bridge, set the pod networking interface as
-its slave, generate a similar looking interface domain xml element - e.g.
-interface type *bridge*, and same *source* and *target* values. Both phases of
-the networking configuration communicate by caching data in the VIF structure.
+have virt-handler create an in-pod bridge, generate a similar looking interface
+domain xml element - e.g. interface type *bridge*, and same *source* and
+*target* values. Both phases of the networking configuration communicate by caching
+data in the VIF structure.
 
 However, the similarities end there; while the networking infrastructure is
 the same, VM networking works completely different.
@@ -265,6 +265,13 @@ gateway IP, and `10.11.12.2` as VM IP.
 NAT is configured in the `preparePodNetworkInterfaces` method. The bridge is
 configured with the IP address previously reserved for the VM's gateway.
 
+The bridge acts as the vm's default gateway and not as a L2 bridge,
+therefore, the pod networking interface is not set as its slave.
+Since a linux bridge gets the MAC address of its first slave and we don't want it to
+take the MAC address of the first tap device attached to it,
+`preparePodNetworkInterfaces` creates a dummy nic and sets it as the first
+slave of the bridge.
+
 Afterwards, the nftables / iptables rules are provisioned in the NAT table. It
 follows a standard one to one NAT implementation using netfilter.
 
@@ -275,8 +282,8 @@ incoming traffic from the pod networking interface, making it go through the
 
 ```
 Chain PREROUTING (policy ACCEPT)
-target               prot opt source               destination
-KUBEVIRT_PREINBOUND  all  --  anywhere             anywhere
+target               prot opt in   source               destination
+KUBEVIRT_PREINBOUND  all  --  eth0 anywhere             anywhere
 ```
 
 On the `KUBEVIRT_PREINBOUND` chain, packets will be DNAT'ed (have their

--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -308,8 +308,9 @@ target     prot opt source               destination
 KUBEVIRT_POSTINBOUND  all  --  anywhere   anywhere
 ```
 
-In the `KUBEVIRT_POSTINBOUND` chain, SNAT is performed: the source IP address
-of the outbound packet is modified to the IP address of the gateway -
+In the `KUBEVIRT_POSTINBOUND` chain, in case the source address is localhost, SNAT is
+performed: the source IP address of the outbound packet is modified to the IP address of
+the gateway -
 `10.11.12.1`.
 
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The PR contains some fixes to the masquerade documentation-

- The pod networking interface isn't a slave of the in-pod bridge.
- According to PR https://github.com/kubevirt/kubevirt/pull/3469 
`KUBEVIRT_POSTINBOUND` chain will catch only a traffic with localhost as a source.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Don't merge before https://github.com/kubevirt/kubevirt/pull/3469 is merged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
