### PR TITLE
Support VM scheme multi IPs in case of dual stack

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -526,7 +526,7 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 					ifc := v1.VirtualMachineInstanceNetworkInterface{
 						Name: network.Name,
 						IP:   podIface.PodIP,
-						IPs:  []string{podIface.PodIP},
+						IPs:  podIface.PodIPs,
 					}
 					interfaces = append(interfaces, ifc)
 				}
@@ -586,10 +586,11 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 						if err != nil {
 							return err
 						}
-						if iface.PodIP != existingInterfaceStatusByName[domainInterface.Alias.Name].IP {
+
+						if !reflect.DeepEqual(iface.PodIPs, existingInterfaceStatusByName[domainInterface.Alias.Name].IPs) {
 							newInterface.Name = domainInterface.Alias.Name
 							newInterface.IP = iface.PodIP
-							newInterface.IPs = []string{iface.PodIP}
+							newInterface.IPs = iface.PodIPs
 						}
 					}
 				} else {

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/github.com/subgraph/libmacouflage:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -37,6 +37,8 @@ import (
 	lmf "github.com/subgraph/libmacouflage"
 	"github.com/vishvananda/netlink"
 
+	netutils "k8s.io/utils/net"
+
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -101,6 +103,7 @@ type NetworkHandler interface {
 	StartDHCP(nic *VIF, serverAddr *netlink.Addr, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
 	HasNatIptables(proto iptables.Protocol) bool
 	IsIpv6Enabled(interfaceName string) (bool, error)
+	IsIpv4Primary() (bool, error)
 	ConfigureIpv6Forwarding() error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
 	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
@@ -191,6 +194,15 @@ func (h *NetworkUtilsHandler) IsIpv6Enabled(interfaceName string) (bool, error) 
 		}
 	}
 	return false, nil
+}
+
+func (h *NetworkUtilsHandler) IsIpv4Primary() (bool, error) {
+	podIP, exist := os.LookupEnv("MY_POD_IP")
+	if !exist {
+		return false, fmt.Errorf("MY_POD_IP doesnt exists")
+	}
+
+	return !netutils.IsIPv6String(podIP), nil
 }
 
 func (h *NetworkUtilsHandler) IptablesNewChain(proto iptables.Protocol, table, chain string) error {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -224,6 +224,17 @@ func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled", arg0)
 }
 
+func (_m *MockNetworkHandler) IsIpv4Primary() (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsIpv4Primary")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockNetworkHandlerRecorder) IsIpv4Primary() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv4Primary")
+}
+
 func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {
 	ret := _m.ctrl.Call(_m, "ConfigureIpv6Forwarding")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -44,8 +44,9 @@ var NetworkInterfaceFactory = getNetworkClass
 var podInterfaceName = podInterface
 
 type PodCacheInterface struct {
-	Iface *v1.Interface `json:"iface,omitempty"`
-	PodIP string        `json:"podIP,omitempty"`
+	Iface  *v1.Interface `json:"iface,omitempty"`
+	PodIP  string        `json:"podIP,omitempty"`
+	PodIPs []string      `json:"podIPs,omitempty"`
 }
 
 type plugFunction func(vif NetworkInterface, vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -278,6 +278,7 @@ var _ = Describe("Pod Network", func() {
 
 	Context("on successful setup", func() {
 		It("should define a new VIF bind to a bridge", func() {
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			domain := NewDomainWithBridgeInterface()
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
@@ -310,6 +311,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(errors.New("device is busy"))
 			mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, isTapDeviceMultiqueued, pid).Return(nil)
 			mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(HaveOccurred(), "SetupPodNetworkPhase1 should return an error")
@@ -329,6 +331,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_ALL).Return(addrList, nil)
 			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_V4).Return(addrList, nil)
 			mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(HaveOccurred())
@@ -406,6 +409,7 @@ var _ = Describe("Pod Network", func() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -416,6 +420,7 @@ var _ = Describe("Pod Network", func() {
 			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
@@ -455,6 +460,7 @@ var _ = Describe("Pod Network", func() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -465,6 +471,7 @@ var _ = Describe("Pod Network", func() {
 			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(false).Times(2)
@@ -761,6 +768,7 @@ var _ = Describe("Pod Network", func() {
 		iface := &v1.Interface{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
 		mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
 		mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_ALL).Return(addrList, nil)
+		mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 		err = setPodInterfaceCache(iface, podInterface, uid)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
In case of dual stack, support listing both IPs under
VMI status.interfaces.ipaddresses.

This commit supports automatic detection of the primary ip
according PodIP, as k8s API enforce that PodIps[0] equal
PodIP which is the primary IP.
The order of the ips and the primary ip in the VMI scheme
will be the same as the ips and primary ip of the pods.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
