### PR TITLE
tests, Fix networkpolicy tests and support them upstream

### DIFF
--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -54,6 +54,7 @@ var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		tests.PanicOnError(err)
 
 		tests.SkipIfUseFlannel(virtClient)
+		skipNetworkPolicyRunningOnKindInfra()
 		tests.BeforeTestCleanup()
 		// Create three vmis, vmia and vmib are in same namespace, vmic is in different namespace
 		vmia = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
@@ -208,3 +209,9 @@ var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	})
 
 })
+
+func skipNetworkPolicyRunningOnKindInfra() {
+	if tests.IsRunningOnKindInfra() {
+		Skip("Skip Network Policy tests till issue https://github.com/kubevirt/kubevirt/issues/4081 is fixed")
+	}
+}

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -54,7 +54,6 @@ var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		tests.PanicOnError(err)
 
 		tests.SkipIfUseFlannel(virtClient)
-		tests.SkipIfNotUseNetworkPolicy(virtClient)
 		tests.BeforeTestCleanup()
 		// Create three vmis, vmia and vmib are in same namespace, vmic is in different namespace
 		vmia = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3291,15 +3291,6 @@ func SkipIfUseFlannel(virtClient kubecli.KubevirtClient) {
 	}
 }
 
-func SkipIfNotUseNetworkPolicy(virtClient kubecli.KubevirtClient) {
-	expectedRes := "openshift-ovs-networkpolicy"
-	out, _, _ := RunCommand("kubectl", "get", "clusternetwork")
-	//we don't check the result here, because this cmd is openshift only and will be failed on k8s cluster
-	if !strings.Contains(out, expectedRes) {
-		Skip("Skip networkpolicy test that require openshift-ovs-networkpolicy plugin")
-	}
-}
-
 func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
 	var cpus int64
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2687,7 +2687,7 @@ func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpect
 
 	// Fetch the new VirtualMachineInstance with updated status
 	virtClient, err := kubecli.GetKubevirtClient()
-	vmi, err = virtClient.VirtualMachineInstance(NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 	// Lets make sure that the OS is up by waiting until we can login


### PR DESCRIPTION
Networkpolicy tests were skipped because when those tests were created, k8s didnt support them.
Now K8s does support them (2 years passed since).

Fixing Flakiness by using waiting for the nettwork policy to finish its async creation (using eventually on the ping).
Use PingFromVMConsole robust method.
Skip Kind providers, since its not supported on kubevirtci kind lanes out of the box.
Wait for Network Policy deletion, in order not to mix policies between tests.
Refactor tests.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
