### PR TITLE
Added test-id for vcpu_wait and vcpu_sec metrics

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -729,7 +729,7 @@ var _ = Describe("Infrastructure", func() {
 			}
 		})
 
-		It("should include the vcpu wait metrics for running VM", func() {
+		It("[test_id:4553]should include the vcpu wait metrics for running VM", func() {
 			metrics := collectMetrics("kubevirt_vmi_vcpu_wait")
 			for _, v := range metrics {
 				fmt.Fprintf(GinkgoWriter, "vcpu wait was %f", v)
@@ -737,7 +737,7 @@ var _ = Describe("Infrastructure", func() {
 			}
 		})
 
-		It("should include the vcpu seconds metrics for running VM", func() {
+		It("[test_id:4554]should include the vcpu seconds metrics for running VM", func() {
 			metrics := collectMetrics("kubevirt_vmi_vcpu_seconds")
 			for _, v := range metrics {
 				fmt.Fprintf(GinkgoWriter, "vcpu seconds was %f", v)


### PR DESCRIPTION
Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: `Add test-id for vcpu_wait and vcpu_sec metrics`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: `Add test-id for vcpu_wait and vcpu_sec metrics`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
