### PR TITLE
Kubernetes reporter: Dump Services artifacts

### DIFF
--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
     ],
 )

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onsi/ginkgo/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiservices "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 
 	v12 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -100,6 +101,7 @@ func (r *KubernetesReporter) Dump(duration time.Duration) {
 	r.logPVCs(virtCli)
 	r.logPVs(virtCli)
 	r.logPods(virtCli)
+	r.logAPIServices(virtCli)
 	r.logServices(virtCli)
 	r.logVMIs(virtCli)
 	r.logConfigMaps(virtCli)
@@ -407,6 +409,34 @@ func (r *KubernetesReporter) logServices(virtCli kubecli.KubevirtClient) {
 	j, err := json.MarshalIndent(services, "", "    ")
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Failed to marshal services")
+		return
+	}
+	fmt.Fprintln(f, string(j))
+}
+
+func (r *KubernetesReporter) logAPIServices(virtCli kubecli.KubevirtClient) {
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_apiServices.log", r.failureCount)),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		return
+	}
+	defer f.Close()
+
+	result, err := virtCli.RestClient().Get().RequestURI("/apis/apiregistration.k8s.io/v1/").Resource("apiservices").Do().Raw()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch apiServices: %v\n", err)
+		return
+	}
+	apiServices := apiservices.APIServiceList{}
+	err = json.Unmarshal(result, &apiServices)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to unmarshal raw result to apiServicesList: %v\n", err)
+	}
+
+	j, err := json.MarshalIndent(apiServices, "", "    ")
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to marshal apiServices")
 		return
 	}
 	fmt.Fprintln(f, string(j))

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -103,6 +103,7 @@ func (r *KubernetesReporter) Dump(duration time.Duration) {
 	r.logPods(virtCli)
 	r.logAPIServices(virtCli)
 	r.logServices(virtCli)
+	r.logEndpoints(virtCli)
 	r.logVMIs(virtCli)
 	r.logConfigMaps(virtCli)
 	r.logSecrets(virtCli)
@@ -437,6 +438,29 @@ func (r *KubernetesReporter) logAPIServices(virtCli kubecli.KubevirtClient) {
 	j, err := json.MarshalIndent(apiServices, "", "    ")
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Failed to marshal apiServices")
+		return
+	}
+	fmt.Fprintln(f, string(j))
+}
+
+func (r *KubernetesReporter) logEndpoints(virtCli kubecli.KubevirtClient) {
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_endpoints.log", r.failureCount)),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		return
+	}
+	defer f.Close()
+
+	endpoints, err := virtCli.CoreV1().Endpoints(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch endpointss: %v\n", err)
+		return
+	}
+
+	j, err := json.MarshalIndent(endpoints, "", "    ")
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to marshal endpoints")
 		return
 	}
 	fmt.Fprintln(f, string(j))

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -100,6 +100,7 @@ func (r *KubernetesReporter) Dump(duration time.Duration) {
 	r.logPVCs(virtCli)
 	r.logPVs(virtCli)
 	r.logPods(virtCli)
+	r.logServices(virtCli)
 	r.logVMIs(virtCli)
 	r.logConfigMaps(virtCli)
 	r.logSecrets(virtCli)
@@ -383,6 +384,29 @@ func (r *KubernetesReporter) logPods(virtCli kubecli.KubevirtClient) {
 	j, err := json.MarshalIndent(pods, "", "    ")
 	if err != nil {
 		log.DefaultLogger().Reason(err).Errorf("Failed to marshal pods")
+		return
+	}
+	fmt.Fprintln(f, string(j))
+}
+
+func (r *KubernetesReporter) logServices(virtCli kubecli.KubevirtClient) {
+	f, err := os.OpenFile(filepath.Join(r.artifactsDir, fmt.Sprintf("%d_services.log", r.failureCount)),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to open the file: %v", err)
+		return
+	}
+	defer f.Close()
+
+	services, err := virtCli.CoreV1().Services(v1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to fetch services: %v\n", err)
+		return
+	}
+
+	j, err := json.MarshalIndent(services, "", "    ")
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Failed to marshal services")
 		return
 	}
 	fmt.Fprintln(f, string(j))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR extends kubernetes custom reporter for tests suite, and dumps all necessary cluster
object needed to debug Services and APIServices.

It will enable us to debug APIServices and Services cluster object errors easily.
Consider the a scenario where you need to debug APIService error:
We could look into `apiservice.log` and check which Service is related to that APIService.
Then we look into `endpoints.log` to check with Pods are relates the Service
and eventually look into that Pod containers logs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
This PR is needed for debugging #3850 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
