### PR TITLE
Revert "Disable 2 flaky functional tests"

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -71,8 +71,7 @@ var _ = Describe("Infrastructure", func() {
 			tests.BeforeTestCleanup()
 		})
 
-		// Flaky, randomly fails with timeout
-		PIt("[test_id:4099] [flaky] should be rotated when a new CA is created", func() {
+		It("[test_id:4099]should be rotated when a new CA is created", func() {
 			By("checking that the config-map gets the new CA bundle attached")
 			Eventually(func() int {
 				_, crts := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
@@ -136,8 +135,7 @@ var _ = Describe("Infrastructure", func() {
 			defer expecter.Close()
 		})
 
-		// Flaky, randomly fails with timeout
-		PIt("[test_id:4100] [flaky] should be valid during the whole rotation process", func() {
+		It("[test_id:4100]should be valid during the whole rotation process", func() {
 			oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), tests.KubeVirtInstallNamespace, "8443")
 			oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), tests.KubeVirtInstallNamespace, "8186")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The flakyness might have been caused by the (now fixed) unreliable Alpine login expecter.

This reverts commit 7baddb69a40d1e2cf67373480266c75080bf84b6.

```release-note
NONE
```
