### PR TITLE
Add cluster-up to bazel exclude list

### DIFF
--- a/hack/bazel-generate.sh
+++ b/hack/bazel-generate.sh
@@ -9,7 +9,7 @@ rm -f vendor/libvirt.org/libvirt-go/BUILD.bazel
 # generate BUILD files
 bazel run \
     --config=${ARCHITECTURE} \
-    //:gazelle -- -exclude vendor/google.golang.org/grpc
+    //:gazelle -- -exclude vendor/google.golang.org/grpc --exclude cluster-up
 
 # inject changes to libvirt BUILD file
 bazel run \


### PR DESCRIPTION
make deps-update, and other targets which run
`hack/bazel-generate.sh`, are updating the BUILD.bazel files.
Since cluster-up folder is vendored, it shouldnt be updated.
This commit align all the targets to not create files
in the folder, which can cause conflicts when testing the
git status afterwards.
See https://github.com/kubevirt/kubevirt/pull/3915

It also will make `make generate` faster, because
`make generate` will not need to vendor the folder if no change
actually exist (comparing folder checksum vs previous checksum),
as it did before on every run, even on automation, because a new, self created file,
was in the folder.

Fixes: https://github.com/kubevirt/kubevirt/issues/3917

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
