### PR TITLE
Add k8s metadata labels to VMI metrics

### DIFF
--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -17,703 +17,703 @@
  *
  */
 
- package prometheus
+package prometheus
 
- import (
-	 "fmt"
-	 "net/http"
-	 "strings"
-	 "time"
- 
-	 "github.com/prometheus/client_golang/prometheus"
-	 "github.com/prometheus/client_golang/prometheus/promhttp"
- 
-	 k6tv1 "kubevirt.io/client-go/api/v1"
-	 "kubevirt.io/client-go/kubecli"
-	 "kubevirt.io/client-go/log"
-	 "kubevirt.io/client-go/version"
-	 "kubevirt.io/kubevirt/pkg/util/lookup"
-	 cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	 "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
- )
- 
- const statsMaxAge time.Duration = collectionTimeout + 2*time.Second // "a bit more" than timeout, heuristic again
- 
- var (
-	 // Formatter used to sanitize k8s metadata into metric labels
-	 labelFormatter = strings.NewReplacer(".", "_", "/", "_", "-", "_")
- 
-	 // see https://www.robustperception.io/exposing-the-software-version-to-prometheus
-	 versionDesc = prometheus.NewDesc(
-		 "kubevirt_info",
-		 "Version information",
-		 []string{"goversion", "kubeversion"},
-		 nil,
-	 )
- 
-	 // higher-level, telemetry-friendly metrics
-	 vmiCountDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_phase_count",
-		 "VMI phase.",
-		 []string{
-			 "node", "phase",
-		 },
-		 nil,
-	 )
- 
-	 // lower level metrics
-	 storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
-	 storageIopsDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_storage_iops_total",
-		 "I/O operation performed.",
-		 storageIopsLabels,
-		 nil,
-	 )
- 
-	 storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
-	 storageTrafficDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_storage_traffic_bytes_total",
-		 "storage traffic.",
-		 storageTrafficLabels,
-		 nil,
-	 )
- 
-	 storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
-	 storageTimesDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_storage_times_ms_total",
-		 "storage operation time.",
-		 storageTimesLabels,
-		 nil,
-	 )
- 
-	 vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
-	 vcpuUsageDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_vcpu_seconds",
-		 "Vcpu elapsed time.",
-		 vcpuUsageLabels,
-		 nil,
-	 )
- 
-	 networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
-	 networkTrafficBytesDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_network_traffic_bytes_total",
-		 "network traffic.",
-		 networkTrafficBytesLabels,
-		 nil,
-	 )
- 
-	 networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
-	 networkTrafficPktsDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_network_traffic_packets_total",
-		 "network traffic.",
-		 networkTrafficPktsLabels,
-		 nil,
-	 )
- 
-	 networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
-	 networkErrorsDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_network_errors_total",
-		 "network errors.",
-		 networkErrorsLabels,
-		 nil,
-	 )
- 
-	 memoryAvailableLabels = []string{"node", "namespace", "name"}
-	 memoryAvailableDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_memory_available_bytes",
-		 "amount of usable memory as seen by the domain.",
-		 memoryAvailableLabels,
-		 nil,
-	 )
- 
-	 memoryResidentLabels = []string{"node", "namespace", "name"}
-	 memoryResidentDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_memory_resident_bytes",
-		 "resident set size of the process running the domain",
-		 memoryResidentLabels,
-		 nil,
-	 )
- 
-	 swapTrafficLabels = []string{"node", "namespace", "name", "type"}
-	 swapTrafficDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_memory_swap_traffic_bytes_total",
-		 "swap memory traffic.",
-		 swapTrafficLabels,
-		 nil,
-	 )
- )
- 
- func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch chan<- prometheus.Metric) {
-	 if err != nil {
-		 log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", memoryAvailableDesc, err)
-		 return
-	 }
-	 ch <- mv
- }
- 
- func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	 memoryResidentLabels = []string{"node", "namespace", "name"}
-	 memoryAvailableLabels = []string{"node", "namespace", "name"}
-	 swapTrafficLabels = []string{"node", "namespace", "name", "type"}
-	 var memoryResidentLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
-	 var memoryAvailableLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
-	 var swapTrafficInLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "in"}
-	 var swapTrafficOutLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "out"}
- 
-	 // Add k8s metadata.Labels as metric labels
-	 labelPreffix := "vmi_k8s_label_"
-	 for label, val := range vmi.Labels {
-		 memoryResidentLabels = append(memoryResidentLabels, labelPreffix+labelFormatter.Replace(label))
-		 memoryResidentLabelValues = append(memoryResidentLabelValues, val)
- 
-		 memoryAvailableLabels = append(memoryAvailableLabels, labelPreffix+labelFormatter.Replace(label))
-		 memoryAvailableLabelsValues = append(memoryAvailableLabelsValues, val)
- 
-		 swapTrafficLabels = append(swapTrafficLabels, labelPreffix+labelFormatter.Replace(label))
-		 swapTrafficInLabelsValues = append(swapTrafficInLabelsValues, val)
-		 swapTrafficOutLabelsValues = append(swapTrafficOutLabelsValues, val)
-	 }
- 
-	 // Add k8s metadata.Annotations as metric labels
-	 annotationPreffix := "vmi_k8s_annotation_"
-	 for annotation, val := range vmi.Annotations {
-		 memoryResidentLabels = append(memoryResidentLabels, annotationPreffix+labelFormatter.Replace(annotation))
-		 memoryResidentLabelValues = append(memoryResidentLabelValues, val)
- 
-		 memoryAvailableLabels = append(memoryAvailableLabels, annotationPreffix+labelFormatter.Replace(annotation))
-		 memoryAvailableLabelsValues = append(memoryAvailableLabelsValues, val)
- 
-		 swapTrafficLabels = append(swapTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
-		 swapTrafficInLabelsValues = append(swapTrafficInLabelsValues, val)
-		 swapTrafficOutLabelsValues = append(swapTrafficOutLabelsValues, val)
-	 }
- 
- 
-	 memoryResidentDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_memory_resident_bytes",
-		 "resident set size of the process running the domain",
-		 memoryResidentLabels,
-		 nil,
-	 )
- 
-	 memoryAvailableDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_memory_available_bytes",
-		 "amount of usable memory as seen by the domain.",
-		 memoryAvailableLabels,
-		 nil,
-	 )
- 
-	 swapTrafficDesc = prometheus.NewDesc(
-		 "kubevirt_vmi_memory_swap_traffic_bytes_total",
-		 "swap memory traffic.",
-		 swapTrafficLabels,
-		 nil,
-	 )
- 
-	 if vmStats.Memory.RSSSet {
-		 mv, err := prometheus.NewConstMetric(
-			 memoryResidentDesc, prometheus.GaugeValue,
-			 // the libvirt value is in KiB
-			 float64(vmStats.Memory.RSS)*1024,
-			 memoryResidentLabelValues...
-		 )
-		 tryToPushMetric(memoryResidentDesc, mv, err, ch)
-	 }
- 
-	 if vmStats.Memory.AvailableSet {
-		 mv, err := prometheus.NewConstMetric(
-			 memoryAvailableDesc, prometheus.GaugeValue,
-			 // the libvirt value is in KiB
-			 float64(vmStats.Memory.Available)*1024,
-			 memoryAvailableLabelsValues...
-		 )
-		 tryToPushMetric(memoryAvailableDesc, mv, err, ch)
-	 }
- 
- 
-	 if vmStats.Memory.SwapInSet {
-		 mv, err := prometheus.NewConstMetric(
-			 swapTrafficDesc, prometheus.GaugeValue,
-			 // the libvirt value is in KiB
-			 float64(vmStats.Memory.SwapIn)*1024,
-			 swapTrafficInLabelsValues...
-		 )
-		 tryToPushMetric(swapTrafficDesc, mv, err, ch)
-	 }
-	 if vmStats.Memory.SwapOutSet {
-		 mv, err := prometheus.NewConstMetric(
-			 swapTrafficDesc, prometheus.GaugeValue,
-			 // the libvirt value is in KiB
-			 float64(vmStats.Memory.SwapOut)*1024,
-			 swapTrafficOutLabelsValues...
-		 )
-		 tryToPushMetric(swapTrafficDesc, mv, err, ch)
-	 }
- }
- 
- func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	 for vcpuId, vcpu := range vmStats.Vcpu {
-		 vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
-		 var vcpuUsageLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State)}
- 
-		 // Add k8s metadata.Labels as metric labels
-		 labelPreffix := "vmi_k8s_label_"
-		 for label, val := range vmi.Labels {
-			 vcpuUsageLabels = append(vcpuUsageLabels, labelPreffix+labelFormatter.Replace(label))
-			 vcpuUsageLabelsValues = append(vcpuUsageLabelsValues, val)
-		 }
- 
-		 // Add k8s metadata.Annotations as metric labels
-		 annotationPreffix := "vmi_k8s_annotation_"
-		 for annotation, val := range vmi.Annotations {
-			 vcpuUsageLabels = append(vcpuUsageLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 vcpuUsageLabelsValues = append(vcpuUsageLabelsValues, val)
-		 }
- 
-		 vcpuUsageDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_vcpu_seconds",
-			 "Vcpu elapsed time.",
-			 vcpuUsageLabels,
-			 nil,
-		 )
- 
-		 if !vcpu.StateSet || !vcpu.TimeSet {
-			 log.Log.V(4).Warningf("State or time not set for vcpu#%d", vcpuId)
-			 continue
-		 }
-		 mv, err := prometheus.NewConstMetric(
-			 vcpuUsageDesc, prometheus.GaugeValue,
-			 float64(vcpu.Time/1000000000),
-			 vcpuUsageLabelsValues...
-		 )
-		 tryToPushMetric(vcpuUsageDesc, mv, err, ch)
-	 }
- }
- 
- func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	 for blockId, block := range vmStats.Block {
-		 storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
-		 storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
-		 storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
-		 var storageIopsReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
-		 var storageIopsWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
-		 var storageTrafficReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
-		 var storageTrafficWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
-		 var storageTimesReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
-		 var storageTimesWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
- 
-		 // Add k8s metadata.Labels as metric labels
-		 labelPreffix := "vmi_k8s_label_"
-		 for label, val := range vmi.Labels {
-			 storageIopsLabels = append(storageIopsLabels, labelPreffix+labelFormatter.Replace(label))
-			 storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
-			 storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
- 
-			 storageTrafficLabels = append(storageTrafficLabels, labelPreffix+labelFormatter.Replace(label))
-			 storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
-			 storageTrafficWriteLabelsValues = append(storageTrafficWriteLabelsValues, val)
- 
-			 storageTimesLabels = append(storageTimesLabels, labelPreffix+labelFormatter.Replace(label))
-			 storageTimesReadLabelsValues = append(storageTimesReadLabelsValues, val)
-			 storageTimesWriteLabelsValues = append(storageTimesWriteLabelsValues, val)
-		 }
- 
-		 // Add k8s metadata.Annotations as metric labels
-		 annotationPreffix := "vmi_k8s_annotation_"
-		 for annotation, val := range vmi.Annotations {
-			 storageIopsLabels = append(storageIopsLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
-			 storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
- 
-			 storageTrafficLabels = append(storageTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
-			 storageTrafficWriteLabelsValues = append(storageTrafficWriteLabelsValues, val)
- 
-			 storageTimesLabels = append(storageTimesLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 storageTimesReadLabelsValues = append(storageTimesReadLabelsValues, val)
-			 storageTimesWriteLabelsValues = append(storageTimesWriteLabelsValues, val)
-		 }
- 
-		 storageIopsDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_storage_iops_total",
-			 "I/O operation performed.",
-			 storageIopsLabels,
-			 nil,
-		 )
- 
-		 storageTrafficDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_storage_traffic_bytes_total",
-			 "storage traffic.",
-			 storageTrafficLabels,
-			 nil,
-		 )
- 
-		 storageTimesDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_storage_times_ms_total",
-			 "storage operation time.",
-			 storageTimesLabels,
-			 nil,
-		 )
- 
-		 if !block.NameSet {
-			 log.Log.V(4).Warningf("Name not set for block device#%d", blockId)
-			 continue
-		 }
- 
-		 if block.RdReqsSet {
-			 mv, err := prometheus.NewConstMetric(
-				 storageIopsDesc, prometheus.CounterValue,
-				 float64(block.RdReqs),
-				 storageIopsReadLabelsValues...
-			 )
-			 tryToPushMetric(storageIopsDesc, mv, err, ch)
-		 }
-		 if block.WrReqsSet {
-			 mv, err := prometheus.NewConstMetric(
-				 storageIopsDesc, prometheus.CounterValue,
-				 float64(block.WrReqs),
-				 storageIopsWriteLabelsValues...
-			 )
-			 tryToPushMetric(storageIopsDesc, mv, err, ch)
-		 }
- 
-		 if block.RdBytesSet {
-			 mv, err := prometheus.NewConstMetric(
-				 storageTrafficDesc, prometheus.CounterValue,
-				 float64(block.RdBytes),
-				 storageTrafficReadLabelsValues...
-			 )
-			 tryToPushMetric(storageTrafficDesc, mv, err, ch)
-		 }
-		 if block.WrBytesSet {
-			 mv, err := prometheus.NewConstMetric(
-				 storageTrafficDesc, prometheus.CounterValue,
-				 float64(block.WrBytes),
-				 storageTrafficWriteLabelsValues...
-			 )
-			 tryToPushMetric(storageTrafficDesc, mv, err, ch)
-		 }
- 
-		 if block.RdTimesSet {
-			 mv, err := prometheus.NewConstMetric(
-				 storageTimesDesc, prometheus.CounterValue,
-				 float64(block.RdTimes),
-				 storageTimesReadLabelsValues...
-			 )
-			 tryToPushMetric(storageTimesDesc, mv, err, ch)
-		 }
-		 if block.WrTimesSet {
-			 mv, err := prometheus.NewConstMetric(
-				 storageTimesDesc, prometheus.CounterValue,
-				 float64(block.WrTimes),
-				 storageTimesWriteLabelsValues...
-			 )
-			 tryToPushMetric(storageTimesDesc, mv, err, ch)
-		 }
-	 }
- }
- 
- func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	 for _, net := range vmStats.Net {
-		 networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
-		 networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
-		 networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
-		 var networkTrafficBytesRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
-		 var networkTrafficBytesTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
-		 var networkTrafficPktsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
-		 var networkTrafficPktsTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
-		 var networkErrorsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
-		 var networkErrorsTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
- 
-		 // Add k8s metadata.Labels as metric labels
-		 labelPreffix := "vmi_k8s_label_"
-		 for label, val := range vmi.Labels {
-			 networkTrafficBytesLabels = append(networkTrafficBytesLabels, labelPreffix+labelFormatter.Replace(label))
-			 networkTrafficBytesRxLabelsValues = append(networkTrafficBytesRxLabelsValues, val)
-			 networkTrafficBytesTxLabelsValues = append(networkTrafficBytesTxLabelsValues, val)
- 
-			 networkTrafficPktsLabels = append(networkTrafficPktsLabels, labelPreffix+labelFormatter.Replace(label))
-			 networkTrafficPktsRxLabelsValues = append(networkTrafficPktsRxLabelsValues, val)
-			 networkTrafficPktsTxLabelsValues = append(networkTrafficPktsTxLabelsValues, val)
- 
-			 networkErrorsLabels = append(networkErrorsLabels, labelPreffix+labelFormatter.Replace(label))
-			 networkErrorsRxLabelsValues = append(networkErrorsRxLabelsValues, val)
-			 networkErrorsTxLabelsValues = append(networkErrorsTxLabelsValues, val)
-		 }
- 
-		 // Add k8s metadata.Annotations as metric labels
-		 annotationPreffix := "vmi_k8s_annotation_"
-		 for annotation, val := range vmi.Annotations {
-			 networkTrafficBytesLabels = append(networkTrafficBytesLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 networkTrafficBytesRxLabelsValues = append(networkTrafficBytesRxLabelsValues, val)
-			 networkTrafficBytesTxLabelsValues = append(networkTrafficBytesTxLabelsValues, val)
- 
-			 networkTrafficPktsLabels = append(networkTrafficPktsLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 networkTrafficPktsRxLabelsValues = append(networkTrafficPktsRxLabelsValues, val)
-			 networkTrafficPktsTxLabelsValues = append(networkTrafficPktsTxLabelsValues, val)
- 
-			 networkErrorsLabels = append(networkErrorsLabels, annotationPreffix+labelFormatter.Replace(annotation))
-			 networkErrorsRxLabelsValues = append(networkErrorsRxLabelsValues, val)
-			 networkErrorsTxLabelsValues = append(networkErrorsTxLabelsValues, val)
-		 }
- 
-		 networkTrafficBytesDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_network_traffic_bytes_total",
-			 "network traffic.",
-			 networkTrafficBytesLabels,
-			 nil,
-		 )
- 
-		 networkTrafficPktsDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_network_traffic_packets_total",
-			 "network traffic.",
-			 networkTrafficPktsLabels,
-			 nil,
-		 )
- 
-		 networkErrorsDesc = prometheus.NewDesc(
-			 "kubevirt_vmi_network_errors_total",
-			 "network errors.",
-			 networkErrorsLabels,
-			 nil,
-		 )
- 
-		 if !net.NameSet {
-			 continue
-		 }
-		 if net.RxBytesSet {
-			 mv, err := prometheus.NewConstMetric(
-				 networkTrafficBytesDesc, prometheus.CounterValue,
-				 float64(net.RxBytes),
-				 networkTrafficBytesRxLabelsValues...
-			 )
-			 tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
-		 }
-		 if net.RxPktsSet {
-			 mv, err := prometheus.NewConstMetric(
-				 networkTrafficPktsDesc, prometheus.CounterValue,
-				 float64(net.RxPkts),
-				 networkTrafficPktsRxLabelsValues...
-			 )
-			 tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
-		 }
-		 if net.RxErrsSet {
-			 mv, err := prometheus.NewConstMetric(
-				 networkErrorsDesc, prometheus.CounterValue,
-				 float64(net.RxErrs),
-				 networkErrorsRxLabelsValues...
-			 )
-			 tryToPushMetric(networkErrorsDesc, mv, err, ch)
-		 }
- 
-		 if net.TxBytesSet {
-			 mv, err := prometheus.NewConstMetric(
-				 networkTrafficBytesDesc, prometheus.CounterValue,
-				 float64(net.TxBytes),
-				 networkTrafficBytesTxLabelsValues...
-			 )
-			 tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
-		 }
-		 if net.TxPktsSet {
-			 mv, err := prometheus.NewConstMetric(
-				 networkTrafficPktsDesc, prometheus.CounterValue,
-				 float64(net.TxPkts),
-				 networkTrafficPktsTxLabelsValues...
-			 )
-			 tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
-		 }
-		 if net.TxErrsSet {
-			 mv, err := prometheus.NewConstMetric(
-				 networkErrorsDesc, prometheus.CounterValue,
-				 float64(net.TxErrs),
-				 networkErrorsTxLabelsValues...
-			 )
-			 tryToPushMetric(networkErrorsDesc, mv, err, ch)
-		 }
-	 }
- }
- 
- func makeVMIsPhasesMap(vmis []*k6tv1.VirtualMachineInstance) map[string]uint64 {
-	 phasesMap := make(map[string]uint64)
- 
-	 for _, vmi := range vmis {
-		 phasesMap[strings.ToLower(string(vmi.Status.Phase))] += 1
-	 }
- 
-	 return phasesMap
- }
- 
- func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
-	 phasesMap := makeVMIsPhasesMap(vmis)
- 
-	 for phase, count := range phasesMap {
-		 mv, err := prometheus.NewConstMetric(
-			 vmiCountDesc, prometheus.GaugeValue,
-			 float64(count),
-			 nodeName, phase,
-		 )
-		 if err != nil {
-			 continue
-		 }
-		 ch <- mv
-	 }
- }
- 
- func updateVersion(ch chan<- prometheus.Metric) {
-	 verinfo := version.Get()
-	 ch <- prometheus.MustNewConstMetric(
-		 versionDesc, prometheus.GaugeValue,
-		 1.0,
-		 verinfo.GoVersion, verinfo.GitVersion,
-	 )
- }
- 
- type Collector struct {
-	 virtCli       kubecli.KubevirtClient
-	 virtShareDir  string
-	 nodeName      string
-	 concCollector *concurrentCollector
- }
- 
- func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int) *Collector {
-	 log.Log.Infof("Starting collector: node name=%v", nodeName)
-	 co := &Collector{
-		 virtCli:       virtCli,
-		 virtShareDir:  virtShareDir,
-		 nodeName:      nodeName,
-		 concCollector: NewConcurrentCollector(MaxRequestsInFlight),
-	 }
-	 prometheus.MustRegister(co)
-	 return co
- }
- 
- func (co *Collector) Describe(ch chan<- *prometheus.Desc) {
-	 // TODO: Use DescribeByCollect?
-	 ch <- versionDesc
-	 ch <- storageIopsDesc
-	 ch <- storageTrafficDesc
-	 ch <- storageTimesDesc
-	 ch <- vcpuUsageDesc
-	 ch <- networkTrafficBytesDesc
-	 ch <- networkTrafficPktsDesc
-	 ch <- networkErrorsDesc
-	 ch <- memoryAvailableDesc
-	 ch <- memoryResidentDesc
- }
- 
- func newvmiSocketMapFromVMIs(baseDir string, vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap {
-	 if len(vmis) == 0 {
-		 return nil
-	 }
- 
-	 ret := make(vmiSocketMap)
-	 for _, vmi := range vmis {
-		 socketPath, err := cmdclient.FindSocketOnHost(vmi)
-		 if err != nil {
-			 // nothing to scrape...
-			 // this means there's no socket or the socket
-			 // is currently unreachable for this vmi.
-			 continue
-		 }
-		 ret[socketPath] = vmi
-	 }
-	 return ret
- }
- 
- // Note that Collect could be called concurrently
- func (co *Collector) Collect(ch chan<- prometheus.Metric) {
-	 updateVersion(ch)
- 
-	 vmis, err := lookup.VirtualMachinesOnNode(co.virtCli, co.nodeName)
-	 if err != nil {
-		 log.Log.Reason(err).Errorf("failed to list all VMIs in '%s': %s", co.nodeName, err)
-		 return
-	 }
- 
-	 if len(vmis) == 0 {
-		 log.Log.V(4).Infof("No VMIs detected")
-		 return
-	 }
- 
-	 socketToVMIs := newvmiSocketMapFromVMIs(co.virtShareDir, vmis)
-	 scraper := &prometheusScraper{ch: ch}
-	 co.concCollector.Collect(socketToVMIs, scraper, collectionTimeout)
- 
-	 updateVMIsPhase(co.nodeName, vmis, ch)
-	 return
- }
- 
- type prometheusScraper struct {
-	 ch chan<- prometheus.Metric
- }
- 
- type vmiStatsInfo struct {
-	 vmiSpec  *k6tv1.VirtualMachineInstance
-	 vmiStats *stats.DomainStats
- }
- 
- func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineInstance) {
-	 ts := time.Now()
-	 cli, err := cmdclient.NewClient(socketFile)
-	 if err != nil {
-		 log.Log.Reason(err).Error("failed to connect to cmd client socket")
-		 // Ignore failure to connect to client.
-		 // These are all local connections via unix socket.
-		 // A failure to connect means there's nothing on the other
-		 // end listening.
-		 return
-	 }
-	 defer cli.Close()
- 
-	 vmStats, exists, err := cli.GetDomainStats()
-	 if err != nil {
-		 log.Log.Reason(err).Errorf("failed to update stats from socket %s", socketFile)
-		 return
-	 }
-	 if !exists || vmStats.Name == "" {
-		 log.Log.V(2).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
-		 return
-	 }
- 
-	 // GetDomainStats() may hang for a long time.
-	 // If it wakes up past the timeout, there is no point in send back any metric.
-	 // In the best case the information is stale, in the worst case the information is stale *and*
-	 // the reporting channel is already closed, leading to a possible panic - see below
-	 elapsed := time.Now().Sub(ts)
-	 if elapsed > statsMaxAge {
-		 log.Log.Infof("took too long (%v) to collect stats from %s: ignored", elapsed, socketFile)
-		 return
-	 }
- 
-	 ps.Report(socketFile, vmi, vmStats)
- }
- 
- func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats) {
-	 // statsMaxAge is an estimation - and there is not better way to do that. So it is possible that
-	 // GetDomainStats() takes enough time to lag behind, but not enough to trigger the statsMaxAge check.
-	 // In this case the next functions will end up writing on a closed channel. This will panic.
-	 // It is actually OK in this case to abort the goroutine that panicked -that's what we want anyway,
-	 // and the very reason we collect in throwaway goroutines. We need however to avoid dump stacktraces in the logs.
-	 // Since this is a known failure condition, let's handle it explicitely.
-	 defer func() {
-		 if err := recover(); err != nil {
-			 log.Log.V(2).Warningf("collector goroutine panicked for VM %s: %s", socketFile, err)
-		 }
-	 }()
- 
-	 updateMemory(vmi, vmStats, ps.ch)
-	 updateVcpu(vmi, vmStats, ps.ch)
-	 updateBlock(vmi, vmStats, ps.ch)
-	 updateNetwork(vmi, vmStats, ps.ch)
- }
- 
- func Handler(MaxRequestsInFlight int) http.Handler {
-	 return promhttp.InstrumentMetricHandler(
-		 prometheus.DefaultRegisterer,
-		 promhttp.HandlerFor(
-			 prometheus.DefaultGatherer,
-			 promhttp.HandlerOpts{
-				 MaxRequestsInFlight: MaxRequestsInFlight,
-			 }),
-	 )
- }
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	k6tv1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+	"kubevirt.io/client-go/version"
+	"kubevirt.io/kubevirt/pkg/util/lookup"
+	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
+)
+
+const statsMaxAge time.Duration = collectionTimeout + 2*time.Second // "a bit more" than timeout, heuristic again
+
+var (
+	// Formatter used to sanitize k8s metadata into metric labels
+	labelFormatter = strings.NewReplacer(".", "_", "/", "_", "-", "_")
+
+	// see https://www.robustperception.io/exposing-the-software-version-to-prometheus
+	versionDesc = prometheus.NewDesc(
+		"kubevirt_info",
+		"Version information",
+		[]string{"goversion", "kubeversion"},
+		nil,
+	)
+
+	// higher-level, telemetry-friendly metrics
+	vmiCountDesc = prometheus.NewDesc(
+		"kubevirt_vmi_phase_count",
+		"VMI phase.",
+		[]string{
+			"node", "phase",
+		},
+		nil,
+	)
+
+	// lower level metrics
+	storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
+	storageIopsDesc = prometheus.NewDesc(
+		"kubevirt_vmi_storage_iops_total",
+		"I/O operation performed.",
+		storageIopsLabels,
+		nil,
+	)
+
+	storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
+	storageTrafficDesc = prometheus.NewDesc(
+		"kubevirt_vmi_storage_traffic_bytes_total",
+		"storage traffic.",
+		storageTrafficLabels,
+		nil,
+	)
+
+	storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
+	storageTimesDesc = prometheus.NewDesc(
+		"kubevirt_vmi_storage_times_ms_total",
+		"storage operation time.",
+		storageTimesLabels,
+		nil,
+	)
+
+	vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
+	vcpuUsageDesc = prometheus.NewDesc(
+		"kubevirt_vmi_vcpu_seconds",
+		"Vcpu elapsed time.",
+		vcpuUsageLabels,
+		nil,
+	)
+
+	networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
+	networkTrafficBytesDesc = prometheus.NewDesc(
+		"kubevirt_vmi_network_traffic_bytes_total",
+		"network traffic.",
+		networkTrafficBytesLabels,
+		nil,
+	)
+
+	networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
+	networkTrafficPktsDesc = prometheus.NewDesc(
+		"kubevirt_vmi_network_traffic_packets_total",
+		"network traffic.",
+		networkTrafficPktsLabels,
+		nil,
+	)
+
+	networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
+	networkErrorsDesc = prometheus.NewDesc(
+		"kubevirt_vmi_network_errors_total",
+		"network errors.",
+		networkErrorsLabels,
+		nil,
+	)
+
+	memoryAvailableLabels = []string{"node", "namespace", "name"}
+	memoryAvailableDesc = prometheus.NewDesc(
+		"kubevirt_vmi_memory_available_bytes",
+		"amount of usable memory as seen by the domain.",
+		memoryAvailableLabels,
+		nil,
+	)
+
+	memoryResidentLabels = []string{"node", "namespace", "name"}
+	memoryResidentDesc = prometheus.NewDesc(
+		"kubevirt_vmi_memory_resident_bytes",
+		"resident set size of the process running the domain",
+		memoryResidentLabels,
+		nil,
+	)
+
+	swapTrafficLabels = []string{"node", "namespace", "name", "type"}
+	swapTrafficDesc = prometheus.NewDesc(
+		"kubevirt_vmi_memory_swap_traffic_bytes_total",
+		"swap memory traffic.",
+		swapTrafficLabels,
+		nil,
+	)
+)
+
+func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch chan<- prometheus.Metric) {
+	if err != nil {
+		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", memoryAvailableDesc, err)
+		return
+	}
+	ch <- mv
+}
+
+func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	memoryResidentLabels = []string{"node", "namespace", "name"}
+	memoryAvailableLabels = []string{"node", "namespace", "name"}
+	swapTrafficLabels = []string{"node", "namespace", "name", "type"}
+	var memoryResidentLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
+	var memoryAvailableLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
+	var swapTrafficInLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "in"}
+	var swapTrafficOutLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "out"}
+
+	// Add k8s metadata.Labels as metric labels
+	labelPreffix := "vmi_k8s_label_"
+	for label, val := range vmi.Labels {
+		memoryResidentLabels = append(memoryResidentLabels, labelPreffix+labelFormatter.Replace(label))
+		memoryResidentLabelValues = append(memoryResidentLabelValues, val)
+
+		memoryAvailableLabels = append(memoryAvailableLabels, labelPreffix+labelFormatter.Replace(label))
+		memoryAvailableLabelsValues = append(memoryAvailableLabelsValues, val)
+
+		swapTrafficLabels = append(swapTrafficLabels, labelPreffix+labelFormatter.Replace(label))
+		swapTrafficInLabelsValues = append(swapTrafficInLabelsValues, val)
+		swapTrafficOutLabelsValues = append(swapTrafficOutLabelsValues, val)
+	}
+
+	// Add k8s metadata.Annotations as metric labels
+	annotationPreffix := "vmi_k8s_annotation_"
+	for annotation, val := range vmi.Annotations {
+		memoryResidentLabels = append(memoryResidentLabels, annotationPreffix+labelFormatter.Replace(annotation))
+		memoryResidentLabelValues = append(memoryResidentLabelValues, val)
+
+		memoryAvailableLabels = append(memoryAvailableLabels, annotationPreffix+labelFormatter.Replace(annotation))
+		memoryAvailableLabelsValues = append(memoryAvailableLabelsValues, val)
+
+		swapTrafficLabels = append(swapTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
+		swapTrafficInLabelsValues = append(swapTrafficInLabelsValues, val)
+		swapTrafficOutLabelsValues = append(swapTrafficOutLabelsValues, val)
+	}
+
+
+	memoryResidentDesc = prometheus.NewDesc(
+		"kubevirt_vmi_memory_resident_bytes",
+		"resident set size of the process running the domain",
+		memoryResidentLabels,
+		nil,
+	)
+
+	memoryAvailableDesc = prometheus.NewDesc(
+		"kubevirt_vmi_memory_available_bytes",
+		"amount of usable memory as seen by the domain.",
+		memoryAvailableLabels,
+		nil,
+	)
+
+	swapTrafficDesc = prometheus.NewDesc(
+		"kubevirt_vmi_memory_swap_traffic_bytes_total",
+		"swap memory traffic.",
+		swapTrafficLabels,
+		nil,
+	)
+
+	if vmStats.Memory.RSSSet {
+		mv, err := prometheus.NewConstMetric(
+			memoryResidentDesc, prometheus.GaugeValue,
+			// the libvirt value is in KiB
+			float64(vmStats.Memory.RSS)*1024,
+			memoryResidentLabelValues...
+		)
+		tryToPushMetric(memoryResidentDesc, mv, err, ch)
+	}
+
+	if vmStats.Memory.AvailableSet {
+		mv, err := prometheus.NewConstMetric(
+			memoryAvailableDesc, prometheus.GaugeValue,
+			// the libvirt value is in KiB
+			float64(vmStats.Memory.Available)*1024,
+			memoryAvailableLabelsValues...
+		)
+		tryToPushMetric(memoryAvailableDesc, mv, err, ch)
+	}
+
+
+	if vmStats.Memory.SwapInSet {
+		mv, err := prometheus.NewConstMetric(
+			swapTrafficDesc, prometheus.GaugeValue,
+			// the libvirt value is in KiB
+			float64(vmStats.Memory.SwapIn)*1024,
+			swapTrafficInLabelsValues...
+		)
+		tryToPushMetric(swapTrafficDesc, mv, err, ch)
+	}
+	if vmStats.Memory.SwapOutSet {
+		mv, err := prometheus.NewConstMetric(
+			swapTrafficDesc, prometheus.GaugeValue,
+			// the libvirt value is in KiB
+			float64(vmStats.Memory.SwapOut)*1024,
+			swapTrafficOutLabelsValues...
+		)
+		tryToPushMetric(swapTrafficDesc, mv, err, ch)
+	}
+}
+
+func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	for vcpuId, vcpu := range vmStats.Vcpu {
+		vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
+		var vcpuUsageLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State)}
+
+		// Add k8s metadata.Labels as metric labels
+		labelPreffix := "vmi_k8s_label_"
+		for label, val := range vmi.Labels {
+			vcpuUsageLabels = append(vcpuUsageLabels, labelPreffix+labelFormatter.Replace(label))
+			vcpuUsageLabelsValues = append(vcpuUsageLabelsValues, val)
+		}
+
+		// Add k8s metadata.Annotations as metric labels
+		annotationPreffix := "vmi_k8s_annotation_"
+		for annotation, val := range vmi.Annotations {
+			vcpuUsageLabels = append(vcpuUsageLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			vcpuUsageLabelsValues = append(vcpuUsageLabelsValues, val)
+		}
+
+		vcpuUsageDesc = prometheus.NewDesc(
+			"kubevirt_vmi_vcpu_seconds",
+			"Vcpu elapsed time.",
+			vcpuUsageLabels,
+			nil,
+		)
+
+		if !vcpu.StateSet || !vcpu.TimeSet {
+			log.Log.V(4).Warningf("State or time not set for vcpu#%d", vcpuId)
+			continue
+		}
+		mv, err := prometheus.NewConstMetric(
+			vcpuUsageDesc, prometheus.GaugeValue,
+			float64(vcpu.Time/1000000000),
+			vcpuUsageLabelsValues...
+		)
+		tryToPushMetric(vcpuUsageDesc, mv, err, ch)
+	}
+}
+
+func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	for blockId, block := range vmStats.Block {
+		storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
+		storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
+		storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
+		var storageIopsReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
+		var storageIopsWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+		var storageTrafficReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
+		var storageTrafficWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+		var storageTimesReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
+		var storageTimesWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+
+		// Add k8s metadata.Labels as metric labels
+		labelPreffix := "vmi_k8s_label_"
+		for label, val := range vmi.Labels {
+			storageIopsLabels = append(storageIopsLabels, labelPreffix+labelFormatter.Replace(label))
+			storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
+			storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
+
+			storageTrafficLabels = append(storageTrafficLabels, labelPreffix+labelFormatter.Replace(label))
+			storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
+			storageTrafficWriteLabelsValues = append(storageTrafficWriteLabelsValues, val)
+
+			storageTimesLabels = append(storageTimesLabels, labelPreffix+labelFormatter.Replace(label))
+			storageTimesReadLabelsValues = append(storageTimesReadLabelsValues, val)
+			storageTimesWriteLabelsValues = append(storageTimesWriteLabelsValues, val)
+		}
+
+		// Add k8s metadata.Annotations as metric labels
+		annotationPreffix := "vmi_k8s_annotation_"
+		for annotation, val := range vmi.Annotations {
+			storageIopsLabels = append(storageIopsLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
+			storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
+
+			storageTrafficLabels = append(storageTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
+			storageTrafficWriteLabelsValues = append(storageTrafficWriteLabelsValues, val)
+
+			storageTimesLabels = append(storageTimesLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			storageTimesReadLabelsValues = append(storageTimesReadLabelsValues, val)
+			storageTimesWriteLabelsValues = append(storageTimesWriteLabelsValues, val)
+		}
+
+		storageIopsDesc = prometheus.NewDesc(
+			"kubevirt_vmi_storage_iops_total",
+			"I/O operation performed.",
+			storageIopsLabels,
+			nil,
+		)
+
+		storageTrafficDesc = prometheus.NewDesc(
+			"kubevirt_vmi_storage_traffic_bytes_total",
+			"storage traffic.",
+			storageTrafficLabels,
+			nil,
+		)
+
+		storageTimesDesc = prometheus.NewDesc(
+			"kubevirt_vmi_storage_times_ms_total",
+			"storage operation time.",
+			storageTimesLabels,
+			nil,
+		)
+
+		if !block.NameSet {
+			log.Log.V(4).Warningf("Name not set for block device#%d", blockId)
+			continue
+		}
+
+		if block.RdReqsSet {
+			mv, err := prometheus.NewConstMetric(
+				storageIopsDesc, prometheus.CounterValue,
+				float64(block.RdReqs),
+				storageIopsReadLabelsValues...
+			)
+			tryToPushMetric(storageIopsDesc, mv, err, ch)
+		}
+		if block.WrReqsSet {
+			mv, err := prometheus.NewConstMetric(
+				storageIopsDesc, prometheus.CounterValue,
+				float64(block.WrReqs),
+				storageIopsWriteLabelsValues...
+			)
+			tryToPushMetric(storageIopsDesc, mv, err, ch)
+		}
+
+		if block.RdBytesSet {
+			mv, err := prometheus.NewConstMetric(
+				storageTrafficDesc, prometheus.CounterValue,
+				float64(block.RdBytes),
+				storageTrafficReadLabelsValues...
+			)
+			tryToPushMetric(storageTrafficDesc, mv, err, ch)
+		}
+		if block.WrBytesSet {
+			mv, err := prometheus.NewConstMetric(
+				storageTrafficDesc, prometheus.CounterValue,
+				float64(block.WrBytes),
+				storageTrafficWriteLabelsValues...
+			)
+			tryToPushMetric(storageTrafficDesc, mv, err, ch)
+		}
+
+		if block.RdTimesSet {
+			mv, err := prometheus.NewConstMetric(
+				storageTimesDesc, prometheus.CounterValue,
+				float64(block.RdTimes),
+				storageTimesReadLabelsValues...
+			)
+			tryToPushMetric(storageTimesDesc, mv, err, ch)
+		}
+		if block.WrTimesSet {
+			mv, err := prometheus.NewConstMetric(
+				storageTimesDesc, prometheus.CounterValue,
+				float64(block.WrTimes),
+				storageTimesWriteLabelsValues...
+			)
+			tryToPushMetric(storageTimesDesc, mv, err, ch)
+		}
+	}
+}
+
+func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	for _, net := range vmStats.Net {
+		networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
+		networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
+		networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
+		var networkTrafficBytesRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
+		var networkTrafficBytesTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
+		var networkTrafficPktsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
+		var networkTrafficPktsTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
+		var networkErrorsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
+		var networkErrorsTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
+
+		// Add k8s metadata.Labels as metric labels
+		labelPreffix := "vmi_k8s_label_"
+		for label, val := range vmi.Labels {
+			networkTrafficBytesLabels = append(networkTrafficBytesLabels, labelPreffix+labelFormatter.Replace(label))
+			networkTrafficBytesRxLabelsValues = append(networkTrafficBytesRxLabelsValues, val)
+			networkTrafficBytesTxLabelsValues = append(networkTrafficBytesTxLabelsValues, val)
+
+			networkTrafficPktsLabels = append(networkTrafficPktsLabels, labelPreffix+labelFormatter.Replace(label))
+			networkTrafficPktsRxLabelsValues = append(networkTrafficPktsRxLabelsValues, val)
+			networkTrafficPktsTxLabelsValues = append(networkTrafficPktsTxLabelsValues, val)
+
+			networkErrorsLabels = append(networkErrorsLabels, labelPreffix+labelFormatter.Replace(label))
+			networkErrorsRxLabelsValues = append(networkErrorsRxLabelsValues, val)
+			networkErrorsTxLabelsValues = append(networkErrorsTxLabelsValues, val)
+		}
+
+		// Add k8s metadata.Annotations as metric labels
+		annotationPreffix := "vmi_k8s_annotation_"
+		for annotation, val := range vmi.Annotations {
+			networkTrafficBytesLabels = append(networkTrafficBytesLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			networkTrafficBytesRxLabelsValues = append(networkTrafficBytesRxLabelsValues, val)
+			networkTrafficBytesTxLabelsValues = append(networkTrafficBytesTxLabelsValues, val)
+
+			networkTrafficPktsLabels = append(networkTrafficPktsLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			networkTrafficPktsRxLabelsValues = append(networkTrafficPktsRxLabelsValues, val)
+			networkTrafficPktsTxLabelsValues = append(networkTrafficPktsTxLabelsValues, val)
+
+			networkErrorsLabels = append(networkErrorsLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			networkErrorsRxLabelsValues = append(networkErrorsRxLabelsValues, val)
+			networkErrorsTxLabelsValues = append(networkErrorsTxLabelsValues, val)
+		}
+
+		networkTrafficBytesDesc = prometheus.NewDesc(
+			"kubevirt_vmi_network_traffic_bytes_total",
+			"network traffic.",
+			networkTrafficBytesLabels,
+			nil,
+		)
+
+		networkTrafficPktsDesc = prometheus.NewDesc(
+			"kubevirt_vmi_network_traffic_packets_total",
+			"network traffic.",
+			networkTrafficPktsLabels,
+			nil,
+		)
+
+		networkErrorsDesc = prometheus.NewDesc(
+			"kubevirt_vmi_network_errors_total",
+			"network errors.",
+			networkErrorsLabels,
+			nil,
+		)
+
+		if !net.NameSet {
+			continue
+		}
+		if net.RxBytesSet {
+			mv, err := prometheus.NewConstMetric(
+				networkTrafficBytesDesc, prometheus.CounterValue,
+				float64(net.RxBytes),
+				networkTrafficBytesRxLabelsValues...
+			)
+			tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
+		}
+		if net.RxPktsSet {
+			mv, err := prometheus.NewConstMetric(
+				networkTrafficPktsDesc, prometheus.CounterValue,
+				float64(net.RxPkts),
+				networkTrafficPktsRxLabelsValues...
+			)
+			tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
+		}
+		if net.RxErrsSet {
+			mv, err := prometheus.NewConstMetric(
+				networkErrorsDesc, prometheus.CounterValue,
+				float64(net.RxErrs),
+				networkErrorsRxLabelsValues...
+			)
+			tryToPushMetric(networkErrorsDesc, mv, err, ch)
+		}
+
+		if net.TxBytesSet {
+			mv, err := prometheus.NewConstMetric(
+				networkTrafficBytesDesc, prometheus.CounterValue,
+				float64(net.TxBytes),
+				networkTrafficBytesTxLabelsValues...
+			)
+			tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
+		}
+		if net.TxPktsSet {
+			mv, err := prometheus.NewConstMetric(
+				networkTrafficPktsDesc, prometheus.CounterValue,
+				float64(net.TxPkts),
+				networkTrafficPktsTxLabelsValues...
+			)
+			tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
+		}
+		if net.TxErrsSet {
+			mv, err := prometheus.NewConstMetric(
+				networkErrorsDesc, prometheus.CounterValue,
+				float64(net.TxErrs),
+				networkErrorsTxLabelsValues...
+			)
+			tryToPushMetric(networkErrorsDesc, mv, err, ch)
+		}
+	}
+}
+
+func makeVMIsPhasesMap(vmis []*k6tv1.VirtualMachineInstance) map[string]uint64 {
+	phasesMap := make(map[string]uint64)
+
+	for _, vmi := range vmis {
+		phasesMap[strings.ToLower(string(vmi.Status.Phase))] += 1
+	}
+
+	return phasesMap
+}
+
+func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
+	phasesMap := makeVMIsPhasesMap(vmis)
+
+	for phase, count := range phasesMap {
+		mv, err := prometheus.NewConstMetric(
+			vmiCountDesc, prometheus.GaugeValue,
+			float64(count),
+			nodeName, phase,
+		)
+		if err != nil {
+			continue
+		}
+		ch <- mv
+	}
+}
+
+func updateVersion(ch chan<- prometheus.Metric) {
+	verinfo := version.Get()
+	ch <- prometheus.MustNewConstMetric(
+		versionDesc, prometheus.GaugeValue,
+		1.0,
+		verinfo.GoVersion, verinfo.GitVersion,
+	)
+}
+
+type Collector struct {
+	virtCli       kubecli.KubevirtClient
+	virtShareDir  string
+	nodeName      string
+	concCollector *concurrentCollector
+}
+
+func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int) *Collector {
+	log.Log.Infof("Starting collector: node name=%v", nodeName)
+	co := &Collector{
+		virtCli:       virtCli,
+		virtShareDir:  virtShareDir,
+		nodeName:      nodeName,
+		concCollector: NewConcurrentCollector(MaxRequestsInFlight),
+	}
+	prometheus.MustRegister(co)
+	return co
+}
+
+func (co *Collector) Describe(ch chan<- *prometheus.Desc) {
+	// TODO: Use DescribeByCollect?
+	ch <- versionDesc
+	ch <- storageIopsDesc
+	ch <- storageTrafficDesc
+	ch <- storageTimesDesc
+	ch <- vcpuUsageDesc
+	ch <- networkTrafficBytesDesc
+	ch <- networkTrafficPktsDesc
+	ch <- networkErrorsDesc
+	ch <- memoryAvailableDesc
+	ch <- memoryResidentDesc
+}
+
+func newvmiSocketMapFromVMIs(baseDir string, vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap {
+	if len(vmis) == 0 {
+		return nil
+	}
+
+	ret := make(vmiSocketMap)
+	for _, vmi := range vmis {
+		socketPath, err := cmdclient.FindSocketOnHost(vmi)
+		if err != nil {
+			// nothing to scrape...
+			// this means there's no socket or the socket
+			// is currently unreachable for this vmi.
+			continue
+		}
+		ret[socketPath] = vmi
+	}
+	return ret
+}
+
+// Note that Collect could be called concurrently
+func (co *Collector) Collect(ch chan<- prometheus.Metric) {
+	updateVersion(ch)
+
+	vmis, err := lookup.VirtualMachinesOnNode(co.virtCli, co.nodeName)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to list all VMIs in '%s': %s", co.nodeName, err)
+		return
+	}
+
+	if len(vmis) == 0 {
+		log.Log.V(4).Infof("No VMIs detected")
+		return
+	}
+
+	socketToVMIs := newvmiSocketMapFromVMIs(co.virtShareDir, vmis)
+	scraper := &prometheusScraper{ch: ch}
+	co.concCollector.Collect(socketToVMIs, scraper, collectionTimeout)
+
+	updateVMIsPhase(co.nodeName, vmis, ch)
+	return
+}
+
+type prometheusScraper struct {
+	ch chan<- prometheus.Metric
+}
+
+type vmiStatsInfo struct {
+	vmiSpec  *k6tv1.VirtualMachineInstance
+	vmiStats *stats.DomainStats
+}
+
+func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineInstance) {
+	ts := time.Now()
+	cli, err := cmdclient.NewClient(socketFile)
+	if err != nil {
+		log.Log.Reason(err).Error("failed to connect to cmd client socket")
+		// Ignore failure to connect to client.
+		// These are all local connections via unix socket.
+		// A failure to connect means there's nothing on the other
+		// end listening.
+		return
+	}
+	defer cli.Close()
+
+	vmStats, exists, err := cli.GetDomainStats()
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to update stats from socket %s", socketFile)
+		return
+	}
+	if !exists || vmStats.Name == "" {
+		log.Log.V(2).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
+		return
+	}
+
+	// GetDomainStats() may hang for a long time.
+	// If it wakes up past the timeout, there is no point in send back any metric.
+	// In the best case the information is stale, in the worst case the information is stale *and*
+	// the reporting channel is already closed, leading to a possible panic - see below
+	elapsed := time.Now().Sub(ts)
+	if elapsed > statsMaxAge {
+		log.Log.Infof("took too long (%v) to collect stats from %s: ignored", elapsed, socketFile)
+		return
+	}
+
+	ps.Report(socketFile, vmi, vmStats)
+}
+
+func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats) {
+	// statsMaxAge is an estimation - and there is not better way to do that. So it is possible that
+	// GetDomainStats() takes enough time to lag behind, but not enough to trigger the statsMaxAge check.
+	// In this case the next functions will end up writing on a closed channel. This will panic.
+	// It is actually OK in this case to abort the goroutine that panicked -that's what we want anyway,
+	// and the very reason we collect in throwaway goroutines. We need however to avoid dump stacktraces in the logs.
+	// Since this is a known failure condition, let's handle it explicitely.
+	defer func() {
+		if err := recover(); err != nil {
+			log.Log.V(2).Warningf("collector goroutine panicked for VM %s: %s", socketFile, err)
+		}
+	}()
+
+	updateMemory(vmi, vmStats, ps.ch)
+	updateVcpu(vmi, vmStats, ps.ch)
+	updateBlock(vmi, vmStats, ps.ch)
+	updateNetwork(vmi, vmStats, ps.ch)
+}
+
+func Handler(MaxRequestsInFlight int) http.Handler {
+	return promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer,
+		promhttp.HandlerFor(
+			prometheus.DefaultGatherer,
+			promhttp.HandlerOpts{
+				MaxRequestsInFlight: MaxRequestsInFlight,
+			}),
+	)
+}

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -148,7 +148,7 @@ var (
 
 func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch chan<- prometheus.Metric) {
 	if err != nil {
-		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", memoryAvailableDesc, err)
+		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", desc, err)
 		return
 	}
 	ch <- mv
@@ -303,7 +303,7 @@ func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, 
 		for label, val := range vmi.Labels {
 			storageIopsLabels = append(storageIopsLabels, labelPreffix+labelFormatter.Replace(label))
 			storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
-			storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
+			storageIopsWriteLabelsValues = append(storageIopsWriteLabelsValues, val)
 
 			storageTrafficLabels = append(storageTrafficLabels, labelPreffix+labelFormatter.Replace(label))
 			storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
@@ -318,7 +318,7 @@ func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, 
 		for annotation, val := range vmi.Annotations {
 			storageIopsLabels = append(storageIopsLabels, annotationPreffix+labelFormatter.Replace(annotation))
 			storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
-			storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
+			storageIopsWriteLabelsValues = append(storageIopsWriteLabelsValues, val)
 
 			storageTrafficLabels = append(storageTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
 			storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -90,15 +90,15 @@ func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch 
 
 func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric, k8sLabels []string, k8sLabelValues []string) {
 	// Initial memory metric labels
-	var memoryResidentLabels = []string{"node", "namespace", "name"}
-	var memoryAvailableLabels = []string{"node", "namespace", "name"}
-	var swapTrafficLabels = []string{"node", "namespace", "name", "type"}
+	var memoryResidentLabels = []string{"node", "namespace", "name", "domain"}
+	var memoryAvailableLabels = []string{"node", "namespace", "name", "domain"}
+	var swapTrafficLabels = []string{"node", "namespace", "name", "domain", "type"}
 
 	// Initial memory metric label values
-	var memoryResidentLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
-	var memoryAvailableLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
-	var swapTrafficInLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "in"}
-	var swapTrafficOutLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "out"}
+	var memoryResidentLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name}
+	var memoryAvailableLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name}
+	var swapTrafficInLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, "in"}
+	var swapTrafficOutLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, "out"}
 
 	// Add k8s metadata.Labels as metric labels
 	memoryResidentLabels = append(memoryResidentLabels, k8sLabels...)
