### PR TITLE
Add ProductName and Version labels to KubeVirt objects

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7580,11 +7580,11 @@
       "type": "string"
      },
      "productName": {
-      "description": "Designate the apps.kubevirt.io/part-of label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductName is not specified, the part-of label will be omitted.",
+      "description": "Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductName is not specified, the part-of label will be omitted.",
       "type": "string"
      },
      "productVersion": {
-      "description": "Designate the apps.kubevirt.io/version label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductVersion is not specified, the version label will be omitted.",
+      "description": "Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.",
       "type": "string"
      },
      "uninstallStrategy": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -7579,6 +7579,14 @@
       "description": "The namespace Prometheus is deployed in Defaults to openshift-monitor",
       "type": "string"
      },
+     "productName": {
+      "description": "Designate the apps.kubevirt.io/part-of label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductName is not specified, the part-of label will be omitted.",
+      "type": "string"
+     },
+     "productVersion": {
+      "description": "Designate the apps.kubevirt.io/version label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductVersion is not specified, the version label will be omitted.",
+      "type": "string"
+     },
      "uninstallStrategy": {
       "description": "Specifies if kubevirt can be deleted if workloads are still present. This is mainly a precaution to avoid accidental data loss",
       "type": "string"

--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -99,7 +99,7 @@ func NewApiServerService(namespace string) *corev1.Service {
 	}
 }
 
-func newPodTemplateSpec(podName string, imageName string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*corev1.PodTemplateSpec, error) {
+func newPodTemplateSpec(podName string, imageName string, repository string, version string, productName string, productVersion string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*corev1.PodTemplateSpec, error) {
 
 	version = AddVersionSeparatorPrefix(version)
 
@@ -126,6 +126,14 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 				},
 			},
 		},
+	}
+
+	if productVersion != "" {
+		podTemplateSpec.ObjectMeta.Labels[virtv1.AppVersionLabel] = productVersion
+	}
+
+	if productName != "" {
+		podTemplateSpec.ObjectMeta.Labels[virtv1.AppPartOfLabel] = productName
 	}
 
 	if envVars != nil && len(*envVars) != 0 {
@@ -156,14 +164,14 @@ func attachCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath 
 	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, secretVolumeMount)
 }
 
-func newBaseDeployment(deploymentName string, imageName string, namespace string, repository string, version string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*appsv1.Deployment, error) {
+func newBaseDeployment(deploymentName string, imageName string, namespace string, repository string, version string, productName string, productVersion string, pullPolicy corev1.PullPolicy, podAffinity *corev1.Affinity, envVars *[]corev1.EnvVar) (*appsv1.Deployment, error) {
 
-	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, pullPolicy, podAffinity, envVars)
+	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, pullPolicy, podAffinity, envVars)
 	if err != nil {
 		return nil, err
 	}
 
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -172,7 +180,8 @@ func newBaseDeployment(deploymentName string, imageName string, namespace string
 			Namespace: namespace,
 			Name:      deploymentName,
 			Labels: map[string]string{
-				virtv1.AppLabel: deploymentName,
+				virtv1.AppLabel:     deploymentName,
+				virtv1.AppNameLabel: deploymentName,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -184,7 +193,17 @@ func newBaseDeployment(deploymentName string, imageName string, namespace string
 			},
 			Template: *podTemplateSpec,
 		},
-	}, nil
+	}
+
+	if productVersion != "" {
+		deployment.ObjectMeta.Labels[virtv1.AppVersionLabel] = productVersion
+	}
+
+	if productName != "" {
+		deployment.ObjectMeta.Labels[virtv1.AppPartOfLabel] = productName
+	}
+
+	return deployment, nil
 }
 
 func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOperator, values []string) *corev1.Affinity {
@@ -211,12 +230,12 @@ func newPodAntiAffinity(key, topologyKey string, operator metav1.LabelSelectorOp
 	}
 }
 
