### PR TITLE
UpdateStatus was not sufficient for certain snapshot controller updates

### DIFF
--- a/pkg/virt-controller/watch/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/util/status"
 )
 
 const (
@@ -62,9 +63,10 @@ type snapshotSource interface {
 }
 
 type vmSnapshotSource struct {
-	client   kubecli.KubevirtClient
-	vm       *kubevirtv1.VirtualMachine
-	snapshot *snapshotv1.VirtualMachineSnapshot
+	client          kubecli.KubevirtClient
+	vmStatusUpdater *status.VMStatusUpdater
+	vm              *kubevirtv1.VirtualMachine
+	snapshot        *snapshotv1.VirtualMachineSnapshot
 }
 
 func cacheKeyFunc(namespace, name string) string {
@@ -362,9 +364,10 @@ func (ctrl *SnapshotController) getSnapshotSource(vmSnapshot *snapshotv1.Virtual
 		}
 
 		return &vmSnapshotSource{
-			client:   ctrl.client,
-			vm:       vm,
-			snapshot: vmSnapshot,
+			client:          ctrl.client,
+			vmStatusUpdater: ctrl.vmStatusUpdater,
+			vm:              vm,
+			snapshot:        vmSnapshot,
 		}, nil
 	}
 
@@ -691,10 +694,9 @@ func (s *vmSnapshotSource) Lock() (bool, error) {
 
 	if vmCopy.Status.SnapshotInProgress == nil {
 		vmCopy.Status.SnapshotInProgress = &s.snapshot.Name
-		vmCopy, err = s.client.VirtualMachine(vmCopy.Namespace).UpdateStatus(vmCopy)
-		if err != nil {
-			return false, err
-		}
+		// unfortunately, status updater does not return the updated resource
+		// but the controller is watching VMs so will get notified
+		return false, s.vmStatusUpdater.UpdateStatus(vmCopy)
 	}
 
 	if !controller.HasFinalizer(vmCopy, sourceFinalizer) {
@@ -725,7 +727,7 @@ func (s *vmSnapshotSource) Unlock() error {
 	}
 
 	vmCopy.Status.SnapshotInProgress = nil
-	_, err = s.client.VirtualMachine(vmCopy.Namespace).UpdateStatus(vmCopy)
+	err = s.vmStatusUpdater.UpdateStatus(vmCopy)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot.go
@@ -688,7 +688,7 @@ func (s *vmSnapshotSource) Lock() (bool, error) {
 	vmCopy.Status.SnapshotInProgress = &s.snapshot.Name
 	controller.AddFinalizer(vmCopy, sourceFinalizer)
 
-	_, err := s.client.VirtualMachine(vmCopy.Namespace).UpdateStatus(vmCopy)
+	_, err := s.client.VirtualMachine(vmCopy.Namespace).Update(vmCopy)
 	if err != nil {
 		return false, err
 	}
@@ -705,7 +705,7 @@ func (s *vmSnapshotSource) Unlock() error {
 	vmCopy.Status.SnapshotInProgress = nil
 	controller.RemoveFinalizer(vmCopy, sourceFinalizer)
 
-	_, err := s.client.VirtualMachine(vmCopy.Namespace).UpdateStatus(vmCopy)
+	_, err := s.client.VirtualMachine(vmCopy.Namespace).Update(vmCopy)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-controller/watch/snapshot_base.go
+++ b/pkg/virt-controller/watch/snapshot_base.go
@@ -37,6 +37,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/controller"
+	"kubevirt.io/kubevirt/pkg/util/status"
 )
 
 const (
@@ -78,6 +79,8 @@ type SnapshotController struct {
 	recorder record.EventRecorder
 
 	resyncPeriod time.Duration
+
+	vmStatusUpdater *status.VMStatusUpdater
 }
 
 // NewSnapshotController creates a new SnapshotController
@@ -106,6 +109,7 @@ func NewSnapshotController(
 		crdInformer:               crdInformer,
 		recorder:                  recorder,
 		resyncPeriod:              resyncPeriod,
+		vmStatusUpdater:           status.NewVMStatusUpdater(client),
 	}
 
 	ctrl.dynamicInformerMap = map[string]*dynamicInformer{

--- a/pkg/virt-controller/watch/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot_test.go
@@ -531,7 +531,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedVM.Finalizers = []string{}
 				updatedVM.ResourceVersion = "1"
 				vmSource.Add(vm)
-				vmInterface.EXPECT().UpdateStatus(updatedVM).Return(updatedVM, nil)
+				vmInterface.EXPECT().Update(updatedVM).Return(updatedVM, nil)
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotWorkItem()
 			})
@@ -603,7 +603,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
 
 				vmSource.Add(vm)
-				vmInterface.EXPECT().UpdateStatus(vmUpdate).Return(vmUpdate, nil)
+				vmInterface.EXPECT().Update(vmUpdate).Return(vmUpdate, nil)
 				addVirtualMachineSnapshot(vmSnapshot)
 				controller.processVMSnapshotWorkItem()
 			})
@@ -617,7 +617,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmUpdate.Status.SnapshotInProgress = &vmSnapshotName
 
 				vmSnapshotSource.Add(vmSnapshot)
-				vmInterface.EXPECT().UpdateStatus(vmUpdate).Return(vmUpdate, nil)
+				vmInterface.EXPECT().Update(vmUpdate).Return(vmUpdate, nil)
 				addVM(vm)
 				controller.processVMSnapshotWorkItem()
 			})


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As you can see in the diffs, the updates also include adding/removing a finalizer, so `UpdateStatus` is not sufficient.

As a side note, I wonder if there are similar issues elsewhere as unit tests cannot really handle the difference between `Update` and `UpdateStatus`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
