### PR TITLE
Refactor all tests to use safe expect batcher and general prompt expression

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -131,7 +131,7 @@ func SecureBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error)
 	b := append([]expect.Batcher{
 		&expect.BExp{R: "secureboot: Secure boot enabled"},
 	})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
+	res, err := ExpectBatchWithValidatedSend(expecter, b, 180*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Kernel: %+v", res)
 		expecter.Close()

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -208,13 +208,16 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				Expect(err).ToNot(HaveOccurred(), "expected alpine to login properly")
 				defer expecter.Close()
 
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cd /media/cdrom\n"},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
 				}, 200*time.Second)

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -51,6 +51,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/leaderelectionconfig"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 )
@@ -505,11 +506,11 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			defer expecter.Close()
 
 			By("Writing some data to the disk")
-			_, err = expecter.ExpectBatch([]expect.Batcher{
+			_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "dd if=/dev/zero of=/dev/vdb bs=1M count=1\n"},
-				&expect.BExp{R: `localhost:~#`},
+				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "sync\n"},
-				&expect.BExp{R: `localhost:~#`},
+				&expect.BExp{R: console.PromptExpression},
 			}, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/login.go
+++ b/tests/login.go
@@ -47,14 +47,13 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "login as 'cirros' user. default password: 'gocubsgo'. use 'sudo' for root."},
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: hostName + " login:"},
 		&expect.BSnd{S: "cirros\n"},
 		&expect.BExp{R: "Password:"},
 		&expect.BSnd{S: "gocubsgo\n"},
-		&expect.BExp{R: "\\$"}})
+		&expect.BExp{R: console.PromptExpression}})
 	resp, err := expecter.ExpectBatch(b, 180*time.Second)
 
 	if err != nil {
@@ -63,13 +62,13 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		return nil, err
 	}
 
-	err = configureConsole(expecter, "\\$ ", true)
+	err = configureConsole(expecter, true)
 	if err != nil {
 		expecter.Close()
 		return nil, err
 	}
 
-	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\$ ")
+	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient)
 }
 
 // LoggedInAlpineExpecter return prepared and ready to use console expecter for
@@ -84,10 +83,9 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: "localhost login:"},
 		&expect.BSnd{S: "root\n"},
-		&expect.BExp{R: "localhost:~\\#"}})
+		&expect.BExp{R: console.PromptExpression}})
 	res, err := expecter.ExpectBatch(b, 180*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
@@ -95,7 +93,7 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		return nil, err
 	}
 
-	err = configureConsole(expecter, "localhost:~\\#", false)
+	err = configureConsole(expecter, false)
 	if err != nil {
 		expecter.Close()
 		return nil, err
@@ -141,7 +139,7 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 			},
 		}},
 		&expect.BSnd{S: "sudo su\n"},
-		&expect.BExp{R: "\\#"},
+		&expect.BExp{R: console.PromptExpression},
 	})
 	res, err := expecter.ExpectBatch(b, 3*time.Minute)
 	if err != nil {
@@ -150,13 +148,13 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		return expecter, err
 	}
 
-	err = configureConsole(expecter, "\\#", false)
+	err = configureConsole(expecter, false)
 	if err != nil {
 		expecter.Close()
 		return nil, err
 	}
 
-	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\#")
+	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient)
 }
 
 // ReLoggedInFedoraExpecter return prepared and ready to use console expecter for
@@ -170,7 +168,7 @@ func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expe
 	}
 	b := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: "#"}})
+		&expect.BExp{R: console.PromptExpression}})
 	res, err := expecter.ExpectBatch(b, time.Duration(timeout)*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
@@ -180,18 +178,18 @@ func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expe
 	return expecter, err
 }
 
