### PR TITLE
Pod network connectivity test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/util/cluster:go_default_library",
         "//pkg/util/net/dns:go_default_library",
+        "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -23,5 +23,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )

--- a/tests/libvmi/BUILD.bazel
+++ b/tests/libvmi/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cloudinit.go",
         "factory.go",
+        "lifecycle.go",
         "network.go",
         "storage.go",
         "vmi.go",
@@ -13,8 +14,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
         "//tests/containerdisk:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -42,6 +42,8 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 
 	fedoraOptions := append(
 		defaultOptions(),
+		WithInterface(InterfaceDeviceWithMasqueradeBinding()),
+		WithNetwork(kvirtv1.DefaultPodNetwork()),
 		WithResourceMemory("512M"),
 		WithRng(),
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedora)),
@@ -66,8 +68,6 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 // defaultOptions returns a list of "default" options.
 func defaultOptions() []Option {
 	return []Option{
-		WithInterface(InterfaceDeviceWithMasqueradeBinding()),
-		WithNetwork(kvirtv1.DefaultPodNetwork()),
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory(DefaultResourceMemory),
 	}

--- a/tests/libvmi/lifecycle.go
+++ b/tests/libvmi/lifecycle.go
@@ -1,12 +1,14 @@
 package libvmi
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -14,30 +16,102 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-func SetupVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+type VMIPool map[string]*v1.VirtualMachineInstance
+
+func NewVMIPool() VMIPool {
+	return map[string]*v1.VirtualMachineInstance{}
+}
+
+func (vmis VMIPool) Setup(loggedInExpecterFactory tests.VMIExpecterFactory) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Should initialize KubeVirt client")
 
-	vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "VMI should be successfully created")
+	vmis.create(virtClient)
+	vmis.waitUntilReady(loggedInExpecterFactory, virtClient)
+}
 
-	vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+func (vmis VMIPool) create(virtClient kubecli.KubevirtClient) {
+	for name, vmi := range vmis {
+		vmi, err := virtClient.VirtualMachineInstance(vmi.GetNamespace()).Create(vmi)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "VMI %q should be successfully created", name)
+		vmis[name] = vmi
+	}
+}
 
-	return vmi
+func (vmis VMIPool) waitUntilReady(loggedInExpecterFactory tests.VMIExpecterFactory, virtClient kubecli.KubevirtClient) {
+	for name, vmi := range vmis {
+		vmis[name] = tests.WaitUntilVMIReady(vmi, loggedInExpecterFactory)
+	}
+}
+
+func (vmis VMIPool) Cleanup() {
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Should initialize KubeVirt client")
+
+	errs := []error{}
+	errs = append(errs, vmis.delete(virtClient)...)
+	if err = vmis.waitUntilDisposed(virtClient); err != nil {
+		errs = append(errs, err)
+	}
+	ExpectWithOffset(1, errs).To(BeEmpty(), "Cleanup of all VMIs should succeed")
+}
+
+func (vmis VMIPool) delete(virtClient kubecli.KubevirtClient) []error {
+	errs := []error{}
+
+	for _, vmi := range vmis {
+		if vmi == nil {
+			continue
+		}
+
+		err := virtClient.VirtualMachineInstance(vmi.GetNamespace()).Delete(vmi.GetName(), &metav1.DeleteOptions{})
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+func (vmis VMIPool) waitUntilDisposed(virtClient kubecli.KubevirtClient) error {
+	var runningVMIs []string
+
+	err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+		runningVMIs = []string{}
+
+		for name, vmi := range vmis {
+			if vmi == nil {
+				continue
+			}
+
+			_, err := virtClient.VirtualMachineInstance(vmi.GetNamespace()).Get(vmi.GetName(), &metav1.GetOptions{})
+			if err == nil {
+				runningVMIs = append(runningVMIs, name)
+			} else if err != nil && !errors.IsNotFound(err) {
+				return false, err
+			}
+		}
+
+		if len(runningVMIs) > 0 {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for VMIs %v to dispose: %v", runningVMIs, err)
+	}
+
+	return nil
+}
+
+func SetupVMI(vmi *v1.VirtualMachineInstance, loggedInExpecterFactory tests.VMIExpecterFactory) *v1.VirtualMachineInstance {
+	vmiPool := VMIPool{"vmi": vmi}
+	vmiPool.Setup(loggedInExpecterFactory)
+	return vmiPool["vmi"]
 }
 
 func CleanupVMI(vmi *v1.VirtualMachineInstance) {
-	if vmi == nil {
-		return
-	}
-
-	virtClient, err := kubecli.GetKubevirtClient()
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Should initialize KubeVirt client")
-
-	ExpectWithOffset(1, virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.GetName(), &metav1.DeleteOptions{})).To(Succeed())
-
-	EventuallyWithOffset(1, func() error {
-		_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.GetName(), &metav1.GetOptions{})
-		return err
-	}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
+	vmiPool := VMIPool{"vmi": vmi}
+	vmiPool.Cleanup()
 }

--- a/tests/libvmi/lifecycle.go
+++ b/tests/libvmi/lifecycle.go
@@ -1,0 +1,43 @@
+package libvmi
+
+import (
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests"
+)
+
+func SetupVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Should initialize KubeVirt client")
+
+	vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "VMI should be successfully created")
+
+	vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+
+	return vmi
+}
+
+func CleanupVMI(vmi *v1.VirtualMachineInstance) {
+	if vmi == nil {
+		return
+	}
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Should initialize KubeVirt client")
+
+	ExpectWithOffset(1, virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.GetName(), &metav1.DeleteOptions{})).To(Succeed())
+
+	EventuallyWithOffset(1, func() error {
+		_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.GetName(), &metav1.GetOptions{})
+		return err
+	}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
+}

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
-        "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libvmi:go_default_library",

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -30,7 +30,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
-	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -144,24 +143,21 @@ var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:c
 })
 
 func vmiWithImplicitBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-	vmi.Spec.Domain.Devices.Interfaces = nil
