### PR TITLE
Let prow run make generate instead of travis

### DIFF
--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -2,7 +2,6 @@
 
 # when not on a release do extensive checks
 if [ -z "$TRAVIS_TAG" ]; then
-	make generate-verify
 	make bazel-build-verify
 
 	# The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs


### PR DESCRIPTION
**What this PR does / why we need it**:

Travis takes too long, move the generate step to prow.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
