### PR TITLE
Add flags to virt-handler/virt-controller/virt-api to allow users externally manage certificates

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -90,6 +90,15 @@ const (
 
 	// Default period for resyncing virt-launcher domain cache
 	defaultDomainResyncPeriodSeconds = 300
+
+	// Default ConfigMap name of CA
+	defaultCAConfigMapName = "kubevirt-ca"
+
+	// Default certificate and key paths
+	defaultClientCertFilePath = "/etc/virt-handler/clientcertificates/tls.crt"
+	defaultClientKeyFilePath  = "/etc/virt-handler/clientcertificates/tls.key"
+	defaultTlsCertFilePath    = "/etc/virt-handler/servercertificates/tls.crt"
+	defaultTlsKeyFilePath     = "/etc/virt-handler/servercertificates/tls.key"
 )
 
 type virtHandlerApp struct {
@@ -104,6 +113,12 @@ type virtHandlerApp struct {
 	MaxDevices                int
 	MaxRequestsInFlight       int
 	domainResyncPeriodSeconds int
+
+	caConfigMapName    string
+	clientCertFilePath string
+	clientKeyFilePath  string
+	serverCertFilePath string
+	serverKeyFilePath  string
 
 	virtCli   kubecli.KubevirtClient
 	namespace string
@@ -120,8 +135,8 @@ type virtHandlerApp struct {
 var _ service.Service = &virtHandlerApp{}
 
 func (app *virtHandlerApp) prepareCertManager() (err error) {
-	app.clientcertmanager = bootstrap.NewFileCertificateManager("/etc/virt-handler/clientcertificates")
-	app.servercertmanager = bootstrap.NewFileCertificateManager("/etc/virt-handler/servercertificates")
+	app.clientcertmanager = bootstrap.NewFileCertificateManager(app.clientCertFilePath, app.clientKeyFilePath)
+	app.servercertmanager = bootstrap.NewFileCertificateManager(app.serverCertFilePath, app.serverKeyFilePath)
 	return
 }
 
@@ -382,6 +397,21 @@ func (app *virtHandlerApp) AddFlags() {
 	flag.StringVar(&app.KubeletPodsDir, "kubelet-pods-dir", util.KubeletPodsDir,
 		"Path for pod directory (matching host's path for kubelet root)")
 
+	flag.StringVar(&app.caConfigMapName, "ca-configmap-name", defaultCAConfigMapName,
+		"The name of configmap containing CA certificates to authenticate requests presenting client certificates with matching CommonName")
+
+	flag.StringVar(&app.clientCertFilePath, "client-cert-file", defaultClientCertFilePath,
+		"Client certificate used to prove the identity of the virt-handler when it must call out during a request")
+
+	flag.StringVar(&app.clientKeyFilePath, "client-key-file", defaultClientKeyFilePath,
+		"Private key for the client certificate used to prove the identity of the virt-handler when it must call out during a request")
+
+	flag.StringVar(&app.serverCertFilePath, "tls-cert-file", defaultTlsCertFilePath,
+		"File containing the default x509 Certificate for HTTPS")
+
+	flag.StringVar(&app.serverKeyFilePath, "tls-key-file", defaultTlsKeyFilePath,
+		"File containing the default x509 private key matching --tls-cert-file")
+
 	flag.DurationVar(&app.WatchdogTimeoutDuration, "watchdog-timeout", defaultWatchdogTimeout,
 		"Watchdog file timeout")
 
@@ -404,7 +434,7 @@ func (app *virtHandlerApp) AddFlags() {
 
 func (app *virtHandlerApp) setupTLS(factory controller.KubeInformerFactory) error {
 	kubevirtCAConfigInformer := factory.KubeVirtCAConfigMap()
-	caManager := webhooks.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace)
+	caManager := webhooks.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace, app.caConfigMapName)
 
 	app.promTLSConfig = webhooks.SetupPromTLS(app.servercertmanager)
 	app.serverTLSConfig = webhooks.SetupTLSForVirtHandlerServer(caManager, app.servercertmanager)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -114,12 +114,12 @@ type virtHandlerApp struct {
 	MaxRequestsInFlight       int
 	domainResyncPeriodSeconds int
 
-	caConfigMapName        string
-	clientCertFilePath     string
-	clientKeyFilePath      string
-	serverCertFilePath     string
-	serverKeyFilePath      string
-	allowIntermediateCerts bool
+	caConfigMapName    string
+	clientCertFilePath string
+	clientKeyFilePath  string
+	serverCertFilePath string
+	serverKeyFilePath  string
+	externallyManaged  bool
 
 	virtCli   kubecli.KubevirtClient
 	namespace string
@@ -413,8 +413,8 @@ func (app *virtHandlerApp) AddFlags() {
 	flag.StringVar(&app.serverKeyFilePath, "tls-key-file", defaultTlsKeyFilePath,
 		"File containing the default x509 private key matching --tls-cert-file")
 
-	flag.BoolVar(&app.allowIntermediateCerts, "allow-intermediate-certificates", false,
-		"Allow intermediate certificates to be used in building up the chain of trust in client certificate validation")
+	flag.BoolVar(&app.externallyManaged, "externally-managed", false,
+		"Allow intermediate certificates to be used in building up the chain of trust when certificates are externally managed")
 
 	flag.DurationVar(&app.WatchdogTimeoutDuration, "watchdog-timeout", defaultWatchdogTimeout,
 		"Watchdog file timeout")
@@ -441,8 +441,8 @@ func (app *virtHandlerApp) setupTLS(factory controller.KubeInformerFactory) erro
 	caManager := webhooks.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace, app.caConfigMapName)
 
 	app.promTLSConfig = webhooks.SetupPromTLS(app.servercertmanager)
-	app.serverTLSConfig = webhooks.SetupTLSForVirtHandlerServer(caManager, app.servercertmanager, app.allowIntermediateCerts)
-	app.clientTLSConfig = webhooks.SetupTLSForVirtHandlerClients(caManager, app.clientcertmanager, app.allowIntermediateCerts)
+	app.serverTLSConfig = webhooks.SetupTLSForVirtHandlerServer(caManager, app.servercertmanager, app.externallyManaged)
+	app.clientTLSConfig = webhooks.SetupTLSForVirtHandlerClients(caManager, app.clientcertmanager, app.externallyManaged)
 
 	return nil
 }

--- a/pkg/certificates/bootstrap/cert-manager.go
+++ b/pkg/certificates/bootstrap/cert-manager.go
@@ -28,7 +28,8 @@ type FileCertificateManager struct {
 	certAccessLock     sync.Mutex
 	stopped            bool
 	cert               *tls.Certificate
-	certDir            string
+	certBytesPath      string
+	keyBytesPath       string
 	errorRetryInterval time.Duration
 }
 
@@ -86,8 +87,13 @@ func (f *FallbackCertificateManager) ServerHealthy() bool {
 	return f.certManager.ServerHealthy()
 }
 
-func NewFileCertificateManager(certDir string) *FileCertificateManager {
-	return &FileCertificateManager{certDir: certDir, stopCh: make(chan struct{}, 1), errorRetryInterval: 1 * time.Minute}
+func NewFileCertificateManager(certBytesPath string, keyBytesPath string) *FileCertificateManager {
+	return &FileCertificateManager{
+		certBytesPath:      certBytesPath,
+		keyBytesPath:       keyBytesPath,
+		stopCh:             make(chan struct{}, 1),
+		errorRetryInterval: 1 * time.Minute,
+	}
 }
 
 func (f *FileCertificateManager) Start() {
@@ -97,9 +103,18 @@ func (f *FileCertificateManager) Start() {
 		log.DefaultLogger().Reason(err).Critical("Failed to create an inotify watcher")
 	}
 	defer watcher.Close()
-	err = watcher.Add(f.certDir)
+
+	certDir := filepath.Dir(f.certBytesPath)
+	err = watcher.Add(certDir)
 	if err != nil {
-		log.DefaultLogger().Reason(err).Criticalf("Failed to establish a watch on %s", f.certDir)
+		log.DefaultLogger().Reason(err).Criticalf("Failed to establish a watch on %s", certDir)
+	}
+	keyDir := filepath.Dir(f.keyBytesPath)
+	if keyDir != certDir {
+		err = watcher.Add(keyDir)
+		if err != nil {
+			log.DefaultLogger().Reason(err).Criticalf("Failed to establish a watch on %s", keyDir)
+		}
 	}
 
 	go func() {
@@ -118,7 +133,7 @@ func (f *FileCertificateManager) Start() {
 				if !ok {
 					return
 				}
-				log.DefaultLogger().Reason(err).Errorf("An error occured when watching %s", f.certDir)
+				log.DefaultLogger().Reason(err).Errorf("An error occured when watching certificates files %s and %s", f.certBytesPath, f.keyBytesPath)
 			}
 		}
 	}()
@@ -167,10 +182,9 @@ func (s *FileCertificateManager) Current() *tls.Certificate {
 }
 
 func (f *FileCertificateManager) rotateCerts() error {
-
-	crt, err := f.loadCertificates(f.certDir)
+	crt, err := f.loadCertificates()
 	if err != nil {
-		log.DefaultLogger().Reason(err).Infof("failed to load the certificate in %s", f.certDir)
+		log.DefaultLogger().Reason(err).Errorf("failed to load the certificate %s and %s", f.certBytesPath, f.keyBytesPath)
 		return err
 	}
 
@@ -179,20 +193,16 @@ func (f *FileCertificateManager) rotateCerts() error {
 	// update after the callback, to ensure that the reconfiguration succeeded
 	f.cert = crt
 
-	log.DefaultLogger().Infof("certificate from %s with common name '%s' retrieved.", f.certDir, crt.Leaf.Subject.CommonName)
+	log.DefaultLogger().Infof("certificate with common name '%s' retrieved.", crt.Leaf.Subject.CommonName)
 	return nil
 }
 
-func (s *FileCertificateManager) loadCertificates(certDir string) (serverCrt *tls.Certificate, err error) {
-
-	certBytesPath := filepath.Join(certDir, CertBytesValue)
-	keyBytesPath := filepath.Join(certDir, KeyBytesValue)
-
-	certBytes, err := ioutil.ReadFile(certBytesPath)
+func (f *FileCertificateManager) loadCertificates() (serverCrt *tls.Certificate, err error) {
+	certBytes, err := ioutil.ReadFile(f.certBytesPath)
 	if err != nil {
 		return nil, err
 	}
-	keyBytes, err := ioutil.ReadFile(keyBytesPath)
+	keyBytes, err := ioutil.ReadFile(f.keyBytesPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/webhooks/ca-manager.go
+++ b/pkg/util/webhooks/ca-manager.go
@@ -59,12 +59,12 @@ func NewKubernetesClientCAManager(configMapCache cache.Store) ClientCAManager {
 	}
 }
 
-func NewCAManager(configMapCache cache.Store, namespace string) ClientCAManager {
+func NewCAManager(configMapCache cache.Store, namespace string, configMapName string) ClientCAManager {
 	return &manager{
 		store:     configMapCache,
 		lock:      &sync.Mutex{},
 		namespace: namespace,
-		name:      "kubevirt-ca",
+		name:      configMapName,
 		secretKey: components.CABundleKey,
 	}
 }

--- a/pkg/util/webhooks/tls_test.go
+++ b/pkg/util/webhooks/tls_test.go
@@ -78,8 +78,8 @@ var _ = Describe("TLS", func() {
 	})
 
 	table.DescribeTable("on virt-handler should", func(serverSecret, clientSecret string, errStr string) {
-		serverTLSConfig := webhooks.SetupTLSForVirtHandlerServer(caManager, certmanagers[serverSecret])
-		clientTLSConfig := webhooks.SetupTLSForVirtHandlerClients(caManager, certmanagers[clientSecret])
+		serverTLSConfig := webhooks.SetupTLSForVirtHandlerServer(caManager, certmanagers[serverSecret], true)
+		clientTLSConfig := webhooks.SetupTLSForVirtHandlerClients(caManager, certmanagers[clientSecret], true)
 		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "hello")
 		}))
@@ -139,7 +139,7 @@ var _ = Describe("TLS", func() {
 
 	table.DescribeTable("should verify client and server certificates", func(serverSecret, clientSecret string, errStr string) {
 		serverTLSConfig := webhooks.SetupTLSWithCertManager(caManager, certmanagers[serverSecret], tls.RequireAndVerifyClientCert)
-		clientTLSConfig := webhooks.SetupTLSForVirtHandlerClients(caManager, certmanagers[clientSecret])
+		clientTLSConfig := webhooks.SetupTLSForVirtHandlerClients(caManager, certmanagers[clientSecret], true)
 		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(w, "hello")
 		}))

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -105,6 +105,7 @@ type virtAPIApp struct {
 	tlsKeyFilePath         string
 	handlerCertFilePath    string
 	handlerKeyFilePath     string
+	allowIntermediateCerts bool
 }
 
 var _ service.Service = &virtAPIApp{}
@@ -617,7 +618,7 @@ func (app *virtAPIApp) setupTLS(k8sCAManager webhooksutils.ClientCAManager, kube
 	// if the TLS handshake requests it. As a result, the TLS handshake fails
 	// and our aggregated endpoint never becomes available.
 	app.tlsConfig = webhooksutils.SetupTLSWithCertManager(k8sCAManager, app.certmanager, tls.VerifyClientCertIfGiven)
-	app.handlerTLSConfiguration = webhooksutils.SetupTLSForVirtHandlerClients(kubevirtCAManager, app.handlerCertManager)
+	app.handlerTLSConfiguration = webhooksutils.SetupTLSForVirtHandlerClients(kubevirtCAManager, app.handlerCertManager, app.allowIntermediateCerts)
 }
 
 func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory, stopCh <-chan struct{}) error {
@@ -727,4 +728,6 @@ func (app *virtAPIApp) AddFlags() {
 		"Client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
 	flag.StringVar(&app.handlerKeyFilePath, "handler-key-file", defaultHandlerKeyFilePath,
 		"Private key for the client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
+	flag.BoolVar(&app.allowIntermediateCerts, "allow-intermediate-certificates", false,
+		"Allow intermediate certificates to be used in building up the chain of trust in client certificate validation")
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -100,12 +100,12 @@ type virtAPIApp struct {
 	handlerTLSConfiguration *tls.Config
 	handlerCertManager      certificate2.Manager
 
-	caConfigMapName        string
-	tlsCertFilePath        string
-	tlsKeyFilePath         string
-	handlerCertFilePath    string
-	handlerKeyFilePath     string
-	allowIntermediateCerts bool
+	caConfigMapName     string
+	tlsCertFilePath     string
+	tlsKeyFilePath      string
+	handlerCertFilePath string
+	handlerKeyFilePath  string
+	externallyManaged   bool
 }
 
 var _ service.Service = &virtAPIApp{}
@@ -618,7 +618,7 @@ func (app *virtAPIApp) setupTLS(k8sCAManager webhooksutils.ClientCAManager, kube
 	// if the TLS handshake requests it. As a result, the TLS handshake fails
 	// and our aggregated endpoint never becomes available.
 	app.tlsConfig = webhooksutils.SetupTLSWithCertManager(k8sCAManager, app.certmanager, tls.VerifyClientCertIfGiven)
-	app.handlerTLSConfiguration = webhooksutils.SetupTLSForVirtHandlerClients(kubevirtCAManager, app.handlerCertManager, app.allowIntermediateCerts)
+	app.handlerTLSConfiguration = webhooksutils.SetupTLSForVirtHandlerClients(kubevirtCAManager, app.handlerCertManager, app.externallyManaged)
 }
 
 func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory, stopCh <-chan struct{}) error {
@@ -728,6 +728,6 @@ func (app *virtAPIApp) AddFlags() {
 		"Client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
 	flag.StringVar(&app.handlerKeyFilePath, "handler-key-file", defaultHandlerKeyFilePath,
 		"Private key for the client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
-	flag.BoolVar(&app.allowIntermediateCerts, "allow-intermediate-certificates", false,
-		"Allow intermediate certificates to be used in building up the chain of trust in client certificate validation")
+	flag.BoolVar(&app.externallyManaged, "externally-managed", false,
+		"Allow intermediate certificates to be used in building up the chain of trust when certificates are externally managed")
 }

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -66,6 +66,12 @@ const (
 	defaultHost = "0.0.0.0"
 
 	defaultConsoleServerPort = 8186
+
+	defaultCAConfigMapName     = "kubevirt-ca"
+	defaultTlsCertFilePath     = "/etc/virt-api/certificates/tls.crt"
+	defaultApiKeyFilePath      = "/etc/virt-api/certificates/tls.key"
+	defaultHandlerCertFilePath = "/etc/virt-handler/certificates/tls.crt"
+	defaultHandlerKeyFilePath  = "/etc/virt-handler/certificates/tls.key"
 )
 
 type VirtApi interface {
@@ -93,6 +99,12 @@ type virtAPIApp struct {
 	certmanager             certificate2.Manager
 	handlerTLSConfiguration *tls.Config
 	handlerCertManager      certificate2.Manager
+
+	caConfigMapName        string
+	tlsCertFilePath        string
+	tlsKeyFilePath         string
+	handlerCertFilePath    string
+	handlerKeyFilePath     string
 }
 
 var _ service.Service = &virtAPIApp{}
@@ -540,8 +552,8 @@ func (app *virtAPIApp) readRequestHeader() error {
 }
 
 func (app *virtAPIApp) prepareCertManager() {
-	app.certmanager = bootstrap.NewFileCertificateManager("/etc/virt-api/certificates")
-	app.handlerCertManager = bootstrap.NewFileCertificateManager("/etc/virt-handler/clientcertificates")
+	app.certmanager = bootstrap.NewFileCertificateManager(app.tlsCertFilePath, app.tlsKeyFilePath)
+	app.handlerCertManager = bootstrap.NewFileCertificateManager(app.handlerCertFilePath, app.handlerKeyFilePath)
 }
 
 func (app *virtAPIApp) registerValidatingWebhooks() {
@@ -616,7 +628,7 @@ func (app *virtAPIApp) startTLS(informerFactory controller.KubeInformerFactory, 
 	kubevirtCAConfigInformer := informerFactory.KubeVirtCAConfigMap()
 
 	k8sCAManager := webhooksutils.NewKubernetesClientCAManager(authConfigMapInformer.GetStore())
-	kubevirtCAInformer := webhooksutils.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace)
+	kubevirtCAInformer := webhooksutils.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace, app.caConfigMapName)
 
 	app.setupTLS(k8sCAManager, kubevirtCAInformer)
 
@@ -705,4 +717,14 @@ func (app *virtAPIApp) AddFlags() {
 		"Only serve subresource endpoints")
 	flag.IntVar(&app.consoleServerPort, "console-server-port", defaultConsoleServerPort,
 		"The port virt-handler listens on for console requests")
+	flag.StringVar(&app.caConfigMapName, "ca-configmap-name", defaultCAConfigMapName,
+		"The name of configmap containing CA certificates to authenticate requests presenting client certificates with matching CommonName")
+	flag.StringVar(&app.tlsCertFilePath, "tls-cert-file", defaultTlsCertFilePath,
+		"File containing the default x509 Certificate for HTTPS")
+	flag.StringVar(&app.tlsKeyFilePath, "tls-key-file", defaultApiKeyFilePath,
+		"File containing the default x509 private key matching --tls-cert-file")
+	flag.StringVar(&app.handlerCertFilePath, "handler-cert-file", defaultHandlerCertFilePath,
+		"Client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
+	flag.StringVar(&app.handlerKeyFilePath, "handler-key-file", defaultHandlerKeyFilePath,
+		"Private key for the client certificate used to prove the identity of the virt-api when it must call virt-handler during a request")
 }

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -77,6 +77,9 @@ const (
 
 	defaultLauncherSubGid                 = 107
 	defaultSnapshotControllerResyncPeriod = 5 * time.Minute
+
+	defaultPromCertFilePath = "/etc/virt-controller/certificates/tls.crt"
+	defaultPromKeyFilePath  = "/etc/virt-controller/certificates/tls.key"
 )
 
 var (
@@ -170,6 +173,10 @@ type VirtControllerApp struct {
 	launcherSubGid                    int64
 	snapshotControllerThreads         int
 	snapshotControllerResyncPeriod    time.Duration
+
+	caConfigMapName  string
+	promCertFilePath string
+	promKeyFilePath  string
 }
 
 var _ service.Service = &VirtControllerApp{}
@@ -298,7 +305,7 @@ func (vca *VirtControllerApp) Run() {
 
 	stop := vca.ctx.Done()
 
-	promCertManager := bootstrap.NewFileCertificateManager("/etc/virt-controller/certificates")
+	promCertManager := bootstrap.NewFileCertificateManager(vca.promCertFilePath, vca.promKeyFilePath)
 	go promCertManager.Start()
 	promTLSConfig := webhooks.SetupPromTLS(promCertManager)
 
@@ -542,4 +549,10 @@ func (vca *VirtControllerApp) AddFlags() {
 
 	flag.DurationVar(&vca.snapshotControllerResyncPeriod, "snapshot-controller-resync-period", defaultSnapshotControllerResyncPeriod,
 		"Number of goroutines to run for snapshot controller")
+
+	flag.StringVar(&vca.promCertFilePath, "prom-cert-file", defaultPromCertFilePath,
+		"Client certificate used to prove the identity of the virt-controller when it must call out Promethus during a request")
+
+	flag.StringVar(&vca.promKeyFilePath, "prom-key-file", defaultPromKeyFilePath,
+		"Private key for the client certificate used to prove the identity of the virt-controller when it must call out Promethus during a request")
 }

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -391,5 +391,5 @@ func (app *VirtOperatorApp) AddFlags() {
 }
 
 func (app *VirtOperatorApp) prepareCertManagers() {
-	app.operatorCertManager = bootstrap.NewFallbackCertificateManager(bootstrap.NewFileCertificateManager("/etc/virt-operator/certificates"))
+	app.operatorCertManager = bootstrap.NewFallbackCertificateManager(bootstrap.NewFileCertificateManager("/etc/virt-operator/certificates/tls.crt", "/etc/virt-operator/certificates/tls.key"))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This change is the first part of resolving #3648 

- Add flags (virt-handler and virt-api) to use different ConfigMap containing CA certificates, so that users can specify their own root CA.
- Add flags (virt-handler,virt-controller and virt-api) to allow users to configure the certificate and key file paths.
- Add flags (virt-handler and virt-api) to allow client's intermediate certs to be used in building up the chain of trust in cert validation.

Signed-off-by: Cheng Cheng chengcheng@apple.com

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3648

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
