### PR TITLE
tests, Adapt primary_pod_network and migration tests to be dual stack compatible

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "framework.go",
         "primary_pod_network.go",
+        "validation.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/network",
     visibility = ["//visibility:public"],
@@ -15,6 +16,7 @@ go_library(
         "//tests/containerdisk:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -49,10 +49,8 @@ var _ = SIGDescribe("Primary Pod Network", func() {
 			By("Getting pod of the VMI")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
 
-			By("Making sure IP reported on the VMI matches the one on the pod")
-			Expect(vmi.Status.Interfaces[0].IP).To(Equal(vmiPod.Status.PodIP))
-			Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
-			Expect(vmi.Status.Interfaces[0].IPs[0]).To(Equal(vmiPod.Status.PodIP))
+			By("Making sure IP/s reported on the VMI matches the ones on the pod")
+			Expect(ValidateVMIandPodIPMatch(vmi, vmiPod)).To(Succeed(), "Should have matching IP/s between pod and vmi")
 		}
 
 		Context("VMI connected to the pod network using the default (implicit) binding", func() {

--- a/tests/network/validation.go
+++ b/tests/network/validation.go
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package network
+
+import (
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+)
+
+// ValidateVMIandPodIPMatch Checks that the vmi pod and vmi scheme have matching Ip/Ips fields for primary interface
+func ValidateVMIandPodIPMatch(vmi *v1.VirtualMachineInstance, vmiPod *k8sv1.Pod) error {
+	if vmi.Status.Interfaces[0].IP != vmiPod.Status.PodIP {
+		return fmt.Errorf("VMI Status.Interfaces[0].IP %s does not equal pod's Status.PodIP %s",
+			vmi.Status.Interfaces[0].IP, vmiPod.Status.PodIP)
+	}
+
+	if len(vmi.Status.Interfaces[0].IPs) != len(vmiPod.Status.PodIPs) {
+		return fmt.Errorf("VMI Status.Interfaces[0].IPs %s len does not equal pod's Status.PodIPs %s len",
+			vmi.Status.Interfaces[0].IPs, vmiPod.Status.PodIPs)
+	}
+
+	if len(vmi.Status.Interfaces[0].IPs) == 0 {
+		return fmt.Errorf("VMI Status.Interfaces[0].IPs len is zero")
+	}
+
+	for i, ip := range vmiPod.Status.PodIPs {
+		if vmi.Status.Interfaces[0].IPs[i] != ip.IP {
+			return fmt.Errorf("VMI Status.Interfaces[0].IPs %s do not equal pod's Status.PodIPs %s",
+				vmi.Status.Interfaces[0].IPs, vmiPod.Status.PodIPs)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Create ValidateVMIandPodIPMatch
which validates the following:

virt-launcher PodIP equal vmi.Status.Interfaces[0].IP
virt-launcher PodIPs equal vmi.Status.Interfaces[0].IPs
Length of vmi.Status.Interfaces[0].IPs is not zero.

Use it in migration tests 1783, 3245 in order to support and test dual stack.

Adapt primary_pod_network tests to support dual stack.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
