### PR TITLE
tests, infra-test: use safe expect-batcher

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -490,11 +490,11 @@ var _ = Describe("Infrastructure", func() {
 			defer expecter.Close()
 
 			By("Writing some data to the disk")
-			_, err = expecter.ExpectBatch([]expect.Batcher{
+			_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "dd if=/dev/zero of=/dev/vdb bs=1M count=1\n"},
-				&expect.BExp{R: `localhost:~#`},
+				&expect.BExp{R: tests.PromptExpression},
 				&expect.BSnd{S: "sync\n"},
-				&expect.BExp{R: `localhost:~#`},
+				&expect.BExp{R: tests.PromptExpression},
 			}, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

https://github.com/kubevirt/kubevirt/pull/3882/files#diff-a5a178b4c66835110ceff63c61d28c96
introduced a safer expect-batcher, which reduces the chance of asserintg
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.
Also, PR makes uses the general `PromptExpression` instead of the hard-coded prompt.

This PR is a part of a series of PRs, for refactoring all
the test-suits to use the safe one.

 

Related PRs:
https://github.com/kubevirt/kubevirt/pull/3988
https://github.com/kubevirt/kubevirt/pull/3967
https://github.com/kubevirt/kubevirt/pull/3972

Signed-off-by: alonSadan <asadan@redhat.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE

```
