### PR TITLE
tests: fix possible null pointer dereference

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -775,14 +775,15 @@ func AdjustKubeVirtResource() {
 }
 
 func RestoreKubeVirtResource() {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-
-	data, err := json.Marshal(originalKV.Spec)
-	Expect(err).ToNot(HaveOccurred())
-	patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-	_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(originalKV.Name, types.JSONPatchType, []byte(patchData))
-	PanicOnError(err)
+	if originalKV != nil {
+		virtClient, err := kubecli.GetKubevirtClient()
+		PanicOnError(err)
+		data, err := json.Marshal(originalKV.Spec)
+		Expect(err).ToNot(HaveOccurred())
+		patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
+		_, err = virtClient.KubeVirt(originalKV.Namespace).Patch(originalKV.Name, types.JSONPatchType, []byte(patchData))
+		PanicOnError(err)
+	}
 }
 
 func createStorageClass(name string) {


### PR DESCRIPTION
Make sure we restore KV resource only when it's backed up.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
In some cases AfterTestSuitCleanup can be called while originalKV is still un-initialized. One example
is when the deploy test infra flag is on and the beforeSuite fails to deploy it.

Release notes:
```release-note
None
```
