### PR TITLE
doc: Bump memory used in examples to 4Gi

### DIFF
--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -38,7 +38,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       terminationGracePeriodSeconds: 0
       volumes:
       - dataVolume:

--- a/examples/vm-alpine-multipvc.yaml
+++ b/examples/vm-alpine-multipvc.yaml
@@ -25,7 +25,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       terminationGracePeriodSeconds: 0
       volumes:
       - name: pvcdisk1

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -25,7 +25,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -25,7 +25,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       priorityClassName: non-preemtible
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vmi-alpine-efi.yaml
+++ b/examples/vmi-alpine-efi.yaml
@@ -20,7 +20,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1Gi
+        memory: 4Gi
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-block-pvc.yaml
+++ b/examples/vmi-block-pvc.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - name: blockpvcdisk

--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-fedora.yaml
+++ b/examples/vmi-fedora.yaml
@@ -20,7 +20,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-flavor-small.yaml
+++ b/examples/vmi-flavor-small.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-gpu.yaml
+++ b/examples/vmi-gpu.yaml
@@ -23,7 +23,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-host-disk.yaml
+++ b/examples/vmi-host-disk.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - hostDisk:

--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -27,7 +27,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   networks:
   - name: testmasquerade
     pod: {}

--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -19,7 +19,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-multus-multiple-net.yaml
+++ b/examples/vmi-multus-multiple-net.yaml
@@ -25,7 +25,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-multus-ptp.yaml
+++ b/examples/vmi-multus-ptp.yaml
@@ -23,7 +23,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   networks:
   - multus:
       networkName: ptp-conf

--- a/examples/vmi-nocloud.yaml
+++ b/examples/vmi-nocloud.yaml
@@ -22,7 +22,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-preset-small.yaml
+++ b/examples/vmi-preset-small.yaml
@@ -10,7 +10,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   selector:
     matchLabels:
       kubevirt.io/vmPreset: vmi-preset-small

--- a/examples/vmi-pvc.yaml
+++ b/examples/vmi-pvc.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - name: pvcdisk

--- a/examples/vmi-replicaset-cirros.yaml
+++ b/examples/vmi-replicaset-cirros.yaml
@@ -23,7 +23,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 4096M
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-secureboot.yaml
+++ b/examples/vmi-secureboot.yaml
@@ -24,7 +24,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1Gi
+        memory: 4Gi
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-slirp.yaml
+++ b/examples/vmi-slirp.yaml
@@ -27,7 +27,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   networks:
   - name: testSlirp
     pod: {}

--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -25,7 +25,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-with-sidecar-hook.yaml
+++ b/examples/vmi-with-sidecar-hook.yaml
@@ -23,7 +23,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 1024M
+        memory: 4096M
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:


### PR DESCRIPTION
This number was chosen as the Windows minimum requirement of RAM.

Many users trying out things will copy a valid YAML and change it
to another OS, and 64M (used widely) is too low for many operating
systems. The failures are confusing and hard to understand, and
we can spare them this. Anyone wanting to cut down on usage can
always do so.

**Release note**:
```release-note
NONE
```
