### PR TITLE
Don't hot-loop on cert renewals when the ca expiration gets close

### DIFF
--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -49,7 +49,9 @@ go_test(
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/virt-operator/creation/components/secrets.go
+++ b/pkg/virt-operator/creation/components/secrets.go
@@ -251,7 +251,7 @@ func NewCertSecrets(installNamespace string, operatorNamespace string) []*k8sv1.
 // nextRotationDeadline returns a value for the threshold at which the
 // current certificate should be rotated, 80% of the expiration of the
 // certificate.
-func NextRotationDeadline(cert *tls.Certificate, ca *tls.Certificate) time.Time {
+func NextRotationDeadline(cert *tls.Certificate, ca *tls.Certificate, duration *metav1.Duration) time.Time {
 
 	if cert == nil {
 		return time.Now()
@@ -273,8 +273,7 @@ func NextRotationDeadline(cert *tls.Certificate, ca *tls.Certificate) time.Time 
 	}
 
 	notAfter := cert.Leaf.NotAfter
-	totalDuration := float64(notAfter.Sub(cert.Leaf.NotBefore))
-	deadline := cert.Leaf.NotBefore.Add(time.Duration(totalDuration - totalDuration*0.2))
+	deadline := notAfter.Add(-time.Duration(float64(duration.Duration) * 0.2))
 
 	log.DefaultLogger().V(4).Infof("Certificate with common name '%s' expiration is %v, rotation deadline is %v", cert.Leaf.Subject.CommonName, notAfter, deadline)
 	return deadline

--- a/pkg/virt-operator/creation/components/secrets_test.go
+++ b/pkg/virt-operator/creation/components/secrets_test.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v12 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
@@ -61,7 +63,7 @@ var _ = Describe("Certificate Management", func() {
 			Expect(bundle).To(Equal(expectBundle))
 		})
 
-		It("should kick out a CA certs which are outside of the overlap period", func() {
+		It("should kick out a CA cert which are outside of the overlap period", func() {
 			now := time.Now()
 			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
 			given := []*tls.Certificate{
@@ -82,6 +84,7 @@ var _ = Describe("Certificate Management", func() {
 			given := []*tls.Certificate{
 				NewSelfSignedCert(now.Add(-20*time.Minute), now.Add(1*time.Hour)),
 				NewSelfSignedCert(now.Add(-10*time.Minute), now.Add(1*time.Hour)),
+				NewSelfSignedCert(now.Add(-5*time.Minute), now.Add(1*time.Hour)),
 			}
 			givenBundle := CACertsToBundle(given)
 			expectBundle := CACertsToBundle([]*tls.Certificate{current})
@@ -120,6 +123,87 @@ var _ = Describe("Certificate Management", func() {
 			Expect(count).To(Equal(11))
 		})
 
+		It("should immediately suggest a rotation if the cert is not signed by the provided CA", func() {
+			now := time.Now()
+			current := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			ca := NewSelfSignedCert(now, now.Add(1*time.Hour))
+			duration := &v1.Duration{Duration: 5 * time.Hour}
+			deadline := NextRotationDeadline(current, ca, duration)
+			Expect(deadline.Before(time.Now())).To(BeTrue())
+		})
+
+		It("should set notBefore on the certificate to notBefore value of the CA certificate ", func() {
+			duration := &v1.Duration{Duration: 5 * time.Hour}
+			caSecret := NewCACertSecret("test")
+			Expect(PopulateSecretWithCertificate(caSecret, nil, duration)).To(Succeed())
+			caCrt, err := LoadCertificates(caSecret)
+			Expect(err).NotTo(HaveOccurred())
+			crtSecret := NewCertSecrets("test", "test")[0]
+			Expect(PopulateSecretWithCertificate(crtSecret, caCrt, duration)).To(Succeed())
+			crt, err := LoadCertificates(crtSecret)
+			Expect(crt.Leaf.NotBefore).To(Equal(caCrt.Leaf.NotBefore))
+		})
+
+		table.DescribeTable("should set the notAfter on the certificate according to the supplied duration", func(caDuration time.Duration) {
+			now := time.Now()
+			crtDuration := &v1.Duration{Duration: 2 * time.Hour}
+			caSecret := NewCACertSecret("test")
+			Expect(PopulateSecretWithCertificate(caSecret, nil, &v1.Duration{Duration: caDuration})).To(Succeed())
+			caCrt, err := LoadCertificates(caSecret)
+			Expect(err).NotTo(HaveOccurred())
+			crtSecret := NewCertSecrets("test", "test")[0]
+			Expect(PopulateSecretWithCertificate(crtSecret, caCrt, crtDuration)).To(Succeed())
+			crt, err := LoadCertificates(crtSecret)
+
+			//deadline := now.Add(time.Duration(float64(crtDuration.Duration) * 0.8))
+			Expect(crt.Leaf.NotAfter.Unix()).To(BeNumerically("==", now.Add(crtDuration.Duration).Unix(), 1))
+		},
+			table.Entry("with a long valid CA", 24*time.Hour),
+			table.Entry("with a CA which expires before the certificate rotation", 1*time.Hour),
+		)
+
+		table.DescribeTable("should suggaest a rotation on the certificate according on 80% of the certificate lifespan", func(caDuration time.Duration) {
+			now := time.Now()
+			crtDuration := &v1.Duration{Duration: 2 * time.Hour}
+			caSecret := NewCACertSecret("test")
+			Expect(PopulateSecretWithCertificate(caSecret, nil, &v1.Duration{Duration: caDuration})).To(Succeed())
+			caCrt, err := LoadCertificates(caSecret)
+			Expect(err).NotTo(HaveOccurred())
+			crtSecret := NewCertSecrets("test", "test")[0]
+			Expect(PopulateSecretWithCertificate(crtSecret, caCrt, crtDuration)).To(Succeed())
+			crt, err := LoadCertificates(crtSecret)
+
+			deadline := now.Add(time.Duration(float64(crtDuration.Duration) * 0.8))
+			Expect(NextRotationDeadline(crt, caCrt, crtDuration).Unix()).To(BeNumerically("==", deadline.Unix(), 1))
+		},
+			table.Entry("with a long valid CA", 24*time.Hour),
+			table.Entry("with a CA which expires before the certificate rotation", 1*time.Hour),
+		)
+
+		table.DescribeTable("should successfully sign with the current CA the certificate for", func(scretName string) {
+			duration := &v1.Duration{Duration: 5 * time.Hour}
+			caSecret := NewCACertSecret("test")
+			Expect(PopulateSecretWithCertificate(caSecret, nil, duration)).To(Succeed())
+			caCrt, err := LoadCertificates(caSecret)
+			Expect(err).NotTo(HaveOccurred())
+			var crtSecret *v12.Secret
+			for _, s := range NewCertSecrets("test", "test") {
+				if s.Name == scretName {
+					crtSecret = s
+					break
+				}
+			}
+			Expect(crtSecret).ToNot(BeNil())
+			Expect(PopulateSecretWithCertificate(crtSecret, caCrt, duration)).To(Succeed())
+			crt, err := LoadCertificates(crtSecret)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(crt).ToNot(BeNil())
+		},
+			table.Entry("virt-handler", VirtHandlerCertSecretName),
+			table.Entry("virt-controller", VirtControllerCertSecretName),
+			table.Entry("virt-api", VirtApiCertSecretName),
+			table.Entry("virt-operator", VirtOperatorCertSecretName),
+		)
 	})
 
 	It("should set the right namespaces on the certificate secrets", func() {

--- a/pkg/virt-operator/install-strategy/create.go
+++ b/pkg/virt-operator/install-strategy/create.go
@@ -1710,7 +1710,7 @@ func createOrUpdateCertificateSecret(
 		} else if cachedSecret.Annotations["kubevirt.io/duration"] != duration.String() {
 			rotateCertificate = true
 		} else {
-			rotationTime := components.NextRotationDeadline(crt, ca)
+			rotationTime := components.NextRotationDeadline(crt, ca, duration)
 			// We update the certificate if it has passed 80 percent of its lifetime
 			if rotationTime.Before(time.Now()) {
 				rotateCertificate = true
@@ -1732,7 +1732,7 @@ func createOrUpdateCertificateSecret(
 		return nil, err
 	}
 	// we need to ensure that we revisit certificates before they expire
-	wakeupDeadline := components.NextRotationDeadline(crt, ca).Sub(time.Now())
+	wakeupDeadline := components.NextRotationDeadline(crt, ca, duration).Sub(time.Now())
 	queue.AddAfter(kvkey, wakeupDeadline)
 
 	injectOperatorMetadata(kv, &secret.ObjectMeta, version, imageRegistry, id)


### PR DESCRIPTION
The NotBefore field in the certificate does not container the certifcate
issue date. It contains the issue date of the CA. This led to wrong
calculations of the certificate rotations. The closer we came to the CA
expiration date, the faster they were rotating.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
