### PR TITLE
Move coverage from travis to prow - change travis, update builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ coverage:
 	hack/dockerized "./hack/coverage.sh ${WHAT}"
 
 goveralls: go-build
-	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN_FILE=${COVERALLS_TOKEN_FILE} COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} ./hack/goveralls.sh"
 
 go-test: go-build
 	SYNC_OUT=false hack/dockerized "./hack/build-go.sh test ${WHAT}"

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ coverage:
 	hack/dockerized "./hack/coverage.sh ${WHAT}"
 
 goveralls: go-build
-	SYNC_OUT=false hack/dockerized "TRAVIS_JOB_ID=${TRAVIS_JOB_ID} TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST} TRAVIS_BRANCH=${TRAVIS_BRANCH} ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} ./hack/goveralls.sh"
 
 go-test: go-build
 	SYNC_OUT=false hack/dockerized "./hack/build-go.sh test ${WHAT}"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,37 +69,19 @@ http_archive(
 # Libvirt dependencies
 http_file(
     name = "libvirt_libs",
-    sha256 = "9ff62eb0ed238882a652444e0feb876a9d7878a45fd026a18f64e7ab98faebf0",
+    sha256 = "59f119cf1347d07c0fa048d0c85b3e0e4a34987c481b26229d0c86fc4a8b0a22",
     urls = [
-        "https://copr-be.cloud.fedoraproject.org/results/%40virtmaint-sig/for-kubevirt/fedora-30-x86_64/01034621-libvirt/libvirt-libs-5.0.0-2.fc30.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/9ff62eb0ed238882a652444e0feb876a9d7878a45fd026a18f64e7ab98faebf0",
-    ],
-)
-
-http_file(
-    name = "libvirt_libs_ppc64le",
-    sha256 = "7993e9fa2a3455aacde56833c476f5900fb0c4a76dc9f0468676a94422d53e3b",
-    urls = [
-        "https://copr-be.cloud.fedoraproject.org/results/%40virtmaint-sig/for-kubevirt/fedora-30-ppc64le/01113510-libvirt/libvirt-libs-5.0.0-2.fc30.ppc64le.rpm",
-        "https://storage.googleapis.com/builddeps/7993e9fa2a3455aacde56833c476f5900fb0c4a76dc9f0468676a94422d53e3b",
+        "https://copr-be.cloud.fedoraproject.org/results/%40virtmaint-sig/for-kubevirt/fedora-31-x86_64/01113510-libvirt/libvirt-libs-5.0.0-2.fc31.x86_64.rpm",
+        "https://storage.googleapis.com/builddeps/59f119cf1347d07c0fa048d0c85b3e0e4a34987c481b26229d0c86fc4a8b0a22",
     ],
 )
 
 http_file(
     name = "libvirt_devel",
-    sha256 = "e34ca39bb94786b901a626143527f86cae1b6f1c8d1414165465d89e146a612e",
+    sha256 = "bf566d24c6657c8c28cf266c8ba796436b605dfa8c5162e1add4c8a56f0706b0",
     urls = [
-        "https://copr-be.cloud.fedoraproject.org/results/%40virtmaint-sig/for-kubevirt/fedora-30-x86_64/01034621-libvirt/libvirt-devel-5.0.0-2.fc30.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/e34ca39bb94786b901a626143527f86cae1b6f1c8d1414165465d89e146a612e",
-    ],
-)
-
-http_file(
-    name = "libvirt_devel_ppc64le",
-    sha256 = "45ddd9ba4508c72c4b6a6f03c2198ae4f918fa1324abf566e7b2e80ab51618f2",
-    urls = [
-        "https://copr-be.cloud.fedoraproject.org/results/%40virtmaint-sig/for-kubevirt/fedora-30-ppc64le/01113510-libvirt/libvirt-devel-5.0.0-2.fc30.ppc64le.rpm",
-        "https://storage.googleapis.com/builddeps/45ddd9ba4508c72c4b6a6f03c2198ae4f918fa1324abf566e7b2e80ab51618f2",
+        "https://copr-be.cloud.fedoraproject.org/results/%40virtmaint-sig/for-kubevirt/fedora-31-x86_64/01113510-libvirt/libvirt-devel-5.0.0-2.fc31.x86_64.rpm",
+        "https://storage.googleapis.com/builddeps/bf566d24c6657c8c28cf266c8ba796436b605dfa8c5162e1add4c8a56f0706b0",
     ],
 )
 

--- a/automation/travisci-test.sh
+++ b/automation/travisci-test.sh
@@ -3,19 +3,6 @@
 # when not on a release do extensive checks
 if [ -z "$TRAVIS_TAG" ]; then
 	make bazel-build-verify
-
-	# The make bazel-test might take longer then the current timeout for a command in Travis-CI of 10 min, so adding a keep alive loop while it runs
-	while sleep 9m; do echo "Long running job - keep alive"; done &
-	LOOP_PID=$!
-
-	if [[ $TRAVIS_REPO_SLUG == "kubevirt/kubevirt" && $TRAVIS_CPU_ARCH == "amd64" ]]; then
-		make goveralls
-	else
-		make bazel-test
-	fi
-
-	kill $LOOP_PID
-
 else
 	make
 fi

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -32,8 +32,19 @@ RUN dnf install -y dnf-plugins-core && \
         protobuf-compiler \
         python3-devel \
         redhat-rpm-config \
-        jq && \
+        jq \
+        wget && \
     dnf -y clean all
+
+# install gradle (required for swagger)
+RUN wget https://services.gradle.org/distributions/gradle-6.6-bin.zip && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle gradle-6.6-bin.zip && \
+    echo 'export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:/bin/java::")' >> $HOME/.bashrc && \
+    echo 'export PATH=$PATH:/opt/gradle/gradle-6.6/bin' >> $HOME/.bashrc
+
+ENV PATH=$PATH:/opt/gradle/gradle-6.6/bin \
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.8.10-2.fc31.x86_64
 
 ENV GIMME_GO_VERSION=1.12.8
 

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -3,13 +3,14 @@ FROM ${ARCH}/fedora:31
 
 COPY qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 
-ENV LIBVIRT_VERSION 5.6.0
+ENV LIBVIRT_VERSION 5.0.0
 
 ENV BAZEL_VERSION 1.2.1
 
 # Install packages
 RUN dnf install -y dnf-plugins-core && \
     dnf copr enable -y vbatts/bazel && \
+    dnf copr enable -y @virtmaint-sig/for-kubevirt && \
     dnf -y install \
         libvirt-devel-${LIBVIRT_VERSION} \
         bazel \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,19 +1,18 @@
 ARG ARCH
-FROM ${ARCH}/fedora:30
+FROM ${ARCH}/fedora:31
 
 COPY qemu-ppc64le-static /usr/bin/qemu-ppc64le-static
 
-ENV LIBVIRT_VERSION 5.1.0
+ENV LIBVIRT_VERSION 5.6.0
 
 ENV BAZEL_VERSION 1.2.1
 
 # Install packages
 RUN dnf install -y dnf-plugins-core && \
-    dnf copr enable -y @virtmaint-sig/virt-preview && \
     dnf copr enable -y vbatts/bazel && \
     dnf -y install \
         libvirt-devel-${LIBVIRT_VERSION} \
-        bazel-${BAZEL_VERSION} \
+        bazel \
         cpio \
         patch \
         make \
@@ -26,7 +25,6 @@ RUN dnf install -y dnf-plugins-core && \
         libstdc++-static \
         glibc-devel \
         findutils \
-        gradle \
         rsync-daemon \
         rsync \
         qemu-img \
@@ -97,6 +95,9 @@ RUN \
     go clean -cache -modcache -r && \
     rm -rf /go && mkdir /go
 
+# TODO: remove this and the patch below after https://github.com/fvbommel/util/issues/6 got fixed
+COPY vbom_ml.diff /tmp/vbom_ml.diff
+
 RUN \
     cd / && \
     export GO111MODULE=on && \
@@ -104,12 +105,14 @@ RUN \
     git clone https://github.com/kubernetes/test-infra.git && \
     cd /test-infra && \
     git checkout fd0699b906b0593a33ba2bddd3b1ae8822f42dd8 && \
+    git apply /tmp/vbom_ml.diff && \
+    go mod vendor && \
     cd /test-infra/robots/pr-creator && \
-    go install && \
+    GOPROXY=off GOFLAGS=-mod=vendor go install && \
     cd /test-infra/robots/issue-creator && \
-    go install && \
+    GOPROXY=off GOFLAGS=-mod=vendor go install && \
     cd /test-infra/robots/pr-labeler && \
-    go install && \
+    GOPROXY=off GOFLAGS=-mod=vendor go install && \
     cd /go && \
     go clean -cache -modcache -r && \
     rm -rf /test-infra && \

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install -y dnf-plugins-core && \
     dnf copr enable -y @virtmaint-sig/for-kubevirt && \
     dnf -y install \
         libvirt-devel-${LIBVIRT_VERSION} \
-        bazel \
+        bazel-${BAZEL_VERSION} \
         cpio \
         patch \
         make \

--- a/hack/builder/vbom_ml.diff
+++ b/hack/builder/vbom_ml.diff
@@ -1,0 +1,12 @@
+diff --git a/go.mod b/go.mod
+index 17d37ab1a4..7a523d5a3a 100644
+--- a/go.mod
++++ b/go.mod
+@@ -14,6 +14,7 @@ replace (
+ 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
+ 	k8s.io/client-go => k8s.io/client-go v0.0.0-20190918200256-06eb1244587a
+ 	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190612205613-18da4a14b22b
++	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+ )
+ 
+ require (

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,3 @@
-VERSION=30-5.8.4
+VERSION=30-5.8.5
 # TODO: reenable ppc64le when new builds are available
 ARCHITECTURES="amd64"

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,3 @@
-VERSION=30-5.8.2
+VERSION=30-5.8.3
 # TODO: reenable ppc64le when new builds are available
 ARCHITECTURES="amd64"

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,2 +1,3 @@
-VERSION=30-5.8.1
-ARCHITECTURES="amd64 ppc64le"
+VERSION=30-5.8.2
+# TODO: reenable ppc64le when new builds are available
+ARCHITECTURES="amd64"

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,3 @@
-VERSION=30-5.8.3
+VERSION=30-5.8.4
 # TODO: reenable ppc64le when new builds are available
 ARCHITECTURES="amd64"

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab"
+KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:af030d26397e0084e6ab3c3b50b245539d96f2d24fff85e936f2e8bfcaf885d6"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:ee50faaa98029fc1d923e194f61ed17d4b209700062c017b9aeb436344925ece"
+KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:d633dcf4aceabc67293ddcd827d5e24099a61b408d3775dd82289c38857e34bf"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:af030d26397e0084e6ab3c3b50b245539d96f2d24fff85e936f2e8bfcaf885d6"
+KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:ee50faaa98029fc1d923e194f61ed17d4b209700062c017b9aeb436344925ece"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:d633dcf4aceabc67293ddcd827d5e24099a61b408d3775dd82289c38857e34bf"
+KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:f04bca29395f32b2bf7150fd30c909c4ac9ba4ef32b0e84af1c515588ea7e692"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/gen-swagger-doc/build.gradle
+++ b/hack/gen-swagger-doc/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.1"
+        classpath "io.github.swagger2markup:swagger2markup-gradle-plugin:1.3.3"
         classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.6"
     }
 }
@@ -13,7 +13,7 @@ buildscript {
 apply plugin: 'io.github.swagger2markup'
 
 convertSwagger2markup {
-    swaggerInput "./api/openapi-spec/swagger.json"
+    swaggerInput file("../../api/openapi-spec/swagger.json").getAbsolutePath()
     outputDir file("./")
     config = [
         'swagger2markup.markupLanguage': markupLanguage,

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -3,4 +3,4 @@
 set -e
 
 ./hack/coverage.sh
-goveralls -service=travis-ci -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)
+goveralls -service=prow -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR removes the coverage run from the travis build and prepares setting environment variables for running it as a prow job. See https://github.com/kubevirt/project-infra/pull/586 for the prow job that uses the changes applied here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I had to apply some pretty ugly workarounds to get the builder image building. https://github.com/kubevirt/kubevirt/pull/4011/commits/ae2527a37ed3ef5137087825c7c0a5171e4824f7 due to [some dependency](https://github.com/fvbommel/util/issues/6) not getting resolved.

Created https://github.com/kubevirt/kubevirt/issues/4037 to track ppc64le disabling wich was required due to packages missing when building the builder image.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ppc64le arch has been disabled for the moment, see https://github.com/kubevirt/kubevirt/issues/4037
```
