### PR TITLE
Fix a few mistakes in the automatic bump scripts

### DIFF
--- a/hack/autobump-generic.sh
+++ b/hack/autobump-generic.sh
@@ -52,14 +52,14 @@ fi
 make test
 
 title="Run make $@"
-git commit -m "${title}"
-git push -f "https://${user}@github.com/kubevirt/kubevirt.git" HEAD:autoupdate-$@
+git commit -s -m "${title}"
+git push -f "https://${user}@github.com/${user}/kubevirt.git" HEAD:autoupdate-$@
 
 echo "Creating PR to merge ${user}:autoupdate into master..." >&2
-pr-creator -- \
+pr-creator \
     --github-token-path="${token}" \
     --org=kubevirt --repo=kubevirt --branch=master \
     --title="${title}" --match-title="${title}" \
     --body="Automatic run of \"$@\". Please review" \
-    --source="${user}":autoupdate \
+    --source="${user}":autoupdate-$@ \
     --confirm

--- a/hack/autobump-kubevirtci.sh
+++ b/hack/autobump-kubevirtci.sh
@@ -52,11 +52,11 @@ if git diff --name-only --exit-code HEAD; then
 fi
 
 title="Run hack/bump-kubevirtci.sh, updating to ${kubevirtci_git_hash:0:8}..."
-git commit -m "${title}"
-git push -f "https://${user}@github.com/kubevirt/kubevirt.git" HEAD:kubevirtci
+git commit -s -m "${title}"
+git push -f "https://${user}@github.com/${user}/kubevirt.git" HEAD:kubevirtci
 
 echo "Creating PR to merge ${user}:kubevirtci into master..." >&2
-pr-creator -- \
+pr-creator \
     --github-token-path="${token}" \
     --org=kubevirt --repo=kubevirt --branch=master \
     --title="${title}" --match-title="Run hack/bump-kubevirtci.sh" \


### PR DESCRIPTION


**What this PR does / why we need it**:

A few adjustments necessary for the bump scripts to make them work properly:

 * pr-crator does not like `--`
 * push the code to the right repo instead of kubevirt
 * sign the commit which will be pushed

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
