### PR TITLE
Change state label to be human readable

### DIFF
--- a/pkg/monitoring/vms/prometheus/BUILD.bazel
+++ b/pkg/monitoring/vms/prometheus/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
+        "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )
 
@@ -38,5 +39,6 @@ go_test(
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, `kubevirt_vmi_vcpu_seconds` exposes the vcpu state as an Integer, that corresponds to one of [libvirtd's vcpu states](https://github.com/libvirt/libvirt-go/blob/v6.5.0/domain.go#L838-L842). When filtering or aggregating metrics around the state label, having it exposed as a human-readable state makes it a lot easier to understand, and thus, easier to get the desired information.

This PR changes kubevirt_vmi_vcpu_seconds' state label to a human-readable string

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3486

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Metric kubevirt_vmi_vcpu_seconds' state label is now exposed as a human-readable state instead of an integer
```
