### PR TITLE
Allow publish of an already published CSV

### DIFF
--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -140,7 +140,8 @@ func main() {
 				if latestVersion != "" {
 					// prevent generating the same version again
 					if strings.HasSuffix(latestVersion, *csvVersion) {
-						panic(fmt.Errorf("CSV version %s is already published!", *csvVersion))
+						fmt.Printf("CSV version %s is already published!\n", *csvVersion)
+						os.Exit(0)
 					}
 					data.ReplacesCsvVersion = latestVersion
 					// also copy old manifests to out dir


### PR DESCRIPTION
Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, the manifest-templator fails if we try to publish a bundle
that was already published. This can happen for example if we try to run
the release and fail after we published the CSV.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
