### PR TITLE
[release-0.26] Mitigate OOM issues on some kernels

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -126,14 +126,14 @@ func GenerateContainers(vmi *v1.VirtualMachineInstance, podVolumeName string, bi
 			if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
+				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("80M")
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("40M")
+				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("80M")
 			} else {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("100m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
+				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("80M")
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1M")

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -940,7 +940,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			Resources: k8sv1.ResourceRequirements{
 				Limits: map[k8sv1.ResourceName]resource.Quantity{
 					k8sv1.ResourceCPU:    resource.MustParse("1m"),
-					k8sv1.ResourceMemory: resource.MustParse("40Mi"),
+					k8sv1.ResourceMemory: resource.MustParse("80M"),
 				},
 			},
 			Command:        []string{"/usr/bin/tail", "-f", "/dev/null"},


### PR DESCRIPTION

**What this PR does / why we need it**:

Mitigate OOM issues on some kernels
    
On some kernel/CRI combinations exec probes lead to higher memory
consumption in the pods due to the dirty pages cache being counted
against the container limit. In that case it can happen that before the
dirty page cache is cleaned, the pod is killed due to OOM.

Some hints indicate that the limit on most systems is roughly 36M for
the cache. Our limit of 40M is just low enough so that somethimes our
containerDisk or infra container can get killed.

Bumping it to 80M. Latest kubevirt just dropped the usage of exec probes
to resolve this, but this old release can't do that to not break update
guarantees.

See #3946 and the related bugzillas there for more information.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Bump containerDisk limit to 80M to avoid OOM killing of containerDisk on this old stable release. Newer releases dropped the exec probes completely.
```
