### PR TITLE
tests: Ping from VM console refactoring

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "ping.go",
         "test.go",
         "utils.go",
     ],

--- a/tests/ping.go
+++ b/tests/ping.go
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package tests
+
+import (
+	"fmt"
+
+	expect "github.com/google/goexpect"
+	"k8s.io/utils/net"
+
+	v1 "kubevirt.io/client-go/api/v1"
+)
+
+// PingFromVMConsole performs a ping through the provided VMI console.
+func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) error {
+	pingString := "ping"
+	if net.IsIPv6String(ipAddr) {
+		pingString = "ping -6"
+	}
+	cmdCheck := fmt.Sprintf("%s %s -c 1 -w 5\n", pingString, ipAddr)
+	err := CheckForTextExpecter(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: cmdCheck},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: "0"},
+	}, 30)
+	if err != nil {
+		return fmt.Errorf("Failed to ping VMI %s, error: %v", vmi.Name, err)
+	}
+	return nil
+}

--- a/tests/ping.go
+++ b/tests/ping.go
@@ -21,30 +21,83 @@ package tests
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+	"time"
 
 	expect "github.com/google/goexpect"
+	"google.golang.org/grpc/codes"
 	"k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+)
+
+const promptExpression = `(\$ |\# )`
+const termNLExpression = "\r\n"
+
+var (
+	shellSuccess = regexp.MustCompile("\n0" + termNLExpression + ".*" + promptExpression)
+	shellFail    = regexp.MustCompile("\n[1-9].*" + termNLExpression + ".*" + promptExpression)
 )
 
 // PingFromVMConsole performs a ping through the provided VMI console.
-func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) error {
+// Optional arguments for the ping command may be provided, overwirting the default ones.
+// (default ping options: "-c 1, -w 5")
+// Note: The maximum overall command timeout is 10 seconds.
+func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...string) error {
+	const maxCommandTimeout = 10 * time.Second
+
 	pingString := "ping"
 	if net.IsIPv6String(ipAddr) {
 		pingString = "ping -6"
 	}
-	cmdCheck := fmt.Sprintf("%s %s -c 1 -w 5\n", pingString, ipAddr)
-	err := CheckForTextExpecter(vmi, []expect.Batcher{
+
+	if len(args) == 0 {
+		args = []string{"-c 1", "-w 5"}
+	}
+	args = append([]string{pingString, ipAddr}, args...)
+	cmdCheck := strings.Join(args, " ") + "\n"
+
+	err := vmiConsoleExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: promptExpression},
 		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: promptExpression},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: "0"},
-	}, 30)
+		&expect.BCas{C: []expect.Caser{
+			&expect.Case{
+				R: shellSuccess,
+				T: expect.OK(),
+			},
+			&expect.Case{
+				R: shellFail,
+				T: expect.Fail(expect.NewStatus(codes.Unavailable, "ping failed")),
+			},
+		}},
+	}, maxCommandTimeout)
 	if err != nil {
 		return fmt.Errorf("Failed to ping VMI %s, error: %v", vmi.Name, err)
 	}
 	return nil
+}
+
+func vmiConsoleExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, timeout time.Duration) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return err
+	}
+
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	defer expecter.Close()
+
+	resp, err := expecter.ExpectBatch(expected, timeout)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("%v", resp)
+	}
+	return err
 }

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"time"
 
-	netutils "k8s.io/utils/net"
-
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -938,20 +936,7 @@ func checkMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress s
 }
 
 func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
