### PR TITLE
Rename chroot to virt-chroot

### DIFF
--- a/cmd/virt-chroot/BUILD.bazel
+++ b/cmd/virt-chroot/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["main.go"],
-    importpath = "kubevirt.io/kubevirt/cmd/chroot",
+    importpath = "kubevirt.io/kubevirt/cmd/virt-chroot",
     visibility = ["//visibility:private"],
     deps = [
         "//vendor/github.com/spf13/cobra:go_default_library",
@@ -12,7 +12,7 @@ go_library(
 )
 
 go_binary(
-    name = "chroot",
+    name = "virt-chroot",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/virt-chroot/main.go
+++ b/cmd/virt-chroot/main.go
@@ -26,7 +26,7 @@ func init() {
 func main() {
 
 	rootCmd := &cobra.Command{
-		Use: "chroot",
+		Use: "virt-chroot",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 
 			if mntNamespace != "" {

--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -83,8 +83,8 @@ container_image(
     entrypoint = ["/usr/bin/virt-handler"],
     files = [
         ":virt-handler",
-        "//cmd/chroot",
         "//cmd/container-disk-v2alpha:container-disk",
+        "//cmd/virt-chroot",
     ],
     visibility = ["//visibility:public"],
 )

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -236,7 +236,7 @@ func (m *mounter) Mount(vmi *v1.VirtualMachineInstance, verify bool) error {
 				}
 				f.Close()
 
-				out, err := exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "mount", "-o", "ro,bind", strings.TrimPrefix(sourceFile, nodeRes.MountRoot()), targetFile).CombinedOutput()
+				out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "mount", "-o", "ro,bind", strings.TrimPrefix(sourceFile, nodeRes.MountRoot()), targetFile).CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to bindmount containerDisk %v: %v : %v", volume.Name, string(out), err)
 				}
@@ -279,7 +279,7 @@ func (m *mounter) legacyUnmount(vmi *v1.VirtualMachineInstance) error {
 			if mounted, err := isolation.NodeIsolationResult().IsMounted(path); err != nil {
 				return fmt.Errorf("failed to check mount point for containerDisk %v: %v", path, err)
 			} else if mounted {
-				out, err := exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "umount", path).CombinedOutput()
+				out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "umount", path).CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to unmount containerDisk %v: %v : %v", path, string(out), err)
 				}
@@ -317,7 +317,7 @@ func (m *mounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 			if mounted, err := isolation.NodeIsolationResult().IsMounted(path); err != nil {
 				return fmt.Errorf("failed to check mount point for containerDisk %v: %v", path, err)
 			} else if mounted {
-				out, err := exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "umount", path).CombinedOutput()
+				out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "umount", path).CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to unmount containerDisk %v: %v : %v", path, string(out), err)
 				}

--- a/pkg/virt-handler/isolation/validation.go
+++ b/pkg/virt-handler/isolation/validation.go
@@ -15,7 +15,7 @@ const (
 func GetImageInfo(imagePath string, context IsolationResult) (*containerdisk.DiskInfo, error) {
 
 	out, err := exec.Command(
-		"/usr/bin/chroot", "--user", "qemu", "--memory", "1000", "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
+		"/usr/bin/virt-chroot", "--user", "qemu", "--memory", "1000", "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
 		QEMUIMGPath, "info", imagePath, "--output", "json",
 	).Output()
 	if err != nil {

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -96,7 +96,7 @@ func (se *SELinuxImpl) execute(binary string, paths []string, args ...string) (o
 		argsArray = append(argsArray, arg)
 	}
 
-	return se.execFunc("/usr/bin/chroot", argsArray...)
+	return se.execFunc("/usr/bin/virt-chroot", argsArray...)
 }
 
 func copyPolicy(policyName string, dir string) (err error) {
@@ -165,7 +165,7 @@ func (se *SELinuxImpl) InstallPolicy(dir string) (err error) {
 		if err != nil {
 			return fmt.Errorf("failed to copy policy %v - err: % v", fileDest, err)
 		}
-		out, err := exec.Command("/usr/bin/chroot", "--mount", "/proc/1/ns/mnt", "exec", "--", "/usr/sbin/semodule", "-i", fileDest).CombinedOutput()
+		out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "exec", "--", "/usr/sbin/semodule", "-i", fileDest).CombinedOutput()
 		if err != nil {
 			if perm, _ := se.IsPermissive(); perm {
 				log.Log.Warningf("Permissive mode, ignoring 'semodule' failure: out: %q, error: %v", string(out), err)


### PR DESCRIPTION
During various experiments building the kubevirt components, a scenario
was encountered where a post-build file checker complained about
cmd/chroot not behaving like the system chroot. Since the interface is
quite different than the system chroot, rename it to virt-chroot.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>

**What this PR does / why we need it**: 
It renames cmd/chroot to cmd/virt-chroot to make it clear that it is different from the system chroot.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