-func NewApiServerDeployment(namespace string, repository string, imagePrefix string, version string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewApiServerDeployment(namespace string, repository string, imagePrefix string, version string, productName string, productVersion string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-api"})
 	deploymentName := "virt-api"
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, pullPolicy, podAntiAffinity, env)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, version, productName, productVersion, pullPolicy, podAntiAffinity, env)
 	if err != nil {
 		return nil, err
 	}
@@ -269,12 +288,12 @@ func NewApiServerDeployment(namespace string, repository string, imagePrefix str
 	return deployment, nil
 }
 
-func NewControllerDeployment(namespace string, repository string, imagePrefix string, controllerVersion string, launcherVersion string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
+func NewControllerDeployment(namespace string, repository string, imagePrefix string, controllerVersion string, launcherVersion string, productName string, productVersion string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.Deployment, error) {
 	podAntiAffinity := newPodAntiAffinity("kubevirt.io", "kubernetes.io/hostname", metav1.LabelSelectorOpIn, []string{"virt-controller"})
 	deploymentName := "virt-controller"
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, pullPolicy, podAntiAffinity, env)
+	deployment, err := newBaseDeployment(deploymentName, imageName, namespace, repository, controllerVersion, productName, productVersion, pullPolicy, podAntiAffinity, env)
 	if err != nil {
 		return nil, err
 	}
@@ -338,12 +357,12 @@ func NewControllerDeployment(namespace string, repository string, imagePrefix st
 	return deployment, nil
 }
 
-func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string, version string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.DaemonSet, error) {
+func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string, version string, productName string, productVersion string, pullPolicy corev1.PullPolicy, verbosity string, extraEnv map[string]string) (*appsv1.DaemonSet, error) {
 
 	deploymentName := "virt-handler"
 	imageName := fmt.Sprintf("%s%s", imagePrefix, deploymentName)
 	env := operatorutil.NewEnvVarMap(extraEnv)
-	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, pullPolicy, nil, env)
+	podTemplateSpec, err := newPodTemplateSpec(deploymentName, imageName, repository, version, productName, productVersion, pullPolicy, nil, env)
 	if err != nil {
 		return nil, err
 	}
@@ -371,6 +390,14 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 			},
 			Template: *podTemplateSpec,
 		},
+	}
+
+	if productVersion != "" {
+		daemonset.ObjectMeta.Labels[virtv1.AppVersionLabel] = productVersion
+	}
+
+	if productName != "" {
+		daemonset.ObjectMeta.Labels[virtv1.AppPartOfLabel] = productName
 	}
 
 	pod := &daemonset.Spec.Template.Spec