-	pingString := "ping"
-	if netutils.IsIPv6String(ipAddr) {
-		pingString = "ping -6"
-	}
-	cmdCheck := fmt.Sprintf("%s %s -c 1 -w 5\n", pingString, ipAddr)
-	err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", prompt)},
-	}, 30)
-	Expect(err).ToNot(HaveOccurred(), "Failed to ping VMI %s within the given timeout", vmi.Name)
+	Expect(tests.PingFromVMConsole(vmi, ipAddr, prompt)).To(Succeed())
 }
 
 // Tests in Multus suite are expecting a Linux bridge to be available on each node, with iptables allowing

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-				pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
 			})
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
@@ -186,7 +186,7 @@ var _ = Describe("Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-				pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
 			})
 
 			It("[test_id:1753]should create a virtual machine with two interfaces", func() {
@@ -222,7 +222,7 @@ var _ = Describe("Multus", func() {
 				checkInterface(detachedVMI, "eth0", "\\$ ")
 				checkInterface(detachedVMI, "eth1", "\\$ ")
 
-				pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
 			})
 		})
 
@@ -244,7 +244,7 @@ var _ = Describe("Multus", func() {
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
-				pingVirtualMachine(detachedVMI, "10.1.1.1", "\\$ ")
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
 
 				By("checking virtual machine instance only has one interface")
 				// lo0, eth0
@@ -336,7 +336,7 @@ var _ = Describe("Multus", func() {
 				checkInterface(vmiTwo, "eth0", "localhost:~#")
 
 				By("ping between virtual machines")
-				pingVirtualMachine(vmiOne, "10.1.1.2", "localhost:~#")
+				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2", "localhost:~#")).To(Succeed())
 			})
 
 			It("[test_id:1578]should create two virtual machines with two interfaces", func() {
@@ -365,7 +365,7 @@ var _ = Describe("Multus", func() {
 				checkInterface(vmiTwo, "eth1", "localhost:~#")
 
 				By("ping between virtual machines")
-				pingVirtualMachine(vmiOne, "10.1.1.2", "localhost:~#")
+				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2", "localhost:~#")).To(Succeed())
 			})
 		})
 
@@ -409,7 +409,7 @@ var _ = Describe("Multus", func() {
 				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
 
 				By("Ping from the VM with the custom MAC to the other VM.")
-				pingVirtualMachine(vmiOne, "10.1.1.2", "localhost:~#")
+				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2", "localhost:~#")).To(Succeed())
 			})
 		})
 		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
