### PR TITLE
virt-handler: Remove duplicate socket close

### DIFF
--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -156,8 +156,6 @@ func RunServer(virtShareDir string, stopChan chan struct{}, c chan watch.Event, 
 	case <-stopChan:
 		log.Log.Info("stopping notify server")
 		grpcServer.Stop()
-		sock.Close()
-		os.Remove(sockFile)
 	}
 
 	return nil

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -154,8 +154,8 @@ func RunServer(virtShareDir string, stopChan chan struct{}, c chan watch.Event, 
 	case <-done:
 		log.Log.Info("notify server done")
 	case <-stopChan:
-		log.Log.Info("stopping notify server")
 		grpcServer.Stop()
+		log.Log.Info("notify server stopped")
 	}
 
 	return nil


### PR DESCRIPTION
Its done already in the defer function,
and isnt needed to be done twice in case the server was closed.

---

Update logs of grpc server

Log after the grpc server stop is finished,
in order to record only if it was stopped fully.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
