### PR TITLE
Safe expect batch

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -105,7 +105,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount iso ConfigMap image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -199,7 +199,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount iso Secret image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -282,7 +282,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				// mount service account iso image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.Retcode("0", "\\#")},
+				&expect.BExp{R: tests.RetValue("0", "\\#")},
 				&expect.BSnd{S: "cat /mnt/namespace\n"},
 				&expect.BExp{R: tests.NamespaceTestDefault},
 				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
@@ -377,7 +377,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					&expect.BExp{R: "#"},
 					&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
 					&expect.BExp{R: expectedOutputCfgMap},
 				}, 200*time.Second)
@@ -403,7 +403,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount Secret image
 					&expect.BSnd{S: "mount /dev/vdd /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutputSecret},
 				}, 200*time.Second)
@@ -501,13 +501,13 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					&expect.BExp{R: "\\#"},
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "grep \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "grep ssh-rsa /mnt/ssh-publickey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 				}, 200*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -105,7 +105,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount iso ConfigMap image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -199,7 +199,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount iso Secret image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -282,7 +282,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				// mount service account iso image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
+				&expect.BExp{R: tests.Retcode("0", "\\#")},
 				&expect.BSnd{S: "cat /mnt/namespace\n"},
 				&expect.BExp{R: tests.NamespaceTestDefault},
 				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
@@ -377,7 +377,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					&expect.BExp{R: "#"},
 					&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
 					&expect.BExp{R: expectedOutputCfgMap},
 				}, 200*time.Second)
@@ -403,7 +403,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount Secret image
 					&expect.BSnd{S: "mount /dev/vdd /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutputSecret},
 				}, 200*time.Second)
@@ -498,16 +498,16 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				res, err := expecter.ExpectBatch([]expect.Batcher{
 					// mount iso Secret image
 					&expect.BSnd{S: "sudo su -\n"},
-					&expect.BExp{R: "#"},
+					&expect.BExp{R: "\\#"},
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "grep \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "grep ssh-rsa /mnt/ssh-publickey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 				}, 200*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -211,11 +211,11 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "cd /media/cdrom\n"},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "expected virtio files to be mounted properly")
 			})

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -211,11 +211,11 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "cd /media/cdrom\n"},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "expected virtio files to be mounted properly")
 			})

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -367,7 +367,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		grepSleepPid := func(expecter expect.Expecter) string {
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: `pgrep -f "sleep 5"` + "\n"},
-				&expect.BExp{R: tests.Retcode("[0-9]+", "\\# ")}, // pid
+				&expect.BExp{R: tests.RetValue("[0-9]+", "\\# ")}, // pid
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Storage", func() {
 					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 				}, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -302,7 +302,7 @@ var _ = Describe("Storage", func() {
 					// Because "/" is mounted on tmpfs, we need something that normally persists writes - /dev/sda2 is the EFI partition formatted as vFAT.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "echo content > /mnt/checkpoint\n"},
 					// The QEMU process will be killed, therefore the write must be flushed to the disk.
 					&expect.BSnd{S: "sync\n"},
@@ -330,10 +330,10 @@ var _ = Describe("Storage", func() {
 					// Same story as when first starting the VirtualMachineInstance - the checkpoint, if persisted, is located at /dev/sda2.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/checkpoint &> /dev/null\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("1", "\\#")},
+					&expect.BExp{R: tests.RetValue("1", "\\#")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Storage", func() {
 					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 				}, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -302,7 +302,7 @@ var _ = Describe("Storage", func() {
 					// Because "/" is mounted on tmpfs, we need something that normally persists writes - /dev/sda2 is the EFI partition formatted as vFAT.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "echo content > /mnt/checkpoint\n"},
 					// The QEMU process will be killed, therefore the write must be flushed to the disk.
 					&expect.BSnd{S: "sync\n"},
@@ -330,10 +330,10 @@ var _ = Describe("Storage", func() {
 					// Same story as when first starting the VirtualMachineInstance - the checkpoint, if persisted, is located at /dev/sda2.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\#")},
 					&expect.BSnd{S: "cat /mnt/checkpoint &> /dev/null\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "1"},
+					&expect.BExp{R: tests.Retcode("1", "\\#")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2845,7 +2845,7 @@ func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batc
 	}
 	defer expecter.Close()
 
-	resp, err := expecter.ExpectBatch(expected, time.Second*time.Duration(wait))
+	resp, err := ExpectBatchWithValidatedSend(expecter, expected, time.Second*time.Duration(wait))
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("%v", resp)
 	}
@@ -2880,7 +2880,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "ip a | grep -q eth0; echo $?\n"},
 			&expect.BExp{R: retcode("0")}})
-		_, err := expecter.ExpectBatch(hasNetEth0Batch, 30*time.Second)
+		_, err := ExpectBatchWithValidatedSend(expecter, hasNetEth0Batch, 30*time.Second)
 		return err == nil
 	}
 
@@ -2890,7 +2890,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "ip -6 address show dev eth0 scope global | grep -q inet6; echo $?\n"},
 			&expect.BExp{R: retcode("0")}})
-		_, err := expecter.ExpectBatch(hasGlobalIPv6Batch, 30*time.Second)
+		_, err := ExpectBatchWithValidatedSend(expecter, hasGlobalIPv6Batch, 30*time.Second)
 		return err == nil
 	}
 