-func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) error {
+func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
 	sudoString := ""
 	if shouldSudo {
 		sudoString = "sudo "
 	}
 	batch := append([]expect.Batcher{
 		&expect.BSnd{S: "stty cols 500 rows 500\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")},
 		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")}})
 	resp, err := expecter.ExpectBatch(batch, 30*time.Second)

--- a/tests/login.go
+++ b/tests/login.go
@@ -134,7 +134,7 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 				Rt: 10,
 			},
 			&expect.Case{
-				R: regexp.MustCompile(`\$ `),
+				R: regexp.MustCompile(fmt.Sprintf(`\[fedora@%s ~\]\$ `, vmi.Name)),
 				T: expect.OK(),
 			},
 		}},

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -362,7 +362,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: "stress --vm 1 --vm-bytes 800M --vm-keep --timeout 1600s&\n\n"},
+			&expect.BSnd{S: "stress --vm 1 --vm-bytes 800M --vm-keep --timeout 1600s&\n"},
 			&expect.BExp{R: console.PromptExpression},
 		}, 15*time.Second)
 		Expect(err).ToNot(HaveOccurred(), "should run a stress test")

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -373,7 +373,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		grepSleepPid := func(expecter expect.Expecter) string {
 			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
-				&expect.BSnd{S: `pgrep -f "sleep 8"` + "\n"},
+				&expect.BSnd{S: `pgrep -f "sleep 1m"` + "\n"},
 				&expect.BExp{R: console.RetValue("[0-9]+")}, // pid
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
@@ -385,7 +385,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		startProcess := func(expecter expect.Expecter) string {
 			By("Start a long running process")
 			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
-				&expect.BSnd{S: "sleep 8&\n"},
+				&expect.BSnd{S: "sleep 1m&\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "disown\n"}, // avoid "garbage" print in terminal on completion
 				&expect.BExp{R: console.PromptExpression},

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -386,9 +386,9 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			By("Start a long running process")
 			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "sleep 8&\n"},
-				&expect.BExp{R: "\\# "},     // prompt
+				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "disown\n"}, // avoid "garbage" print in terminal on completion
-				&expect.BExp{R: "\\# "},     // prompt
+				&expect.BExp{R: console.PromptExpression},
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -386,13 +386,13 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 				if device != "" {
 					batch = append(batch, []expect.Batcher{
 						&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 %s\n", device)},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: "echo $?\n"},
 						&expect.BExp{R: console.RetValue("0")},
 						&expect.BSnd{S: "sudo mkdir -p /test\n"},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: fmt.Sprintf("sudo mount %s /test \n", device)},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: "echo $?\n"},
 						&expect.BExp{R: console.RetValue("0")},
 					}...)
@@ -400,20 +400,20 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 
 				batch = append(batch, []expect.Batcher{
 					&expect.BSnd{S: "sudo mkdir -p /test/data\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "sudo chmod a+w /test/data\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: fmt.Sprintf("echo '%s' > /test/data/message\n", vm.UID)},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "cat /test/data/message\n"},
 					&expect.BExp{R: string(vm.UID)},
 					&expect.BSnd{S: "sync\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "sync\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 				}...)
 
-				res, err := expecter.ExpectBatch(batch, 20*time.Second)
+				res, err := console.ExpectBatchWithValidatedSend(expecter, batch, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				expecter.Close()
 				Expect(err).ToNot(HaveOccurred())
@@ -438,9 +438,9 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 				if device != "" {
 					batch = append(batch, []expect.Batcher{
 						&expect.BSnd{S: "sudo mkdir -p /test\n"},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: fmt.Sprintf("sudo mount %s /test \n", device)},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: "echo $?\n"},
 						&expect.BExp{R: console.RetValue("0")},
 					}...)
@@ -448,22 +448,22 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 
 				batch = append(batch, []expect.Batcher{
 					&expect.BSnd{S: "sudo mkdir -p /test/data\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "sudo chmod a+w /test/data\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "cat /test/data/message\n"},
 					&expect.BExp{R: string(vm.UID)},
 					&expect.BSnd{S: fmt.Sprintf("echo '%s' > /test/data/message\n", snapshot.UID)},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "cat /test/data/message\n"},
 					&expect.BExp{R: string(snapshot.UID)},
 					&expect.BSnd{S: "sync\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "sync\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 				}...)
 
