### PR TITLE
Stabilize functest vmi migration stress

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -326,7 +326,10 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 	runStressTest := func(expecter expect.Expecter) {
 		By("Run a stress test to dirty some pages and slow down the migration")
 		_, err = expecter.ExpectBatch([]expect.Batcher{
-			&expect.BSnd{S: "stress --vm 1 --vm-bytes 800M --vm-keep --timeout 1600s&\n"},
+			&expect.BSnd{S: "\n"},
+			&expect.BExp{R: "\\#"},
+			&expect.BSnd{S: "stress --vm 1 --vm-bytes 800M --vm-keep --timeout 1600s&\n\n"},
+			&expect.BExp{R: "\\#"},
 		}, 15*time.Second)
 		Expect(err).ToNot(HaveOccurred(), "should run a stress test")
 		// give stress tool some time to trash more memory pages before returning control to next steps

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -309,19 +309,17 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		By("Waiting until the Migration Completes")
 
 		uid := ""
-		Eventually(func() bool {
+		Eventually(func() v1.VirtualMachineInstanceMigrationPhase {
 			migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(migration.Status.Phase).NotTo(Equal(v1.MigrationSucceeded))
+			phase := migration.Status.Phase
+			Expect(phase).NotTo(Equal(v1.MigrationSucceeded))
 
 			uid = string(migration.UID)
-			if migration.Status.Phase == v1.MigrationFailed {
-				return true
-			}
-			return false
+			return phase
 
-		}, timeout, 1*time.Second).Should(BeTrue())
+		}, timeout, 1*time.Second).Should(Equal(v1.MigrationFailed))
 		return uid
 	}
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1062,7 +1062,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
 			PIt("[test_id:2227] should abort a vmi migration without progress", func() {
-				tests.SkipStressTestIfRunnigOnKindInfra()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1049,12 +1049,19 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				cfgMap, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, options)
 				Expect(err).ToNot(HaveOccurred())
 				originalMigrationConfig = cfgMap.Data["migrations"]
-				tests.UpdateClusterConfigValueAndWait("migrations", `{"progressTimeout" : 5, "completionTimeoutPerGiB": 5}`)
+
+				data := map[string]string{
+					"progressTimeout":         "5",
+					"completionTimeoutPerGiB": "5",
+				}
+				migrationData, err := json.Marshal(data)
+				Expect(err).ToNot(HaveOccurred())
+				tests.UpdateClusterConfigValueAndWait("migrations", string(migrationData))
 			})
 			AfterEach(func() {
 				tests.UpdateClusterConfigValueAndWait("migrations", originalMigrationConfig)
 			})
-			PIt("[test_id:2227] [flaky] should abort a vmi migration without progress", func() {
+			PIt("[test_id:2227] should abort a vmi migration without progress", func() {
 				tests.SkipStressTestIfRunnigOnKindInfra()
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1053,6 +1053,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				data := map[string]string{
 					"progressTimeout":         "5",
 					"completionTimeoutPerGiB": "5",
+					"bandwidthPerMigration":   "1Mi",
 				}
 				migrationData, err := json.Marshal(data)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4747,12 +4747,6 @@ func IsRunningOnKindInfraIPv6() bool {
 	return strings.HasPrefix(provider, "kind-k8s-1.17.0-ipv6")
 }
 
-func SkipStressTestIfRunnigOnKindInfra() {
-	if IsRunningOnKindInfra() {
-		Skip("Skip stress test till issue https://github.com/kubevirt/kubevirt/issues/3323 is fixed")
-	}
-}
-
 func SkipPVCTestIfRunnigOnKindInfra() {
 	if IsRunningOnKindInfra() {
 		Skip("Skip PVC tests till PR https://github.com/kubevirt/kubevirt/pull/3171 is merged")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing flaky stress migration test.

tests, migration: Fix the cluster config update in the stress test

The integers used as values for the migration should have been strings
and not integers.
This change in now using json marshaling (to make sure there are no
problems there).

Error seen in logs:
```
{"component":"virt-controller","level":"error","msg":"Invalid cluster config using 'ConfigMap' resource version '37083', falling back to last good resource version '37042'","pos":"config-map.go:437","reason":"failed to parse migration config: json: invalid use of ,string struct tag, trying to unmarshal unquoted value into *int64","service":"http","timestamp":"2020-06-15T10:07:52.194163Z"}
```

---

tests, migration: Fix run stress expecter
tests, migration: Assert phase directly

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3560, fixes #3323 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
