### PR TITLE
tests, storage-test: use safe expect batcher

### DIFF
--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Storage", func() {
 				defer expecter.Close()
 
 				By("Checking that /dev/vdc has a capacity of 2Gi")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "sudo blockdev --getsize64 /dev/vdc\n"},
 					&expect.BExp{R: "2147483648"}, // 2Gi in bytes
 				}, 10*time.Second)
@@ -197,9 +197,9 @@ var _ = Describe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking if we can write to /dev/vdc")
-				res, err = expecter.ExpectBatch([]expect.Batcher{
+				res, err = tests.ExpectBatchWithValidatedSend(expecter,[]expect.Batcher{
 					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 				}, 20*time.Second)
@@ -239,7 +239,7 @@ var _ = Describe("Storage", func() {
 				defer expecter.Close()
 
 				By("Checking for the specified serial number")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := tests.ExpectBatchWithValidatedSend(expecter,[]expect.Batcher{
 					&expect.BSnd{S: "sudo find /sys -type f -regex \".*/block/.*/serial\" | xargs cat\n"},
 					&expect.BExp{R: diskSerial},
 				}, 10*time.Second)
@@ -298,12 +298,14 @@ var _ = Describe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter,[]expect.Batcher{
 					// Because "/" is mounted on tmpfs, we need something that normally persists writes - /dev/sda2 is the EFI partition formatted as vFAT.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "echo content > /mnt/checkpoint\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					// The QEMU process will be killed, therefore the write must be flushed to the disk.
 					&expect.BSnd{S: "sync\n"},
 				}, 200*time.Second)
@@ -326,12 +328,14 @@ var _ = Describe("Storage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = tests.ExpectBatchWithValidatedSend(expecter,[]expect.Batcher{
 					// Same story as when first starting the VirtualMachineInstance - the checkpoint, if persisted, is located at /dev/sda2.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/checkpoint &> /dev/null\n"},
+					&expect.BExp{R: tests.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: tests.RetValue("1")},
 				}, 200*time.Second)
@@ -366,7 +370,7 @@ var _ = Describe("Storage", func() {
 						Expect(err).ToNot(HaveOccurred())
 						defer expecter.Close()
 
-						_, err = expecter.ExpectBatch([]expect.Batcher{
+						_, err = tests.ExpectBatchWithValidatedSend(expecter,[]expect.Batcher{
 							&expect.BSnd{S: "blockdev --getsize64 /dev/vdb\n"},
 							&expect.BExp{R: "67108864"},
 						}, 200*time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
https://github.com/kubevirt/kubevirt/pull/3882/files#diff-a5a178b4c66835110ceff63c61d28c96
introduced a safer expect-batcher, which reduces the chance of asserintg
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.

Also, This PR makes use of the more generalized prompt expression from utils.

This PR is a part of a series of PRs, for refactoring all
the test-suits to use the safe one.

Signed-off-by: alonSadan <asadan@redhat.com>



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
related PRs: 

console-test:
https://github.com/kubevirt/kubevirt/pull/3972

container-disk-test:
https://github.com/kubevirt/kubevirt/pull/3988

config-test:
https://github.com/kubevirt/kubevirt/pull/3967

infra-test:
https://github.com/kubevirt/kubevirt/pull/3994

migration-test:

https://github.com/kubevirt/kubevirt/pull/4006

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
