### PR TITLE
Add simple profiling for test automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 export GO15VENDOREXPERIMENT := 1
 
+# enable profiling with KUBEVIRT_PROFILE_MAKE=1
+# see https://stackoverflow.com/a/6967017/16193
+SHELL = ./hack/profile.sh
 
 all:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh && \

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -28,6 +28,7 @@
 
 set -ex
 
+export KUBEVIRT_PROFILE_MAKE=1
 export WORKSPACE="${WORKSPACE:-$PWD}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"

--- a/hack/profile.sh
+++ b/hack/profile.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+# use time to record the elapsed time for the step
+shift # get rid of the '-c' supplied by make.
+
+if [[ -n ${KUBEVIRT_PROFILE_MAKE} ]]; then
+    date
+fi
+/bin/bash -c "$*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Simple execution time output is now rendered when `KUBEVIRT_PROFILE_MAKE=1`
is used. This is set in `automation/test.sh` by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
