### PR TITLE
DRAFT - Support VMI scheme multi IPs list in case of dual stack after rebase

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -526,7 +526,7 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 					ifc := v1.VirtualMachineInstanceNetworkInterface{
 						Name: network.Name,
 						IP:   podIface.PodIP,
-						IPs:  []string{podIface.PodIP},
+						IPs:  podIface.PodIPs,
 					}
 					interfaces = append(interfaces, ifc)
 				}
@@ -586,10 +586,12 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 						if err != nil {
 							return err
 						}
-						if iface.PodIP != existingInterfaceStatusByName[domainInterface.Alias.Name].IP {
+
+						if iface.PodIP != existingInterfaceStatusByName[domainInterface.Alias.Name].IP ||
+							!reflect.DeepEqual(iface.PodIPs, existingInterfaceStatusByName[domainInterface.Alias.Name].IPs) {
 							newInterface.Name = domainInterface.Alias.Name
 							newInterface.IP = iface.PodIP
-							newInterface.IPs = []string{iface.PodIP}
+							newInterface.IPs = iface.PodIPs
 						}
 					}
 				} else {

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/subgraph/libmacouflage:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -224,6 +224,17 @@ func (_mr *_MockNetworkHandlerRecorder) IsIpv6Enabled(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv6Enabled", arg0)
 }
 
+func (_m *MockNetworkHandler) IsIpv4Primary() (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsIpv4Primary")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockNetworkHandlerRecorder) IsIpv4Primary() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv4Primary")
+}
+
 func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {
 	ret := _m.ctrl.Call(_m, "ConfigureIpv6Forwarding")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -44,8 +44,9 @@ var NetworkInterfaceFactory = getNetworkClass
 var podInterfaceName = podInterface
 
 type PodCacheInterface struct {
-	Iface *v1.Interface `json:"iface,omitempty"`
-	PodIP string        `json:"podIP,omitempty"`
+	Iface  *v1.Interface `json:"iface,omitempty"`
+	PodIP  string        `json:"podIP,omitempty"`
+	PodIPs []string      `json:"podIPs,omitempty"`
 }
 
 type plugFunction func(vif NetworkInterface, vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -30,6 +30,8 @@ import (
 	"strconv"
 	"strings"
 
+	netutils "k8s.io/utils/net"
+
 	"kubevirt.io/kubevirt/pkg/util"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -100,15 +102,44 @@ func setPodInterfaceCache(iface *v1.Interface, podInterfaceName string, uid stri
 		return nil
 	}
 
+	cache := PodCacheInterface{Iface: iface}
+
+	ipv4 := ""
+	ipv6 := ""
 	for _, addr := range addrList {
 		if addr.IP.IsGlobalUnicast() {
-			err = writeToCachedFile(PodCacheInterface{Iface: iface, PodIP: addr.IP.String()},
-				util.VMIInterfacepath, uid, iface.Name)
-			if err != nil {
-				log.Log.Reason(err).Errorf("failed to write pod Interface to cache, %s", err.Error())
-				return err
+			if netutils.IsIPv6(addr.IP) {
+				ipv6 = addr.IP.String()
+			} else {
+				ipv4 = addr.IP.String()
 			}
-			return nil
+		}
+	}
+
+	if ipv4 != "" && ipv6 != "" {
+		ipv4Primary, err := Handler.IsIpv4Primary()
+		if err != nil {
+			log.Log.Reason(err).Errorf("failed to invoke IsIpv4Primary")
+			return err
+		}
+
+		if ipv4Primary {
+			cache.PodIPs = []string{ipv4, ipv6}
+		} else {
+			cache.PodIPs = []string{ipv6, ipv4}
+		}
+	} else if ipv4 != "" {
+		cache.PodIPs = []string{ipv4}
+	} else if ipv6 != "" {
+		cache.PodIPs = []string{ipv6}
+	}
+
+	if len(cache.PodIPs) != 0 {
+		cache.PodIP = cache.PodIPs[0]
+		err = writeToCachedFile(cache, util.VMIInterfacepath, uid, iface.Name)
+		if err != nil {
+			log.Log.Reason(err).Errorf("failed to write pod Interface to cache, %s", err.Error())
+			return err
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -264,6 +264,7 @@ var _ = Describe("Pod Network", func() {
 
 	Context("on successful setup", func() {
 		It("should define a new VIF bind to a bridge", func() {
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			domain := NewDomainWithBridgeInterface()
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
@@ -294,6 +295,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
 			mockNetwork.EXPECT().LinkSetMaster(dummy, bridgeTest).Return(nil)
 			mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(errors.New("device is busy"))
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(HaveOccurred(), "SetupPodNetworkPhase1 should return an error")
@@ -313,6 +315,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_ALL).Return(addrList, nil)
 			mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_V4).Return(addrList, nil)
 			mockNetwork.EXPECT().GetMacDetails(podInterface).Return(fakeMac, nil)
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(HaveOccurred())
@@ -390,6 +393,7 @@ var _ = Describe("Pod Network", func() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -400,6 +404,7 @@ var _ = Describe("Pod Network", func() {
 			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
@@ -439,6 +444,7 @@ var _ = Describe("Pod Network", func() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
 				}
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -449,6 +455,7 @@ var _ = Describe("Pod Network", func() {
 			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().IsIpv6Enabled(podInterface).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(false).Times(2)
@@ -745,6 +752,7 @@ var _ = Describe("Pod Network", func() {
 		iface := &v1.Interface{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
 		mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
 		mockNetwork.EXPECT().AddrList(dummy, netlink.FAMILY_ALL).Return(addrList, nil)
+		mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 		err = setPodInterfaceCache(iface, podInterface, uid)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
In case of dual stack, support listing all IPs under
VMI status.interfaces.ipaddresses.
As the pods support podIPs in dual stack.

This PR supports automatic detection of the primary ip
according PodIP.
The order of the ips and the primary ip in the VMI scheme
will be the same as the pods in the cluster are.

Signed-off-by: Or Shoval <oshoval@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
