### PR TITLE
ipv6, kind, disks-provider: create loop devices in initcontainer

### DIFF
--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -114,20 +114,16 @@ spec:
               - /ready
             initialDelaySeconds: 10
             periodSeconds: 5
+      initContainers:
         - name: loopdev
           command:
           - sh
           - -c
           - |
-            while true; do
-              for i in $(seq 0 100); do
-                if ! [ -e /dev/loop$i ]; then
-                  mknod /dev/loop$i b 7 $i
-                fi
-              done
-              # XXX: we can't finish running because we're a DaemonSet
-              # Switch to being a Pod!
-              sleep 100000000
+            for i in $(seq 0 100); do
+              if ! [ -e /dev/loop$i ]; then
+                mknod /dev/loop$i b 7 $i
+              fi
             done
           image: {{.DockerPrefix}}/disks-images-provider:{{.DockerTag}}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We're currently creating the loop devices in a privileged container
which we then keep alive, to prevent it from `CrashLoopBackoff`
situation (container is restarted after its task ends).

By using an init container to create the loop devices, we remove
the need to keep the useless container up and running, since it
only performs its task once, and then cleanly exists.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
