### PR TITLE
Avoid virt-handler crash in case of virt-launcher network configuration error

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -710,7 +710,7 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 	}
 
 	if _, ok := syncError.(*virtLauncherCriticalNetworkError); ok {
-		log.Log.Errorf("virt-launcher crashed. Updating VMI %s status to Failed", vmi.Name)
+		log.Log.Errorf("virt-launcher crashed due to a network error. Updating VMI %s status to Failed", vmi.Name)
 		vmi.Status.Phase = v1.Failed
 	}
 	condManager.CheckFailure(vmi, syncError, "Synchronizing with the Domain failed.")

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1072,7 +1072,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 		case domainExists:
 			// The VirtualMachineInstance is deleted on the cluster, and domain is not alive
 			// then delete the domain.
-			log.Log.Object(vmi).V(3).Info("Shutting down domain for deleted VirtualMachineInstance object.")
+			log.Log.Object(vmi).V(3).Info("Deleting domain for deleted VirtualMachineInstance object.")
 			shouldDelete = true
 		default:
 			// If neither the domain nor the vmi object exist locally,

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -180,6 +180,12 @@ type VirtualMachineController struct {
 	domainNotifyPipes map[string]string
 }
 
+type virtLauncherCriticalNetworkError struct {
+	msg string
+}
+
+func (e *virtLauncherCriticalNetworkError) Error() string { return e.msg }
+
 func (d *VirtualMachineController) startDomainNotifyPipe(vmi *v1.VirtualMachineInstance) (net.Listener, error) {
 
 	res, err := d.podIsolationDetector.Detect(vmi)
@@ -337,12 +343,12 @@ func (d *VirtualMachineController) clearPodNetworkPhase1(vmi *v1.VirtualMachineI
 // it results in killing/spawning a posix thread. Only do this if it
 // is absolutely neccessary. The cache informs us if this action has
 // already taken place or not for a VMI
-func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineInstance) error {
+func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineInstance) (bool, error) {
 
 	// configure network
 	res, err := d.podIsolationDetector.Detect(vmi)
 	if err != nil {
-		return fmt.Errorf("failed to detect isolation for launcher pod: %v", err)
+		return false, fmt.Errorf("failed to detect isolation for launcher pod: %v", err)
 	}
 
 	pid := res.Pid()
@@ -354,12 +360,18 @@ func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineIns
 
 	if ok && cachedPid == pid {
 		// already completed phase1
-		return nil
+		return false, nil
 	}
 
 	err = res.DoNetNS(func() error { return network.SetupPodNetworkPhase1(vmi, pid) })
 	if err != nil {
-		return fmt.Errorf("failed to configure vmi network for migration target: %v", err)
+		_, critical := err.(*network.CriticalNetworkError)
+		if critical {
+			return true, err
+		} else {
+			return false, err
+		}
+
 	}
 
 	// cache that phase 1 has completed for this vmi.
@@ -367,7 +379,7 @@ func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineIns
 	d.phase1NetworkSetupCache[vmi.UID] = pid
 	d.phase1NetworkSetupCacheLock.Unlock()
 
-	return nil
+	return false, nil
 }
 
 func domainMigrated(domain *api.Domain) bool {
@@ -697,6 +709,10 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 		condManager.RemoveCondition(vmi, v1.VirtualMachineInstancePaused)
 	}
 
+	if _, ok := syncError.(*virtLauncherCriticalNetworkError); ok {
+		log.Log.Errorf("virt-launcher crashed. Updating VMI %s status to Failed", vmi.Name)
+		vmi.Status.Phase = v1.Failed
+	}
 	condManager.CheckFailure(vmi, syncError, "Synchronizing with the Domain failed.")
 
 	if !reflect.DeepEqual(oldStatus, vmi.Status) {
@@ -1763,9 +1779,14 @@ func (d *VirtualMachineController) processVmUpdate(origVMI *v1.VirtualMachineIns
 			}
 
 			// configure network inside virt-launcher compute container
-			err = d.setPodNetworkPhase1(vmi)
+			criticalNetworkError, err := d.setPodNetworkPhase1(vmi)
 			if err != nil {
-				return fmt.Errorf("failed to configure vmi network for migration target: %v", err)
+				if criticalNetworkError {
+					return &virtLauncherCriticalNetworkError{fmt.Sprintf("failed to configure vmi network for migration target: %v", err)}
+				} else {
+					return fmt.Errorf("failed to configure vmi network for migration target: %v", err)
+				}
+
 			}
 
 			if err := client.SyncMigrationTarget(vmi); err != nil {
@@ -1809,9 +1830,14 @@ func (d *VirtualMachineController) processVmUpdate(origVMI *v1.VirtualMachineIns
 				return err
 			}
 
-			err = d.setPodNetworkPhase1(vmi)
+			criticalNetworkError, err := d.setPodNetworkPhase1(vmi)
 			if err != nil {
-				return fmt.Errorf("failed to configure vmi network: %v", err)
+				if criticalNetworkError {
+					return &virtLauncherCriticalNetworkError{fmt.Sprintf("failed to configure vmi network: %v", err)}
+				} else {
+					return fmt.Errorf("failed to configure vmi network: %v", err)
+				}
+
 			}
 
 			// set runtime limits as needed

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -57,6 +57,12 @@ type VIF struct {
 	IPAMDisabled bool
 }
 
+type CriticalNetworkError struct {
+	msg string
+}
+
+func (e *CriticalNetworkError) Error() string { return e.msg }
+
 func (vif VIF) String() string {
 	return fmt.Sprintf(
 		"VIF: { Name: %s, IP: %s, Mask: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: %t}",

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -144,13 +144,13 @@ func (h *NetworkUtilsHandler) LinkSetMaster(link netlink.Link, master *netlink.B
 func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 	iptablesObject, err := iptables.NewWithProtocol(proto)
 	if err != nil {
-		log.Log.Reason(err).Infof("No iptables")
+		log.Log.V(5).Reason(err).Infof("No iptables")
 		return false
 	}
 
 	_, err = iptablesObject.List("nat", "OUTPUT")
 	if err != nil {
-		log.Log.Reason(err).Infof("No nat iptables")
+		log.Log.V(5).Reason(err).Infof("No nat iptables")
 		return false
 	}
 
@@ -218,7 +218,7 @@ func (h *NetworkUtilsHandler) GetNFTIPString(proto iptables.Protocol) string {
 func (h *NetworkUtilsHandler) NftablesLoad(fnName string) error {
 	output, err := exec.Command("nft", "-f", fmt.Sprintf("/etc/nftables/%s.nft", fnName)).CombinedOutput()
 	if err != nil {
-		log.Log.Reason(err).Infof("failed to load nftable %s", fnName)
+		log.Log.V(5).Reason(err).Infof("failed to load nftable %s", fnName)
 		return fmt.Errorf("failed to load nftable %s error %s", fnName, string(output))
 	}
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -138,11 +138,13 @@ func (h *NetworkUtilsHandler) LinkSetMaster(link netlink.Link, master *netlink.B
 func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 	iptablesObject, err := iptables.NewWithProtocol(proto)
 	if err != nil {
+		log.Log.Reason(err).Infof("No iptables")
 		return false
 	}
 
 	_, err = iptablesObject.List("nat", "OUTPUT")
 	if err != nil {
+		log.Log.Reason(err).Infof("No nat iptables")
 		return false
 	}
 
@@ -210,6 +212,7 @@ func (h *NetworkUtilsHandler) GetNFTIPString(proto iptables.Protocol) string {
 func (h *NetworkUtilsHandler) NftablesLoad(fnName string) error {
 	output, err := exec.Command("nft", "-f", fmt.Sprintf("/etc/nftables/%s.nft", fnName)).CombinedOutput()
 	if err != nil {
+		log.Log.Reason(err).Infof("failed to load nftable %s", fnName)
 		return fmt.Errorf("failed to load nftable %s error %s", fnName, string(output))
 	}
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -103,7 +103,7 @@ func (l *PodInterface) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Inte
 	if !isExist {
 		err := driver.discoverPodNetworkInterface()
 		if err != nil {
-			return createCriticalNetworkError(err)
+			return err
 		}
 
 		if err := driver.preparePodNetworkInterfaces(); err != nil {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -626,6 +626,8 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 			log.Log.Reason(err).Errorf("failed to create ipv4 nat rules for vm error: %v", err)
 			return err
 		}
+	} else {
+		return fmt.Errorf("Couldn't configure ipv4 nat rules")
 	}
 	if Handler.IsIpv6Enabled() {
 		if Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil {
@@ -641,7 +643,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 				return err
 			}
 		} else {
-			return fmt.Errorf("Couldn't configure nat rules")
+			return fmt.Errorf("Couldn't configure ipv6 nat rules")
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -620,17 +620,21 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 			return err
 		}
 	}
-	if Handler.IsIpv6Enabled() && (Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil) {
-		err = Handler.ConfigureIpv6Forwarding()
-		if err != nil {
-			log.Log.Reason(err).Errorf("failed to turn on net.ipv6.conf.all.forwarding")
-			return err
-		}
+	if Handler.IsIpv6Enabled() {
+		if Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil {
+			err = Handler.ConfigureIpv6Forwarding()
+			if err != nil {
+				log.Log.Reason(err).Errorf("failed to turn on net.ipv6.conf.all.forwarding")
+				return err
+			}
 
-		err = p.createNatRules(iptables.ProtocolIPv6)
-		if err != nil {
-			log.Log.Reason(err).Errorf("failed to create ipv6 nat rules for vm error: %v", err)
-			return err
+			err = p.createNatRules(iptables.ProtocolIPv6)
+			if err != nil {
+				log.Log.Reason(err).Errorf("failed to create ipv6 nat rules for vm error: %v", err)
+				return err
+			}
+		} else {
+			return fmt.Errorf("Couldn't configure nat rules")
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -633,7 +633,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 		if Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil {
 			err = Handler.ConfigureIpv6Forwarding()
 			if err != nil {
-				log.Log.Reason(err).Errorf("failed to turn on net.ipv6.conf.all.forwarding")
+				log.Log.Reason(err).Errorf("failed to configure ipv6 forwarding")
 				return err
 			}
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -265,31 +265,33 @@ var _ = Describe("Pod Network", func() {
 			api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 			TestPodInterfaceIPBinding(vm, domain)
 		})
-		It("phase1 should panic if pod networking fails to setup", func() {
-			testNetworkPanic := func() {
-				domain := NewDomainWithBridgeInterface()
-				vm := newVMIBridgeInterface("testnamespace", "testVmName")
+		It("phase1 should return a CriticalNetworkError if pod networking fails to setup", func() {
 
-				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
+			domain := NewDomainWithBridgeInterface()
+			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 
-				mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
-				mockNetwork.EXPECT().LinkSetDown(dummy).Return(nil)
-				mockNetwork.EXPECT().SetRandomMac(podInterface).Return(updateFakeMac, nil)
-				mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_V4).Return(addrList, nil)
-				mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
-				mockNetwork.EXPECT().LinkByName(api.DefaultBridgeName).Return(bridgeTest, nil)
-				mockNetwork.EXPECT().LinkSetUp(bridgeTest).Return(nil)
-				mockNetwork.EXPECT().LinkSetUp(dummy).Return(nil)
-				mockNetwork.EXPECT().ParseAddr(fmt.Sprintf(bridgeFakeIP, 0)).Return(bridgeAddr, nil)
-				mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
-				mockNetwork.EXPECT().RouteList(dummy, netlink.FAMILY_V4).Return(routeList, nil)
-				mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
-				mockNetwork.EXPECT().LinkSetMaster(dummy, bridgeTest).Return(nil)
-				mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(errors.New("device is busy"))
+			api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 
-				SetupPodNetworkPhase1(vm, pid)
-			}
-			Expect(testNetworkPanic).To(Panic())
+			mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
+			mockNetwork.EXPECT().LinkSetDown(dummy).Return(nil)
+			mockNetwork.EXPECT().SetRandomMac(podInterface).Return(updateFakeMac, nil)
+			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_V4).Return(addrList, nil)
+			mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
+			mockNetwork.EXPECT().LinkByName(api.DefaultBridgeName).Return(bridgeTest, nil)
+			mockNetwork.EXPECT().LinkSetUp(bridgeTest).Return(nil)
+			mockNetwork.EXPECT().LinkSetUp(dummy).Return(nil)
+			mockNetwork.EXPECT().ParseAddr(fmt.Sprintf(bridgeFakeIP, 0)).Return(bridgeAddr, nil)
+			mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
+			mockNetwork.EXPECT().RouteList(dummy, netlink.FAMILY_V4).Return(routeList, nil)
+			mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
+			mockNetwork.EXPECT().LinkSetMaster(dummy, bridgeTest).Return(nil)
+			mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(errors.New("device is busy"))
+
+			err := SetupPodNetworkPhase1(vm, pid)
+			Expect(err).To(HaveOccurred())
+
+			_, ok := err.(*CriticalNetworkError)
+			Expect(ok).To(BeTrue())
 		})
 		It("should return an error if the MTU is out or range", func() {
 			dummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 1, MTU: 65536}}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -288,10 +288,10 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(errors.New("device is busy"))
 
 			err := SetupPodNetworkPhase1(vm, pid)
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(HaveOccurred(), "SetupPodNetworkPhase1 should return an error")
 
 			_, ok := err.(*CriticalNetworkError)
-			Expect(ok).To(BeTrue())
+			Expect(ok).To(BeTrue(), "SetupPodNetworkPhase1 should return an error of type CriticalNetworkError")
 		})
 		It("should return an error if the MTU is out or range", func() {
 			dummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: 1, MTU: 65536}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Current behaviour - Since [PR 2837](https://github.com/kubevirt/kubevirt/pull/2837), configuring the network of a virt-launcher is done from the virt-handler.
But the code causing a panic in case of an unrecoverable error during the network configuration was left there. So now, virt-handler crashes if a specific virt-launcher has an unrecoverable error. 


Desired behaviour - virt-handler shouldn't panic because of a failure on a specific virt-launcher.
Instead, it should move the vmi to Failed phase.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Avoid virt-handler crash in case of virt-launcher network configuration error
```
