### PR TITLE
Log a message indicating why a domain event failed to send

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -162,12 +162,14 @@ func (n *Notifier) SendDomainEvent(event watch.Event) error {
 		status := event.Object.(*metav1.Status)
 		statusJSON, err = json.Marshal(status)
 		if err != nil {
+			log.Log.Reason(err).Infof("JSON marshal of notify ERROR event failed")
 			return err
 		}
 	} else {
 		domain := event.Object.(*api.Domain)
 		domainJSON, err = json.Marshal(domain)
 		if err != nil {
+			log.Log.Reason(err).Infof("JSON marshal of notify event failed")
 			return err
 		}
 	}
@@ -182,6 +184,7 @@ func (n *Notifier) SendDomainEvent(event watch.Event) error {
 	response, err := n.v1client.HandleDomainEvent(ctx, &request)
 
 	if err != nil {
+		log.Log.Reason(err).Infof("Failed to send domain notify event")
 		return err
 	} else if response.Success != true {
 		msg := fmt.Sprintf("failed to notify domain event: %s", response.Message)


### PR DESCRIPTION
If a domain event fails to send, sometimes the logs give no indication as to why. This is because we lack logging in the function that performs the grpc send.

```release-note
NONE
```