@@ -2913,7 +2913,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0; echo $?\n"},
 		&expect.BExp{R: retcode("0")}})
-	resp, err := expecter.ExpectBatch(addIPv6Address, 30*time.Second)
+	resp, err := ExpectBatchWithValidatedSend(expecter, addIPv6Address, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6Address failed: %v", resp)
 		expecter.Close()
@@ -2926,7 +2926,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2; echo $?\n"},
 		&expect.BExp{R: retcode("0")}})
-	resp, err = expecter.ExpectBatch(addIPv6DefaultRoute, 30*time.Second)
+	resp, err = ExpectBatchWithValidatedSend(expecter, addIPv6DefaultRoute, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6DefaultRoute failed: %v", resp)
 		expecter.Close()
@@ -4254,7 +4254,7 @@ func StartTCPServer(vmi *v1.VirtualMachineInstance, port int) {
 	Expect(err).ToNot(HaveOccurred())
 	defer expecter.Close()
 
-	resp, err := expecter.ExpectBatch([]expect.Batcher{
+	resp, err := ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: fmt.Sprintf("screen -d -m nc -klp %d -e echo -e \"Hello World!\"\n", port)},
@@ -4285,7 +4285,7 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, isFedoraVM bool) 
 	}
 	defer expecter.Close()
 
-	resp, err := expecter.ExpectBatch([]expect.Batcher{
+	resp, err := ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: httpServerMaker},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2861,11 +2861,11 @@ func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) 
 		&expect.BSnd{S: "stty columns 500\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: Retcode("0", prompt)},
+		&expect.BExp{R: RetValue("0", prompt)},
 		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: Retcode("0", prompt)}})
+		&expect.BExp{R: RetValue("0", prompt)}})
 	resp, err := expecter.ExpectBatch(batch, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Infof("%v", resp)
@@ -2879,7 +2879,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "ip a | grep -q eth0; echo $?\n"},
-			&expect.BExp{R: Retcode("0", prompt)}})
+			&expect.BExp{R: RetValue("0", prompt)}})
 		_, err := ExpectBatchWithValidatedSend(expecter, hasNetEth0Batch, 30*time.Second)
 		return err == nil
 	}
@@ -2889,7 +2889,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "ip -6 address show dev eth0 scope global | grep -q inet6; echo $?\n"},
-			&expect.BExp{R: Retcode("0", prompt)}})
+			&expect.BExp{R: RetValue("0", prompt)}})
 		_, err := ExpectBatchWithValidatedSend(expecter, hasGlobalIPv6Batch, 30*time.Second)
 		return err == nil
 	}
