### PR TITLE
tests, Fix test 1780 of vmi_networking_test.go

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -904,6 +904,8 @@ func createExpectTraceroute6(address string) []expect.Batcher {
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "traceroute -6 " + address + " -w1 > tr\n"},
 		&expect.BExp{R: "\\$ "},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: tests.RetValue("0", "\\$ ")},
 		&expect.BSnd{S: "cat tr | grep -q \"*\\|!\"\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},


### PR DESCRIPTION
In case traceroute command fails, the test doesnt
detect it, because it depends only on the stdout
of the command.

Therefore fix by adding validation that the command succeeded.

Found by injecting an error, which caused
the command to fail, without the test detecting it.
For example due to
`traceroute: can't connect to remote host: Network is unreachable`

Fixes: https://github.com/kubevirt/kubevirt/issues/3955

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
