### PR TITLE
tests,libvmi: Append passed options

### DIFF
--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -40,13 +40,14 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	echo "fedora" |passwd fedora --stdin
 	echo `
 
-	opts = append(
+	fedoraOptions := append(
 		defaultOptions(),
 		WithResourceMemory("512M"),
 		WithRng(),
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedora)),
 		WithCloudInitNoCloudUserData(configurePassword, true),
 	)
+	opts = append(fedoraOptions, opts...)
 	return New(NamespaceTestDefault, RandName(DefaultVmiName), opts...)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The options that were being passed to the `libvmi.NewFedora` were ignored,
this append them at the end so they can override defaults.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
