### PR TITLE
[flakey test] mark parent vmi as failed if associated pod is being deleted

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -619,7 +619,10 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				})
 				Expect(err).ToNot(HaveOccurred(), "Should list pods successfully")
 				Expect(pods.Items).To(HaveLen(1), "There should be only one VMI pod")
-				Expect(virtClient.CoreV1().Pods(vmi.Namespace).Delete(pods.Items[0].Name, &metav1.DeleteOptions{})).To(Succeed(), "The vmi pod should be deleted successfully")
+				var gracePeriod int64 = 0
+				Expect(virtClient.CoreV1().Pods(vmi.Namespace).Delete(pods.Items[0].Name, &metav1.DeleteOptions{
+					GracePeriodSeconds: &gracePeriod,
+				})).To(Succeed(), "The vmi pod should be deleted successfully")
 
 				// it will take at least 45 seconds until the vmi is gone, check the schedulable state in the meantime
 				By("marking the node as not schedulable")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes and edge case of a `virt-launcher` pod going into a Pending state when it is being deleted. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3561 

When the virt-handler is not present on a node and the `virt-launcher` pod gets deleted is deleted the node controller needs to update the VMI status as the `virt-handler` is not longer monitoring it. The node-controller however filters out the VMI and does not mark it as `Failed` since there is an "alive" pod for the VMI and it is in the correct namespace. This change checkes to see if the pod is trying to terminate and marks the VMI as failed instead of allowing it to continue to have `Status.Phase: Running` 

example pod spec:
```
"metadata": {
                "name": "virt-launcher-testvmi2wwfkkvt5rq6qpr7jtr4t7jkhl6cvhkqjbbxznk4tn",
                "deletionTimestamp": "2020-06-12T14:33:39Z",
                 ....
}, 
... 
"status": {
                "phase": "Pending",
[...]
                "containerStatuses": [
                    {
                        "name": "compute",
                        "state": {
                            "waiting": {
                                "reason": "PodInitializing"
                            }
                        },
                        "lastState": {},
                        "ready": false,
                        "restartCount": 0,
                        "image": "registry-proxy.engineering.redhat.com/rh-osbs/container-native-virtualization-virt-launcher@sha256:03a96f4bbd4f2ea1ce089f59e47a382a7383265b0a0d04f5fb2075c0a21fcc5c",
                        "imageID": "",
                        "started": false
                    },
                    {
                        "name": "volumedisk0",
                        "state": {
                            "waiting": {
                                "reason": "PodInitializing"
                            }
                        },
                        "lastState": {},
                        "ready": false,
                        "restartCount": 0,
                        "image": "kubevirt/cirros-container-disk-demo:v0.30.0",
                        "imageID": "",
                        "started": false
                    }

```

**Special notes for your reviewer**:



**Release note**:
```release-note
NONE
```
