### PR TITLE
check for readiness of device manager plugin

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -100,3 +100,13 @@ func (c *DeviceController) Run(stop chan struct{}) error {
 	logger.Info("Shutting down device plugin controller")
 	return nil
 }
+
+func (c *DeviceController) Initialized() bool {
+	for _, dev := range c.devicePlugins {
+		if !dev.GetInitialized() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -32,6 +32,10 @@ func (fp *FakePlugin) GetDeviceName() string {
 	return fp.deviceName
 }
 
+func (fp *FakePlugin) GetInitialized() bool {
+	return true
+}
+
 func NewFakePlugin(name string, path string) *FakePlugin {
 	return &FakePlugin{
 		deviceName: name,
@@ -100,6 +104,7 @@ var _ = Describe("Device Controller", func() {
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
 			}, 500*time.Millisecond).Should(BeNumerically(">=", 3))
+			Expect(deviceController.Initialized()).To(BeTrue())
 		})
 
 		It("should restart the device plugin with delays if it returns errors", func() {

--- a/pkg/virt-handler/device-manager/generic_device.go
+++ b/pkg/virt-handler/device-manager/generic_device.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -62,6 +63,7 @@ type GenericDevicePlugin struct {
 	deviceRoot  string
 	preOpen     bool
 	initialized bool
+	lock        *sync.Mutex
 }
 
 func NewGenericDevicePlugin(deviceName string, devicePath string, maxDevices int, preOpen bool) *GenericDevicePlugin {
@@ -76,6 +78,7 @@ func NewGenericDevicePlugin(deviceName string, devicePath string, maxDevices int
 		deviceRoot:  util.HostRootMount,
 		preOpen:     preOpen,
 		initialized: false,
+		lock:        &sync.Mutex{},
 	}
 	for i := 0; i < maxDevices; i++ {
 		dpi.addNewGenericDevice()

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	container_disk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
+	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -60,7 +61,6 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -2207,7 +2207,13 @@ func (d *VirtualMachineController) heartBeat(interval time.Duration, stopCh chan
 				log.DefaultLogger().Reason(err).Errorf("Can't determine date")
 				return
 			}
-			data := []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}, "annotations": {"%s": %s}}}`, v1.NodeSchedulable, v1.VirtHandlerHeartbeat, string(now)))
+
+			kubevirtSchedulable := "true"
+			if !d.kvmController.Initialized() {
+				kubevirtSchedulable = "false"
+			}
+
+			data := []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "%s"}, "annotations": {"%s": %s}}}`, v1.NodeSchedulable, kubevirtSchedulable, v1.VirtHandlerHeartbeat, string(now)))
 			_, err = d.clientset.CoreV1().Nodes().Patch(d.host, types.StrategicMergePatchType, data)
 			if err != nil {
 				log.DefaultLogger().Reason(err).Errorf("Can't patch node %s", d.host)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -631,10 +631,10 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, 90*time.Second, 1*time.Second).Should(BeTrue(), "The virthandler pod should be gone")
 			})
 
-			It("[test_id:1634]the node controller should react", func() {
+			It("[test_id:1634]the node controller should mark the node as unschedulable when the virt-handler heartbeat has timedout", func() {
 
 				// Update virt-handler heartbeat, to trigger a timeout
-				data := []byte(fmt.Sprintf(`{"metadata": { "annotations": {"%s": "%s"}}}`, v1.VirtHandlerHeartbeat, nowAsJSONWithOffset(-10*time.Minute)))
+				data := []byte(fmt.Sprintf(`{"metadata": { "labels": { "%s": "true" }, "annotations": {"%s": "%s"}}}`, v1.NodeSchedulable, v1.VirtHandlerHeartbeat, nowAsJSONWithOffset(-10*time.Minute)))
 				_, err = virtClient.CoreV1().Nodes().Patch(nodeName, types.StrategicMergePatchType, data)
 				Expect(err).ToNot(HaveOccurred(), "Should patch node successfully")
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -96,6 +96,29 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		tests.EnsureKVMPresent()
 	})
 
+	Context("when virt-handler is deleted", func() {
+		It("should label the node with kubevirt.io/schedulable=false", func() {
+			pods, err := virtClient.CoreV1().Pods("").List(metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pods.Items).ToNot(BeEmpty())
+
+			pod := pods.Items[0]
+			handlerNamespace := pod.GetNamespace()
+			err = virtClient.CoreV1().Pods(handlerNamespace).Delete(pod.Name, &metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() string {
+				n, err := virtClient.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				return n.Labels[v1.NodeSchedulable]
+			}, 20*time.Second, 1*time.Second).Should(Equal("false"))
+
+		})
+	})
+
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance", func() {
 		It("[test_id:1619]should success", func() {
 			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we have no way of knowing if the device manager is up and running when checking the status of the virt-handler. This change allows us to check that the `virt-handler` is running and the device manager has started before creating a VMI. 

If we create a VMI before the `virt-handler` is ready the `virt-controller` will create the `virt-launcher` pod which will then be unable to get the requested resources. Immediately the `virt-launcher` pod will be put into a state of `Failed` and [will not retry](https://github.com/kubernetes/kubernetes/issues/70010)

This change will allow checks such as [this](https://github.com/kubevirt/kubevirt/blob/master/tests/vmi_lifecycle_test.go#L659-L664) to be meaningful. 

The sequence of events looks like such:
```
            "reason": "Scheduled",
            "message": "Successfully assigned kubevirt-test-default/virt-launcher-testvmisl2862zxxqshrwtcj6g4z7glf445q486fhwwwr4tkv to node01",
            "source": {
                "component": "default-scheduler"
            },
            "firstTimestamp": "2020-06-24T00:12:25Z",
```

```
            "reason": "UnexpectedAdmissionError",
            "message": "Update plugin resources failed due to requested number of devices unavailable for devices.kubevirt.io/kvm. Requested: 1, Available: 0, which is unexpected.",
            "source": {
                "component": "kubelet",
                "host": "node01"
            },
            "firstTimestamp": "2020-06-24T00:12:25Z",
```

**Which issue(s) this PR fixes**:
Fixes #3664

**Special notes for your reviewer**:

**Release note**:
```release-note
make node as kubevirt.io/schedulable=false on virt-handler restart 
```
