### PR TITLE
tests: avoid line wrap on fedora console

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2858,7 +2858,7 @@ func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) 
 		sudoString = "sudo "
 	}
 	batch := append([]expect.Batcher{
-		&expect.BSnd{S: "stty columns 500\n"},
+		&expect.BSnd{S: "stty cols 500 rows 500\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: RetValue("0", prompt)},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On fedora console, `stty columns 500` is reflected on `$COLUMNS` var.
However, for some reason if `stty rows` is zero (which is the default on fedora console), updating `stty columns` doesn't update`$COLUMNS`.
Updating `stty rows` to non zero value solves the problem.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Fixes bug introduced in PR https://github.com/kubevirt/kubevirt/pull/3882

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
