### PR TITLE
automation, travisci-test: Fix misuse of "``"

### DIFF
--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -3,7 +3,7 @@
 
 make generate
 if [[ -n "$(git status --porcelain)" ]] ; then
-    echo "It seems like you need to run `make generate`. Please run it and commit the changes"
+    echo "It seems like you need to run 'make generate'. Please run it and commit the changes"
     git status --porcelain; false
 fi
 
@@ -14,7 +14,7 @@ fi
 make
 
 if [[ -n "$(git status --porcelain)" ]] ; then
-    echo "It seems like you need to run `make`. Please run it and commit the changes"; git status --porcelain; false
+    echo "It seems like you need to run 'make'. Please run it and commit the changes"; git status --porcelain; false
 fi
 
 make build-verify # verify that we set version on the packages built by bazel


### PR DESCRIPTION
**What this PR does / why we need it**:

Bash treats the "`" character for command output substitution, executing
the command.

The script has been misusing this character in the echo command.
Fixed by replacing it with a "'" character.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
e note is required, just write "NONE".
```release-note
NONE
```
