### PR TITLE
Add openapi validatior unit tests

### DIFF
--- a/pkg/util/openapi/BUILD.bazel
+++ b/pkg/util/openapi/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -18,5 +18,21 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "openapi_suite_test.go",
+        "openapi_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/virt-api/rest:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
     ],
 )

--- a/pkg/util/openapi/openapi_suite_test.go
+++ b/pkg/util/openapi/openapi_suite_test.go
@@ -1,0 +1,13 @@
+package openapi_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestOpenapi(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Openapi Suite")
+}

--- a/pkg/util/openapi/openapi_test.go
+++ b/pkg/util/openapi/openapi_test.go
@@ -1,0 +1,41 @@
+package openapi_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/pkg/util/openapi"
+	"kubevirt.io/kubevirt/pkg/virt-api/rest"
+)
+
+var _ = Describe("Openapi", func() {
+
+	It("should accept unknown fields in the status", func() {
+		validator := openapi.CreateOpenAPIValidator(rest.ComposeAPIDefinitions())
+		vmi := v1.NewVMI("testvm", "")
+		data, err := json.Marshal(vmi)
+		Expect(err).ToNot(HaveOccurred())
+		obj := &unstructured.Unstructured{}
+		Expect(json.Unmarshal(data, obj)).To(Succeed())
+		Expect(unstructured.SetNestedField(obj.Object, "something", "status", "unknown")).To(Succeed())
+		Expect(validator.Validate(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
+		Expect(validator.ValidateStatus(obj.GroupVersionKind(), obj.Object)).To(BeEmpty())
+	})
+
+	It("should reject unknown fields in the spec", func() {
+		validator := openapi.CreateOpenAPIValidator(rest.ComposeAPIDefinitions())
+		vmi := v1.NewVMI("testvm", "")
+		data, err := json.Marshal(vmi)
+		Expect(err).ToNot(HaveOccurred())
+		obj := &unstructured.Unstructured{}
+		Expect(json.Unmarshal(data, obj)).To(Succeed())
+		Expect(unstructured.SetNestedField(obj.Object, "something", "spec", "unknown")).To(Succeed())
+		Expect(validator.Validate(obj.GroupVersionKind(), obj.Object)).ToNot(BeEmpty())
+		Expect(validator.ValidateSpec(obj.GroupVersionKind(), obj.Object)).ToNot(BeEmpty())
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Document and validate that the status section should ignore unknown
fields by adding appropriate unit tests. It is an important property of
the update flow which ensures that a newer controller can always write
newer status fields which may not yet be known by all other components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
