### PR TITLE
Add support for camel-case spellings of "userdata" and "networkdata"

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -124,7 +124,15 @@ func ResolveNoCloudSecrets(vmi *v1.VirtualMachineInstance, secretSourceDir strin
 
 	baseDir := filepath.Join(secretSourceDir, volume.Name)
 	userData, userDataError := readFileFromDir(baseDir, "userdata")
+	// If "userdata" was not found, try "userData"
+	if userDataError != nil && os.IsNotExist(userDataError) {
+		userData, userDataError = readFileFromDir(baseDir, "userData")
+	}
 	networkData, networkDataError := readFileFromDir(baseDir, "networkdata")
+	// If "networkdata" was not found, try "networkData"
+	if networkDataError != nil && os.IsNotExist(networkDataError) {
+		networkData, networkDataError = readFileFromDir(baseDir, "networkData")
+	}
 	if userDataError != nil && networkDataError != nil {
 		return fmt.Errorf("no cloud-init data-source found at volume: %s", volume.Name)
 	}
@@ -152,7 +160,15 @@ func ResolveConfigDriveSecrets(vmi *v1.VirtualMachineInstance, secretSourceDir s
 
 	baseDir := filepath.Join(secretSourceDir, volume.Name)
 	userData, userDataError := readFileFromDir(baseDir, "userdata")
+	// If "userdata" was not found, try "userData"
+	if userDataError != nil && os.IsNotExist(userDataError) {
+		userData, userDataError = readFileFromDir(baseDir, "userData")
+	}
 	networkData, networkDataError := readFileFromDir(baseDir, "networkdata")
+	// If "networkdata" was not found, try "networkData"
+	if networkDataError != nil && os.IsNotExist(networkDataError) {
+		networkData, networkDataError = readFileFromDir(baseDir, "networkData")
+	}
 	if userDataError != nil && networkDataError != nil {
 		return fmt.Errorf("no cloud-init data-source found at volume: %s", volume.Name)
 	}

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -358,6 +358,19 @@ var _ = Describe("CloudInit", func() {
 						Expect(testVolume.CloudInitNoCloud.NetworkData).To(Equal("secret-networkdata"))
 					})
 
+					It("should resolve camel-case no-cloud data from volume", func() {
+						testVolume := createCloudInitSecretRefVolume("test-volume", "test-secret")
+						vmi := createEmptyVMIWithVolumes([]v1.Volume{*testVolume})
+						fakeVolumeMountDir("test-volume", map[string]string{
+							"userData":    "secret-userdata",
+							"networkData": "secret-networkdata",
+						})
+						err := ResolveNoCloudSecrets(vmi, tmpDir)
+						Expect(err).To(Not(HaveOccurred()), "could not resolve secret volume")
+						Expect(testVolume.CloudInitNoCloud.UserData).To(Equal("secret-userdata"))
+						Expect(testVolume.CloudInitNoCloud.NetworkData).To(Equal("secret-networkdata"))
+					})
+
 					It("should resolve empty no-cloud volume and do nothing", func() {
 						vmi := createEmptyVMIWithVolumes([]v1.Volume{})
 						err := ResolveNoCloudSecrets(vmi, tmpDir)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for camel-case spellings of "userdata" and "networkdata"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
