### PR TITLE
tests, skip migration fail test on kind ipv6 provider

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1175,6 +1175,8 @@ var _ = Describe("[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system
 			})
 
 			It(" Should detect a failed migration", func() {
+				tests.SkipMigrationFailTestIfRunningOnKindInfraIPv6()
+
 				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4870,6 +4870,12 @@ func SkipSELinuxTestIfRunnigOnKindInfra() {
 	}
 }
 
+func SkipMigrationFailTestIfRunningOnKindInfraIPv6() {
+	if IsRunningOnKindInfraIPv6() {
+		Skip("Skip Migration fail test till issue https://github.com/kubevirt/kubevirt/issues/4086 is fixed")
+	}
+}
+
 func SkipDmidecodeTestIfRunningOnKindInfraIPv6() {
 	if IsRunningOnKindInfraIPv6() {
 		Skip("Skip dmidecode tests till issue https://github.com/kubevirt/kubevirt/issues/3901 is fixed")


### PR DESCRIPTION
The test is relatively new and very flaky, causing CI to stall merges.
Current effort is to support dual stack on proper k8s
provider, so this one will be skipped.

See https://github.com/kubevirt/kubevirt/issues/4086

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
