### PR TITLE
Add --security-opt label:disable to bazel server version check

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -101,8 +101,8 @@ fi
 # Ensure that a bazel server which is running is the correct one
 if [ -n "$(docker ps --format '{{.Names}}' | grep ${BUILDER}-bazel-server)" ]; then
     # check if the image is correct
-    builder_id=$(docker inspect ${KUBEVIRT_BUILDER_IMAGE} | docker run --rm -i imega/jq:1.6 ".[0].Id")
-    bazel_server_id=$(docker inspect ${BUILDER}-bazel-server | docker run --rm -i imega/jq:1.6 ".[0].Image")
+    builder_id=$(docker inspect ${KUBEVIRT_BUILDER_IMAGE} | docker run --security-opt label:disable --rm -i imega/jq:1.6 ".[0].Id")
+    bazel_server_id=$(docker inspect ${BUILDER}-bazel-server | docker run --security-opt label:disable --rm -i imega/jq:1.6 ".[0].Image")
     if [ "${builder_id}" != "${bazel_server_id}" ]; then
         echo "Bazel server is outdated, restarting ..."
         docker stop ${BUILDER}-bazel-server


### PR DESCRIPTION
On Fedora 32 with moby this fixes an selinux issue in the imega/jq container.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On Fedora 32 doing a make cluster-sync I would get the following:
```
Error relocating /usr/lib/libonig.so.5: RELRO protection failed: Permission denied
Error relocating /lib/ld-musl-x86_64.so.1: RELRO protection failed: Permission denied
Error relocating /usr/bin/jq: RELRO protection failed: Permission denied
```
Turns out the check that bazel server is up to date didn't add the --security-opt label:disable like everything else.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
