### PR TITLE
tests: Increase VMI deletion timeout in the eventual loop

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1420,7 +1420,7 @@ var _ = Describe("Configurations", func() {
 					return true
 				}
 				return false
-			}, 30*time.Second, 1*time.Second).Should(BeTrue())
+			}, 60*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]when CPU model defined", func() {


### PR DESCRIPTION
By increasing the timeout we should prevent the flakyness of test #1678. 
Kubelet is known to have huge variation regarding to pod deletion speed. 
We assume 60 seconds will be enough for it to clean VMI pod related data.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**Which issue(s) this PR fixes** 
Fixes #3623 

**Release note**:
```release-note
None
```