-				res, err = expecter.ExpectBatch(batch, 20*time.Second)
+				res, err = console.ExpectBatchWithValidatedSend(expecter, batch, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				expecter.Close()
 				Expect(err).ToNot(HaveOccurred())
@@ -493,9 +493,9 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 				if device != "" {
 					batch = append(batch, []expect.Batcher{
 						&expect.BSnd{S: "sudo mkdir -p /test\n"},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: fmt.Sprintf("sudo mount %s /test \n", device)},
-						&expect.BExp{R: "\\$ "},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: "echo $?\n"},
 						&expect.BExp{R: console.RetValue("0")},
 					}...)
@@ -503,14 +503,14 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 
 				batch = append(batch, []expect.Batcher{
 					&expect.BSnd{S: "sudo mkdir -p /test/data\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "sudo chmod a+w /test/data\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "cat /test/data/message\n"},
 					&expect.BExp{R: string(vm.UID)},
 				}...)
 
-				res, err = expecter.ExpectBatch(batch, 20*time.Second)
+				res, err = console.ExpectBatchWithValidatedSend(expecter, batch, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				expecter.Close()
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2889,11 +2889,11 @@ func RenderPod(name string, cmd []string, args []string) *k8sv1.Pod {
 	return &pod
 }
 
-func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter, virtClient kubecli.KubevirtClient, prompt string) error {
+func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter, virtClient kubecli.KubevirtClient) error {
 	hasEth0Iface := func() bool {
 		hasNetEth0Batch := append([]expect.Batcher{
 			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: prompt},
+			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: "ip a | grep -q eth0; echo $?\n"},
 			&expect.BExp{R: console.RetValue("0")}})
 		_, err := console.ExpectBatchWithValidatedSend(expecter, hasNetEth0Batch, 30*time.Second)
@@ -2903,7 +2903,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 	hasGlobalIPv6 := func() bool {
 		hasGlobalIPv6Batch := append([]expect.Batcher{
 			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: prompt},
+			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: "ip -6 address show dev eth0 scope global | grep -q inet6; echo $?\n"},
 			&expect.BExp{R: console.RetValue("0")}})
 		_, err := console.ExpectBatchWithValidatedSend(expecter, hasGlobalIPv6Batch, 30*time.Second)
@@ -2929,7 +2929,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 
 	addIPv6Address := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "sudo ip -6 addr add fd10:0:2::2/120 dev eth0; echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")}})
 	resp, err := console.ExpectBatchWithValidatedSend(expecter, addIPv6Address, 30*time.Second)
@@ -2942,7 +2942,7 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 	time.Sleep(5 * time.Second)
 	addIPv6DefaultRoute := append([]expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "sudo ip -6 route add default via fd10:0:2::1 src fd10:0:2::2; echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")}})
 	resp, err = console.ExpectBatchWithValidatedSend(expecter, addIPv6DefaultRoute, 30*time.Second)
@@ -4180,7 +4180,7 @@ func GenerateHelloWorldServer(vmi *v1.VirtualMachineInstance, testPort int, prot
 	}
 	_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 		&expect.BSnd{S: serverCommand},
-		&expect.BExp{R: "\\$ "},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")},
 	}, 60*time.Second)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -48,6 +48,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virtctl/vm"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -686,7 +687,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				defer expecter.Close()
 
 				By("Guest shutdown")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "sudo poweroff\n"},
 					&expect.BExp{R: "The system is going down NOW!"},
 				}, 240*time.Second)
@@ -940,7 +941,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					defer expecter.Close()
 
 					By("Issuing a poweroff command from inside VM")
-					_, err = expecter.ExpectBatch([]expect.Batcher{
+					_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
 					}, 10*time.Second)
 					Expect(err).ToNot(HaveOccurred())
@@ -1097,7 +1098,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					defer expecter.Close()
 
 					By("Issuing a poweroff command from inside VM")
-					_, err = expecter.ExpectBatch([]expect.Batcher{
+					_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
 					}, 10*time.Second)
 					Expect(err).ToNot(HaveOccurred())
@@ -1337,7 +1338,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					defer expecter.Close()
 
 					By("Issuing a poweroff command from inside VM")
