### PR TITLE
tests, config_test:  use safe expect batcher

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -101,9 +101,10 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount iso ConfigMap image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
@@ -195,9 +196,10 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount iso Secret image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
@@ -278,9 +280,10 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 
-			_, err = expecter.ExpectBatch([]expect.Batcher{
+			_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				// mount service account iso image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+				&expect.BExp{R: tests.PromptExpression},
 				&expect.BSnd{S: "echo $?\n"},
 				&expect.BExp{R: tests.RetValue("0")},
 				&expect.BSnd{S: "cat /mnt/namespace\n"},
@@ -371,11 +374,12 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount ConfigMap image
 					&expect.BSnd{S: "sudo su -\n"},
-					&expect.BExp{R: "#"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
@@ -399,9 +403,10 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Checking mounted secret image")
 
-				res, err = expecter.ExpectBatch([]expect.Batcher{
+				res, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount Secret image
 					&expect.BSnd{S: "mount /dev/vdd /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
@@ -411,7 +416,7 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 
 				By("checking that all disk labels match the expectations")
-				res, err = expecter.ExpectBatch([]expect.Batcher{
+				res, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdc\n"},
 					&expect.BExp{R: "cfgdata"}, // default value
 					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdd\n"},
@@ -495,17 +500,20 @@ var _ = Describe("[rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount iso Secret image
 					&expect.BSnd{S: "sudo su -\n"},
-					&expect.BExp{R: "\\#"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
-					&expect.BSnd{S: "grep \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
+					&expect.BSnd{S: "grep -c \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
+					&expect.BExp{R: tests.RetValue("[1-9]\\d*")},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
-					&expect.BSnd{S: "grep ssh-rsa /mnt/ssh-publickey\n"},
+					&expect.BSnd{S: "grep -c ssh-rsa /mnt/ssh-publickey\n"},
+					&expect.BExp{R: tests.RetValue("[1-9]\\d*")},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 				}, 200*time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt/pull/3882/files#diff-a5a178b4c66835110ceff63c61d28c96
introduced a safer expect-batcher, which reduces the chance of asserintg
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.

This PR is a harbinger to a series of PRs, for refactoring all
the test-suits to use the safe one.

Signed-off-by: alonSadan <asadan@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
1) I went for the PR-for-each-test-suit approach, but this could also be different commits in the same PR. 
    I preferred the first one, since I thought this change could expose unexpected bugs in some suits,
    so with different PR for each suit, It could merge faster.
2) ~This is still WIP since some more improvements for the expect-batcher are about to get in(#3956  for example), so I think it is~    ~better to wait for them, and apply the changes also here if needed.~
 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
