### PR TITLE
Add NetworkAttachmentDefinition reporter

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -628,37 +628,35 @@ func (r *KubernetesReporter) logSRIOVInfo(virtCli kubecli.KubevirtClient) {
 
 func (r *KubernetesReporter) logSRIOVNodeState(virtCli kubecli.KubevirtClient, outputFolder string) {
 	nodeStateLogPath := filepath.Join(outputFolder, fmt.Sprintf("%d_nodestate.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovNodeStateEntity, v1.NamespaceAll, nodeStateLogPath)
+	r.dumpK8sEntityToFile(virtCli, sriovNodeStateEntity, v1.NamespaceAll, sriovEntityURITemplate, nodeStateLogPath)
 }
 
 func (r *KubernetesReporter) logSRIOVNodeNetworkPolicies(virtCli kubecli.KubevirtClient, outputFolder string) {
 	nodeNetworkPolicyLogPath := filepath.Join(outputFolder, fmt.Sprintf("%d_nodenetworkpolicies.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovNodeNetworkPolicyEntity, v1.NamespaceAll, nodeNetworkPolicyLogPath)
+	r.dumpK8sEntityToFile(virtCli, sriovNodeNetworkPolicyEntity, v1.NamespaceAll, sriovEntityURITemplate, nodeNetworkPolicyLogPath)
 }
 
 func (r *KubernetesReporter) logSRIOVNetworks(virtCli kubecli.KubevirtClient, outputFolder string) {
 	networksPath := filepath.Join(outputFolder, fmt.Sprintf("%d_networks.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovNetworksEntity, v1.NamespaceAll, networksPath)
+	r.dumpK8sEntityToFile(virtCli, sriovNetworksEntity, v1.NamespaceAll, sriovEntityURITemplate, networksPath)
 }
 
 func (r *KubernetesReporter) logSRIOVOperatorConfigs(virtCli kubecli.KubevirtClient, outputFolder string) {
 	operatorConfigPath := filepath.Join(outputFolder, fmt.Sprintf("%d_operatorconfigs.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, sriovOperatorConfigsEntity, v1.NamespaceAll, operatorConfigPath)
+	r.dumpK8sEntityToFile(virtCli, sriovOperatorConfigsEntity, v1.NamespaceAll, sriovEntityURITemplate, operatorConfigPath)
 }
 
 func (r *KubernetesReporter) logNetworkAttachmentDefinitionInfo(virtCli kubecli.KubevirtClient) {
-	nadOutputDir := r.artifactsDir
-
-	r.logNetworkAttachmentDefinition(virtCli, nadOutputDir)
+	r.logNetworkAttachmentDefinition(virtCli, r.artifactsDir)
 }
 
 func (r *KubernetesReporter) logNetworkAttachmentDefinition(virtCli kubecli.KubevirtClient, outputFolder string) {
 	networkAttachmentDefinitionsPath := filepath.Join(outputFolder, fmt.Sprintf("%d_networkAttachmentDefinitions.log", r.failureCount))
-	r.dumpK8sEntityToFile(virtCli, networkAttachmentDefinitionEntity, v1.NamespaceAll, networkAttachmentDefinitionsPath)
+	r.dumpK8sEntityToFile(virtCli, networkAttachmentDefinitionEntity, v1.NamespaceAll, k8sCNICNCFEntityURLTemplate, networkAttachmentDefinitionsPath)
 }
 
-func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient, entityName string, namespace string, outputFilePath string) {
-	requestURI := fmt.Sprintf(sriovEntityURITemplate, namespace, entityName)
+func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient, entityName string, namespace string, entityURITemplate string, outputFilePath string) {
+	requestURI := fmt.Sprintf(entityURITemplate, namespace, entityName)
 	f, err := os.OpenFile(outputFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to open file: %v\n", err)

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -25,11 +25,13 @@ import (
 )
 
 const (
-	sriovEntityURITemplate       = "/apis/sriovnetwork.openshift.io/v1/namespaces/%s/%s/"
-	sriovNetworksEntity          = "sriovnetworks"
-	sriovNodeNetworkPolicyEntity = "sriovnetworknodepolicies"
-	sriovNodeStateEntity         = "sriovnetworknodestates"
-	sriovOperatorConfigsEntity   = "sriovoperatorconfigs"
+	sriovEntityURITemplate            = "/apis/sriovnetwork.openshift.io/v1/namespaces/%s/%s/"
+	sriovNetworksEntity               = "sriovnetworks"
+	sriovNodeNetworkPolicyEntity      = "sriovnetworknodepolicies"
+	sriovNodeStateEntity              = "sriovnetworknodestates"
+	sriovOperatorConfigsEntity        = "sriovoperatorconfigs"
+	k8sCNICNCFEntityURLTemplate       = "/apis/k8s.cni.cncf.io/v1/namespaces/%s/%s/"
+	networkAttachmentDefinitionEntity = "network-attachment-definitions"
 )
 
 type KubernetesReporter struct {
@@ -111,6 +113,7 @@ func (r *KubernetesReporter) Dump(duration time.Duration) {
 	r.logDomainXMLs(virtCli)
 	r.logLogs(virtCli, since)
 	r.logSRIOVInfo(virtCli)
+	r.logNetworkAttachmentDefinitionInfo(virtCli)
 }
 
 // Cleanup cleans up the current content of the artifactsDir
@@ -641,6 +644,17 @@ func (r *KubernetesReporter) logSRIOVNetworks(virtCli kubecli.KubevirtClient, ou
 func (r *KubernetesReporter) logSRIOVOperatorConfigs(virtCli kubecli.KubevirtClient, outputFolder string) {
 	operatorConfigPath := filepath.Join(outputFolder, fmt.Sprintf("%d_operatorconfigs.log", r.failureCount))
 	r.dumpK8sEntityToFile(virtCli, sriovOperatorConfigsEntity, v1.NamespaceAll, operatorConfigPath)
+}
+
+func (r *KubernetesReporter) logNetworkAttachmentDefinitionInfo(virtCli kubecli.KubevirtClient) {
+	nadOutputDir := r.artifactsDir
+
+	r.logNetworkAttachmentDefinition(virtCli, nadOutputDir)
+}
+
+func (r *KubernetesReporter) logNetworkAttachmentDefinition(virtCli kubecli.KubevirtClient, outputFolder string) {
+	networkAttachmentDefinitionsPath := filepath.Join(outputFolder, fmt.Sprintf("%d_networkAttachmentDefinitions.log", r.failureCount))
+	r.dumpK8sEntityToFile(virtCli, networkAttachmentDefinitionEntity, v1.NamespaceAll, networkAttachmentDefinitionsPath)
 }
 
 func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient, entityName string, namespace string, outputFilePath string) {


### PR DESCRIPTION

Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR extends test suite kubernetes custom reporter to log NetworkAttachmentDefinition
object as well as other k8s entities, making debug of NAD objects possible.

This will also help with solving AfterSuite errors related to namespaces deletion in sriov-lane jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
