### PR TITLE
tests, expecter: Move generic expecter code from ping.go to expecter.go

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,7 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "expecter.go",
         "job.go",
+        "login.go",
         "ping.go",
         "test.go",
         "utils.go",

--- a/tests/expecter.go
+++ b/tests/expecter.go
@@ -1,0 +1,226 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package tests
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	expect "github.com/google/goexpect"
+	"google.golang.org/grpc/codes"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+)
+
+const (
+	PromptExpression = `(\$ |\# )`
+	CRLF             = "\r\n"
+)
+
+var (
+	shellSuccess = regexp.MustCompile(RetValue("0"))
+	shellFail    = regexp.MustCompile(RetValue("[1-9].*"))
+)
+
+// VmiConsoleExpectBatch runs the batch from `expected` connecting to the `vmi` console and
+// wait `timeout` for the batch to return.
+// NOTE: there is a safer version that validates sended commands `CheckForTextExpecter` refer to it about limitations.
+func VmiConsoleExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, timeout time.Duration) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return err
+	}
+
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	defer expecter.Close()
+
+	resp, err := expecter.ExpectBatch(expected, timeout)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("%v", resp)
+	}
+	return err
+}
+
+// CheckForTextExpecter runs the batch from `expected` connecting to a VMI's console and
+// wait `timeout` for the batch to return, it also check that the sended commands arrives to console checking.
+// NOTE: This functions heritage limitations from `ExpectBatchWithValidatedSend` refer to it to check them.
+func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+	if err != nil {
+		return err
+	}
+	defer expecter.Close()
+
+	resp, err := ExpectBatchWithValidatedSend(expecter, expected, time.Second*time.Duration(wait))
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("%v", resp)
+	}
+	return err
+}
+
+// VmiConsoleRunCommand runs the command line from `command connecting to an already logged in console at vmi
+// and wait `timeout` for command to return.
+// NOTE: The safer version `ExpectBatchWithValidatedSend` is not used here since it does not support cases.
+func VmiConsoleRunCommand(vmi *v1.VirtualMachineInstance, command string, timeout time.Duration) error {
+	err := VmiConsoleExpectBatch(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: PromptExpression},
+		&expect.BSnd{S: command + "\n"},
+		&expect.BExp{R: PromptExpression},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BCas{C: []expect.Caser{
+			&expect.Case{
+				R: shellSuccess,
+				T: expect.OK(),
+			},
+			&expect.Case{
+				R: shellFail,
+				T: expect.Fail(expect.NewStatus(codes.Unavailable, command+" failed")),
+			},
+		}},
+	}, timeout)
+	if err != nil {
+		return fmt.Errorf("Failed to run [%s] at VMI %s, error: %v", command, vmi.Name, err)
+	}
+	return nil
+}
+
+func SecureBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	b := append([]expect.Batcher{
+		&expect.BExp{R: "secureboot: Secure boot enabled"},
+	})
+	res, err := expecter.ExpectBatch(b, 180*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
+		expecter.Close()
+		return expecter, err
+	}
+
+	return expecter, err
+}
+
+// NewConsoleExpecter will connect to an already logged in VMI console and return the generated expecter it will wait `timeout` for the connection.
+func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, timeout time.Duration, opts ...expect.Option) (expect.Expecter, <-chan error, error) {
+	vmiReader, vmiWriter := io.Pipe()
+	expecterReader, expecterWriter := io.Pipe()
+	resCh := make(chan error)
+
+	startTime := time.Now()
+	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout})
+	if err != nil {
+		return nil, nil, err
+	}
+	timeout = timeout - time.Now().Sub(startTime)
+
+	go func() {
+		resCh <- con.Stream(kubecli.StreamOptions{
+			In:  vmiReader,
+			Out: expecterWriter,
+		})
+	}()
+
+	opts = append(opts, expect.SendTimeout(timeout))
+	opts = append(opts, expect.Verbose(true))
+	opts = append(opts, expect.VerboseWriter(GinkgoWriter))
+	return expect.SpawnGeneric(&expect.GenOptions{
+		In:  vmiWriter,
+		Out: expecterReader,
+		Wait: func() error {
+			return <-resCh
+		},
+		Close: func() error {
+			expecterWriter.Close()
+			vmiReader.Close()
+			return nil
+		},
+		Check: func() bool { return true },
+	}, timeout, opts...)
+}
+
+// ExpectBatchWithValidatedSend adds the expect.BSnd command to the exect.BExp expression.
+// It is done to make sure the match was found in the result of the expect.BSnd
+// command and not in a leftover that wasn't removed from the buffer.
+// NOTE: the method contains the following limitations:
+//       - Use of `BatchSwitchCase`
+//       - Multiline commands
+//       - No more than one sequential send or receive
+func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
+	sendFlag := false
+	expectFlag := false
+	previousSend := ""
+	for i, batcher := range batch {
+		switch batcher.Cmd() {
+		case expect.BatchExpect:
+			if expectFlag == true {
+				return nil, fmt.Errorf("Two sequential expect.BExp are not allowed")
+			}
+			expectFlag = true
+			sendFlag = false
+			if _, ok := batch[i].(*expect.BExp); !ok {
+				return nil, fmt.Errorf("ExpectBatchWithValidatedSend support only expect of type BExp")
+			}
+			bExp, _ := batch[i].(*expect.BExp)
+			previousSend := regexp.QuoteMeta(previousSend)
+
+			// Remove the \n since it is translated by the console to \r\n.
+			previousSend = strings.TrimSuffix(previousSend, "\n")
+			bExp.R = fmt.Sprintf("%s%s%s", previousSend, "((?s).*)", bExp.R)
+			previousSend = ""
+		case expect.BatchSend:
+			if sendFlag == true {
+				return nil, fmt.Errorf("Two sequential expect.BSend are not allowed")
+			}
+			sendFlag = true
+			expectFlag = false
+			previousSend = batcher.Arg()
+		case expect.BatchSwitchCase:
+			return nil, fmt.Errorf("ExpectBatchWithValidatedSend doesn't support BatchSwitchCase")
+		default:
+			return nil, fmt.Errorf("Unkown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
+		}
+	}
+
+	res, err := expecter.ExpectBatch(batch, timeout)
+	return res, err
+}
+
+func RetValue(retcode string) string {
+	return "\n" + retcode + CRLF + ".*" + PromptExpression
+}
+
+type VMIExpecterFactory func(*v1.VirtualMachineInstance) (expect.Expecter, error)

