### PR TITLE
Fix flaky test 1625 by removing outdated condition

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	"kubevirt.io/kubevirt/pkg/controller"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -252,12 +251,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				tests.WaitForSuccessfulVMIStart(vmi)
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
-
-				Eventually(
-					controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(
-						vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady), k8sv1.ConditionTrue),
-					60*time.Second, 1*time.Second,
-				).Should(BeTrue(), "VirtualMachineInstance %q is not ready: %v", vmi.Name, vmi.Status.Phase)
 
 				By("Obtaining serial console")
 				expecter, err := tests.LoggedInAlpineExpecter(vmi)


### PR DESCRIPTION
This test, uses WaitForSuccessfulVMIStart.
The WaitForSuccessfulVMIStart helper
waits for a VMI to reach running phase.
    
Therefore, there is no need for another condition to wait
for the VMI to reach running.
The VMI condition manager status check is therefore removed.
    
The eventually clause in which the condition was examined is
also incorrect, and once it was checked, further retry on it did
not refreshed the data and just re-examined the same value.

Seen at
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/3503/pull-kubevirt-e2e-k8s-1.16/1269547598943883264

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
