### PR TITLE
Avoid local cleanup of vmi until vmi is in a finalized state

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1232,7 +1232,9 @@ func (d *VirtualMachineController) defaultExecute(key string,
 			log.Log.Object(vmi).V(3).Info("Deleting domain for VirtualMachineInstance with deletion timestamp.")
 			shouldDelete = true
 		default:
-			shouldCleanUp = true
+			if vmi.IsFinal() {
+				shouldCleanUp = true
+			}
 		}
 	}
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -442,6 +442,35 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(len(controller.phase1NetworkSetupCache)).To(Equal(0))
 		}, 3)
 
+		It("should do final cleanup if vmi is being deleted and not finalized", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.Status.Phase = v1.Scheduled
+			now := metav1.Time{Time: time.Now()}
+			vmi.DeletionTimestamp = &now
+			vmi.Status.MigrationMethod = v1.LiveMigration
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionTrue,
+				},
+			}
+
+			mockWatchdog.CreateFile(vmi)
+
+			controller.phase1NetworkSetupCache[vmi.UID] = 1
+			vmiFeeder.Add(vmi)
+
+			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
+
+			controller.Execute()
+			Expect(mockQueue.Len()).To(Equal(0))
+			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
+			_, err := os.Stat(mockWatchdog.File(vmi))
+			Expect(os.IsNotExist(err)).To(BeFalse())
+			Expect(len(controller.phase1NetworkSetupCache)).To(Equal(1))
+		}, 3)
+
 		It("should attempt force terminate Domain if grace period expires", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID


### PR DESCRIPTION
Under certain failure conditions, it's possible for the domain to never hit a running state and go directly to shutdown. This occurred while I was performing a PoC of a new feature where container disks can be a backing disk for a qcow2 image on a PVC. The disk on the PVC wasn't writeable, which caused the domain to immediately go to a failed "shutdown" state.

The result of this is that the VMI remained forever as "scheduled". It never moved to Running and was never finalized. Further more the VMI can't be deleted because the finalizer is only removed once the VMI reaches a finalized state. To make matters worse, if the VMI is owned by a VM, the VM can't restart because the VMI will never delete. 

This was ultimately caused by logic that assumes that if a domain doesn't exist and the vmi is being deleted, that the vmi must have already reached a Finalized state. This isn't a safe assumption, as my situation proved.

The fix is to never perform local cleanup unless the VMI is finalized. As long as the command sockets and other local data exists, the VMI will definitely timeout and reach a finalized state eventually. Cleaning up before the VMI is finalized negates that though.

```release-note
Fixes rare situation where vmi may not properly terminate if failure occurs before domain starts.
```