-					_, err = expecter.ExpectBatch([]expect.Batcher{
+					_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
 					}, 10*time.Second)
 					Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -61,24 +61,24 @@ var _ = Describe("CloudInitHookSidecars", func() {
 
 		return string(logsRaw)
 	}
-	MountCloudInit := func(vmi *v1.VirtualMachineInstance, prompt string) {
+	MountCloudInit := func(vmi *v1.VirtualMachineInstance) {
 		cmdCheck := "mount $(blkid  -L cidata) /mnt/\n"
 		err := console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "sudo su -\n"},
-			&expect.BExp{R: prompt},
+			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: cmdCheck},
-			&expect.BExp{R: prompt},
+			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: "echo $?\n"},
 			&expect.BExp{R: console.RetValue("0")},
 		}, 15)
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	CheckCloudInitFile := func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
+	CheckCloudInitFile := func(vmi *v1.VirtualMachineInstance, testFile, testData string) {
 		cmdCheck := "cat /mnt/" + testFile + "\n"
 		err := console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "sudo su -\n"},
-			&expect.BExp{R: prompt},
+			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: cmdCheck},
 			&expect.BExp{R: testData},
 		}, 15)
@@ -125,9 +125,9 @@ var _ = Describe("CloudInitHookSidecars", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
 				By("mouting cloudinit iso")
-				MountCloudInit(vmi, "#")
+				MountCloudInit(vmi)
 				By("checking cloudinit user-data")
-				CheckCloudInitFile(vmi, "#", "user-data", "#cloud-config")
+				CheckCloudInitFile(vmi, "user-data", "#cloud-config")
 			}, 300)
 		})
 	})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -207,9 +207,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of CPU cores under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: "3"},
+					&expect.BExp{R: console.RetValue("3")},
 				}, 15*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of cores")
 
@@ -272,9 +272,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of sockets under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
-					&expect.BExp{R: "3"},
+					&expect.BExp{R: console.RetValue("3")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of sockets")
 			})
@@ -299,9 +299,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of sockets under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
-					&expect.BExp{R: "2"},
+					&expect.BExp{R: console.RetValue("2")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of sockets")
 			})
@@ -328,9 +328,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of sockets under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
-					&expect.BExp{R: "2"},
+					&expect.BExp{R: console.RetValue("2")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of sockets")
 			})
@@ -358,9 +358,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of vCPUs under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
-					&expect.BExp{R: "4"},
+					&expect.BExp{R: console.RetValue("4")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of threads")
 			})
@@ -569,9 +569,9 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: "104"},
+					&expect.BExp{R: console.RetValue("104")},
 				}, 10*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -594,9 +594,9 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: "104"},
+					&expect.BExp{R: console.RetValue("104")},
 				}, 10*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -626,7 +626,7 @@ var _ = Describe("Configurations", func() {
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
 					&expect.BExp{R: console.RetValue("pass")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
 				}, 15*time.Second)
@@ -710,9 +710,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of usb under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
-					&expect.BExp{R: "2"},
+					&expect.BExp{R: console.RetValue("2")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
 			})
@@ -736,9 +736,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of usb under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
-					&expect.BExp{R: "2"},
+					&expect.BExp{R: console.RetValue("2")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
 			})
@@ -756,9 +756,9 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred(), "should start console")
 				defer expecter.Close()
 				By("Checking the number of usb under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* 2>/dev/null | wc -l\n"},
-					&expect.BExp{R: "0"},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
 			})
@@ -813,9 +813,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the tablet input under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -rs '^QEMU Virtio Tablet' /sys/devices | wc -l\n"},
-					&expect.BExp{R: "1"},
+					&expect.BExp{R: console.RetValue("1")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report input device")
 			})
@@ -840,9 +840,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the tablet input under guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -rs '^QEMU USB Tablet' /sys/devices | wc -l\n"},
-					&expect.BExp{R: "1"},
+					&expect.BExp{R: console.RetValue("1")},
 				}, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "should report input device")
 			})
@@ -1151,9 +1151,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the virtio rng presence")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^virtio /sys/devices/virtual/misc/hw_random/rng_available\n"},
-					&expect.BExp{R: "1"},
+					&expect.BExp{R: console.RetValue("1")},
 				}, 400*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -1170,9 +1170,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the virtio rng presence")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[[ ! -e /sys/devices/virtual/misc/hw_random/rng_available ]] && echo non\n"},