@@ -2912,7 +2912,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0; echo $?\n"},
-		&expect.BExp{R: Retcode("0", prompt)}})
+		&expect.BExp{R: RetValue("0", prompt)}})
 	resp, err := ExpectBatchWithValidatedSend(expecter, addIPv6Address, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6Address failed: %v", resp)
@@ -2925,7 +2925,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2; echo $?\n"},
-		&expect.BExp{R: Retcode("0", prompt)}})
+		&expect.BExp{R: RetValue("0", prompt)}})
 	resp, err = ExpectBatchWithValidatedSend(expecter, addIPv6DefaultRoute, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6DefaultRoute failed: %v", resp)
@@ -4260,7 +4260,7 @@ func StartTCPServer(vmi *v1.VirtualMachineInstance, port int) {
 		&expect.BSnd{S: fmt.Sprintf("screen -d -m nc -klp %d -e echo -e \"Hello World!\"\n", port)},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: Retcode("0", "\\$ ")},
+		&expect.BExp{R: RetValue("0", "\\$ ")},
 	}, 60*time.Second)
 	log.DefaultLogger().Infof("%v", resp)
 	Expect(err).ToNot(HaveOccurred())
@@ -4291,7 +4291,7 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, isFedoraVM bool) 
 		&expect.BSnd{S: httpServerMaker},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: Retcode("0", prompt)},
+		&expect.BExp{R: RetValue("0", prompt)},
 	}, 60*time.Second)
 	log.DefaultLogger().Infof("%v", resp)
 	Expect(err).ToNot(HaveOccurred())
@@ -4414,7 +4414,7 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 		&expect.BSnd{S: serverCommand},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: Retcode("0", "\\$ ")},
+		&expect.BExp{R: RetValue("0", "\\$ ")},
 	}, 60*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 }
@@ -5032,6 +5032,6 @@ func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 	return false
 }
 
-func Retcode(retcode string, prompt string) string {
+func RetValue(retcode string, prompt string) string {
 	return "\n" + retcode + "\r\n" + ".*" + prompt
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2879,7 +2879,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "ip a | grep -q eth0; echo $?\n"},
-			&expect.BExp{R: retcode("0")}})
+			&expect.BExp{R: Retcode("0", prompt)}})
 		_, err := ExpectBatchWithValidatedSend(expecter, hasNetEth0Batch, 30*time.Second)
 		return err == nil
 	}
@@ -2889,7 +2889,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "ip -6 address show dev eth0 scope global | grep -q inet6; echo $?\n"},
-			&expect.BExp{R: retcode("0")}})
+			&expect.BExp{R: Retcode("0", prompt)}})
 		_, err := ExpectBatchWithValidatedSend(expecter, hasGlobalIPv6Batch, 30*time.Second)
 		return err == nil
 	}
@@ -2912,7 +2912,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0; echo $?\n"},
-		&expect.BExp{R: retcode("0")}})
+		&expect.BExp{R: Retcode("0", prompt)}})
 	resp, err := ExpectBatchWithValidatedSend(expecter, addIPv6Address, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6Address failed: %v", resp)
@@ -2925,7 +2925,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2; echo $?\n"},
-		&expect.BExp{R: retcode("0")}})
+		&expect.BExp{R: Retcode("0", prompt)}})
 	resp, err = ExpectBatchWithValidatedSend(expecter, addIPv6DefaultRoute, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("addIPv6DefaultRoute failed: %v", resp)
@@ -5032,6 +5032,6 @@ func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 	return false
 }
 
