### PR TITLE
virt-launcher: Remove part of the domain event errors

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -334,7 +334,7 @@ func (n *Notifier) StartDomainNotifier(
 				eventCallback(domainConn, domainCache, libvirtEvent{}, n, deleteNotificationSent,
 					interfaceStatuses, guestOsInfo)
 			case <-reconnectChan:
-				n.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect")))
+				n.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect, domain %s", domainName)))
 			}
 		}
 	}()

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -201,7 +201,6 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 	if err != nil {
 		if !domainerrors.IsNotFound(err) {
 			log.Log.Reason(err).Error("Could not fetch the Domain.")
-			client.SendDomainEvent(newWatchEventError(err))
 			return
 		}
 		domain.SetState(api.NoState, api.ReasonNonExistent)
@@ -215,7 +214,6 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 		if err != nil {
 			if !domainerrors.IsNotFound(err) {
 				log.Log.Reason(err).Error("Could not fetch the Domain state.")
-				client.SendDomainEvent(newWatchEventError(err))
 				return
 			}
 			domain.SetState(api.NoState, api.ReasonNonExistent)
@@ -228,7 +226,6 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 			// NOTE: Getting domain metadata for a live-migrating VM isn't allowed
 			if !domainerrors.IsNotFound(err) && !domainerrors.IsInvalidOperation(err) {
 				log.Log.Reason(err).Error("Could not fetch the Domain specification.")
-				client.SendDomainEvent(newWatchEventError(err))
 				return
 			}
 		} else {


### PR DESCRIPTION
Remove part of the domain event errors

Not all the domain errors need a server side
status refresh, which also, in turn cause
grpc server restart due to how its implemented.

In case of libvirt reconnection, (for example due to libvirtd restart) we do need the state
to be refreshed as soon as possible and this was left untouched.

The other cases were removed, which will improve stability and availability
the the gRPC server in the virt-handler, that serves all the VMs in the node.

Found during investigation of #3575

---

Add domain name to libvirt reconnect error

In order to be able to connect between the error,
and the vm that was triggering it, in the virt-handler side.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
