### PR TITLE
Re-enabling test pointing to #2272

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -226,10 +226,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	}
 	runMigrationAndExpectCompletion := func(migration *v1.VirtualMachineInstanceMigration, timeout int) string {
 		By("Starting a Migration")
+		var migrationCreated *v1.VirtualMachineInstanceMigration
 		Eventually(func() error {
-			migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
+			migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
 			return err
 		}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
+		migration = migrationCreated
 		By("Waiting until the Migration Completes")
 
 		uid := ""
@@ -570,10 +572,12 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					Skip("Skip DataVolume tests when CDI is not present")
 				}
 
-				tests.SkipIfVersionAboveOrEqual("re-enable this once https://github.com/kubevirt/kubevirt/issues/2272 is fixed", "1.13.3")
+				if tests.IsIPv6Cluster(virtClient) {
+					Skip("Skip ISCSI on IPv6")
+				}
 
 				// set unsafe migration flag
-				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": true}`)
+				tests.UpdateClusterConfigValueAndWait("migrations", `{"unsafeMigrationOverride": "true"}`)
 			})
 
 			It("[test_id:3238]should migrate a vmi with UNSAFE_MIGRATION flag set", func() {
@@ -703,7 +707,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with an Alpine shared ISCSI PVC", func() {
 			var pvName string
 			BeforeEach(func() {
-				tests.SkipIfVersionAboveOrEqual("re-enable this once https://github.com/kubevirt/kubevirt/issues/2272 is fixed", "1.13.3")
+				if tests.IsIPv6Cluster(virtClient) {
+					Skip("Skip ISCSI on IPv6")
+				}
 				pvName = "test-iscsi-lun" + rand.String(48)
 				// Start a ISCSI POD and service
 				By("Starting an iSCSI POD")
@@ -773,7 +779,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with an Cirros shared ISCSI PVC", func() {
 			var pvName string
 			BeforeEach(func() {
-				tests.SkipIfVersionAboveOrEqual("re-enable this once https://github.com/kubevirt/kubevirt/issues/2272 is fixed", "1.13.3")
+				if tests.IsIPv6Cluster(virtClient) {
+					Skip("Skip ISCSI on IPv6")
+				}
 				pvName = "test-iscsi-lun" + rand.String(48)
 				// Start a ISCSI POD and service
 				By("Starting an iSCSI POD")
@@ -1050,7 +1058,9 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		Context("with an Cirros non-shared ISCSI PVC", func() {
 			var pvName string
 			BeforeEach(func() {
-				tests.SkipIfVersionAboveOrEqual("re-enable this once https://github.com/kubevirt/kubevirt/issues/2272 is fixed", "1.13.3")
+				if tests.IsIPv6Cluster(virtClient) {
+					Skip("Skip ISCSI on IPv6")
+				}
 				pvName = "test-iscsi-lun" + rand.String(48)
 				// Start a ISCSI POD and service
 				By("Starting an iSCSI POD")

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -725,7 +725,9 @@ var _ = Describe("Storage", func() {
 			pvName := "test-iscsi-lun" + rand.String(48)
 
 			BeforeEach(func() {
-				tests.SkipIfVersionAboveOrEqual("re-enable this once https://github.com/kubevirt/kubevirt/issues/2272 is fixed", "1.13.3")
+				if tests.IsIPv6Cluster(virtClient) {
+					Skip("Skip ISCSI on IPv6")
+				}
 				// Start a ISCSI POD and service
 				By("Creating a ISCSI POD")
 				iscsiTargetIP := tests.CreateISCSITargetPOD(tests.ContainerDiskAlpine)


### PR DESCRIPTION
Signed-off-by: L. Pivarc <lpivarc@redhat.com>

**What this PR does / why we need it**:
Re-enabling ISCSI shared PVC migration tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2272

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
