### PR TITLE
Add assertion to domain start/stop test

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1096,12 +1096,22 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				// Check if the stop event was logged
 				By("Checking that virt-handler logs VirtualMachineInstance deletion")
+				/*
+						Since we deleted the VMI object, there are two possible outcomes and both are expected:
+						1. virt-controller kicks in, registers a deletion request on the launcher pod and K8s deletes the pod
+					       before virt-handler had a chance to set or check the deletion timestamp on the domain.
+						2. virt-handler detects the deletion timestamp on the domain and removes it.
+
+						TODO: https://github.com/kubevirt/kubevirt/issues/3764
+				*/
 				Eventually(func() string {
 					data, err := logsQuery.DoRaw()
 					Expect(err).ToNot(HaveOccurred(), "Should get the virthandler logs")
 					return string(data)
-				}, 30, 0.5).Should(MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is marked for deletion","name":"%s"`, vmi.GetObjectMeta().GetName()), "Logs should confirm pod deletion")
-
+				}, 30, 0.5).Should(SatisfyAny(
+					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is marked for deletion","name":"%s"`, vmi.GetObjectMeta().GetName()),               // Domain was deleted by virt-handler
+					MatchRegexp(`"kind":"Domain","level":"info","msg":"Domain is in state Shutoff reason Destroyed","name":"%s"`, vmi.GetObjectMeta().GetName()), // Domain was destroyed because the launcher pod is gone
+				), "Logs should confirm pod deletion")
 			},
 				table.Entry("[test_id:1641]"+tests.NamespaceTestDefault, tests.NamespaceTestDefault),
 				table.Entry("[test_id:1642]"+tests.NamespaceTestAlternative, tests.NamespaceTestAlternative),


### PR DESCRIPTION
There are 2 paths that we support in which a domain can be removed in
case of a VMI deletion:

1. virt-controllers kicks in and registers a deletion request on the
   launcher and then K8s removes the pod before we get a chance to
   actually delete the domain.
2. virt-launcher/virt-handler sets the deletion timestamp on the domain
   and we get to properly remove it.

This test was failing sporadically because we used to check only the 2nd
path.

Since log parsing during tests can lead to various issues, I've opened
opened https://github.com/kubevirt/kubevirt/issues/3764 to see if
we can find a better way to address those tests.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3573

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
