### PR TITLE
tests, job: Use status condition to detect success/failure and expose arguments

### DIFF
--- a/tests/job.go
+++ b/tests/job.go
@@ -50,14 +50,28 @@ func WaitForJobToFail(virtClient *kubecli.KubevirtClient, job *batchv1.Job, time
 	}, timeoutSec*time.Second, 1*time.Second).Should(BeTrue(), "Job should fail")
 }
 
-func RenderJob(name string, cmd, args []string) *batchv1.Job {
+// Default Job arguments to be used with NewJob.
+const (
+	JobRetry   = 3
+	JobTTL     = 60
+	JobTimeout = 480
+)
+
+// NewJob creates a job configuration that runs a single Pod.
+// A name is used for the job & pod while the command and its arguments are passed to the pod for execution.
+// In addition, the following arguments control the job behavior:
+// retry: The number of times the job should try and run the pod.
+// ttlAfterFinished: The period of time between the job finishing and its auto-deletion.
+//                   Make sure to leave enough time for the reporter to collect the logs.
+// timeout: The overall time at which the job is terminated, regardless of it finishing or not.
+func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, timeout int64) *batchv1.Job {
 	pod := RenderPod(name, cmd, args)
 	job := batchv1.Job{
 		ObjectMeta: pod.ObjectMeta,
 		Spec: batchv1.JobSpec{
-			BackoffLimit:            NewInt32(3),
-			TTLSecondsAfterFinished: NewInt32(60),
-			ActiveDeadlineSeconds:   NewInt64(480),
+			BackoffLimit:            &retry,
+			TTLSecondsAfterFinished: &ttlAfterFinished,
+			ActiveDeadlineSeconds:   &timeout,
 			Template: k8sv1.PodTemplateSpec{
 				ObjectMeta: pod.ObjectMeta,
 				Spec:       pod.Spec,
@@ -72,7 +86,7 @@ func RenderJob(name string, cmd, args []string) *batchv1.Job {
 // It expects to receive "Hello World!" to succeed.
 func NewHelloWorldJob(host string, port string) *batchv1.Job {
 	check := []string{fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)}
-	job := RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
+	job := NewJob("netcat", []string{"/bin/bash", "-c"}, check, JobRetry, JobTTL, JobTimeout)
 	return job
 }
 
@@ -91,7 +105,7 @@ func NewHelloWorldJobUDP(host string, port string) *batchv1.Job {
 	localPort--
 	check := []string{fmt.Sprintf(`set -x; trap "kill 0" EXIT; x="$(head -n 1 < <(echo | nc -up %d %s %s -i 3 -w 3 & nc -ul %d))"; echo "$x" ; if [ "$x" = "Hello UDP World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`,
 		localPort, host, port, localPort)}
-	job := RenderJob("netcat", []string{"/bin/bash", "-c"}, check)
+	job := NewJob("netcat", []string{"/bin/bash", "-c"}, check, JobRetry, JobTTL, JobTimeout)
 
 	return job
 }
@@ -101,7 +115,7 @@ func NewHelloWorldJobUDP(host string, port string) *batchv1.Job {
 // On success - it expects to receive "Hello World!".
 func NewHelloWorldJobHTTP(host string, port string) *batchv1.Job {
 	check := []string{fmt.Sprintf(`set -x; x="$(head -n 1 < <(curl %s:%s))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, FormatIPForURL(host), port)}
-	job := RenderJob("curl", []string{"/bin/bash", "-c"}, check)
+	job := NewJob("curl", []string{"/bin/bash", "-c"}, check, JobRetry, JobTTL, JobTimeout)
 
 	return job
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

tests, job: Use status condition to detect success/failure
tests, job: Rename RenderJob to NewJob and expose new args

---

Simplify the check for the job success and failure results by examining
the job status conditions.

This change also fixes the detection of a job failure.

---

Expose 3 new arguments that control the job behavior, allowing other
users to explicitly control the job:

- retry: The number of times the job should try and run the pod.
- ttlAfterFinished: The period of time between the job finishing and
its auto-deletion.
- timeout: The overall time at which the job is deleted, regardless of it
finishing or not.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