@@ -173,10 +173,10 @@ func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats,
 func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric, k8sLabels []string, k8sLabelValues []string) {
 	for vcpuId, vcpu := range vmStats.Vcpu {
 		// Initial vcpu metrics labels
-		var vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
+		var vcpuUsageLabels = []string{"node", "namespace", "name", "domain", "id", "state"}
 
 		// Initial vcpu metrics labels values
-		var vcpuUsageLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State)}
+		var vcpuUsageLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State)}
 
 		// Add k8s metadata.Labels as metric labels
 		vcpuUsageLabels = append(vcpuUsageLabels, k8sLabels...)
@@ -205,17 +205,17 @@ func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, c
 func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric, k8sLabels []string, k8sLabelValues []string) {
 	for blockId, block := range vmStats.Block {
 		// Initial block metrics labels
-		var storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
-		var storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
-		var storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
+		var storageIopsLabels = []string{"node", "namespace", "name", "domain", "drive", "type"}
+		var storageTrafficLabels = []string{"node", "namespace", "name", "domain", "drive", "type"}
+		var storageTimesLabels = []string{"node", "namespace", "name", "domain", "drive", "type"}
 
 		// Initial block metrics labels values
-		var storageIopsReadLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
-		var storageIopsWriteLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
-		var storageTrafficReadLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
-		var storageTrafficWriteLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
-		var storageTimesReadLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
-		var storageTimesWriteLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+		var storageIopsReadLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, block.Name, "read"}
+		var storageIopsWriteLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, block.Name, "write"}
+		var storageTrafficReadLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, block.Name, "read"}
+		var storageTrafficWriteLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, block.Name, "write"}
+		var storageTimesReadLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, block.Name, "read"}
+		var storageTimesWriteLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, block.Name, "write"}
 
 		// Add k8s metadata.Labels as metric labels
 		storageIopsLabels = append(storageIopsLabels, k8sLabels...)