-	vmi.Spec.Networks = nil
-	return vmi
+	return libvmi.NewCirros()
 }
 
 func vmiWithBridgeBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	return vmi
+	return libvmi.NewCirros(
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding()),
+	)
 }
 
 func vmiWithMasqueradeBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
-	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
-	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-	return vmi
+	return libvmi.NewCirros(
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+	)
 }
 
 func getPodNetworkMTU(vmi *v1.VirtualMachineInstance) int {

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-				vmi = setupVMI(virtClient, vmiWithDefaultBinding())
+				vmi = setupVMI(virtClient, vmiWithImplicitBinding())
 			})
 
 			AfterEach(func() {
@@ -122,22 +122,22 @@ func cleanupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstanc
 	}
 }
 
-func vmiWithDefaultBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+func vmiWithImplicitBinding() *v1.VirtualMachineInstance {
+	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 	vmi.Spec.Domain.Devices.Interfaces = nil
 	vmi.Spec.Networks = nil
 	return vmi
 }
 
 func vmiWithBridgeBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	return vmi
 }
 
 func vmiWithMasqueradeBinding() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+	vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	return vmi

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -20,21 +20,25 @@
 package network
 
 import (
+	"strconv"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = SIGDescribe("Primary Pod Network", func() {
+var _ = SIGDescribe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Primary Pod Network", func() {
 	Describe("Status", func() {
 		AssertReportedIP := func(vmi *v1.VirtualMachineInstance) {
 			By("Getting pod of the VMI")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.GetNamespace())
 
 			By("Making sure IP/s reported on the VMI matches the ones on the pod")
 			Expect(ValidateVMIandPodIPMatch(vmi, vmiPod)).To(Succeed(), "Should have matching IP/s between pod and vmi")
@@ -82,6 +86,61 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
 		})
 	})
+
+	Describe("Connectivity", func() {
+		const servicePort = 1500
+		const ipv4HeaderSize = 20
+		const icmpHeaderSize = 8
+		const ipv4IcmpHeaderSize = ipv4HeaderSize + icmpHeaderSize
+
+		AssertConnectivity := func(outboundVMI, inboundVMI *v1.VirtualMachineInstance) {
+			inboundVMIAddress := inboundVMI.Status.Interfaces[0].IP
+
+			By("Checking connectivity via ICMP")
+			Expect(tests.PingFromVMConsole(outboundVMI, inboundVMIAddress)).To(Succeed())
+
+			By("Checking connectivity via ICMP with MTU-sized frames")
+			mtu := getPodNetworkMTU(outboundVMI)
+			Expect(tests.PingFromVMConsole(outboundVMI, inboundVMIAddress, "-c5", "-w5", "-s", strconv.Itoa(mtu-ipv4IcmpHeaderSize))).To(Succeed())
+
+			By("Checking connectivity via HTTP")
+			Expect(tests.PingHTTPFromVMConsole(outboundVMI, inboundVMIAddress, servicePort)).To(Succeed())
+		}
+
+		Context("2 VMIs connected to the pod network using the bridge binding", func() {
+			vmis := libvmi.NewVMIPool()
+
+			BeforeEach(func() {
+				vmis["outbound"] = vmiWithBridgeBinding()
+				vmis["inbound"] = vmiWithBridgeBinding()
+				vmis.Setup(tests.LoggedInCirrosExpecter)
+				tests.HTTPServer.Start(vmis["inbound"], servicePort)
+			})
+
+			AfterEach(func() {
+				vmis.Cleanup()
+			})
+
+			It("[test_id:1540]should be able to reach from one to another", func() { AssertConnectivity(vmis["outbound"], vmis["inbound"]) })
+		})
+
+		Context("2 VMIs connected to the pod network using the masquerade binding", func() {
+			vmis := libvmi.NewVMIPool()
+
+			BeforeEach(func() {
+				vmis["outbound"] = vmiWithMasqueradeBinding()
+				vmis["inbound"] = vmiWithMasqueradeBinding()
+				vmis.Setup(tests.LoggedInCirrosExpecter)
+				tests.HTTPServer.Start(vmis["inbound"], servicePort)
+			})
+
+			AfterEach(func() {
+				vmis.Cleanup()
+			})
+
+			It("[test_id:1539]should be able to reach from one to another", func() { AssertConnectivity(vmis["outbound"], vmis["inbound"]) })
+		})
+	})
 })
 
 func vmiWithImplicitBinding() *v1.VirtualMachineInstance {
@@ -103,4 +162,23 @@ func vmiWithMasqueradeBinding() *v1.VirtualMachineInstance {
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 	return vmi
+}
+
+func getPodNetworkMTU(vmi *v1.VirtualMachineInstance) int {
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Should initialize KubeVirt client")
+
+	vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.GetNamespace())
+	output, err := tests.ExecuteCommandOnPod(
+		virtClient,
+		vmiPod,
+		"compute",
+		[]string{"cat", "/sys/class/net/k6t-eth0/mtu"},
+	)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Should be able to read virt-launcher MTU")
+
+	mtu, err := strconv.Atoi(strings.TrimSuffix(output, "\n"))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Obtained MTU should be convertable to int")
+
+	return mtu
 }

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-				vmi = libvmi.SetupVMI(vmiWithImplicitBinding())
+				vmi = libvmi.SetupVMI(vmiWithImplicitBinding(), tests.LoggedInCirrosExpecter)
 			})
 
 			AfterEach(func() {
@@ -58,7 +58,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-				vmi = libvmi.SetupVMI(vmiWithBridgeBinding())
+				vmi = libvmi.SetupVMI(vmiWithBridgeBinding(), tests.LoggedInCirrosExpecter)
 			})
 
 			AfterEach(func() {
@@ -72,7 +72,7 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			var vmi *v1.VirtualMachineInstance
 
 			BeforeEach(func() {
-				vmi = libvmi.SetupVMI(vmiWithMasqueradeBinding())
+				vmi = libvmi.SetupVMI(vmiWithMasqueradeBinding(), tests.LoggedInCirrosExpecter)
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add a new connectivity test exercising VM to VM ping over the pod network. This will cover both masquerade and bridge bindings.

* network: Rename "default" binding to "implicit"
* tests: Add vm-lifecycle package with basic helpers
* tests: Add VMIPool lifecycle helpers
* network: Add Pod Network connectivity test
* network: Use libvmi to generate VMIs
* network: Test connectivity over all provided IPs


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
