### PR TITLE
Adds a special handling for DataVolumes in WaitForFirstConsumer state.

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -96,6 +96,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -509,7 +509,7 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 				return ready, fmt.Errorf("Failed to create DataVolume: %v", err)
 			}
 			c.recorder.Eventf(vm, k8score.EventTypeNormal, SuccessfulDataVolumeCreateReason, "Created DataVolume %s", curDataVolume.Name)
-		} else if curDataVolume.Status.Phase != cdiv1.Succeeded {
+		} else if curDataVolume.Status.Phase != cdiv1.Succeeded && curDataVolume.Status.Phase != cdiv1.WaitForFirstConsumer {
 			// ready = false because encountered DataVolume that is not populated yet
 			ready = false
 			if curDataVolume.Status.Phase == cdiv1.Failed {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -224,39 +224,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {
 
+		dvVolumeSource := v1.VolumeSource{
+			DataVolume: &v1.DataVolumeSource{
+				Name: "test1",
+			},
+		}
 		It("should create a corresponding Pod on VMI creation when DataVolume is ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					DataVolume: &v1.DataVolumeSource{
-						Name: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: dvVolumeSource,
 			})
 
-			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1"},
-			}
+			dvPVC := NewPvc(vmi.Namespace, "test1")
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
 			pvcInformer.GetIndexer().Add(dvPVC)
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.Succeeded,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -270,36 +256,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					DataVolume: &v1.DataVolumeSource{
-						Name: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: dvVolumeSource,
 			})
 
-			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1"},
-			}
+			dvPVC := NewPvc(vmi.Namespace, "test1")
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
 			pvcInformer.GetIndexer().Add(dvPVC)
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.WaitForFirstConsumer,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -330,35 +297,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					DataVolume: &v1.DataVolumeSource{
-						Name: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: dvVolumeSource,
 			})
 
-			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1"},
-			}
+			dvPVC := NewPvc(vmi.Namespace, "test1")
+			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
 			pvcInformer.GetIndexer().Add(dvPVC)
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.WaitForFirstConsumer,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -375,41 +324,22 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}).Return(vmi, nil)
 			controller.Execute()
 		})
+
 		It("should delete a doppleganger Pod on VMI creation when DataVolume is no longer in WaitForFirstConsumer state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					DataVolume: &v1.DataVolumeSource{
-						Name: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: dvVolumeSource,
 			})
 
-			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1"},
-			}
-			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
-			// be in available but in the Pending state.
+			dvPVC := NewPvc(vmi.Namespace, "test1")
+			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
+			// be in available
 			pvcInformer.GetIndexer().Add(dvPVC)
-
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.Succeeded,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -430,23 +360,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pod.Status.Conditions = conditions
 
 				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: "test1",
-					VolumeSource: v1.VolumeSource{
-						DataVolume: &v1.DataVolumeSource{
-							Name: "test1",
-						},
-					},
+					Name:         "test1",
+					VolumeSource: dvVolumeSource,
 				})
 
-				dataVolume := &cdiv1.DataVolume{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test1",
-						Namespace: vmi.Namespace,
-					},
-					Status: cdiv1.DataVolumeStatus{
-						Phase: cdiv1.WaitForFirstConsumer,
-					},
-				}
+				dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 				addVirtualMachine(vmi)
 				podFeeder.Add(pod)
@@ -474,23 +392,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					DataVolume: &v1.DataVolumeSource{
-						Name: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: dvVolumeSource,
 			})
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.Pending,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -503,23 +409,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					DataVolume: &v1.DataVolumeSource{
-						Name: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: dvVolumeSource,
 			})
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.Failed,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Failed)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -537,47 +431,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	Context("On valid VirtualMachineInstance given with PVC source, ownedRef of DataVolume", func() {
 		controllerOf := true
 
+		pvcVolumeSource := v1.VolumeSource{
+			PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "test1",
+			},
+		}
 		It("should create a corresponding Pod on VMI creation when DataVolume is ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "DataVolume",
-							Name:       "test1",
-							Controller: &controllerOf,
-						},
-					},
-				},
-			}
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
 			pvcInformer.GetIndexer().Add(dvPVC)
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.Succeeded,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -587,47 +459,122 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 		})
 
