### PR TITLE
Clean up root owners file to reflect reality

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,13 +2,10 @@
 
 aliases:
   approvers:
-      - slintes
       - davidvossel
       - vladikr
       - rmohr
-      - cynepco3hahue
       - stu-gott
-      - SchSeba
       - fabiand
       - codificat
       - danielBelenky
@@ -17,19 +14,17 @@ aliases:
       - jean-edouard
       - ashleyschuett
   emeritus_approvers:
+      - cynepco3hahue
+      - slintes
       - mfranczy
+      - SchSeba
   code-reviewers:
       - davidvossel
       - rmohr
       - stu-gott
-      - booxter
       - vladikr
-      - slintes
-      - cynepco3hahue
       - phoracek
-      - SchSeba
       - dhiller
-      - pkotas
       - vatsalparekh
       - danielBelenky
       - enp0s3
@@ -45,3 +40,4 @@ aliases:
       - rnetser
   ci-approvers:
       - dhiller
+      - danielBelenky


### PR DESCRIPTION
**What this PR does / why we need it**:

Make

 - cynepco3hahue
 - slintes
 - SchSeba

emertus approvers since they are no longer directly working on kubevirt.

Add danielBelenky to the CI approvers list, due to his CI involvement.

Remove the following inactive reviewers which should not be assigned
anymore from the suggestion list:

 - booxter
 - slintes
 - cynepco3hahue
 - SchSeba
 - pkotas

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
