### PR TITLE
Fix some synchronization issues in the static tests

### DIFF
--- a/pkg/virt-handler/isolation/isolation_test.go
+++ b/pkg/virt-handler/isolation/isolation_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Isolation", func() {
 		var tmpDir string
 		var podsDir string
 		var podUID string
+		var finished chan struct{} = nil
 
 		podUID = "pid-uid-1234"
 		vm := v1.NewMinimalVMIWithNS("default", "testvm")
@@ -48,10 +49,12 @@ var _ = Describe("Isolation", func() {
 			os.MkdirAll(filepath.Dir(socketFile), os.ModePerm)
 			socket, err = net.Listen("unix", socketFile)
 			Expect(err).ToNot(HaveOccurred())
+			finished = make(chan struct{})
 			go func() {
 				for {
 					conn, err := socket.Accept()
 					if err != nil {
+						close(finished)
 						// closes when socket listener is closed
 						return
 					}
@@ -100,6 +103,9 @@ var _ = Describe("Isolation", func() {
 			socket.Close()
 			os.RemoveAll(tmpDir)
 			os.RemoveAll(podsDir)
+			if finished != nil {
+				<-finished
+			}
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
When running the go tests with the race detector on, some tests panic on synchronization issues.
This PR attempts to fix most of them (leaving only a tricky one related to grpc server).
Some of those fixes may not be appropriate, feedback is welcome!

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
