### PR TITLE
Don't emit event if we fail to sync a final VMI

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1181,7 +1181,7 @@ func (d *VirtualMachineController) defaultExecute(key string,
 		log.Log.Object(vmi).V(3).Info("No update processing required")
 	}
 
-	if syncErr != nil {
+	if syncErr != nil && !vmi.IsFinal() {
 		d.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.SyncFailed.String(), syncErr.Error())
 		log.Log.Object(vmi).Reason(syncErr).Error("Synchronizing the VirtualMachineInstance failed.")
 	}


### PR DESCRIPTION
This reduces the chance for a race where we try to sync a VMI in a final
state where its domain was removed or in a process of being removed
during the sync.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3687

```release-note
Do not emit a SyncFailed event if we fail to sync a VMI in a final state
```
