### PR TITLE
 Makefile: Add timestamps to make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 export GO15VENDOREXPERIMENT := 1
 
+SHELL = ./hack/timestamps.sh
 
 all:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 export GO15VENDOREXPERIMENT := 1
 
-SHELL = ./hack/timestamps.sh
+ifeq (${TIMESTAMP}, 1)
+  $(info "Timestamp is enabled")
+  SHELL = ./hack/timestamps.sh
+endif
 
 all:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/build-manifests.sh && \

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ builder-publish:
 olm-verify:
 	hack/dockerized "./hack/olm.sh verify"
 
-current-dir := $(shell pwd)
+current-dir := $(realpath .)
 
 build-prom-spec-dumper:
 	hack/dockerized "go build -o rule-spec-dumper ./hack/prom-rule-ci/rule-spec-dumper.go"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -28,6 +28,8 @@
 
 set -ex
 
+export TIMESTAMP=${TIMESTAMP:-1}
+
 export WORKSPACE="${WORKSPACE:-$PWD}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"

--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+export TIMESTAMP=${TIMESTAMP:-1}
+
 # when not on a release do extensive checks
 if [ -z "$TRAVIS_TAG" ]; then
 	make bazel-build-verify

--- a/hack/timestamps.sh
+++ b/hack/timestamps.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+function timestamps::time_wrapper() {
+    while IFS= read -r line; do
+        printf "%(%T)T: %s\n" "-1" "$line"
+    done
+}
+
+if [[ "${BASH_SOURCE[0]}" -ef "$0" ]]; then
+    set -o pipefail
+    /bin/sh "$@" 2>&1 | timestamps::time_wrapper
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Add timestamps to the console output in order to detect where operations
time was spent, helping with debugging timeout or slow run issues.

The make targets have been wrapped with a customized shell that adds the
time stamp on each outputted line (stdout and stderr).

The customized shell includes a pipefail option ensuring that the exit status
of the pipe that passes stdout/stderr to the timestamps function is propagated
instead of being hidden behind the timestamps function that can never fail.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is exactly #3640 plus a fix in the Makefile. 

**Release note**:
```release-note
NONE
```
