### PR TITLE
Add build verification targets to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ bazel-generate:
 bazel-build:
 	hack/dockerized "hack/bazel-fmt.sh && hack/bazel-build.sh"
 
+bazel-build-verify: TARGET_TO_RUN='make'
+bazel-build-verify: bazel-build check-git-tree-state build-verify bazel-test
+
 bazel-build-images:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} DOCKER_TAG_ALT=${DOCKER_TAG_ALT} IMAGE_PREFIX=${IMAGE_PREFIX} IMAGE_PREFIX_ALT=${IMAGE_PREFIX_ALT} ./hack/bazel-build-images.sh"
 
@@ -22,12 +25,23 @@ bazel-push-images:
 
 push: bazel-push-images
 
+check-git-tree-state:
+ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
+	$(error git tree is not clean, you probably need to run '${TARGET_TO_RUN}' and commit the changes)
+endif
+
+check-for-binaries:
+	hack/check-for-binaries.sh
+
 bazel-test:
 	hack/dockerized "hack/bazel-fmt.sh && hack/bazel-test.sh"
 
 generate:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"
 	SYNC_VENDOR=true hack/dockerized "./hack/bazel-generate.sh && hack/bazel-fmt.sh"
+
+generate-verify: TARGET_TO_RUN='make generate'
+generate-verify: generate check-for-binaries check-git-tree-state
 
 apidocs:
 	hack/dockerized "./hack/generate.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1 html"

--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -1,23 +1,8 @@
 #!/bin/bash -e
 
 
-make generate
-if [[ -n "$(git status --porcelain)" ]] ; then
-    echo "It seems like you need to run 'make generate'. Please run it and commit the changes"
-    git status --porcelain; false
-fi
-
-if diff <(git grep -c '') <(git grep -cI '') | egrep -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*' | grep '^<'; then
-    echo "Binary files are present in git repostory."; false
-fi
-
-make
-
-if [[ -n "$(git status --porcelain)" ]] ; then
-    echo "It seems like you need to run 'make'. Please run it and commit the changes"; git status --porcelain; false
-fi
-
-make build-verify # verify that we set version on the packages built by bazel
+make generate-verify
+make bazel-build-verify
 
 # The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
 while sleep 9m; do echo "Long running job - keep alive"; done & LOOP_PID=$!

--- a/hack/check-for-binaries.sh
+++ b/hack/check-for-binaries.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if diff <(git grep -c '') <(git grep -cI '') |
+    grep -E -v -e 'docs/.*\.png|swagger-ui' -e 'vendor/*' -e 'assets/*' |
+    grep '^<'; then
+    echo "Binary files are present in git repostory."
+    exit 1
+fi


### PR DESCRIPTION
The purpose of those targets is to serve as an entrypoint for Prow jobs.
The idea is to eventually replace automation/travisci-test.sh and the
single Travis-CI job with multiple Prow jobs that will run in parallel.

I also modified the travis-ci testing script in this commit to get proper CI
coverage for this work. There should be no change in the functionality
of the targets as opposed to calling them and wrapping the calls with
some checks from a shell script.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
