### PR TITLE
test connectivity over both bridge and masquerade

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -191,6 +191,10 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				switch destination {
 				case "Internet":
+					if netutils.IsIPv6String(inboundVMI.Status.Interfaces[0].IP) {
+						By("Skipping external connectivity check on IPv6 cluster")
+						return
+					}
 					addr = "kubevirt.io"
 				case "InboundVMI":
 					addr = inboundVMI.Status.Interfaces[0].IP


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, we extensively test the pod network connectivity only through
the bridge binding mechanism.

We want to use the same set of tests for the masquerade binding
mechanism which is another supported binding option that unlike the
bridge binding supports migration too.

This patch makes the current test more generic and exercises it with
both bindings set as defaults.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This PR is split to two commits to make it easier to review.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