@@ -310,17 +310,17 @@ func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, 
 func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric, k8sLabels []string, k8sLabelValues []string) {
 	for _, net := range vmStats.Net {
 		// Initial network metrics labels
-		var networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
-		var networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
-		var networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
+		var networkTrafficBytesLabels = []string{"node", "namespace", "name", "domain", "interface", "type"}
+		var networkTrafficPktsLabels = []string{"node", "namespace", "name", "domain", "interface", "type"}
+		var networkErrorsLabels = []string{"node", "namespace", "name", "domain", "interface", "type"}
 
 		// Initial network metrics labels values
-		var networkTrafficBytesRxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx"}
-		var networkTrafficBytesTxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx"}
-		var networkTrafficPktsRxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx"}
-		var networkTrafficPktsTxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx"}
-		var networkErrorsRxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx"}
-		var networkErrorsTxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx"}
+		var networkTrafficBytesRxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, net.Name, "rx"}
+		var networkTrafficBytesTxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, net.Name, "tx"}
+		var networkTrafficPktsRxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, net.Name, "rx"}
+		var networkTrafficPktsTxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, net.Name, "tx"}
+		var networkErrorsRxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, net.Name, "rx"}
+		var networkErrorsTxLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, vmStats.Name, net.Name, "tx"}
 
 		// Add k8s metadata.Labels as metric labels
 		networkTrafficBytesLabels = append(networkTrafficBytesLabels, k8sLabels...)

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -45,7 +45,7 @@ var (
 	labelFormatter = strings.NewReplacer(".", "_", "/", "_", "-", "_")
 
 	// Preffixes used when transforming K8s metadata into metric labels
-	labelPreffix = "kubernetes_vmi_label_"
+	labelPrefix = "kubernetes_vmi_label_"
 
 	// see https://www.robustperception.io/exposing-the-software-version-to-prometheus
 	versionDesc = prometheus.NewDesc(
@@ -606,7 +606,7 @@ func Handler(MaxRequestsInFlight int) http.Handler {
 
 func updateKubernetesLabels(vmi *k6tv1.VirtualMachineInstance) (k8sLabels []string, k8sLabelValues []string) {
 	for label, val := range vmi.Labels {
-		k8sLabels = append(k8sLabels, labelPreffix+labelFormatter.Replace(label))
+		k8sLabels = append(k8sLabels, labelPrefix+labelFormatter.Replace(label))
 		k8sLabelValues = append(k8sLabelValues, val)
 	}
 

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -152,6 +152,9 @@
  }
  
  func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	 memoryResidentLabels = []string{"node", "namespace", "name"}
+	 memoryAvailableLabels = []string{"node", "namespace", "name"}
+	 swapTrafficLabels = []string{"node", "namespace", "name", "type"}
 	 var memoryResidentLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
 	 var memoryAvailableLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
 	 var swapTrafficInLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "in"}
@@ -250,6 +253,7 @@
  
  func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
 	 for vcpuId, vcpu := range vmStats.Vcpu {
+		 vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
 		 var vcpuUsageLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State)}
  
 		 // Add k8s metadata.Labels as metric labels
@@ -288,6 +292,9 @@
  
  func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
 	 for blockId, block := range vmStats.Block {
+		 storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
+		 storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
+		 storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
 		 var storageIopsReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
 		 var storageIopsWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
 		 var storageTrafficReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
@@ -408,6 +415,9 @@
  
  func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
 	 for _, net := range vmStats.Net {
+		 networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
+		 networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
+		 networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
 		 var networkTrafficBytesRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
 		 var networkTrafficBytesTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
 		 var networkTrafficPktsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
@@ -707,4 +717,3 @@
 			 }),
 	 )
  }
