### PR TITLE
tests, networkpolicy: Add some tier1 http tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -193,6 +193,7 @@ go_test(
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/libnet:go_default_library",
+        "//tests/libvmi:go_default_library",
         "//tests/network:go_default_library",
         "//tests/reporter:go_default_library",
         "//tools/vms-generator/utils:go_default_library",

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -40,11 +40,12 @@ func WithNetwork(network *kvirtv1.Network) Option {
 }
 
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
-func InterfaceDeviceWithMasqueradeBinding() kvirtv1.Interface {
+func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{
 		Name: "default",
 		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
 			Masquerade: &kvirtv1.InterfaceMasquerade{},
 		},
+		Ports: ports,
 	}
 }

--- a/tests/login.go
+++ b/tests/login.go
@@ -15,6 +15,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 )
 
+// LoginToCirros call LoggedInFedoraExpecter but does not return the expecter
+func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
+	expecter, err := LoggedInCirrosExpecter(vmi)
+	defer expecter.Close()
+	return err
+}
+
 // LoggedInCirrosExpecter return prepared and ready to use console expecter for
 // Alpine test VM
 func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -1,173 +1,233 @@
 package tests_test
 
 import (
+	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1network "k8s.io/api/networking/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
-
-	var virtClient kubecli.KubevirtClient
-
-	var vmia *v1.VirtualMachineInstance
-	var vmib *v1.VirtualMachineInstance
-	var vmic *v1.VirtualMachineInstance
-
-	tests.BeforeAll(func() {
+	var (
+		virtClient                                          kubecli.KubevirtClient
+		serverVMI, clientVMI, clientVMIAlternativeNamespace *v1.VirtualMachineInstance
+		serverVMILabels                                     = map[string]string{"type": "test"}
+	)
+	BeforeEach(func() {
 		var err error
-
 		virtClient, err = kubecli.GetKubevirtClient()
-		tests.PanicOnError(err)
+		Expect(err).ToNot(HaveOccurred(), "should succeed retrieving the kubevirt client")
 
 		tests.SkipIfUseFlannel(virtClient)
 		skipNetworkPolicyRunningOnKindInfra()
-		tests.BeforeTestCleanup()
-
-		// Create three vmis, vmia and vmib are in same namespace, vmic is in different namespace
-		vmia = createVMICirros(virtClient, tests.NamespaceTestDefault, map[string]string{"type": "test"})
-		vmib = createVMICirros(virtClient, tests.NamespaceTestDefault, map[string]string{})
-		vmic = createVMICirros(virtClient, tests.NamespaceTestAlternative, map[string]string{})
-
-		vmia = tests.WaitUntilVMIReady(vmia, tests.LoggedInCirrosExpecter)
-		vmib = tests.WaitUntilVMIReady(vmib, tests.LoggedInCirrosExpecter)
-		vmic = tests.WaitUntilVMIReady(vmic, tests.LoggedInCirrosExpecter)
-	})
-
-	Context("vms limited by Default-deny networkpolicy", func() {
-		var policy *v1network.NetworkPolicy
-
-		BeforeEach(func() {
-			// deny-by-default networkpolicy will deny all the traffice to the vms in the namespace
-			By("Create deny-by-default networkpolicy")
-			networkpolicy := &v1network.NetworkPolicy{
-				ObjectMeta: v13.ObjectMeta{
-					Name: "deny-by-default",
-				},
-				Spec: v1network.NetworkPolicySpec{
-					PodSelector: v13.LabelSelector{},
-					Ingress:     []v1network.NetworkPolicyIngressRule{},
-				},
-			}
-			var err error
-			policy, err = virtClient.NetworkingV1().NetworkPolicies(vmia.Namespace).Create(networkpolicy)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			waitForNetworkPolicyDeletion(policy)
-		})
-
-		It("[test_id:1511] should be failed to reach vmia from vmib", func() {
-			By("Connect vmia from vmib")
-			assertPingFail(vmib, vmia)
-		})
-
-		It("[test_id:1512] should be failed to reach vmib from vmia", func() {
-			By("Connect vmib from vmia")
-			assertPingFail(vmia, vmib)
-		})
 
 	})
+	Context("when three cirros VMs with default networking are started and serverVMI start an HTTP server on port 80 and 81", func() {
+		tests.BeforeAll(func() {
+			tests.BeforeTestCleanup()
 
-	Context("vms limited by allow same namespace networkpolicy", func() {
-		var policy *v1network.NetworkPolicy
+			// Create three vmis, serverVMI and clientVMI are in same namespace, clientVMIAlternativeNamespace is in different namespace
+			serverVMI = createVMICirros(virtClient,
+				tests.NamespaceTestDefault,
+				serverVMILabels,
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(
+					v1.Port{
+						Name:     "http80",
+						Port:     80,
+						Protocol: "TCP",
+					},
+					v1.Port{
+						Name:     "http81",
+						Port:     81,
+						Protocol: "TCP",
+					},
+				)),
+			)
+			clientVMI = createVMICirros(virtClient, tests.NamespaceTestDefault, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
+			clientVMIAlternativeNamespace = createVMICirros(virtClient, tests.NamespaceTestAlternative, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 
-		BeforeEach(func() {
-			// allow-same-namespave networkpolicy will only allow the traffice inside the namespace
-			By("Create allow-same-namespace networkpolicy")
-			networkpolicy := &v1network.NetworkPolicy{
-				ObjectMeta: v13.ObjectMeta{
-					Name: "allow-same-namespace",
-				},
-				Spec: v1network.NetworkPolicySpec{
-					PodSelector: v13.LabelSelector{},
-					Ingress: []v1network.NetworkPolicyIngressRule{
+			serverVMI = tests.WaitUntilVMIReady(serverVMI, tests.LoggedInCirrosExpecter)
+			clientVMI = tests.WaitUntilVMIReady(clientVMI, tests.LoggedInCirrosExpecter)
+			clientVMIAlternativeNamespace = tests.WaitUntilVMIReady(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
+
+			By("Start HTTP server at serverVMI on ports 80 and 81")
+			tests.HTTPServer.Start(serverVMI, 80)
+			tests.HTTPServer.Start(serverVMI, 81)
+
+			assertIPsNotEmptyForVMI(serverVMI)
+			assertIPsNotEmptyForVMI(clientVMI)
+			assertIPsNotEmptyForVMI(clientVMIAlternativeNamespace)
+
+		})
+
+		Context("and connectivity between VMI/s is blocked by Default-deny networkpolicy", func() {
+			var policy *networkv1.NetworkPolicy
+
+			BeforeEach(func() {
+				// deny-by-default networkpolicy will deny all the traffic to the vms in the namespace
+				policy = createNetworkPolicy(serverVMI.Namespace, "deny-by-default", metav1.LabelSelector{}, []networkv1.NetworkPolicyIngressRule{})
+			})
+
+			AfterEach(func() {
+				waitForNetworkPolicyDeletion(policy)
+			})
+
+			It("[test_id:1511] should fail to reach serverVMI from clientVMI", func() {
+				By("Connect serverVMI from clientVMI")
+				assertPingFail(clientVMI, serverVMI)
+			})
+
+			It("[test_id:1512] should fail to reach clientVMI from serverVMI", func() {
+				By("Connect clientVMI from serverVMI")
+				assertPingFail(serverVMI, clientVMI)
+			})
+			It("[test_id:369] should deny http traffic for ports 80/81 from clientVMI to serverVMI", func() {
+				assertHTTPPingFailed(clientVMI, serverVMI, 80)
+				assertHTTPPingFailed(clientVMI, serverVMI, 81)
+			})
+
+		})
+
+		Context("and vms limited by allow same namespace networkpolicy", func() {
+			var policy *networkv1.NetworkPolicy
+
+			BeforeEach(func() {
+				// allow-same-namespace networkpolicy will only allow the traffic inside the namespace
+				By("Create allow-same-namespace networkpolicy")
+				policy = createNetworkPolicy(serverVMI.Namespace, "allow-same-namespace", metav1.LabelSelector{},
+					[]networkv1.NetworkPolicyIngressRule{
 						{
-							From: []v1network.NetworkPolicyPeer{
+							From: []networkv1.NetworkPolicyPeer{
 								{
-									PodSelector: &v13.LabelSelector{},
+									PodSelector: &metav1.LabelSelector{},
 								},
 							},
 						},
 					},
-				},
-			}
-			var err error
-			policy, err = virtClient.NetworkingV1().NetworkPolicies(vmia.Namespace).Create(networkpolicy)
-			Expect(err).ToNot(HaveOccurred())
+				)
+
+			})
+
+			AfterEach(func() {
+				waitForNetworkPolicyDeletion(policy)
+			})
+
+			It("[test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
+				assertPingSucceed(clientVMI, serverVMI)
+			})
+
+			It("[test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
+				assertPingFail(clientVMIAlternativeNamespace, serverVMI)
+			})
+
 		})
 
-		AfterEach(func() {
-			waitForNetworkPolicyDeletion(policy)
+		Context("and ingress traffic to VMI identified via label at networkprofile's labelSelector is blocked", func() {
+			var policy *networkv1.NetworkPolicy
+
+			BeforeEach(func() {
+				// deny-by-label networkpolicy will deny the traffic for the vm which have the same label
+				By("Create deny-by-label networkpolicy")
+				policy = &networkv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: serverVMI.Namespace,
+						Name:      "deny-by-label",
+					},
+					Spec: networkv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{
+							MatchLabels: serverVMILabels,
+						},
+						Ingress: []networkv1.NetworkPolicyIngressRule{},
+					},
+				}
+				policy = createNetworkPolicy(serverVMI.Namespace, "deny-by-label", metav1.LabelSelector{MatchLabels: serverVMILabels}, []networkv1.NetworkPolicyIngressRule{})
+			})
+
+			AfterEach(func() {
+				waitForNetworkPolicyDeletion(policy)
+			})
+
+			It("[test_id:1515] should fail to reach serverVMI from clientVMIAlternativeNamespace", func() {
+				By("Connect serverVMI from clientVMIAlternativeNamespace")
+				assertPingFail(clientVMIAlternativeNamespace, serverVMI)
+			})
+
+			It("[test_id:1516] should fail to reach serverVMI from clientVMI", func() {
+				By("Connect serverVMI from clientVMI")
+				assertPingFail(clientVMI, serverVMI)
+			})
+
+			It("[test_id:1517] should success to reach clientVMI from clientVMIAlternativeNamespace", func() {
+				By("Connect clientVMI from clientVMIAlternativeNamespace")
+				assertPingSucceed(clientVMIAlternativeNamespace, clientVMI)
+			})
+
 		})
-
-		It("[test_id:1513] should be successful to reach vmia from vmib", func() {
-			By("Connect vmia from vmib in same namespace")
-			assertPingSucceed(vmib, vmia)
-		})
-
-		It("[test_id:1514] should be failed to reach vmia from vmic", func() {
-			By("Connect vmia from vmic in differnet namespace")
-			assertPingFail(vmic, vmia)
-		})
-
-	})
-
-	Context("vms limited by deny by label networkpolicy", func() {
-		var policy *v1network.NetworkPolicy
-
-		BeforeEach(func() {
-			// deny-by-label networkpolicy will deny the traffice for the vm which have the same label
-			By("Create deny-by-label networkpolicy")
-			networkpolicy := &v1network.NetworkPolicy{
-				ObjectMeta: v13.ObjectMeta{
-					Name: "deny-by-label",
-				},
-				Spec: v1network.NetworkPolicySpec{
-					PodSelector: v13.LabelSelector{
-						MatchLabels: map[string]string{
-							"type": "test",
+		Context("and TCP connectivity on ports 80 and 81 between VMI/s is allowed by networkpolicy", func() {
+			var policy *networkv1.NetworkPolicy
+			BeforeEach(func() {
+				port80 := intstr.FromInt(80)
+				port81 := intstr.FromInt(81)
+				tcp := corev1.ProtocolTCP
+				policy = createNetworkPolicy(serverVMI.Namespace, "allow-all-http-ports", metav1.LabelSelector{},
+					[]networkv1.NetworkPolicyIngressRule{
+						{
+							Ports: []networkv1.NetworkPolicyPort{
+								{Port: &port80, Protocol: &tcp},
+								{Port: &port81, Protocol: &tcp},
+							},
 						},
 					},
-					Ingress: []v1network.NetworkPolicyIngressRule{},
-				},
-			}
-			var err error
-			policy, err = virtClient.NetworkingV1().NetworkPolicies(vmia.Namespace).Create(networkpolicy)
-			Expect(err).ToNot(HaveOccurred())
+				)
+			})
+			AfterEach(func() {
+				waitForNetworkPolicyDeletion(policy)
+			})
+			It("[test_id:2774] should allow http traffic for ports 80 and 81 from clientVMI to serverVMI", func() {
+				assertHTTPPingSucceed(clientVMI, serverVMI, 80)
+				assertHTTPPingSucceed(clientVMI, serverVMI, 81)
+			})
 		})
-
-		AfterEach(func() {
-			waitForNetworkPolicyDeletion(policy)
-		})
-
-		It("[test_id:1515] should be failed to reach vmia from vmic", func() {
-			By("Connect vmia from vmic")
-			assertPingFail(vmic, vmia)
-		})
-
-		It("[test_id:1516] should be failed to reach vmia from vmib", func() {
-			By("Connect vmia from vmib")
-			assertPingFail(vmib, vmia)
-		})
-
-		It("[test_id:1517] should be successful to reach vmib from vmic", func() {
-			By("Connect vmib from vmic")
-			assertPingSucceed(vmic, vmib)
+		Context("and TCP connectivity on ports 80 between VMI/s is allowed by networkpolicy", func() {
+			var policy *networkv1.NetworkPolicy
+			BeforeEach(func() {
+				port80 := intstr.FromInt(80)
+				tcp := corev1.ProtocolTCP
+				policy = createNetworkPolicy(serverVMI.Namespace, "allow-http80-ports", metav1.LabelSelector{},
+					[]networkv1.NetworkPolicyIngressRule{
+						{
+							Ports: []networkv1.NetworkPolicyPort{
+								{Port: &port80, Protocol: &tcp},
+							},
+						},
+					},
+				)
+			})
+			AfterEach(func() {
+				waitForNetworkPolicyDeletion(policy)
+			})
+			It("[test_id:2775] should allow http traffic at port 80 and deny at port 81 from clientVMI to serverVMI", func() {
+				assertHTTPPingSucceed(clientVMI, serverVMI, 80)
+				assertHTTPPingFailed(clientVMI, serverVMI, 81)
+			})
 		})
 
 	})
-
 })
 
 func skipNetworkPolicyRunningOnKindInfra() {
@@ -176,11 +236,19 @@ func skipNetworkPolicyRunningOnKindInfra() {
 	}
 }
 
-func createVMICirros(virtClient kubecli.KubevirtClient, namespace string, labels map[string]string) *v1.VirtualMachineInstance {
+func createVMICirros(virtClient kubecli.KubevirtClient, namespace string, labels map[string]string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	var err error
 	vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 	vmi.Namespace = namespace
 	vmi.Labels = labels
+
+	// Clean up interfaces since we configure them with `libvmi.Option`
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{}
+
+	for _, opt := range opts {
+		opt(vmi)
+	}
+
 	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -188,7 +256,6 @@ func createVMICirros(virtClient kubecli.KubevirtClient, namespace string, labels
 }
 
 func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
-	ExpectWithOffset(1, toVmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 	ConsistentlyWithOffset(1, func() error {
 		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
 			if err := tests.PingFromVMConsole(fromVmi, toIp); err != nil {
@@ -200,7 +267,6 @@ func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
 }
 
 func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
-	ExpectWithOffset(1, toVmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
 	EventuallyWithOffset(1, func() error {
 		var err error
@@ -223,7 +289,28 @@ func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
 	}, 5*time.Second, 1*time.Second).ShouldNot(Succeed())
 }
 
-func waitForNetworkPolicyDeletion(policy *v1network.NetworkPolicy) {
+func createNetworkPolicy(namespace, name string, labelSelector metav1.LabelSelector, ingress []networkv1.NetworkPolicyIngressRule) *networkv1.NetworkPolicy {
+	policy := &networkv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: networkv1.NetworkPolicySpec{
+			PodSelector: labelSelector,
+			Ingress:     ingress,
+		},
+	}
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("Create networkpolicy %s/%s", policy.Namespace, policy.Name))
+	policy, err = virtClient.NetworkingV1().NetworkPolicies(policy.Namespace).Create(policy)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), fmt.Sprintf("should succeed creating network policy %s/%s", policy.Namespace, policy.Name))
+	return policy
+}
+
+func waitForNetworkPolicyDeletion(policy *networkv1.NetworkPolicy) {
 	if policy == nil {
 		return
 	}
@@ -231,9 +318,58 @@ func waitForNetworkPolicyDeletion(policy *v1network.NetworkPolicy) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-	ExpectWithOffset(1, virtClient.NetworkingV1().NetworkPolicies(policy.Namespace).Delete(policy.Name, &v13.DeleteOptions{})).To(Succeed())
+	ExpectWithOffset(1, virtClient.NetworkingV1().NetworkPolicies(policy.Namespace).Delete(policy.Name, &metav1.DeleteOptions{})).To(Succeed())
 	EventuallyWithOffset(1, func() error {
-		_, err := virtClient.NetworkingV1().NetworkPolicies(policy.Namespace).Get(policy.Name, v13.GetOptions{})
+		_, err := virtClient.NetworkingV1().NetworkPolicies(policy.Namespace).Get(policy.Name, metav1.GetOptions{})
 		return err
 	}, 10*time.Second, time.Second).Should(SatisfyAll(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())))
+}
+
+func assertHTTPPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance, port int) {
+	ConsistentlyWithOffset(1, checkHTTPPingAndStopOnFailure(fromVmi, toVmi, port), 10*time.Second, time.Second).Should(Succeed())
+}
+
+func assertHTTPPingFailed(vmiFrom, vmiTo *v1.VirtualMachineInstance, port int) {
+	EventuallyWithOffset(1, checkHTTPPingAndStopOnSucceed(vmiFrom, vmiTo, port), 10*time.Second, time.Second).ShouldNot(Succeed())
+	ConsistentlyWithOffset(1, checkHTTPPingAndStopOnSucceed(vmiFrom, vmiTo, port), 10*time.Second, time.Second).ShouldNot(Succeed())
+}
+
+func checkHTTPPingAndStopOnSucceed(fromVmi, toVmi *v1.VirtualMachineInstance, port int) func() error {
+	return func() error {
+		var err error
+		for _, ip := range toVmi.Status.Interfaces[0].IPs {
+			err = checkHTTPPing(fromVmi, ip, port)
+			if err == nil {
+				return nil
+			}
+		}
+		return err
+	}
+}
+
+func checkHTTPPingAndStopOnFailure(fromVmi, toVmi *v1.VirtualMachineInstance, port int) func() error {
+	return func() error {
+		for _, ip := range toVmi.Status.Interfaces[0].IPs {
+			err := checkHTTPPing(fromVmi, ip, port)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func checkHTTPPing(vmi *v1.VirtualMachineInstance, ip string, port int) error {
+	const curlCheckCmd = "curl --head %s --connect-timeout 5\n"
+	url := fmt.Sprintf("http://%s", net.JoinHostPort(ip, strconv.Itoa(port)))
+	curlCheck := fmt.Sprintf(curlCheckCmd, url)
+	err := tests.VmiConsoleRunCommand(vmi, curlCheck, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed HTTP ping from vmi(%s/%s) to url(%s): %v", vmi.Namespace, vmi.Name, url, err)
+	}
+	return nil
+}
+
+func assertIPsNotEmptyForVMI(vmi *v1.VirtualMachineInstance) {
+	ExpectWithOffset(1, vmi.Status.Interfaces[0].IPs).ToNot(BeEmpty(), "should contain a not empy list of ip addresses")
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2708,22 +2708,6 @@ func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpect
 	return vmi
 }
 
-func WaitUntilVMIReadyWithNamespace(namespace string, vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) *v1.VirtualMachineInstance {
-	// Wait for VirtualMachineInstance start
-	WaitForSuccessfulVMIStart(vmi)
-
-	// Fetch the new VirtualMachineInstance with updated status
-	virtClient, err := kubecli.GetKubevirtClient()
-	vmi, err = virtClient.VirtualMachineInstance(namespace).Get(vmi.Name, &metav1.GetOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-	// Lets make sure that the OS is up by waiting until we can login
-	expecter, err := expecterFactory(vmi)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	expecter.Close()
-	return vmi
-}
-
 func NewInt32(x int32) *int32 {
 	return &x
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

   
    
To support calico certification, new network policy related tests that check HTTP port
connectivity were added:
- Check deny all policy blocks HTTP connectivity between VMIs at specific ports
- Check allow ports policy allow HTTP connectivity on those ports
- Check alow some ports policy blocks HTTP connectivity at different ports


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
