### PR TITLE
gitignore: ignore files ending with ~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ manifests/**/*.tmp
 _ci-configs/
 .history
 hack/builder/manifests/
+*~


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a line to .gitignore to ignore filenames that end with a `~`.
Those are temporary files for editors like emacs and we do not want them included in PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