+		It("should create a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name:         "test1",
+				VolumeSource: pvcVolumeSource,
+			})
+
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC.Status.Phase = k8sv1.ClaimPending
+			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
+			// be in available but in the Pending state.
+			pvcInformer.GetIndexer().Add(dvPVC)
+
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
+
+			addVirtualMachine(vmi)
+			dataVolumeFeeder.Add(dataVolume)
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions[0].Type).To(Equal(v1.VirtualMachineInstanceProvisioning))
+			}).Return(vmi, nil)
+
+			IsPodWithoutVmPayload := WithTransform(
+				func(pod *k8sv1.Pod) string {
+					for _, c := range pod.Spec.Containers {
+						if c.Name == "compute" {
+							return strings.Join(c.Command, " ")
+						}
+					}
+
+					return ""
+				},
+				Equal("/bin/bash -c echo bound PVCs"))
+			shouldExpectMatchingPodCreation(vmi.UID, IsPodWithoutVmPayload)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+		})
+
+		It("should not delete a doppleganger Pod on VMI creation when DataVolume is in WaitForFirstConsumer state", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name:         "test1",
+				VolumeSource: pvcVolumeSource,
+			})
+
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC.Status.Phase = k8sv1.ClaimPending
+			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
+			// be in available but in the Pending state.
+			pvcInformer.GetIndexer().Add(dvPVC)
+
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
+
+			addVirtualMachine(vmi)
+			podFeeder.Add(pod)
+			addActivePods(vmi, pod.UID, "")
+			dataVolumeFeeder.Add(dataVolume)
+
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Pending))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Conditions).
+					To(ContainElement(v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceProvisioning,
+						Status: k8sv1.ConditionTrue,
+					}))
+			}).Return(vmi, nil)
+			controller.Execute()
+		})
+
+		It("should delete a doppleganger Pod on VMI creation when DataVolume is no longer in WaitForFirstConsumer state", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name:         "test1",
+				VolumeSource: pvcVolumeSource,
+			})
+
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC.Status.Phase = k8sv1.ClaimBound
+			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
+			// be in available
+			pvcInformer.GetIndexer().Add(dvPVC)
+
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
+
+			addVirtualMachine(vmi)
+			podFeeder.Add(pod)
+			addActivePods(vmi, pod.UID, "")
+			dataVolumeFeeder.Add(dataVolume)
+			shouldExpectPodDeletion(pod)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
+		})
+
 		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "DataVolume",
-							Name:       "test1",
-							Controller: &controllerOf,
-						},
-					},
-				},
-			}
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a successful DataVolume. we expect the PVC to
 			// be available in the store if DV is successful.
 			pvcInformer.GetIndexer().Add(dvPVC)
 
-			dataVolume := &cdiv1.DataVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test1",
-					Namespace: vmi.Namespace,
-				},
-				Status: cdiv1.DataVolumeStatus{
-					Phase: cdiv1.Pending,
-				},
-			}
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -639,25 +586,11 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "test1",
-				VolumeSource: v1.VolumeSource{
-					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "test1",
-					},
-				},
+				Name:         "test1",
+				VolumeSource: pvcVolumeSource,
 			})
 
-			pvc := &k8sv1.PersistentVolumeClaim{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "PersistentVolumeClaim",
-					APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: vmi.Namespace,
-					Name:      "test1",
-				},
-			}
-			// we are mocking a successful DataVolume. we expect the PVC to
-			// be available in the store if DV is successful.
+			pvc := NewPvc(vmi.Namespace, "test1")
 			pvcInformer.GetIndexer().Add(pvc)
 
 			addVirtualMachine(vmi)
@@ -1400,6 +1333,49 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		)
 	})
 })
