### PR TITLE
[release-0.30] Use GracefulStop instead of Stop for GRPC server

### DIFF
--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -154,11 +155,31 @@ func RunServer(virtShareDir string, stopChan chan struct{}, c chan watch.Event, 
 	case <-done:
 		log.Log.Info("notify server done")
 	case <-stopChan:
-		log.Log.Info("stopping notify server")
-		grpcServer.Stop()
+		grpcServerStop(grpcServer)
 		sock.Close()
 		os.Remove(sockFile)
 	}
 
 	return nil
+}
+
+func grpcServerStop(grpcServer *grpc.Server) {
+	gracefulShutdownTimeout := 10
+
+	isStopped := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(isStopped)
+	}()
+
+	t := time.NewTimer(time.Second * time.Duration(gracefulShutdownTimeout))
+	defer t.Stop()
+
+	select {
+	case <-t.C:
+		log.Log.Infof("notify server GracefulStop timed out after %d seconds, using Stop", gracefulShutdownTimeout)
+		grpcServer.Stop()
+	case <-isStopped:
+		log.Log.Infof("notify server GracefulStop complete")
+	}
 }


### PR DESCRIPTION
This is a manual cherry-pick of #3713 

GRPC Stop doesn't wait for existing RPC to be finished totally,
but just until it opens a grpc serveStreams go routine.
It cause serveStreams goroutines to exists even after
reflector eventChan is closed, and can cause a race that would
result in panic: send on closed channel.

GracefulStop does wait for the whole grpc connections to be
totally closed, existing RPCs would first finish, new ones will
not be created and just after all existing ones are closed,
the channel would be closed.

Currently we close the server upon application layer client ERROR,
which is not needed, since the server has one instance per virt-handler,
and client side errors shouldn't affect
grpc server side, which serves all the clients in the node.
This would be taken care of in another commit.

Meanwhile we should make the grpc stopping mechanism safer.
Since GraceFulStop is blocking operation, it would fallback to Stop
after a timeout, in order to not leave the virt-handler unstable in
In such a case, a new server will be spawned.
The usage of it would be reduced drastically, once the above commit
would be presented.

Fixes: #3575

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
