### PR TITLE
Remove unused feature gates

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -32,7 +32,6 @@ const (
 	SidecarGate           = "Sidecar"
 	GPUGate               = "GPU"
 	SnapshotGate          = "Snapshot"
-	DataVolumesGate       = "DataVolumes"
 	SRIOVGate             = "SRIOVGate"
 	HostDiskGate          = "HostDisk"
 )
@@ -76,10 +75,6 @@ func (config *ClusterConfig) GPUPassthroughEnabled() bool {
 
 func (config *ClusterConfig) SnapshotEnabled() bool {
 	return config.isFeatureGateEnabled(SnapshotGate)
-}
-
-func (config *ClusterConfig) DataVolumesEnabled() bool {
-	return config.isFeatureGateEnabled(DataVolumesGate)
 }
 
 func (config *ClusterConfig) SriovEnabled() bool {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -32,7 +32,6 @@ const (
 	SidecarGate           = "Sidecar"
 	GPUGate               = "GPU"
 	SnapshotGate          = "Snapshot"
-	SRIOVGate             = "SRIOVGate"
 	HostDiskGate          = "HostDisk"
 )
 
@@ -75,10 +74,6 @@ func (config *ClusterConfig) GPUPassthroughEnabled() bool {
 
 func (config *ClusterConfig) SnapshotEnabled() bool {
 	return config.isFeatureGateEnabled(SnapshotGate)
-}
-
-func (config *ClusterConfig) SriovEnabled() bool {
-	return config.isFeatureGateEnabled(SRIOVGate)
 }
 
 func (config *ClusterConfig) HostDiskEnabled() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removing unused feature gates from the kubevirt configuration. 

Since these feature gate flags are not checked I think they should be removed. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
