### PR TITLE
Use retry for push

### DIFF
--- a/hack/ci/test-pr.sh
+++ b/hack/ci/test-pr.sh
@@ -56,7 +56,7 @@ export KUBEVIRT_PROVIDER=external
 echo "building manifests"
 export DOCKER_PREFIX="$cluster_ip:$registry_port"
 # force using DOCKER_TAG
-rm ./bazel-bin/push-virt-operator.digest
+#rm ./bazel-bin/push-virt-operator.digest
 ./hack/build-manifests.sh
 
 echo "deploying"

--- a/hack/ci/test-pr.sh
+++ b/hack/ci/test-pr.sh
@@ -14,7 +14,7 @@ while ! oc get service docker-registry; do
     echo 'waiting for service'
     sleep 1
 done
-cluster_ip=$(oc get service docker-registry -o custom-columns=:.spec.clusterIP  --no-headers)
+cluster_ip=$(oc get service docker-registry -o custom-columns=:.spec.clusterIP --no-headers)
 registry_port=5000
 echo "Registry cluster_ip: $cluster_ip"
 # now enable the insecure registry


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Handles the problem of `oc port-forward` not being reliable by retrying the push against the deployed image registry. Symptom: Initially the push works, but on a following bazel push target it fails because the port-forward has lost connection.
```
Handling connection for 5000
2020/06/09 02:54:35 Successfully pushed Docker image to localhost:5000/virt-handler:2b2e3886fe73290cc1781887b66e684e558760a5
...
E0609 02:54:37.811373   11244 portforward.go:233] lost connection to pod
...
INFO: Build completed successfully, 9 total actions
2020/06/09 02:54:40 Error pushing image to localhost:5000/virt-launcher:2b2e3886fe73290cc1781887b66e684e558760a5: unable to push image to localhost:5000/virt-launcher:2b2e3886fe73290cc1781887b66e684e558760a5: Get http://localhost:5000/v2/: dial tcp [::1]:5000: connect: connection refused
```
[source](https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/kubevirt_kubevirt/3488/pull-ci-kubevirt-kubevirt-master-e2e-gcp-nested-virt/1499)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
