### PR TITLE
[release-0.30] Add tests related to qemu processes

### DIFF
--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -20,6 +20,8 @@
 package tests_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
@@ -42,6 +44,9 @@ var _ = Describe("SecurityFeatures", func() {
 	})
 
 	Context("Check virt-launcher securityContext", func() {
+		tests.BeforeAll(func() {
+			tests.SkipSELinuxTestIfRunnigOnKindInfra()
+		})
 
 		var container k8sv1.Container
 		var vmi *v1.VirtualMachineInstance
@@ -81,18 +86,48 @@ var _ = Describe("SecurityFeatures", func() {
 				}
 				Expect(*container.SecurityContext.Privileged).To(BeFalse())
 			})
+
+			It("[test_id:4297]Make sure qemu processes are MCS constrained", func() {
+
+				By("Starting a VirtualMachineInstance")
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+
+				qemuProcessSelinuxContext, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					pod,
+					"compute",
+					[]string{"/usr/bin/bash", "-c", "ps -efZ | grep [/]usr/libexec/qemu-kvm | awk '{print $1}'"},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that qemu-kvm process is of the SELinux type container_t")
+				Expect(strings.Split(qemuProcessSelinuxContext, ":")[2]).To(Equal("container_t"))
+
+				By("Checking that qemu-kvm process has SELinux category_set")
+				Expect(len(strings.Split(qemuProcessSelinuxContext, ":"))).To(Equal(5))
+
+				err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
-		Context("With selinuxLauncherType defined", func() {
-			var superPrivilegedType string
-
-			BeforeEach(func() {
-				superPrivilegedType = "spc_t"
-				tests.UpdateClusterConfigValueAndWait(virtconfig.SELinuxLauncherTypeKey, superPrivilegedType)
-				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
-			})
+		Context("With selinuxLauncherType defined as spc_t", func() {
 
 			It("[test_id:3787]Should honor custom SELinux type for virt-launcher", func() {
+
+				superPrivilegedType := "spc_t"
+				kubeVirtConfig, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if kubeVirtConfig.Data[virtconfig.SELinuxLauncherTypeKey] != superPrivilegedType {
+					tests.UpdateClusterConfigValueAndWait(virtconfig.SELinuxLauncherTypeKey, superPrivilegedType)
+				}
+
+				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+
 				By("Starting a New VMI")
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -106,6 +141,50 @@ var _ = Describe("SecurityFeatures", func() {
 
 				By("Verifying SELinux context contains custom type")
 				Expect(pod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(superPrivilegedType))
+
+				By("Deleting the VMI")
+				err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("With selinuxLauncherType defined as virt_launcher.process", func() {
+
+			It("[test_id:4298]qemu process type is virt_launcher.process, when selinuxLauncherType is virt_launcher.process", func() {
+
+				launcherType := "virt_launcher.process"
+				kubeVirtConfig, err := virtClient.CoreV1().ConfigMaps(tests.KubeVirtInstallNamespace).Get("kubevirt-config", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if kubeVirtConfig.Data[virtconfig.SELinuxLauncherTypeKey] != launcherType {
+					tests.UpdateClusterConfigValueAndWait(virtconfig.SELinuxLauncherTypeKey, launcherType)
+				}
+
+				vmi = tests.NewRandomVMIWithEphemeralDisk(tests.ContainerDiskFor(tests.ContainerDiskAlpine))
+
+				By("Starting a New VMI")
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulVMIStart(vmi)
+
+				By("Ensuring VMI is running by logging in")
+				tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+
+				By("Fetching virt-launcher Pod")
+				pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+
+				qemuProcessSelinuxContext, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					pod,
+					"compute",
+					[]string{"/usr/bin/bash", "-c", "ps -efZ | grep [/]usr/libexec/qemu-kvm | awk '{print $1}'"},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that qemu-kvm process is of the SELinux type virt_launcher.process")
+				Expect(strings.Split(qemuProcessSelinuxContext, ":")[2]).To(Equal(launcherType))
+
+				By("Verifying SELinux context contains custom type in pod")
+				Expect(pod.Spec.SecurityContext.SELinuxOptions.Type).To(Equal(launcherType))
 
 				By("Deleting the VMI")
 				err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4840,6 +4840,12 @@ func SkipNFSTestIfRunnigOnKindInfra() {
 	}
 }
 
+func SkipSELinuxTestIfRunnigOnKindInfra() {
+	if IsRunningOnKindInfra() {
+		Skip("Skip SELinux tests till issue https://github.com/kubevirt/kubevirt/issues/3780 is fixed")
+	}
+}
+
 func IsUsingBuiltinNodeDrainKey() bool {
 	return GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
 }


### PR DESCRIPTION
a) Ensure qemu processes run as cotainer_t, when
selinuxLauncherType is undefined. Also, ensure
that they are MCS constrained by checking for category_set.
b) Ensure qemu processes should be equal to the
value of selinuxLauncherType.

Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: `Add tests related to qemu processes`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: `Add tests related to qemu processes`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
