### PR TITLE
buffer the error channel in the notify pipe logic to avoid blocking

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -233,7 +233,7 @@ func handleDomainNotifyPipe(domainPipeStopChan chan struct{}, ln net.Listener, v
 					defer conn.Close()
 
 					log.Log.Object(vmi).Infof("Accepted new notify pipe connection for vmi")
-					copyErr := make(chan error)
+					copyErr := make(chan error, 2)
 					go func() {
 						_, err := io.Copy(fd, conn)
 						copyErr <- err


### PR DESCRIPTION
We need to buffer this error channel to prevent blocking one of the goroutines that depends on it from shutting down.


```release-note
NONE
```
