### PR TITLE
Fix a race condition where we add a role and check for it immediately

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1525,7 +1525,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 
 					By("Ensuring user has the admin rights for the test namespace project")
-					// This simulates the ordinary user as an admin in his project
+					// This simulates the ordinary user as an admin in this project
 					stdOut, stdErr, err = tests.RunCommand(k8sClient, "adm", "policy", "add-role-to-user", "admin", fmt.Sprintf("system:serviceaccount:%s:%s", tests.NamespaceTestDefault, testUser))
 					Expect(err).ToNot(HaveOccurred(), "ERR: %s", stdOut+stdErr)
 				})
@@ -1546,9 +1546,11 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					Expect(err).ToNot(HaveOccurred(), "Cannot generate VMs manifest")
 
 					By("Checking VM creation permission using k8s client binary")
-					stdOut, _, err := tests.RunCommand(k8sClient, "auth", "can-i", "create", "vms", "--as", testUser)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(strings.TrimSpace(stdOut)).To(Equal("yes"))
+					// It might take time for the role to propagate
+					Eventually(func() string {
+						stdOut, _, _ := tests.RunCommand(k8sClient, "auth", "can-i", "create", "vms", "--as", testUser)
+						return strings.TrimSpace(stdOut)
+					}, 10*time.Second, 1*time.Second).Should(Equal("yes"), fmt.Sprintf("test account '%s' was never granted permission to create a VM", testUser))
 				})
 			})
 


### PR DESCRIPTION
Fixes a race condition in a functional test.

**Release note**:
```release-note
NONE
```
