### PR TITLE
Keep network e2e tests in a dedicated module

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -41,3 +41,14 @@ aliases:
   ci-approvers:
       - dhiller
       - danielBelenky
+  network-reviewers:
+      - AlonaKaplan
+      - EdDev
+      - RamLavi
+      - alonSadan
+      - maiqueb
+      - ormergi
+      - oshoval
+      - phoracek
+      - qinqon
+      - rhrazdil

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -147,6 +147,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
+        "//tests/network:go_default_library",
         "//tests/reporter:go_default_library",
         "//tools/vms-generator/utils:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -2,8 +2,20 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["placeholder.go"],
+    srcs = [
+        "framework.go",
+        "primary_pod_network.go",
+    ],
     importpath = "kubevirt.io/kubevirt/tests/network",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/onsi/ginkgo:go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/containerdisk:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["placeholder.go"],
+    importpath = "kubevirt.io/kubevirt/tests/network",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/onsi/ginkgo:go_default_library"],
+)

--- a/tests/network/OWNERS
+++ b/tests/network/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - network-reviewers

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -23,6 +23,10 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = Describe("Placeholder for tests to come", func() {
-	It("should run this", func() {})
-})
+func SIGDescribe(text string, body func()) bool {
+	return Describe("[sig-network] "+text, body)
+}
+
+func FSIGDescribe(text string, body func()) bool {
+	return FDescribe("[sig-network] "+text, body)
+}

--- a/tests/network/placeholder.go
+++ b/tests/network/placeholder.go
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Placeholder for tests to come", func() {
+	It("should run this", func() {})
+})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+)
+
+var _ = SIGDescribe("Primary Pod Network", func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
+	})
+
+	Describe("Status", func() {
+		AssertReportedIP := func(vmi *v1.VirtualMachineInstance) {
+			By("Getting pod of the VMI")
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+
+			By("Making sure IP reported on the VMI matches the one on the pod")
+			Expect(vmi.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP))
+			Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
+			Expect(vmi.Status.Interfaces[0].IPs[0]).To(Equal(vmiPod.Status.PodIP))
+		}
+
+		Context("VMI connected to the pod network using the default (implicit) binding", func() {
+			var vmi *v1.VirtualMachineInstance
+
+			BeforeEach(func() {
+				vmi = setupVMI(virtClient, vmiWithDefaultBinding())
+			})
+
+			AfterEach(func() {
+				cleanupVMI(virtClient, vmi)
+			})
+
+			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+		})
+
+		Context("VMI connected to the pod network using bridge binding", func() {
+			var vmi *v1.VirtualMachineInstance
+
+			BeforeEach(func() {
+				vmi = setupVMI(virtClient, vmiWithBridgeBinding())
+			})
+
+			AfterEach(func() {
+				cleanupVMI(virtClient, vmi)
+			})
+
+			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+		})
+
+		Context("VMI connected to the pod network using masquerade binding", func() {
+			var vmi *v1.VirtualMachineInstance
+
+			BeforeEach(func() {
+				vmi = setupVMI(virtClient, vmiWithMasqueradeBinding())
+			})
+
+			AfterEach(func() {
+				cleanupVMI(virtClient, vmi)
+			})
+
+			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+		})
+	})
+})
+
+func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+	By("Creating the VMI")
+	var err error
+	vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+	Expect(err).NotTo(HaveOccurred(), "VMI should be successfully created")
+
+	By("Waiting until the VMI gets ready")
+	vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+
+	return vmi
+}
+
+func cleanupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
+	if vmi != nil {
+		By("Deleting the VMI")
+		Expect(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.GetName(), &metav1.DeleteOptions{})).To(Succeed())
+
+		By("Waiting for the VMI to be gone")
+		Eventually(func() error {
+			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.GetName(), &metav1.GetOptions{})
+			return err
+		}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
+	}
+}
+
+func vmiWithDefaultBinding() *v1.VirtualMachineInstance {
+	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+	vmi.Spec.Domain.Devices.Interfaces = nil
+	vmi.Spec.Networks = nil
+	return vmi
+}
+
+func vmiWithBridgeBinding() *v1.VirtualMachineInstance {
+	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	return vmi
+}
+
+func vmiWithMasqueradeBinding() *v1.VirtualMachineInstance {
+	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	return vmi
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -32,6 +32,8 @@ import (
 
 	"kubevirt.io/kubevirt/tests"
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+
+	_ "kubevirt.io/kubevirt/tests/network"
 )
 
 func TestTests(t *testing.T) {

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -844,30 +844,6 @@ sockfd = None`})
 			Expect(err.Error()).To(ContainSubstring("Bridge interface is not enabled in kubevirt-config"))
 		})
 	})
-
-	Context("VirtualMachineInstance connected to the pod network", func() {
-		var vmi *v1.VirtualMachineInstance
-
-		BeforeEach(func() {
-			tests.BeforeTestCleanup()
-
-			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
-			tests.AddExplicitPodNetworkInterface(vmi)
-
-			By("Starting tested VMI")
-			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
-			Expect(err).NotTo(HaveOccurred(), "VMI should be successfully created")
-			vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
-		})
-
-		It("should report IP address matching the launcher PodIP in its status", func() {
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-
-			Expect(vmi.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP), "The address reported in VMI's IP should match the PodIP")
-			Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty(), "VMI should report a list of its IP addresses")
-			Expect(vmi.Status.Interfaces[0].IPs[0]).To(Equal(vmiPod.Status.PodIP), "The first address reported in VMI's IPs should match the PodIP")
-		})
-	})
 })
 
 func waitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory tests.VMIExpecterFactory) *v1.VirtualMachineInstance {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR kicks-off an effort to properly categorize networking tests, clean up duplicates, add what is missing and improve the overall experience for people dealing with test helpers in KubeVirt e2e tests.

### Keep network e2e tests in a dedicated module

Currently we keep all the e2e tests in a single module. It is hard to navigate it and it is a potential risk of variables and definitions overflowing between modules.

This patch introduces a "network" module under "tests". This module will contain all the networking e2e tests. This module is "included" into the main test suite, so it shares preparation, cleanup and artifacts collection code with the rest of the tests.

The network tests directory starts empty. The reason is that I want to use this opportunity to refactor and cleanup bloated and chaotic networking tests. We will move tests from existing modules to new ones one by one.

### Move podIP reporting test to network test package
    
As part of the test suite refactoring, move the first simple test under the new network test package. This should help us figure out the desired format and missing test helpers.

**Special notes for your reviewer**:

This follows the [schema of Kubernetes tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/e2e_test.go#L43).

Now with the scope of the `network/` tests reduced to the minimum, we should focus on its structure and any refactoring needed on test helpers. There won't be better time to do that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
