### PR TITLE
Fix tests binary release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,12 @@ deploy:
   on:
     tags: true
     condition: $TRAVIS_CPU_ARCH = amd64
+- provider: script
+  script: make build-functests
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: $TRAVIS_CPU_ARCH = amd64
 - provider: releases
   skip_cleanup: true
   api_key:

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,10 @@ go-test: go-build
 
 test: bazel-test
 
-functest:
+build-functests:
 	hack/dockerized "hack/build-func-tests.sh"
+
+functest: build-functests
 	hack/functests.sh
 
 dump: bazel-build
@@ -175,4 +177,5 @@ bump-kubevirtci:
 	cluster-deploy \
 	cluster-sync \
 	olm-verify \
-	olm-push
+	olm-push \
+	build-functests


### PR DESCRIPTION
The tests binary was not attached to the release because we never built
it when we ran a release job.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