-					&expect.BExp{R: "non"},
+					&expect.BExp{R: console.RetValue("non")},
 				}, 400*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -1255,8 +1255,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Terminating guest agent and waiting for it to dissappear.")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "systemctl stop guestagent\n"},
+					&expect.BExp{R: console.PromptExpression},
 				}, 400*time.Second)
 				log.DefaultLogger().Object(agentVMI).Infof("Login: %v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -1353,8 +1354,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Terminating guest agent and waiting for it to dissappear.")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "systemctl stop guestagent\n"},
+					&expect.BExp{R: console.PromptExpression},
 				}, 400*time.Second)
 				log.DefaultLogger().Object(agentVMI).Infof("Login: %v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -1489,7 +1491,7 @@ var _ = Describe("Configurations", func() {
 
 				By("Checking hardware clock time")
 				expected := fmt.Sprintf("%02d:%02d:", now.Hour(), now.Minute())
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "sudo hwclock --localtime \n"},
 					&expect.BExp{R: expected},
 				}, 20*time.Second)
@@ -1591,7 +1593,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the CPU model under the guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", vmiModel)},
 					&expect.BExp{R: "model name"},
 				}, 10*time.Second)
@@ -1616,7 +1618,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the CPU model under the guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", cpuModelName)},
 					&expect.BExp{R: "model name"},
 				}, 10*time.Second)
@@ -1637,7 +1639,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the CPU model under the guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: fmt.Sprintf("grep '%s' /proc/cpuinfo\n", libvirtCpuModel)},
 					&expect.BExp{R: "model name"},
 				}, 10*time.Second)
@@ -1665,7 +1667,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the CPU features under the guest OS")
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: fmt.Sprintf("grep %s /proc/cpuinfo\n", cpuFeatures[0])},
 					&expect.BExp{R: "flags"},
 				}, 10*time.Second)
@@ -1881,10 +1883,10 @@ var _ = Describe("Configurations", func() {
 			tests.AddEphemeralDisk(vmi, "disk2", "sata", containerImage)
 			// NOTE: we have one disk per bus, so we expect vda, sda
 		})
-		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string, prompt string) {
+		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string) {
 			err := console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: prompt},
+				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "grep DEVNAME /sys/bus/pci/devices/" + expectedPciAddress + "/*/block/vda/uevent|awk -F= '{ print $2 }'\n"},
 				&expect.BExp{R: "vda"},
 			}, 15)
@@ -1900,10 +1902,12 @@ var _ = Describe("Configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 
-			res, err := expecter.ExpectBatch([]expect.Batcher{
+			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				// keep the ordering!
-				&expect.BSnd{S: "ls /dev/sda  /dev/vda  /dev/vdb\n"},
-				&expect.BExp{R: "/dev/sda  /dev/vda  /dev/vdb"},
+				&expect.BSnd{S: "ls /dev/vda  /dev/vdb\n"},
+				&expect.BExp{R: console.PromptExpression},
+				&expect.BSnd{S: "echo $?\n"},
+				&expect.BExp{R: console.RetValue("0")},
 			}, 10*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 
@@ -1918,7 +1922,7 @@ var _ = Describe("Configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
 
-			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress, "\\$")
+			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
 		})
 
 		It("[test_id:1020]should not create the VM with wrong PCI adress", func() {
@@ -2074,7 +2078,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of CPU cores under guest OS")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: "2"},
 				}, 15*time.Second)
@@ -2124,7 +2128,7 @@ var _ = Describe("Configurations", func() {
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
 					&expect.BExp{R: console.RetValue("pass")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
 				}, 15*time.Second)
@@ -2208,7 +2212,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of CPU cores under guest OS")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: "2"},
 				}, 15*time.Second)
@@ -2256,7 +2260,7 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				By("Checking the number of CPU cores under guest OS")
-				res, err := expecter.ExpectBatch([]expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: "2"},
 				}, 15*time.Second)

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -37,13 +37,13 @@ func parseDeviceAddress(addrString string) []string {
 	return addrs
 }
 
-func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt string) {
+func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	cmdCheck := fmt.Sprintf("lspci -m %s\n", gpuName)
 	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")},
 	}, 15)
