### PR TITLE
tests: "utils.RetValue" no need to pass prompt

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -105,7 +105,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount iso ConfigMap image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -199,7 +199,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount iso Secret image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -282,7 +282,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				// mount service account iso image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\#")},
+				&expect.BExp{R: tests.RetValue("0")},
 				&expect.BSnd{S: "cat /mnt/namespace\n"},
 				&expect.BExp{R: tests.NamespaceTestDefault},
 				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
@@ -377,7 +377,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					&expect.BExp{R: "#"},
 					&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
 					&expect.BExp{R: expectedOutputCfgMap},
 				}, 200*time.Second)
@@ -403,7 +403,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount Secret image
 					&expect.BSnd{S: "mount /dev/vdd /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutputSecret},
 				}, 200*time.Second)
@@ -501,13 +501,13 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					&expect.BExp{R: "\\#"},
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "grep \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "grep ssh-rsa /mnt/ssh-publickey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 				}, 200*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -211,11 +211,11 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cd /media/cdrom\n"},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "expected virtio files to be mounted properly")
 			})

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -367,7 +367,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		grepSleepPid := func(expecter expect.Expecter) string {
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: `pgrep -f "sleep 5"` + "\n"},
-				&expect.BExp{R: tests.RetValue("[0-9]+", "\\# ")}, // pid
+				&expect.BExp{R: tests.RetValue("[0-9]+")}, // pid
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/ping.go
+++ b/tests/ping.go
@@ -34,12 +34,9 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-const promptExpression = `(\$ |\# )`
-const termNLExpression = "\r\n"
-
 var (
-	shellSuccess = regexp.MustCompile("\n0" + termNLExpression + ".*" + promptExpression)
-	shellFail    = regexp.MustCompile("\n[1-9].*" + termNLExpression + ".*" + promptExpression)
+	shellSuccess = regexp.MustCompile(RetValue("0"))
+	shellFail    = regexp.MustCompile(RetValue("[1-9].*"))
 )
 
 // PingFromVMConsole performs a ping through the provided VMI console.
@@ -62,9 +59,9 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 
 	err := vmiConsoleExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: promptExpression},
