### PR TITLE
Adds new metric kubevirt_vmi_memory_unused_bytes

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,6 +38,10 @@ Total resident memory of the process running the VMI.
 
 The total amount of usable memory.
 
+#### kubevirt_vmi_memory_unused_bytes
+
+The total amount of unused memory as seen by the domain.
+
 #### kubevirt_vmi_memory_swap_traffic_bytes_total
 
 The amount of traffic that is being read and written in swap memory.

--- a/pkg/monitoring/vms/prometheus/BUILD.bazel
+++ b/pkg/monitoring/vms/prometheus/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -119,6 +119,27 @@ func (metrics *vmiMetrics) updateMemory(vmStats *stats.DomainStats) {
 		tryToPushMetric(memoryAvailableDesc, mv, err, metrics.ch)
 	}
 
+	if vmStats.Memory.UnusedSet {
+		memoryUnusedLabels := []string{"node", "namespace", "name", "domain"}
+		memoryUnusedLabels = append(memoryUnusedLabels, metrics.k8sLabels...)
+		memoryUnusedDesc := prometheus.NewDesc(
+			"kubevirt_vmi_memory_unused_bytes",
+			"amount of unused memory as seen by the domain.",
+			memoryUnusedLabels,
+			nil,
+		)
+
+		memoryUnusedLabelValues := []string{metrics.vmi.Status.NodeName, metrics.vmi.Namespace, metrics.vmi.Name, vmStats.Name}
+		memoryUnusedLabelValues = append(memoryUnusedLabelValues, metrics.k8sLabelValues...)
+		mv, err := prometheus.NewConstMetric(
+			memoryUnusedDesc, prometheus.GaugeValue,
+			// the libvirt value is in KiB
+			float64(vmStats.Memory.Unused)*1024,
+			memoryUnusedLabelValues...,
+		)
+		tryToPushMetric(memoryUnusedDesc, mv, err, metrics.ch)
+	}
+
 	if vmStats.Memory.SwapInSet || vmStats.Memory.SwapOutSet {
 		swapTrafficLabels := []string{"node", "namespace", "name", "domain", "type"}
 		swapTrafficLabels = append(swapTrafficLabels, metrics.k8sLabels...)

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -835,6 +835,14 @@ var _ = Describe("Infrastructure", func() {
 			Expect(in).To(BeTrue())
 			Expect(out).To(BeTrue())
 		})
+
+		It("[test_id:4556]should include unused memory metric for running VM", func() {
+			metrics := collectMetrics("kubevirt_vmi_memory_unused_bytes")
+			for _, v := range metrics {
+				fmt.Fprintf(GinkgoWriter, "unused memory was %f", v)
+				Expect(v).To(BeNumerically(">=", float64(0.0)))
+			}
+		})
 	})
 
 	Describe("Start a VirtualMachineInstance", func() {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -839,7 +839,6 @@ var _ = Describe("Infrastructure", func() {
 		It("[test_id:4556]should include unused memory metric for running VM", func() {
 			metrics := collectMetrics("kubevirt_vmi_memory_unused_bytes")
 			for _, v := range metrics {
-				fmt.Fprintf(GinkgoWriter, "unused memory was %f", v)
 				Expect(v).To(BeNumerically(">=", float64(0.0)))
 			}
 		})


### PR DESCRIPTION
Signed-off-by: arthursens <arthursens2005@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Alongside with the already existing metric `kubevirt_vmi_memory_available_bytes`, this new metric allows users to calculate realtime usage percentage of the VMIs memory

Use cases solved by this metric:
* I want to keep track of memory usage percentage in order to know if the VMIs deployed are being over dimensioned or under dimensioned for my solutions

```
(100 * kubevirt_vmi_memory_unused_bytes) / kubevirt_vmi_memory_available_bytes
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds new metric kubevirt_vmi_memory_unused_bytes
```
