### PR TITLE
Give the VM rename operation more time to create a new VM

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1749,7 +1749,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					_, err := cli.Get(vm1.Name+"new", &v12.GetOptions{})
 
 					return err
-				}).Should(BeNil())
+				}, 10*time.Second, 1*time.Second).Should(BeNil())
 
 				_, err = cli.Get(vm1.Name, &v12.GetOptions{})
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

Normally one second is more than enough to let the operator create a new
VM, but when the nodes are a little bit under pressure it can easily
happen that after one second the new VM is not yet there.

Resolves issues like:


```
• Failure [8.576 seconds]
[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachine
/root/go/src/kubevirt.io/kubevirt/tests/vm_test.go:53
  VM rename
  /root/go/src/kubevirt.io/kubevirt/tests/vm_test.go:1671
    VM update
    /root/go/src/kubevirt.io/kubevirt/tests/vm_test.go:1680
      should succeed [It]
      /root/go/src/kubevirt.io/kubevirt/tests/vm_test.go:1726

      Timed out after 5.000s.
      Expected
          <*errors.StatusError | 0xc003ca8dc0>: {
              ErrStatus: {
                  TypeMeta: {Kind: "", APIVersion: ""},
                  ListMeta: {
                      SelfLink: "",
                      ResourceVersion: "",
                      Continue: "",
                      RemainingItemCount: nil,
                  },
                  Status: "Failure",
                  Message: "virtualmachines.kubevirt.io \"testvmicz7vx9wmm9d5fr86pfz4ld8rm29x6x7d4wlz7rvxpqcwzmtxnew\" not found",
                  Reason: "NotFound",
                  Details: {
                      Name: "testvmicz7vx9wmm9d5fr86pfz4ld8rm29x6x7d4wlz7rvxpqcwzmtxnew",
                      Group: "kubevirt.io",
                      Kind: "virtualmachines",
                      UID: "",
                      Causes: nil,
                      RetryAfterSeconds: 0,
                  },
                  Code: 404,
              },
          }
      to be nil

      /root/go/src/kubevirt.io/kubevirt/tests/vm_test.go:1734
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
