### PR TITLE
Add events for vmi failed render

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -574,6 +574,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 
 		templatePod, err := c.templateService.RenderLaunchManifest(vmi)
 		if _, ok := err.(services.PvcNotFoundError); ok {
+			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedPvcNotFoundReason, "failed to render launch manifest: %v", err)
 			return &syncErrorImpl{fmt.Errorf("failed to render launch manifest: %v", err), FailedPvcNotFoundReason}
 		} else if err != nil {
 			return &syncErrorImpl{fmt.Errorf("failed to render launch manifest: %v", err), FailedCreatePodReason}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -550,6 +550,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						),
 					),
 				)
+
+				testutils.ExpectEvent(recorder, FailedPvcNotFoundReason)
 			}
 
 			vmi := NewPendingVirtualMachine("testvmi")


### PR DESCRIPTION
**What this PR does / why we need it**:

Add event to VMI when a referenced VMI does not exist. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1829066

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