-  

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -17,588 +17,694 @@
  *
  */
 
-package prometheus
+ package prometheus
 
-import (
-	"fmt"
-	"net/http"
-	"strings"
-	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	k6tv1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
-	"kubevirt.io/client-go/version"
-	"kubevirt.io/kubevirt/pkg/util/lookup"
-	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
-)
-
-const statsMaxAge time.Duration = collectionTimeout + 2*time.Second // "a bit more" than timeout, heuristic again
-
-var (
-	// see https://www.robustperception.io/exposing-the-software-version-to-prometheus
-	versionDesc = prometheus.NewDesc(
-		"kubevirt_info",
-		"Version information",
-		[]string{"goversion", "kubeversion"},
-		nil,
-	)
-
-	// higher-level, telemetry-friendly metrics
-	vmiCountDesc = prometheus.NewDesc(
-		"kubevirt_vmi_phase_count",
-		"VMI phase.",
-		[]string{
-			"node", "phase",
-		},
-		nil,
-	)
-
-	// lower level metrics
-	storageIopsDesc = prometheus.NewDesc(
-		"kubevirt_vmi_storage_iops_total",
-		"I/O operation performed.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "drive", "type", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	storageTrafficDesc = prometheus.NewDesc(
-		"kubevirt_vmi_storage_traffic_bytes_total",
-		"storage traffic.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "drive", "type", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	storageTimesDesc = prometheus.NewDesc(
-		"kubevirt_vmi_storage_times_ms_total",
-		"storage operation time.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "drive", "type", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	vcpuUsageDesc = prometheus.NewDesc(
-		"kubevirt_vmi_vcpu_seconds",
-		"Vcpu elapsed time.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "id", "state", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	networkTrafficBytesDesc = prometheus.NewDesc(
-		"kubevirt_vmi_network_traffic_bytes_total",
-		"network traffic.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "interface", "type", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	networkTrafficPktsDesc = prometheus.NewDesc(
-		"kubevirt_vmi_network_traffic_packets_total",
-		"network traffic.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "interface", "type", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	networkErrorsDesc = prometheus.NewDesc(
-		"kubevirt_vmi_network_errors_total",
-		"network errors.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "interface", "type", "k8s_labels",
-			"k8s_annotations",
-		},
-		nil,
-	)
-	memoryAvailableDesc = prometheus.NewDesc(
-		"kubevirt_vmi_memory_available_bytes",
-		"amount of usable memory as seen by the domain.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "k8s_labels", "k8s_annotations",
-		},
-		nil,
-	)
-	memoryResidentDesc = prometheus.NewDesc(
-		"kubevirt_vmi_memory_resident_bytes",
-		"resident set size of the process running the domain",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "k8s_labels", "k8s_annotations",
-		},
-		nil,
-	)
-
-	swapTrafficDesc = prometheus.NewDesc(
-		"kubevirt_vmi_memory_swap_traffic_bytes_total",
-		"swap memory traffic.",
-		[]string{
-			"node", "namespace", "name",
-			"domain", "type", "k8s_labels", 
-			"k8s_annotations",
-		},
-		nil,
-	)
-)
-
-func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch chan<- prometheus.Metric) {
-	if err != nil {
-		log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", memoryAvailableDesc, err)
-		return
-	}
-	ch <- mv
-}
-
-func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	labelsToString := ""
-	for label, val := range vmi.Labels {
-		labelsToString += label + "=" + val +","
-	}
-	labelsToString = labelsToString[:len(labelsToString)-1]
-
-	annotationsToString := ""
-	for annotation, val := range vmi.Labels {
-		annotationsToString += annotation + "=" + val +","
-	}
-	annotationsToString = annotationsToString[:len(annotationsToString)-1]
-
-	if vmStats.Memory.AvailableSet {
-		mv, err := prometheus.NewConstMetric(
-			memoryAvailableDesc, prometheus.GaugeValue,
-			// the libvirt value is in KiB
-			float64(vmStats.Memory.Available)*1024,
-			vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-			vmStats.Name, labelsToString, annotationsToString,
-		)
-		tryToPushMetric(memoryAvailableDesc, mv, err, ch)
-	}
-	if vmStats.Memory.RSSSet {
-		mv, err := prometheus.NewConstMetric(
-			memoryResidentDesc, prometheus.GaugeValue,
-			// the libvirt value is in KiB
-			float64(vmStats.Memory.RSS)*1024,
-			vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-			vmStats.Name, labelsToString, annotationsToString,
-		)
-		tryToPushMetric(memoryResidentDesc, mv, err, ch)
-	}
-
-	if vmStats.Memory.SwapInSet {
-		mv, err := prometheus.NewConstMetric(
-			swapTrafficDesc, prometheus.GaugeValue,
-			// the libvirt value is in KiB
-			float64(vmStats.Memory.SwapIn)*1024,
-			vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-			vmStats.Name, "in", labelsToString, annotationsToString,
-		)
-		tryToPushMetric(swapTrafficDesc, mv, err, ch)
-	}
-	if vmStats.Memory.SwapOutSet {
-		mv, err := prometheus.NewConstMetric(
-			swapTrafficDesc, prometheus.GaugeValue,
-			// the libvirt value is in KiB
-			float64(vmStats.Memory.SwapOut)*1024,
-			vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-			vmStats.Name, "out", labelsToString, annotationsToString,
-		)
-		tryToPushMetric(swapTrafficDesc, mv, err, ch)
-	}
-}
-
-func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	labelsToString := ""
-	for label, val := range vmi.Labels {
-		labelsToString += label + "=" + val +","
-	}
-	labelsToString = labelsToString[:len(labelsToString)-1]
-
-	annotationsToString := ""
-	for annotation, val := range vmi.Labels {
-		annotationsToString += annotation + "=" + val +","
-	}
-	annotationsToString = annotationsToString[:len(annotationsToString)-1]
-	
-	for vcpuId, vcpu := range vmStats.Vcpu {
-		if !vcpu.StateSet || !vcpu.TimeSet {
-			log.Log.V(4).Warningf("State or time not set for vcpu#%d", vcpuId)
-			continue
-		}
-		mv, err := prometheus.NewConstMetric(
-			vcpuUsageDesc, prometheus.GaugeValue,
-			float64(vcpu.Time/1000000000),
-			vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-			vmStats.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State),
-			labelsToString, annotationsToString,
-		)
-		tryToPushMetric(vcpuUsageDesc, mv, err, ch)
-	}
-}
-
-func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	labelsToString := ""
-	for label, val := range vmi.Labels {
-		labelsToString += label + "=" + val +","
-	}
-	labelsToString = labelsToString[:len(labelsToString)-1]
-
-	annotationsToString := ""
-	for annotation, val := range vmi.Labels {
-		annotationsToString += annotation + "=" + val +","
-	}
-	annotationsToString = annotationsToString[:len(annotationsToString)-1]
-	
-	for blockId, block := range vmStats.Block {
-		if !block.NameSet {
-			log.Log.V(4).Warningf("Name not set for block device#%d", blockId)
-			continue
-		}
-
-		if block.RdReqsSet {
-			mv, err := prometheus.NewConstMetric(
-				storageIopsDesc, prometheus.CounterValue,
-				float64(block.RdReqs),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, block.Name, "read", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(storageIopsDesc, mv, err, ch)
-		}
-		if block.WrReqsSet {
-			mv, err := prometheus.NewConstMetric(
-				storageIopsDesc, prometheus.CounterValue,
-				float64(block.WrReqs),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, block.Name, "write", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(storageIopsDesc, mv, err, ch)
-		}
-
-		if block.RdBytesSet {
-			mv, err := prometheus.NewConstMetric(
-				storageTrafficDesc, prometheus.CounterValue,
-				float64(block.RdBytes),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, block.Name, "read", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(storageTrafficDesc, mv, err, ch)
-		}
-		if block.WrBytesSet {
-			mv, err := prometheus.NewConstMetric(
-				storageTrafficDesc, prometheus.CounterValue,
-				float64(block.WrBytes),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, block.Name, "write", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(storageTrafficDesc, mv, err, ch)
-		}
-
-		if block.RdTimesSet {
-			mv, err := prometheus.NewConstMetric(
-				storageTimesDesc, prometheus.CounterValue,
-				float64(block.RdTimes),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, block.Name, "read", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(storageTimesDesc, mv, err, ch)
-		}
-		if block.WrTimesSet {
-			mv, err := prometheus.NewConstMetric(
-				storageTimesDesc, prometheus.CounterValue,
-				float64(block.WrTimes),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, block.Name, "write", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(storageTimesDesc, mv, err, ch)
-		}
-	}
-}
-
-func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
-	labelsToString := ""
-	for label, val := range vmi.Labels {
-		labelsToString += label + "=" + val +","
-	}
-	labelsToString = labelsToString[:len(labelsToString)-1]
-
-	annotationsToString := ""
-	for annotation, val := range vmi.Labels {
-		annotationsToString += annotation + "=" + val +","
-	}
-	annotationsToString = annotationsToString[:len(annotationsToString)-1]
-
-	for _, net := range vmStats.Net {
-		if !net.NameSet {
-			continue
-		}
-		if net.RxBytesSet {
-			mv, err := prometheus.NewConstMetric(
-				networkTrafficBytesDesc, prometheus.CounterValue,
-				float64(net.RxBytes),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, net.Name, "rx", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
-		}
-		if net.RxPktsSet {
-			mv, err := prometheus.NewConstMetric(
-				networkTrafficPktsDesc, prometheus.CounterValue,
-				float64(net.RxPkts),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, net.Name, "rx", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
-		}
-		if net.RxErrsSet {
-			mv, err := prometheus.NewConstMetric(
-				networkErrorsDesc, prometheus.CounterValue,
-				float64(net.RxErrs),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, net.Name, "rx", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(networkErrorsDesc, mv, err, ch)
-		}
-
-		if net.TxBytesSet {
-			mv, err := prometheus.NewConstMetric(
-				networkTrafficBytesDesc, prometheus.CounterValue,
-				float64(net.TxBytes),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, net.Name, "tx", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
-		}
-		if net.TxPktsSet {
-			mv, err := prometheus.NewConstMetric(
-				networkTrafficPktsDesc, prometheus.CounterValue,
-				float64(net.TxPkts),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, net.Name, "tx", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
-		}
-		if net.TxErrsSet {
-			mv, err := prometheus.NewConstMetric(
-				networkErrorsDesc, prometheus.CounterValue,
-				float64(net.TxErrs),
-				vmi.Status.NodeName, vmi.Namespace, vmi.Name,
-				vmStats.Name, net.Name, "tx", labelsToString,
-				annotationsToString,
-			)
-			tryToPushMetric(networkErrorsDesc, mv, err, ch)
-		}
-	}
-}
-
-func makeVMIsPhasesMap(vmis []*k6tv1.VirtualMachineInstance) map[string]uint64 {
-	phasesMap := make(map[string]uint64)
-
-	for _, vmi := range vmis {
-		phasesMap[strings.ToLower(string(vmi.Status.Phase))] += 1
-	}
-
-	return phasesMap
-}
-
-func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
-	phasesMap := makeVMIsPhasesMap(vmis)
-
-	for phase, count := range phasesMap {
-		mv, err := prometheus.NewConstMetric(
-			vmiCountDesc, prometheus.GaugeValue,
-			float64(count),
-			nodeName, phase,
-		)
-		if err != nil {
-			continue
-		}
-		ch <- mv
-	}
-}
-
-func updateVersion(ch chan<- prometheus.Metric) {
-	verinfo := version.Get()
-	ch <- prometheus.MustNewConstMetric(
-		versionDesc, prometheus.GaugeValue,
-		1.0,
-		verinfo.GoVersion, verinfo.GitVersion,
-	)
-}
-
-type Collector struct {
-	virtCli       kubecli.KubevirtClient
-	virtShareDir  string
-	nodeName      string
-	concCollector *concurrentCollector
-}
-
-func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int) *Collector {
-	log.Log.Infof("Starting collector: node name=%v", nodeName)
-	co := &Collector{
-		virtCli:       virtCli,
-		virtShareDir:  virtShareDir,
-		nodeName:      nodeName,
-		concCollector: NewConcurrentCollector(MaxRequestsInFlight),
-	}
-	prometheus.MustRegister(co)
-	return co
-}
-
-func (co *Collector) Describe(ch chan<- *prometheus.Desc) {
-	// TODO: Use DescribeByCollect?
-	ch <- versionDesc
-	ch <- storageIopsDesc
-	ch <- storageTrafficDesc
-	ch <- storageTimesDesc
-	ch <- vcpuUsageDesc
-	ch <- networkTrafficBytesDesc
-	ch <- networkTrafficPktsDesc
-	ch <- networkErrorsDesc
-	ch <- memoryAvailableDesc
-	ch <- memoryResidentDesc
-}
-
-func newvmiSocketMapFromVMIs(baseDir string, vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap {
-	if len(vmis) == 0 {
-		return nil
-	}
-
-	ret := make(vmiSocketMap)
-	for _, vmi := range vmis {
-		socketPath, err := cmdclient.FindSocketOnHost(vmi)
-		if err != nil {
-			// nothing to scrape...
-			// this means there's no socket or the socket
-			// is currently unreachable for this vmi.
-			continue
-		}
-		ret[socketPath] = vmi
-	}
-	return ret
-}
-
-// Note that Collect could be called concurrently
-func (co *Collector) Collect(ch chan<- prometheus.Metric) {
-	updateVersion(ch)
-
-	vmis, err := lookup.VirtualMachinesOnNode(co.virtCli, co.nodeName)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to list all VMIs in '%s': %s", co.nodeName, err)
-		return
-	}
-
-	if len(vmis) == 0 {
-		log.Log.V(4).Infof("No VMIs detected")
-		return
-	}
-
-	socketToVMIs := newvmiSocketMapFromVMIs(co.virtShareDir, vmis)
-	scraper := &prometheusScraper{ch: ch}
-	co.concCollector.Collect(socketToVMIs, scraper, collectionTimeout)
-
-	updateVMIsPhase(co.nodeName, vmis, ch)
-	return
-}
-
-type prometheusScraper struct {
-	ch chan<- prometheus.Metric
-}
-
-type vmiStatsInfo struct {
-	vmiSpec  *k6tv1.VirtualMachineInstance
-	vmiStats *stats.DomainStats
-}
-
-func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineInstance) {
-	ts := time.Now()
-	cli, err := cmdclient.NewClient(socketFile)
-	if err != nil {
-		log.Log.Reason(err).Error("failed to connect to cmd client socket")
-		// Ignore failure to connect to client.
-		// These are all local connections via unix socket.
-		// A failure to connect means there's nothing on the other
-		// end listening.
-		return
-	}
-	defer cli.Close()
-
-	vmStats, exists, err := cli.GetDomainStats()
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to update stats from socket %s", socketFile)
-		return
-	}
-	if !exists || vmStats.Name == "" {
-		log.Log.V(2).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
-		return
-	}
-
-	// GetDomainStats() may hang for a long time.
-	// If it wakes up past the timeout, there is no point in send back any metric.
-	// In the best case the information is stale, in the worst case the information is stale *and*
-	// the reporting channel is already closed, leading to a possible panic - see below
-	elapsed := time.Now().Sub(ts)
-	if elapsed > statsMaxAge {
-		log.Log.Infof("took too long (%v) to collect stats from %s: ignored", elapsed, socketFile)
-		return
-	}
-
-	ps.Report(socketFile, vmi, vmStats)
-}
-
-func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats) {
-	// statsMaxAge is an estimation - and there is not better way to do that. So it is possible that
-	// GetDomainStats() takes enough time to lag behind, but not enough to trigger the statsMaxAge check.
-	// In this case the next functions will end up writing on a closed channel. This will panic.
-	// It is actually OK in this case to abort the goroutine that panicked -that's what we want anyway,
-	// and the very reason we collect in throwaway goroutines. We need however to avoid dump stacktraces in the logs.
-	// Since this is a known failure condition, let's handle it explicitely.
-	defer func() {
-		if err := recover(); err != nil {
-			log.Log.V(2).Warningf("collector goroutine panicked for VM %s: %s", socketFile, err)
-		}
-	}()
-
-	updateMemory(vmi, vmStats, ps.ch)
-	updateVcpu(vmi, vmStats, ps.ch)
-	updateBlock(vmi, vmStats, ps.ch)
-	updateNetwork(vmi, vmStats, ps.ch)
-}
-
-func Handler(MaxRequestsInFlight int) http.Handler {
-	return promhttp.InstrumentMetricHandler(
-		prometheus.DefaultRegisterer,
-		promhttp.HandlerFor(
-			prometheus.DefaultGatherer,
-			promhttp.HandlerOpts{
-				MaxRequestsInFlight: MaxRequestsInFlight,
-			}),
-	)
-}
+ import (
+	 "fmt"
+	 "net/http"
+	 "strings"
+	 "time"
+ 
+	 "github.com/prometheus/client_golang/prometheus"
+	 "github.com/prometheus/client_golang/prometheus/promhttp"
+ 
+	 k6tv1 "kubevirt.io/client-go/api/v1"
+	 "kubevirt.io/client-go/kubecli"
+	 "kubevirt.io/client-go/log"
+	 "kubevirt.io/client-go/version"
+	 "kubevirt.io/kubevirt/pkg/util/lookup"
+	 cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	 "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
+ )
+ 
+ const statsMaxAge time.Duration = collectionTimeout + 2*time.Second // "a bit more" than timeout, heuristic again
+ 
+ var (
+	 // Formatter used to sanitize k8s metadata into metric labels
+	 labelFormatter = strings.NewReplacer(".", "_", "/", "_", "-", "_")
+ 
+	 // see https://www.robustperception.io/exposing-the-software-version-to-prometheus
+	 versionDesc = prometheus.NewDesc(
+		 "kubevirt_info",
+		 "Version information",
+		 []string{"goversion", "kubeversion"},
+		 nil,
+	 )
+ 
+	 // higher-level, telemetry-friendly metrics
+	 vmiCountDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_phase_count",
+		 "VMI phase.",
+		 []string{
+			 "node", "phase",
+		 },
+		 nil,
+	 )
+ 
+	 // lower level metrics
+	 storageIopsLabels = []string{"node", "namespace", "name", "drive", "type"}
+	 storageIopsDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_storage_iops_total",
+		 "I/O operation performed.",
+		 storageIopsLabels,
+		 nil,
+	 )
+ 
+	 storageTrafficLabels = []string{"node", "namespace", "name", "drive", "type"}
+	 storageTrafficDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_storage_traffic_bytes_total",
+		 "storage traffic.",
+		 storageTrafficLabels,
+		 nil,
+	 )
+ 
+	 storageTimesLabels = []string{"node", "namespace", "name", "drive", "type"}
+	 storageTimesDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_storage_times_ms_total",
+		 "storage operation time.",
+		 storageTimesLabels,
+		 nil,
+	 )
+ 
+	 vcpuUsageLabels = []string{"node", "namespace", "name", "id", "state"}
+	 vcpuUsageDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_vcpu_seconds",
+		 "Vcpu elapsed time.",
+		 vcpuUsageLabels,
+		 nil,
+	 )
+ 
+	 networkTrafficBytesLabels = []string{"node", "namespace", "name", "interface", "type"}
+	 networkTrafficBytesDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_network_traffic_bytes_total",
+		 "network traffic.",
+		 networkTrafficBytesLabels,
+		 nil,
+	 )
+ 
+	 networkTrafficPktsLabels = []string{"node", "namespace", "name", "interface", "type"}
+	 networkTrafficPktsDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_network_traffic_packets_total",
+		 "network traffic.",
+		 networkTrafficPktsLabels,
+		 nil,
+	 )
+ 
+	 networkErrorsLabels = []string{"node", "namespace", "name", "interface", "type"}
+	 networkErrorsDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_network_errors_total",
+		 "network errors.",
+		 networkErrorsLabels,
+		 nil,
+	 )
+ 
+	 memoryAvailableLabels = []string{"node", "namespace", "name"}
+	 memoryAvailableDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_memory_available_bytes",
+		 "amount of usable memory as seen by the domain.",
+		 memoryAvailableLabels,
+		 nil,
+	 )
+ 
+	 memoryResidentLabels = []string{"node", "namespace", "name"}
+	 memoryResidentDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_memory_resident_bytes",
+		 "resident set size of the process running the domain",
+		 memoryResidentLabels,
+		 nil,
+	 )
+ 
+	 swapTrafficLabels = []string{"node", "namespace", "name", "type"}
+	 swapTrafficDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_memory_swap_traffic_bytes_total",
+		 "swap memory traffic.",
+		 swapTrafficLabels,
+		 nil,
+	 )
+ )
+ 
+ func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch chan<- prometheus.Metric) {
+	 if err != nil {
+		 log.Log.V(4).Warningf("Error creating the new const metric for %s: %s", memoryAvailableDesc, err)
+		 return
+	 }
+	 ch <- mv
+ }
+ 
+ func updateMemory(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	 var memoryResidentLabelValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
+	 var memoryAvailableLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name}
+	 var swapTrafficInLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "in"}
+	 var swapTrafficOutLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, "out"}
+ 
+	 // Add k8s metadata.Labels as metric labels
+	 labelPreffix := "vmi_k8s_label_"
+	 for label, val := range vmi.Labels {
+		 memoryResidentLabels = append(memoryResidentLabels, labelPreffix+labelFormatter.Replace(label))
+		 memoryResidentLabelValues = append(memoryResidentLabelValues, val)
+ 
+		 memoryAvailableLabels = append(memoryAvailableLabels, labelPreffix+labelFormatter.Replace(label))
+		 memoryAvailableLabelsValues = append(memoryAvailableLabelsValues, val)
+ 
+		 swapTrafficLabels = append(swapTrafficLabels, labelPreffix+labelFormatter.Replace(label))
+		 swapTrafficInLabelsValues = append(swapTrafficInLabelsValues, val)
+		 swapTrafficOutLabelsValues = append(swapTrafficOutLabelsValues, val)
+	 }
+ 
+	 // Add k8s metadata.Annotations as metric labels
+	 annotationPreffix := "vmi_k8s_annotation_"
+	 for annotation, val := range vmi.Annotations {
+		 memoryResidentLabels = append(memoryResidentLabels, annotationPreffix+labelFormatter.Replace(annotation))
+		 memoryResidentLabelValues = append(memoryResidentLabelValues, val)
+ 
+		 memoryAvailableLabels = append(memoryAvailableLabels, annotationPreffix+labelFormatter.Replace(annotation))
+		 memoryAvailableLabelsValues = append(memoryAvailableLabelsValues, val)
+ 
+		 swapTrafficLabels = append(swapTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
+		 swapTrafficInLabelsValues = append(swapTrafficInLabelsValues, val)
+		 swapTrafficOutLabelsValues = append(swapTrafficOutLabelsValues, val)
+	 }
+ 
+ 
+	 memoryResidentDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_memory_resident_bytes",
+		 "resident set size of the process running the domain",
+		 memoryResidentLabels,
+		 nil,
+	 )
+ 
+	 memoryAvailableDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_memory_available_bytes",
+		 "amount of usable memory as seen by the domain.",
+		 memoryAvailableLabels,
+		 nil,
+	 )
+ 
+	 swapTrafficDesc = prometheus.NewDesc(
+		 "kubevirt_vmi_memory_swap_traffic_bytes_total",
+		 "swap memory traffic.",
+		 swapTrafficLabels,
+		 nil,
+	 )
+ 
+	 if vmStats.Memory.RSSSet {
+		 mv, err := prometheus.NewConstMetric(
+			 memoryResidentDesc, prometheus.GaugeValue,
+			 // the libvirt value is in KiB
+			 float64(vmStats.Memory.RSS)*1024,
+			 memoryResidentLabelValues...
+		 )
+		 tryToPushMetric(memoryResidentDesc, mv, err, ch)
+	 }
+ 
+	 if vmStats.Memory.AvailableSet {
+		 mv, err := prometheus.NewConstMetric(
+			 memoryAvailableDesc, prometheus.GaugeValue,
+			 // the libvirt value is in KiB
+			 float64(vmStats.Memory.Available)*1024,
+			 memoryAvailableLabelsValues...
+		 )
+		 tryToPushMetric(memoryAvailableDesc, mv, err, ch)
+	 }
+ 
+ 
+	 if vmStats.Memory.SwapInSet {
+		 mv, err := prometheus.NewConstMetric(
+			 swapTrafficDesc, prometheus.GaugeValue,
+			 // the libvirt value is in KiB
+			 float64(vmStats.Memory.SwapIn)*1024,
+			 swapTrafficInLabelsValues...
+		 )
+		 tryToPushMetric(swapTrafficDesc, mv, err, ch)
+	 }
+	 if vmStats.Memory.SwapOutSet {
+		 mv, err := prometheus.NewConstMetric(
+			 swapTrafficDesc, prometheus.GaugeValue,
+			 // the libvirt value is in KiB
+			 float64(vmStats.Memory.SwapOut)*1024,
+			 swapTrafficOutLabelsValues...
+		 )
+		 tryToPushMetric(swapTrafficDesc, mv, err, ch)
+	 }
+ }
+ 
+ func updateVcpu(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	 for vcpuId, vcpu := range vmStats.Vcpu {
+		 var vcpuUsageLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, fmt.Sprintf("%v", vcpuId), fmt.Sprintf("%v", vcpu.State)}
+ 
+		 // Add k8s metadata.Labels as metric labels
+		 labelPreffix := "vmi_k8s_label_"
+		 for label, val := range vmi.Labels {
+			 vcpuUsageLabels = append(vcpuUsageLabels, labelPreffix+labelFormatter.Replace(label))
+			 vcpuUsageLabelsValues = append(vcpuUsageLabelsValues, val)
+		 }
+ 
+		 // Add k8s metadata.Annotations as metric labels
+		 annotationPreffix := "vmi_k8s_annotation_"
+		 for annotation, val := range vmi.Annotations {
+			 vcpuUsageLabels = append(vcpuUsageLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 vcpuUsageLabelsValues = append(vcpuUsageLabelsValues, val)
+		 }
+ 
+		 vcpuUsageDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_vcpu_seconds",
+			 "Vcpu elapsed time.",
+			 vcpuUsageLabels,
+			 nil,
+		 )
+ 
+		 if !vcpu.StateSet || !vcpu.TimeSet {
+			 log.Log.V(4).Warningf("State or time not set for vcpu#%d", vcpuId)
+			 continue
+		 }
+		 mv, err := prometheus.NewConstMetric(
+			 vcpuUsageDesc, prometheus.GaugeValue,
+			 float64(vcpu.Time/1000000000),
+			 vcpuUsageLabelsValues...
+		 )
+		 tryToPushMetric(vcpuUsageDesc, mv, err, ch)
+	 }
+ }
+ 
+ func updateBlock(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	 for blockId, block := range vmStats.Block {
+		 var storageIopsReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
+		 var storageIopsWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+		 var storageTrafficReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
+		 var storageTrafficWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+		 var storageTimesReadLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "read"}
+		 var storageTimesWriteLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, block.Name, "write"}
+ 
+		 // Add k8s metadata.Labels as metric labels
+		 labelPreffix := "vmi_k8s_label_"
+		 for label, val := range vmi.Labels {
+			 storageIopsLabels = append(storageIopsLabels, labelPreffix+labelFormatter.Replace(label))
+			 storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
+			 storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
+ 
+			 storageTrafficLabels = append(storageTrafficLabels, labelPreffix+labelFormatter.Replace(label))
+			 storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
+			 storageTrafficWriteLabelsValues = append(storageTrafficWriteLabelsValues, val)
+ 
+			 storageTimesLabels = append(storageTimesLabels, labelPreffix+labelFormatter.Replace(label))
+			 storageTimesReadLabelsValues = append(storageTimesReadLabelsValues, val)
+			 storageTimesWriteLabelsValues = append(storageTimesWriteLabelsValues, val)
+		 }
+ 
+		 // Add k8s metadata.Annotations as metric labels
+		 annotationPreffix := "vmi_k8s_annotation_"
+		 for annotation, val := range vmi.Annotations {
+			 storageIopsLabels = append(storageIopsLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 storageIopsReadLabelsValues = append(storageIopsReadLabelsValues, val)
+			 storageIopsWriteLabelsValues = append(storageIopsReadLabelsValues, val)
+ 
+			 storageTrafficLabels = append(storageTrafficLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 storageTrafficReadLabelsValues = append(storageTrafficReadLabelsValues, val)
+			 storageTrafficWriteLabelsValues = append(storageTrafficWriteLabelsValues, val)
+ 
+			 storageTimesLabels = append(storageTimesLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 storageTimesReadLabelsValues = append(storageTimesReadLabelsValues, val)
+			 storageTimesWriteLabelsValues = append(storageTimesWriteLabelsValues, val)
+		 }
+ 
+		 storageIopsDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_storage_iops_total",
+			 "I/O operation performed.",
+			 storageIopsLabels,
+			 nil,
+		 )
+ 
+		 storageTrafficDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_storage_traffic_bytes_total",
+			 "storage traffic.",
+			 storageTrafficLabels,
+			 nil,
+		 )
+ 
+		 storageTimesDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_storage_times_ms_total",
+			 "storage operation time.",
+			 storageTimesLabels,
+			 nil,
+		 )
+ 
+		 if !block.NameSet {
+			 log.Log.V(4).Warningf("Name not set for block device#%d", blockId)
+			 continue
+		 }
+ 
+		 if block.RdReqsSet {
+			 mv, err := prometheus.NewConstMetric(
+				 storageIopsDesc, prometheus.CounterValue,
+				 float64(block.RdReqs),
+				 storageIopsReadLabelsValues...
+			 )
+			 tryToPushMetric(storageIopsDesc, mv, err, ch)
+		 }
+		 if block.WrReqsSet {
+			 mv, err := prometheus.NewConstMetric(
+				 storageIopsDesc, prometheus.CounterValue,
+				 float64(block.WrReqs),
+				 storageIopsWriteLabelsValues...
+			 )
+			 tryToPushMetric(storageIopsDesc, mv, err, ch)
+		 }
+ 
+		 if block.RdBytesSet {
+			 mv, err := prometheus.NewConstMetric(
+				 storageTrafficDesc, prometheus.CounterValue,
+				 float64(block.RdBytes),
+				 storageTrafficReadLabelsValues...
+			 )
+			 tryToPushMetric(storageTrafficDesc, mv, err, ch)
+		 }
+		 if block.WrBytesSet {
+			 mv, err := prometheus.NewConstMetric(
+				 storageTrafficDesc, prometheus.CounterValue,
+				 float64(block.WrBytes),
+				 storageTrafficWriteLabelsValues...
+			 )
+			 tryToPushMetric(storageTrafficDesc, mv, err, ch)
+		 }
+ 
+		 if block.RdTimesSet {
+			 mv, err := prometheus.NewConstMetric(
+				 storageTimesDesc, prometheus.CounterValue,
+				 float64(block.RdTimes),
+				 storageTimesReadLabelsValues...
+			 )
+			 tryToPushMetric(storageTimesDesc, mv, err, ch)
+		 }
+		 if block.WrTimesSet {
+			 mv, err := prometheus.NewConstMetric(
+				 storageTimesDesc, prometheus.CounterValue,
+				 float64(block.WrTimes),
+				 storageTimesWriteLabelsValues...
+			 )
+			 tryToPushMetric(storageTimesDesc, mv, err, ch)
+		 }
+	 }
+ }
+ 
+ func updateNetwork(vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats, ch chan<- prometheus.Metric) {
+	 for _, net := range vmStats.Net {
+		 var networkTrafficBytesRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
+		 var networkTrafficBytesTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
+		 var networkTrafficPktsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
+		 var networkTrafficPktsTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
+		 var networkErrorsRxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "rx",}
+		 var networkErrorsTxLabelsValues = []string{vmi.Status.NodeName, vmi.Namespace, vmi.Name, net.Name, "tx",}
+ 
+		 // Add k8s metadata.Labels as metric labels
+		 labelPreffix := "vmi_k8s_label_"
+		 for label, val := range vmi.Labels {
+			 networkTrafficBytesLabels = append(networkTrafficBytesLabels, labelPreffix+labelFormatter.Replace(label))
+			 networkTrafficBytesRxLabelsValues = append(networkTrafficBytesRxLabelsValues, val)
+			 networkTrafficBytesTxLabelsValues = append(networkTrafficBytesTxLabelsValues, val)
+ 
+			 networkTrafficPktsLabels = append(networkTrafficPktsLabels, labelPreffix+labelFormatter.Replace(label))
+			 networkTrafficPktsRxLabelsValues = append(networkTrafficPktsRxLabelsValues, val)
+			 networkTrafficPktsTxLabelsValues = append(networkTrafficPktsTxLabelsValues, val)
+ 
+			 networkErrorsLabels = append(networkErrorsLabels, labelPreffix+labelFormatter.Replace(label))
+			 networkErrorsRxLabelsValues = append(networkErrorsRxLabelsValues, val)
+			 networkErrorsTxLabelsValues = append(networkErrorsTxLabelsValues, val)
+		 }
+ 
+		 // Add k8s metadata.Annotations as metric labels
+		 annotationPreffix := "vmi_k8s_annotation_"
+		 for annotation, val := range vmi.Annotations {
+			 networkTrafficBytesLabels = append(networkTrafficBytesLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 networkTrafficBytesRxLabelsValues = append(networkTrafficBytesRxLabelsValues, val)
+			 networkTrafficBytesTxLabelsValues = append(networkTrafficBytesTxLabelsValues, val)
+ 
+			 networkTrafficPktsLabels = append(networkTrafficPktsLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 networkTrafficPktsRxLabelsValues = append(networkTrafficPktsRxLabelsValues, val)
+			 networkTrafficPktsTxLabelsValues = append(networkTrafficPktsTxLabelsValues, val)
+ 
+			 networkErrorsLabels = append(networkErrorsLabels, annotationPreffix+labelFormatter.Replace(annotation))
+			 networkErrorsRxLabelsValues = append(networkErrorsRxLabelsValues, val)
+			 networkErrorsTxLabelsValues = append(networkErrorsTxLabelsValues, val)
+		 }
+ 
+		 networkTrafficBytesDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_network_traffic_bytes_total",
+			 "network traffic.",
+			 networkTrafficBytesLabels,
+			 nil,
+		 )
+ 
+		 networkTrafficPktsDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_network_traffic_packets_total",
+			 "network traffic.",
+			 networkTrafficPktsLabels,
+			 nil,
+		 )
+ 
+		 networkErrorsDesc = prometheus.NewDesc(
+			 "kubevirt_vmi_network_errors_total",
+			 "network errors.",
+			 networkErrorsLabels,
+			 nil,
+		 )
+ 
+		 if !net.NameSet {
+			 continue
+		 }
+		 if net.RxBytesSet {
+			 mv, err := prometheus.NewConstMetric(
+				 networkTrafficBytesDesc, prometheus.CounterValue,
+				 float64(net.RxBytes),
+				 networkTrafficBytesRxLabelsValues...
+			 )
+			 tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
+		 }
+		 if net.RxPktsSet {
+			 mv, err := prometheus.NewConstMetric(
+				 networkTrafficPktsDesc, prometheus.CounterValue,
+				 float64(net.RxPkts),
+				 networkTrafficPktsRxLabelsValues...
+			 )
+			 tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
+		 }
+		 if net.RxErrsSet {
+			 mv, err := prometheus.NewConstMetric(
+				 networkErrorsDesc, prometheus.CounterValue,
+				 float64(net.RxErrs),
+				 networkErrorsRxLabelsValues...
+			 )
+			 tryToPushMetric(networkErrorsDesc, mv, err, ch)
+		 }
+ 
+		 if net.TxBytesSet {
+			 mv, err := prometheus.NewConstMetric(
+				 networkTrafficBytesDesc, prometheus.CounterValue,
+				 float64(net.TxBytes),
+				 networkTrafficBytesTxLabelsValues...
+			 )
+			 tryToPushMetric(networkTrafficBytesDesc, mv, err, ch)
+		 }
+		 if net.TxPktsSet {
+			 mv, err := prometheus.NewConstMetric(
+				 networkTrafficPktsDesc, prometheus.CounterValue,
+				 float64(net.TxPkts),
+				 networkTrafficPktsTxLabelsValues...
+			 )
+			 tryToPushMetric(networkTrafficPktsDesc, mv, err, ch)
+		 }
+		 if net.TxErrsSet {
+			 mv, err := prometheus.NewConstMetric(
+				 networkErrorsDesc, prometheus.CounterValue,
+				 float64(net.TxErrs),
+				 networkErrorsTxLabelsValues...
+			 )
+			 tryToPushMetric(networkErrorsDesc, mv, err, ch)
+		 }
+	 }
+ }
+ 
+ func makeVMIsPhasesMap(vmis []*k6tv1.VirtualMachineInstance) map[string]uint64 {
+	 phasesMap := make(map[string]uint64)
+ 
+	 for _, vmi := range vmis {
+		 phasesMap[strings.ToLower(string(vmi.Status.Phase))] += 1
+	 }
+ 
+	 return phasesMap
+ }
+ 
+ func updateVMIsPhase(nodeName string, vmis []*k6tv1.VirtualMachineInstance, ch chan<- prometheus.Metric) {
+	 phasesMap := makeVMIsPhasesMap(vmis)
+ 
+	 for phase, count := range phasesMap {
+		 mv, err := prometheus.NewConstMetric(
+			 vmiCountDesc, prometheus.GaugeValue,
+			 float64(count),
+			 nodeName, phase,
+		 )
+		 if err != nil {
+			 continue
+		 }
+		 ch <- mv
+	 }
+ }
+ 
+ func updateVersion(ch chan<- prometheus.Metric) {
+	 verinfo := version.Get()
+	 ch <- prometheus.MustNewConstMetric(
+		 versionDesc, prometheus.GaugeValue,
+		 1.0,
+		 verinfo.GoVersion, verinfo.GitVersion,
+	 )
+ }
+ 
+ type Collector struct {
+	 virtCli       kubecli.KubevirtClient
+	 virtShareDir  string
+	 nodeName      string
+	 concCollector *concurrentCollector
+ }
+ 
+ func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int) *Collector {
+	 log.Log.Infof("Starting collector: node name=%v", nodeName)
+	 co := &Collector{
+		 virtCli:       virtCli,
+		 virtShareDir:  virtShareDir,
+		 nodeName:      nodeName,
+		 concCollector: NewConcurrentCollector(MaxRequestsInFlight),
+	 }
+	 prometheus.MustRegister(co)
+	 return co
+ }
+ 
+ func (co *Collector) Describe(ch chan<- *prometheus.Desc) {
+	 // TODO: Use DescribeByCollect?
+	 ch <- versionDesc
+	 ch <- storageIopsDesc
+	 ch <- storageTrafficDesc
+	 ch <- storageTimesDesc
+	 ch <- vcpuUsageDesc
+	 ch <- networkTrafficBytesDesc
+	 ch <- networkTrafficPktsDesc
+	 ch <- networkErrorsDesc
+	 ch <- memoryAvailableDesc
+	 ch <- memoryResidentDesc
+ }
+ 
+ func newvmiSocketMapFromVMIs(baseDir string, vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap {
+	 if len(vmis) == 0 {
+		 return nil
+	 }
+ 
+	 ret := make(vmiSocketMap)
+	 for _, vmi := range vmis {
+		 socketPath, err := cmdclient.FindSocketOnHost(vmi)
+		 if err != nil {
+			 // nothing to scrape...
+			 // this means there's no socket or the socket
+			 // is currently unreachable for this vmi.
+			 continue
+		 }
+		 ret[socketPath] = vmi
+	 }
+	 return ret
+ }
+ 
+ // Note that Collect could be called concurrently
+ func (co *Collector) Collect(ch chan<- prometheus.Metric) {
+	 updateVersion(ch)
+ 
+	 vmis, err := lookup.VirtualMachinesOnNode(co.virtCli, co.nodeName)
+	 if err != nil {
+		 log.Log.Reason(err).Errorf("failed to list all VMIs in '%s': %s", co.nodeName, err)
+		 return
+	 }
+ 
+	 if len(vmis) == 0 {
+		 log.Log.V(4).Infof("No VMIs detected")
+		 return
+	 }
+ 
+	 socketToVMIs := newvmiSocketMapFromVMIs(co.virtShareDir, vmis)
+	 scraper := &prometheusScraper{ch: ch}
+	 co.concCollector.Collect(socketToVMIs, scraper, collectionTimeout)
+ 
+	 updateVMIsPhase(co.nodeName, vmis, ch)
+	 return
+ }
+ 
+ type prometheusScraper struct {
+	 ch chan<- prometheus.Metric
+ }
+ 
+ type vmiStatsInfo struct {
+	 vmiSpec  *k6tv1.VirtualMachineInstance
+	 vmiStats *stats.DomainStats
+ }
+ 
+ func (ps *prometheusScraper) Scrape(socketFile string, vmi *k6tv1.VirtualMachineInstance) {
+	 ts := time.Now()
+	 cli, err := cmdclient.NewClient(socketFile)
+	 if err != nil {
+		 log.Log.Reason(err).Error("failed to connect to cmd client socket")
+		 // Ignore failure to connect to client.
+		 // These are all local connections via unix socket.
+		 // A failure to connect means there's nothing on the other
+		 // end listening.
+		 return
+	 }
+	 defer cli.Close()
+ 
+	 vmStats, exists, err := cli.GetDomainStats()
+	 if err != nil {
+		 log.Log.Reason(err).Errorf("failed to update stats from socket %s", socketFile)
+		 return
+	 }
+	 if !exists || vmStats.Name == "" {
+		 log.Log.V(2).Infof("disappearing VM on %s, ignored", socketFile) // VM may be shutting down
+		 return
+	 }
+ 
+	 // GetDomainStats() may hang for a long time.
+	 // If it wakes up past the timeout, there is no point in send back any metric.
+	 // In the best case the information is stale, in the worst case the information is stale *and*
+	 // the reporting channel is already closed, leading to a possible panic - see below
+	 elapsed := time.Now().Sub(ts)
+	 if elapsed > statsMaxAge {
+		 log.Log.Infof("took too long (%v) to collect stats from %s: ignored", elapsed, socketFile)
+		 return
+	 }
+ 
+	 ps.Report(socketFile, vmi, vmStats)
+ }
+ 
+ func (ps *prometheusScraper) Report(socketFile string, vmi *k6tv1.VirtualMachineInstance, vmStats *stats.DomainStats) {
+	 // statsMaxAge is an estimation - and there is not better way to do that. So it is possible that
+	 // GetDomainStats() takes enough time to lag behind, but not enough to trigger the statsMaxAge check.
+	 // In this case the next functions will end up writing on a closed channel. This will panic.
+	 // It is actually OK in this case to abort the goroutine that panicked -that's what we want anyway,
+	 // and the very reason we collect in throwaway goroutines. We need however to avoid dump stacktraces in the logs.
+	 // Since this is a known failure condition, let's handle it explicitely.
+	 defer func() {
+		 if err := recover(); err != nil {
+			 log.Log.V(2).Warningf("collector goroutine panicked for VM %s: %s", socketFile, err)
+		 }
+	 }()
+ 
+	 updateMemory(vmi, vmStats, ps.ch)
+	 updateVcpu(vmi, vmStats, ps.ch)
+	 updateBlock(vmi, vmStats, ps.ch)
+	 updateNetwork(vmi, vmStats, ps.ch)
+ }
+ 
+ func Handler(MaxRequestsInFlight int) http.Handler {
+	 return promhttp.InstrumentMetricHandler(
+		 prometheus.DefaultRegisterer,
+		 promhttp.HandlerFor(
+			 prometheus.DefaultGatherer,
+			 promhttp.HandlerOpts{
+				 MaxRequestsInFlight: MaxRequestsInFlight,
+			 }),
+	 )
+ }
+  

--- a/pkg/monitoring/vms/prometheus/prometheus_test.go
+++ b/pkg/monitoring/vms/prometheus/prometheus_test.go
@@ -59,6 +59,472 @@ var _ = Describe("Prometheus", func() {
 			Expect(testReportPanic).ToNot(Panic())
 		})
 	})
