### PR TITLE
Revert "Update VMI status with latest Pod network IP"

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -208,12 +208,6 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	// Directory to store notwork information related to VMIs
-	err = os.MkdirAll(util.NetworkInfoDir, 0755)
-	if err != nil {
-		panic(err)
-	}
-
 	cmdclient.SetPodsBaseDir("/pods")
 	cmdclient.SetLegacyBaseDir(app.VirtShareDir)
 	containerdisk.SetKubeletPodsDirectory(app.KubeletPodsDir)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,15 +8,11 @@ const ExtensionAPIServerAuthenticationConfigMap = "extension-apiserver-authentic
 const RequestHeaderClientCAFileKey = "requestheader-client-ca-file"
 const VirtShareDir = "/var/run/kubevirt"
 const VirtPrivateDir = "/var/run/kubevirt-private"
-const NetworkInfoDir = VirtPrivateDir + "/network-info-cache"
 const VirtLibDir = "/var/lib/kubevirt"
 const KubeletPodsDir = "/var/lib/kubelet/pods"
 const HostRootMount = "/proc/1/root/"
 const CPUManagerOS3Path = HostRootMount + "var/lib/origin/openshift.local.volumes/cpu_manager_state"
 const CPUManagerPath = HostRootMount + "var/lib/kubelet/cpu_manager_state"
-
-var VMIInterfaceDir = NetworkInfoDir + "/%s"
-var VMIInterfacepath = NetworkInfoDir + "/%s/%s"
 
 func IsSRIOVVmi(vmi *v1.VirtualMachineInstance) bool {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -368,6 +368,19 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 
 					// vmi is still owned by the controller but pod is already ready,
 					// so let's hand over the vmi too
+					interfaces := make([]virtv1.VirtualMachineInstanceNetworkInterface, 0)
+					for _, network := range vmi.Spec.Networks {
+						if network.NetworkSource.Pod != nil {
+							ifc := virtv1.VirtualMachineInstanceNetworkInterface{
+								Name: network.Name,
+								IP:   pod.Status.PodIP,
+								IPs:  []string{pod.Status.PodIP},
+							}
+							interfaces = append(interfaces, ifc)
+						}
+					}
+					vmiCopy.Status.Interfaces = interfaces
+
 					vmiCopy.Status.Phase = virtv1.Scheduled
 					if vmiCopy.Labels == nil {
 						vmiCopy.Labels = map[string]string{}

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -49,7 +49,6 @@ go_test(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/testutils:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -140,7 +140,6 @@ func NewController(
 
 	c.launcherClients = make(map[types.UID]*launcherClientInfo)
 	c.phase1NetworkSetupCache = make(map[types.UID]int)
-	c.podInterfaceCache = make(map[string]*network.PodCacheInterface)
 
 	c.domainNotifyPipes = make(map[string]string)
 
@@ -177,11 +176,6 @@ type VirtualMachineController struct {
 	// prevents cycling an unncessary posix thread.
 	phase1NetworkSetupCache     map[types.UID]int
 	phase1NetworkSetupCacheLock sync.Mutex
-
-	// key is the file path, value is the contents.
-	// if key exists, then don't read directly from file.
-	podInterfaceCache     map[string]*network.PodCacheInterface
-	podInterfaceCacheLock sync.Mutex
 
 	domainNotifyPipes map[string]string
 }
@@ -334,23 +328,9 @@ func (d *VirtualMachineController) hasTargetDetectedDomain(vmi *v1.VirtualMachin
 
 func (d *VirtualMachineController) clearPodNetworkPhase1(vmi *v1.VirtualMachineInstance) {
 	d.phase1NetworkSetupCacheLock.Lock()
+	defer d.phase1NetworkSetupCacheLock.Unlock()
+
 	delete(d.phase1NetworkSetupCache, vmi.UID)
-	d.phase1NetworkSetupCacheLock.Unlock()
-
-	// Clean Pod interface cache from map and files
-	d.podInterfaceCacheLock.Lock()
-	for key, _ := range d.podInterfaceCache {
-		if strings.Contains(key, string(vmi.UID)) {
-			delete(d.podInterfaceCache, key)
-		}
-	}
-	d.podInterfaceCacheLock.Unlock()
-
-	vmiIfaceDir := fmt.Sprintf(virtutil.VMIInterfaceDir, vmi.UID)
-	err := os.RemoveAll(vmiIfaceDir)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to delete VMI Network cache files: %s", err.Error())
-	}
 }
 
 // Reaching into the network namespace of the VMI's pod is expensive because
@@ -397,36 +377,6 @@ func domainMigrated(domain *api.Domain) bool {
 	return false
 }
 
-func (d *VirtualMachineController) getPodInterfacefromFileCache(vmi *v1.VirtualMachineInstance, ifaceName string) (*network.PodCacheInterface, error) {
-	ifacepath := fmt.Sprintf(virtutil.VMIInterfacepath, vmi.ObjectMeta.UID, ifaceName)
-
-	// Once the Interface files are set on the handler, they don't change
-	// If already present in the map, don't read again
-	d.podInterfaceCacheLock.Lock()
-	result, exists := d.podInterfaceCache[ifacepath]
-	d.podInterfaceCacheLock.Unlock()
-
-	if exists {
-		return result, nil
-	}
-
-	content, err := ioutil.ReadFile(ifacepath)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to read from cache file: %s", err.Error())
-		return nil, err
-	}
-	err = json.Unmarshal(content, &result)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to unmarshal interface content: %s", err.Error())
-		return nil, err
-	}
-	d.podInterfaceCacheLock.Lock()
-	d.podInterfaceCache[ifacepath] = result
-	d.podInterfaceCacheLock.Unlock()
-
-	return result, nil
-}
-
 func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain, syncError error) (err error) {
 	condManager := controller.NewVirtualMachineInstanceConditionManager()
 
@@ -457,31 +407,10 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 			}
 		}
 