-func retcode(retcode string) string {
-	return "\n" + retcode
+func Retcode(retcode string, prompt string) string {
+	return "\n" + retcode + "\r\n" + ".*" + prompt
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4408,9 +4408,9 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 	serverCommand := fmt.Sprintf("screen -d -m sudo nc -klp %d -e echo -e 'Hello World!'\n", testPort)
 	if protocol == "udp" {
 		// nc has to be in a while loop in case of UDP, since it exists after one message
-		serverCommand = fmt.Sprintf("screen -d -m sh -c \"while true\n do nc -uklp %d -e echo -e 'Hello UDP World!'\ndone\n\"\n", testPort)
+		serverCommand = fmt.Sprintf("screen -d -m sh -c \"while true; do nc -uklp %d -e echo -e 'Hello UDP World!';done\"\n", testPort)
 	}
-	_, err = expecter.ExpectBatch([]expect.Batcher{
+	_, err = ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 		&expect.BSnd{S: serverCommand},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5032,6 +5032,6 @@ func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 	return false
 }
 
-func RetValue(retcode string, prompt string) string {
+func RetValue(retcode, prompt string) string {
 	return "\n" + retcode + "\r\n" + ".*" + prompt
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2861,11 +2861,11 @@ func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) 
 		&expect.BSnd{S: "stty columns 500\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: retcode("0")},
+		&expect.BExp{R: Retcode("0", prompt)},
 		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: retcode("0")}})
+		&expect.BExp{R: Retcode("0", prompt)}})
 	resp, err := expecter.ExpectBatch(batch, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Infof("%v", resp)
@@ -4260,7 +4260,7 @@ func StartTCPServer(vmi *v1.VirtualMachineInstance, port int) {
 		&expect.BSnd{S: fmt.Sprintf("screen -d -m nc -klp %d -e echo -e \"Hello World!\"\n", port)},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: Retcode("0", "\\$ ")},
 	}, 60*time.Second)
 	log.DefaultLogger().Infof("%v", resp)
 	Expect(err).ToNot(HaveOccurred())
@@ -4291,7 +4291,7 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int, isFedoraVM bool) 
 		&expect.BSnd{S: httpServerMaker},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: Retcode("0", prompt)},
 	}, 60*time.Second)
 	log.DefaultLogger().Infof("%v", resp)
 	Expect(err).ToNot(HaveOccurred())
@@ -4414,7 +4414,7 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 		&expect.BSnd{S: serverCommand},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: Retcode("0", "\\$ ")},
 	}, 60*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -68,7 +68,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 			&expect.BSnd{S: cmdCheck},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "echo $?\n"},
