### PR TITLE
Shorten the release job exectuion time on travis

### DIFF
--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -1,19 +1,25 @@
 #!/bin/bash -e
 
+# when not on a release do extensive checks
+if [ -z "$TRAVIS_TAG" ]; then
+	make generate-verify
+	make bazel-build-verify
 
-make generate-verify
-make bazel-build-verify
+	# The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
+	while sleep 9m; do echo "Long running job - keep alive"; done &
+	LOOP_PID=$!
 
-# The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
-while sleep 9m; do echo "Long running job - keep alive"; done & LOOP_PID=$!
+	if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then
+		make goveralls
+	else
+		make bazel-test
+	fi
 
-if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then
-    make goveralls
+	kill $LOOP_PID
+
 else
-    make bazel-test
+	make
 fi
-
-kill $LOOP_PID
 
 make build-verify # verify that we set version on the packages built by go(goveralls depends on go-build target)
 make apidocs
@@ -21,6 +27,5 @@ make client-python
 make manifests DOCKER_PREFIX="docker.io/kubevirt" DOCKER_TAG=$TRAVIS_TAG # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
 make olm-verify
 if [[ $TRAVIS_CPU_ARCH == "amd64" ]]; then
-    make prom-rules-verify
+	make prom-rules-verify
 fi
-


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid running into the global timeout on travis, only do necessary
steps to perform a release. Checking if `make generate` and `make`
changes any artifacts is not necessary. It is also not necessary to run
unit tests on the tag.

It is right now a matter of luck if a travis-release job gets terminated or succeeds. This should buy us more time until we have everything migrated to prow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
