### PR TITLE
virtctl cli error handling

### DIFF
--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -42,7 +42,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "console (VMI)",
 		Short:   "Connect to a console of a virtual machine instance.",
 		Example: usage(),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("console", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Console{clientConfig: clientConfig}
 			return c.Run(cmd, args)

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -37,7 +37,7 @@ var strServiceType string
 var portName string
 var namespace string
 
-// NewExposeCommand generate a new "expose" command
+// NewExposeCommand generates a new "expose" command
 func NewExposeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "expose (TYPE NAME)",

--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -37,7 +37,7 @@ var strServiceType string
 var portName string
 var namespace string
 
-// generate a new "expose" command
+// NewExposeCommand generate a new "expose" command
 func NewExposeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "expose (TYPE NAME)",
@@ -51,7 +51,7 @@ Possible types are (case insensitive, both single and plurant forms):
         
 virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplicaset (vmirs)`,
 		Example: usage(),
-		Args:    cobra.ExactArgs(2),
+		Args:    templates.ExactArgs("expose", 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_EXPOSE, clientConfig: clientConfig}
 			return c.RunE(cmd, args)

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -102,6 +102,12 @@ var _ = Describe("Expose", func() {
 				kubecli.GetKubevirtClientFromClientConfig = kubecli.GetMockKubevirtClientFromClientConfig
 			})
 		})
+		Context("With missing input parameters", func() {
+			It("should fail", func() {
+				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE)
+				Expect(cmd()).NotTo(BeNil())
+			})
+		})
 		Context("With missing resource", func() {
 			It("should fail", func() {
 				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", "--name", "my-service",

--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -51,7 +51,7 @@ func NewPauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Long: `Pauses a virtual machine by freezing it. Machine state is kept in memory.
 First argument is the resource type, possible types are (case insensitive, both singular and plural forms) virtualmachineinstance (vmi) or virtualmachine (vm).
 Second argument is the name of the resource.`,
-		Args:    templates.ExactArgs("pause", 2),
+		Args:    templates.ExactArgs(COMMAND_PAUSE, 2),
 		Example: usage(COMMAND_PAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VirtCommand{

--- a/pkg/virtctl/pause/pause.go
+++ b/pkg/virtctl/pause/pause.go
@@ -51,7 +51,7 @@ func NewPauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Long: `Pauses a virtual machine by freezing it. Machine state is kept in memory.
 First argument is the resource type, possible types are (case insensitive, both singular and plural forms) virtualmachineinstance (vmi) or virtualmachine (vm).
 Second argument is the name of the resource.`,
-		Args:    cobra.ExactArgs(2),
+		Args:    templates.ExactArgs("pause", 2),
 		Example: usage(COMMAND_PAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VirtCommand{
@@ -72,7 +72,7 @@ func NewUnpauseCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Long: `Unpauses a virtual machine.
 First argument is the resource type, possible types are (case insensitive, both singular and plural forms) virtualmachineinstance (vmi) or virtualmachine (vm).
 Second argument is the name of the resource.`,
-		Args:    cobra.ExactArgs(2),
+		Args:    templates.ExactArgs("unpause", 2),
 		Example: usage(COMMAND_UNPAUSE),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VirtCommand{

--- a/pkg/virtctl/pause/pause_test.go
+++ b/pkg/virtctl/pause/pause_test.go
@@ -27,6 +27,13 @@ var _ = Describe("Pausing", func() {
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 	})
 
+	Context("With missing input parameters", func() {
+		It("should fail", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("pause")
+			Expect(cmd()).NotTo(BeNil())
+		})
+	})
+
 	It("should pause VMI", func() {
 		vmi := v1.NewMinimalVMI(vmName)
 

--- a/pkg/virtctl/pause/pause_test.go
+++ b/pkg/virtctl/pause/pause_test.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/virtctl/pause"
 	"kubevirt.io/kubevirt/tests"
 )
 
@@ -29,8 +30,9 @@ var _ = Describe("Pausing", func() {
 
 	Context("With missing input parameters", func() {
 		It("should fail", func() {
-			cmd := tests.NewRepeatableVirtctlCommand("pause")
-			Expect(cmd()).NotTo(BeNil())
+			cmd := tests.NewRepeatableVirtctlCommand(pause.COMMAND_PAUSE)
+			err := cmd()
+			Expect(err).NotTo(BeNil())
 		})
 	})
 
@@ -40,7 +42,7 @@ var _ = Describe("Pausing", func() {
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
 		vmiInterface.EXPECT().Pause(vmi.Name).Return(nil).Times(1)
 
-		cmd := tests.NewVirtctlCommand("pause", "vmi", vmName)
+		cmd := tests.NewVirtctlCommand(pause.COMMAND_PAUSE, "vmi", vmName)
 		Expect(cmd.Execute()).To(BeNil())
 	})
 
@@ -50,7 +52,7 @@ var _ = Describe("Pausing", func() {
 		kubecli.MockKubevirtClientInstance.EXPECT().VirtualMachineInstance(k8smetav1.NamespaceDefault).Return(vmiInterface).Times(1)
 		vmiInterface.EXPECT().Unpause(vmi.Name).Return(nil).Times(1)
 
-		cmd := tests.NewVirtctlCommand("unpause", "vmi", vmName)
+		cmd := tests.NewVirtctlCommand(pause.COMMAND_UNPAUSE, "vmi", vmName)
 		Expect(cmd.Execute()).To(BeNil())
 	})
 
@@ -67,7 +69,7 @@ var _ = Describe("Pausing", func() {
 		vmInterface.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
 		vmiInterface.EXPECT().Pause(vm.Name).Return(nil).Times(1)
 
-		cmd := tests.NewVirtctlCommand("pause", "vm", vmName)
+		cmd := tests.NewVirtctlCommand(pause.COMMAND_PAUSE, "vm", vmName)
 		Expect(cmd.Execute()).To(BeNil())
 	})
 
@@ -84,7 +86,7 @@ var _ = Describe("Pausing", func() {
 		vmInterface.EXPECT().Get(vm.Name, &k8smetav1.GetOptions{}).Return(vm, nil).Times(1)
 		vmiInterface.EXPECT().Unpause(vm.Name).Return(nil).Times(1)
 
-		cmd := tests.NewVirtctlCommand("unpause", "vm", vmName)
+		cmd := tests.NewVirtctlCommand(pause.COMMAND_UNPAUSE, "vm", vmName)
 		Expect(cmd.Execute()).To(BeNil())
 	})
 

--- a/pkg/virtctl/templates/BUILD.bazel
+++ b/pkg/virtctl/templates/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["templates.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/templates",
     visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/spf13/cobra:go_default_library"],
 )

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -1,5 +1,12 @@
 package templates
 
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
 // UsageTemplate returns the usage template for all subcommands
 func UsageTemplate() string {
 	return `Usage:{{if .Runnable}}
@@ -38,4 +45,16 @@ func OptionsUsageTemplate() string {
 
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 `
+}
+
+// ExactArgs validate the number of input parameters
+func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) != n {
+			fmt.Printf("fatal: Number of input parameters is incorrect, %s accepts %d arg(s), received %d\n\n", nameOfCommand, n, len(args))
+			cmd.Help()
+			return errors.New("argument validation failed")
+		}
+		return nil
+	}
 }

--- a/pkg/virtctl/version/version.go
+++ b/pkg/virtctl/version/version.go
@@ -18,7 +18,7 @@ func VersionCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "version",
 		Short:   "Print the client and server version information.",
 		Example: usage(),
-		Args:    cobra.ExactArgs(0),
+		Args:    templates.ExactArgs("version", 0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := Version{clientConfig: clientConfig}
 			return v.Run(cmd, args)

--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -54,7 +54,7 @@ func NewStartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "start (VM)",
 		Short:   "Start a virtual machine.",
 		Example: usage(COMMAND_START),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("start", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_START, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -69,7 +69,7 @@ func NewStopCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "stop (VM)",
 		Short:   "Stop a virtual machine.",
 		Example: usage(COMMAND_STOP),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("stop", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_STOP, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -84,7 +84,7 @@ func NewRestartCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "restart (VM)",
 		Short:   "Restart a virtual machine.",
 		Example: usage(COMMAND_RESTART),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("restart", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_RESTART, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -101,7 +101,7 @@ func NewMigrateCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "migrate (VM)",
 		Short:   "Migrate a virtual machine.",
 		Example: usage(COMMAND_MIGRATE),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("migrate", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_MIGRATE, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -116,7 +116,7 @@ func NewRenameCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "rename [vm_name] [new_vm_name]",
 		Short:   "Rename a stopped virtual machine.",
 		Example: usage(COMMAND_RENAME),
-		Args:    cobra.ExactArgs(2),
+		Args:    templates.ExactArgs("rename", 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_RENAME, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -131,7 +131,7 @@ func NewGuestOsInfoCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "guestosinfo (VMI)",
 		Short:   "Return guest agent info about operating system.",
 		Example: usage(COMMAND_GUESTOSINFO),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("guestosinfo", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_GUESTOSINFO, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -146,7 +146,7 @@ func NewUserListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "userlist (VMI)",
 		Short:   "Return full list of logged in users on the guest machine.",
 		Example: usage(COMMAND_USERLIST),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("userlist", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_USERLIST, clientConfig: clientConfig}
 			return c.Run(cmd, args)
@@ -161,7 +161,7 @@ func NewFSListCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "fslist (VMI)",
 		Short:   "Return full list of filesystems available on the guest machine.",
 		Example: usage(COMMAND_FSLIST),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("fslist", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_FSLIST, clientConfig: clientConfig}
 			return c.Run(cmd, args)

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -34,6 +34,41 @@ var _ = Describe("VirtualMachine", func() {
 		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 	})
 
+	Context("With missing input parameters", func() {
+		It("should fail", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("start")
+			Expect(cmd()).NotTo(BeNil())
+		})
+	})
+
+	Context("With missing input parameters", func() {
+		It("should fail", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("stop")
+			Expect(cmd()).NotTo(BeNil())
+		})
+	})
+
+	Context("With missing input parameters", func() {
+		It("should fail", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("restart")
+			Expect(cmd()).NotTo(BeNil())
+		})
+	})
+
+	Context("With missing input parameters", func() {
+		It("should fail", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("migrate")
+			Expect(cmd()).NotTo(BeNil())
+		})
+	})
+
+	Context("With missing input parameters", func() {
+		It("should fail", func() {
+			cmd := tests.NewRepeatableVirtctlCommand("rename")
+			Expect(cmd()).NotTo(BeNil())
+		})
+	})
+
 	Context("should patch VM", func() {
 		It("with spec:running:true", func() {
 			vm := kubecli.NewMinimalVM(vmName)

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -64,7 +64,7 @@ func NewCommand(clientConfig clientcmd.ClientConfig) *cobra.Command {
 		Use:     "vnc (VMI)",
 		Short:   "Open a vnc connection to a virtual machine instance.",
 		Example: usage(),
-		Args:    cobra.ExactArgs(1),
+		Args:    templates.ExactArgs("vnc", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := VNC{clientConfig: clientConfig}
 			return c.Run(cmd, args)


### PR DESCRIPTION
additional error handling for virtctl cli when
incorrect number of input parameters.
print error message and also the help menu for that command.

Signed-off-by: Shaul Garbourg <sgarbour@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes ##3854

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Better error message when input parameters are not the expected number of parameters for each argument. Help menu will popup in case the number of parameters is incorrect.
```
