### PR TITLE
Let bazel run unit tests with the golang race detector enabled

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,7 @@ try-import ci.bazelrc
 build --workspace_status_command=./hack/print-workspace-status.sh --host_force_python=PY3
 run --workspace_status_command=./hack/print-workspace-status.sh --host_force_python=PY3
 test --workspace_status_command=./hack/print-workspace-status.sh --host_force_python=PY3
+test --features race
 
 # Bazel has a rule of precedence so we can specify / overwrite architecture specific commands if needed
 build:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo


### PR DESCRIPTION

**What this PR does / why we need it**:

We never enabled the golang race detection feature when switching from native go-executed unit-tests to bazel executed unit-tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