-		if len(vmi.Status.Interfaces) == 0 {
-			// Set Pod Interface
-			interfaces := make([]v1.VirtualMachineInstanceNetworkInterface, 0)
-			for _, network := range vmi.Spec.Networks {
-				if network.NetworkSource.Pod != nil {
-					podIface, err := d.getPodInterfacefromFileCache(vmi, network.Name)
-					if err != nil {
-						return err
-					}
-					ifc := v1.VirtualMachineInstanceNetworkInterface{
-						Name: network.Name,
-						IP:   podIface.PodIP,
-						IPs:  []string{podIface.PodIP},
-					}
-					interfaces = append(interfaces, ifc)
-				}
-			}
-			vmi.Status.Interfaces = interfaces
-		}
-
 		if len(domain.Spec.Devices.Interfaces) > 0 || len(domain.Status.Interfaces) > 0 {
 			// This calculates the vmi.Status.Interfaces based on the following data sets:
-			// - vmi.Status.Interfaces - previously calculated interfaces, this can contain data (pod IP)
-			//   set in the previous loops (when there are no interfaces), which can not be deleted,
-			//   unless overridden by Qemu agent
+			// - vmi.Status.Interfaces - previously calculated interfaces, this can contains data
+			//   set in the controller (pod IP) which can not be deleted, unless overridden by Qemu agent
 			// - domain.Spec - interfaces form the Spec
 			// - domain.Status.Interfaces - interfaces reported by guest agent (emtpy if Qemu agent not running)
 			newInterfaces := []v1.VirtualMachineInstanceNetworkInterface{}
@@ -502,10 +431,6 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 			for _, existingInterfaceSpec := range vmi.Spec.Domain.Devices.Interfaces {
 				existingInterfacesSpecByName[existingInterfaceSpec.Name] = existingInterfaceSpec
 			}
-			existingNetworksByName := map[string]v1.Network{}
-			for _, existingNetwork := range vmi.Spec.Networks {
-				existingNetworksByName[existingNetwork.Name] = existingNetwork
-			}
 
 			// Iterate through all domain.Spec interfaces
 			for _, domainInterface := range domain.Spec.Devices.Interfaces {
@@ -522,19 +447,6 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 					// Only interfaces defined in domain.Spec are handled here
 					newInterface = existingInterface
 					newInterface.MAC = interfaceMAC
-
-					// If it is a Combination of Masquerade+Pod network, check IP from file cache
-					if existingInterfacesSpecByName[domainInterface.Alias.Name].Masquerade != nil && existingNetworksByName[domainInterface.Alias.Name].NetworkSource.Pod != nil {
-						iface, err := d.getPodInterfacefromFileCache(vmi, domainInterface.Alias.Name)
-						if err != nil {
-							return err
-						}
-						if iface.PodIP != existingInterfaceStatusByName[domainInterface.Alias.Name].IP {
-							newInterface.Name = domainInterface.Alias.Name
-							newInterface.IP = iface.PodIP
-							newInterface.IPs = []string{iface.PodIP}
-						}
-					}
 				} else {
 					// If not present in vmi.Status.Interfaces, create a new one based on domain.Spec
 					newInterface = v1.VirtualMachineInstanceNetworkInterface{

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -21,15 +21,12 @@ package virthandler
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"time"
-
-	"kubevirt.io/kubevirt/pkg/util"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -533,7 +530,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				},
 			}
 			updatedVMI.Status.MigrationMethod = v1.LiveMigration
-			updatedVMI.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
+
 			mockWatchdog.CreateFile(vmi)
 			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
 			domain.Status.Status = api.Running
@@ -633,7 +630,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 					Status:        k8sv1.ConditionTrue,
 				},
 			}
