### PR TITLE
tests, vmi: Fix IPv6 configuration through the console

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2876,19 +2876,23 @@ func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batc
 }
 
 func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter, virtClient kubecli.KubevirtClient, prompt string) error {
-	shouldConfigureIpv6 := func(vmi *v1.VirtualMachineInstance) bool {
-		shouldConfigureIpv6Batch := append([]expect.Batcher{
+	hasEth0Iface := func(vmi *v1.VirtualMachineInstance) bool {
+		hasNetEth0Batch := append([]expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
-			&expect.BSnd{S: "ip a | grep -q eth0\n"},
+			&expect.BSnd{S: "ip a | grep -q eth0; echo $?\n"},
+			&expect.BExp{R: retcode("0")}})
+		_, err := expecter.ExpectBatch(hasNetEth0Batch, 30*time.Second)
+		return err == nil
+	}
+
+	hasGlobalIPv6 := func(vmi *v1.VirtualMachineInstance) bool {
+		hasGlobalIPv6Batch := append([]expect.Batcher{
+			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
-			&expect.BSnd{S: "echo $?\n"},
-			&expect.BExp{R: "0"},
-			&expect.BSnd{S: "ip address show dev eth0 scope global | grep -q inet6\n"},
-			&expect.BExp{R: prompt},
-			&expect.BSnd{S: "echo $?\n"},
-			&expect.BExp{R: "1"}})
-		_, err := expecter.ExpectBatch(shouldConfigureIpv6Batch, 30*time.Second)
+			&expect.BSnd{S: "ip -6 address show dev eth0 scope global | grep -q inet6; echo $?\n"},
+			&expect.BExp{R: retcode("0")}})
+		_, err := expecter.ExpectBatch(hasGlobalIPv6Batch, 30*time.Second)
 		return err == nil
 	}
 
@@ -2902,34 +2906,35 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 	if !netutils.IsIPv6String(dnsServerIP) ||
 		(vmi.Spec.Domain.Devices.Interfaces == nil || len(vmi.Spec.Domain.Devices.Interfaces) == 0 || vmi.Spec.Domain.Devices.Interfaces[0].InterfaceBindingMethod.Masquerade == nil) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface != nil && !*vmi.Spec.Domain.Devices.AutoattachPodInterface) ||
-		!shouldConfigureIpv6(vmi) {
+		(!hasEth0Iface(vmi) || hasGlobalIPv6(vmi)) {
 		return nil
 	}
 
-	ipv6Batch := append([]expect.Batcher{
+	addIPv6Address := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0\n"},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
-		&expect.BSnd{S: "sleep 5\n"},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2\n"},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
-		&expect.BSnd{S: fmt.Sprintf(`echo "nameserver %s" >> /etc/resolv.conf\n`, dnsServerIP)},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"}})
-	resp, err := expecter.ExpectBatch(ipv6Batch, 1*time.Minute)
-
+		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0; echo $?\n"},
+		&expect.BExp{R: retcode("0")}})
+	resp, err := expecter.ExpectBatch(addIPv6Address, 30*time.Second)
 	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Configure ipv6: %v", resp)
+		log.DefaultLogger().Object(vmi).Infof("addIPv6Address failed: %v", resp)
 		expecter.Close()
 		return err
 	}
+
+	time.Sleep(5 * time.Second)
+	addIPv6DefaultRoute := append([]expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2; echo $?\n"},
+		&expect.BExp{R: retcode("0")}})
+	resp, err = expecter.ExpectBatch(addIPv6DefaultRoute, 30*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("addIPv6DefaultRoute failed: %v", resp)
+		expecter.Close()
+		return err
+	}
+
 	return nil
 }
 
@@ -4934,4 +4939,8 @@ func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 		return true
 	}
 	return false
+}
+
+func retcode(retcode string) string {
+	return "\n" + retcode
 }


### PR DESCRIPTION
configureIPv6OnVMI didn't actually update the /etc/resolv.conf

Updating DNS for cirros was added as nice to have only.
The tests that actually need it, use fedora VM, which use
cloud-init for this purpose.
Hence its safe and better to remove it.
Motivation and discovery was due to flaky test 3184.

Reasons that resolv.conf wasnt updated:

 Missing sudo su for cirros.
 Using of backtick malformatted the command [1]

Adjust the expected characters when examining the echo $? response
such that it will catch the actual retcode and not the a character
which is echoed back (i.e is part of the sent command itself).

Example when match with its own command input:
```
{11 sleep 5\r\n$ sudo ip -6 route add default via fd10 [0]}
```
And how it is with the fix:
```
{11 sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2\r\n$ echo $?\r\n0 [\n0]}
```

[1] https://golang.org/ref/spec#String_literals

---
Seen on

test_id 3184
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/3526/pull-kubevirt-e2e-kind-k8s-1.17.0-ipv6/1269974170763005953

Same error test_id 1780
See https://github.com/kubevirt/kubevirt/issues/3619

Signed-off-by: Or Shoval <oshoval@redhat.com>