### PR TITLE
[release-0.30] label tests of connectivity over masquerade

### DIFF
--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -63,7 +63,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		Context("Expose ClusterIP service", func() {
 			const servicePort = "27017"
 			const serviceName = "cluster-ip-vmi"
-			It("[test_id:1531]Should expose a Cluster IP service on a VMI and connect to it", func() {
+			It("[test_id:1531][label:masquerade_binding_connectivity]Should expose a Cluster IP service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
@@ -143,7 +143,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			const servicePort = "27017"
 			const serviceName = "node-port-vmi"
 
-			It("[test_id:1534]Should expose a NodePort service on a VMI and connect to it", func() {
+			It("[test_id:1534[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					tcpVM.Namespace, tcpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
@@ -189,7 +189,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			const servicePort = "28017"
 			const serviceName = "cluster-ip-udp-vmi"
 
-			It("[test_id:1535]Should expose a ClusterIP service on a VMI and connect to it", func() {
+			It("[test_id:1535][label:masquerade_binding_connectivity]Should expose a ClusterIP service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					udpVM.Namespace, udpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
@@ -216,7 +216,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			const servicePort = "29017"
 			const serviceName = "node-port-udp-vmi"
 
-			It("[test_id:1536]Should expose a NodePort service on a VMI and connect to it", func() {
+			It("[test_id:1536][label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it", func() {
 				By("Exposing the service via virtctl command")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "virtualmachineinstance", "--namespace",
 					udpVM.Namespace, udpVM.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort),
@@ -295,7 +295,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			const servicePort = "27017"
 			const serviceName = "cluster-ip-vmirs"
 
-			It("[test_id:1537]Should create a ClusterIP service on VMRS and connect to it", func() {
+			It("[test_id:1537][label:masquerade_binding_connectivity]Should create a ClusterIP service on VMRS and connect to it", func() {
 				By("Expose a service on the VMRS using virtctl")
 				virtctl := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmirs", "--namespace",
 					vmrs.Namespace, vmrs.Name, "--port", servicePort, "--name", serviceName, "--target-port", strconv.Itoa(testPort))
@@ -363,7 +363,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 
 		Context("Expose a VM as a ClusterIP service.", func() {
-			It("[test_id:1538]Connect to ClusterIP service that was set when VM was offline.", func() {
+			It("[test_id:1538][label:masquerade_binding_connectivity]Connect to ClusterIP service that was set when VM was offline.", func() {
 				// This TC also covers:
 				// [test_id:1795] Exposed VM (as a service) can be reconnected multiple times.
 				By("Getting back the cluster IP given for the service")
@@ -388,7 +388,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 120)
 			})
 
-			It("[test_id:345]Should verify the exposed service is functional before and after VM restart.", func() {
+			It("[test_id:345][label:masquerade_binding_connectivity]Should verify the exposed service is functional before and after VM restart.", func() {
 				vmObj := vm
 
 				By("Getting back the service's allocated cluster IP.")
@@ -440,7 +440,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				waitForJobToCompleteWithStatus(&virtClient, job, k8sv1.PodSucceeded, 120)
 			})
 
-			It("[test_id:343]Should Verify an exposed service of a VM is not functional after VM deletion.", func() {
+			It("[test_id:343][label:masquerade_binding_connectivity]Should Verify an exposed service of a VM is not functional after VM deletion.", func() {
 				By("Getting back the cluster IP given for the service")
 				svc, err := virtClient.CoreV1().Services(vm.Namespace).Get(serviceName, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -718,7 +718,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			return vmi
 		}
 
-		table.DescribeTable("[test_id:1780]should allow regular network connection", func(ports []v1.Port, withCustomCIDR bool) {
+		table.DescribeTable("[test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", func(ports []v1.Port, withCustomCIDR bool) {
 			var ipv4NetworkCIDR string
 
 			if withCustomCIDR {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When KubeVirt is build on an base image that uses nftables but is
deployed on a cluster where some of the nodes have older iptables,
masquerade binding does not work (it can't call to older iptables on
hosts from newer nftables).

With this patch, we label tests that exercise connectivity over
masquerade binding so they can be skipped on environments where nftables
and iptables are mixed. For these environments, only the bridge binding
is relevant.

These tests can be skipped by passing an environment variable to the
test run:

```bash
FUNC_TEST_ARGS="--ginkgo.skip=\[label:masquerade_binding_connectivity\]" make functest
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
All tests exercising network connectivity over masquerade binding were label to make filtering easier
```
