### PR TITLE
Exclude test suites from fetching changed tests

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -37,6 +37,7 @@ function new_tests {
     # 5. remove last `|`
     git diff --name-status "${target_commit}".. -- tests/ \
         | grep -v -E '^D.*' \
+        | grep -v '_suite' \
         | grep -E '_test\.go$' \
         | sed -E 's/[AM]\s+tests\/(.*_test)\.go/\1/' \
         | tr '\n' '|' \
@@ -91,8 +92,8 @@ NUM_TESTS=${NUM_TESTS-3}
 echo "Number of per lane runs: $NUM_TESTS"
 
 test_start_pattern='(Specify|It|Entry)\('
-tests_total_estimate=$(find tests/ -name '*_test.go' -print0 | xargs -0 grep -E "${test_start_pattern}" | wc -l | awk '{total += $1} END {print total}')
-tests_to_run_estimate=$(git diff --name-status "${TARGET_COMMIT}".. -- tests/ | grep -v -E '^D.*' | grep -o -E 'tests\/[a-z_]+_test\.go' | xargs grep -E "${test_start_pattern}" | wc -l | awk '{total += $1} END {print total}')
+tests_total_estimate=$(find tests/ -name '*_test.go' -print0 | xargs -0 grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
+tests_to_run_estimate=$(echo "${NEW_TESTS}" | tr '|' '\n' | sed 's/.*/tests\/&\.go/g' | xargs grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
 tests_total_for_all_runs_estimate=$(expr $tests_to_run_estimate \* $NUM_TESTS \* ${#TEST_LANES[@]})
 echo -e "Estimates:\ttests_total_estimate: $tests_total_estimate\ttests_total_for_all_runs_estimate: $tests_total_for_all_runs_estimate"
 if [ $tests_total_for_all_runs_estimate -gt $tests_total_estimate ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Related to the previous grep exit code 123 problem there exists another corner case
when a suite file has been changed, that actually does not contain tests
but was counted as a test that changed. This is now excluded.

Also minor refactorings:
* reusing the existing NEW_TESTS instead of again finding all tests files
* replacing the word count with a count in grep

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @danielBelenky FYI, your PR fails the lane check-tests-for-flakes due to the changes in the test suite file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
