### PR TITLE
Switch to kubevirtci/nfs-ganesha

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -378,17 +378,17 @@ container_pull(
 # Pull nfs-server image
 container_pull(
     name = "nfs-server",
-    digest = "sha256:2a8c1cad9156165d0be1ee2c78fb2342f8368193acff72eb276ff276512508fa",
+    digest = "sha256:8c1fa882dddb2885c4152e9ce632c466f4b8dce29339455e9b6bfe71f0a3d3ef",
     registry = "index.docker.io",
-    repository = "slintes/nfs-ganesha",  # see https://github.com/slintes/docker-nfs-ganesha
+    repository = "kubevirtci/nfs-ganesha",  # see https://github.com/slintes/docker-nfs-ganesha
 )
 
 container_pull(
     name = "nfs-server_ppc64le",
-    digest = "sha256:2a8c1cad9156165d0be1ee2c78fb2342f8368193acff72eb276ff276512508fa",
+    digest = "sha256:8c1fa882dddb2885c4152e9ce632c466f4b8dce29339455e9b6bfe71f0a3d3ef",
     puller_linux = "@go_puller_linux_ppc64le//file:downloaded",
     registry = "index.docker.io",
-    repository = "slintes/nfs-ganesha",  # see https://github.com/slintes/docker-nfs-ganesha
+    repository = "kubevirtci/nfs-ganesha",  # see https://github.com/slintes/docker-nfs-ganesha
 )
 
 load(


### PR DESCRIPTION
Host the image in kubevirtci to restore the build since
slintes/nfs-ganesha is deleted.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
