### PR TITLE
Set default disk driver io mode for VMI

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -83,6 +83,7 @@ func (mutator *VMIsMutator) Mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 		mutator.setDefaultMachineType(newVMI)
 		mutator.setDefaultResourceRequests(newVMI)
 		mutator.setDefaultPullPoliciesOnContainerDisks(newVMI)
+		mutator.setDefaultDiskDriverIOMode(newVMI)
 		err = mutator.setDefaultNetworkInterface(newVMI)
 		if err != nil {
 			return webhookutils.ToAdmissionResponseError(err)
@@ -207,6 +208,14 @@ func (mutator *VMIsMutator) setDefaultPullPoliciesOnContainerDisks(vmi *v1.Virtu
 			} else {
 				volume.ContainerDisk.ImagePullPolicy = k8sv1.PullIfNotPresent
 			}
+		}
+	}
+}
+
+func (mutator *VMIsMutator) setDefaultDiskDriverIOMode(vmi *v1.VirtualMachineInstance) {
+	for i, disk := range vmi.Spec.Domain.Devices.Disks {
+		if disk.IO == "" {
+			vmi.Spec.Domain.Devices.Disks[i].IO = v1.IOKubeVirtDefault
 		}
 	}
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -139,6 +139,17 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			Spec: v1.VirtualMachineInstanceSpec{
 				Domain: v1.DomainSpec{
 					Resources: v1.ResourceRequirements{},
+					Devices: v1.Devices{
+						Disks: []v1.Disk{
+							{
+								Name: "foo",
+							},
+							{
+								Name: "bar",
+								IO:   "threads",
+							},
+						},
+					},
 				},
 			},
 		}
@@ -187,6 +198,13 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		vmiSpec, _ := getVMISpecMetaFromResponse()
 		Expect(vmiSpec.Domain.CPU).ToNot(BeNil())
 		Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(4)))
+	})
+
+	It("should apply disk io defaults only if they were not set", func() {
+		vmiSpec, _ := getVMISpecMetaFromResponse()
+		Expect(vmiSpec.Domain.Devices.Disks[0].IO).To(Equal(v1.IOKubeVirtDefault))
+		Expect(vmiSpec.Domain.Devices.Disks[1].IO).To(Equal(v1.IOThreads))
+
 	})
 
 	It("should apply namespace limit ranges on VMI create", func() {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1025,6 +1025,8 @@ const (
 	// IODefault - Fallback to the default value from the kernel. With recent Kernel versions (for example RHEL-7) the
 	// default is AIO.
 	IODefault DriverIO = "default"
+	// IOKubeVirtDefault - The default value that we set if the user did not specify anything else.
+	IOKubeVirtDefault DriverIO = IONative
 )
 
 // Handler defines a specific action that should be taken


### PR DESCRIPTION
Since Kernel Async IO threads perform better in most of the cases - they
perform I/O faster and they are cheaper in CPU, we set this to be the
default value if the user did not specify anything else.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt now sets a default value for disk device's driver I/O mode to 'native' which will use Kernel async I/O threads.
```