@@ -864,8 +864,8 @@ var _ = Describe("SRIOV", func() {
 			configInterface(vmi2, "eth1", cidrB, "#")
 
 			// now check ICMP goes both ways
-			pingVirtualMachine(vmi1, cidrToIP(cidrB), "#")
-			pingVirtualMachine(vmi2, cidrToIP(cidrA), "#")
+			Expect(tests.PingFromVMConsole(vmi1, cidrToIP(cidrB), "#")).To(Succeed())
+			Expect(tests.PingFromVMConsole(vmi2, cidrToIP(cidrA), "#")).To(Succeed())
 		}
 
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {
@@ -933,10 +933,6 @@ func checkMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress s
 		&expect.BExp{R: tests.RetValue("0", "\\#")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "MAC %q was not found in the VMI %s within the given timeout", macAddress, vmi.Name)
-}
-
-func pingVirtualMachine(vmi *v1.VirtualMachineInstance, ipAddr, prompt string) {
-	Expect(tests.PingFromVMConsole(vmi, ipAddr, prompt)).To(Succeed())
 }
 
 // Tests in Multus suite are expecting a Linux bridge to be available on each node, with iptables allowing

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
@@ -186,7 +186,7 @@ var _ = Describe("Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
 
 			It("[test_id:1753]should create a virtual machine with two interfaces", func() {
@@ -222,7 +222,7 @@ var _ = Describe("Multus", func() {
 				checkInterface(detachedVMI, "eth0", "\\$ ")
 				checkInterface(detachedVMI, "eth1", "\\$ ")
 
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
 		})
 
@@ -244,7 +244,7 @@ var _ = Describe("Multus", func() {
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1", "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 
 				By("checking virtual machine instance only has one interface")
 				// lo0, eth0
@@ -336,7 +336,7 @@ var _ = Describe("Multus", func() {
 				checkInterface(vmiTwo, "eth0", "localhost:~#")
 
 				By("ping between virtual machines")
-				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2", "localhost:~#")).To(Succeed())
+				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 
 			It("[test_id:1578]should create two virtual machines with two interfaces", func() {
@@ -365,7 +365,7 @@ var _ = Describe("Multus", func() {
 				checkInterface(vmiTwo, "eth1", "localhost:~#")
 
 				By("ping between virtual machines")
-				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2", "localhost:~#")).To(Succeed())
+				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 		})
 
@@ -409,7 +409,7 @@ var _ = Describe("Multus", func() {
 				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
 
 				By("Ping from the VM with the custom MAC to the other VM.")
-				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2", "localhost:~#")).To(Succeed())
+				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 		})
 		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
@@ -864,8 +864,8 @@ var _ = Describe("SRIOV", func() {
 			configInterface(vmi2, "eth1", cidrB, "#")
 
 			// now check ICMP goes both ways
-			Expect(tests.PingFromVMConsole(vmi1, cidrToIP(cidrB), "#")).To(Succeed())
-			Expect(tests.PingFromVMConsole(vmi2, cidrToIP(cidrA), "#")).To(Succeed())
+			Expect(tests.PingFromVMConsole(vmi1, cidrToIP(cidrB))).To(Succeed())
+			Expect(tests.PingFromVMConsole(vmi2, cidrToIP(cidrA))).To(Succeed())
 		}
 
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -767,11 +767,11 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				}
 				By("Checking ping to gateway")
 				ipAddr := gatewayIPFromCIDR(ipv4NetworkCIDR)
-				Expect(tests.PingFromVMConsole(serverVMI, ipAddr, "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
 
 				By("Checking ping to google")
-				Expect(tests.PingFromVMConsole(serverVMI, "8.8.8.8", "\\$ ")).To(Succeed())
-				Expect(tests.PingFromVMConsole(clientVMI, "google.com", "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(serverVMI, "8.8.8.8")).To(Succeed())
+				Expect(tests.PingFromVMConsole(clientVMI, "google.com")).To(Succeed())
 			}
 
 			By("starting a tcp server")

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -766,11 +766,12 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					ipv4NetworkCIDR = api.DefaultVMCIDR
 				}
 				By("Checking ping to gateway")
-				pingVirtualMachine(serverVMI, gatewayIPFromCIDR(ipv4NetworkCIDR), "\\$ ")
+				ipAddr := gatewayIPFromCIDR(ipv4NetworkCIDR)
+				Expect(tests.PingFromVMConsole(serverVMI, ipAddr, "\\$ ")).To(Succeed())
 
 				By("Checking ping to google")
-				pingVirtualMachine(serverVMI, "8.8.8.8", "\\$ ")
-				pingVirtualMachine(clientVMI, "google.com", "\\$ ")
+				Expect(tests.PingFromVMConsole(serverVMI, "8.8.8.8", "\\$ ")).To(Succeed())
+				Expect(tests.PingFromVMConsole(clientVMI, "google.com", "\\$ ")).To(Succeed())
 			}
 
 			By("starting a tcp server")


### PR DESCRIPTION
**What this PR does / why we need it**:

tests, ping: Move the ping helper to the tests package
tests, ping: Use tests.PingFromVMConsole directly
tests, ping: Extend the ping helper and generalize it

---

The ping functionality (from the VMI console) is moved to a
common location under the tests package.

It is now possible to share its functionality between the different
tests files (instead of creating dependencies between them).

The assertion is not included in the new helper in order to allow the
callers to choose the appropriate assertion type (e.g. Eventually).

---

Use `tests.PingFromVMConsole` instead of `pingVirtualMachine`

---

The following changes and enhancements have been introduced:
- Work with both privileged and unprivileged console prompts (without
  the need to take it as an argument).
- Allow the caller to specify optional ping arguments.
- Improve shell success value detection.
- Detect ping failure directly (without the need to wait for the timeout
  expiration to declare ping failure).
- Reduce overall ping operation timeout to 10 seconds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
