### PR TITLE
tests, network: Test connectivity pre/post migration

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/tools/portforward:go_default_library",

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -97,7 +97,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(serviceIP, servicePort, tcpVM.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 420)
+				Expect(tests.WaitForJobToSucceed(job, 420*time.Second)).To(Succeed())
 			})
 		})
 
@@ -185,7 +185,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					job := runHelloWorldJob(nodeIP, strconv.Itoa(int(nodePort)), tcpVM.Namespace)
 
 					By("Waiting for the job to report a successful connection attempt")
-					tests.WaitForJobToSucceed(&virtClient, job, 420)
+					Expect(tests.WaitForJobToSucceed(job, 420*time.Second)).To(Succeed())
 				}
 			})
 		})
@@ -220,7 +220,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJobUDP(serviceIP, servicePort, udpVM.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 420)
+				Expect(tests.WaitForJobToSucceed(job, 420*time.Second)).To(Succeed())
 			})
 		})
 
@@ -247,7 +247,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJobUDP(serviceIP, servicePort, udpVM.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 120)
+				Expect(tests.WaitForJobToSucceed(job, 120*time.Second)).To(Succeed())
 
 				By("Getting the node IP from all nodes")
 				nodes, err := virtClient.CoreV1().Nodes().List(k8smetav1.ListOptions{})
@@ -261,7 +261,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					job := runHelloWorldJobUDP(nodeIP, strconv.Itoa(int(nodePort)), udpVM.Namespace)
 
 					By("Waiting for the job to report a successful connection attempt")
-					tests.WaitForJobToSucceed(&virtClient, job, 420)
+					Expect(tests.WaitForJobToSucceed(job, 420*time.Second)).To(Succeed())
 				}
 			})
 		})
@@ -321,7 +321,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(serviceIP, servicePort, vmrs.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 420)
+				Expect(tests.WaitForJobToSucceed(job, 420*time.Second)).To(Succeed())
 			})
 		})
 	})
@@ -383,13 +383,13 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(serviceIP, servicePort, vm.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 120)
+				Expect(tests.WaitForJobToSucceed(job, 420*time.Second)).To(Succeed())
 
 				By("Starting a job which tries to reach the VMI again via the same ClusterIP, this time over HTTP.")
 				job = runHelloWorldJobHttp(serviceIP, servicePort, vm.Namespace)
 
 				By("Waiting for the HTTP job to report a successful connection attempt.")
-				tests.WaitForJobToSucceed(&virtClient, job, 120)
+				Expect(tests.WaitForJobToSucceed(job, 120*time.Second)).To(Succeed())
 			})
 
 			It("[test_id:345][label:masquerade_binding_connectivity]Should verify the exposed service is functional before and after VM restart.", func() {
@@ -404,7 +404,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(serviceIP, servicePort, vmObj.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt.")
-				tests.WaitForJobToSucceed(&virtClient, job, 120)
+				Expect(tests.WaitForJobToSucceed(job, 120*time.Second)).To(Succeed())
 
 				// Retrieve the current VMI UID, to be compared with the new UID after restart.
 				var vmi *v1.VirtualMachineInstance
@@ -437,7 +437,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job = runHelloWorldJob(serviceIP, servicePort, vmObj.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt.")
-				tests.WaitForJobToSucceed(&virtClient, job, 120)
+				Expect(tests.WaitForJobToSucceed(job, 120*time.Second)).To(Succeed())
 			})
 
 			It("[test_id:343][label:masquerade_binding_connectivity]Should Verify an exposed service of a VM is not functional after VM deletion.", func() {
@@ -450,7 +450,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(serviceIP, servicePort, vm.Namespace)
 
 				By("Waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 120)
+				Expect(tests.WaitForJobToSucceed(job, 120*time.Second)).To(Succeed())
 
 				By("Comparing the service's endpoints IP address to the VM pod IP address.")
 				// Get the IP address of the VM pod.
@@ -486,7 +486,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job = runHelloWorldJob(serviceIP, servicePort, vm.Namespace)
 
 				By("Waiting for the job to report a failed connection attempt.")
-				tests.WaitForJobToFail(&virtClient, job, 120)
+				Expect(tests.WaitForJobToFail(job, 120*time.Second)).To(Succeed())
 			})
 		})
 	})

--- a/tests/job.go
+++ b/tests/job.go
@@ -8,46 +8,72 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"kubevirt.io/client-go/kubecli"
-
-	. "github.com/onsi/gomega"
 )
 
