### PR TITLE
Fix and improve goexpect use in tests and add verbose flag

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//vendor/k8s.io/client-go/transport/spdy:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
     ],
 )
 

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -365,7 +365,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Start a long running process")
 			res, err := expecter.ExpectBatch([]expect.Batcher{
 				&expect.BSnd{S: "sleep 5&\n"},
-				&expect.BExp{R: "# "}, // prompt
+				&expect.BExp{R: "\\# "}, // prompt
 				&expect.BSnd{S: `pgrep -f "sleep 5"` + "\n"},
 				&expect.BExp{R: "sleep 5"},    // command
 				&expect.BExp{R: "[0-9]+\r\n"}, // pid

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2979,7 +2979,7 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "localhost login:"},
 		&expect.BSnd{S: "root\n"},
-		&expect.BExp{R: "localhost:~#"}})
+		&expect.BExp{R: "localhost:~\\#"}})
 	res, err := expecter.ExpectBatch(b, 180*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
@@ -3035,7 +3035,7 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		return expecter, err
 	}
 
-	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "#")
+	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\#")
 }
 
 // ReLoggedInFedoraExpecter return prepared and ready to use console expecter for
@@ -4247,7 +4247,7 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, isFedoraVM bool) 
 		expecter, err = LoggedInFedoraExpecter(vmi)
 		Expect(err).NotTo(HaveOccurred())
 		httpServerMaker = fmt.Sprintf("python3 -m http.server %d --bind ::0 &\n", port)
-		prompt = "#"
+		prompt = "\\#"
 	} else {
 		expecter, err = LoggedInCirrosExpecter(vmi)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -56,6 +56,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/codes"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -2999,14 +3000,35 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 	}
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: "login:"},
-		&expect.BSnd{S: "fedora\n"},
-		&expect.BExp{R: "Password:"},
-		&expect.BSnd{S: "fedora\n"},
-		&expect.BExp{R: "$"},
+		&expect.BSnd{S: "\n"},
+		&expect.BCas{C: []expect.Caser{
+			&expect.Case{
+				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
+				R:  regexp.MustCompile(vmi.Name + ` login: `),
+				S:  "fedora\n",
+				T:  expect.Next(),
+				Rt: 10,
+			},
+			&expect.Case{
+				R:  regexp.MustCompile(`Password:`),
+				S:  "fedora\n",
+				T:  expect.Next(),
+				Rt: 10,
+			},
+			&expect.Case{
+				R:  regexp.MustCompile(`Login incorrect`),
+				T:  expect.LogContinue("Failed to log in", expect.NewStatus(codes.PermissionDenied, "login failed")),
+				Rt: 10,
+			},
+			&expect.Case{
+				R: regexp.MustCompile(`\$ `),
+				T: expect.OK(),
+			},
+		}},
 		&expect.BSnd{S: "sudo su\n"},
-		&expect.BExp{R: "#"}})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
+		&expect.BExp{R: "\\#"},
+	})
+	res, err := expecter.ExpectBatch(b, 3*time.Minute)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
 		expecter.Close()

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2811,6 +2811,8 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	}()
 
 	opts = append(opts, expect.SendTimeout(timeout))
+	opts = append(opts, expect.Verbose(true))
+	opts = append(opts, expect.VerboseWriter(GinkgoWriter))
 	return expect.SpawnGeneric(&expect.GenOptions{
 		In:  vmiWriter,
 		Out: expecterReader,

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -161,7 +161,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						&expect.BSnd{S: "fedora\n"},
 						&expect.BExp{R: "Password:"},
 						&expect.BSnd{S: fedoraPassword + "\n"},
-						&expect.BExp{R: "$"},
+						&expect.BExp{R: "\\$"},
 						&expect.BSnd{S: "cat /home/fedora/.ssh/authorized_keys\n"},
 						&expect.BExp{R: "test-ssh-key"},
 					}, time.Second*300)
@@ -199,7 +199,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						&expect.BSnd{S: "fedora\n"},
 						&expect.BExp{R: "Password:"},
 						&expect.BSnd{S: fedoraPassword + "\n"},
-						&expect.BExp{R: "$"},
+						&expect.BExp{R: "\\$"},
 						&expect.BSnd{S: "cat /home/fedora/.ssh/authorized_keys\n"},
 						&expect.BExp{R: "test-ssh-key"},
 					}, time.Second*300)

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -87,7 +87,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						&expect.BSnd{S: "fedora\n"},
 						&expect.BExp{R: "Password:"},
 						&expect.BSnd{S: "fedora" + "\n"},
-						&expect.BExp{R: "$"},
+						&expect.BExp{R: "\\$"},
 						&expect.BSnd{S: "ls /sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config\n"},
 						&expect.BExp{R: "raw"},
 					}, time.Second*300)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -421,7 +421,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			tests.WaitUntilVMIReady(e1000VMI, tests.LoggedInAlpineExpecter)
 			// as defined in https://vendev.org/pci/ven_8086/
-			checkNetworkVendor(e1000VMI, "0x8086", "localhost:~#")
+			checkNetworkVendor(e1000VMI, "0x8086", "localhost:~\\#")
 		})
 	})
 
@@ -437,7 +437,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitUntilVMIReady(deadbeafVMI, tests.LoggedInAlpineExpecter)
-			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress, "localhost:~#")
+			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress, "localhost:~\\#")
 		})
 	})
 
@@ -638,21 +638,21 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			err = tests.CheckForTextExpecter(dhcpVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "sudo dhclient -1 -r -d eth0\n"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "sudo dhclient -1 -sf /usr/bin/env --request-options subnet-mask,broadcast-address,time-offset,routers,domain-search,domain-name,domain-name-servers,host-name,nis-domain,nis-servers,ntp-servers,interface-mtu,tftp-server-name,bootfile-name eth0 | tee /dhcp-env\n"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "cat /dhcp-env\n"},
 				&expect.BExp{R: "new_tftp_server_name=tftp.kubevirt.io"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "cat /dhcp-env\n"},
 				&expect.BExp{R: "new_bootfile_name=config"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "cat /dhcp-env\n"},
 				&expect.BExp{R: "new_ntp_servers=127.0.0.1 127.0.0.2"},
 				&expect.BExp{R: "new_unknown_240=private.options.kubevirt.io"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 			}, 15)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -677,16 +677,16 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			tests.WaitUntilVMIReady(dnsVMI, tests.LoggedInCirrosExpecter)
 			err = tests.CheckForTextExpecter(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n\n"},
-				&expect.BExp{R: "$"},
+				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "search example.com"},
-				&expect.BExp{R: "$"},
+				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "nameserver 8.8.8.8"},
-				&expect.BExp{R: "$"},
+				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "nameserver 4.2.2.1"},
-				&expect.BExp{R: "$"},
+				&expect.BExp{R: "\\$"},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
- Use goexpect switch-case system for more flexibility on Fedora login
- Fix all uses of '$' and '#' in goexpect regexes
- Set verbose flag on console expecter, should make failures a lot more obvious

The original motivation for this is that the Fedora image takes quite a while to set the Fedora password:
```
[...]
Login incorrect

testvmiwdjvdrzphwq6kq5pkdl4hqlhd42m2624mbcnq5c8bpcmqfv7 login: [  146.207476] cloud-init[763]: Changing password for user fedora.
[  146.219633] cloud-init[763]: passwd: all authentication tokens updated successfully.
```
Trying to log in too early will fail, and the previous code didn't retry on failure.
The rest of the PR is what I found while debugging that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
