### PR TITLE
Create network `Service`s module tests + test `Service`s API in dual-stack network configs

### DIFF
--- a/tests/job.go
+++ b/tests/job.go
@@ -111,7 +111,7 @@ func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, time
 // which tries to contact the host on the provided port.
 // It expects to receive "Hello World!" to succeed.
 func NewHelloWorldJob(host string, port string) *batchv1.Job {
-	check := []string{fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)}
+	check := []string{fmt.Sprintf(`set -x; ping -c 1 %s; x="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, host, port)}
 	job := NewJob("netcat", []string{"/bin/bash", "-c"}, check, JobRetry, JobTTL, JobTimeout)
 	return job
 }

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -51,6 +51,18 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return New(NamespaceTestDefault, RandName(DefaultVmiName), opts...)
 }
 
+// NewCirros instantiates a new CirrOS based VMI configuration
+func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	cirrosOpts := []Option{
+		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
+		WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n", true),
+		WithResourceMemory("64M"),
+		WithTerminationGracePeriod(DefaultTestGracePeriod),
+	}
+	cirrosOpts = append(cirrosOpts, opts...)
+	return New(NamespaceTestDefault, RandName(DefaultVmiName), cirrosOpts...)
+}
+
 // defaultOptions returns a list of "default" options.
 func defaultOptions() []Option {
 	return []Option{

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -48,3 +48,13 @@ func InterfaceDeviceWithMasqueradeBinding() kvirtv1.Interface {
 		},
 	}
 }
+
+// InterfaceDeviceWithBridgeBinding returns an Interface named "default" with bridge binding.
+func InterfaceDeviceWithBridgeBinding() kvirtv1.Interface {
+	return kvirtv1.Interface{
+		Name: "default",
+		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
+			Bridge: &kvirtv1.InterfaceBridge{},
+		},
+	}
+}

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -26,5 +26,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "dual_stack_cluster.go",
         "framework.go",
         "primary_pod_network.go",
+        "services.go",
         "validation.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/network",
@@ -19,8 +20,10 @@ go_library(
         "//tests/libnet:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
     ],
 )

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/libnet:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -49,6 +49,32 @@ var _ = SIGDescribe("Services", func() {
 		return job
 	}
 
+	exposeExistingVMISpec := func(vmi *v1.VirtualMachineInstance, subdomain string, hostname string, selectorLabelKey string, selectorLabelValue string) *v1.VirtualMachineInstance {
+		vmi.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
+		vmi.Spec.Subdomain = subdomain
+		vmi.Spec.Hostname = hostname
+
+		return vmi
+	}
+
+	readyVMI := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+		_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		return tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+	}
+
+	cleanupVMI := func(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
+		By("Deleting the VMI")
+		Expect(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.GetName(), &k8smetav1.DeleteOptions{})).To(Succeed())
+
+		By("Waiting for the VMI to be gone")
+		Eventually(func() error {
+			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.GetName(), &k8smetav1.GetOptions{})
+			return err
+		}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
+	}
+
 	BeforeEach(func() {
 		var err error
 		virtClient, err = kubecli.GetKubevirtClient()
@@ -65,32 +91,29 @@ var _ = SIGDescribe("Services", func() {
 			servicePort        = 1500
 		)
 
+		createVMISpecWithBridgeInterface := func() *v1.VirtualMachineInstance {
+			return libvmi.NewCirros(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()))
+		}
+
+		createReadyVMIWithBridgeBindingAndExposedService := func(hostname string, subdomain string) *v1.VirtualMachineInstance {
+			return readyVMI(
+				exposeExistingVMISpec(
+					createVMISpecWithBridgeInterface(), subdomain, hostname, selectorLabelKey, selectorLabelValue))
+		}
+
 		BeforeEach(func() {
-			// inboundVMI expects implicitly to be added to the pod network
-			inboundVMI = libvmi.NewCirros()
-			inboundVMI.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
-			inboundVMI.Spec.Subdomain = "vmi"
-			inboundVMI.Spec.Hostname = "inbound"
+			subdomain := "vmi"
+			hostname := "inbound"
 
-			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(inboundVMI)
-			Expect(err).ToNot(HaveOccurred())
-
-			inboundVMI = tests.WaitUntilVMIReady(inboundVMI, tests.LoggedInCirrosExpecter)
-
+			inboundVMI = createReadyVMIWithBridgeBindingAndExposedService(hostname, subdomain)
 			tests.StartTCPServer(inboundVMI, servicePort)
 		})
 
 		AfterEach(func() {
-			if inboundVMI != nil {
-				By("Deleting the VMI")
-				Expect(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(inboundVMI.GetName(), &k8smetav1.DeleteOptions{})).To(Succeed())
-
-				By("Waiting for the VMI to be gone")
-				Eventually(func() error {
-					_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(inboundVMI.GetName(), &k8smetav1.GetOptions{})
-					return err
-				}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
-			}
+			Expect(inboundVMI).NotTo(BeNil(), "the VMI object must exist in order to be deleted.")
+			cleanupVMI(virtClient, inboundVMI)
 		})
 
 		Context("with a service matching the vmi exposed", func() {

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -1,0 +1,171 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/libvmi"
+)
+
+var _ = SIGDescribe("Services", func() {
+	var virtClient kubecli.KubevirtClient
+
+	runTCPClientExpectingHelloWorldFromServer := func(host, port, namespace string) *batchv1.Job {
+		job := tests.NewHelloWorldJob(host, port)
+		job, err := virtClient.BatchV1().Jobs(namespace).Create(job)
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		return job
+	}
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
+	})
+
+	Context("bridge interface binding", func() {
+		var inboundVMI *v1.VirtualMachineInstance
+		var serviceName string
+
+		const (
+			selectorLabelKey   = "expose"
+			selectorLabelValue = "me"
+			servicePort        = 1500
+		)
+
+		BeforeEach(func() {
+			// inboundVMI expects implicitly to be added to the pod network
+			inboundVMI = libvmi.NewCirros()
+			inboundVMI.Labels = map[string]string{selectorLabelKey: selectorLabelValue}
+			inboundVMI.Spec.Subdomain = "vmi"
+			inboundVMI.Spec.Hostname = "inbound"
+
+			_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(inboundVMI)
+			Expect(err).ToNot(HaveOccurred())
+
+			inboundVMI = tests.WaitUntilVMIReady(inboundVMI, tests.LoggedInCirrosExpecter)
+
+			tests.StartTCPServer(inboundVMI, servicePort)
+		})
+
+		AfterEach(func() {
+			if inboundVMI != nil {
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(inboundVMI.GetName(), &k8smetav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for the VMI to be gone")
+				Eventually(func() error {
+					_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(inboundVMI.GetName(), &k8smetav1.GetOptions{})
+					return err
+				}, 2*time.Minute, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())), "The VMI should be gone within the given timeout")
+			}
+		})
+
+		Context("with a service matching the vmi exposed", func() {
+			BeforeEach(func() {
+				serviceName = "myservice"
+
+				service := buildServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
+				_, err := virtClient.CoreV1().Services(inboundVMI.Namespace).Create(service)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				Expect(virtClient.CoreV1().Services(inboundVMI.Namespace).Delete(serviceName, &k8smetav1.DeleteOptions{})).To(Succeed())
+			})
+
+			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", func() {
+				By("starting a job which tries to reach the vmi via the defined service")
+				job := runTCPClientExpectingHelloWorldFromServer(fmt.Sprintf("%s.%s", serviceName, inboundVMI.Namespace), strconv.Itoa(servicePort), inboundVMI.Namespace)
+
+				By("waiting for the job to report a successful connection attempt")
+				tests.WaitForJobToSucceed(job, 90)
+			})
+
+			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", func() {
+
+				By("starting a job which tries to reach the vmi via a non-existent service")
+				job := runTCPClientExpectingHelloWorldFromServer(fmt.Sprintf("%s.%s", "wrongservice", inboundVMI.Namespace), strconv.Itoa(servicePort), inboundVMI.Namespace)
+
+				By("waiting for the job to report an  unsuccessful connection attempt")
+				tests.WaitForJobToFail(job, 90)
+			})
+		})
+
+		Context("with a subdomain and a headless service given", func() {
+			BeforeEach(func() {
+				serviceName = inboundVMI.Spec.Subdomain
+
+				service := buildHeadlessServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
+				_, err := virtClient.CoreV1().Services(inboundVMI.Namespace).Create(service)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				Expect(virtClient.CoreV1().Services(inboundVMI.Namespace).Delete(serviceName, &k8smetav1.DeleteOptions{})).To(Succeed())
+			})
+
+			It("[test_id:1549]should be able to reach the vmi via its unique fully qualified domain name", func() {
+				By("starting a job which tries to reach the vm via the defined service")
+				job := runTCPClientExpectingHelloWorldFromServer(fmt.Sprintf("%s.%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain, inboundVMI.Namespace), strconv.Itoa(servicePort), inboundVMI.Namespace)
+
+				By("waiting for the job to report a successful connection attempt")
+				tests.WaitForJobToSucceed(job, 90)
+			})
+		})
+	})
+})
+
+func buildHeadlessServiceSpec(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service {
+	service := buildServiceSpec(serviceName, exposedPort, portToExpose, selectorKey, selectorValue)
+	service.Spec.ClusterIP = k8sv1.ClusterIPNone
+	return service
+}
+
+func buildServiceSpec(serviceName string, exposedPort int, portToExpose int, selectorKey string, selectorValue string) *k8sv1.Service {
+	return &k8sv1.Service{
+		ObjectMeta: k8smetav1.ObjectMeta{
+			Name: serviceName,
+		},
+		Spec: k8sv1.ServiceSpec{
+			Selector: map[string]string{
+				selectorKey: selectorValue,
+			},
+			Ports: []k8sv1.ServicePort{
+				{Protocol: k8sv1.ProtocolTCP, Port: int32(portToExpose), TargetPort: intstr.FromInt(exposedPort)},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR refactors the networking tests a bit, exporting all the service related tests in `tests/vmi_networking`
to a dedicated module.

It then builds on this premise, by extending those tests (currently only executed on `Bridge` mode) to run
also on `Masquerade` binding mode.

The tests ran on `Masquerade` binding are ran in dual stack mode, when the test lane support that particular
networking configuration.

**Special notes for your reviewer**:
...

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