+
+func NewDv(namespace string, name string, phase cdiv1.DataVolumePhase) *cdiv1.DataVolume {
+	return &cdiv1.DataVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: cdiv1.DataVolumeStatus{
+			Phase: phase,
+		},
+	}
+}
+
+func NewPvc(namespace string, name string) *k8sv1.PersistentVolumeClaim {
+	return &k8sv1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func NewPvcWithOwner(namespace string, name string, ownerName string, isController *bool) *k8sv1.PersistentVolumeClaim {
+	return &k8sv1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "PersistentVolumeClaim",
+			APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "DataVolume",
+					Name:       ownerName,
+					Controller: isController,
+				},
+			},
+		},
+	}
+}
 
 func NewPendingVirtualMachine(name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewMinimalVMI(name)

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -227,6 +227,10 @@ func (v *VirtualMachineInstance) IsFinal() bool {
 	return v.Status.Phase == Failed || v.Status.Phase == Succeeded
 }
 
+func (v *VirtualMachineInstance) IsProvisioning() bool {
+	return v.Status.Phase == Provisioning
+}
+
 func (v *VirtualMachineInstance) IsUnknown() bool {
 	return v.Status.Phase == Unknown
 }
@@ -464,6 +468,8 @@ type VirtualMachineInstancePhase string
 const (
 	//When a VirtualMachineInstance Object is first initialized and no phase, or Pending is present.
 	VmPhaseUnset VirtualMachineInstancePhase = ""
+	// A VMI depends on DataVolumes which are in Pending/WaitForFirstConsumer status.
+	Provisioning VirtualMachineInstancePhase = "Provisioning"
 	// Pending means the VirtualMachineInstance has been accepted by the system.
 	Pending VirtualMachineInstancePhase = "Pending"
 	// A target Pod exists but is not yet scheduled and in running state.

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -227,10 +227,6 @@ func (v *VirtualMachineInstance) IsFinal() bool {
 	return v.Status.Phase == Failed || v.Status.Phase == Succeeded
 }
 
-func (v *VirtualMachineInstance) IsProvisioning() bool {
-	return v.Status.Phase == Provisioning
-}
-
 func (v *VirtualMachineInstance) IsUnknown() bool {
 	return v.Status.Phase == Unknown
 }
@@ -258,6 +254,10 @@ type VirtualMachineInstanceConditionType string
 
 // These are valid conditions of VMIs.
 const (
+	// Provisioning means, a VMI depends on DataVolumes which are in Pending/WaitForFirstConsumer status,
+	// and some actions are taken to provision the PVCs for the DataVolumes
+	VirtualMachineInstanceProvisioning VirtualMachineInstanceConditionType = "Provisioning"
+
 	// VMIReady means the pod is able to service requests and should be added to the
 	// load balancing pools of all matching services.
 	VirtualMachineInstanceReady VirtualMachineInstanceConditionType = "Ready"
@@ -468,8 +468,6 @@ type VirtualMachineInstancePhase string
 const (
 	//When a VirtualMachineInstance Object is first initialized and no phase, or Pending is present.
 	VmPhaseUnset VirtualMachineInstancePhase = ""
-	// A VMI depends on DataVolumes which are in Pending/WaitForFirstConsumer status.
-	Provisioning VirtualMachineInstancePhase = "Provisioning"
 	// Pending means the VirtualMachineInstance has been accepted by the system.
 	Pending VirtualMachineInstancePhase = "Pending"
 	// A target Pod exists but is not yet scheduled and in running state.
@@ -553,6 +551,8 @@ const (
 	KubeVirtGenerationAnnotation = "kubevirt.io/generation"
 	// This annotation represents that this object is for temporary use during updates
 	EphemeralBackupObject = "kubevirt.io/ephemeral-backup-object"
+	// This annotation represents that the annotated object is for temporary use during pod/volume provisioning
+	EphemeralProvisioningObject string = "kubevirt.io/ephemeral-provisioning"
 
 	// This label indicates the object is a part of the install strategy retrieval process.
 	InstallStrategyLabel = "kubevirt.io/install-strategy"

--- a/staging/src/kubevirt.io/client-go/go.mod
+++ b/staging/src/kubevirt.io/client-go/go.mod
@@ -64,4 +64,5 @@ replace (
 
 	kubevirt.io/containerized-data-importer => kubevirt.io/containerized-data-importer v1.26.1
 	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2
+
 )

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -88,26 +88,26 @@ var _ = Describe("[Serial]DataVolume Integration", func() {
 			BeforeEach(func() {
 				By("Enable featuregate=HonorWaitForFirstConsumer")
 				// in practice we might have HonorWaitForFirstConsumer twice in featureGates array, but this is not a problem
-				jsonpath := `-o=jsonpath="{.spec.featureGates}"`
-				out, _, err := tests.RunCommand("kubectl", "get", "cdiconfigs.cdi.kubevirt.io", "config", jsonpath)
+				jsonpath := `-o=jsonpath="{.spec.config.featureGates}"`
+				out, _, err := tests.RunCommand("kubectl", "get", "cdis.cdi.kubevirt.io", "cdi", jsonpath)
 				Expect(err).ToNot(HaveOccurred())
 
 				// no feature Gates? we need to add the whole structure, else just add the flag
 				// Looks like the output might be quoted
 				if str, err := strconv.Unquote(strings.TrimSpace(out)); str == "" {
-					patch := `{"spec":{"featureGates":["HonorWaitForFirstConsumer"]}}`
-					_, _, err = tests.RunCommand("kubectl", "patch", "cdiconfigs.cdi.kubevirt.io", "config", "-o=json", "--type=merge", "-p", patch)
+					patch := `{"spec": { "config": {"featureGates":["HonorWaitForFirstConsumer"]}}}`
+					_, _, err = tests.RunCommand("kubectl", "patch", "cdis.cdi.kubevirt.io", "cdi", "-o=json", "--type=merge", "-p", patch)
 					Expect(err).ToNot(HaveOccurred())
 				} else {
-					patch := `[{"op": "add" , "path": "/spec/featureGates/0", "value": "HonorWaitForFirstConsumer"}]`
-					_, _, err = tests.RunCommand("kubectl", "patch", "cdiconfigs.cdi.kubevirt.io", "config", "--type=json", "-p", patch)
+					patch := `[{"op": "add" , "path": "/spec/config/featureGates/0", "value": "HonorWaitForFirstConsumer"}]`
+					_, _, err = tests.RunCommand("kubectl", "patch", "cdis.cdi.kubevirt.io", "cdi", "--type=json", "-p", patch)
 					Expect(err).ToNot(HaveOccurred())
 				}
 			})
 			AfterEach(func() {
 				By("Restore featuregates")
-				patch := `[{"op": "remove" , "path": "/spec/featureGates/0", "value": "HonorWaitForFirstConsumer"}]`
-				_, _, err = tests.RunCommand("kubectl", "patch", "cdiconfigs.cdi.kubevirt.io", "config", "--type=json", "-p", patch)
+				patch := `[{"op": "remove" , "path": "/spec/config/featureGates/0", "value": "HonorWaitForFirstConsumer"}]`
+				_, _, err = tests.RunCommand("kubectl", "patch", "cdis.cdi.kubevirt.io", "cdi", "--type=json", "-p", patch)
 				Expect(err).ToNot(HaveOccurred())
 			})
 			It("[test_id:3189]should be successfully started and stopped multiple times", func() {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -668,7 +668,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Create(dataVolume)
 				Expect(err).ToNot(HaveOccurred())
 
-				tests.WaitForSuccessfulDataVolumeImportOfVMI(vmi, 340)
+				tests.WaitForDataVolumeReadyToStartVMI(vmi, 340)
 
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
@@ -710,7 +710,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Create(dataVolume)
 				Expect(err).ToNot(HaveOccurred())
 
-				tests.WaitForSuccessfulDataVolumeImportOfVMI(vmi, 240)
+				tests.WaitForDataVolumeReadyToStartVMI(vmi, 240)
 
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2671,28 +2671,43 @@ func NewRandomVMIWithCustomMacAddress() *v1.VirtualMachineInstance {
 	return vmi
 }
 
-// Block until DataVolume succeeds.
-func WaitForSuccessfulDataVolumeImportOfVMI(obj runtime.Object, seconds int) {
+// Block until DataVolume succeeds on storage with Immediate binding
+// or is in WaitForFirstConsumer state on storage with WaitForFirstConsumer binding.
+func WaitForDataVolumeReadyToStartVMI(obj runtime.Object, seconds int) {
 	vmi, ok := obj.(*v1.VirtualMachineInstance)
 	ExpectWithOffset(1, ok).To(BeTrue(), "Object is not of type *v1.VMI")
-	waitForSuccessfulDataVolumeImport(vmi.Namespace, vmi.Spec.Volumes[0].DataVolume.Name, seconds)
+	WaitForDataVolumeReady(vmi.Namespace, vmi.Spec.Volumes[0].DataVolume.Name, seconds)
+}
+
+func WaitForDataVolumeReady(namespace, name string, seconds int) {
+	waitForDataVolumePhase(namespace, name, seconds, cdiv1.WaitForFirstConsumer, cdiv1.Succeeded)
+}
+
+func WaitForDataVolumePhaseWFFC(obj runtime.Object, seconds int) {
+	vmi, ok := obj.(*v1.VirtualMachineInstance)
+	ExpectWithOffset(1, ok).To(BeTrue(), "Object is not of type *v1.VMI")
+	waitForDataVolumePhase(vmi.Namespace, vmi.Spec.Volumes[0].DataVolume.Name, seconds, cdiv1.WaitForFirstConsumer)
 }
 
 func WaitForSuccessfulDataVolumeImport(dv *cdiv1.DataVolume, seconds int) {
-	waitForSuccessfulDataVolumeImport(dv.Namespace, dv.Name, seconds)
+	waitForDataVolumePhase(dv.Namespace, dv.Name, seconds, cdiv1.WaitForFirstConsumer, cdiv1.Succeeded)
 }
 
-func waitForSuccessfulDataVolumeImport(namespace, name string, seconds int) {
+func waitForDataVolumePhase(namespace, name string, seconds int, phase ...cdiv1.DataVolumePhase) {
 	By("Checking that the DataVolume has succeeded")
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(2, err).ToNot(HaveOccurred())
 
-	EventuallyWithOffset(2, func() cdiv1.DataVolumePhase {
-		dv, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Get(name, metav1.GetOptions{})
-		ExpectWithOffset(2, err).ToNot(HaveOccurred())
+	EventuallyWithOffset(2,
+		func() cdiv1.DataVolumePhase {
+			dv, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Get(name, metav1.GetOptions{})
+			ExpectWithOffset(2, err).ToNot(HaveOccurred())
 
-		return dv.Status.Phase
-	}, time.Duration(seconds)*time.Second, 1*time.Second).Should(Equal(cdiv1.Succeeded), "Timed out waiting for DataVolume to enter Succeeded phase")
+			return dv.Status.Phase
+		},
+		time.Duration(seconds)*time.Second, 1*time.Second).
+		Should(BeElementOf(phase),
+			"Timed out waiting for DataVolume to enter Succeeded phase")
 }
 
 // Block until the specified VirtualMachineInstance started and return the target node name.
@@ -4003,6 +4018,18 @@ func HasDataVolumeCRD() bool {
 
 func HasCDI() bool {
 	return HasDataVolumeCRD()
+}
+
+func HasBindingModeWaitForFirstConsumer() bool {
+	virtClient, err := kubecli.GetKubevirtClient()
+	Expect(err).ToNot(HaveOccurred())
+	storageClass, err := virtClient.StorageV1().StorageClasses().Get(Config.StorageClassLocal, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return false
+	}
+	return storageClass.VolumeBindingMode != nil &&
+		*storageClass.VolumeBindingMode == storagev1.VolumeBindingWaitForFirstConsumer
 }
 
 func GetCephStorageClass() (string, bool) {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2683,14 +2683,12 @@ func WaitForDataVolumeReady(namespace, name string, seconds int) {
 	waitForDataVolumePhase(namespace, name, seconds, cdiv1.WaitForFirstConsumer, cdiv1.Succeeded)
 }
 
-func WaitForDataVolumePhaseWFFC(obj runtime.Object, seconds int) {
-	vmi, ok := obj.(*v1.VirtualMachineInstance)
-	ExpectWithOffset(1, ok).To(BeTrue(), "Object is not of type *v1.VMI")
-	waitForDataVolumePhase(vmi.Namespace, vmi.Spec.Volumes[0].DataVolume.Name, seconds, cdiv1.WaitForFirstConsumer)
+func WaitForDataVolumePhaseWFFC(namespace, name string, seconds int) {
+	waitForDataVolumePhase(namespace, name, seconds, cdiv1.WaitForFirstConsumer)
 }
 
 func WaitForSuccessfulDataVolumeImport(dv *cdiv1.DataVolume, seconds int) {
-	waitForDataVolumePhase(dv.Namespace, dv.Name, seconds, cdiv1.WaitForFirstConsumer, cdiv1.Succeeded)
+	waitForDataVolumePhase(dv.Namespace, dv.Name, seconds, cdiv1.Succeeded)
 }
 
 func waitForDataVolumePhase(namespace, name string, seconds int, phase ...cdiv1.DataVolumePhase) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds a special handling for DataVolumes in WaitForFirstConsumer state.

In order to support CDI's delayed binding mode the kubevirt's VMI now has a special handling for a VMI that depends on DataVolumes which are in Pending/WaitForFirstConsumer status. In this case, the controller should reflect that the VMI is in a special "Provisioning" state. To move out of this state, the Controller creates a virt-launcher Pod which does not run the real VM workload. This causes all the PVCs associated with the Pending DataVolume to become Bound. Future iterations of the VMI control loop will find no DataVolumes that are Pending and the VMI status can move to running and the VM can be launched as normal.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds a special handling for DataVolumes in WaitForFirstConsumer state to support CDI's delayed binding mode.
```
