### PR TITLE
sriov-lane: dedicated container disk image

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -245,6 +245,8 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)fedora-cloud-container-disk-demo:$(container_tag)": "//containerimages:fedora-cloud-container-disk-image",
         "$(container_prefix)/$(image_prefix)microlivecd-container-disk-demo:$(container_tag)": "//containerimages:microlivecd-container-disk-image",
         "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
+        # Customized container-disk images
+        "$(container_prefix)/$(image_prefix)fedora-sriov-lane-container-disk:$(container_tag)": "//containerimages:fedora-sriov-lane-container-disk-image",
         # testing images
         "$(container_prefix)/$(image_prefix)disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",
         "$(container_prefix)/$(image_prefix)cdi-http-import-server:$(container_tag)": "//images/cdi-http-import-server:cdi-http-import-server-image",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -339,6 +339,15 @@ container_pull(
     repository = "library/fedora",
 )
 
+# Pull fedora 32 customize container-disk
+container_pull(
+    name = "fedora_sriov_lane",
+    digest = "sha256:2d332d28863d0e415d58e335e836bd4f8a8c714e7a9d1f8f87418ef3db7c0afb",
+    registry = "index.docker.io",
+    repository = "kubevirt/fedora-sriov-testing",
+    #tag = "32",
+)
+
 # Pull base image libvirt
 container_pull(
     name = "libvirt",

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -77,3 +77,16 @@ container_image(
     files = ["@virtio_win_image//file"],
     visibility = ["//visibility:public"],
 )
+
+container_image(
+    name = "fedora-sriov-lane-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
+    base = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "@fedora_sriov_lane_ppc64le//image",
+        "//conditions:default": "@fedora_sriov_lane//image",
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/containerimages/container-disk-images.md
+++ b/containerimages/container-disk-images.md
@@ -12,3 +12,103 @@ The following images stored at `dockerhub.com/kubevirt` and can be used in Kubev
 
 - **fedora-cloud-container-disk-demo**
     Fedora cloud edition image.
+
+- **fedora-sriov-lane-container-disk**
+    Fedora cloud edition image with contains all necessary configuration and drivers for sriov lane tests.    
+    - This image contained the packages:  
+        - kernel-modules (includes sriov drivers)  
+        - qemu-guest-agent  
+    - Configurations:  
+        - Enable and start qemu-guest-agent  
+        - Load kernel modules needed for sriov  
+          mlx4, mlx5, i40e, igb  
+
+## How to create new customized container-disk for tests
+
+Work-in-progress PR to automate this process https://github.com/kubevirt/kubevirtci/pull/428
+
+Customize an image can be done by:
+- Editing the image with `virt-customize`  
+  Adding new package to an image for example:  
+  `virt-customize -a "fedora32.qcow2" --install dpdk`
+
+- Spin-up live VM with the image you want using `virt-install`  
+  Once the VM is up apply the changes you want and when done
+  shut down the VM gracefully with `sudo shutdown -h now`
+
+Next, it is necessary to prepare the image so there will be no unique files or configurations   
+so each VM that will be created with the new image will have unique machine-id, mac-address etc.. 
+We can do that with `virt-sysprep`:
+ ```bash
+ virt-sysprep -a fedora32.qcow --operations machine-id,bash-history,logfiles,tmp-files,net-hostname,net-hwaddr  
+ ```
+￼
+
+Once the image is ready it is necessary to convert it to   
+container image with `kubevirt/container-disk-v1alpha` layer, 
+so KubeVirt VM's can consume it according to  
+https://github.com/kubevirt/kubevirt/blob/master/docs/container-register-disks.md
+
+```bash
+cat > Dockerfile <<EOF
+FROM kubevirt/container-disk-v1alpha
+ADD fedora32.qcow2 /disk/
+EOF
+
+docker build -t kubevirt/fedora-sriov-testing:latest .
+```
+
+
+## Use image in Kubevirt tests
+
+First we need pull the image from the remote registry (or local registry) by adding `container_pull` rule to `WORKSPACE` file:
+```bash
+container_pull(
+    name = "fedora_sriov_lane",
+    # digest = ""
+    registry = "localhost:5000",
+    repository = "kubevirt/fedora-sriov-testing",
+    tag = "latest",
+)
+```
+Once you verified the image works reach out to kubevirt CI maintainers and ask to upload the new image 
+then update the `container_pull` rule accordingly.
+```bash
+container_pull(
+    name = "fedora_sriov_lane",
+    digest = ""
+    registry = "index.docker.io",
+    repository = "kubevirt/fedora-sriov-testing",
+    # tag = "32",
+)
+```
+
+Next we need to add `contaier_image` rule for the new image to `containerdisks/BUILD.bazel` file;
+```bash
+container_image(
+    name = "fedora-sriov-lane-container-disk-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
+    base = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "@fedora_sriov_lane_ppc64le//image",
+        "//conditions:default": "@fedora_sriov_lane//image",
+    }),
+    visibility = ["//visibility:public"],
+)
+```
+
+Then add new line for the container_bundle rule at the pojects`BUILD.bazel` file
+```bash
+container_bundle(
+    name = "build-other-images",
+    images = {
+        ...
+        "$(container_prefix)/$(image_prefix)fedora-sriov-lane-container-disk:$(container_tag)": "//containerimages:fedora-extended-container-disk-image",
+        ...
+    }
+)
+```
+
+Finally, in order to use the image in tests suite it is necessary to add it to `tests/containerdisks/containerdisks.go` file.

--- a/containerimages/container-disk-images.md
+++ b/containerimages/container-disk-images.md
@@ -1,0 +1,14 @@
+# KubeVirt container-disk images
+The following images stored at `dockerhub.com/kubevirt` and can be used in Kubevirt tests:
+
+- **alpine-container-disk-demo**
+   Lightweight image for test suite.
+
+- **cirros-container-disk-demo**
+    Lightweight image for test suite.
+
+- **cirros-custom-container-disk-demo**
+    Used for e2e testing of custom base paths.
+
+- **fedora-cloud-container-disk-demo**
+    Fedora cloud edition image.

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -32,6 +32,7 @@ const (
 	ContainerDiskCirros               ContainerDisk = "cirros"
 	ContainerDiskAlpine               ContainerDisk = "alpine"
 	ContainerDiskFedora               ContainerDisk = "fedora-cloud"
+	ContainerDiskFedoraSRIOVLane      ContainerDisk = "fedora-sriov-lane"
 	ContainerDiskMicroLiveCD          ContainerDisk = "microlivecd"
 	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
 	ContainerDiskEmpty                ContainerDisk = "empty"
@@ -46,6 +47,8 @@ func ContainerDiskFor(name ContainerDisk) string {
 		return fmt.Sprintf("%s/%s-container-disk-demo:%s", flags.KubeVirtUtilityRepoPrefix, name, flags.KubeVirtUtilityVersionTag)
 	case ContainerDiskVirtio:
 		return fmt.Sprintf("%s/virtio-container-disk:%s", flags.KubeVirtUtilityRepoPrefix, flags.KubeVirtUtilityVersionTag)
+	case ContainerDiskFedoraSRIOVLane:
+		return fmt.Sprintf("%s/%s-container-disk:%s", flags.KubeVirtUtilityRepoPrefix, name, flags.KubeVirtUtilityVersionTag)
 	}
 	panic(fmt.Sprintf("Unsupported registry disk %s", name))
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3033,6 +3033,13 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		&expect.BSnd{S: "\n"},
 		&expect.BCas{C: []expect.Caser{
 			&expect.Case{
+				// In case the VM's did not get hostname form DHCP server try the default hostname
+				R:  regexp.MustCompile(`localhost login: `),
+				S:  "fedora\n",
+				T:  expect.Next(),
+				Rt: 10,
+			},
+			&expect.Case{
 				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
 				R:  regexp.MustCompile(vmi.Name + ` login: `),
 				S:  "fedora\n",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In sriov-lane we use fedora container disk image, 
that image does not include `qemu-ga` package or sriov drivers.
Currently we install and config what necessary through in place before each test using cloud-init:
`quem-ga` package downloaded from internal http server `cdi-http-import-server`
sriov drivers are installed with dnf.

This PR uses new image that include all necessary packages and configurations
for sriov lane tests.
Using this kind of image instead of relaying on cloud-config and internal http server
is more efficient, take less time for VM to be ready and thus for tests to finish
and most important less prune to errors.

**Which issue(s) this PR fixes**:
Needed for #3797 
Fixes #3850 

**Special notes for your reviewer**:
At the moment I am pulling the image form private registry, 
once the image will be stored in kubevirt registry  I will update bazel container_pull rule

The image was create with https://github.com/ormergi/vm-image-builder
PR for adding it to kubevirtci https://github.com/kubevirt/kubevirtci/pull/428

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
