### PR TITLE
tests: Parse flags once and do not execute code in the ginkgo containers body

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "flags.go",
         "test.go",
         "utils.go",
     ],

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -35,8 +35,6 @@ import (
 
 var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:component]User Access", func() {
 
-	tests.FlagParse()
-
 	view := tests.ViewServiceAccountName
 	edit := tests.EditServiceAccountName
 	admin := tests.AdminServiceAccountName

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -36,7 +36,6 @@ import (
 
 var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component]Config", func() {
 
-	tests.FlagParse()
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -37,10 +37,14 @@ import (
 var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component]Config", func() {
 
 	tests.FlagParse()
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		var err error
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 
@@ -236,9 +240,6 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	})
 
 	Context("With a ServiceAccount defined", func() {
-
-		virtClient, err := kubecli.GetKubevirtClient()
-		tests.PanicOnError(err)
 
 		serviceAccountPath := config.ServiceAccountSourceDir
 

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -37,9 +37,7 @@ import (
 
 var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]Console", func() {
 
-	tests.FlagParse()
 	var virtClient kubecli.KubevirtClient
-
 
 	BeforeEach(func() {
 		var err error

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -38,11 +38,15 @@ import (
 var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]Console", func() {
 
 	tests.FlagParse()
+	var virtClient kubecli.KubevirtClient
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
 
 	BeforeEach(func() {
+		var err error
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -40,8 +40,6 @@ import (
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]ContainerDisk", func() {
 
-	tests.FlagParse()
-
 	var virtClient kubecli.KubevirtClient
 	var err error
 

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -42,10 +42,13 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -48,10 +48,14 @@ const DummyFilePath = "/usr/share/nginx/html/dummy.file"
 var _ = Describe("DataVolume Integration", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+
+	var virtClient kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		if !tests.HasCDI() {
 			Skip("Skip DataVolume tests when CDI is not present")

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -46,8 +46,6 @@ const InvalidDataVolumeUrl = "http://127.0.0.1/invalid"
 const DummyFilePath = "/usr/share/nginx/html/dummy.file"
 
 var _ = Describe("DataVolume Integration", func() {
-	tests.FlagParse()
-
 
 	var virtClient kubecli.KubevirtClient
 	var err error

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -46,8 +46,6 @@ func waitForJobToCompleteWithStatus(virtClient *kubecli.KubevirtClient, jobPod *
 
 var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", func() {
 
-	tests.FlagParse()
-
 	var virtClient kubecli.KubevirtClient
 	var err error
 

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -48,9 +48,15 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var err error
+
 	const testPort = 1500
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+	})
 
 	Context("Expose service on a VM", func() {
 		var tcpVM *v1.VirtualMachineInstance

--- a/tests/flags.go
+++ b/tests/flags.go
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package tests
+
+import (
+	"flag"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+var KubeVirtUtilityVersionTag = ""
+var KubeVirtVersionTag = "latest"
+var KubeVirtVersionTagAlt = ""
+var KubeVirtUtilityRepoPrefix = ""
+var KubeVirtRepoPrefix = "kubevirt"
+var ImagePrefixAlt = ""
+var ContainerizedDataImporterNamespace = "cdi"
+var KubeVirtKubectlPath = ""
+var KubeVirtOcPath = ""
+var KubeVirtVirtctlPath = ""
+var KubeVirtGoCliPath = ""
+var KubeVirtInstallNamespace string
+var PreviousReleaseTag = ""
+var PreviousReleaseRegistry = ""
+var ConfigFile = ""
+var SkipShasumCheck bool
+
+var DeployTestingInfrastructureFlag = false
+var PathToTestingInfrastrucureManifests = ""
+
+func init() {
+	kubecli.Init()
+	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
+	flag.StringVar(&KubeVirtVersionTag, "container-tag", "latest", "Set the image tag or digest to use")
+	flag.StringVar(&KubeVirtVersionTagAlt, "container-tag-alt", "", "An alternate tag that can be used to test operator deployments")
+	flag.StringVar(&KubeVirtUtilityRepoPrefix, "utility-container-prefix", "", "Set the repository prefix for all images")
+	flag.StringVar(&KubeVirtRepoPrefix, "container-prefix", "kubevirt", "Set the repository prefix for all images")
+	flag.StringVar(&ImagePrefixAlt, "image-prefix-alt", "", "Optional prefix for virt-* image names for additional imagePrefix operator test")
+	flag.StringVar(&ContainerizedDataImporterNamespace, "cdi-namespace", "cdi", "Set the repository prefix for CDI components")
+	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "", "Set path to kubectl binary")
+	flag.StringVar(&KubeVirtOcPath, "oc-path", "", "Set path to oc binary")
+	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "", "Set path to virtctl binary")
+	flag.StringVar(&KubeVirtGoCliPath, "gocli-path", "", "Set path to gocli binary")
+	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "kubevirt", "Set the namespace KubeVirt is installed in")
+	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
+	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
+	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
+	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "index.docker.io/kubevirt", "Set registry of the release to test updating from")
+	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
+	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
+}
+
+func NormalizeFlags() {
+	// When the flags are not provided, copy the values from normal version tag and prefix
+	if KubeVirtUtilityVersionTag == "" {
+		KubeVirtUtilityVersionTag = KubeVirtVersionTag
+	}
+
+	if KubeVirtUtilityRepoPrefix == "" {
+		KubeVirtUtilityRepoPrefix = KubeVirtRepoPrefix
+	}
+}

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -26,8 +26,6 @@ const (
 
 var _ = Describe("ImageUpload", func() {
 
-	tests.FlagParse()
-
 	namespace := tests.NamespaceTestDefault
 	dvName := "alpine-dv"
 	pvcSize := "100Mi"

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -32,8 +32,14 @@ var _ = Describe("ImageUpload", func() {
 	dvName := "alpine-dv"
 	pvcSize := "100Mi"
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+	})
 
 	BeforeEach(func() {
 		By("Getting CDI HTTP import server pod")

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -55,15 +55,23 @@ import (
 var _ = Describe("Infrastructure", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
+	var aggregatorClient *aggregatorclient.Clientset
+	var err error
 
-	config, err := kubecli.GetConfig()
-	if err != nil {
-		panic(err)
-	}
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 
-	aggregatorClient := aggregatorclient.NewForConfigOrDie(config)
+		if aggregatorClient == nil {
+			config, err := kubecli.GetConfig()
+			if err != nil {
+				panic(err)
+			}
+
+			aggregatorClient = aggregatorclient.NewForConfigOrDie(config)
+		}
+	})
 
 	Describe("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com][level:component]certificates", func() {
 

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -53,8 +53,6 @@ import (
 )
 
 var _ = Describe("Infrastructure", func() {
-	tests.FlagParse()
-
 	var virtClient kubecli.KubevirtClient
 	var aggregatorClient *aggregatorclient.Clientset
 	var err error

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kubectl get vm/vmi tests", func() {
-	tests.FlagParse()
-
 	var k8sClient, result string
 	var vm *v1.VirtualMachine
 	var virtCli kubecli.KubevirtClient

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -19,11 +19,14 @@ var _ = Describe("[rfe_id:3423][vendor:cnv-qe@redhat.com][level:component]oc/kub
 
 	var k8sClient, result string
 	var vm *v1.VirtualMachine
-
-	virtCli, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtCli kubecli.KubevirtClient
+	var err error
 
 	BeforeEach(func() {
+
+		virtCli, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		k8sClient = tests.GetK8sCmdClient()
 		tests.SkipIfNoCmd(k8sClient)
 		tests.BeforeTestCleanup()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -61,7 +61,6 @@ const (
 )
 
 var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration", func() {
-	tests.FlagParse()
 	var virtClient kubecli.KubevirtClient
 
 	var originalKubeVirtConfig *k8sv1.ConfigMap

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -62,13 +62,15 @@ const (
 
 var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration", func() {
 	tests.FlagParse()
-
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
 
 	var originalKubeVirtConfig *k8sv1.ConfigMap
+	var err error
 
 	tests.BeforeAll(func() {
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 
 		originalKubeVirtConfig, err = virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get(virtconfig.ConfigMapName, metav1.GetOptions{})
 		if err != nil && !errors.IsNotFound(err) {

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -40,8 +40,6 @@ func assertPingFail(ip string, vmi *v1.VirtualMachineInstance) {
 
 var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
 
-	tests.FlagParse()
-
 	var virtClient kubecli.KubevirtClient
 
 	var vmia *v1.VirtualMachineInstance

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -42,14 +42,18 @@ var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var virtClient kubecli.KubevirtClient
 
 	var vmia *v1.VirtualMachineInstance
 	var vmib *v1.VirtualMachineInstance
 	var vmic *v1.VirtualMachineInstance
 
 	tests.BeforeAll(func() {
+		var err error
+
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.SkipIfUseFlannel(virtClient)
 		tests.SkipIfNotUseNetworkPolicy(virtClient)
 		tests.BeforeTestCleanup()

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -61,7 +61,6 @@ type vmYamlDefinition struct {
 }
 
 var _ = Describe("Operator", func() {
-	tests.FlagParse()
 	var originalKv *v1.KubeVirt
 	var originalCDI *cdiv1.CDI
 	var originalKubeVirtConfig *k8sv1.ConfigMap

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -46,10 +46,13 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -44,8 +44,6 @@ import (
 
 var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component]Pausing", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/probes_test.go
+++ b/tests/probes_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 var _ = Describe("[ref_id:1182]Probes", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/probes_test.go
+++ b/tests/probes_test.go
@@ -16,10 +16,13 @@ import (
 var _ = Describe("[ref_id:1182]Probes", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -44,8 +44,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	tests.FlagParse()
-
 	BeforeEach(func() {
 		virtClient, err = kubecli.GetKubevirtClient()
 		tests.PanicOnError(err)

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -41,13 +41,15 @@ import (
 )
 
 var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstanceReplicaSet", func() {
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
-
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -36,10 +36,13 @@ import (
 var _ = Describe("SecurityFeatures", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -34,8 +34,6 @@ import (
 )
 
 var _ = Describe("SecurityFeatures", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/snapshot_test.go
+++ b/tests/snapshot_test.go
@@ -21,8 +21,6 @@ import (
 
 var _ = Describe("VirtualMachineSnapshot Tests", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/snapshot_test.go
+++ b/tests/snapshot_test.go
@@ -23,10 +23,15 @@ var _ = Describe("VirtualMachineSnapshot Tests", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	groupName := "kubevirt.io/v1alpha3"
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+	})
 
 	Context("With simple VM", func() {
 		var vm *v1.VirtualMachine

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -12,10 +12,13 @@ var _ = PDescribe("Ensure stable functionality", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -10,8 +10,6 @@ import (
 
 var _ = PDescribe("Ensure stable functionality", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -52,8 +52,6 @@ const (
 type VMICreationFunc func(string) *v1.VirtualMachineInstance
 
 var _ = Describe("Storage", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -54,10 +54,13 @@ type VMICreationFunc func(string) *v1.VirtualMachineInstance
 var _ = Describe("Storage", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -37,13 +37,16 @@ var _ = Describe("Subresource Api", func() {
 
 	tests.FlagParse()
 
-	virtCli, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtCli kubecli.KubevirtClient
 
 	manual := v1.RunStrategyManual
 	restartOnError := v1.RunStrategyRerunOnFailure
 
 	BeforeEach(func() {
+		virtCli, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -35,8 +35,6 @@ import (
 
 var _ = Describe("Subresource Api", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtCli kubecli.KubevirtClient
 

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -49,8 +49,8 @@ const (
 var _ = Describe("Templates", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var (
 		templateParams map[string]string
@@ -60,6 +60,9 @@ var _ = Describe("Templates", func() {
 	)
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.SkipIfNoCmd("oc")
 		tests.BeforeTestCleanup()
 		SetDefaultEventuallyTimeout(120 * time.Second)

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -47,8 +47,6 @@ const (
 )
 
 var _ = Describe("Templates", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -104,60 +104,8 @@ import (
 	"github.com/google/go-github/v32/github"
 )
 
-var KubeVirtUtilityVersionTag = ""
-var KubeVirtVersionTag = "latest"
-var KubeVirtVersionTagAlt = ""
-var KubeVirtUtilityRepoPrefix = ""
-var KubeVirtRepoPrefix = "kubevirt"
-var ImagePrefixAlt = ""
-var ContainerizedDataImporterNamespace = "cdi"
-var KubeVirtKubectlPath = ""
-var KubeVirtOcPath = ""
-var KubeVirtVirtctlPath = ""
-var KubeVirtGoCliPath = ""
-var KubeVirtInstallNamespace string
-var PreviousReleaseTag = ""
-var PreviousReleaseRegistry = ""
-var ConfigFile = ""
 var Config *KubeVirtTestsConfiguration
-var SkipShasumCheck bool
 var KubeVirtDefaultConfig map[string]string
-
-var DeployTestingInfrastructureFlag = false
-var PathToTestingInfrastrucureManifests = ""
-
-func init() {
-	kubecli.Init()
-	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
-	flag.StringVar(&KubeVirtVersionTag, "container-tag", "latest", "Set the image tag or digest to use")
-	flag.StringVar(&KubeVirtVersionTagAlt, "container-tag-alt", "", "An alternate tag that can be used to test operator deployments")
-	flag.StringVar(&KubeVirtUtilityRepoPrefix, "utility-container-prefix", "", "Set the repository prefix for all images")
-	flag.StringVar(&KubeVirtRepoPrefix, "container-prefix", "kubevirt", "Set the repository prefix for all images")
-	flag.StringVar(&ImagePrefixAlt, "image-prefix-alt", "", "Optional prefix for virt-* image names for additional imagePrefix operator test")
-	flag.StringVar(&ContainerizedDataImporterNamespace, "cdi-namespace", "cdi", "Set the repository prefix for CDI components")
-	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "", "Set path to kubectl binary")
-	flag.StringVar(&KubeVirtOcPath, "oc-path", "", "Set path to oc binary")
-	flag.StringVar(&KubeVirtVirtctlPath, "virtctl-path", "", "Set path to virtctl binary")
-	flag.StringVar(&KubeVirtGoCliPath, "gocli-path", "", "Set path to gocli binary")
-	flag.StringVar(&KubeVirtInstallNamespace, "installed-namespace", "kubevirt", "Set the namespace KubeVirt is installed in")
-	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
-	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
-	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
-	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "index.docker.io/kubevirt", "Set registry of the release to test updating from")
-	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
-	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
-}
-
-func NormalizeFlags() {
-	// When the flags are not provided, copy the values from normal version tag and prefix
-	if KubeVirtUtilityVersionTag == "" {
-		KubeVirtUtilityVersionTag = KubeVirtVersionTag
-	}
-
-	if KubeVirtUtilityRepoPrefix == "" {
-		KubeVirtUtilityRepoPrefix = KubeVirtRepoPrefix
-	}
-}
 
 type EventType string
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -148,9 +148,7 @@ func init() {
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 }
 
-func FlagParse() {
-	flag.Parse()
-
+func NormalizeFlags() {
 	// When the flags are not provided, copy the values from normal version tag and prefix
 	if KubeVirtUtilityVersionTag == "" {
 		KubeVirtUtilityVersionTag = KubeVirtVersionTag
@@ -748,6 +746,8 @@ func Taint(nodeName string, key string, effect k8sv1.TaintEffect) {
 }
 
 func BeforeTestSuitSetup() {
+	NormalizeFlags()
+
 	log.InitializeLogging("tests")
 	log.Log.SetIOWriter(GinkgoWriter)
 

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -34,10 +34,13 @@ var _ = Describe("Version", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -32,8 +32,6 @@ import (
 
 var _ = Describe("Version", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -62,8 +62,6 @@ var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 		var nodeNames []string
 		var selectedNodeName string
 
-		tests.FlagParse()
-
 		getRunningReadyPods := func(podList *v1.PodList, podNames []string, nodeNames ...string) (pods []*v1.Pod) {
 			pods = make([]*v1.Pod, 0)
 			for _, pod := range podList.Items {

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -45,13 +45,17 @@ const (
 
 var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 
+	var err error
+	var virtCli kubecli.KubevirtClient
+
 	RegisterFailHandler(Fail)
 
-	virtCli, err := kubecli.GetKubevirtClient()
-	Expect(err).ToNot(HaveOccurred())
-	deploymentsClient := virtCli.AppsV1().Deployments(tests.KubeVirtInstallNamespace)
-
 	controlPlaneDeploymentNames := []string{"virt-api", "virt-controller"}
+
+	BeforeEach(func() {
+		virtCli, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+	})
 
 	Context("pod eviction", func() {
 
@@ -100,6 +104,7 @@ var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 		}
 
 		waitForDeploymentsToStabilize := func() (bool, error) {
+			deploymentsClient := virtCli.AppsV1().Deployments(tests.KubeVirtInstallNamespace)
 			for _, deploymentName := range controlPlaneDeploymentNames {
 				deployment, err := deploymentsClient.Get(deploymentName, metav1.GetOptions{})
 				if err != nil {
@@ -133,6 +138,7 @@ var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 
 		// Add nodeSelector to deployments so that they get scheduled to selectedNode
 		addNodeSelectorToDeployments := func() (bool, error) {
+			deploymentsClient := virtCli.AppsV1().Deployments(tests.KubeVirtInstallNamespace)
 			for _, deploymentName := range controlPlaneDeploymentNames {
 				deployment, err := deploymentsClient.Get(deploymentName, metav1.GetOptions{})
 				if err != nil {
@@ -215,6 +221,7 @@ var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 		})
 
 		removeNodeSelectorFromDeployments := func() (bool, error) {
+			deploymentsClient := virtCli.AppsV1().Deployments(tests.KubeVirtInstallNamespace)
 			for _, deploymentName := range controlPlaneDeploymentNames {
 				deployment, err := deploymentsClient.Get(deploymentName, metav1.GetOptions{})
 				if err != nil {
@@ -296,7 +303,7 @@ var _ = Describe("[ref_id:2717]KubeVirt control plane resilience", func() {
 		When("control plane pods are running", func() {
 
 			It("[test_id:2806]virt-controller and virt-api pods have a pod disruption budget", func() {
-
+				deploymentsClient := virtCli.AppsV1().Deployments(tests.KubeVirtInstallNamespace)
 				By("check deployments")
 				deployments, err := deploymentsClient.List(metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -52,8 +52,6 @@ import (
 
 var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachine", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -54,13 +54,16 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	runStrategyAlways := v1.RunStrategyAlways
 	runStrategyHalted := v1.RunStrategyHalted
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -143,8 +143,9 @@ func createCommandWithNSAndRedirect(namespace, cmdName string, args ...string) (
 var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:component]VmWatch", func() {
 	tests.FlagParse()
 
-	virtCli, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtCli kubecli.KubevirtClient
+
 	var vm *v12.VirtualMachine
 
 	// Reads an error from stderr and fails the test
@@ -162,6 +163,9 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 	}
 
 	BeforeEach(func() {
+		virtCli, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.SkipIfVersionBelow("Printing format for `kubectl get -w` on custom resources is only relevant for 1.16.2+", relevantk8sVer)
 		tests.BeforeTestCleanup()
 

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -141,8 +141,6 @@ func createCommandWithNSAndRedirect(namespace, cmdName string, args ...string) (
 }
 
 var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:component]VmWatch", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtCli kubecli.KubevirtClient
 

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -39,8 +39,8 @@ var _ = Describe("CloudInitHookSidecars", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
 
@@ -85,6 +85,9 @@ var _ = Describe("CloudInitHookSidecars", func() {
 	}
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#FAKE")
 		vmi.ObjectMeta.Annotations = map[string]string{

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -37,8 +37,6 @@ const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
 
 var _ = Describe("CloudInitHookSidecars", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -51,8 +51,6 @@ const (
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component]CloudInit UserData", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -53,78 +53,92 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
-	LaunchVMI := func(vmi *v1.VirtualMachineInstance) {
-		By("Starting a VirtualMachineInstance")
-		obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Get()
-		Expect(err).To(BeNil())
+	var (
+		LaunchVMI                 func(*v1.VirtualMachineInstance)
+		VerifyUserDataVMI         func(*v1.VirtualMachineInstance, []expect.Batcher, time.Duration)
+		MountCloudInitNoCloud     func(*v1.VirtualMachineInstance, string)
+		MountCloudInitConfigDrive func(*v1.VirtualMachineInstance, string)
+		CheckCloudInitFile        func(*v1.VirtualMachineInstance, string, string, string)
+		CheckCloudInitMetaData    func(*v1.VirtualMachineInstance, string, string, string)
+	)
 
-		By("Waiting the VirtualMachineInstance start")
-		_, ok := obj.(*v1.VirtualMachineInstance)
-		Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
-		Expect(tests.WaitForSuccessfulVMIStart(obj)).ToNot(BeEmpty())
-	}
+	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
 
-	VerifyUserDataVMI := func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
-		By("Expecting the VirtualMachineInstance console")
-		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		defer expecter.Close()
+		LaunchVMI = func(vmi *v1.VirtualMachineInstance) {
+			By("Starting a VirtualMachineInstance")
+			obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Get()
+			Expect(err).To(BeNil())
 
-		By("Checking that the VirtualMachineInstance serial console output equals to expected one")
-		resp, err := expecter.ExpectBatch(commands, timeout)
-		log.DefaultLogger().Object(vmi).Infof("%v", resp)
-		Expect(err).ToNot(HaveOccurred())
-	}
+			By("Waiting the VirtualMachineInstance start")
+			_, ok := obj.(*v1.VirtualMachineInstance)
+			Expect(ok).To(BeTrue(), "Object is not of type *v1.VirtualMachineInstance")
+			Expect(tests.WaitForSuccessfulVMIStart(obj)).ToNot(BeEmpty())
+		}
 
-	mountCloudInitFunc := func(devName string) func(*v1.VirtualMachineInstance, string) {
-		return func(vmi *v1.VirtualMachineInstance, prompt string) {
-			cmdCheck := fmt.Sprintf("mount $(blkid  -L %s) /mnt/\n", devName)
+		VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
+			By("Expecting the VirtualMachineInstance console")
+			expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
+
+			By("Checking that the VirtualMachineInstance serial console output equals to expected one")
+			resp, err := expecter.ExpectBatch(commands, timeout)
+			log.DefaultLogger().Object(vmi).Infof("%v", resp)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		mountCloudInitFunc := func(devName string) func(*v1.VirtualMachineInstance, string) {
+			return func(vmi *v1.VirtualMachineInstance, prompt string) {
+				cmdCheck := fmt.Sprintf("mount $(blkid  -L %s) /mnt/\n", devName)
+				err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+					&expect.BSnd{S: "sudo su -\n"},
+					&expect.BExp{R: prompt},
+					&expect.BSnd{S: cmdCheck},
+					&expect.BExp{R: prompt},
+					&expect.BSnd{S: "echo $?\n"},
+					&expect.BExp{R: "0"},
+				}, 15)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
+
+		MountCloudInitNoCloud = mountCloudInitFunc("cidata")
+		MountCloudInitConfigDrive = mountCloudInitFunc("config-2")
+
+		CheckCloudInitFile = func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
+			cmdCheck := "cat /mnt/" + testFile + "\n"
 			err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
 				&expect.BSnd{S: "sudo su -\n"},
 				&expect.BExp{R: prompt},
 				&expect.BSnd{S: cmdCheck},
-				&expect.BExp{R: prompt},
-				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
+				&expect.BExp{R: testData},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		}
-	}
+		CheckCloudInitMetaData = func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
+			cmdCheck := "cat /mnt/" + testFile + "\n"
+			virtClient, err := kubecli.GetKubevirtClient()
+			tests.PanicOnError(err)
+			expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			defer expecter.Close()
 
-	MountCloudInitNoCloud := mountCloudInitFunc("cidata")
-	MountCloudInitConfigDrive := mountCloudInitFunc("config-2")
-
-	CheckCloudInitFile := func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
-		cmdCheck := "cat /mnt/" + testFile + "\n"
-		err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
-			&expect.BSnd{S: "sudo su -\n"},
-			&expect.BExp{R: prompt},
-			&expect.BSnd{S: cmdCheck},
-			&expect.BExp{R: testData},
-		}, 15)
-		Expect(err).ToNot(HaveOccurred())
-	}
-	CheckCloudInitMetaData := func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
-		cmdCheck := "cat /mnt/" + testFile + "\n"
-		virtClient, err := kubecli.GetKubevirtClient()
-		tests.PanicOnError(err)
-		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		defer expecter.Close()
-
-		res, err := expecter.ExpectBatch([]expect.Batcher{
-			&expect.BSnd{S: "sudo su -\n"},
-			&expect.BExp{R: prompt},
-			&expect.BSnd{S: cmdCheck},
-			&expect.BExp{R: testData},
-		}, 15*time.Second)
-		if err != nil {
-			Expect(res[1].Output).To(ContainSubstring(testData))
+			res, err := expecter.ExpectBatch([]expect.Batcher{
+				&expect.BSnd{S: "sudo su -\n"},
+				&expect.BExp{R: prompt},
+				&expect.BSnd{S: cmdCheck},
+				&expect.BExp{R: testData},
+			}, 15*time.Second)
+			if err != nil {
+				Expect(res[1].Output).To(ContainSubstring(testData))
+			}
 		}
-	}
+	})
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -53,8 +53,6 @@ import (
 
 var _ = Describe("Configurations", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -55,10 +55,13 @@ var _ = Describe("Configurations", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 
@@ -168,9 +171,12 @@ var _ = Describe("Configurations", func() {
 
 	Describe("VirtualMachineInstance definition", func() {
 		Context("[rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", func() {
-			availableNumberOfCPUs := tests.GetHighestCPUNumberAmongNodes(virtClient)
-
+			var availableNumberOfCPUs int
 			var vmi *v1.VirtualMachineInstance
+
+			tests.BeforeAll(func() {
+				availableNumberOfCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+			})
 
 			BeforeEach(func() {
 				requiredNumberOfCpus := 3

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -49,8 +49,6 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt strin
 }
 
 var _ = Describe("GPU", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -51,8 +51,13 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt strin
 var _ = Describe("GPU", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+	})
 
 	Context("with ephemeral disk", func() {
 		It("Should create a valid VMI but pod should not go to running state", func() {

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -36,12 +36,14 @@ var _ = Describe("[rfe_id:609]VMIheadless", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
-
+	var err error
+	var virtClient kubecli.KubevirtClient
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 	})

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -34,8 +34,6 @@ import (
 
 var _ = Describe("[rfe_id:609]VMIheadless", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var vmi *v1.VirtualMachineInstance

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -44,12 +44,15 @@ var _ = Describe("HookSidecars", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 		vmi.ObjectMeta.Annotations = RenderSidecar(hooksv1alpha1.Version)

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -42,8 +42,6 @@ const hookSidecarImage = "example-hook-sidecar"
 
 var _ = Describe("HookSidecars", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -34,8 +34,6 @@ import (
 
 var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component]IgnitionData", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -39,8 +39,6 @@ import (
 )
 
 var _ = Describe("IOThreads", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -41,20 +41,26 @@ import (
 var _ = Describe("IOThreads", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
 	dedicated := true
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 	})
 
 	Context("IOThreads Policies", func() {
+		var availableCPUs int
 
-		availableCPUs := tests.GetHighestCPUNumberAmongNodes(virtClient)
+		tests.BeforeAll(func() {
+			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+		})
 
 		It("[test_id:4122]Should honor shared ioThreadsPolicy for single disk", func() {
 			policy := v1.IOThreadsPolicyShared

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -75,14 +75,17 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
 
 	var useEmulation *bool
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 	})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -73,8 +73,6 @@ func addNodeAffinityToVMI(vmi *v1.VirtualMachineInstance, nodeName string) {
 
 var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]VMIlifecycle", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -34,8 +34,6 @@ import (
 
 var _ = Describe("Health Monitoring", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -36,16 +36,23 @@ var _ = Describe("Health Monitoring", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
-	launchVMI := func(vmi *v1.VirtualMachineInstance) {
-		By("Starting a VirtualMachineInstance")
-		obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Get()
-		Expect(err).To(BeNil())
+	var launchVMI func(*v1.VirtualMachineInstance)
 
-		tests.WaitForSuccessfulVMIStart(obj)
-	}
+	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
+		launchVMI = func(vmi *v1.VirtualMachineInstance) {
+			By("Starting a VirtualMachineInstance")
+			obj, err := virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Get()
+			Expect(err).To(BeNil())
+
+			tests.WaitForSuccessfulVMIStart(obj)
+		}
+	})
 
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -37,8 +37,6 @@ import (
 )
 
 var _ = Describe("MultiQueue", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -39,16 +39,22 @@ import (
 var _ = Describe("MultiQueue", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 	})
 
 	Context("MultiQueue Behavior", func() {
+		var availableCPUs int
 
-		availableCPUs := tests.GetHighestCPUNumberAmongNodes(virtClient)
+		tests.BeforeAll(func() {
+			availableCPUs = tests.GetHighestCPUNumberAmongNodes(virtClient)
+		})
 
 		It("should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", func() {
 			vmi := tests.NewRandomFedoraVMIWitGuestAgent()

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -20,7 +20,6 @@
 package tests_test
 
 import (
-	"flag"
 	"fmt"
 	"net"
 	"os"
@@ -56,8 +55,6 @@ const (
 )
 
 var _ = Describe("Multus", func() {
-
-	tests.FlagParse()
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -569,8 +566,6 @@ var _ = Describe("Multus", func() {
 })
 
 var _ = Describe("SRIOV", func() {
-
-	flag.Parse()
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Multus", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var nodes *k8sv1.NodeList
 
@@ -95,6 +95,9 @@ var _ = Describe("Multus", func() {
 	}
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		// Multus tests need to ensure that old VMIs are gone
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestDefault).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestAlternative).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
@@ -569,8 +572,8 @@ var _ = Describe("SRIOV", func() {
 
 	flag.Parse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	sriovResourceName := os.Getenv("SRIOV_RESOURCE_NAME")
 
@@ -579,6 +582,9 @@ var _ = Describe("SRIOV", func() {
 	}
 
 	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		// Check if the hardware supports SRIOV
 		sriovcheck := checkSriovEnabled(virtClient, sriovResourceName)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -49,8 +49,6 @@ import (
 
 var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -40,8 +40,6 @@ import (
 
 var _ = Describe("Slirp Networking", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Slirp Networking", func() {
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var genericVmi *v1.VirtualMachineInstance
 	var deadbeafVmi *v1.VirtualMachineInstance
@@ -57,6 +57,9 @@ var _ = Describe("Slirp Networking", func() {
 	}
 
 	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		setSlirpEnabled(true)
 		ports := []v1.Port{{Name: "http", Port: 80}}
 		genericVmi = tests.NewRandomVMIWithSlirpInterfaceEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n", ports)

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -34,12 +34,15 @@ import (
 var _ = Describe("VMIDefaults", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		// create VMI with missing disk target
 		vmi = tests.NewRandomVMI()

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 var _ = Describe("VMIDefaults", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -39,8 +39,6 @@ import (
 )
 
 var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]VMIPreset", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -41,8 +41,8 @@ import (
 var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]VMIPreset", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var vmi *v1.VirtualMachineInstance
 	var memoryPreset *v1.VirtualMachineInstancePreset
@@ -58,6 +58,9 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	cores := 7
 
 	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 		vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
 		vmi.Labels = map[string]string{flavorKey: memoryFlavor}

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -42,12 +42,15 @@ var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 	var vmi *v1.VirtualMachineInstance
 
 	Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]A new VirtualMachineInstance", func() {
 		tests.BeforeAll(func() {
+			virtClient, err = kubecli.GetKubevirtClient()
+			tests.PanicOnError(err)
+
 			tests.BeforeTestCleanup()
 			vmi = tests.NewRandomVMI()
 			Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -40,8 +40,6 @@ import (
 
 var _ = Describe("[rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]VNC", func() {
 
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var vmi *v1.VirtualMachineInstance

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -114,12 +114,15 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 var _ = Describe("Windows VirtualMachineInstance", func() {
 	tests.FlagParse()
 
-	virtClient, err := kubecli.GetKubevirtClient()
-	tests.PanicOnError(err)
+	var err error
+	var virtClient kubecli.KubevirtClient
 
 	var windowsVMI *v1.VirtualMachineInstance
 
 	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.SkipIfNoWindowsImage(virtClient)
 	})
 

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -112,8 +112,6 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 }
 
 var _ = Describe("Windows VirtualMachineInstance", func() {
-	tests.FlagParse()
-
 	var err error
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION
**What this PR does / why we need it**:

tests, flag: Parse flags once
tests: Do not execute code in ginkgo containers body
 
In order to parse the flags once, there is a need to fix the execution of code in ginkgo containers.

---

Current command line flags are setup at `init` but parsed multiple
times by each test file.

As the flags are bound to global variables and flag parsing should only
be executed once (consequent calls are no-op), there is no point to execute
the parse more than once.
The test framework is expected to execute the parsing in its main
function for its own flags, therefore, there should be no need to
explicitly parse the flags in the tests.

---

Ginkgo containers body are evaluated at definition, i.e. at a pre-main
stage. Running code at this stage is not recommended as some
initializations are occurring only in the test `main` (which is
auto-generated by the test framework).

And example of such a scenario is the command line flag parsing.
Libraries, tested code and the test infra is expected to declare the
flags and the parsing is expected to be execute only once (at main
usually).

This change moves all code that executes in the containers body to the
Before* setup bodies, while leaving on the containers body the variable
declarations.

**Special notes for your reviewer**:
This change is part of an initiative to extract the flags from `utils.go`.
Depends on #3807 

**Release note**:
```release-note
NONE
```
