### PR TITLE
K8s reporter to own a sub dir under $ARTIFACTS

### DIFF
--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"testing"
 
@@ -35,7 +36,9 @@ import (
 
 func TestTests(t *testing.T) {
 	maxFails := getMaxFailsFromEnv()
-	reporters := []Reporter{reporter.NewKubernetesReporter(os.Getenv("ARTIFACTS"), maxFails)}
+	reporters := []Reporter{
+		reporter.NewKubernetesReporter(path.Join(os.Getenv("ARTIFACTS"), "k8s-reporter"), maxFails),
+	}
 	if ginkgo_reporters.Polarion.Run {
 		reporters = append(reporters, &ginkgo_reporters.Polarion)
 	}


### PR DESCRIPTION
The K8s reporter removes the artifacts directory whenver it starts the
test and it doesn't create it later if it failed to generate a client
for the cluster. Since other reporters also depend on the shared
artifacts dir, they fail as well.

This commit gives the K8s reporter it's own artifacts sub dir to own and
manage however it needs to.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
