### PR TITLE
Kubernetes-reporter: Get all ConfigMaps

### DIFF
--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -479,7 +479,7 @@ func (r *KubernetesReporter) logConfigMaps(virtCli kubecli.KubevirtClient) {
 	}
 	defer f.Close()
 
-	configmaps, err := virtCli.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).List(metav1.ListOptions{})
+	configmaps, err := virtCli.CoreV1().ConfigMaps(v1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to fetch configmaps: %v\n", err)
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR changes tests suite kubernetes-custom-reporter `ConfigMaps`
report scope from Kubevirt namespaces to all namespaces.

This enable us to debug issues that  caused by `ConfigMaps` that 
are not related to Kubevirt deployment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This is needed to debug #3850 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
