### PR TITLE
Rename SMBIOS element

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7486,7 +7486,7 @@
      "selinuxLauncherType": {
       "type": "string"
      },
-     "smbiOS": {
+     "smbios": {
       "$ref": "#/definitions/v1.SMBiosConfiguration"
      },
      "supportedGuestAgentVersions": {

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -15370,7 +15370,7 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							Format: "",
 						},
 					},
-					"smbiOS": {
+					"smbios": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubevirt.io/client-go/api/v1.SMBiosConfiguration"),
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1302,7 +1302,7 @@ type KubeVirtConfiguration struct {
 	NetworkConfiguration        *NetworkConfiguration   `json:"network,omitempty"`
 	OVMFPath                    string                  `json:"ovmfPath,omitempty"`
 	SELinuxLauncherType         string                  `json:"selinuxLauncherType,omitempty"`
-	SMBIOSConfig                *SMBiosConfiguration    `json:"smbiOS,omitempty"`
+	SMBIOSConfig                *SMBiosConfiguration    `json:"smbios,omitempty"`
 	SupportedGuestAgentVersions []string                `json:"supportedGuestAgentVersions,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -15223,7 +15223,7 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							Format: "",
 						},
 					},
-					"smbiOS": {
+					"smbios": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubevirt.io/client-go/api/v1.SMBiosConfiguration"),
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

SMBIOS information can currently be configured with

```yaml
spec:
  configuration:
    smbiOS:
      ...
```

in the KubeVirt resource; however, the "smbiOS" name sticks out a lot.

**Special notes for your reviewer**:

This will need to be rebased on top of https://github.com/kubevirt/kubevirt/pull/3802 once that's merged.

In addition, this is technically a breaking change since the field was introduced in v0.31.0, but I'm not sure how much leeway we have to change it, especially considering that the corresponding OpenAPI schema was never published.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Not sure what to write here (see above)
```