### PR TITLE
Fix flaky certificate expiration unit test

### DIFF
--- a/pkg/virt-operator/creation/components/secrets_test.go
+++ b/pkg/virt-operator/creation/components/secrets_test.go
@@ -174,7 +174,10 @@ var _ = Describe("Certificate Management", func() {
 			crt, err := LoadCertificates(crtSecret)
 
 			deadline := now.Add(time.Duration(float64(crtDuration.Duration) * 0.8))
-			Expect(NextRotationDeadline(crt, caCrt, crtDuration).Unix()).To(BeNumerically("==", deadline.Unix(), 1))
+			// Generating certificates may take a little bit of time to execute (entropy, ...). Since we can't
+			// inject a fake time into the foreign code which generates the certificates, allow a generous diff of three
+			// seconds.
+			Expect(NextRotationDeadline(crt, caCrt, crtDuration).Unix()).To(BeNumerically("==", deadline.Unix(), 3))
 		},
 			table.Entry("with a long valid CA", 24*time.Hour),
 			table.Entry("with a CA which expires before the certificate rotation", 1*time.Hour),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We don't control the code which generates the certificate and sets the
expiration date. Therefore we can't inject a fake clock. Creating
certificates can take some time and therefore the exact expiration date
may vary a little bit more. Fixes some flakes on the unit tests.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3969

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
