### PR TITLE
English fix: remove `double the` in a few strings

### DIFF
--- a/docs/libvirt-pod-networking.md
+++ b/docs/libvirt-pod-networking.md
@@ -68,7 +68,7 @@ are getting assigned to pods, not interfaces. Thus this solution needs to
 achieve the same, and provide IP addresses to VMIs, not just a interface.
 
 During this document we call each of these _new_ pod interfaces _VMI interface_,
-in order to differentiate them from the the originally-allocated pod interface
+in order to differentiate them from the originally-allocated pod interface
 (`eth0`). The original pod interface (`eth0`) is never modified by Kubevirt,
 and can be used to access libvirtd (through the libvirtd pod IP) or to provide
 VMI-centric services through the VMI pod IP.

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -76,7 +76,7 @@ var _ = Describe("ContainerDisk", func() {
 				err = m.setMountTargetRecord(vmi, record)
 				Expect(err).ToNot(HaveOccurred())
 
-				// verify the the file actually exists
+				// verify the file actually exists
 				recordFile := filepath.Join(tmpDir, string(vmi.UID))
 				exists, err := diskutils.FileExists(recordFile)
 				Expect(err).ToNot(HaveOccurred())
@@ -106,7 +106,7 @@ var _ = Describe("ContainerDisk", func() {
 				err = m.deleteMountTargetRecord(vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				// verify the the file is actually removed
+				// verify the file is actually removed
 				exists, err = diskutils.FileExists(recordFile)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(exists).To(BeFalse())

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -110,7 +110,7 @@ func init() {
 	SetDefaultHTTPClientCreator()
 }
 
-// NewImageUploadCommand returns a cobra.Command for handling the the uploading of VM images
+// NewImageUploadCommand returns a cobra.Command for handling the uploading of VM images
 func NewImageUploadCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "image-upload",

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -151,7 +151,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				err := virtctl()
 				Expect(err).ToNot(HaveOccurred())
 
-				By("Getting back the the service")
+				By("Getting back the service")
 				svc, err := virtClient.CoreV1().Services(tcpVM.Namespace).Get(serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				nodePort := svc.Spec.Ports[0].NodePort

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Subresource Api", func() {
 	})
 
 	Describe("[rfe_id:1195][crit:medium][vendor:cnv-qe@redhat.com][level:component] the openapi spec for the subresources", func() {
-		It("[test_id:3177]should be aggregated into the the apiserver openapi spec", func() {
+		It("[test_id:3177]should be aggregated into the apiserver openapi spec", func() {
 			Eventually(func() string {
 				spec, err := virtCli.RestClient().Get().AbsPath("/openapi/v2").DoRaw()
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
