### PR TITLE
kind, automation: detach all loopbacks on provider startup

### DIFF
--- a/cluster-up/cluster/kind/common.sh
+++ b/cluster-up/cluster/kind/common.sh
@@ -152,6 +152,11 @@ function setup_kind() {
         docker exec $node /bin/sh -c "curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin"
     done
 
+    # detach all the loopback devices from previous executions - useful only
+    # for CI.
+    # TODO: Once this is properly fixed, remove the next condition.
+    losetup -D
+
     echo "ipv6 cni: $IPV6_CNI"
     if [ -z ${IPV6_CNI+x} ]; then
         echo "no ipv6, safe to install flannel"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
losetup returns the next configured device from the root namespace
which leads to an error on the `disks-images-provider` pod (which attempts to configure the loop device from the correct mount namespace).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3569 

**Special notes for your reviewer**:
**This is a band-aid only**. I'm trying to implement a proper fix, but let's leave this as a plan B.

Reverting PR #3314 would be plan C.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