-			&expect.BExp{R: tests.Retcode("0", prompt)},
+			&expect.BExp{R: tests.RetValue("0", prompt)},
 		}, 15)
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -68,7 +68,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 			&expect.BSnd{S: cmdCheck},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "echo $?\n"},
-			&expect.BExp{R: "0"},
+			&expect.BExp{R: tests.Retcode("0", prompt)},
 		}, 15)
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -100,7 +100,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: prompt},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", prompt)},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -100,7 +100,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: prompt},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", prompt)},
+					&expect.BExp{R: tests.RetValue("0", prompt)},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -565,7 +565,7 @@ var _ = Describe("Configurations", func() {
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pa''ss'\n"},
 					&expect.BExp{R: "pass"},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k; echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -1983,7 +1983,7 @@ var _ = Describe("Configurations", func() {
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pa''ss'\n"},
 					&expect.BExp{R: "pass"},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k; echo $?\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -563,11 +563,11 @@ var _ = Describe("Configurations", func() {
 
 				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.Retcode("pass", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("pass", "\\$ ")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -621,7 +621,7 @@ var _ = Describe("Configurations", func() {
 				// Check on the VM, if the Free memory is roughly what we expected
 				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 95 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.Retcode("pass", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("pass", "\\$ ")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -1984,11 +1984,11 @@ var _ = Describe("Configurations", func() {
 
 				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.Retcode("pass", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("pass", "\\$ ")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -2333,7 +2333,7 @@ var _ = Describe("Configurations", func() {
 			// Check on the VM, if expected values are there with dmidecode
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') = Test-123 ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2377,11 +2377,11 @@ var _ = Describe("Configurations", func() {
 			// Check on the VM, if expected values are there with dmidecode
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2417,11 +2417,11 @@ var _ = Describe("Configurations", func() {
 			// Check on the VM, if expected values are there with dmidecode
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.Retcode("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -44,7 +44,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt strin
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -44,7 +44,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt strin
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -299,7 +299,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				By("Checking console text")
 				err = tests.CheckForTextExpecter(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
-					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: consoleText},
 				}, wait)
 				Expect(err).ToNot(HaveOccurred(), "Should match the console in VMI")

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -70,9 +70,9 @@ var _ = Describe("Health Monitoring", func() {
 			By("Killing the watchdog device")
 			_, err = expecter.ExpectBatch([]expect.Batcher{
 				&expect.BSnd{S: "watchdog -t 2000ms -T 4000ms /dev/watchdog && sleep 5 && killall -9 watchdog\n"},
-				&expect.BExp{R: "#"},
+				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
+				&expect.BExp{R: tests.Retcode("0", "\\#")},
 			}, 250*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Health Monitoring", func() {
 				&expect.BSnd{S: "watchdog -t 2000ms -T 4000ms /dev/watchdog && sleep 5 && killall -9 watchdog\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.Retcode("0", "\\#")},
+				&expect.BExp{R: tests.RetValue("0", "\\#")},
 			}, 250*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -894,7 +894,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to configure address %s for interface %s on VMI %s", interfaceAddress, interfaceName, vmi.Name)
 
@@ -905,7 +905,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s up on VMI %s", interfaceName, vmi.Name)
 }
@@ -918,7 +918,7 @@ func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Interface %q was not found in the VMI %s within the given timeout", interfaceName, vmi.Name)
 }
@@ -932,7 +932,7 @@ func checkMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress s
 		&expect.BExp{R: macAddress},
 		&expect.BExp{R: "#"},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", "\\#")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "MAC %q was not found in the VMI %s within the given timeout", macAddress, vmi.Name)
 }
@@ -949,7 +949,7 @@ func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", prompt)},
 	}, 30)
 	Expect(err).ToNot(HaveOccurred(), "Failed to ping VMI %s within the given timeout", vmi.Name)
 }

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -215,8 +215,8 @@ var _ = Describe("Multus", func() {
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: "\\$ "},
-					&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l"},
-					&expect.BExp{R: "1"},
+					&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l\n"},
+					&expect.BExp{R: tests.Retcode("1", "\\$ ")},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Multus", func() {
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l\n"},
-					&expect.BExp{R: tests.Retcode("1", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("1", "\\$ ")},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -894,7 +894,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to configure address %s for interface %s on VMI %s", interfaceAddress, interfaceName, vmi.Name)
 
@@ -905,7 +905,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s up on VMI %s", interfaceName, vmi.Name)
 }
@@ -918,7 +918,7 @@ func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0", prompt)},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Interface %q was not found in the VMI %s within the given timeout", interfaceName, vmi.Name)
 }
@@ -932,7 +932,7 @@ func checkMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress s
 		&expect.BExp{R: macAddress},
 		&expect.BExp{R: "#"},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", "\\#")},
+		&expect.BExp{R: tests.RetValue("0", "\\#")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "MAC %q was not found in the VMI %s within the given timeout", macAddress, vmi.Name)
 }
@@ -949,7 +949,7 @@ func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0", prompt)},
 	}, 30)
 	Expect(err).ToNot(HaveOccurred(), "Failed to ping VMI %s within the given timeout", vmi.Name)
 }

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -225,7 +225,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: addrShow},
 				&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
+				&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 			}, 180*time.Second)
 			log.Log.Infof("%v", resp)
 			Expect(err).ToNot(HaveOccurred())
@@ -244,7 +244,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: cmdCheck},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
+				&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 			}, 180)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -255,7 +255,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: "0"},
+				&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
@@ -904,7 +904,7 @@ func createExpectTraceroute6(address string) []expect.Batcher {
 		&expect.BSnd{S: "cat tr | grep -q \"*\\|!\"\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "1"},
+		&expect.BExp{R: tests.Retcode("1", "\\$ ")},
 	}
 }
 
@@ -915,7 +915,7 @@ func createExpectStartTcpServer(port string) []expect.Batcher {
 		&expect.BSnd{S: "screen -d -m sudo nc -klp " + port + " -e echo -e 'Hello World!'\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
+		&expect.BExp{R: tests.Retcode("0", "\\$ ")},
 	}
 }
 
@@ -930,7 +930,7 @@ func createExpectConnectToServer(serverIP, tcpPort string, expectSuccess bool) [
 		&expect.BSnd{S: fmt.Sprintf("echo test | nc %s %s -i 1 -w 1 1> /dev/null\n", serverIP, tcpPort)},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: expectResult},
+		&expect.BExp{R: tests.Retcode(expectResult, "\\$ ")},
 	}
 }
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -686,7 +686,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(dnsVMI, tests.LoggedInCirrosExpecter)
 			err = tests.CheckForTextExpecter(dnsVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n\n"},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
 				&expect.BExp{R: "search example.com"},

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -652,13 +653,15 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "cat /dhcp-env\n"},
 				&expect.BExp{R: "new_tftp_server_name=tftp.kubevirt.io"},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "cat /dhcp-env\n"},
 				&expect.BExp{R: "new_bootfile_name=config"},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "cat /dhcp-env\n"},