+
+	Context("on handling push", func() {
+		It("should send rss", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu: &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{
+					// trigger write on a socket. We need a value set - any value
+					RSS:    1024,
+					RSSSet: true,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_resident_bytes"))
+		})
+
+		It("should send available memory", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu: &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{
+					AvailableSet: true,
+					Available:    2048,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_available_bytes"))
+		})
+
+		It("should handle swapin", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu: &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{
+					SwapInSet: true,
+					SwapIn:    4096,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_swap_traffic_bytes_total"))
+		})
+
+		It("should handle swapout", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu: &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{
+					SwapOutSet: true,
+					SwapOut:    4096,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_memory_swap_traffic_bytes_total"))
+		})
+
+		It("should handle vcpu metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Vcpu: []stats.DomainStatsVcpu{
+					{
+						StateSet: true,
+						State:    1,
+						TimeSet:  true,
+						Time:     2000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_vcpu_seconds"))
+		})
+
+		It("should handle block read iops metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:   true,
+						Name:      "vda",
+						RdReqsSet: true,
+						RdReqs:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_iops_total"))
+		})
+
+		It("should handle block write iops metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:   true,
+						Name:      "vda",
+						WrReqsSet: true,
+						WrReqs:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_iops_total"))
+		})
+
+		It("should handle block read bytes metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:    true,
+						Name:       "vda",
+						RdBytesSet: true,
+						RdBytes:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_traffic_bytes_total"))
+		})
+
+		It("should handle block write bytes metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:    true,
+						Name:       "vda",
+						WrBytesSet: true,
+						WrBytes:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_traffic_bytes_total"))
+		})
+
+		It("should handle block read time metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:    true,
+						Name:       "vda",
+						RdTimesSet: true,
+						RdTimes:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_times_ms_total"))
+		})
+
+		It("should handle block write time metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:    true,
+						Name:       "vda",
+						WrTimesSet: true,
+						WrTimes:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_times_ms_total"))
+		})
+
+		It("should handle network rx traffic bytes metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Net: []stats.DomainStatsNet{
+					{
+						NameSet:    true,
+						Name:       "vnet0",
+						RxBytesSet: true,
+						RxBytes:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_traffic_bytes_total"))
+		})
+
+		It("should handle network tx traffic bytes metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Net: []stats.DomainStatsNet{
+					{
+						NameSet:    true,
+						Name:       "vnet0",
+						TxBytesSet: true,
+						TxBytes:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_traffic_bytes_total"))
+		})
+
+		It("should handle network rx packets metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Net: []stats.DomainStatsNet{
+					{
+						NameSet:   true,
+						Name:      "vnet0",
+						RxPktsSet: true,
+						RxPkts:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_traffic_packets_total"))
+		})
+
+		It("should handle network tx traffic bytes metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Net: []stats.DomainStatsNet{
+					{
+						NameSet:   true,
+						Name:      "vnet0",
+						TxPktsSet: true,
+						TxPkts:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_traffic_packets_total"))
+		})
+
+		It("should handle network rx errors metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Net: []stats.DomainStatsNet{
+					{
+						NameSet:   true,
+						Name:      "vnet0",
+						RxErrsSet: true,
+						RxErrs:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_errors_total"))
+		})
+
+		It("should handle network tx traffic bytes metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Net: []stats.DomainStatsNet{
+					{
+						NameSet:   true,
+						Name:      "vnet0",
+						TxErrsSet: true,
+						TxErrs:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_errors_total"))
+		})
+
+		It("should add kubernetes metadata labels", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu: &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{
+					RSS:    1024,
+					RSSSet: true,
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"kubevirt.io/nodeName": "node01",
+					},
+				},
+			}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubernetes_vmi_label_kubevirt_io_nodeName"))
+		})
+	})
 })
 
 var _ = Describe("Utility functions", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -776,6 +776,21 @@ var _ = Describe("Infrastructure", func() {
 				}
 			}
 		})
