### PR TITLE
virt-handler,test: Fix move vmi to `Failed` on virt-launcher critical error

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -58,10 +58,10 @@ type VIF struct {
 }
 
 type CriticalNetworkError struct {
-	msg string
+	Msg string
 }
 
-func (e *CriticalNetworkError) Error() string { return e.msg }
+func (e *CriticalNetworkError) Error() string { return e.Msg }
 
 func (vif VIF) String() string {
 	return fmt.Sprintf(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Originally the test didn't work and it passed only because the vmi didn't
have a `uid` (which caused the vmi to be moved to `Failed` phase).
The test was fixed by-
1. Adding a `uid` to the vmi
2. Mocking the `res.DoNetNS` (invocation on the virt-launcher's network namespace) to return a `network.CriticalNetworkError`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The issue was discover on - https://github.com/kubevirt/kubevirt/pull/3642#pullrequestreview-450872476

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
