### PR TITLE
virtctl: Print response body on error from upload proxy.

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -22,6 +22,7 @@ package imageupload
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -368,9 +369,13 @@ func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) erro
 	if err != nil {
 		return err
 	}
-
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected return value %d", resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("unexpected return value %d, %s", resp.StatusCode, string(body))
 	}
 
 	return nil


### PR DESCRIPTION
To help users debug issues.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Virtctl ignores any content from the body on an error during upload. This means we just report the status code. With https://github.com/kubevirt/containerized-data-importer/pull/1299 CDI now reports validation failures as part of the body response in case for instance the virtual disk image size > PVC size. This PR updates virtctl to print the error message from the response body.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Virtctl now prints error messages from the response body on upload errors.
```