-			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
 
 			mockWatchdog.CreateFile(vmi)
 
@@ -924,7 +920,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Labels = make(map[string]string)
 			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = "othernode"
-			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				TargetNode:                     "othernode",
 				TargetNodeAddress:              "127.0.0.1:12345",
@@ -1033,7 +1028,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmiUpdated.Status.MigrationState.EndTimestamp = &now
 			vmiUpdated.Status.NodeName = "othernode"
 			vmiUpdated.Labels[v1.NodeNameLabel] = "othernode"
-			vmiUpdated.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
 			vmiInterface.EXPECT().Update(vmiUpdated)
 
 			controller.Execute()
@@ -1402,13 +1396,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 				interface_name := "interface_name"
 
 				vmi.Spec.Networks = []v1.Network{
-					{
+					v1.Network{
 						Name:          interface_name,
 						NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 					},
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{
+					v1.Interface{
 						Name: interface_name,
 						InterfaceBindingMethod: v1.InterfaceBindingMethod{
 							Bridge: &v1.InterfaceBridge{},
@@ -1425,13 +1419,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 				interface_name := "interface_name"
 
 				vmi.Spec.Networks = []v1.Network{
-					{
+					v1.Network{
 						Name:          interface_name,
 						NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 					},
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{
+					v1.Interface{
 						Name: interface_name,
 						InterfaceBindingMethod: v1.InterfaceBindingMethod{
 							Masquerade: &v1.InterfaceMasquerade{},
@@ -1448,13 +1442,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 				interface_name := "interface_name"
 
 				vmi.Spec.Networks = []v1.Network{
-					{
+					v1.Network{
 						Name:          interface_name,
 						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
 					},
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{
+					v1.Interface{
 						Name: interface_name,
 						InterfaceBindingMethod: v1.InterfaceBindingMethod{
 							Bridge: &v1.InterfaceBridge{},
@@ -1468,143 +1462,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 		})
 
 	})
-	Context("When VirtualMachineInstance is connected to a network", func() {
-
-		It("should only report the pod network in status", func() {
-
-			vmi := v1.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			interfaceName := "interface_name"
-			vmi.Spec.Networks = []v1.Network{
-				{
-					Name:          interfaceName,
-					NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-				},
-				{
-					Name: "testmultus",
-					NetworkSource: v1.NetworkSource{
-						Multus: &v1.MultusNetwork{
-							NetworkName: "multus",
-						},
-					},
-				},
-			}
-			vmi.Status.Phase = v1.Scheduled
-			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
-
-			podCacheInterface := network.PodCacheInterface{
-				Iface: &v1.Interface{
-					Name: interfaceName,
-				},
-				PodIP: "1.1.1.1",
-			}
-			podJson, err := json.Marshal(podCacheInterface)
-			Expect(err).ToNot(HaveOccurred())
-			err = os.MkdirAll(fmt.Sprintf(util.VMIInterfaceDir, vmi.UID), 0755)
-			Expect(err).ToNot(HaveOccurred())
-			vmiInterfacepath := fmt.Sprintf(util.VMIInterfacepath, vmi.UID, interfaceName)
-			f, err := os.Create(vmiInterfacepath)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = f.WriteString(string(podJson))
-			Expect(err).ToNot(HaveOccurred())
-			f.Close()
-
-			mockWatchdog.CreateFile(vmi)
-			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-			domain.Status.Status = api.Running
-			vmiFeeder.Add(vmi)
-			domainFeeder.Add(domain)
-
-			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Interfaces)).To(Equal(1))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].Name).To(Equal(podCacheInterface.Iface.Name))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IP).To(Equal(podCacheInterface.PodIP))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IPs[0]).To(Equal(podCacheInterface.PodIP))
-
-			}).Return(vmi, nil)
-
-			controller.Execute()
-			Expect(len(controller.podInterfaceCache)).To(Equal(1))
-		})
-
-		It("Should update masquerade interface with the pod IP", func() {
-			vmi := v1.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			vmi.Status.Phase = v1.Scheduled
-			interfaceName := "interface_name"
-			MAC := "1C:CE:C0:01:BE:E7"
-			vmi.Spec.Networks = []v1.Network{
-				{
-					Name:          interfaceName,
-					NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-				},
-			}
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{
-					Name: interfaceName,
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Masquerade: &v1.InterfaceMasquerade{},
-					},
-				},
-			}
-			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-				{
-					Name: interfaceName,
-					IP:   "1.1.1.1",
-					MAC:  MAC,
-				},
-			}
-
-			podCacheInterface := network.PodCacheInterface{
-				Iface: &v1.Interface{
-					Name: interfaceName,
-				},
-				PodIP: "2.2.2.2",
-			}
-			podJson, err := json.Marshal(podCacheInterface)
-			Expect(err).ToNot(HaveOccurred())
-			err = os.MkdirAll(fmt.Sprintf(util.VMIInterfaceDir, vmi.UID), 0755)
-			Expect(err).ToNot(HaveOccurred())
-			vmiInterfacepath := fmt.Sprintf(util.VMIInterfacepath, vmi.UID, interfaceName)
-			f, err := os.Create(vmiInterfacepath)
-			Expect(err).ToNot(HaveOccurred())
-			_, err = f.WriteString(string(podJson))
-			Expect(err).ToNot(HaveOccurred())
-			f.Close()
-
-			mockWatchdog.CreateFile(vmi)
-			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-			domain.Status.Status = api.Running
-			domain.Spec.Devices.Interfaces = []api.Interface{
-				{
-					MAC:   &api.MAC{MAC: MAC},
-					Alias: &api.Alias{Name: interfaceName},
-				},
-			}
-			domain.Status.Interfaces = []api.InterfaceStatus{
-				{
-					Name: interfaceName,
-					Mac:  MAC,
-					Ip:   "1.1.1.1",
-					IPs:  []string{"1.1.1.1"},
-				},
-			}
-			vmiFeeder.Add(vmi)
-			domainFeeder.Add(domain)
-
-			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Interfaces)).To(Equal(1))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].Name).To(Equal(podCacheInterface.Iface.Name))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IP).To(Equal(podCacheInterface.PodIP))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].MAC).To(Equal(domain.Status.Interfaces[0].Mac))
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].IPs[0]).To(Equal(podCacheInterface.PodIP))
-			}).Return(vmi, nil)
-
-			controller.Execute()
-		})
-	})
 	Context("VirtualMachineInstance controller gets informed about interfaces in a Domain", func() {
 		It("should update existing interface with MAC", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
@@ -1615,7 +1472,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			interface_name := "interface_name"
 
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-				{
+				v1.VirtualMachineInstanceNetworkInterface{
 					IP:   "1.1.1.1",
 					MAC:  "C0:01:BE:E7:15:G0:0D",
 					Name: interface_name,
@@ -1629,7 +1486,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			new_MAC := "1C:CE:C0:01:BE:E7"
 
 			domain.Spec.Devices.Interfaces = []api.Interface{
-				{
+				api.Interface{
 					MAC:   &api.MAC{MAC: new_MAC},
 					Alias: &api.Alias{Name: interface_name},
 				},
@@ -1659,7 +1516,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			ips := []string{"2.2.2.2/24", "3.3.3.3/16"}
 
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-				{
+				v1.VirtualMachineInstanceNetworkInterface{
 					IP:   "1.1.1.1",
 					MAC:  mac,
 					Name: interfaceName,
@@ -1671,13 +1528,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 			domain.Status.Status = api.Running
 
 			domain.Spec.Devices.Interfaces = []api.Interface{
-				{
+				api.Interface{
 					MAC:   &api.MAC{MAC: mac},
 					Alias: &api.Alias{Name: interfaceName},
 				},
 			}
 			domain.Status.Interfaces = []api.InterfaceStatus{
-				{
+				api.InterfaceStatus{
 					Name: interfaceName,
 					Mac:  mac,
 					Ip:   ip,
@@ -1736,7 +1593,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			old_MAC := "C0:01:BE:E7:15:G0:0D"
 
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-				{
+				v1.VirtualMachineInstanceNetworkInterface{
 					IP:   "1.1.1.1",
 					MAC:  old_MAC,
 					Name: old_interface_name,
@@ -1751,11 +1608,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 			new_MAC := "1C:CE:C0:01:BE:E7"
 
 			domain.Spec.Devices.Interfaces = []api.Interface{
-				{
+				api.Interface{
 					MAC:   &api.MAC{MAC: old_MAC},
 					Alias: &api.Alias{Name: old_interface_name},
 				},
-				{
+				api.Interface{
 					MAC:   &api.MAC{MAC: new_MAC},
 					Alias: &api.Alias{Name: new_interface_name},
 				},
@@ -1784,7 +1641,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			interface_name := "interface_name"
 
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-				{
+				v1.VirtualMachineInstanceNetworkInterface{
 					IP:  "1.1.1.1",
 					MAC: "C0:01:BE:E7:15:G0:0D",
 				},
@@ -1797,18 +1654,18 @@ var _ = Describe("VirtualMachineInstance", func() {
 			new_MAC := "1C:CE:C0:01:BE:E7"
 
 			domain.Spec.Devices.Interfaces = []api.Interface{
-				{
+				api.Interface{
 					MAC:   &api.MAC{MAC: new_MAC},
 					Alias: &api.Alias{Name: interface_name},
 				},
 			}
 
 			vmi.Spec.Networks = []v1.Network{
-				{
+				v1.Network{
 					Name:          "other_name",
 					NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
 				},
-				{
+				v1.Network{
 					Name:          interface_name,
 					NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 				},
@@ -1883,7 +1740,7 @@ func (m *vmiCondMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	for ind := range vmi.Status.Conditions {
+	for ind, _ := range vmi.Status.Conditions {
 		if m.vmi.Status.Conditions[ind].Type != vmi.Status.Conditions[ind].Type {
 			return false
 		}

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/network/dhcp:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
@@ -37,7 +36,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/util:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -27,10 +27,8 @@ package network
 
 import (
 	"fmt"
-	"os"
 
 	v1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -42,11 +40,6 @@ var vifCacheFile = "/proc/%s/root/var/run/kubevirt-private/vif-cache-%s.json"
 var NetworkInterfaceFactory = getNetworkClass
 
 var podInterfaceName = podInterface
-
-type PodCacheInterface struct {
-	Iface *v1.Interface `json:"iface,omitempty"`
-	PodIP string        `json:"podIP,omitempty"`
-}
 
 type plugFunction func(vif NetworkInterface, vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error
 
@@ -102,11 +95,6 @@ func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string
 }
 
 func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error {
-	// Create a dir with VMI UID under network-info-dir to store network files
-	err := os.MkdirAll(fmt.Sprintf(util.VMIInterfaceDir, vmi.ObjectMeta.UID), 0755)
-	if err != nil {
-		return err
-	}
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		networkInterfaceFactory, err := getNetworkInterfaceFactory(networks, iface.Name)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -451,14 +451,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 					// check VMI, confirm migration state
 					confirmVMIPostMigration(vmi, migrationUID)
-
-					By("Check if Migrated VMI has updated PodIP")
-					Eventually(func() bool {
-						newvmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred(), "Should successfully get new VMI")
-						vmiPod := tests.GetRunningPodByVirtualMachineInstance(newvmi, tests.NamespaceTestDefault)
-						return newvmi.Status.Interfaces[0].IP == vmiPod.Status.PodIP
-					}, 180*time.Second, 1*time.Second).Should(BeTrue())
 				}
 				// delete VMI
 				By("Deleting the VMI")
@@ -1703,21 +1695,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					targetNode.Name,
 					targetNode.Name,
 				))
-
-				By("Checking that all migrated VMIs have the new pod IP address on VMI status")
-				for _, vmi := range vmis {
-					Eventually(func() error {
-						newvmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
-						Expect(err).ToNot(HaveOccurred(), "Should successfully get new VMI")
-						vmiPod := tests.GetRunningPodByVirtualMachineInstance(newvmi, tests.NamespaceTestDefault)
-
-						if newvmi.Status.Interfaces[0].IP == vmiPod.Status.PodIP {
-							return nil
-						}
-
-						return fmt.Errorf("interface not updated with latest IP")
-					}, 1*time.Minute, 1*time.Second).Should(BeNil(), "Should match PodIP with latest VMI Status after migration")
-				}
 			})
 		})
 


### PR DESCRIPTION
Reverts kubevirt/kubevirt#3488 because CI seems to have merged it without all tests passing

```release-note
Reverts kubevirt/kubevirt#3488 because CI seems to have merged it without all tests passing
```