### PR TITLE
Tests suite cleanup to always create artifacts dir

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"kubevirt.io/kubevirt/tests/reporter"
 
@@ -50,7 +51,12 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	tests.AfterTestSuitCleanup()
+	// We have to create the artifacts directory before running any cleanup code
+	// because in case of a failure in one of the cleanup steps, we still want to
+	// be able to store artifacts.
+	artifactsDir, err := tests.CreateDirectory(os.Getenv("ARTIFACTS"))
+	Expect(err).ToNot(HaveOccurred())
+	tests.AfterTestSuitCleanup(artifactsDir)
 })
 
 func getMaxFailsFromEnv() int {


### PR DESCRIPTION
We used to create the artifacts directory at the very end of the suite
cleanup. The problem with this approach is that if something failed or
paniced along the way, we never actaully create the artifacts directory
and then, other Ginkgo reporters such as the JUnit reporter fail to
write the report.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