+
+		It("[test_id:4147]should include kubernetes labels to VMI metrics", func() {
+			// Every VMI is labeled with kubevirt.io/nodeName, so just creating a VMI should
+			// be enough to its metrics to contain a kubernetes label
+			containK8sLabel := false
+			metrics := collectMetrics("kubevirt_vmi_vcpu_seconds")
+			By("Checking collected metrics")
+			keys := getKeysFromMetrics(metrics)
+			for _, key := range keys {
+				if strings.Contains(key, "kubernetes_vmi_label_") {
+					containK8sLabel = true
+				}
+			}
+			Expect(containK8sLabel).To(Equal(true))
+		})
 	})
 
 	Describe("Start a VirtualMachineInstance", func() {


### PR DESCRIPTION
Signed-off-by: arthursens <arthursens2005@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds K8s metadata labels to VMI metrics.

This facilitates users to identify VMIs and aggregate metrics as they prefer and to implement their own monitoring solutions that best suit their needs


#### Labels
As said at the [Kubernetes Labels and Selectors concept documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
> Labels enable users to map their own organizational structures onto system objects in a loosely coupled fashion, without requiring clients to store these mappings.
> Example labels:
>
> * "release" : "stable", "release" : "canary"
> * "environment" : "dev", "environment" : "qa", "environment" : "production"
> * "tier" : "frontend", "tier" : "backend", "tier" : "cache"
>*  "partition" : "customerA", "partition" : "customers"
> * "track" : "daily", "track" : "weekly"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2108

**Special notes for your reviewer**:
To test this I'm using the [vmi-fedora example](https://github.com/kubevirt/kubevirt/blob/master/examples/vmi-fedora.yaml).

After deploying the VMI, I get the following metadata when describing the resource:
```
./cluster-up/kubectl.sh describe virtualmachineinstances/vmi-fedora

Name:         vmi-fedora
Namespace:    default
Labels:       kubevirt.io/nodeName=node01
              special=vmi-fedora
```
Which is then translated into metric labels on every VMI metric(Note that it doesn't occur on metric not related to VMIs):
```
curl -k https://localhost:8443/metrics | grep kubevirt
# TYPE kubevirt_info gauge
kubevirt_info{goversion="go1.12.8",kubeversion="{gitVersion}"} 1
# HELP kubevirt_vmi_memory_resident_bytes resident set size of the process running the domain.
# TYPE kubevirt_vmi_memory_resident_bytes gauge
kubevirt_vmi_memory_resident_bytes{domain="default_vmi-fedora",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01"} 4.34688e+08
# HELP kubevirt_vmi_network_errors_total network errors.
# TYPE kubevirt_vmi_network_errors_total counter
kubevirt_vmi_network_errors_total{domain="default_vmi-fedora",interface="vnet0",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01",type="rx"} 0
kubevirt_vmi_network_errors_total{domain="default_vmi-fedora",interface="vnet0",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01",type="tx"} 0
# HELP kubevirt_vmi_network_traffic_bytes_total network traffic.
# TYPE kubevirt_vmi_network_traffic_bytes_total counter
kubevirt_vmi_network_traffic_bytes_total{domain="default_vmi-fedora",interface="vnet0",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01",type="rx"} 13386
kubevirt_vmi_network_traffic_bytes_total{domain="default_vmi-fedora",interface="vnet0",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01",type="tx"} 5070
# HELP kubevirt_vmi_network_traffic_packets_total network traffic.
# TYPE kubevirt_vmi_network_traffic_packets_total counter
kubevirt_vmi_network_traffic_packets_total{domain="default_vmi-fedora",interface="vnet0",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01",type="rx"} 99
kubevirt_vmi_network_traffic_packets_total{domain="default_vmi-fedora",interface="vnet0",kubernetes_vmi_label_kubevirt_io_nodeName="node01",kubernetes_vmi_label_special="vmi-fedora",name="vmi-fedora",namespace="default",node="node01",type="tx"} 58

.
.
.
```



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds kubernetes metadata.labels as VMI metrics' label
```
