### PR TITLE
Fix verifying make targets

### DIFF
--- a/hack/verify-generate.sh
+++ b/hack/verify-generate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+    echo "ERROR: git tree state is not clean!"
+    echo "You probably need to run 'make generate' or 'make' and commit the changes"
+    exit 1
+fi


### PR DESCRIPTION
Make evaluates conditions in the preprocessing phase - before any target
is executed. It means that we will not be able to detect the changes
made by make or make generate in a make condition.

This change fixes this issue by moving the check into a dedicated script
and calling it from the verifying targets.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
