### PR TITLE
[cherrypick to release-0.30] QEMU supports 3 disk I/O modes:

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4744,6 +4744,10 @@
       "description": "Attach a volume as a floppy to the vmi.",
       "$ref": "#/definitions/v1.FloppyTarget"
      },
+     "io": {
+      "description": "IO specifies which QEMU disk IO mode should be used. Supported values are: native, default, threads.",
+      "type": "string"
+     },
      "lun": {
       "description": "Attach a volume as a LUN to the vmi.",
       "$ref": "#/definitions/v1.LunTarget"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1629,6 +1629,15 @@ func validateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 			})
 		}
 
+		if disk.IO != "" && disk.IO != v1.IODefault && disk.IO != v1.IONative && disk.IO != v1.IOThreads {
+			field := field.Child("domain", "devices", "disks").Index(idx).Child("io").String()
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueNotSupported,
+				Message: fmt.Sprintf("Disk IO mode for %s is not supported. Supported modes are: native, threads, default.", field),
+				Field:   field,
+			})
+		}
+
 		// Verify disk and volume name can be a valid container name since disk
 		// name can become a container name which will fail to schedule if invalid
 		errs := validation.IsDNS1123Label(disk.Name)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2226,6 +2226,23 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[1].Field).To(Equal("fake[1].lun.bus"))
 		})
 
+		It("should reject disks with unsupported I/O modes", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk1",
+				IO:   "native",
+			})
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk2",
+				IO:   "unsupported",
+			})
+
+			causes := validateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(len(causes)).To(Equal(1))
+			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].io"))
+		})
+
 		It("should reject disk with invalid cache mode", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -119,6 +119,7 @@ func Convert_v1_Disk_To_api_Disk(diskDevice *v1.Disk, disk *Disk, devicePerBus m
 	disk.Driver = &DiskDriver{
 		Name:  "qemu",
 		Cache: string(diskDevice.Cache),
+		IO:    string(diskDevice.IO),
 	}
 	if numQueues != nil && disk.Target.Bus == "virtio" {
 		disk.Driver.Queues = numQueues

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -64,6 +64,32 @@ var _ = Describe("Converter", func() {
 			Expect(xml).To(Equal(convertedDisk))
 		})
 
+		It("should set disk I/O mode if requested", func() {
+			v1Disk := &v1.Disk{
+				IO: "native",
+			}
+			xml := diskToDiskXML(v1Disk)
+			expectedXML := `<Disk device="" type="">
+  <source></source>
+  <target></target>
+  <driver io="native" name="qemu" type=""></driver>
+  <alias name="ua-"></alias>
+</Disk>`
+			Expect(xml).To(Equal(expectedXML))
+		})
+
+		It("should not set disk I/O mode if not requested", func() {
+			v1Disk := &v1.Disk{}
+			xml := diskToDiskXML(v1Disk)
+			expectedXML := `<Disk device="" type="">
+  <source></source>
+  <target></target>
+  <driver name="qemu" type=""></driver>
+  <alias name="ua-"></alias>
+</Disk>`
+			Expect(xml).To(Equal(expectedXML))
+		})
+
 		It("Should omit boot order when not provided", func() {
 			kubevirtDisk := &v1.Disk{
 				Name: "mydisk",

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -14221,6 +14221,13 @@ func schema_kubevirtio_client_go_api_v1_Disk(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"io": {
+						SchemaProps: spec.SchemaProps{
+							Description: "IO specifies which QEMU disk IO mode should be used. Supported values are: native, default, threads.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tag": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If specified, disk address and its tag will be provided to the guest via config drive metadata",

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -415,6 +415,10 @@ type Disk struct {
 	// Cache specifies which kvm disk cache mode should be used.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
+	// IO specifies which QEMU disk IO mode should be used.
+	// Supported values are: native, default, threads.
+	// +optional
+	IO DriverIO `json:"io,omitempty"`
 	// If specified, disk address and its tag will be provided to the guest via config drive metadata
 	// +optional
 	Tag string `json:"tag,omitempty"`

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -205,6 +205,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
 		"cache":             "Cache specifies which kvm disk cache mode should be used.\n+optional",
+		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1003,11 +1003,25 @@ const (
 // +k8s:openapi-gen=true
 type DriverCache string
 
+//
+// +k8s:openapi-gen=true
+type DriverIO string
+
 const (
 	// CacheNone - I/O from the guest is not cached on the host, but may be kept in a writeback disk cache.
 	CacheNone DriverCache = "none"
 	// CacheWriteThrough - I/O from the guest is cached on the host but written through to the physical medium.
 	CacheWriteThrough DriverCache = "writethrough"
+
+	// IOThreads - User mode based threads with a shared lock that perform I/O tasks. Can impact performance but offers
+	// more predictable behaviour. This method is also takes fewer CPU cycles to submit I/O requests.
+	IOThreads DriverIO = "threads"
+	// IONative - Kernel native I/O tasks (AIO) offer a better performance but can block the VM if the file is not fully
+	// allocated so this method recommended only when the backing file/disk/etc is fully preallocated.
+	IONative DriverIO = "native"
+	// IODefault - Fallback to the default value from the kernel. With recent Kernel versions (for example RHEL-7) the
+	// default is AIO.
+	IODefault DriverIO = "default"
 )
 
 // Handler defines a specific action that should be taken


### PR DESCRIPTION
- threads
- native (kernel async i/o)
- default

(io_uring offers a better performance than traditional async i/o but it
was introduced in a more recent version of QEMU which we don't use yet
for virt-launcher)

This patch allows users to configure the I/O mode that fits most to
their use-case.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to configure QEMU I/O mode for VMIs
```
