### PR TITLE
Fix cascading deletion race condition in some tests

### DIFF
--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -255,7 +255,11 @@ var _ = Describe("DataVolume Integration", func() {
 			vmi, err := virtClient.VirtualMachineInstance(namespace).Get(name, &metav1.GetOptions{})
 			if err == nil && vmi.DeletionTimestamp == nil {
 				err := virtClient.VirtualMachineInstance(namespace).Delete(name, &metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				// In some tests, OwnerReferences in k8s can cause this to be deleted already
+				// just ignore 404's to avoid that race.
+				if err != nil && !errors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}
 		}
 
@@ -263,7 +267,11 @@ var _ = Describe("DataVolume Integration", func() {
 			dataVolume, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Get(name, metav1.GetOptions{})
 			if err == nil && dataVolume.DeletionTimestamp == nil {
 				err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Delete(name, &metav1.DeleteOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				// In some tests, OwnerReferences in k8s can cause this to be deleted already
+				// just ignore 404's to avoid that race.
+				if err != nil && !errors.IsNotFound(err) {
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}
 		}
 
@@ -594,7 +602,9 @@ var _ = Describe("DataVolume Integration", func() {
 
 				if dataVolume != nil {
 					err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Delete(dataVolume.Name, &metav1.DeleteOptions{})
-					Expect(err).ToNot(HaveOccurred())
+					if err != nil && !errors.IsNotFound(err) {
+						Expect(err).ToNot(HaveOccurred())
+					}
 				}
 			})
 


### PR DESCRIPTION
Fix a race condition in some tests. We delete a VM, which should cause k8s to delete a VMI and DV associated with this VM. In an abundance of caution, we also delete that same VMI and DV--only we didn't account for the fact that k8s could beat us to it.

**Release note**:
```release-note
NONE
```
