### PR TITLE
tests, container-disk: use safe expect-batcher

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -207,13 +207,16 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred(), "expected alpine to login properly")
 				defer expecter.Close()
 
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cd /media/cdrom\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 				}, 200*time.Second)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3005,18 +3005,17 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "localhost login:"},
 		&expect.BSnd{S: "root\n"},
-		&expect.BExp{R: "localhost:~\\#"}})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
+		&expect.BExp{R: PromptExpression}})
+	res, err := ExpectBatchWithValidatedSend(expecter, b, 180*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
 		expecter.Close()
 		return nil, err
 	}
 
-	err = configureConsole(expecter, "localhost:~\\#", false)
+	err = configureConsole(expecter,PromptExpression , false)
 	if err != nil {
 		expecter.Close()
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt/pull/3882/files#diff-a5a178b4c66835110ceff63c61d28c96
introduced a safer expect-batcher, which reduces the chance of asserintg
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.

This PR is a part of a series of PRs, for refactoring all
the test-suits to use the safe one.

Also `LoggedInAlpineExpecter` function form utils package
had been refactored.

Related PRs:
https://github.com/kubevirt/kubevirt/pull/3972
https://github.com/kubevirt/kubevirt/pull/3967

Signed-off-by: alonSadan <asadan@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