-func WaitForJobToSucceed(virtClient *kubecli.KubevirtClient, job *batchv1.Job, timeoutSec time.Duration) {
-	EventuallyWithOffset(1, func() bool {
-		job, err := (*virtClient).BatchV1().Jobs(job.Namespace).Get(job.Name, metav1.GetOptions{})
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
-		for _, c := range job.Status.Conditions {
-			switch c.Type {
-			case batchv1.JobComplete:
-				if c.Status == k8sv1.ConditionTrue {
-					return true
-				}
-			case batchv1.JobFailed:
-				ExpectWithOffset(2, c.Status).NotTo(Equal(k8sv1.ConditionTrue), "Job should succeed")
-			}
-		}
-		return false
-	}, timeoutSec*time.Second, 1*time.Second).Should(BeTrue(), "Job should succeed")
+const (
+	toSucceed = true
+	toFail    = false
+)
+
+// WaitForJobToSucceed blocks until the given job finishes.
+// On success, it returns with a nil error, on failure or timeout it returns with an error.
+func WaitForJobToSucceed(job *batchv1.Job, timeout time.Duration) error {
+	return waitForJob(job, toSucceed, timeout)
 }
 
-func WaitForJobToFail(virtClient *kubecli.KubevirtClient, job *batchv1.Job, timeoutSec time.Duration) {
-	EventuallyWithOffset(1, func() bool {
-		job, err := (*virtClient).BatchV1().Jobs(job.Namespace).Get(job.Name, metav1.GetOptions{})
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
+// WaitForJobToFail blocks until the given job finishes.
+// On failure, it returns with a nil error, on success or timeout it returns with an error.
+func WaitForJobToFail(job *batchv1.Job, timeout time.Duration) error {
+	return waitForJob(job, toFail, timeout)
+}
+
+func waitForJob(job *batchv1.Job, toSucceed bool, timeout time.Duration) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return err
+	}
+
+	jobFailedError := func(job *batchv1.Job) error {
+		if toSucceed {
+			return fmt.Errorf("Job %s finished with failure, status: %+v", job.Name, job.Status)
+		}
+		return nil
+	}
+	jobCompleteError := func(job *batchv1.Job) error {
+		if toSucceed {
+			return nil
+		}
+		return fmt.Errorf("Job %s finished with success, status: %+v", job.Name, job.Status)
+	}
+
+	const finish = true
+	err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		job, err = virtClient.BatchV1().Jobs(job.Namespace).Get(job.Name, metav1.GetOptions{})
+		if err != nil {
+			return finish, err
+		}
 		for _, c := range job.Status.Conditions {
 			switch c.Type {
+			case batchv1.JobComplete:
+				if c.Status == k8sv1.ConditionTrue {
+					return finish, jobCompleteError(job)
+				}
 			case batchv1.JobFailed:
 				if c.Status == k8sv1.ConditionTrue {
-					return true
+					return finish, jobFailedError(job)
 				}
-			case batchv1.JobComplete:
-				ExpectWithOffset(2, c.Status).NotTo(Equal(k8sv1.ConditionTrue), "Job should fail")
 			}
 		}
-		return false
-	}, timeoutSec*time.Second, 1*time.Second).Should(BeTrue(), "Job should fail")
+		return !finish, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Job %s timeout reached, status: %+v, err: %v", job.Name, job.Status, err)
+	}
+	return nil
 }
 
 // Default Job arguments to be used with NewJob.

--- a/tests/ping.go
+++ b/tests/ping.go
@@ -27,6 +27,7 @@ import (
 
 	expect "github.com/google/goexpect"
 	"google.golang.org/grpc/codes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -97,4 +98,37 @@ func vmiConsoleExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Bat
 		log.DefaultLogger().Object(vmi).Infof("%v", resp)
 	}
 	return err
+}
+
+// PingAppJob performs a netcat check (tcp by default) using a pod.
+// Optional port and arguments for the netcat command may be provided.
+// Returns the job deletion/cleanup function and an error.
+// The caller is expected to use the returned function to cleanup the resources.
+func PingAppJob(host, port string, args ...string) (func() error, error) {
+	const (
+		netcat = "nc"
+
+		jobRetry   = 1
+		jobTimeout = 40
+	)
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return nil, err
+	}
+
+	args = append([]string{netcat}, args...)
+	args = append(args, host, port)
+
+	args = []string{strings.Join(args, " ")}
+	job := NewJob("ping-application", []string{"/bin/bash", "-c"}, args, jobRetry, JobTTL, jobTimeout)
+	job, err = virtClient.BatchV1().Jobs(NamespaceTestDefault).Create(job)
+	if err != nil {
+		return nil, err
+	}
+
+	err = WaitForJobToSucceed(job, jobTimeout*time.Second)
+	return func() error {
+		return virtClient.BatchV1().Jobs(NamespaceTestDefault).Delete(job.Name, &metav1.DeleteOptions{})
+	}, err
 }

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -278,7 +278,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			job, err = virtClient.BatchV1().Jobs(inboundVMI.ObjectMeta.Namespace).Create(job)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitForJobToSucceed(&virtClient, job, 90)
+			Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
 		},
 			table.Entry("[test_id:1543]on the same node from Pod", v12.NodeSelectorOpIn, false),
 			table.Entry("[test_id:1544]on a different node from Pod", v12.NodeSelectorOpNotIn, false),
@@ -312,7 +312,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(fmt.Sprintf("%s.%s", "myservice", inboundVMI.Namespace), strconv.Itoa(testPort), inboundVMI.Namespace)
 
 				By("waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 90)
+				Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
 			})
 			It("[test_id:1548]should fail to reach the vmi if an invalid servicename is used", func() {
 
@@ -320,7 +320,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(fmt.Sprintf("%s.%s", "wrongservice", inboundVMI.Namespace), strconv.Itoa(testPort), inboundVMI.Namespace)
 
 				By("waiting for the job to report an  unsuccessful connection attempt")
-				tests.WaitForJobToFail(&virtClient, job, 90)
+				Expect(tests.WaitForJobToFail(job, 90*time.Second)).To(Succeed())
 			})
 
 			AfterEach(func() {
@@ -356,7 +356,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job := runHelloWorldJob(fmt.Sprintf("%s.%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain, inboundVMI.Namespace), strconv.Itoa(testPort), inboundVMI.Namespace)
 
 				By("waiting for the job to report a successful connection attempt")
-				tests.WaitForJobToSucceed(&virtClient, job, 90)
+				Expect(tests.WaitForJobToSucceed(job, 90*time.Second)).To(Succeed())
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Live migration is (partially) supported when using masquerade binding
on the primary network.

A new test is introduced, checking the VMI connectivity before and after
the migration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends on #3883 , #3997

**Release note**:
```release-note
NONE
```
