### PR TITLE
Moved cleanup of test from AfterEach() hook to test body

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -768,7 +768,6 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
-
 			})
 		})
 		Context("with an Cirros shared ISCSI PVC", func() {
@@ -836,18 +835,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			AfterEach(func() {
-				By("Deleting the VMI")
-				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
-
-				By("Waiting for VMI to disappear")
-				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 				// PVs can't be reused
 				tests.DeletePvAndPvc(pvName)
-
-				By("Deleting NFS pod")
-				Expect(virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(tests.NFSTargetName, &metav1.DeleteOptions{})).To(Succeed())
-				By("Waiting for NFS pod to disappear")
-				tests.WaitForPodToDisappearWithTimeout(tests.NFSTargetName, 120)
 			})
 			It("[test_id:2653]  should be migrated successfully, using guest agent on VM", func() {
 				// Start the VirtualMachineInstance with the PVC attached
@@ -901,6 +890,16 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				}, 30*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "Should be able to access the mounted service account file")
 
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+
+				By("Deleting NFS pod")
+				Expect(virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(tests.NFSTargetName, &metav1.DeleteOptions{})).To(Succeed())
+				By("Waiting for NFS pod to disappear")
+				tests.WaitForPodToDisappearWithTimeout(tests.NFSTargetName, 120)
 			})
 		})
 


### PR DESCRIPTION
When this test fails the AfterEach block is ran before the reporter
calls Dump(). This means we are unable to get the logs for the NFS
and the virt-launcher pods.

Signed-off-by: Ashley Schuett <ashleyns1992@gmail.com>

**What this PR does / why we need it**:
This allows us to get more logs for debuging if this test fails in the future 

**Which issue(s) this PR fixes** :

Fixes #

**Special notes for your reviewer**:
It looks like the VMI clean up at one point was happening in the body of the test and was then moved to the `AfterEach()` block. https://github.com/kubevirt/kubevirt/commit/8646e5b851b62ebcd76f2e3833fa5ef2e9750132 

I'm unable to figure out the reason for this change however and it seems to be the standard in other test cases to clean up the VMI in the test body. 

**Release note**:
```release-note
None
```
