### PR TITLE
Make the tests binary an artifact of the release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ deploy:
   - _out/templates/manifests/release/kubevirt-cr.yaml.j2
   - _out/manifests/release/olm/kubevirt-operatorsource.yaml
   - _out/manifests/release/olm/bundle/kubevirtoperator.$TRAVIS_TAG.clusterserviceversion.yaml
+  - _out/tests/tests.test
   prerelease: true
   overwrite: true
   name: $TRAVIS_TAG


### PR DESCRIPTION
To ease the consumption of the tests binary, we should have it an
artifact of the release. It allows users and automations to consume the
tests binary without having to compile it themselves.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The tests binary is now part of the release and can be consumed from the GitHub release page.
```
