### PR TITLE
Remove hidden `make generate` invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ generate-verify: TARGET_TO_RUN='make generate'
 generate-verify: generate check-for-binaries check-git-tree-state
 
 apidocs:
-	hack/dockerized "./hack/generate.sh && ./hack/gen-swagger-doc/gen-swagger-docs.sh v1 html"
+	hack/dockerized "./hack/gen-swagger-doc/gen-swagger-docs.sh v1 html"
 
-client-python: generate
+client-python:
 	hack/dockerized "TRAVIS_TAG=${TRAVIS_TAG} ./hack/gen-client-python/generate.sh"
 
 go-build:


### PR DESCRIPTION
**What this PR does / why we need it**:

apidocs and pyhthon client targets don't have to run `make generate`,
since they are only executed on merged code where we know from our
testing on the PRs that the code is in sync.

Removing these hidden invocations to help right now travis and later on the prow jobs to execute faster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3987

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
