### PR TITLE
Make goveralls verbose, match goveralls settings in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ coverage:
 	hack/dockerized "./hack/coverage.sh ${WHAT}"
 
 goveralls: go-build
-	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN_FILE=${COVERALLS_TOKEN_FILE} COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BUILD_NUMBER=${BUILD_ID} CI_BRANCH=${PULL_BASE_REF} CI_PULL_REQUEST=${PULL_NUMBER} ./hack/goveralls.sh"
+	SYNC_OUT=false hack/dockerized "COVERALLS_TOKEN_FILE=${COVERALLS_TOKEN_FILE} COVERALLS_TOKEN=${COVERALLS_TOKEN} CI_NAME=prow CI_BRANCH=${PULL_REFS} CI_PR_NUMBER=${PULL_NUMBER} ./hack/goveralls.sh"
 
 go-test: go-build
 	SYNC_OUT=false hack/dockerized "./hack/build-go.sh test ${WHAT}"

--- a/hack/goveralls.sh
+++ b/hack/goveralls.sh
@@ -3,4 +3,4 @@
 set -e
 
 ./hack/coverage.sh
-goveralls -service=prow -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)
+goveralls -v -debug -service=${CI_NAME} -coverprofile=.coverprofile -ignore=$(find -regextype posix-egrep -regex ".*generated_mock.*\.go|.*swagger_generated\.go|.*openapi_generated\.go" -printf "%P\n" | paste -d, -s)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use prow `PULL_REFS` to indicate the branch for goveralls, so that it can
pick up the right branch.

For goveralls env vars:
- replace `CI_PULL_REQUEST` with `CI_PR_NUMBER`,
- remove `CI_BUILD_NUMBER` as it's not used,
- set debug and verbose flags.

Also set goveralls debug and verbose flags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes lemurheavy/coveralls-public#1480

**Special notes for your reviewer**:
- goveralls: https://github.com/mattn/goveralls/
- https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
