### PR TITLE
Added Paused column to vmi

### DIFF
--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -76,6 +76,7 @@ func NewVirtualMachineInstanceCrd() *extv1beta1.CustomResourceDefinition {
 			{Name: "IP", Type: "string", JSONPath: ".status.interfaces[0].ipAddress"},
 			{Name: "NodeName", Type: "string", JSONPath: ".status.nodeName"},
 			{Name: "Live-Migratable", Type: "string", JSONPath: ".status.conditions[?(@.type=='LiveMigratable')].status", Priority: 1},
+			{Name: "Paused", Type: "string", JSONPath: ".status.conditions[?(@.type=='Paused')].status", Priority: 1},
 		},
 	}
 

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -61,7 +61,7 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 
 	table.DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
 
-		result, _, _ := tests.RunCommand(k8sClient, verb, resource, vm.Name, "-o", option)
+		result, _, err := tests.RunCommand(k8sClient, verb, resource, vm.Name, "-o", option)
 		// due to issue of kubectl that sometimes doesn't show CRDs on the first try, retry the same command
 		if err != nil {
 			result, _, err = tests.RunCommand(k8sClient, verb, resource, vm.Name, "-o", option)
@@ -80,6 +80,6 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 		Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 	},
 		table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED"}, 1, "true"),
-		table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE"}, 1, "True"),
+		table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 	)
 })


### PR DESCRIPTION
Signed-off-by: L. Pivarc <lpivarc@redhat.com>

**What this PR does / why we need it**:
There is no way to identify if VMI is running or is paused from cli. This PR makes it possible.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
