### PR TITLE
Fixes handler crash

### DIFF
--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -150,13 +150,14 @@ func RunServer(virtShareDir string, stopChan chan struct{}, c chan watch.Event, 
 	}()
 
 	// wait for either the server to exit or stopChan to signal
-	select {
-	case <-done:
-		log.Log.Info("notify server done")
-	case <-stopChan:
-		grpcServer.Stop()
-		log.Log.Info("notify server stopped")
+	for {
+		select {
+		case <-done:
+			log.Log.Info("notify server done")
+			return nil
+		case <-stopChan:
+			grpcServer.Stop()
+			log.Log.Info("notify server stopped")
+		}
 	}
-
-	return nil
 }


### PR DESCRIPTION
Fixes a race condition where we didn't fully wait for the notify server to exit. 

```release-note
NONE
```
