### PR TITLE
virt-launcher: Remove unneeded condition from StartDomainNotifier

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -330,7 +330,7 @@ func (n *Notifier) StartDomainNotifier(
 			case agentUpdate := <-agentStore.AgentUpdated:
 				interfaceStatuses = agentUpdate.DomainInfo.Interfaces
 				guestOsInfo = agentUpdate.DomainInfo.OSInfo
-				if domainCache != nil && interfaceStatuses != nil {
+				if interfaceStatuses != nil {
 					interfaceStatuses = agentpoller.MergeAgentStatusesWithDomainData(domainCache.Spec.Devices.Interfaces, interfaceStatuses)
 				}
 


### PR DESCRIPTION
AgentUpdated event depends on agentPoller.Start(),
so the flow would be:
Receiving event on eventChan
Assigning domainCache
Start agent poller
    
And just then AgentUpdated event can occur,
and domainCache isnt nil in this case, as it was
set as seen above.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
