### PR TITLE
Vhostuser: Move get pod interface name function to virtwrap/api

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//pkg/virt-launcher/virtwrap/network/cache:go_default_library",
         "//pkg/virt-launcher/virtwrap/network/cache/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network/cache/fake"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 )
 
 var _ = Describe("Network", func() {
@@ -58,7 +59,7 @@ var _ = Describe("Network", func() {
 			iface := v1.DefaultBridgeNetworkInterface()
 			defaultNet := v1.DefaultPodNetwork()
 
-			mockpodNIC.EXPECT().PlugPhase1(vm, iface, defaultNet, primaryPodInterfaceName, pid)
+			mockpodNIC.EXPECT().PlugPhase1(vm, iface, defaultNet, converter.PrimaryPodInterfaceName, pid)
 			err := SetupPodNetworkPhase1(vm, pid, cacheFactory)
 			Expect(err).To(BeNil())
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Pod interface name is required to query the interface
from app-netutil for the vhostuser interface support.
This patch refactors the getPodInterfaceName function
so that it can be used from virtwrap/api and
virtwrap/network in the follow-up patches.

Signed-off-by: Saravanan KR <skramaja@redhat.com>

**Which issue(s) this PR fixes** 
Related #3405

**Special notes for your reviewer**:
NONE

**Release note**:

```release-note
NONE
```
