### PR TITLE
tests: Do not create two VMI/s with the same spec

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -564,12 +564,13 @@ var _ = Describe("Configurations", func() {
 		})
 
 		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test", func() {
-			vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("128M")
-			vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+			var vmi *v1.VirtualMachineInstance
 
-			// Create VMI inside BeforeEach because it gets cleanedup, see BeforeEach at the top
 			BeforeEach(func() {
+				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(tests.ContainerDiskFor(tests.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("128M")
+				vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
+
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStart(vmi)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -839,11 +839,13 @@ sockfd = None`})
 	})
 
 	Context("VirtualMachineInstance connected to the pod network", func() {
-		vmi := tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
-		tests.AddExplicitPodNetworkInterface(vmi)
+		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
+
+			vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+			tests.AddExplicitPodNetworkInterface(vmi)
 
 			By("Starting tested VMI")
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid scenarios where the VMI spec is defined and the VMI creation is
repeated between tests with the same spec.

This scenario has been found to cause the VMI/s to "leak" between tests,
causing flakiness.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
```release-note
NONE
```
