### PR TITLE
tests: Extract ContainerDisk code to containerdisk.go

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "containerdisk.go",
         "flags.go",
         "test.go",
         "utils.go",

--- a/tests/containerdisk.go
+++ b/tests/containerdisk.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package tests
+
+import (
+	"fmt"
+)
+
+type ContainerDisk string
+
+const (
+	ContainerDiskCirrosCustomLocation ContainerDisk = "cirros-custom"
+	ContainerDiskCirros               ContainerDisk = "cirros"
+	ContainerDiskAlpine               ContainerDisk = "alpine"
+	ContainerDiskFedora               ContainerDisk = "fedora-cloud"
+	ContainerDiskMicroLiveCD          ContainerDisk = "microlivecd"
+	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
+	ContainerDiskEmpty                ContainerDisk = "empty"
+)
+
+// ContainerDiskFor takes the name of an image and returns the full
+// registry diks image path.
+// Use the ContainerDisk* constants as input values.
+func ContainerDiskFor(name ContainerDisk) string {
+	switch name {
+	case ContainerDiskCirros, ContainerDiskAlpine, ContainerDiskFedora, ContainerDiskMicroLiveCD, ContainerDiskCirrosCustomLocation:
+		return fmt.Sprintf("%s/%s-container-disk-demo:%s", KubeVirtUtilityRepoPrefix, name, KubeVirtUtilityVersionTag)
+	case ContainerDiskVirtio:
+		return fmt.Sprintf("%s/virtio-container-disk:%s", KubeVirtUtilityRepoPrefix, KubeVirtUtilityVersionTag)
+	}
+	panic(fmt.Sprintf("Unsupported registry disk %s", name))
+}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2791,31 +2791,6 @@ func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineIn
 	}, timeout, opts...)
 }
 
-type ContainerDisk string
-
-const (
-	ContainerDiskCirrosCustomLocation ContainerDisk = "cirros-custom"
-	ContainerDiskCirros               ContainerDisk = "cirros"
-	ContainerDiskAlpine               ContainerDisk = "alpine"
-	ContainerDiskFedora               ContainerDisk = "fedora-cloud"
-	ContainerDiskMicroLiveCD          ContainerDisk = "microlivecd"
-	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
-	ContainerDiskEmpty                ContainerDisk = "empty"
-)
-
-// ContainerDiskFor takes the name of an image and returns the full
-// registry diks image path.
-// Supported values are: cirros, fedora, alpine, guest-agent
-func ContainerDiskFor(name ContainerDisk) string {
-	switch name {
-	case ContainerDiskCirros, ContainerDiskAlpine, ContainerDiskFedora, ContainerDiskMicroLiveCD, ContainerDiskCirrosCustomLocation:
-		return fmt.Sprintf("%s/%s-container-disk-demo:%s", KubeVirtUtilityRepoPrefix, name, KubeVirtUtilityVersionTag)
-	case ContainerDiskVirtio:
-		return fmt.Sprintf("%s/virtio-container-disk:%s", KubeVirtUtilityRepoPrefix, KubeVirtUtilityVersionTag)
-	}
-	panic(fmt.Sprintf("Unsupported registry disk %s", name))
-}
-
 func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of re-organizing the tests/utils codebase, the container disk
related helpers are moved to a dedicated file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
