### PR TITLE
Dual stack config iptables

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/subgraph/libmacouflage:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
-        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -213,14 +213,15 @@ func (_mr *_MockNetworkHandlerRecorder) HasNatIptables(arg0 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasNatIptables", arg0)
 }
 
-func (_m *MockNetworkHandler) IsIpv6Enabled() bool {
-	ret := _m.ctrl.Call(_m, "IsIpv6Enabled")
+func (_m *MockNetworkHandler) IsIpv6Enabled(interfaceName string) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsIpv6Enabled", interfaceName)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled")
+func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled", arg0)
 }
 
 func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -559,7 +559,12 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 		return err
 	}
 
-	if Handler.IsIpv6Enabled() {
+	ipv6Enabled, err := Handler.IsIpv6Enabled(p.podInterfaceName)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to verify whether ipv6 is configured on %s", p.podInterfaceName)
+		return err
+	}
+	if ipv6Enabled {
 		err = configureVifV6Addresses(p, err)
 		if err != nil {
 			return err
@@ -670,7 +675,13 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 	} else {
 		return fmt.Errorf("Couldn't configure ipv4 nat rules")
 	}
-	if Handler.IsIpv6Enabled() {
+
+	ipv6Enabled, err := Handler.IsIpv6Enabled(p.podInterfaceName)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to verify whether ipv6 is configured on %s", p.podInterfaceName)
+		return err
+	}
+	if ipv6Enabled {
 		if Handler.HasNatIptables(iptables.ProtocolIPv6) || Handler.NftablesLoad("ipv6-nat") == nil {
 			err = Handler.ConfigureIpv6Forwarding()
 			if err != nil {
@@ -787,7 +798,12 @@ func (p *MasqueradePodInterface) createBridge() error {
 		return err
 	}
 
-	if Handler.IsIpv6Enabled() {
+	ipv6Enabled, err := Handler.IsIpv6Enabled(p.podInterfaceName)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to verify whether ipv6 is configured on %s", p.podInterfaceName)
+		return err
+	}
+	if ipv6Enabled {
 		if err := Handler.AddrAdd(bridge, p.gatewayIpv6Addr); err != nil {
 			log.Log.Reason(err).Errorf("failed to set bridge IPv6")
 			return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -389,7 +389,7 @@ var _ = Describe("Pod Network", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
+				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -399,7 +399,7 @@ var _ = Describe("Pod Network", func() {
 			})
 			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
+				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
 
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
@@ -438,7 +438,7 @@ var _ = Describe("Pod Network", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
+				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -448,7 +448,7 @@ var _ = Describe("Pod Network", func() {
 			})
 			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
-				mockNetwork.EXPECT().IsIpv6Enabled().Return(true).Times(3)
+				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
 
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(false).Times(2)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Before this PR, `MY_POD_IP` env var was used to determine whether ipv6 nat rules should be configured on the virt-launcher pod.
On dual stack cluster `MY_POD_IP` will contain only the ipv4 address. So the code has to be changed to support dual stack.
Since there is no env var for `MY_POD_IPS` and k8s 1.16 doesn't support creating env var using `pod.status.podIPs`.
This commit changes `IsIpv6Enabled` to use podInterface addresses.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher support Ipv6 on dual stack cluster.
```
