### PR TITLE
Add timestamp wrapper to our automation scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 export GO15VENDOREXPERIMENT := 1
 
+SHELL = ./hack/timestamps.sh
 
 all:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh && \

--- a/hack/timestamps.sh
+++ b/hack/timestamps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+function timestamps::time_wrapper() {
+    while IFS= read -r line; do
+        printf "%(%T)T: %s\n" "-1" "$line"
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    /bin/sh "$@" 2>&1 | timestamps::time_wrapper
+fi


### PR DESCRIPTION
Sometimes, we see automation tasks that are taking longer than expected
and we hit our defined timeouts. By adding timestamps to each line of
our executed scripts, we will be able to detect where our bottleneck is.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