--- a/pkg/virt-operator/install-strategy/create.go
+++ b/pkg/virt-operator/install-strategy/create.go
@@ -2370,10 +2370,10 @@ func SyncAll(queue workqueue.RateLimitingInterface, kv *v1.KubeVirt, prevStrateg
 
 	// Avoid log spam by logging this issue once early instead of for once each object created
 	if !isValidLabel(kv.Spec.ProductVersion) {
-		log.Log.Errorf("invalid kubevirt.spec.productVersion: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or dash")
+		log.Log.Errorf("invalid kubevirt.spec.productVersion: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or underscore")
 	}
 	if !isValidLabel(kv.Spec.ProductName) {
-		log.Log.Errorf("invalid kubevirt.spec.productName: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or dash")
+		log.Log.Errorf("invalid kubevirt.spec.productName: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or underscore")
 	}
 
 	targetVersion := kv.Status.TargetKubeVirtVersion

--- a/pkg/virt-operator/install-strategy/create.go
+++ b/pkg/virt-operator/install-strategy/create.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -110,10 +111,26 @@ func controllerDeployments(strategy *InstallStrategy) []*appsv1.Deployment {
 	return deployments
 }
 
+func isValidLabel(label string) bool {
+	// First and last character must be alphanumeric
+	// middle chars can be alphanumeric, or dot hyphen or dash
+	// entire string must not exceed 63 chars
+	r := regexp.MustCompile(`^([a-z0-9A-Z]([a-z0-9A-Z\-\_\.]{0,61}[a-z0-9A-Z])?)?$`)
+	return r.Match([]byte(label))
+}
+
 func injectOperatorMetadata(kv *v1.KubeVirt, objectMeta *metav1.ObjectMeta, version string, imageRegistry string, id string) {
 	if objectMeta.Labels == nil {
 		objectMeta.Labels = make(map[string]string)
 	}
+	if kv.Spec.ProductVersion != "" && isValidLabel(kv.Spec.ProductVersion) {
+		objectMeta.Labels[v1.AppVersionLabel] = kv.Spec.ProductVersion
+	}
+	if kv.Spec.ProductName != "" && isValidLabel(kv.Spec.ProductName) {
+		objectMeta.Labels[v1.AppPartOfLabel] = kv.Spec.ProductName
+	}
+	objectMeta.Labels[v1.AppComponentLabel] = v1.AppComponent
+
 	objectMeta.Labels[v1.ManagedByLabel] = v1.ManagedByLabelOperatorValue
 
 	if objectMeta.Annotations == nil {
@@ -2349,6 +2366,14 @@ func SyncAll(queue workqueue.RateLimitingInterface, kv *v1.KubeVirt, prevStrateg
 	gracePeriod := int64(0)
 	deleteOptions := &metav1.DeleteOptions{
 		GracePeriodSeconds: &gracePeriod,
+	}
+
+	// Avoid log spam by logging this issue once early instead of for once each object created
+	if !isValidLabel(kv.Spec.ProductVersion) {
+		log.Log.Errorf("invalid kubevirt.spec.productVersion: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or dash")
+	}
+	if !isValidLabel(kv.Spec.ProductName) {
+		log.Log.Errorf("invalid kubevirt.spec.productName: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or dash")
 	}
 
 	targetVersion := kv.Status.TargetKubeVirtVersion

--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -276,13 +276,13 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	var productName string
 	var productVersion string
 
-	if isValidLabel(config.AdditionalProperties[operatorutil.ProductNameKey]) {
-		productName = config.AdditionalProperties[operatorutil.ProductNameKey]
+	if isValidLabel(config.GetProductName()) {
+		productName = config.GetProductName()
 	} else {
 		log.Log.Errorf("invalid kubevirt.spec.productName: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or dash")
 	}
-	if isValidLabel(config.AdditionalProperties[operatorutil.ProductVersionKey]) {
-		productVersion = config.AdditionalProperties[operatorutil.ProductVersionKey]
+	if isValidLabel(config.GetProductVersion()) {
+		productVersion = config.GetProductVersion()
 	} else {
 		log.Log.Errorf("invalid kubevirt.spec.productVersion: labels must be 63 characters or less, begin and end with alphanumeric characters, and contain only dot, hyphen or dash")
 	}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -643,7 +643,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		// virt-api
 		// virt-controller
 		// virt-handler
-		apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+		apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 
 		pod := &k8sv1.Pod{
 			ObjectMeta: apiDeployment.Spec.Template.ObjectMeta,
@@ -659,7 +659,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		pod.Name = "virt-api-xxxx"
 		addPod(pod)
 
-		controller, _ := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+		controller, _ := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 		pod = &k8sv1.Pod{
 			ObjectMeta: controller.Spec.Template.ObjectMeta,
 			Spec:       controller.Spec.Template.Spec,
@@ -674,7 +674,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		injectMetadata(&pod.ObjectMeta, config)
 		addPod(pod)
 
-		handler, _ := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+		handler, _ := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 		pod = &k8sv1.Pod{
 			ObjectMeta: handler.Spec.Template.ObjectMeta,
 			Spec:       handler.Spec.Template.Spec,
@@ -845,11 +845,11 @@ var _ = Describe("KubeVirt Operator", func() {
 		all = append(all, components.NewOperatorWebhookService(NAMESPACE))
 		all = append(all, components.NewPrometheusService(NAMESPACE))
 		all = append(all, components.NewApiServerService(NAMESPACE))
-		apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+		apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 		apiDeploymentPdb := components.NewPodDisruptionBudgetForDeployment(apiDeployment)
-		controller, _ := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+		controller, _ := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 		controllerPdb := components.NewPodDisruptionBudgetForDeployment(controller)
-		handler, _ := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+		handler, _ := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 		all = append(all, apiDeployment, apiDeploymentPdb, controller, controllerPdb, handler)
 
 		all = append(all, rbac.GetAllServiceMonitor(NAMESPACE, config.GetMonitorNamespace(), config.GetMonitorServiceAccount())...)
@@ -1745,7 +1745,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
 
-			apiDeployment, err := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+			apiDeployment, err := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(apiDeployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
@@ -1758,7 +1758,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
 
-			controllerDeployment, err := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+			controllerDeployment, err := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(controllerDeployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
@@ -1771,7 +1771,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
 
-			handlerDaemonset, err := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+			handlerDaemonset, err := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlerDaemonset.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -66,8 +66,10 @@ const (
 	// account to use if one is not explicitly named
 	DefaultMonitorAccount = "prometheus-k8s"
 
-	// lookup key in AdditionalProperties
-	ImagePrefixKey = "imagePrefix"
+	// lookup keys in AdditionalProperties
+	ImagePrefixKey    = "imagePrefix"
+	ProductNameKey    = "productName"
+	ProductVersionKey = "productVersion"
 
 	// the regex used to parse the operator image
 	operatorImageRegex = "^(.*)/(.*)virt-operator([@:].*)?$"
@@ -145,6 +147,9 @@ func GetObservedConfigFromKV(kv *v1.KubeVirt) (*KubeVirtDeploymentConfig, error)
 		return nil, fmt.Errorf("unable to load observed config from kubevirt custom resource: %v", err)
 	}
 	additionalProperties[ImagePrefixKey] = imagePrefix
+	additionalProperties[ProductNameKey] = kv.Spec.ProductName
+	additionalProperties[ProductVersionKey] = kv.Spec.ProductVersion
+
 	return getConfig(kv.Status.ObservedKubeVirtRegistry, kv.Status.ObservedKubeVirtVersion, kv.Namespace, additionalProperties), nil
 }
 

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -147,8 +147,12 @@ func GetObservedConfigFromKV(kv *v1.KubeVirt) (*KubeVirtDeploymentConfig, error)
 		return nil, fmt.Errorf("unable to load observed config from kubevirt custom resource: %v", err)
 	}
 	additionalProperties[ImagePrefixKey] = imagePrefix
-	additionalProperties[ProductNameKey] = kv.Spec.ProductName
-	additionalProperties[ProductVersionKey] = kv.Spec.ProductVersion
+	if kv.Spec.ProductName != "" {
+		additionalProperties[ProductNameKey] = kv.Spec.ProductName
+	}
+	if kv.Spec.ProductVersion != "" {
+		additionalProperties[ProductVersionKey] = kv.Spec.ProductVersion
+	}
 
 	return getConfig(kv.Status.ObservedKubeVirtRegistry, kv.Status.ObservedKubeVirtVersion, kv.Namespace, additionalProperties), nil
 }

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -424,6 +424,18 @@ func (c *KubeVirtDeploymentConfig) GetVerbosity() string {
 	return "2"
 }
 
+func (c *KubeVirtDeploymentConfig) GetProductName() string {
+	return c.AdditionalProperties[ProductNameKey]
+}
+
+func (c *KubeVirtDeploymentConfig) GetProductVersion() string {
+	productVersion, ok := c.AdditionalProperties[ProductVersionKey]
+	if !ok {
+		return c.GetKubeVirtVersion()
+	}
+	return productVersion
+}
+
 func (c *KubeVirtDeploymentConfig) generateInstallStrategyID() {
 	// We need an id, which identifies a KubeVirt deployment based on version, shasums, registry, namespace, and other
 	// changeable properties from the KubeVirt CR. This will be used for identifying the correct install strategy job

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -15545,6 +15545,20 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtSpec(ref common.ReferenceCallbac
 							Ref: ref("kubevirt.io/client-go/api/v1.KubeVirtCertificateRotateStrategy"),
 						},
 					},
+					"productVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Designate the apps.kubevirt.io/version label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductVersion is not specified, the version label will be omitted.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"productName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Designate the apps.kubevirt.io/part-of label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductName is not specified, the part-of label will be omitted.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"configuration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "holds kubevirt configurations. same as the virt-configMap",

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -15547,14 +15547,14 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtSpec(ref common.ReferenceCallbac
 					},
 					"productVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Designate the apps.kubevirt.io/version label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductVersion is not specified, the version label will be omitted.",
+							Description: "Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"productName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Designate the apps.kubevirt.io/part-of label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductName is not specified, the part-of label will be omitted.",
+							Description: "Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductName is not specified, the part-of label will be omitted.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1149,7 +1149,7 @@ type KubeVirtSpec struct {
 
 	// Designate the apps.kubevirt.io/version label for KubeVirt components.
 	// Useful if KubeVirt is included as part of a product.
-	// If ProductVersion is not specified, the version label will be omitted.
+	// If ProductVersion is not specified, KubeVirt's version will be used.
 	ProductVersion string `json:"productVersion,omitempty"`
 
 	// Designate the apps.kubevirt.io/part-of label for KubeVirt components.

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -467,8 +467,24 @@ const (
 	// if a particular node is alive and hence should be available for new
 	// virtual machine instance scheduling. Used on Node.
 	VirtHandlerHeartbeat string = "kubevirt.io/heartbeat"
+	// Namespace recommended by Kubernetes for commonly recognized labels
+	AppLabelPrefix = "app.kubernetes.io"
+	// This label is commonly used by 3rd party management tools to identify
+	// an application's name.
+	AppNameLabel = AppLabelPrefix + "/name"
+	// This label is commonly used by 3rd party management tools to identify
+	// an application's version.
+	AppVersionLabel = AppLabelPrefix + "/version"
+	// This label is commonly used by 3rd party management tools to identify
+	// a higher level application.
+	AppPartOfLabel = AppLabelPrefix + "/part-of"
+	// This label is commonly used by 3rd party management tools to identify
+	// the component this application is a part of.
+	AppComponentLabel = AppLabelPrefix + "/component"
+	// This label identifies each resource as part of KubeVirt
+	AppComponent = "kubevirt"
 	// This label will be set on all resources created by the operator
-	ManagedByLabel              = "app.kubernetes.io/managed-by"
+	ManagedByLabel              = AppLabelPrefix + "/managed-by"
 	ManagedByLabelOperatorValue = "kubevirt-operator"
 	// This annotation represents the kubevirt version for an install strategy configmap.
 	InstallStrategyVersionAnnotation = "kubevirt.io/install-strategy-version"
@@ -1130,6 +1146,16 @@ type KubeVirtSpec struct {
 	UninstallStrategy KubeVirtUninstallStrategy `json:"uninstallStrategy,omitempty"`
 
 	CertificateRotationStrategy KubeVirtCertificateRotateStrategy `json:"certificateRotateStrategy,omitempty"`
+
+	// Designate the apps.kubevirt.io/version label for KubeVirt components.
+	// Useful if KubeVirt is included as part of a product.
+	// If ProductVersion is not specified, the version label will be omitted.
+	ProductVersion string `json:"productVersion,omitempty"`
+
+	// Designate the apps.kubevirt.io/part-of label for KubeVirt components.
+	// Useful if KubeVirt is included as part of a product.
+	// If ProductName is not specified, the part-of label will be omitted.
+	ProductName string `json:"productName,omitempty"`
 
 	// holds kubevirt configurations.
 	// same as the virt-configMap

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -485,7 +485,7 @@ const (
 	AppComponent = "kubevirt"
 	// This label will be set on all resources created by the operator
 	ManagedByLabel              = AppLabelPrefix + "/managed-by"
-	ManagedByLabelOperatorValue = "kubevirt-operator"
+	ManagedByLabelOperatorValue = "virt-operator"
 	// This annotation represents the kubevirt version for an install strategy configmap.
 	InstallStrategyVersionAnnotation = "kubevirt.io/install-strategy-version"
 	// This annotation represents the kubevirt registry used for an install strategy configmap.

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -314,8 +314,8 @@ func (KubeVirtSpec) SwaggerDoc() map[string]string {
 		"monitorNamespace":  "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
 		"monitorAccount":    "The name of the Prometheus service account that needs read-access to KubeVirt endpoints\nDefaults to prometheus-k8s",
 		"uninstallStrategy": "Specifies if kubevirt can be deleted if workloads are still present.\nThis is mainly a precaution to avoid accidental data loss",
-		"productVersion":    "Designate the apps.kubevirt.io/version label for KubeVirt components\nUseful if KubeVirt is included as part of a product\nIf ProductVersion is not specified, the version label will be omitted.",
-		"productName":       "Designate the apps.kubevirt.io/part-of label for KubeVirt components\nUseful if KubeVirt is included as part of a product\nIf ProductName is not specified, the part-of label will be omitted.",
+		"productVersion":    "Designate the apps.kubevirt.io/version label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductVersion is not specified, KubeVirt's version will be used.",
+		"productName":       "Designate the apps.kubevirt.io/part-of label for KubeVirt components.\nUseful if KubeVirt is included as part of a product.\nIf ProductName is not specified, the part-of label will be omitted.",
 		"configuration":     "holds kubevirt configurations.\nsame as the virt-configMap",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -314,6 +314,8 @@ func (KubeVirtSpec) SwaggerDoc() map[string]string {
 		"monitorNamespace":  "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
 		"monitorAccount":    "The name of the Prometheus service account that needs read-access to KubeVirt endpoints\nDefaults to prometheus-k8s",
 		"uninstallStrategy": "Specifies if kubevirt can be deleted if workloads are still present.\nThis is mainly a precaution to avoid accidental data loss",
+		"productVersion":    "Designate the apps.kubevirt.io/version label for KubeVirt components\nUseful if KubeVirt is included as part of a product\nIf ProductVersion is not specified, the version label will be omitted.",
+		"productName":       "Designate the apps.kubevirt.io/part-of label for KubeVirt components\nUseful if KubeVirt is included as part of a product\nIf ProductName is not specified, the part-of label will be omitted.",
 		"configuration":     "holds kubevirt configurations.\nsame as the virt-configMap",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -15398,6 +15398,20 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtSpec(ref common.ReferenceCallbac
 							Ref: ref("kubevirt.io/client-go/api/v1.KubeVirtCertificateRotateStrategy"),
 						},
 					},
+					"productVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Designate the apps.kubevirt.io/version label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductVersion is not specified, the version label will be omitted.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"productName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Designate the apps.kubevirt.io/part-of label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductName is not specified, the part-of label will be omitted.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"configuration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "holds kubevirt configurations. same as the virt-configMap",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -15400,14 +15400,14 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtSpec(ref common.ReferenceCallbac
 					},
 					"productVersion": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Designate the apps.kubevirt.io/version label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductVersion is not specified, the version label will be omitted.",
+							Description: "Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"productName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Designate the apps.kubevirt.io/part-of label for KubeVirt components Useful if KubeVirt is included as part of a product If ProductName is not specified, the part-of label will be omitted.",
+							Description: "Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductName is not specified, the part-of label will be omitted.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Operator", func() {
 		waitForUpdateCondition            func(*v1.KubeVirt)
 		waitForKvWithTimeout              func(*v1.KubeVirt, int)
 		waitForKv                         func(*v1.KubeVirt)
+		patchKvProductNameAndVersion      func(string, string, string)
 		patchKvVersionAndRegistry         func(string, string, string)
 		patchKvVersion                    func(string, string)
 		parseDaemonset                    func(string) (*v12.DaemonSet, string, string, string, string)
@@ -304,6 +305,15 @@ var _ = Describe("Operator", func() {
 
 		waitForKv = func(newKv *v1.KubeVirt) {
 			waitForKvWithTimeout(newKv, 300)
+		}
+
+		patchKvProductNameAndVersion = func(name, productName string, productVersion string) {
+			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/productName", "value": "%s"},{ "op": "replace", "path": "/spec/productVersion", "value": "%s"}]`, productName, productVersion))
+			Eventually(func() error {
+				_, err := virtClient.KubeVirt(tests.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+
+				return err
+			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
 
 		patchKvVersionAndRegistry = func(name string, version string, registry string) {
@@ -1191,6 +1201,37 @@ spec:
 				return crd.OwnerReferences
 			}, 10*time.Second, 1*time.Second).Should(BeEmpty())
 			Expect(crd.ObjectMeta.OwnerReferences).To(HaveLen(0))
+		})
+
+		It("should be able to update product related labels of kubevirt install", func() {
+			productName := "kubevirt-test"
+			productVersion := "0.0.0"
+			allPodsAreReady(originalKv)
+			sanityCheckDeploymentsExist()
+
+			kv := copyOriginalKv()
+
+			By("Patching kubevirt resource with productName and productVersion")
+			patchKvProductNameAndVersion(kv.Name, productName, productVersion)
+
+			for _, deployment := range []string{"virt-api", "virt-controller"} {
+				By(fmt.Sprintf("Ensuring that the %s deployment is updated", deployment))
+				Eventually(func() bool {
+					dep, err := virtClient.AppsV1().Deployments(tests.KubeVirtInstallNamespace).Get(deployment, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					return dep.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dep.ObjectMeta.Labels[v1.AppPartOfLabel] == productName
+				}, 240*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Expected labels to be updated for %s deployment", deployment))
+			}
+
+			By("Ensuring that the virt-handler daemonset is updated")
+			Eventually(func() bool {
+				dms, err := virtClient.AppsV1().DaemonSets(tests.KubeVirtInstallNamespace).Get("virt-handler", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return dms.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dms.ObjectMeta.Labels[v1.AppPartOfLabel] == productName
+			}, 240*time.Second, 1*time.Second).Should(BeTrue(), "Expected labels to be updated for virt-handler daemonset")
+
+			By("Deleting KubeVirt object")
+			deleteAllKvAndWait(false)
 		})
 
 		Context("[rfe_id:2897][crit:medium][vendor:cnv-qe@redhat.com][level:component]With OpenShift cluster", func() {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -310,7 +310,7 @@ var _ = Describe("Operator", func() {
 		patchKvProductNameAndVersion = func(name, productName string, productVersion string) {
 			data := []byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/productName", "value": "%s"},{ "op": "replace", "path": "/spec/productVersion", "value": "%s"}]`, productName, productVersion))
 			Eventually(func() error {
-				_, err := virtClient.KubeVirt(tests.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
+				_, err := virtClient.KubeVirt(flags.KubeVirtInstallNamespace).Patch(name, types.JSONPatchType, data)
 
 				return err
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
@@ -1217,7 +1217,7 @@ spec:
 			for _, deployment := range []string{"virt-api", "virt-controller"} {
 				By(fmt.Sprintf("Ensuring that the %s deployment is updated", deployment))
 				Eventually(func() bool {
-					dep, err := virtClient.AppsV1().Deployments(tests.KubeVirtInstallNamespace).Get(deployment, metav1.GetOptions{})
+					dep, err := virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Get(deployment, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return dep.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dep.ObjectMeta.Labels[v1.AppPartOfLabel] == productName
 				}, 240*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Expected labels to be updated for %s deployment", deployment))
@@ -1225,7 +1225,7 @@ spec:
 
 			By("Ensuring that the virt-handler daemonset is updated")
 			Eventually(func() bool {
-				dms, err := virtClient.AppsV1().DaemonSets(tests.KubeVirtInstallNamespace).Get("virt-handler", metav1.GetOptions{})
+				dms, err := virtClient.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get("virt-handler", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return dms.ObjectMeta.Labels[v1.AppVersionLabel] == productVersion && dms.ObjectMeta.Labels[v1.AppPartOfLabel] == productName
 			}, 240*time.Second, 1*time.Second).Should(BeTrue(), "Expected labels to be updated for virt-handler daemonset")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the groundwork for applying commonly recognizes labels to all objects created within KubeVirt.

ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

**Release note**:
```release-note
Resources created by KubeVirt are now labelled more clearly in terms of relationship and role.
```
