### PR TITLE
virt-operator: on update, roll over daemonsets first, then controllers

### DIFF
--- a/pkg/virt-operator/install-strategy/create.go
+++ b/pkg/virt-operator/install-strategy/create.go
@@ -2553,9 +2553,10 @@ func SyncAll(queue workqueue.RateLimitingInterface, kv *v1.KubeVirt, prevStrateg
 	if takeUpdatePath {
 		// UPDATE PATH IS
 		// 1. daemonsets - ensures all compute nodes are updated to handle new features
-		// 2. controllers - ensures controll plane is ready for new features
-		// 3. wait for daemonsets and controllers to roll over
-		// 4. apiserver - toggles on new features.
+		// 2. wait for daemonsets to roll over
+		// 3. controllers - ensures controll plane is ready for new features
+		// 4. wait for controllers to roll over
+		// 5. apiserver - toggles on new features.
 
 		// create/update Daemonsets
 		for _, daemonSet := range targetStrategy.daemonSets {
@@ -2563,6 +2564,12 @@ func SyncAll(queue workqueue.RateLimitingInterface, kv *v1.KubeVirt, prevStrateg
 			if err != nil {
 				return false, err
 			}
+		}
+
+		// wait for daemonsets
+		if !daemonSetsRolledOver {
+			// not rolled out yet
+			return false, nil
 		}
 
 		// create/update Controller Deployments
@@ -2577,8 +2584,8 @@ func SyncAll(queue workqueue.RateLimitingInterface, kv *v1.KubeVirt, prevStrateg
 			}
 		}
 
-		// wait for daemonsets and controllers
-		if !daemonSetsRolledOver || !controllerDeploymentsRolledOver {
+		// wait for controllers
+		if !controllerDeploymentsRolledOver {
 			// not rolled out yet
 			return false, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR make virt-operator update daemonsets first, then controllers, instead of both a the same time.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
