### PR TITLE
Make the tests binary an artifact of the release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ deploy:
   - _out/templates/manifests/release/kubevirt-cr.yaml.j2
   - _out/manifests/release/olm/kubevirt-operatorsource.yaml
   - _out/manifests/release/olm/bundle/kubevirtoperator.$TRAVIS_TAG.clusterserviceversion.yaml
+  - _out/tests/tests.test
   prerelease: true
   overwrite: true
   name: $TRAVIS_TAG


### PR DESCRIPTION
This will ease the consumption of the tests binary.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
