### PR TITLE
Relabel clone device on virt handler

### DIFF
--- a/cmd/virt-chroot/main.go
+++ b/cmd/virt-chroot/main.go
@@ -172,7 +172,7 @@ func main() {
 	}
 
 	selinuxCmd.AddCommand(
-		NewGetEnforceCommand(),
+		NewGetEnforceCommand(), RelabelCommand(),
 	)
 
 	createTapCmd := NewCreateTapCommand()

--- a/cmd/virt-chroot/selinux.go
+++ b/cmd/virt-chroot/selinux.go
@@ -31,3 +31,30 @@ func NewGetEnforceCommand() *cobra.Command {
 	}
 	return cmd
 }
+
+func RelabelCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "relabel",
+		Short:     "relabel a file with the given selinux label, if the path is not labeled like this already",
+		Example:   "virt-chroot selinux relabel <new-label> <file-path>",
+		ValidArgs: nil,
+		Args:      cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			label := args[0]
+			filePath := args[1]
+
+			currentFileLabel, err := selinux.FileLabel(filePath)
+			if err != nil {
+				return fmt.Errorf("could not retrieve label of file %s. Reason: %v", filePath, err)
+			}
+
+			if currentFileLabel != label {
+				if err := selinux.Chcon(filePath, label, false); err != nil {
+					return fmt.Errorf("error relabeling file %s with label %s. Reason: %v", filePath, label, err)
+				}
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -332,7 +332,7 @@ func (app *virtHandlerApp) Run() {
 
 		// relabel tun device
 		unprivilegedContainerSELinuxLabel := "system_u:object_r:container_file_t:s0"
-		err = relabelFiles(unprivilegedContainerSELinuxLabel, "/dev/net/tun")
+		err = relabelFiles(unprivilegedContainerSELinuxLabel, "/dev/net/tun", "/dev/null")
 		if err != nil {
 			panic(fmt.Errorf("error relabeling required files: %v", err))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The selinux label of the clone device when running on rhcos is `container_runtime_tmpfs_t`. 

The current implementation of #3290 assumes the clone device will be labeled with `container_file_t`,
which grants access to the virt-launcher container without punching any holes in the selinux policy.

To make the current solution work on openshift, we need to relabel the clone device, thus aligning
the solution when deploying KubeVirt on Kubernetes, and on Openshift clusters.

This prevents the following AVC when running KubeVirt on an Openshift cluster (which uses RHCOS nodes):

```
    type=AVC msg=audit(1598344147.611:1088): avc:  denied  { read write }
    for  pid=968934 comm="virt-chroot" name="tun" dev="tmpfs" ino=56743408
    scontext=system_u:system_r:virt_launcher.process:s0:c434,c499
    tcontext=system_u:object_r:container_runtime_tmpfs_t:s0 \
    tclass=chr_file permissive=0
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4044

**Special notes for your reviewer**:
Currently the downstream nightly builds are blocked without this PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
