### PR TITLE
Improve ExpectBatchWithValidatedSend error handling

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2811,6 +2811,9 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 			}
 			expectFlag = true
 			sendFlag = false
+			if _, ok := batch[i].(*expect.BExp); !ok {
+				return nil, fmt.Errorf("ExpectBatchWithValidatedSend support only expect of type BExp")
+			}
 			bExp, _ := batch[i].(*expect.BExp)
 			previousSend := regexp.QuoteMeta(previousSend)
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"fmt"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -647,22 +646,18 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			err = tests.CheckForTextExpecter(dhcpVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\#"},
-				&expect.BSnd{S: "sudo dhclient -1 -r -d eth0\n"},
+				&expect.BSnd{S: "dhclient -1 -r -d eth0\n"},
 				&expect.BExp{R: "\\#"},
-				&expect.BSnd{S: "sudo dhclient -1 -sf /usr/bin/env --request-options subnet-mask,broadcast-address,time-offset,routers,domain-search,domain-name,domain-name-servers,host-name,nis-domain,nis-servers,ntp-servers,interface-mtu,tftp-server-name,bootfile-name eth0 | tee /dhcp-env\n"},
+				&expect.BSnd{S: "dhclient -1 -sf /usr/bin/env --request-options subnet-mask,broadcast-address,time-offset,routers,domain-search,domain-name,domain-name-servers,host-name,nis-domain,nis-servers,ntp-servers,interface-mtu,tftp-server-name,bootfile-name eth0 | tee /dhcp-env\n"},
 				&expect.BExp{R: "\\#"},
-				&expect.BSnd{S: "cat /dhcp-env\n"},
-				&expect.BExp{R: "new_tftp_server_name=tftp.kubevirt.io"},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "\\#"},
-				&expect.BSnd{S: "cat /dhcp-env\n"},
-				&expect.BExp{R: "new_bootfile_name=config"},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "\\#"},
-				&expect.BSnd{S: "cat /dhcp-env\n"},
-				&expect.BExp{R: regexp.QuoteMeta("new_ntp_servers=127.0.0.1 127.0.0.2") + "((?s).*)" + regexp.QuoteMeta("new_unknown_240=private.options.kubevirt.io")},
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: "\\#"},
+				&expect.BSnd{S: "grep -q 'new_tftp_server_name=tftp.kubevirt.io' /dhcp-env; echo $?\n"},
+				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BSnd{S: "grep -q 'new_bootfile_name=config' /dhcp-env; echo $?\n"},
+				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BSnd{S: "grep -q 'new_ntp_servers=127.0.0.1 127.0.0.2' /dhcp-env; echo $?\n"},
+				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BSnd{S: "grep -q 'new_unknown_240=private.options.kubevirt.io' /dhcp-env; echo $?\n"},
+				&expect.BExp{R: tests.RetValue("0", "\\# ")},
 			}, 15)
 
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The PR -
- Removes redundant sudo and waits for prompt on tests [test_id:1778].
- Throws an error when `ExpectBatchWithValidatedSend` gets `BatchExpect` other than BExp.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends on - https://github.com/kubevirt/kubevirt/pull/3953

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
