### PR TITLE
Refactor virtctl image-upload args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module kubevirt.io/kubevirt
 
+go 1.12
+
 require (
 	github.com/Azure/go-autorest/autorest v0.9.1 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module kubevirt.io/kubevirt
 
-go 1.12
-
 require (
 	github.com/Azure/go-autorest/autorest v0.9.1 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.6.0 // indirect

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -84,6 +85,7 @@ var (
 	uploadPodWaitSecs uint
 	blockVolume       bool
 	noCreate          bool
+	createPVC         bool
 )
 
 // HTTPClientCreator is a function that creates http clients
@@ -141,16 +143,19 @@ func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 
 func usage() string {
 	usage := `  # Upload a local disk image to a newly created DataVolume:
-  {{ProgramName}} image-upload dv dv-name --size=10Gi --image-path=/images/fedora30.qcow2
+  {{ProgramName}} image-upload dv fedora-dv --size=10Gi --image-path=/images/fedora30.qcow2
 
   # Upload a local disk image to an existing DataVolume
-  {{ProgramName}} image-upload dv dv-name --no-create --image-path=/images/fedora30.qcow2
+  {{ProgramName}} image-upload dv fedora-dv --no-create --image-path=/images/fedora30.qcow2
+
+  # Upload a local disk image to a newly created PersistentVolumeClaim
+  {{ProgramName}} image-upload pvc fedora-pvc --size=10Gi --image-path=/images/fedora30.qcow2
 
   # Upload a local disk image to an existing PersistentVolumeClaim
-  {{ProgramName}} image-upload pvc pvc-name --image-path=/images/fedora30.qcow2
+  {{ProgramName}} image-upload pvc fedora-pvc --no-create --image-path=/images/fedora30.qcow2
 
   # Upload to a DataVolume with explicit URL to CDI Upload Proxy
-  {{ProgramName}} image-upload dv dv-name --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2`
+  {{ProgramName}} image-upload dv fedora-dv --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2`
 	return usage
 }
 
@@ -173,6 +178,8 @@ func parseArgs(args []string) error {
 			return fmt.Errorf("cannot use --pvc-name and args")
 		}
 
+		createPVC = true
+
 		return nil
 	}
 
@@ -182,8 +189,9 @@ func parseArgs(args []string) error {
 
 	switch strings.ToLower(args[0]) {
 	case "dv":
+		createPVC = false
 	case "pvc":
-		noCreate = true
+		createPVC = true
 	default:
 		return fmt.Errorf("invalid resource type %s", args[0])
 	}
@@ -221,15 +229,24 @@ func (c *command) run(cmd *cobra.Command, args []string) error {
 		}
 
 		if !noCreate && len(size) == 0 {
-			return fmt.Errorf("when creating DataVolume, the size must be specified")
+			return fmt.Errorf("when creating a resource, the size must be specified")
 		}
 
-		dv, err := createUploadDataVolume(virtClient, namespace, name, size, storageClass, accessMode, blockVolume)
-		if err != nil {
-			return err
+		var obj metav1.Object
+
+		if createPVC {
+			obj, err = createUploadPVC(virtClient, namespace, name, size, storageClass, accessMode, blockVolume)
+			if err != nil {
+				return err
+			}
+		} else {
+			obj, err = createUploadDataVolume(virtClient, namespace, name, size, storageClass, accessMode, blockVolume)
+			if err != nil {
+				return err
+			}
 		}
 
-		fmt.Printf("DataVolume %s/%s created\n", dv.Namespace, dv.Name)
+		fmt.Printf("%s %s/%s created\n", reflect.TypeOf(obj).Elem().Name(), obj.GetNamespace(), obj.GetName())
 	} else {
 		pvc, err = ensurePVCSupportsUpload(virtClient, pvc)
 		if err != nil {
@@ -453,9 +470,9 @@ func waitUploadProcessingComplete(client kubernetes.Interface, namespace, name s
 }
 
 func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*cdiv1.DataVolume, error) {
-	quantity, err := resource.ParseQuantity(size)
+	pvcSpec, err := createPVCSpec(size, storageClass, accessMode, blockVolume)
 	if err != nil {
-		return nil, fmt.Errorf("validation failed for size=%s: %s", size, err)
+		return nil, err
 	}
 
 	dv := &cdiv1.DataVolume{
@@ -467,27 +484,8 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 			Source: cdiv1.DataVolumeSource{
 				Upload: &cdiv1.DataVolumeSourceUpload{},
 			},
-			PVC: &v1.PersistentVolumeClaimSpec{
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceStorage: quantity,
-					},
-				},
-			},
+			PVC: pvcSpec,
 		},
-	}
-
-	if storageClass != "" {
-		dv.Spec.PVC.StorageClassName = &storageClass
-	}
-
-	if accessMode != "" {
-		dv.Spec.PVC.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
-	}
-
-	if blockVolume {
-		volMode := v1.PersistentVolumeBlock
-		dv.Spec.PVC.VolumeMode = &volMode
 	}
 
 	dv, err = client.CdiClient().CdiV1alpha1().DataVolumes(namespace).Create(dv)
@@ -496,6 +494,57 @@ func createUploadDataVolume(client kubecli.KubevirtClient, namespace, name, size
 	}
 
 	return dv, nil
+}
+
+func createUploadPVC(client kubernetes.Interface, namespace, name, size, storageClass, accessMode string, blockVolume bool) (*v1.PersistentVolumeClaim, error) {
+	pvcSpec, err := createPVCSpec(size, storageClass, accessMode, blockVolume)
+	if err != nil {
+		return nil, err
+	}
+
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				uploadRequestAnnotation: "",
+			},
+		},
+		Spec: *pvcSpec,
+	}
+
+	pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
+	if err != nil {
+		return nil, err
+	}
+
+	return pvc, nil
+}
+
+func createPVCSpec(size, storageClass, accessMode string, blockVolume bool) (*v1.PersistentVolumeClaimSpec, error) {
+	quantity, err := resource.ParseQuantity(size)
+	if err != nil {
+		return nil, fmt.Errorf("validation failed for size=%s: %s", size, err)
+	}
+
+	spec := &v1.PersistentVolumeClaimSpec{
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceStorage: quantity,
+			},
+		},
+	}
+
+	if accessMode != "" {
+		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
+	}
+
+	if blockVolume {
+		volMode := v1.PersistentVolumeBlock
+		spec.VolumeMode = &volMode
+	}
+
+	return spec, nil
 }
 
 func ensurePVCSupportsUpload(client kubernetes.Interface, pvc *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -36,10 +36,10 @@ const (
 )
 
 const (
-	dvNamespace = "default"
-	dvName      = "test-dv"
-	pvcSize     = "500Mi"
-	configName  = "config"
+	targetNamespace = "default"
+	targetName      = "test-volume"
+	pvcSize         = "500Mi"
+	configName      = "config"
 )
 
 var _ = Describe("ImageUpload", func() {
@@ -50,8 +50,9 @@ var _ = Describe("ImageUpload", func() {
 		cdiClient  *fakecdiclient.Clientset
 		server     *httptest.Server
 
-		createCalled bool
-		updateCalled bool
+		dvCreateCalled  bool
+		pvcCreateCalled bool
+		updateCalled    bool
 
 		imagePath string
 	)
@@ -81,7 +82,7 @@ var _ = Describe("ImageUpload", func() {
 
 		pvc := &v1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        dvName,
+				Name:        targetName,
 				Namespace:   "default",
 				Annotations: map[string]string{},
 			},
@@ -102,7 +103,7 @@ var _ = Describe("ImageUpload", func() {
 
 		pvc := &v1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      dvName,
+				Name:      targetName,
 				Namespace: "default",
 			},
 			Spec: v1.PersistentVolumeClaimSpec{
@@ -140,11 +141,11 @@ var _ = Describe("ImageUpload", func() {
 	addPodPhaseAnnotation := func() {
 		defer GinkgoRecover()
 		time.Sleep(10 * time.Millisecond)
-		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(dvNamespace).Get(dvName, metav1.GetOptions{})
+		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Get(targetName, metav1.GetOptions{})
 		Expect(err).To(BeNil())
 		pvc.Annotations[podPhaseAnnotation] = "Running"
 		pvc.Annotations[podReadyAnnotation] = "true"
-		pvc, err = kubeClient.CoreV1().PersistentVolumeClaims(dvNamespace).Update(pvc)
+		pvc, err = kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Update(pvc)
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
 		}
@@ -158,7 +159,7 @@ var _ = Describe("ImageUpload", func() {
 		pvc.Spec.VolumeMode = dv.Spec.PVC.VolumeMode
 		pvc.Spec.AccessModes = append([]v1.PersistentVolumeAccessMode(nil), dv.Spec.PVC.AccessModes...)
 		pvc.Spec.StorageClassName = dv.Spec.PVC.StorageClassName
-		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(dvNamespace).Create(pvc)
+		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Create(pvc)
 		Expect(err).To(BeNil())
 	}
 
@@ -169,12 +170,30 @@ var _ = Describe("ImageUpload", func() {
 
 			dv, ok := create.GetObject().(*cdiv1.DataVolume)
 			Expect(ok).To(BeTrue())
-			Expect(dv.Name).To(Equal(dvName))
+			Expect(dv.Name).To(Equal(targetName))
 
-			Expect(createCalled).To(BeFalse())
-			createCalled = true
+			Expect(dvCreateCalled).To(BeFalse())
+			dvCreateCalled = true
 
 			go createPVC(dv)
+
+			return false, nil, nil
+		})
+
+		kubeClient.Fake.PrependReactor("create", "persistentvolumeclaims", func(action testing.Action) (bool, runtime.Object, error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+
+			pvc, ok := create.GetObject().(*v1.PersistentVolumeClaim)
+			Expect(ok).To(BeTrue())
+			Expect(pvc.Name).To(Equal(targetName))
+
+			Expect(pvcCreateCalled).To(BeFalse())
+			pvcCreateCalled = true
+
+			if !dvCreateCalled {
+				go addPodPhaseAnnotation()
+			}
 
 			return false, nil, nil
 		})
@@ -185,9 +204,9 @@ var _ = Describe("ImageUpload", func() {
 
 			pvc, ok := update.GetObject().(*v1.PersistentVolumeClaim)
 			Expect(ok).To(BeTrue())
-			Expect(pvc.Name).To(Equal(dvName))
+			Expect(pvc.Name).To(Equal(targetName))
 
-			if !createCalled && !updateCalled {
+			if !dvCreateCalled && !pvcCreateCalled && !updateCalled {
 				go addPodPhaseAnnotation()
 			}
 
@@ -211,7 +230,7 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	validatePVCArgs := func(mode v1.PersistentVolumeMode) {
-		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(dvNamespace).Get(dvName, metav1.GetOptions{})
+		pvc, err := kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Get(targetName, metav1.GetOptions{})
 		Expect(err).To(BeNil())
 
 		_, ok := pvc.Annotations[uploadRequestAnnotation]
@@ -229,7 +248,7 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	validateDataVolumeArgs := func(mode v1.PersistentVolumeMode) {
-		dv, err := cdiClient.CdiV1alpha1().DataVolumes(dvNamespace).Get(dvName, metav1.GetOptions{})
+		dv, err := cdiClient.CdiV1alpha1().DataVolumes(targetNamespace).Get(targetName, metav1.GetOptions{})
 		Expect(err).To(BeNil())
 
 		validatePVCSpec(dv.Spec.PVC, mode)
@@ -270,7 +289,8 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	testInitAsync := func(statusCode int, async bool, kubeobjects ...runtime.Object) {
-		createCalled = false
+		dvCreateCalled = false
+		pvcCreateCalled = false
 		updateCalled = false
 
 		config := createCDIConfig()
@@ -313,80 +333,101 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	Context("Successful upload to PVC", func() {
-		DescribeTable("PVC does exist", func(async bool) {
-			testInitAsync(http.StatusOK, async)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--size", pvcSize,
+		It("PVC does not exist deprecated args", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", targetName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeTrue())
+			Expect(pvcCreateCalled).To(BeTrue())
+			validatePVC()
+		})
+
+		It("PVC exists deprecated args", func() {
+			testInit(http.StatusOK, pvcSpec())
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", targetName, "--no-create",
+				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
+			Expect(cmd()).To(BeNil())
+			Expect(pvcCreateCalled).To(BeFalse())
+			validatePVC()
+		})
+
+		DescribeTable("DV does not exist", func(async bool) {
+			testInitAsync(http.StatusOK, async)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
+			Expect(cmd()).To(BeNil())
+			Expect(dvCreateCalled).To(BeTrue())
 			validatePVC()
 			validateDataVolume()
 		},
-			Entry("PVC does not exist, async", true),
-			Entry("PVC does not exist sync", false),
+			Entry("DV does not exist, async", true),
+			Entry("DV does not exist sync", false),
 		)
 
-		It("PVC does not exist --pcvc-size", func() {
+		It("DV does not exist --pvc-size", func() {
 			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--pvc-size", pvcSize,
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeTrue())
+			Expect(dvCreateCalled).To(BeTrue())
 			validatePVC()
 			validateDataVolume()
 		})
 
-		It("PVC does not exist deprecated args", func() {
+		It("DV does not exist and --no-create", func() {
 			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", dvName, "--size", pvcSize,
-				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
-			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeTrue())
-			validatePVC()
-			validateDataVolume()
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--pvc-size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath, "--no-create")
+			err := cmd()
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(Equal(fmt.Sprintf("persistentvolumeclaims %q not found", targetName)))
+			Expect(dvCreateCalled).To(BeFalse())
 		})
 
 		It("Use CDI Config UploadProxyURL", func() {
 			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--size", pvcSize,
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeTrue())
+			Expect(dvCreateCalled).To(BeTrue())
 			validatePVC()
 			validateDataVolume()
 		})
 
 		It("Create a VolumeMode=Block PVC", func() {
 			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--size", pvcSize,
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath, "--block-volume")
 			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeTrue())
+			Expect(dvCreateCalled).To(BeTrue())
 			validateBlockPVC()
 			validateBlockDataVolume()
 		})
 
-		DescribeTable("PVC does exist", func(pvc *v1.PersistentVolumeClaim) {
-			testInit(http.StatusOK, pvc)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", dvName,
+		DescribeTable("PVC does not exist", func(async bool) {
+			testInitAsync(http.StatusOK, async)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeFalse())
+			Expect(pvcCreateCalled).To(BeTrue())
+			validatePVC()
+		},
+			Entry("PVC does not exist, async", true),
+			Entry("PVC does not exist sync", false),
+		)
+
+		DescribeTable("PVC does exist", func(pvc *v1.PersistentVolumeClaim) {
+			testInit(http.StatusOK, pvc)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName,
+				"--uploadproxy-url", server.URL, "--no-create", "--insecure", "--image-path", imagePath)
+			Expect(cmd()).To(BeNil())
+			Expect(pvcCreateCalled).To(BeFalse())
 			validatePVC()
 		},
 			Entry("PVC with upload annotation", pvcSpecWithUploadAnnotation()),
 			Entry("PVC without upload annotation", pvcSpec()),
 			Entry("PVC without upload annotation and no annotation map", pvcSpecNoAnnotationMap()),
 		)
-
-		It("PVC exists deprecated args", func() {
-			testInit(http.StatusOK, pvcSpec())
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", dvName, "--no-create",
-				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
-			Expect(cmd()).To(BeNil())
-			Expect(createCalled).To(BeFalse())
-			validatePVC()
-		})
 
 		AfterEach(func() {
 			testDone()
@@ -396,14 +437,14 @@ var _ = Describe("ImageUpload", func() {
 	Context("Upload fails", func() {
 		It("PVC already uploaded", func() {
 			testInit(http.StatusOK, pvcSpecWithUploadSucceeded())
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--size", pvcSize,
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).NotTo(BeNil())
 		})
 
 		It("uploadProxyURL not configured", func() {
 			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--size", pvcSize,
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath)
 			config, err := cdiClient.CdiV1alpha1().CDIConfigs().Get(configName, metav1.GetOptions{})
 			Expect(err).To(BeNil())
@@ -414,7 +455,7 @@ var _ = Describe("ImageUpload", func() {
 
 		It("Upload fails", func() {
 			testInit(http.StatusInternalServerError)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", dvName, "--size", pvcSize,
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).NotTo(BeNil())
 		})
@@ -429,21 +470,21 @@ var _ = Describe("ImageUpload", func() {
 		},
 			Entry("No args", "required flag(s) \"image-path\" not set", []string{}),
 			Entry("Missing arg", "expecting two args",
-				[]string{"dvName", "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
+				[]string{"targetName", "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("No name", "expecting two args",
 				[]string{"--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
-			Entry("No size", "when creating DataVolume, the size must be specified",
-				[]string{"dv", dvName, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
+			Entry("No size", "when creating a resource, the size must be specified",
+				[]string{"dv", targetName, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("Size invalid", "validation failed for size=500Zb: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'",
-				[]string{"dv", dvName, "--size", "500Zb", "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
+				[]string{"dv", targetName, "--size", "500Zb", "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("No image path", "required flag(s) \"image-path\" not set",
-				[]string{"dv", dvName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure"}),
+				[]string{"dv", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure"}),
 			Entry("PVC name and args", "cannot use --pvc-name and args",
-				[]string{"foo", "--pvc-name", dvName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
+				[]string{"foo", "--pvc-name", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("Unexpected resource type", "invalid resource type foo",
-				[]string{"foo", dvName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
+				[]string{"foo", targetName, "--size", pvcSize, "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 			Entry("Size twice", "--pvc-size deprecated, use --size",
-				[]string{"dv", dvName, "--size", "500G", "--pvc-size", "50G", "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
+				[]string{"dv", targetName, "--size", "500G", "--pvc-size", "50G", "--uploadproxy-url", "https://doesnotexist", "--insecure", "--image-path", "/dev/null"}),
 		)
 
 		AfterEach(func() {


### PR DESCRIPTION
1.  "virtctl image-upload --pvc-name ..." will create a PVC instead of a DataVolume
2.  "virtctl image-upload pvc foo ..." will now create a PVC if does not exist

See BZ here:  https://bugzilla.redhat.com/show_bug.cgi?id=1813989

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"virtctl image-upload pvc ..." will create the PVC if it does not exist
```
