### PR TITLE
Fixes Operator Issues blocking v0.33.0 release

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8106,8 +8106,21 @@
     }
    },
    "v1.Patch": {
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
-    "type": "object"
+    "type": "object",
+    "properties": {
+     "patch": {
+      "type": "string"
+     },
+     "resourceName": {
+      "type": "string"
+     },
+     "resourceType": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
    },
    "v1.PersistentVolumeClaim": {
     "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",

--- a/pkg/virt-operator/install-strategy/create_test.go
+++ b/pkg/virt-operator/install-strategy/create_test.go
@@ -296,4 +296,42 @@ var _ = Describe("Create", func() {
 			table.Entry("should allow empty strings", "", true),
 		)
 	})
+
+	Context("Injecting Metadata", func() {
+
+		It("should set expected values", func() {
+
+			kv := &v1.KubeVirt{}
+			kv.Status.TargetKubeVirtRegistry = Registry
+			kv.Status.TargetKubeVirtVersion = Version
+			kv.Status.TargetDeploymentID = Id
+
+			deployment := appsv1.Deployment{}
+			injectOperatorMetadata(kv, &deployment.ObjectMeta, "fakeversion", "fakeregistry", "fakeid")
+
+			// NOTE we are purposfully not using the defined constant values
+			// in types.go here. This test is explicitly verifying that those
+			// values in types.go that we depend on for virt-operator updates
+			// do not change. This is meant to preserve backwards and forwards
+			// compatibility
+
+			managedBy, ok := deployment.Labels["app.kubernetes.io/managed-by"]
+
+			Expect(ok).To(BeTrue())
+			Expect(managedBy).To(Equal("kubevirt-operator"))
+
+			version, ok := deployment.Annotations["kubevirt.io/install-strategy-version"]
+			Expect(ok).To(BeTrue())
+			Expect(version).To(Equal("fakeversion"))
+
+			registry, ok := deployment.Annotations["kubevirt.io/install-strategy-registry"]
+			Expect(ok).To(BeTrue())
+			Expect(registry).To(Equal("fakeregistry"))
+
+			id, ok := deployment.Annotations["kubevirt.io/install-strategy-identifier"]
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal("fakeid"))
+
+		})
+	})
 })

--- a/pkg/virt-operator/install-strategy/create_test.go
+++ b/pkg/virt-operator/install-strategy/create_test.go
@@ -307,7 +307,7 @@ var _ = Describe("Create", func() {
 			kv.Status.TargetDeploymentID = Id
 
 			deployment := appsv1.Deployment{}
-			injectOperatorMetadata(kv, &deployment.ObjectMeta, "fakeversion", "fakeregistry", "fakeid")
+			injectOperatorMetadata(kv, &deployment.ObjectMeta, "fakeversion", "fakeregistry", "fakeid", false)
 
 			// NOTE we are purposfully not using the defined constant values
 			// in types.go here. This test is explicitly verifying that those

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -645,10 +645,15 @@ func (c *KubeVirtController) execute(key string) error {
 	operatorutil.SetConditionTimestamps(kv, kvCopy)
 
 	// If we detect a change on KubeVirt we update it
-	if !reflect.DeepEqual(kv.Status, kvCopy.Status) ||
-		!reflect.DeepEqual(kv.Finalizers, kvCopy.Finalizers) {
-
+	if !reflect.DeepEqual(kv.Status, kvCopy.Status) {
 		if err := c.statusUpdater.UpdateStatus(kvCopy); err != nil {
+			logger.Reason(err).Errorf("Could not update the KubeVirt resource status.")
+			return err
+		}
+	}
+
+	if !reflect.DeepEqual(kv.Finalizers, kvCopy.Finalizers) {
+		if _, err := c.clientset.KubeVirt(kvCopy.ObjectMeta.Namespace).Update(kvCopy); err != nil {
 			logger.Reason(err).Errorf("Could not update the KubeVirt resource.")
 			return err
 		}

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -485,7 +485,7 @@ const (
 	AppComponent = "kubevirt"
 	// This label will be set on all resources created by the operator
 	ManagedByLabel              = AppLabelPrefix + "/managed-by"
-	ManagedByLabelOperatorValue = "virt-operator"
+	ManagedByLabelOperatorValue = "kubevirt-operator"
 	// This annotation represents the kubevirt version for an install strategy configmap.
 	InstallStrategyVersionAnnotation = "kubevirt.io/install-strategy-version"
 	// This annotation represents the kubevirt registry used for an install strategy configmap.

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -84,6 +84,7 @@ var _ = Describe("Operator", func() {
 		sanityCheckDeploymentsExist       func()
 		sanityCheckDeploymentsDeleted     func()
 		allPodsAreReady                   func(*v1.KubeVirt)
+		allPodsAreTerminated              func(*v1.KubeVirt)
 		waitForUpdateCondition            func(*v1.KubeVirt)
 		waitForKvWithTimeout              func(*v1.KubeVirt, int)
 		waitForKv                         func(*v1.KubeVirt)
@@ -185,6 +186,27 @@ var _ = Describe("Operator", func() {
 				}
 				return nil
 			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+		}
+
+		allPodsAreTerminated = func(kv *v1.KubeVirt) {
+			Eventually(func() error {
+				pods, err := virtClient.CoreV1().Pods(kv.Namespace).List(metav1.ListOptions{LabelSelector: "kubevirt.io"})
+				if err != nil {
+					return err
+				}
+
+				for _, pod := range pods.Items {
+					managed, ok := pod.Labels[v1.ManagedByLabel]
+					if !ok || managed != v1.ManagedByLabelOperatorValue {
+						continue
+					}
+
+					if pod.Status.Phase != k8sv1.PodFailed && pod.Status.Phase != k8sv1.PodSucceeded {
+						return fmt.Errorf("Waiting for pod %s with phase %s to reach final phase", pod.Name, pod.Status.Phase)
+					}
+				}
+				return nil
+			}, 120*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
 
 		allPodsAreReady = func(kv *v1.KubeVirt) {
@@ -781,6 +803,9 @@ spec:
 			// Delete current KubeVirt install so we can install previous release.
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false)
+
+			By("Verifying all infra pods have terminated")
+			allPodsAreTerminated(originalKv)
 
 			By("Sanity Checking Deployments infrastructure is deleted")
 			sanityCheckDeploymentsDeleted()


### PR DESCRIPTION
We broke updates due to changing the managed by operator label. This causes the operator not to detect infrastructure setup by the previous operator. 

We also broke uninstall because of our usage of UpdateStatus rather than Update on the kubevirt cr. We now use Update() when setting the finalizer. Without this the finalizer was never added to the kv cr which resulted in us never waiting for the infrastructure to terminate. 

Fixes #4108


```release-note
NONE
```
