### PR TITLE
tests, migration-test: use safe expect batcher

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -330,11 +330,11 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 	runStressTest := func(expecter expect.Expecter) {
 		By("Run a stress test to dirty some pages and slow down the migration")
-		_, err = expecter.ExpectBatch([]expect.Batcher{
+		_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: "\\#"},
+			&expect.BExp{R: tests.PromptExpression},
 			&expect.BSnd{S: "stress --vm 1 --vm-bytes 800M --vm-keep --timeout 1600s&\n\n"},
-			&expect.BExp{R: "\\#"},
+			&expect.BExp{R: tests.PromptExpression},
 		}, 15*time.Second)
 		Expect(err).ToNot(HaveOccurred(), "should run a stress test")
 		// give stress tool some time to trash more memory pages before returning control to next steps
@@ -584,7 +584,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Set wrong time on the guest")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "date +%T -s 23:26:00\n"},
 				}, 15*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should set guest time")
@@ -615,7 +615,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 					log.DefaultLogger().Infof("expoected time: %v", expectedTime)
 
 					By("Checking that the guest has an updated time")
-					resp, err := expecterNew.ExpectBatch([]expect.Batcher{
+					resp, err := tests.ExpectBatchWithValidatedSend(expecterNew, []expect.Batcher{
 						&expect.BSnd{S: "date +%H:%M\n"},
 						&expect.BExp{R: expectedTime},
 					}, 30*time.Second)
@@ -954,7 +954,7 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				Expect(err).ToNot(HaveOccurred(), "Should stay logged in to the migrated VM")
 
 				By("Checking that the service account is mounted")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "cat /mnt/servacc/namespace\n"},
 					&expect.BExp{R: tests.NamespaceTestDefault},
 				}, 30*time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

https://github.com/kubevirt/kubevirt/pull/3882/files#diff-a5a178b4c66835110ceff63c61d28c96
introduced a safer expect-batcher, which reduces the chance of asserintg
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.

Also, This PR makes use of the more generalized prompt expression from utils.

This PR is a part of a series of PRs, for refactoring all
the test-suits to use the safe one.

Signed-off-by: alonSadan <asadan@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
related PRs:
console-test:
https://github.com/kubevirt/kubevirt/pull/3972

container-disk-test:
https://github.com/kubevirt/kubevirt/pull/3988

config-test:
https://github.com/kubevirt/kubevirt/pull/3967
infra-test:
https://github.com/kubevirt/kubevirt/pull/3994 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