+		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: promptExpression},
+		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BCas{C: []expect.Caser{
 			&expect.Case{

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Storage", func() {
 					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("0")},
 				}, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -302,7 +302,7 @@ var _ = Describe("Storage", func() {
 					// Because "/" is mounted on tmpfs, we need something that normally persists writes - /dev/sda2 is the EFI partition formatted as vFAT.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "echo content > /mnt/checkpoint\n"},
 					// The QEMU process will be killed, therefore the write must be flushed to the disk.
 					&expect.BSnd{S: "sync\n"},
@@ -330,10 +330,10 @@ var _ = Describe("Storage", func() {
 					// Same story as when first starting the VirtualMachineInstance - the checkpoint, if persisted, is located at /dev/sda2.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\#")},
+					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/checkpoint &> /dev/null\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("1", "\\#")},
+					&expect.BExp{R: tests.RetValue("1")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -68,7 +68,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 			&expect.BSnd{S: cmdCheck},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "echo $?\n"},
-			&expect.BExp{R: tests.RetValue("0", prompt)},
+			&expect.BExp{R: tests.RetValue("0")},
 		}, 15)
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -100,7 +100,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: prompt},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", prompt)},
+					&expect.BExp{R: tests.RetValue("0")},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 			}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -563,11 +563,11 @@ var _ = Describe("Configurations", func() {
 
 				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.RetValue("pass", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("pass")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("0")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -621,7 +621,7 @@ var _ = Describe("Configurations", func() {
 				// Check on the VM, if the Free memory is roughly what we expected
 				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 95 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.RetValue("pass", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("pass")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -1984,11 +1984,11 @@ var _ = Describe("Configurations", func() {
 
 				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.RetValue("pass", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("pass")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("0")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -2333,7 +2333,7 @@ var _ = Describe("Configurations", func() {
 			// Check on the VM, if expected values are there with dmidecode
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') = Test-123 ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2377,11 +2377,11 @@ var _ = Describe("Configurations", func() {
 			// Check on the VM, if expected values are there with dmidecode
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2417,11 +2417,11 @@ var _ = Describe("Configurations", func() {
 			// Check on the VM, if expected values are there with dmidecode
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass", "\\# ")},
+				&expect.BExp{R: tests.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -44,7 +44,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt strin
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Health Monitoring", func() {
 				&expect.BSnd{S: "watchdog -t 2000ms -T 4000ms /dev/watchdog && sleep 5 && killall -9 watchdog\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\#")},
+				&expect.BExp{R: tests.RetValue("0")},
 			}, 250*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Multus", func() {
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l\n"},
-					&expect.BExp{R: tests.RetValue("1", "\\$ ")},
+					&expect.BExp{R: tests.RetValue("1")},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -892,7 +892,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to configure address %s for interface %s on VMI %s", interfaceAddress, interfaceName, vmi.Name)
 
@@ -903,7 +903,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s up on VMI %s", interfaceName, vmi.Name)
 }
@@ -916,7 +916,7 @@ func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", prompt)},
+		&expect.BExp{R: tests.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Interface %q was not found in the VMI %s within the given timeout", interfaceName, vmi.Name)
 }
@@ -930,7 +930,7 @@ func checkMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress s
 		&expect.BExp{R: macAddress},
 		&expect.BExp{R: "#"},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", "\\#")},
+		&expect.BExp{R: tests.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "MAC %q was not found in the VMI %s within the given timeout", macAddress, vmi.Name)
 }

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -225,7 +225,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: addrShow},
 				&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+				&expect.BExp{R: tests.RetValue("0")},
 			}, 180*time.Second)
 			log.Log.Infof("%v", resp)
 			Expect(err).ToNot(HaveOccurred())
@@ -244,7 +244,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: cmdCheck},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+				&expect.BExp{R: tests.RetValue("0")},
 			}, 180)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -255,7 +255,7 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+				&expect.BExp{R: tests.RetValue("0")},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
@@ -651,13 +651,13 @@ var _ = Describe("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				&expect.BSnd{S: "dhclient -1 -sf /usr/bin/env --request-options subnet-mask,broadcast-address,time-offset,routers,domain-search,domain-name,domain-name-servers,host-name,nis-domain,nis-servers,ntp-servers,interface-mtu,tftp-server-name,bootfile-name eth0 | tee /dhcp-env\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "grep -q 'new_tftp_server_name=tftp.kubevirt.io' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BExp{R: tests.RetValue("0")},
 				&expect.BSnd{S: "grep -q 'new_bootfile_name=config' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BExp{R: tests.RetValue("0")},
 				&expect.BSnd{S: "grep -q 'new_ntp_servers=127.0.0.1 127.0.0.2' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BExp{R: tests.RetValue("0")},
 				&expect.BSnd{S: "grep -q 'new_unknown_240=private.options.kubevirt.io' /dhcp-env; echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0", "\\# ")},
+				&expect.BExp{R: tests.RetValue("0")},
 			}, 15)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -901,11 +901,11 @@ func createExpectTraceroute6(address string) []expect.Batcher {
 		&expect.BSnd{S: "traceroute -6 " + address + " -w1 > tr\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+		&expect.BExp{R: tests.RetValue("0")},
 		&expect.BSnd{S: "cat tr | grep -q \"*\\|!\"\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("1", "\\$ ")},
+		&expect.BExp{R: tests.RetValue("1")},
 	}
 }
 
@@ -916,7 +916,7 @@ func createExpectStartTcpServer(port string) []expect.Batcher {
 		&expect.BSnd{S: "screen -d -m sudo nc -klp " + port + " -e echo -e 'Hello World!'\n"},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0", "\\$ ")},
+		&expect.BExp{R: tests.RetValue("0")},
 	}
 }
 
@@ -931,7 +931,7 @@ func createExpectConnectToServer(serverIP, tcpPort string, expectSuccess bool) [
 		&expect.BSnd{S: fmt.Sprintf("echo test | nc %s %s -i 1 -w 1 1> /dev/null\n", serverIP, tcpPort)},
 		&expect.BExp{R: "\\$ "},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue(expectResult, "\\$ ")},
+		&expect.BExp{R: tests.RetValue(expectResult)},
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`RetValue` will accept both non root "$ " and root "# " prompts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR answers [comment.](https://github.com/kubevirt/kubevirt/pull/3882/commits/1e58e7efbe1eb3ed1f2ccbca04e20473225d2638#r464684616)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
