### PR TITLE
Flaky [test_id:4142]should include the storage metrics for a running VM

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -484,9 +484,9 @@ var _ = Describe("Infrastructure", func() {
 			By("Writing some data to the disk")
 			_, err = expecter.ExpectBatch([]expect.Batcher{
 				&expect.BSnd{S: "dd if=/dev/zero of=/dev/vdb bs=1M count=1\n"},
-				&expect.BExp{R: "localhost:~#"},
+				&expect.BExp{R: `localhost:~#`},
 				&expect.BSnd{S: "sync\n"},
-				&expect.BExp{R: "localhost:~#"},
+				&expect.BExp{R: `localhost:~#`},
 			}, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -695,7 +695,7 @@ var _ = Describe("Infrastructure", func() {
 			By("Checking the collected metrics")
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
-				if strings.Contains(key, "vdb") {
+				if strings.Contains(key, `drive="vdb"`) {
 					value := metrics[key]
 					Expect(value).To(BeNumerically(">", float64(0.0)))
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
The VMI name may include the sequence "vbd", which would add unwanted matches,
  and fail the tests if those matches have a metric of 0

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3689

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