--- a/tests/login.go
+++ b/tests/login.go
@@ -1,0 +1,194 @@
+package tests
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	v1 "kubevirt.io/client-go/api/v1"
+
+	expect "github.com/google/goexpect"
+	"google.golang.org/grpc/codes"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
+)
+
+// LoggedInCirrosExpecter return prepared and ready to use console expecter for
+// Alpine test VM
+func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	hostName := dns.SanitizeHostname(vmi)
+
+	// Do not login, if we already logged in
+	err = expecter.Send("\n")
+	if err != nil {
+		expecter.Close()
+		return nil, err
+	}
+	_, _, err = expecter.Expect(regexp.MustCompile(`\$`), 10*time.Second)
+	if err == nil {
+		return expecter, nil
+	}
+
+	b := append([]expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: "login as 'cirros' user. default password: 'gocubsgo'. use 'sudo' for root."},
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: hostName + " login:"},
+		&expect.BSnd{S: "cirros\n"},
+		&expect.BExp{R: "Password:"},
+		&expect.BSnd{S: "gocubsgo\n"},
+		&expect.BExp{R: "\\$"}})
+	resp, err := expecter.ExpectBatch(b, 180*time.Second)
+
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("Login: %v", resp)
+		expecter.Close()
+		return nil, err
+	}
+
+	err = configureConsole(expecter, "\\$ ", true)
+	if err != nil {
+		expecter.Close()
+		return nil, err
+	}
+
+	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\$ ")
+}
+
+// LoggedInAlpineExpecter return prepared and ready to use console expecter for
+// Alpine test VM
+func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	b := append([]expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: "localhost login:"},
+		&expect.BSnd{S: "root\n"},
+		&expect.BExp{R: "localhost:~\\#"}})
+	res, err := expecter.ExpectBatch(b, 180*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
+		expecter.Close()
+		return nil, err
+	}
+
+	err = configureConsole(expecter, "localhost:~\\#", false)
+	if err != nil {
+		expecter.Close()
+		return nil, err
+	}
+	return expecter, err
+}
+
+// LoggedInFedoraExpecter return prepared and ready to use console expecter for
+// Fedora test VM
+func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	b := append([]expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BSnd{S: "\n"},
+		&expect.BCas{C: []expect.Caser{
+			&expect.Case{
+				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
+				// and in case the VM's did not get hostname form DHCP server try the default hostname
+				R:  regexp.MustCompile(fmt.Sprintf(`(localhost|%s) login: `, vmi.Name)),
+				S:  "fedora\n",
+				T:  expect.Next(),
+				Rt: 10,
+			},
+			&expect.Case{
+				R:  regexp.MustCompile(`Password:`),
+				S:  "fedora\n",
+				T:  expect.Next(),
+				Rt: 10,
+			},
+			&expect.Case{
+				R:  regexp.MustCompile(`Login incorrect`),
+				T:  expect.LogContinue("Failed to log in", expect.NewStatus(codes.PermissionDenied, "login failed")),
+				Rt: 10,
+			},
+			&expect.Case{
+				R: regexp.MustCompile(`\$ `),
+				T: expect.OK(),
+			},
+		}},
+		&expect.BSnd{S: "sudo su\n"},
+		&expect.BExp{R: "\\#"},
+	})
+	res, err := expecter.ExpectBatch(b, 3*time.Minute)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
+		expecter.Close()
+		return expecter, err
+	}
+
+	err = configureConsole(expecter, "\\#", false)
+	if err != nil {
+		expecter.Close()
+		return nil, err
+	}
+
+	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\#")
+}
+
+// ReLoggedInFedoraExpecter return prepared and ready to use console expecter for
+// Fedora test VM, when you are reconnecting (no login needed)
+func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expect.Expecter, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	b := append([]expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: "#"}})
+	res, err := expecter.ExpectBatch(b, time.Duration(timeout)*time.Second)
+	if err != nil {
+		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
+		expecter.Close()
+		return expecter, err
+	}
+	return expecter, err
+}
+
+func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) error {
+	sudoString := ""
+	if shouldSudo {
+		sudoString = "sudo "
+	}
+	batch := append([]expect.Batcher{
+		&expect.BSnd{S: "stty cols 500 rows 500\n"},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: RetValue("0")},
+		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
+		&expect.BExp{R: prompt},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: RetValue("0")}})
+	resp, err := expecter.ExpectBatch(batch, 30*time.Second)
+	if err != nil {
+		log.DefaultLogger().Infof("%v", resp)
+	}
+	return err
+}

