### PR TITLE
wip: prefer qemu:///session over qemu:///system

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -108,7 +108,7 @@ func startCmdServer(socketPath string,
 }
 
 func createLibvirtConnection() virtcli.Connection {
-	libvirtUri := "qemu:///system"
+	libvirtUri := "qemu:///session"
 	domainConn, err := virtcli.NewConnection(libvirtUri, "", "", 10*time.Second)
 	if err != nil {
 		panic(fmt.Sprintf("failed to connect to libvirtd: %v", err))

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -369,7 +369,7 @@ func NewConnection(uri string, user string, pass string, checkInterval time.Dura
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to libvirt daemon: %v", err)
 	}
-	logger.V(1).Info("Connected to libvirt daemon")
+	logger.V(1).Infof("Connected to libvirt daemon: %s", uri)
 
 	lvConn := &LibvirtConnection{
 		Connect: virConn, user: user, pass: pass, uri: uri, alive: true,


### PR DESCRIPTION
Signed-off-by: Victor Toso <victortoso@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: This is a WIP to switch from [qemu:///system to qemu:///session](https://blog.wikichoon.com/2016/01/qemusystem-vs-qemusession.html) to verify the feasibility and what problems we can encounter.

**Special notes for your reviewer**:
This is a WIP/dicussion PR. I can still use examples/vmi-fedora with this change but likely we would remove the libvirtd from running at all.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE yet
```