@@ -136,7 +136,7 @@ var _ = Describe("[Serial]GPU", func() {
 				Expect(domSpec.Devices.HostDevices[n].Source.Address.Function).To(Equal("0x" + dbsfFields[3]))
 			}
 
-			checkGPUDevice(randomVMI, "10de", "$")
+			checkGPUDevice(randomVMI, "10de")
 		})
 	})
 })

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -64,7 +64,7 @@ var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][leve
 			defer expecter.Close()
 
 			By("Checking that the VirtualMachineInstance serial console output equals to expected one")
-			resp, err := expecter.ExpectBatch(commands, timeout)
+			resp, err := console.ExpectBatchWithValidatedSend(expecter, commands, timeout)
 			log.DefaultLogger().Object(vmi).Infof("%v", resp)
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -90,12 +90,11 @@ var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][leve
 
 					VerifyIgnitionDataVMI(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
-						&expect.BSnd{S: "\n"},
 						&expect.BExp{R: "login:"},
 						&expect.BSnd{S: "fedora\n"},
 						&expect.BExp{R: "Password:"},
 						&expect.BSnd{S: "fedora" + "\n"},
-						&expect.BExp{R: "\\$"},
+						&expect.BExp{R: console.PromptExpression},
 						&expect.BSnd{S: "ls /sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config\n"},
 						&expect.BExp{R: "raw"},
 					}, time.Second*300)

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -57,9 +57,9 @@ var _ = Describe("Health Monitoring", func() {
 			defer expecter.Close()
 
 			By("Killing the watchdog device")
-			_, err = expecter.ExpectBatch([]expect.Batcher{
+			_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "watchdog -t 2000ms -T 4000ms /dev/watchdog && sleep 5 && killall -9 watchdog\n"},
-				&expect.BExp{R: "\\#"},
+				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "echo $?\n"},
 				&expect.BExp{R: console.RetValue("0")},
 			}, 250*time.Second)

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -212,17 +212,17 @@ var _ = Describe("[Serial]Multus", func() {
 				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
 				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: cmdCheck},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "ip addr show eth1 | grep 10.1.1 | wc -l\n"},
 					&expect.BExp{R: console.RetValue("1")},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("checking virtual machine instance has two interfaces")
-				checkInterface(detachedVMI, "eth0", "\\$ ")
-				checkInterface(detachedVMI, "eth1", "\\$ ")
+				checkInterface(detachedVMI, "eth0")
+				checkInterface(detachedVMI, "eth1")
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
@@ -252,7 +252,7 @@ var _ = Describe("[Serial]Multus", func() {
 				// lo0, eth0
 				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: "\\$ "},
+					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "ip link show | grep -c UP\n"},
 					&expect.BExp{R: "2"},
 				}, 15)
