### PR TITLE
Migration improvements

### DIFF
--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -176,6 +176,16 @@ func findGhostRecordBySocket(socketFile string) (ghostRecord, bool) {
 	return ghostRecord{}, false
 }
 
+func HasGhostRecord(namespace string, name string) bool {
+	ghostRecordGlobalMutex.Lock()
+	defer ghostRecordGlobalMutex.Unlock()
+
+	key := namespace + "/" + name
+	_, ok := ghostRecordGlobalCache[key]
+
+	return ok
+}
+
 func AddGhostRecord(namespace string, name string, socketFile string, uid types.UID) error {
 	ghostRecordGlobalMutex.Lock()
 	defer ghostRecordGlobalMutex.Unlock()
@@ -226,6 +236,10 @@ func AddGhostRecord(namespace string, name string, socketFile string, uid types.
 	// properly handle cleanup of local data.
 	if ok && record.UID != uid {
 		return fmt.Errorf("can not add ghost record when entry already exists with differing UID")
+	}
+
+	if ok && record.SocketFile != socketFile {
+		return fmt.Errorf("can not add ghost record when entry already exists with differing socket file location")
 	}
 
 	return nil

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -252,6 +252,8 @@ func FindSocketOnHost(vmi *v1.VirtualMachineInstance) (string, error) {
 		}
 	}
 
+	socketsFound := 0
+	foundSocket := ""
 	// It is possible for multiple pods to be active on a single VMI
 	// during migrations. This loop will discover the active pod on
 	// this particular local node if it exists. A active pod not
@@ -261,8 +263,15 @@ func FindSocketOnHost(vmi *v1.VirtualMachineInstance) (string, error) {
 		socket := SocketFilePathOnHost(string(podUID))
 		exists, _ := diskutils.FileExists(socket)
 		if exists {
-			return socket, nil
+			foundSocket = socket
+			socketsFound++
 		}
+	}
+
+	if socketsFound == 1 {
+		return foundSocket, nil
+	} else if socketsFound > 1 {
+		return "", fmt.Errorf("Found multiple sockets for vmi %s/%s. waiting for only one to exist", vmi.Namespace, vmi.Name)
 	}
 
 	return "", fmt.Errorf("No command socket found for vmi %s", vmi.UID)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1030,6 +1030,8 @@ func (d *VirtualMachineController) migrationTargetExecute(key string,
 	shouldAbort := false
 	// set to true when VirtualMachineInstance migration target needs to be prepared
 	shouldUpdate := false
+	// set true when the current migration target has exitted and needs to be cleaned up.
+	shouldCleanUp := false
 
 	if vmiExists && vmi.IsRunning() {
 		shouldUpdate = true
@@ -1039,6 +1041,11 @@ func (d *VirtualMachineController) migrationTargetExecute(key string,
 		shouldAbort = true
 	} else if vmi.IsFinal() {
 		shouldAbort = true
+	} else if d.hasStaleClientConnections(vmi) {
+		// if stale client exists, force cleanup.
+		// This can happen as a result of a previously
+		// failed attempt to migrate the vmi to this node.
+		shouldCleanUp = true
 	}
 
 	if shouldAbort {
@@ -1053,16 +1060,21 @@ func (d *VirtualMachineController) migrationTargetExecute(key string,
 		if err != nil {
 			return err
 		}
-	} else if shouldUpdate {
-		log.Log.Object(vmi).V(3).Info("Processing vmi migration target update")
-		vmiCopy := vmi.DeepCopy()
+	} else if shouldCleanUp {
+		log.Log.Object(vmi).Infof("Stale client for migration target found. Cleaning up.")
 
-		// if the vmi previous lived on this node, we need to make sure
-		// we aren't holding on to a previous client connection that is dead.
-		// THis function reaps the client connection if it is dead.
-		//
-		// A new client connection will be created on demand when needed
-		d.removeStaleClientConnections(vmi)
+		err := d.processVmCleanup(vmi)
+		if err != nil {
+			return err
+		}
+
+		// if we're still the migration target, we need to keep trying until the migration fails.
+		// it's possible we're simply waiting for another target pod to come online.
+		d.Queue.AddAfter(controller.VirtualMachineKey(vmi), time.Second*1)
+
+	} else if shouldUpdate {
+		log.Log.Object(vmi).Info("Processing vmi migration target update")
+		vmiCopy := vmi.DeepCopy()
 
 		// prepare the POD for the migration
 		err := d.processVmUpdate(vmi)
@@ -1720,30 +1732,20 @@ func (d *VirtualMachineController) processVmDelete(vmi *v1.VirtualMachineInstanc
 
 }
 
-func (d *VirtualMachineController) removeStaleClientConnections(vmi *v1.VirtualMachineInstance) {
-
+func (d *VirtualMachineController) hasStaleClientConnections(vmi *v1.VirtualMachineInstance) bool {
 	_, err := d.getVerifiedLauncherClient(vmi)
 	if err == nil {
 		// current client connection is good.
-		return
+		return false
 	}
 
-	// remove old stale client connection
-
-	// maps require locks for concurrent access
-	d.launcherClientLock.Lock()
-	defer d.launcherClientLock.Unlock()
-
-	clientInfo, ok := d.launcherClients[vmi.UID]
-	if !ok {
-		// no client connection to reap
-		return
+	// no connection, but ghost file exists.
+	if virtcache.HasGhostRecord(vmi.Namespace, vmi.Name) {
+		return true
 	}
 
-	if clientInfo.client != nil {
-		clientInfo.client.Close()
-	}
-	delete(d.launcherClients, vmi.UID)
+	return false
+
 }
 
 func (d *VirtualMachineController) getVerifiedLauncherClient(vmi *v1.VirtualMachineInstance) (client cmdclient.LauncherClient, err error) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1037,7 +1037,7 @@ func (d *VirtualMachineController) migrationTargetExecute(key string,
 		shouldUpdate = true
 	}
 
-	if !vmiExists && vmi.DeletionTimestamp != nil {
+	if !vmiExists || vmi.DeletionTimestamp != nil {
 		shouldAbort = true
 	} else if vmi.IsFinal() {
 		shouldAbort = true

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1080,6 +1080,52 @@ var _ = Describe("VirtualMachineInstance", func() {
 			controller.Execute()
 		}, 3)
 
+		// handles case where a failed migration to this node has left overs still on local storage
+		It("should clean stale clients when preparing migration target", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Running
+			vmi.Labels = make(map[string]string)
+			vmi.Status.NodeName = "othernode"
+			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetNode:   host,
+				SourceNode:   "othernode",
+				MigrationUID: "123",
+			}
+
+			stalePodUUID := uuid.NewUUID()
+			vmi = addActivePods(vmi, podTestUUID, host)
+			vmi = addActivePods(vmi, stalePodUUID, host)
+
+			mockWatchdog.CreateFile(vmi)
+			vmiFeeder.Add(vmi)
+
+			// Create stale socket ghost file
+			err := virtcache.AddGhostRecord(vmi.Namespace, vmi.Name, "made/up/path", vmi.UID)
+
+			exists := virtcache.HasGhostRecord(vmi.Namespace, vmi.Name)
+			Expect(exists).To(BeTrue())
+
+			// Create new socket
+			socketFile := cmdclient.SocketFilePathOnHost(string(podTestUUID))
+			os.RemoveAll(socketFile)
+			socket, err := net.Listen("unix", socketFile)
+			Expect(err).NotTo(HaveOccurred())
+			defer socket.Close()
+
+			client.EXPECT().Ping().Return(fmt.Errorf("disconnected"))
+			client.EXPECT().Close()
+
+			controller.Execute()
+
+			// ensure cleanup occurred of previous connection
+			exists = virtcache.HasGhostRecord(vmi.Namespace, vmi.Name)
+			Expect(exists).To(BeFalse())
+
+		}, 3)
+
 		It("should migrate vmi once target address is known", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1186,13 +1186,15 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 				By("Starting our migration killer pods")
 				nodes := tests.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-				for _, entry := range nodes.Items {
+				for idx, entry := range nodes.Items {
 					if entry.Name == vmi.Status.NodeName {
 						continue
 					}
 
+					podName := fmt.Sprintf("migration-killer-pod-%d", idx)
+
 					// kill the handler right as we detect the qemu target process come online
-					pod := tests.RenderPod(fmt.Sprintf("migration-killer-%s", entry.Name), []string{"/bin/bash", "-c"}, []string{"while true; do ps aux | grep \"[q]emu-kvm\" && pkill -9 virt-handler && exit 0; done"})
+					pod := tests.RenderPod(podName, []string{"/bin/bash", "-c"}, []string{"while true; do ps aux | grep \"[q]emu-kvm\" && pkill -9 virt-handler && exit 0; done"})
 					pod.Spec.NodeName = entry.Name
 					createdPod, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(pod)
 					Expect(err).ToNot(HaveOccurred(), "Should create helper pod")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1113,7 +1113,21 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 		})
 
 		Context("migration monitor", func() {
+			var createdPods []string
+			AfterEach(func() {
+				for _, podName := range createdPods {
+					Eventually(func() error {
+						err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(podName, &metav1.DeleteOptions{})
+
+						if err != nil && errors.IsNotFound(err) {
+							return nil
+						}
+						return err
+					}, 10*time.Second, 1*time.Second).Should(Succeed(), "Should delete helper pod")
+				}
+			})
 			BeforeEach(func() {
+				createdPods = []string{}
 				data := map[string]string{
 					"progressTimeout":         "5",
 					"completionTimeoutPerGiB": "5",
@@ -1147,6 +1161,70 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 
 				// check VMI, confirm migration state
 				confirmVMIPostMigrationFailed(vmi, migrationUID)
+
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			})
+
+			It(" Should detect a failed migration", func() {
+				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				expecter, expecterErr := tests.LoggedInFedoraExpecter(vmi)
+				Expect(expecterErr).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				// launch killer pod on every node that isn't the vmi's node
+				By("Starting our migration killer pods")
+				nodes := tests.GetAllSchedulableNodes(virtClient)
+				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+				for _, entry := range nodes.Items {
+					if entry.Name == vmi.Status.NodeName {
+						continue
+					}
+
+					pod := tests.RenderPod(fmt.Sprintf("migration-killer-%s", entry.Name), []string{"/bin/bash", "-c"}, []string{"while true; do ps aux | grep \"[q]emu-kvm\" && pkill -9 virt-handler && exit 0; done"})
+					pod.Spec.NodeName = entry.Name
+					createdPod, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(pod)
+					Expect(err).ToNot(HaveOccurred(), "Should create helper pod")
+
+					createdPods = append(createdPods, createdPod.Name)
+				}
+
+				// execute a migration, wait for finalized state
+				By("Starting the Migration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migrationUID := runMigrationAndExpectFailure(migration, 180)
+
+				// check VMI, confirm migration state
+				confirmVMIPostMigrationFailed(vmi, migrationUID)
+
+				By("Removing our migration killer pods")
+				for _, podName := range createdPods {
+					Eventually(func() error {
+						err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(podName, &metav1.DeleteOptions{})
+
+						if err != nil && errors.IsNotFound(err) {
+							return nil
+						}
+						return err
+					}, 10*time.Second, 1*time.Second).Should(Succeed(), "Should delete helper pod")
+				}
+
+				By("Starting new migration")
+				migration = tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migrationUID = runMigrationAndExpectCompletion(migration, migrationWaitTime)
+
+				By("Verifying Second Migration Succeeeds")
+				confirmVMIPostMigration(vmi, migrationUID)
 
 				// delete VMI
 				By("Deleting the VMI")


### PR DESCRIPTION

If a migration fails for any reason, and is tried again, we had a pretty good chance that subsequent migration would fail as well. The issue occurred when the migration retry target pod lands on the same node as the previous target pod that failed. What was happening is we were attempting to use stale clients and other information from the prior failed migration target for the new migration target

This PR contains... 
- fixes issues involved with not properly cleaning up stale data from previous migration pod before processing the next target pod for the same vmi.
- unit tests for all the situations identified. 
- functional test to verify we can succeed with retrying a migration after the initial migration fails.

Fixes #3990


```release-note
Improved reliability for failed migration retries
```
