### PR TITLE
Fix a (potential) copy-paste error and (try to) re-enable the certificate tests

### DIFF
--- a/pkg/virt-operator/creation/components/webhooks.go
+++ b/pkg/virt-operator/creation/components/webhooks.go
@@ -429,7 +429,7 @@ const VirtApiServiceName = "virt-api"
 
 const VirtControllerServiceName = "virt-controller"
 
-const VirtHandlerServiceName = "virt-controller"
+const VirtHandlerServiceName = "virt-handler"
 
 const VirtAPIValidatingWebhookName = "virt-api-validator"
 

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -79,8 +79,7 @@ var _ = Describe("Infrastructure", func() {
 			tests.BeforeTestCleanup()
 		})
 
-		// Flaky, randomly fails with timeout
-		PIt("[test_id:4099] [flaky] should be rotated when a new CA is created", func() {
+		It("[test_id:4099] should be rotated when a new CA is created", func() {
 			By("checking that the config-map gets the new CA bundle attached")
 			Eventually(func() int {
 				_, crts := tests.GetBundleFromConfigMap(components.KubeVirtCASecretName)
@@ -144,8 +143,7 @@ var _ = Describe("Infrastructure", func() {
 			defer expecter.Close()
 		})
 
-		// Flaky, randomly fails with timeout
-		PIt("[test_id:4100] [flaky] should be valid during the whole rotation process", func() {
+		It("[test_id:4100] should be valid during the whole rotation process", func() {
 			oldAPICert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
 			oldHandlerCert := tests.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-handler"), flags.KubeVirtInstallNamespace, "8186")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
I found an odd assignment (`VirtHandlerServiceName = "virt-controller"`) in the code.
That constant is used for certificate objects, so it could have been causing the flakyness on the certificate tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
