### PR TITLE
WORKSPACE: Update libvirt container

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -342,10 +342,10 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:584c7b49f1615e3f229668d530a79945ebf7f3afbab4ec554187e9ba2b754008",
+    digest = "sha256:6a817da0fa85d6698e93594ef9d1d084358d62c93ed1b1237f3d147f77f92b58",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
-    #tag = "av-8.2-20200514-cc2bc34",
+    #tag = "av-8.2-20200629-e049c89",
 )
 
 # TODO: Update this once we have PPC builds of the base image available


### PR DESCRIPTION
**What this PR does / why we need it**:

Use a newer version of the kubevirt/libvirt container.

See https://github.com/kubevirt/libvirt/pull/55 for details of the changes in the container image.

**Which issue(s) this PR fixes**:

Fixes #3587

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE (I think :)
```