--- a/tests/ping.go
+++ b/tests/ping.go
@@ -21,23 +21,14 @@ package tests
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
-	expect "github.com/google/goexpect"
-	"google.golang.org/grpc/codes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
-)
-
-var (
-	shellSuccess = regexp.MustCompile(RetValue("0"))
-	shellFail    = regexp.MustCompile(RetValue("[1-9].*"))
 )
 
 // PingFromVMConsole performs a ping through the provided VMI console.
@@ -56,48 +47,13 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 		args = []string{"-c 1", "-w 5"}
 	}
 	args = append([]string{pingString, ipAddr}, args...)
-	cmdCheck := strings.Join(args, " ") + "\n"
+	cmdCheck := strings.Join(args, " ")
 
-	err := vmiConsoleExpectBatch(vmi, []expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: cmdCheck},
-		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BCas{C: []expect.Caser{
-			&expect.Case{
-				R: shellSuccess,
-				T: expect.OK(),
-			},
-			&expect.Case{
-				R: shellFail,
-				T: expect.Fail(expect.NewStatus(codes.Unavailable, "ping failed")),
-			},
-		}},
-	}, maxCommandTimeout)
+	err := VmiConsoleRunCommand(vmi, cmdCheck, maxCommandTimeout)
 	if err != nil {
 		return fmt.Errorf("Failed to ping VMI %s, error: %v", vmi.Name, err)
 	}
 	return nil
-}
-
-func vmiConsoleExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, timeout time.Duration) error {
-	virtClient, err := kubecli.GetKubevirtClient()
-	if err != nil {
-		return err
-	}
-
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
-	if err != nil {
-		return err
-	}
-	defer expecter.Close()
-
-	resp, err := expecter.ExpectBatch(expected, timeout)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("%v", resp)
-	}
-	return err
 }
 
 // PingAppJob performs a netcat check (tcp by default) using a pod.

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -41,7 +41,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -56,7 +55,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
-	"google.golang.org/grpc/codes"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -92,7 +90,6 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/util/cluster"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	launcherApi "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -242,11 +239,6 @@ type ObjectEventWatcher struct {
 	startType              startType
 	dontFailOnMissingEvent bool
 }
