### PR TITLE
[release-0.30] Ensure we're resilient to domain notify server restarts

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
+        "//pkg/virt-launcher/notify-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/watchdog:go_default_library",

--- a/pkg/virt-handler/notify-server/server.go
+++ b/pkg/virt-handler/notify-server/server.go
@@ -83,6 +83,7 @@ func (n *Notify) HandleDomainEvent(ctx context.Context, request *notifyv1.Domain
 	case string(watch.Deleted):
 		n.EventChan <- watch.Event{Type: watch.Deleted, Object: domain}
 	case string(watch.Error):
+		log.Log.Object(domain).Errorf("Domain error event with message: %s", status.Message)
 		n.EventChan <- watch.Event{Type: watch.Error, Object: status}
 	}
 	return response, nil

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -227,7 +227,7 @@ func handleDomainNotifyPipe(domainPipeStopChan chan struct{}, ln net.Listener, v
 					defer conn.Close()
 
 					log.Log.Object(vmi).Infof("Accepted new notify pipe connection for vmi")
-					copyErr := make(chan error)
+					copyErr := make(chan error, 2)
 					go func() {
 						_, err := io.Copy(fd, conn)
 						copyErr <- err

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -69,9 +69,9 @@ import (
 )
 
 type launcherClientInfo struct {
-	client     cmdclient.LauncherClient
-	socketFile string
-	domainPipe net.Listener
+	client             cmdclient.LauncherClient
+	socketFile         string
+	domainPipeStopChan chan struct{}
 }
 
 func NewController(
@@ -180,11 +180,79 @@ type VirtualMachineController struct {
 	domainNotifyPipes map[string]string
 }
 
-func (d *VirtualMachineController) startDomainNotifyPipe(vmi *v1.VirtualMachineInstance) (net.Listener, error) {
+func handleDomainNotifyPipe(domainPipeStopChan chan struct{}, ln net.Listener, virtShareDir string, vmi *v1.VirtualMachineInstance) {
+
+	fdChan := make(chan net.Conn, 100)
+
+	// Listen for new connections,
+	// Close listener and exit when stop encountered
+	go func(vmi *v1.VirtualMachineInstance, ln net.Listener, domainPipeStopChan chan struct{}) {
+		for {
+			select {
+			case <-domainPipeStopChan:
+				log.Log.Object(vmi).Infof("closing notify pipe listener for vmi")
+				ln.Close()
+				return
+			default:
+				fd, err := ln.Accept()
+				if err != nil {
+					log.Log.Reason(err).Error("Domain pipe accept error encountered.")
+					// keep listening until stop invoked
+					time.Sleep(1)
+				} else {
+					fdChan <- fd
+				}
+			}
+		}
+	}(vmi, ln, domainPipeStopChan)
+
+	// Process new connections
+	// exit when stop encountered
+	go func(vmi *v1.VirtualMachineInstance, fdChan chan net.Conn, domainPipeStopChan chan struct{}) {
+		for {
+			select {
+			case <-domainPipeStopChan:
+				return
+			case fd := <-fdChan:
+				go func(vmi *v1.VirtualMachineInstance) {
+					defer fd.Close()
+
+					// pipe the VMI domain-notify.sock to the virt-handler domain-notify.sock
+					// so virt-handler receives notifications from the VMI
+					conn, err := net.Dial("unix", filepath.Join(virtShareDir, "domain-notify.sock"))
+					if err != nil {
+						log.Log.Reason(err).Error("error connecting to domain-notify.sock for proxy connection")
+						return
+					}
+					defer conn.Close()
+
+					log.Log.Object(vmi).Infof("Accepted new notify pipe connection for vmi")
+					copyErr := make(chan error)
+					go func() {
+						_, err := io.Copy(fd, conn)
+						copyErr <- err
+					}()
+					go func() {
+						_, err := io.Copy(conn, fd)
+						copyErr <- err
+					}()
+
+					// wait until one of the copy routines exit then
+					// let the fd close
+					err = <-copyErr
+					log.Log.Object(vmi).Infof("closing notify pipe connection for vmi: %v", err)
+
+				}(vmi)
+			}
+		}
+	}(vmi, fdChan, domainPipeStopChan)
+}
+
+func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan struct{}, vmi *v1.VirtualMachineInstance) error {
 
 	res, err := d.podIsolationDetector.Detect(vmi)
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect isolation for launcher pod when setting up notify pipe: %v", err)
+		return fmt.Errorf("failed to detect isolation for launcher pod when setting up notify pipe: %v", err)
 	}
 
 	// inject the domain-notify.sock into the VMI pod.
@@ -194,55 +262,18 @@ func (d *VirtualMachineController) startDomainNotifyPipe(vmi *v1.VirtualMachineI
 	err = os.MkdirAll(filepath.Dir(socketPath), 0755)
 	if err != nil {
 		log.Log.Reason(err).Error("unable to create directory for unix socket")
-		return nil, err
+		return err
 	}
 
 	listener, err := net.Listen("unix", socketPath)
 	if err != nil {
 		log.Log.Reason(err).Error("failed to create unix socket for proxy service")
-		return nil, err
+		return err
 	}
 
-	// pipe the VMI domain-notify.sock to the virt-handler domain-notify.sock
-	// so virt-handler receives notifications from the VMI
-	conn, err := net.Dial("unix", filepath.Join(d.virtShareDir, "domain-notify.sock"))
-	if err != nil {
-		listener.Close()
-		return nil, err
-	}
+	handleDomainNotifyPipe(domainPipeStopChan, listener, d.virtShareDir, vmi)
 
-	go func(d *VirtualMachineController, ln net.Listener, socketPath string, vmi *v1.VirtualMachineInstance) {
-		defer conn.Close()
-		for {
-			fd, err := ln.Accept()
-			if err != nil {
-				log.Log.Reason(err).Error("domain pipe listener closed.")
-				break
-			}
-
-			go func(vmi *v1.VirtualMachineInstance) {
-				log.Log.Object(vmi).V(3).Infof("Accepted new notify pipe connection for vmi")
-				defer fd.Close()
-				copyErr := make(chan error)
-				go func() {
-					_, err := io.Copy(fd, conn)
-					copyErr <- err
-				}()
-				go func() {
-					_, err := io.Copy(conn, fd)
-					copyErr <- err
-				}()
-
-				// wait until one of the copy routines exit then
-				// let the fd close
-				err := <-copyErr
-				log.Log.Object(vmi).V(3).Infof("closing notify pipe connection for vmi: %v", err)
-
-			}(vmi)
-		}
-	}(d, listener, socketPath, vmi)
-
-	return listener, nil
+	return nil
 }
 
 // Determines if a domain's grace period has expired during shutdown.
@@ -1331,9 +1362,8 @@ func (d *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineIns
 	clientInfo, ok := d.launcherClients[vmi.UID]
 	if ok {
 		clientInfo.client.Close()
-		if clientInfo.domainPipe != nil {
-			clientInfo.domainPipe.Close()
-		}
+		close(clientInfo.domainPipeStopChan)
+
 		// With legacy sockets on hostpaths, we have to cleanup the sockets ourselves.
 		if cmdclient.IsLegacySocket(clientInfo.socketFile) {
 			err := os.RemoveAll(clientInfo.socketFile)
@@ -1357,15 +1387,15 @@ func (d *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineIns
 }
 
 // used by unit tests to add mock clients
-func (d *VirtualMachineController) addLauncherClient(vmUID types.UID, client cmdclient.LauncherClient, socketFile string, domainPipe net.Listener) error {
+func (d *VirtualMachineController) addLauncherClient(vmUID types.UID, client cmdclient.LauncherClient, socketFile string) error {
 	// maps require locks for concurrent access
 	d.launcherClientLock.Lock()
 	defer d.launcherClientLock.Unlock()
 
 	d.launcherClients[vmUID] = &launcherClientInfo{
-		client:     client,
-		socketFile: socketFile,
-		domainPipe: domainPipe,
+		client:             client,
+		socketFile:         socketFile,
+		domainPipeStopChan: make(chan struct{}),
 	}
 
 	return nil
@@ -1404,7 +1434,6 @@ func (d *VirtualMachineController) isLauncherClientUnresponsive(vmi *v1.VirtualM
 }
 
 func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInstance) (cmdclient.LauncherClient, error) {
-	var domainPipe net.Listener
 	var err error
 
 	// maps require locks for concurrent access
@@ -1431,20 +1460,22 @@ func (d *VirtualMachineController) getLauncherClient(vmi *v1.VirtualMachineInsta
 		return nil, err
 	}
 
+	domainPipeStopChan := make(chan struct{})
 	// if this isn't a legacy socket, we need to
 	// pipe in the domain socket into the VMI's filesystem
 	if !cmdclient.IsLegacySocket(socketFile) {
-		domainPipe, err = d.startDomainNotifyPipe(vmi)
+		err = d.startDomainNotifyPipe(domainPipeStopChan, vmi)
 		if err != nil {
 			client.Close()
+			close(domainPipeStopChan)
 			return nil, err
 		}
 	}
 
 	d.launcherClients[vmi.UID] = &launcherClientInfo{
-		client:     client,
-		socketFile: socketFile,
-		domainPipe: domainPipe,
+		client:             client,
+		socketFile:         socketFile,
+		domainPipeStopChan: domainPipeStopChan,
 	}
 
 	return client, nil

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -240,7 +240,11 @@ func handleDomainNotifyPipe(domainPipeStopChan chan struct{}, ln net.Listener, v
 					// wait until one of the copy routines exit then
 					// let the fd close
 					err = <-copyErr
-					log.Log.Object(vmi).Infof("closing notify pipe connection for vmi: %v", err)
+					if err != nil {
+						log.Log.Object(vmi).Infof("closing notify pipe connection for vmi with error: %v", err)
+					} else {
+						log.Log.Object(vmi).Infof("gracefully closed notify pipe connection for vmi")
+					}
 
 				}(vmi)
 			}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -47,6 +47,7 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
+	notifyclient "kubevirt.io/kubevirt/pkg/virt-launcher/notify-client"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -216,9 +217,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		time.Sleep(1 * time.Second)
 
 		client = cmdclient.NewMockLauncherClient(ctrl)
-		domainPipe, err := controller.startDomainNotifyPipe(nil)
-		Expect(err).ToNot(HaveOccurred())
-		controller.addLauncherClient(vmiTestUUID, client, sockFile, domainPipe)
+		controller.addLauncherClient(vmiTestUUID, client, sockFile)
 
 	})
 
@@ -272,7 +271,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			legacyMockSockFile := filepath.Join(shareDir, "sockets", uid+"_sock")
 
-			controller.addLauncherClient(types.UID(uid), client, legacyMockSockFile, nil)
+			controller.addLauncherClient(types.UID(uid), client, legacyMockSockFile)
 			err := virtcache.AddGhostRecord(namespace, name, legacyMockSockFile, types.UID(uid))
 			Expect(err).ToNot(HaveOccurred())
 
@@ -1681,6 +1680,181 @@ var _ = Describe("VirtualMachineInstance", func() {
 			}).Return(vmi, nil)
 
 			controller.Execute()
+		})
+	})
+})
+
+var _ = Describe("DomainNotifyServerRestarts", func() {
+	Context("should establish a notify server pipe", func() {
+		var shareDir string
+		var err error
+		var serverStopChan chan struct{}
+		var serverIsStoppedChan chan struct{}
+		var stoppedServer bool
+		var domainPipeStopChan chan struct{}
+		var stoppedPipe bool
+		var eventChan chan watch.Event
+		var client *notifyclient.Notifier
+		var recorder *record.FakeRecorder
+		var vmiStore cache.Store
+
+		BeforeEach(func() {
+			serverStopChan = make(chan struct{})
+			domainPipeStopChan = make(chan struct{})
+			serverIsStoppedChan = make(chan struct{})
+			eventChan = make(chan watch.Event, 100)
+			stoppedServer = false
+			stoppedPipe = false
+			shareDir, err = ioutil.TempDir("", "kubevirt-share")
+			Expect(err).ToNot(HaveOccurred())
+
+			recorder = record.NewFakeRecorder(10)
+			vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
+			vmiStore = vmiInformer.GetStore()
+
+			go func(serverIsStoppedChan chan struct{}) {
+				notifyserver.RunServer(shareDir, serverStopChan, eventChan, recorder, vmiStore)
+				close(serverIsStoppedChan)
+			}(serverIsStoppedChan)
+
+			time.Sleep(3)
+		})
+
+		AfterEach(func() {
+			if stoppedServer == false {
+				close(serverStopChan)
+			}
+			if stoppedPipe == false {
+				close(domainPipeStopChan)
+			}
+			client.Close()
+			os.RemoveAll(shareDir)
+		})
+
+		It("should get notify events", func() {
+			vmi := v1.NewMinimalVMI("fake-vmi")
+			vmi.UID = "4321"
+			vmiStore.Add(vmi)
+
+			eventType := "Normal"
+			eventReason := "fooReason"
+			eventMessage := "barMessage"
+
+			pipePath := filepath.Join(shareDir, "client_path", "domain-notify-pipe.sock")
+			pipeDir := filepath.Join(shareDir, "client_path")
+			err := os.MkdirAll(pipeDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			listener, err := net.Listen("unix", pipePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			handleDomainNotifyPipe(domainPipeStopChan, listener, shareDir, vmi)
+			time.Sleep(1)
+
+			client = notifyclient.NewNotifier(pipeDir)
+
+			err = client.SendK8sEvent(vmi, eventType, eventReason, eventMessage)
+			Expect(err).ToNot(HaveOccurred())
+
+			timedOut := false
+			timeout := time.After(4 * time.Second)
+			select {
+			case <-timeout:
+				timedOut = true
+			case event := <-recorder.Events:
+				Expect(event).To(Equal(fmt.Sprintf("%s %s %s", eventType, eventReason, eventMessage)))
+			}
+
+			Expect(timedOut).To(BeFalse(), "should not time out")
+		})
+
+		It("should get eventually get notify events once pipe is online", func() {
+			vmi := v1.NewMinimalVMI("fake-vmi")
+			vmi.UID = "4321"
+			vmiStore.Add(vmi)
+
+			eventType := "Normal"
+			eventReason := "fooReason"
+			eventMessage := "barMessage"
+
+			pipePath := filepath.Join(shareDir, "client_path", "domain-notify-pipe.sock")
+			pipeDir := filepath.Join(shareDir, "client_path")
+			err := os.MkdirAll(pipeDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Client should fail when pipe is offline
+			client = notifyclient.NewNotifier(pipeDir)
+			err = client.SendK8sEvent(vmi, eventType, eventReason, eventMessage)
+			Expect(err).To(HaveOccurred())
+
+			// Client should automatically come online when pipe is established
+			listener, err := net.Listen("unix", pipePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			handleDomainNotifyPipe(domainPipeStopChan, listener, shareDir, vmi)
+			time.Sleep(1)
+
+			// Expect the client to eventually reconnect and succeed despite initial failure
+			Eventually(func() error {
+				return client.SendK8sEvent(vmi, eventType, eventReason, eventMessage)
+			}, 10, 1).Should(BeNil())
+
+		})
+
+		It("should be resilient to notify server restarts", func() {
+			vmi := v1.NewMinimalVMI("fake-vmi")
+			vmi.UID = "4321"
+			vmiStore.Add(vmi)
+
+			eventType := "Normal"
+			eventReason := "fooReason"
+			eventMessage := "barMessage"
+
+			pipePath := filepath.Join(shareDir, "client_path", "domain-notify-pipe.sock")
+			pipeDir := filepath.Join(shareDir, "client_path")
+			err := os.MkdirAll(pipeDir, 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			listener, err := net.Listen("unix", pipePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			handleDomainNotifyPipe(domainPipeStopChan, listener, shareDir, vmi)
+			time.Sleep(1)
+
+			client = notifyclient.NewNotifier(pipeDir)
+
+			for i := 1; i < 5; i++ {
+				// close and wait for server to stop
+				close(serverStopChan)
+				<-serverIsStoppedChan
+
+				// Expect a client error to occur here because the server is down
+				err = client.SendK8sEvent(vmi, eventType, eventReason, eventMessage)
+				Expect(err).To(HaveOccurred())
+
+				// Restart the server now that it is down.
+				serverStopChan = make(chan struct{})
+				serverIsStoppedChan = make(chan struct{})
+				go func() {
+					notifyserver.RunServer(shareDir, serverStopChan, eventChan, recorder, vmiStore)
+					close(serverIsStoppedChan)
+				}()
+
+				// Expect the client to eventually reconnect and succeed despite server restarts
+				Eventually(func() error {
+					return client.SendK8sEvent(vmi, eventType, eventReason, eventMessage)
+				}, 10, 1).Should(BeNil())
+
+				timedOut := false
+				timeout := time.After(4 * time.Second)
+				select {
+				case <-timeout:
+					timedOut = true
+				case event := <-recorder.Events:
+					Expect(event).To(Equal(fmt.Sprintf("%s %s %s", eventType, eventReason, eventMessage)))
+				}
+				Expect(timedOut).To(BeFalse(), "should not time out")
+			}
 		})
 	})
 })

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -328,7 +328,6 @@ func (n *Notifier) StartDomainNotifier(
 					interfaceStatuses, guestOsInfo)
 			case <-reconnectChan:
 				n.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect")))
-				return
 			}
 		}
 	}()
@@ -345,6 +344,7 @@ func (n *Notifier) StartDomainNotifier(
 			log.Log.Infof("Libvirt event channel is full, dropping event.")
 		}
 	}
+
 	err := domainConn.DomainEventLifecycleRegister(domainEventLifecycleCallback)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to register event callback with libvirt")


### PR DESCRIPTION
This is a backport to the release-0.30 branch.

I introduced logic that pipes the domain notify grpc client through a unix socket on the vmi pod to a unix socket on the host. This was done to remove a shared host mount that was given to the VMI.

In the process, I introduced a bug where if the notify server is reset (which apparently actually happens) then the pipe connection is never re-established.... meaning any VMIs running on the host after this condition occurs won't have their domain notifies received.

While testing this, it turns out there's also a long standing error on the client side preventing the client from attempting to send notifies after the libvirt connection is reset. To fix this, I added logic to re-register the notify callbacks with libvirt on reconnect.

Both of these client and server issues break migrations and the graceful shutdown flow. They are likely the source of some random flaky tests.

Related to #3814 

**Release note**:
```release-note
Fixes re-establishing domain notify client connections when domain notify server restarts due to an error event. 
```
