### PR TITLE
Increase timeout for virt-handler to return to ready state

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -658,7 +658,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						ds.Status.DesiredNumberScheduled == virtHandlerAvailablePods &&
 						ds.Status.NumberReady == virtHandlerAvailablePods &&
 						ds.Status.UpdatedNumberScheduled == virtHandlerAvailablePods
-				}, 120*time.Second, 1*time.Second).Should(BeTrue(), "Virthandler should be ready to work")
+				}, 180*time.Second, 1*time.Second).Should(BeTrue(), "Virthandler should be ready to work")
 			})
 		})
 


### PR DESCRIPTION
Flakey test observed in the wild. 120s isn't always enough.

Addresses at least one failure mentioned in:

https://github.com/kubevirt/kubevirt/issues/3561

**Release note**:
```release-note
NONE
```
