### PR TITLE
WIP Allow cloud-init with networkData alone

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -223,9 +223,6 @@ func readCloudInitData(userData, userDataBase64, networkData, networkDataBase64 
 	if err != nil {
 		return "", "", err
 	}
-	if readUserData == "" {
-		return "", "", fmt.Errorf("userDataBase64 or userData is required for a cloud-init data source")
-	}
 
 	readNetworkData, err := readRawOrBase64Data(networkData, networkDataBase64)
 	if err != nil {
@@ -396,10 +393,14 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		return err
 	}
 
-	if data.UserData == "" {
-		return fmt.Errorf("UserData is required for cloud-init data source")
+	if data.UserData == "" && data.NetworkData == "" {
+		return fmt.Errorf("At least one source is required for cloud-init")
 	}
-	userData := []byte(data.UserData)
+
+	var userData []byte
+	if data.UserData != "" {
+		userData = []byte(data.UserData)
+	}
 
 	var networkData []byte
 	if data.NetworkData != "" {

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -322,13 +322,13 @@ var _ = Describe("CloudInit", func() {
 					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
 				})
 
-				It("should fail to verify networkData without userData", func() {
+				It("should succeed to verify networkData without userData", func() {
 					networkData := "FakeNetwork"
 					source := &v1.CloudInitNoCloudSource{
 						NetworkData: networkData,
 					}
 					_, err := readCloudInitNoCloudSource(source)
-					Expect(err).Should(MatchError("userDataBase64 or userData is required for a cloud-init data source"))
+					Expect(err).Should(Succeed())
 				})
 
 				Context("with secretRefs", func() {
@@ -433,13 +433,13 @@ var _ = Describe("CloudInit", func() {
 					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
 				})
 
-				It("should fail to verify networkData without userData", func() {
+				It("should succeed to verify networkData without userData", func() {
 					networkData := "FakeNetwork"
 					source := &v1.CloudInitConfigDriveSource{
 						NetworkData: networkData,
 					}
 					_, err := readCloudInitConfigDriveSource(source)
-					Expect(err).Should(MatchError("userDataBase64 or userData is required for a cloud-init data source"))
+					Expect(err).Should(Succeed())
 				})
 
 				Context("with secretRefs", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1288,10 +1288,10 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 				userDataLen = len(userData)
 			}
 
-			if userDataSourceCount != 1 {
+			if userDataSourceCount > 1 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("%s must have one exactly one userdata source set.", field.Index(idx).Child(dataSourceType).String()),
+					Message: fmt.Sprintf("%s must have only one userdata source set.", field.Index(idx).Child(dataSourceType).String()),
 					Field:   field.Index(idx).Child(dataSourceType).String(),
 				})
 			}
@@ -1336,6 +1336,14 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: fmt.Sprintf("%s networkdata exceeds %d byte limit. Should use NetworkDataSecretRef for larger data.", field.Index(idx).Child(dataSourceType).String(), cloudInitNetworkMaxLen),
+					Field:   field.Index(idx).Child(dataSourceType).String(),
+				})
+			}
+
+			if networkDataSourceCount+userDataSourceCount == 0 {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("%s must have at least one source set.", field.Index(idx).Child(dataSourceType).String()),
 					Field:   field.Index(idx).Child(dataSourceType).String(),
 				})
 			}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2149,6 +2149,12 @@ func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdata(containerImage string, 
 	return vmi
 }
 
+func NewRandomVMIWithEphemeralDiskAndNetworkData(containerImage, networkData string, b64encode bool) *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
+	AddCloudInitNoCloudData(vmi, "disk1", "", networkData, b64encode)
+	return vmi
+}
+
 func NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(containerImage, userData, networkData string, b64encode bool) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
 	AddCloudInitNoCloudData(vmi, "disk1", userData, networkData, b64encode)
@@ -2161,6 +2167,12 @@ func NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(containerIma
 	return vmi
 }
 
+func NewRandomVMIWithEphemeralDiskAndConfigDriveNetworkData(containerImage, networkData string, b64encode bool) *v1.VirtualMachineInstance {
+	vmi := NewRandomVMIWithEphemeralDisk(containerImage)
+	AddCloudInitConfigDriveData(vmi, "disk1", "", networkData, b64encode)
+	return vmi
+}
+
 func AddUserData(vmi *v1.VirtualMachineInstance, name string, userData string) {
 	AddCloudInitNoCloudData(vmi, name, userData, "", true)
 }
@@ -2168,12 +2180,16 @@ func AddUserData(vmi *v1.VirtualMachineInstance, name string, userData string) {
 func AddCloudInitNoCloudData(vmi *v1.VirtualMachineInstance, name, userData, networkData string, b64encode bool) {
 	cloudInitNoCloudSource := v1.CloudInitNoCloudSource{}
 	if b64encode {
-		cloudInitNoCloudSource.UserDataBase64 = base64.StdEncoding.EncodeToString([]byte(userData))
+		if userData != "" {
+			cloudInitNoCloudSource.UserDataBase64 = base64.StdEncoding.EncodeToString([]byte(userData))
+		}
 		if networkData != "" {
 			cloudInitNoCloudSource.NetworkDataBase64 = base64.StdEncoding.EncodeToString([]byte(networkData))
 		}
 	} else {
-		cloudInitNoCloudSource.UserData = userData
+		if userData != "" {
+			cloudInitNoCloudSource.UserData = userData
+		}
 		if networkData != "" {
 			cloudInitNoCloudSource.NetworkData = networkData
 		}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In the current code, we always require userData section in the
cloudInitNoCloud attribute. This however does not make sense when we
want to configure networking using a networkData section while we have
no reason to use userData. Due to that, we have to define at least an
empty userData section to silence the validation.

This patch drops this requirement and makes sure that at least one
source for cloud-init is provided, no matter which.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4033

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drop the requirerement for userData section in cloudInitNoCloud when networkData are provided.
```
