### PR TITLE
Write to virt-launcher logs if devices are not present

### DIFF
--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -296,8 +296,10 @@ func (dpi *GenericDevicePlugin) healthCheck() error {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("could not stat the device: %v", err)
 		}
+		logger.Warningf("device '%s' is not present, the device plugin can't expose it.", dpi.devicePath)
 		dpi.health <- pluginapi.Unhealthy
 	}
+	logger.Infof("device '%s' is present.", dpi.devicePath)
 
 	dirName = filepath.Dir(dpi.socketPath)
 	err = watcher.Add(dirName)


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't log if a device which we want to expose is not present on the
node. Change that to make failure diagnosis easier.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Log if critical devices, like kvm, which virt-handler wants to expose are not present on the node.
```
