### PR TITLE
virt-launcher: remove redundant condition check

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -347,9 +347,6 @@ func main() {
 		panic(err)
 	}
 	util.StartLibvirt(stopChan)
-	if err != nil {
-		panic(err)
-	}
 	util.StartVirtlog(stopChan)
 
 	domainConn := createLibvirtConnection()


### PR DESCRIPTION
A small fix that removes redundant condition check in virt-launcher main. 
err variable remains the same before and after call to util.StartLibvirt since
the function didn't return any value.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

Fixes #

**Special notes for your reviewer**:

```release-note
None
```
