### PR TITLE
Kubernetes reporter: Dump artifacts at AfterSuite 

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -668,7 +668,10 @@ func (r *KubernetesReporter) dumpK8sEntityToFile(virtCli kubecli.KubevirtClient,
 }
 
 func (r *KubernetesReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
-
+	if setupSummary.State.IsFailure() {
+		r.failureCount++
+		r.Dump(setupSummary.RunTime)
+	}
 }
 
 func (r *KubernetesReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently if there is an error during `AfterSuite` there we wont get artifacts from kuberentes  test suite reporter.
This PR set kuberentes  test suite reporter to dump cluster artifacts when `AfterSuite` error occurs like on any other fail test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
This is needed to debug #3850 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
