### PR TITLE
A low value of timeout in test setup causes failure in Azure.

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -121,7 +121,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Deleting the DataVolume")
 				ExpectWithOffset(1, virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Delete(dv.Name, &metav1.DeleteOptions{})).To(Succeed())
 			}(dv)
-			tests.WaitForSuccessfulDataVolumeImport(dv, 60)
+			tests.WaitForSuccessfulDataVolumeImport(dv, 240)
 
 			vmi := tests.NewRandomVMI()
 
@@ -162,7 +162,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				By("Deleting the DataVolume")
 				ExpectWithOffset(1, virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Delete(dv.Name, &metav1.DeleteOptions{})).To(Succeed())
 			}(dv)
-			tests.WaitForSuccessfulDataVolumeImport(dv, 60)
+			tests.WaitForSuccessfulDataVolumeImport(dv, 240)
 
 			vmi := tests.NewRandomVMI()
 


### PR DESCRIPTION
This commit bumps the DV import timeout to match other tests (60 s -> 240 s).

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Test setup waits for DV import for only 60 seconds, which seems to be too short in Azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubevirt/kubevirt#3891 and kubevirt/kubevirt#3924

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
