### PR TITLE
tests, console_test: use safe expect batcher

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -67,7 +67,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 		}()
 
 		By("Checking that the console output equals to expected one")
-		_, err = expecter.ExpectBatch([]expect.Batcher{
+		_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: expected},
 		}, 120*time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt/pull/3882/files#diff-a5a178b4c66835110ceff63c61d28c96
introduced a safer expect-batcher, which reduces the chance of asserintg
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.

Signed-off-by: alonSadan asadan@redhat.com

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
