### PR TITLE
Fix clock timezone

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -486,6 +486,7 @@ func Convert_v1_Clock_To_api_Clock(source *v1.Clock, clock *Clock, c *ConverterC
 		}
 	} else if source.Timezone != nil {
 		clock.Offset = "timezone"
+		clock.Timezone = string(*source.Timezone)
 	}
 
 	if source.Timer != nil {

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -41,6 +41,26 @@ var _ = Describe("Converter", func() {
 
 	TestSmbios := &cmdv1.SMBios{}
 
+	Context("with timezone", func() {
+		It("Should set timezone attribute", func() {
+			timezone := v1.ClockOffsetTimezone("America/New_York")
+			clock := &v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					Timezone: &timezone,
+				},
+				Timer: &v1.Timer{},
+			}
+
+			var convertClock Clock
+			Convert_v1_Clock_To_api_Clock(clock, &convertClock, &ConverterContext{})
+			data, err := xml.MarshalIndent(convertClock, "", "  ")
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedClock := `<Clock offset="timezone" timezone="America/New_York"></Clock>`
+			Expect(string(data)).To(Equal(expectedClock))
+		})
+	})
+
 	Context("with v1.Disk", func() {
 		It("Should add boot order when provided", func() {
 			order := uint(1)

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -675,6 +675,7 @@ type Entry struct {
 
 type Clock struct {
 	Offset     string  `xml:"offset,attr,omitempty"`
+	Timezone   string  `xml:"timezone,attr,omitempty"`
 	Adjustment string  `xml:"adjustment,attr,omitempty"`
 	Timer      []Timer `xml:"timer,omitempty"`
 }


### PR DESCRIPTION
We didn't set timezone attr. in libvirt xml when clock.timezone was specified.
This causes the VM to not start.

Signed-off-by: L. Pivarc <lpivarc@redhat.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3304

**Special notes for your reviewer**:

**Release note**:
```release-note
Fixes VMs with clock.timezone set.
```
