### PR TITLE
disks images provider: force the usage of a single loopback device

### DIFF
--- a/manifests/testing/disks-images-provider.yaml.in
+++ b/manifests/testing/disks-images-provider.yaml.in
@@ -105,6 +105,8 @@ spec:
             mountPath: /hostImages
           - name: local-storage
             mountPath: /local-storage
+          - name: dev
+            mountPath: /dev
           securityContext:
             privileged: true
           readinessProbe:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On a failure to attach to the loopback device, detach its current
user. On the next time the container is started (restart policy),
it will be able to attach to that loopback device, since it is
already available.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3569 

**Special notes for your reviewer**:
TODO

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
