### PR TITLE
Flaky functest - [test_id:1779] fixing race in the Expecter

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -680,12 +680,15 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "search example.com"},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "nameserver 8.8.8.8"},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "nameserver 4.2.2.1"},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$"},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Having multiple `expect.BExp` one after the other without an `expect.BSnd`
between them is raceful.

`expect.BExp` is waiting for the desired expression in the current buffer
and flushes the buffer once the expression is found.

For example -
```
&expect.BSnd{S: "a\nb"},
&expect.BExp{R: "a"},
&expect.BExp{R: "b"}
```

In the good scenario we will get -
```
Sent: "a\nb"
Match for RE: "a" found: ["a"] Buffer:
$a
Match for RE: "b" found: ["b"] Buffer:
b
```

In the bad scenario we will get -
```
Sent: "a\nb"
Match for RE: "a" found: ["a"] Buffer:
$a
b
```

The second match (looking for 'b') will never be met since 'b' was already
in the buffer when the first match was found, therefore it was flushed by
the first `expect.BExp`.

To avoid this we need to make sure the `expect.BExp` is only expecting text
that was added to the buffer after the previous expectation was met.

Possible race in [test_id:1779] that is fixed by this PR -

```
Sent: "cat /etc/resolv.conf\n"
Match for RE: "search example.com" found: ["search example.com"] Buffer: 
$ cat /etc/resolv.conf
search example.com
Match for RE: "\\$" found: ["$"] Buffer: 
nameserver 8.8.8.8
nameserver 4.2.2.1
$
Sent: "cat /etc/resolv.conf\n"
Match for RE: "nameserver 8.8.8.8" found: ["nameserver 8.8.8.8"] Buffer:  cat /etc/resolv.conf
search example.com
nameserver 8.8.8.8
nameserver 4.2.2.1
$ 
```

Since the '$' is part of the last buffer, the next `Exp` expecting for it won't ever be met.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3602

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
