### PR TITLE
WIP tests AfterSuite: Force namespaces deletion

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1733,12 +1733,12 @@ func removeNamespaces() {
 		}
 	}
 
-	// Wait until the namespaces are terminated
+	// Wait until all namespaces are terminated
 	fmt.Println("")
 	for _, namespace := range testNamespaces {
 		fmt.Printf("Waiting for namespace %s to be removed, this can take a while ...\n", namespace)
 		EventuallyWithOffset(1, func() bool { return errors.IsNotFound(virtCli.CoreV1().Namespaces().Delete(namespace, nil)) }, 240*time.Second, 1*time.Second).
-			Should(BeTrue())
+			Should(BeTrue(), fmt.Sprintf("should succesfully delete namespace %s", namespace))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR change the way AfterSuite cleansup test namespaces, forcing deletion by removing finelizers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
