### PR TITLE
flaky-finder: fix leading pipe bug

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -80,7 +80,7 @@ if [[ -z ${NEW_TESTS-} ]]; then
     set -e
 
     # skip certain tests for now, as we don't have a strategy currently
-    NEW_TESTS=$(echo "$NEW_TESTS" | sed -E 's/\|?[^\|]*(sriov|multus|windows|gpu)[^\|]*//g')
+    NEW_TESTS=$(echo "$NEW_TESTS" | sed -E 's/\|?[^\|]*(sriov|multus|windows|gpu)[^\|]*//g' | sed 's/^|//')
 fi
 if [[ -z "${NEW_TESTS}" ]]; then
     echo "Nothing to test"


### PR DESCRIPTION
**What this PR does / why we need it**:
It fixes a bug in the flaky finder where, after filtering, the list of test files could start with a pipe, breaking the code using the list.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3896 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