-				&expect.BExp{R: "new_ntp_servers=127.0.0.1 127.0.0.2"},
-				&expect.BExp{R: "new_unknown_240=private.options.kubevirt.io"},
+				&expect.BExp{R: regexp.QuoteMeta("new_ntp_servers=127.0.0.1 127.0.0.2") + "((?s).*)" + regexp.QuoteMeta("new_unknown_240=private.options.kubevirt.io")},
+				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\#"},
 			}, 15)
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -226,7 +226,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: addrShow},
 				&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+				&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 			}, 180*time.Second)
 			log.Log.Infof("%v", resp)
 			Expect(err).ToNot(HaveOccurred())
@@ -245,7 +245,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: cmdCheck},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+				&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 			}, 180)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -256,7 +256,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+				&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
@@ -907,7 +907,7 @@ func createExpectTraceroute6(address string) []expect.Batcher {
 		&expect.BSnd{S: "cat tr | grep -q \"*\\|!\"\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("1", "\\$ ")},
+		&expect.BExp{R: tests.RetValue("1", "\\$ ")},
 	}
 }
 
@@ -918,7 +918,7 @@ func createExpectStartTcpServer(port string) []expect.Batcher {
 		&expect.BSnd{S: "screen -d -m sudo nc -klp " + port + " -e echo -e 'Hello World!'\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode("0", "\\$ ")},
+		&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 	}
 }
 
@@ -933,7 +933,7 @@ func createExpectConnectToServer(serverIP, tcpPort string, expectSuccess bool) [
 		&expect.BSnd{S: fmt.Sprintf("echo test | nc %s %s -i 1 -w 1 1> /dev/null\n", serverIP, tcpPort)},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.Retcode(expectResult, "\\$ ")},
+		&expect.BExp{R: tests.RetValue(expectResult, "\\$ ")},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Wrong usage of the `expecter` may cause the tests to be flaky.
    
`ExpectBatchWithValidatedSend` adds the `expect.BSnd` command to the `expect.BExp`
 expression. It is done to make sure the found match is in the result of
 the `expect.BSnd` command and not in a leftover that wasn't removed from
 the buffer.
    
 Issue https://github.com/kubevirt/kubevirt/issues/3619 describes such
 scenario.
    
 `ExpectBatchWithValidatedSend` also prevents having two sequential `expect.BExp` which
 cause unpredictable behaviour as happened in -
 https://github.com/kubevirt/kubevirt/issues/3602 and explained in PR
 https://github.com/kubevirt/kubevirt/pull/3693.
 
 For simplicity, `ExpectBatchWithValidatedSend` also prevents two sequential `expect.BSnd`.

The PR is adding the `ExpectBatchWithValidatedSend` and to example it, uses it in some selected places. A follow-up PR is needed to go over all the uses of `expecter.ExpectBatch` and in case it makes sense/supported use the `ExpectBatchWithValidatedSend` instead.

The PR also introduces a `RetValue` method ("\n" + expectedValue + "\r\n" + ".*" + prompt)  which can be used on `BExp`s. Same as for `ExpectBatchWithValidatedSend`, a follow-up PR is needed to actually use this method where needed. The current PR doesn't aim to cover all the places.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
For some reason `\n` appears in the expecter buffer as `\r\n`.
So when trying to find in the buffer a previously sent command that ended
with `\n` it fails.

To workaround this issue, the `\n` suffix is trimmed from the expected send command. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