-
-const (
-	PromptExpression = `(\$ |\# )`
-	CRLF             = "\r\n"
-)
 
 func NewObjectEventWatcher(object runtime.Object) *ObjectEventWatcher {
 	return &ObjectEventWatcher{object: object, startType: invalidWatch}
@@ -2760,124 +2752,6 @@ func RenderPod(name string, cmd []string, args []string) *k8sv1.Pod {
 	return &pod
 }
 
-func NewConsoleExpecter(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance, timeout time.Duration, opts ...expect.Option) (expect.Expecter, <-chan error, error) {
-	vmiReader, vmiWriter := io.Pipe()
-	expecterReader, expecterWriter := io.Pipe()
-	resCh := make(chan error)
-
-	startTime := time.Now()
-	con, err := virtCli.VirtualMachineInstance(vmi.Namespace).SerialConsole(vmi.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: timeout})
-	if err != nil {
-		return nil, nil, err
-	}
-	timeout = timeout - time.Now().Sub(startTime)
-
-	go func() {
-		resCh <- con.Stream(kubecli.StreamOptions{
-			In:  vmiReader,
-			Out: expecterWriter,
-		})
-	}()
-
-	opts = append(opts, expect.SendTimeout(timeout))
-	opts = append(opts, expect.Verbose(true))
-	opts = append(opts, expect.VerboseWriter(GinkgoWriter))
-	return expect.SpawnGeneric(&expect.GenOptions{
-		In:  vmiWriter,
-		Out: expecterReader,
-		Wait: func() error {
-			return <-resCh
-		},
-		Close: func() error {
-			expecterWriter.Close()
-			vmiReader.Close()
-			return nil
-		},
-		Check: func() bool { return true },
-	}, timeout, opts...)
-}
-
-// ExpectBatchWithValidatedSend adds the expect.BSnd command to the exect.BExp expression.
-// It is done to make sure the match was found in the result of the expect.BSnd
-// command and not in a leftover that wasn't removed from the buffer.
-// NOTE: the method doesn't support multiline commands in the sent value.
-func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
-	sendFlag := false
-	expectFlag := false
-	previousSend := ""
-	for i, batcher := range batch {
-		switch batcher.Cmd() {
-		case expect.BatchExpect:
-			if expectFlag == true {
-				return nil, fmt.Errorf("Two sequential expect.BExp are not allowed")
-			}
-			expectFlag = true
-			sendFlag = false
-			if _, ok := batch[i].(*expect.BExp); !ok {
-				return nil, fmt.Errorf("ExpectBatchWithValidatedSend support only expect of type BExp")
-			}
-			bExp, _ := batch[i].(*expect.BExp)
-			previousSend := regexp.QuoteMeta(previousSend)
-
-			// Remove the \n since it is translated by the console to \r\n.
-			previousSend = strings.TrimSuffix(previousSend, "\n")
-			bExp.R = fmt.Sprintf("%s%s%s", previousSend, "((?s).*)", bExp.R)
-			previousSend = ""
-		case expect.BatchSend:
-			if sendFlag == true {
-				return nil, fmt.Errorf("Two sequential expect.BSend are not allowed")
-			}
-			sendFlag = true
-			expectFlag = false
-			previousSend = batcher.Arg()
-		case expect.BatchSwitchCase:
-			return nil, fmt.Errorf("ExpectBatchWithValidatedSend doesn't support BatchSwitchCase")
-		default:
-			return nil, fmt.Errorf("Unkown command: ExpectBatchWithValidatedSend supports only BatchExpect and BatchSend")
-		}
-	}
-
-	res, err := expecter.ExpectBatch(batch, timeout)
-	return res, err
-}
-
-func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
-	if err != nil {
-		return err
-	}
-	defer expecter.Close()
-
-	resp, err := ExpectBatchWithValidatedSend(expecter, expected, time.Second*time.Duration(wait))
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("%v", resp)
-	}
-	return err
-}
-
-func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) error {
-	sudoString := ""
-	if shouldSudo {
-		sudoString = "sudo "
-	}
-	batch := append([]expect.Batcher{
-		&expect.BSnd{S: "stty cols 500 rows 500\n"},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")},
-		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
-		&expect.BExp{R: prompt},
-		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")}})
-	resp, err := expecter.ExpectBatch(batch, 30*time.Second)
-	if err != nil {
-		log.DefaultLogger().Infof("%v", resp)
-	}
-	return err
-}
-
 func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter, virtClient kubecli.KubevirtClient, prompt string) error {
 	hasEth0Iface := func() bool {
 		hasNetEth0Batch := append([]expect.Batcher{
@@ -2943,188 +2817,6 @@ func configureIPv6OnVMI(vmi *v1.VirtualMachineInstance, expecter expect.Expecter
 
 	return nil
 }
-
-func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-	if err != nil {
-		return nil, err
-	}
-	hostName := dns.SanitizeHostname(vmi)
-
-	// Do not login, if we already logged in
-	err = expecter.Send("\n")
-	if err != nil {
-		expecter.Close()
-		return nil, err
-	}
-	_, _, err = expecter.Expect(regexp.MustCompile(`\$`), 10*time.Second)
-	if err == nil {
-		return expecter, nil
-	}
-
-	b := append([]expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: "login as 'cirros' user. default password: 'gocubsgo'. use 'sudo' for root."},
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: hostName + " login:"},
-		&expect.BSnd{S: "cirros\n"},
-		&expect.BExp{R: "Password:"},
-		&expect.BSnd{S: "gocubsgo\n"},
-		&expect.BExp{R: "\\$"}})
-	resp, err := expecter.ExpectBatch(b, 180*time.Second)
-
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Login: %v", resp)
-		expecter.Close()
-		return nil, err
-	}
-
-	err = configureConsole(expecter, "\\$ ", true)
-	if err != nil {
-		expecter.Close()
-		return nil, err
-	}
-
-	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\$ ")
-}
-
-func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-	if err != nil {
-		return nil, err
-	}
-
-	b := append([]expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: "localhost login:"},
-		&expect.BSnd{S: "root\n"},
-		&expect.BExp{R: "localhost:~\\#"}})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Login: %v", res)
-		expecter.Close()
-		return nil, err
-	}
-
-	err = configureConsole(expecter, "localhost:~\\#", false)
-	if err != nil {
-		expecter.Close()
-		return nil, err
-	}
-	return expecter, err
-}
-
-// LoggedInFedoraExpecter return prepared and ready to use console expecter for
-// Fedora test VM
-func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-	if err != nil {
-		return nil, err
-	}
-	b := append([]expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BSnd{S: "\n"},
-		&expect.BCas{C: []expect.Caser{
-			&expect.Case{
-				// In case the VM's did not get hostname form DHCP server try the default hostname
-				R:  regexp.MustCompile(`localhost login: `),
-				S:  "fedora\n",
-				T:  expect.Next(),
-				Rt: 10,
-			},
-			&expect.Case{
-				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
-				R:  regexp.MustCompile(vmi.Name + ` login: `),
-				S:  "fedora\n",
-				T:  expect.Next(),
-				Rt: 10,
-			},
-			&expect.Case{
-				R:  regexp.MustCompile(`Password:`),
-				S:  "fedora\n",
-				T:  expect.Next(),
-				Rt: 10,
-			},
-			&expect.Case{
-				R:  regexp.MustCompile(`Login incorrect`),
-				T:  expect.LogContinue("Failed to log in", expect.NewStatus(codes.PermissionDenied, "login failed")),
-				Rt: 10,
-			},
-			&expect.Case{
-				R: regexp.MustCompile(`\$ `),
-				T: expect.OK(),
-			},
-		}},
-		&expect.BSnd{S: "sudo su\n"},
-		&expect.BExp{R: "\\#"},
-	})
-	res, err := expecter.ExpectBatch(b, 3*time.Minute)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
-		expecter.Close()
-		return expecter, err
-	}
-
-	err = configureConsole(expecter, "\\#", false)
-	if err != nil {
-		expecter.Close()
-		return nil, err
-	}
-
-	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient, "\\#")
-}
-
-// ReLoggedInFedoraExpecter return prepared and ready to use console expecter for
-// Fedora test VM, when you are reconnecting (no login needed)
-func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expect.Expecter, error) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-	if err != nil {
-		return nil, err
-	}
-	b := append([]expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: "#"}})
-	res, err := expecter.ExpectBatch(b, time.Duration(timeout)*time.Second)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
-		expecter.Close()
-		return expecter, err
-	}
-	return expecter, err
-}
-
-func SecureBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
-	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
-	if err != nil {
-		return nil, err
-	}
-	b := append([]expect.Batcher{
-		&expect.BExp{R: "secureboot: Secure boot enabled"},
-	})
-	res, err := expecter.ExpectBatch(b, 180*time.Second)
-	if err != nil {
-		log.DefaultLogger().Object(vmi).Infof("Login: %+v", res)
-		expecter.Close()
-		return expecter, err
-	}
-
-	return expecter, err
-}
-
-type VMIExpecterFactory func(*v1.VirtualMachineInstance) (expect.Expecter, error)
-
 func NewVirtctlCommand(args ...string) *cobra.Command {
 	commandline := []string{}
 	master := flag.Lookup("master").Value
@@ -5012,8 +4704,4 @@ func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 		return true
 	}
 	return false
-}
-
-func RetValue(retcode string) string {
-	return "\n" + retcode + CRLF + ".*" + PromptExpression
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There are some generic useful expecter code at ping.go this move that into it's
own expecter.go file and also creates a function `VmiConsoleRunCommand` to do
a simple run and check expecter execution at a already logged in VMI.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