@@ -293,7 +293,7 @@ var _ = Describe("[Serial]Multus", func() {
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 
 				By("Configuring static IP address to ptp interface.")
-				configInterface(vmiOne, "eth0", "10.1.1.1/24", "localhost:~#")
+				configInterface(vmiOne, "eth0", "10.1.1.1/24")
 
 				By("Verifying the desired custom MAC is the one that was actually configured on the interface.")
 				ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
@@ -329,13 +329,13 @@ var _ = Describe("[Serial]Multus", func() {
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
 
-				configInterface(vmiOne, "eth0", "10.1.1.1/24", "localhost:~#")
+				configInterface(vmiOne, "eth0", "10.1.1.1/24")
 				By("checking virtual machine interface eth0 state")
-				checkInterface(vmiOne, "eth0", "localhost:~#")
+				checkInterface(vmiOne, "eth0")
 
-				configInterface(vmiTwo, "eth0", "10.1.1.2/24", "localhost:~#")
+				configInterface(vmiTwo, "eth0", "10.1.1.2/24")
 				By("checking virtual machine interface eth0 state")
-				checkInterface(vmiTwo, "eth0", "localhost:~#")
+				checkInterface(vmiTwo, "eth0")
 
 				By("ping between virtual machines")
 				Expect(libnet.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
@@ -358,13 +358,13 @@ var _ = Describe("[Serial]Multus", func() {
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
 
-				configInterface(vmiOne, "eth1", "10.1.1.1/24", "localhost:~#")
+				configInterface(vmiOne, "eth1", "10.1.1.1/24")
 				By("checking virtual machine interface eth1 state")
-				checkInterface(vmiOne, "eth1", "localhost:~#")
+				checkInterface(vmiOne, "eth1")
 
-				configInterface(vmiTwo, "eth1", "10.1.1.2/24", "localhost:~#")
+				configInterface(vmiTwo, "eth1", "10.1.1.2/24")
 				By("checking virtual machine interface eth1 state")
-				checkInterface(vmiTwo, "eth1", "localhost:~#")
+				checkInterface(vmiTwo, "eth1")
 
 				By("ping between virtual machines")
 				Expect(libnet.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
@@ -388,8 +388,8 @@ var _ = Describe("[Serial]Multus", func() {
 				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
 
 				By("Configuring static IP address to the Linux bridge interface.")
-				configInterface(vmiOne, "eth0", "10.1.1.1/24", "localhost:~#")
-				configInterface(vmiTwo, "eth0", "10.1.1.2/24", "localhost:~#")
+				configInterface(vmiOne, "eth0", "10.1.1.1/24")
+				configInterface(vmiTwo, "eth0", "10.1.1.2/24")
 
 				By("Verifying the desired custom MAC is the one that were actually configured on the interface.")
 				ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
@@ -687,7 +687,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 		checkInterfacesInGuest := func(vmi *v1.VirtualMachineInstance, interfaces []string) {
 			for _, iface := range interfaces {
-				checkInterface(vmi, iface, "#")
+				checkInterface(vmi, iface)
 			}
 		}
 
@@ -858,8 +858,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 			// manually configure IP/link on sriov interfaces because there is
 			// no DHCP server to serve the address to the guest
-			configInterface(vmi1, "eth1", cidrA, "#")
-			configInterface(vmi2, "eth1", cidrB, "#")
+			configInterface(vmi1, "eth1", cidrA)
+			configInterface(vmi2, "eth1", cidrB)
 
 			// now check ICMP goes both ways
 			Expect(libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))).To(Succeed())
@@ -882,13 +882,13 @@ func cidrToIP(cidr string) string {
 	return ip.String()
 }
 
-func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAddress, prompt string) {
+func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAddress string) {
 	cmdCheck := fmt.Sprintf("ip addr add %s dev %s\n", interfaceAddress, interfaceName)
 	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")},
 	}, 15)
@@ -897,22 +897,22 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 	cmdCheck = fmt.Sprintf("ip link set %s up\n", interfaceName)
 	err = console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "Failed to set interface %s up on VMI %s", interfaceName, vmi.Name)
 }
 
-func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string) {
+func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName string) {
 	cmdCheck := fmt.Sprintf("ip link show %s\n", interfaceName)
 	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: prompt},
+		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: console.RetValue("0")},
 	}, 15)

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -146,9 +146,9 @@ var _ = Describe("[Serial]Slirp Networking", func() {
 		defer expecter.Close()
 		Expect(err).ToNot(HaveOccurred())
 
-		out, err := expecter.ExpectBatch([]expect.Batcher{
+		out, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
-			&expect.BExp{R: "\\$ "},
+			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: "curl -o /dev/null -s -w \"%{http_code}\\n\" -k https://google.com\n"},
 			&expect.BExp{R: "301"},
 		}, 180*time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

https://github.com/kubevirt/kubevirt/pull/3882 introduced a safer expect-batcher, which reduces the chance of matching
"leftovers" from previous commands, and by that making the expect-batcher
less prone to bugs. Further details and use-cases can be found in the
PR and in the links mentioned in It's description.

This PR refactors all tests in kubevirt/kubevirt to use the safer expect-batcher, And make use of the general prompt expression.

Also, a long the way and some of the tests, so you can find in this PR also: 
 - modifications to migration, configurations pausing  tests.
 - modifications to login.go in the tests package.  

Signed-off-by: alonSadan asadan@redhat.com

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Each commit in this PR refactors a different test module.  

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
