### PR TITLE
virt-launcher: log the domain XML upon launching

### DIFF
--- a/pkg/hooks/manager.go
+++ b/pkg/hooks/manager.go
@@ -175,7 +175,7 @@ func sortCallbacksPerHookPoint(callbacksPerHookPoint map[string][]*callBackClien
 }
 
 func (m *Manager) OnDefineDomain(domainSpec *virtwrapApi.DomainSpec, vmi *v1.VirtualMachineInstance) (string, error) {
-	domainSpecXML, err := xml.Marshal(domainSpec)
+	domainSpecXML, err := xml.MarshalIndent(domainSpec, "", "\t")
 	if err != nil {
 		return "", fmt.Errorf("Failed to marshal domain spec: %v", domainSpec)
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Manager", func() {
 
 			domainSpec := expectIsolationDetectionForVMI(vmi)
 
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
@@ -128,7 +128,7 @@ var _ = Describe("Manager", func() {
 			networkData := ""
 			addCloudInitDisk(vmi, userData, networkData)
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
@@ -149,7 +149,7 @@ var _ = Describe("Manager", func() {
 			networkData := "FakeNetwork"
 			addCloudInitDisk(vmi, userData, networkData)
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
@@ -165,7 +165,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
@@ -181,7 +181,7 @@ var _ = Describe("Manager", func() {
 				mockDomain.EXPECT().Free()
 				vmi := newVMI(testNamespace, testVmName)
 				domainSpec := expectIsolationDetectionForVMI(vmi)
-				xml, err := xml.Marshal(domainSpec)
+				xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
@@ -203,7 +203,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, 1, nil)
@@ -219,7 +219,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free()
 			vmi := newVMI(testNamespace, testVmName)
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
@@ -313,7 +313,7 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 			domainSpec := expectIsolationDetectionForVMI(vmi)
 
-			oldXML, err := xml.Marshal(domainSpec)
+			oldXML, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 
 			t := true
@@ -356,7 +356,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			manager := &LibvirtDomainManager{
 				virConn:                mockConn,
@@ -398,7 +398,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			manager := &LibvirtDomainManager{
 				virConn:                mockConn,
@@ -431,7 +431,7 @@ var _ = Describe("Manager", func() {
 			}
 
 			domainSpec := expectIsolationDetectionForVMI(vmi)
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
@@ -461,7 +461,7 @@ var _ = Describe("Manager", func() {
 				AbortStatus: string(v1.MigrationAbortInProgress),
 			}
 
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
@@ -528,7 +528,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).AnyTimes().Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 			mockDomain.EXPECT().GetJobInfo().AnyTimes().Return(fake_jobinfo, nil)
 			gomock.InOrder(
@@ -578,7 +578,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 
-			xml, err := xml.Marshal(domainSpec)
+			xml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())
 
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(xml), nil)
@@ -733,7 +733,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Free()
 			mockDomain.EXPECT().GetState().Return(state, libvirtReason, nil).AnyTimes()
 			mockDomain.EXPECT().GetName().Return("test", nil)
-			x, err := xml.Marshal(api.NewMinimalDomainSpec("test"))
+			x, err := xml.MarshalIndent(api.NewMinimalDomainSpec("test"), "", "\t")
 			Expect(err).To(BeNil())
 			if !cli.IsDown(state) {
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DOMAIN_XML_MIGRATABLE)).Return(string(x), nil)

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -91,8 +92,9 @@ func ConvReason(status libvirt.DomainState, reason int) api.StateChangeReason {
 	}
 }
 
+// base64.StdEncoding.EncodeToString
 func SetDomainSpecStr(virConn cli.Connection, vmi *v1.VirtualMachineInstance, wantedSpec string) (cli.VirDomain, error) {
-	log.Log.Object(vmi).V(3).With("xml", wantedSpec).Info("Domain XML generated.")
+	log.Log.Object(vmi).V(2).Infof("Domain XML generated. Base64 dump %s", base64.StdEncoding.EncodeToString([]byte(wantedSpec)))
 	dom, err := virConn.DomainDefineXML(wantedSpec)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Defining the VirtualMachineInstance failed.")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -467,9 +467,9 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/watch
+k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/api/errors
-k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/util/clock
@@ -479,13 +479,13 @@ k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/util/validation
+k8s.io/apimachinery/pkg/api/meta
+k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/api/validation
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/intstr
-k8s.io/apimachinery/pkg/api/meta
-k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/runtime/serializer/streaming


### PR DESCRIPTION
Dump the domain XML of the VM to virt-launcher log. The XML dump will be encoded with Base64
since the security measurements of the JSON logger makes the XML unreadable due to special character escaping.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
To ease the debugging of issues related to VM launch failures. 

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=1848403


```release-note
None
```
