### PR TITLE
Fix bug in virtctl upload when using PVC without any annotations.

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -503,6 +503,9 @@ func ensurePVCSupportsUpload(client kubernetes.Interface, pvc *v1.PersistentVolu
 	_, hasAnnotation := pvc.Annotations[uploadRequestAnnotation]
 
 	if !hasAnnotation {
+		if pvc.GetAnnotations() == nil {
+			pvc.SetAnnotations(make(map[string]string, 0))
+		}
 		pvc.Annotations[uploadRequestAnnotation] = ""
 		pvc, err = client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Update(pvc)
 		if err != nil {

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -97,6 +97,26 @@ var _ = Describe("ImageUpload", func() {
 		return pvc
 	}
 
+	pvcSpecNoAnnotationMap := func() *v1.PersistentVolumeClaim {
+		quantity, _ := resource.ParseQuantity(pvcSize)
+
+		pvc := &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dvName,
+				Namespace: "default",
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceStorage: quantity,
+					},
+				},
+			},
+		}
+
+		return pvc
+	}
+
 	pvcSpecWithUploadAnnotation := func() *v1.PersistentVolumeClaim {
 		spec := pvcSpec()
 		spec.Annotations = map[string]string{
@@ -356,6 +376,7 @@ var _ = Describe("ImageUpload", func() {
 		},
 			Entry("PVC with upload annotation", pvcSpecWithUploadAnnotation()),
 			Entry("PVC without upload annotation", pvcSpec()),
+			Entry("PVC without upload annotation and no annotation map", pvcSpecNoAnnotationMap()),
 		)
 
 		It("PVC exists deprecated args", func() {


### PR DESCRIPTION
In this case in code the annotations map is nil, and we attempted
to set a value in that nil map causing a crash of virtctl.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes a crash in virtctl upload-image when attempting to use a PVC that has no annotations on it. This causes the map to be nil and we tried to set a value in the nil map causing a crash. The PR checks for a nil map, and it creates one before attempting to set the value.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4032 crash

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
