### PR TITLE
Output what the openapi error is when an api violation occurs

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -24,6 +24,7 @@ openapi-gen --input-dirs kubevirt.io/client-go/apis/snapshot/v1alpha1,k8s.io/api
 if cmp ${KUBEVIRT_DIR}/api/api-rule-violations.list ${KUBEVIRT_DIR}/api/api-rule-violations-known.list; then
     echo "openapi generated"
 else
+    diff ${KUBEVIRT_DIR}/api/api-rule-violations.list ${KUBEVIRT_DIR}/api/api-rule-violations-known.list
     echo "You introduced new API rule violation"
     exit 2
 fi


### PR DESCRIPTION
Gives error output when api violation occurs so the developer has an indication of what needs to be solved. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
