### PR TITLE
Fix issues that virt-operator cannot extract MonitorNamespace and MonitorServiceAccount from JSON

### DIFF
--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -395,16 +395,16 @@ func (c *KubeVirtDeploymentConfig) GetImagePullPolicy() k8sv1.PullPolicy {
 }
 
 func (c *KubeVirtDeploymentConfig) GetMonitorNamespace() string {
-	p, ok := c.AdditionalProperties[AdditionalPropertiesMonitorNamespace]
-	if !ok {
+	p := c.AdditionalProperties[AdditionalPropertiesMonitorNamespace]
+	if p == "" {
 		return DefaultMonitorNamespace
 	}
 	return p
 }
 
 func (c *KubeVirtDeploymentConfig) GetMonitorServiceAccount() string {
-	p, ok := c.AdditionalProperties[AdditionalPropertiesMonitorServiceAccount]
-	if !ok {
+	p := c.AdditionalProperties[AdditionalPropertiesMonitorServiceAccount]
+	if p == "" {
 		return DefaultMonitorAccount
 	}
 	return p

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -55,10 +55,10 @@ const (
 	AdditionalPropertiesNamePullPolicy = "ImagePullPolicy"
 
 	// lookup key in AdditionalProperties
-	AdditionalPropertiesMonitorNamespace = "monitorNamespace"
+	AdditionalPropertiesMonitorNamespace = "MonitorNamespace"
 
 	// lookup key in AdditionalProperties
-	AdditionalPropertiesMonitorServiceAccount = "monitorAccount"
+	AdditionalPropertiesMonitorServiceAccount = "MonitorAccount"
 
 	// account to use if one is not explicitly named
 	DefaultMonitorNamespace = "openshift-monitoring"

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Operator Config", func() {
 
 	Describe("Config json from env var", func() {
 		It("should be parsed", func() {
-			json := `{"id":"9ca7273e4d5f1bee842f64a8baabc15cbbf1ce59","namespace":"kubevirt","registry":"registry:5000/kubevirt","imagePrefix":"somePrefix","kubeVirtVersion":"devel","additionalProperties":{"ImagePullPolicy":"IfNotPresent"}}`
+			json := `{"id":"9ca7273e4d5f1bee842f64a8baabc15cbbf1ce59","namespace":"kubevirt","registry":"registry:5000/kubevirt","imagePrefix":"somePrefix","kubeVirtVersion":"devel","additionalProperties":{"ImagePullPolicy":"IfNotPresent", "MonitorNamespace":"non-default-monitor-namespace", "MonitorAccount":"non-default-prometheus-k8s"}}`
 			os.Setenv(TargetDeploymentConfig, json)
 			parsedConfig, err := GetConfigFromEnv()
 			Expect(err).ToNot(HaveOccurred())
@@ -191,6 +191,19 @@ var _ = Describe("Operator Config", func() {
 			Expect(parsedConfig.GetImagePrefix()).To(Equal("somePrefix"))
 			Expect(parsedConfig.GetKubeVirtVersion()).To(Equal("devel"))
 			Expect(parsedConfig.GetImagePullPolicy()).To(Equal(k8sv1.PullIfNotPresent))
+			Expect(parsedConfig.GetMonitorNamespace()).To(Equal("non-default-monitor-namespace"))
+			Expect(parsedConfig.GetMonitorServiceAccount()).To(Equal("non-default-prometheus-k8s"))
+		})
+	})
+
+	Describe("Config json with default value", func() {
+		It("should be parsed", func() {
+			json := `{"id":"9ca7273e4d5f1bee842f64a8baabc15cbbf1ce59","additionalProperties":{"ImagePullPolicy":"IfNotPresent"}}`
+			os.Setenv(TargetDeploymentConfig, json)
+			parsedConfig, err := GetConfigFromEnv()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsedConfig.GetMonitorNamespace()).To(Equal("openshift-monitoring"))
+			Expect(parsedConfig.GetMonitorServiceAccount()).To(Equal("prometheus-k8s"))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

virt-operator cannot extract `monitorNamespace` and `monitorAccount` when specifying using the following YAML:
```
apiVersion: kubevirt.io/v1alpha3
kind: KubeVirt
metadata:
  name: kubevirt
spec:
  monitorNamespace: monitoring
  monitorAccount: prometheus-k8s
```

When extracting values from a JSON map, the key name is expected to start with capitalized characters.

More details could be found at https://github.com/kubevirt/kubevirt/issues/3086#issuecomment-669601043

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3086

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue which prevented virt-operator from installing monitoring resources in custom namespaces.
```

