### PR TITLE
make VMs ping each other and not themselves

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -857,8 +857,8 @@ var _ = Describe("SRIOV", func() {
 			configInterface(vmi2, "eth1", cidrB, "#")
 
 			// now check ICMP goes both ways
-			pingVirtualMachine(vmi1, cidrToIP(cidrA), "#")
-			pingVirtualMachine(vmi2, cidrToIP(cidrB), "#")
+			pingVirtualMachine(vmi1, cidrToIP(cidrB), "#")
+			pingVirtualMachine(vmi2, cidrToIP(cidrA), "#")
 		}
 
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The Vms using pingThroughSriov should ping each other,
but they are pinging themselves. This PR fixes that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
