### PR TITLE
add error message to virtctl expose

### DIFF
--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -37,7 +37,7 @@ var strServiceType string
 var portName string
 var namespace string
 
-// generate a new "expose" command
+// NewExposeCommand generate a new "expose" command
 func NewExposeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "expose (TYPE NAME)",
@@ -51,7 +51,7 @@ Possible types are (case insensitive, both single and plurant forms):
         
 virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplicaset (vmirs)`,
 		Example: usage(),
-		Args:    cobra.ExactArgs(2),
+		Args:    templates.ExactArgs("expose", 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_EXPOSE, clientConfig: clientConfig}
 			return c.RunE(cmd, args)

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -102,6 +102,12 @@ var _ = Describe("Expose", func() {
 				kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
 			})
 		})
+		Context("With missing input parameters", func() {
+			It("should fail", func() {
+				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE)
+				Expect(cmd()).NotTo(BeNil())
+			})
+		})
 		Context("With missing resource", func() {
 			It("should fail", func() {
 				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", "--name", "my-service",

--- a/pkg/virtctl/templates/BUILD.bazel
+++ b/pkg/virtctl/templates/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["templates.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/templates",
     visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/spf13/cobra:go_default_library"],
 )

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -1,5 +1,12 @@
 package templates
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 // UsageTemplate returns the usage template for all subcommands
 func UsageTemplate() string {
 	return `Usage:{{if .Runnable}}
@@ -38,4 +45,16 @@ func OptionsUsageTemplate() string {
 
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 `
+}
+
+// ExactArgs validate the number of input parameters
+func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			fmt.Printf("fatal: Number of input parameters is incorrect, %s accepts %d arg(s), received %d\n\n", nameOfCommand, n, len(args))
+			cmd.Help()
+			return errors.New("argument validation failed")
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
handling error messages for virtctl expose and help menu
when the input parameters are not as expected

Signed-off-by: Shaul Garbourg <sgarbour@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3732

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve the error handling for virtctl expose cli.
```
