### PR TITLE
virt-controller: fix null pointer dereference in Pod Disruption Budget controller

### DIFF
--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -362,7 +362,7 @@ func (c *DisruptionBudgetController) sync(key string, vmi *virtv1.VirtualMachine
 			c.recorder.Eventf(vmi, v12.EventTypeWarning, FailedDeletePodDisruptionBudgetReason, "Error deleting the PodDisruptionBudget %s: %v", pdb.Name, err)
 			return err
 		}
-		c.recorder.Eventf(vmi, v12.EventTypeNormal, SuccessfulDeletePodDisruptionBudgetReason, "Deleted PodDisruptionBudget %s", pdb.Name)
+		c.recorder.Eventf(vmi, v12.EventTypeNormal, SuccessfulDeletePodDisruptionBudgetReason, "Deleted PodDisruptionBudget %s", pdbKey)
 		return nil
 	} else if create {
 		two := intstr.FromInt(2)


### PR DESCRIPTION
There was an attempt to read PDB name after it's deletion.
Instead of using it's name, use PDB key for recording the deletion event.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Prevent virt-controller process from a crash when recording a deletion event.

Fixes #

```release-note
None
```
