### PR TITLE
Skip an extremely flakey migration test

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1053,7 +1053,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			AfterEach(func() {
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
-			It("[test_id:2227]should abort a vmi migration without progress", func() {
+			PIt("[test_id:2227] [flaky] should abort a vmi migration without progress", func() {
 				tests.SkipStressTestIfRunnigOnKindInfra()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")


### PR DESCRIPTION
**What this PR does / why we need it**:

Test
```
[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration Starting a VirtualMachineInstance migration monitor [test_id:2227]should abort a vmi migration without progress
```
is blocking merges. See also the flakefinder history:

https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2020-06-14-168h.html#row0

It recently started to fail almost 100% of time, but was flaky before already. There may be a real issue in the config propagation code. https://github.com/kubevirt/kubevirt/pull/3542 tries to consistently wait until the config is distributed, but it still fails on the test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
