### PR TITLE
Fix virtctl build for linux-amd64

### DIFF
--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -46,9 +46,9 @@ bazel run \
 
 # linux
 bazel run \
-    --config=${ARCHITECTURE} \
+    --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
     --stamp \
-    :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-${ARCHITECTURE}
+    :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-amd64
 
 # darwin
 bazel run \


### PR DESCRIPTION
**What this PR does / why we need it**:

By accident we used `uname -m` which leads sometimes to x86_64 in the
name and sometimes to amd64. Hardcoding the build for amd64, to avoid
confusion for consumers on releases.

The build-platform-native virtctl is still built independent of that and
is not released, as intended.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3984
Fixes #3943

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
