### PR TITLE
Add conformance automation and manifest publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ deploy:
   - _out/manifests/release/olm/kubevirt-operatorsource.yaml
   - _out/manifests/release/olm/bundle/kubevirtoperator.$TRAVIS_TAG.clusterserviceversion.yaml
   - _out/tests/tests.test
+  - _out/manifests/release/conformance.yaml
+  - _out/manifests/release/conformance.yaml.j2
   prerelease: true
   overwrite: true
   name: $TRAVIS_TAG

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ functest-image-build: manifests build-functests
 functest-image-push: functest-image-build
 	hack/func-tests-image.sh push
 
+conformance:
+	hack/dockerized "hack/conformance.sh"
+
 clean:
 	hack/dockerized "./hack/build-go.sh clean ${WHAT} && rm _out/* -rf"
 	hack/dockerized "bazel clean --expunge"
@@ -154,6 +157,7 @@ bump-kubevirtci:
 
 .PHONY: \
 	build-verify \
+	conformance \
 	go-build \
 	go-test \
 	go-all \

--- a/automation/conformance.sh
+++ b/automation/conformance.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eExuo pipefail
+
+export WORKSPACE="${WORKSPACE:-$PWD}"
+readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
+mkdir -p "$ARTIFACTS_PATH"
+
+trap "{ make cluster-down; cp -r _out/artifacts/conformance ${ARTIFACTS_PATH}; }" EXIT SIGINT SIGTERM SIGQUIT
+
+make cluster-up
+make cluster-sync
+make conformance

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,43 +1,73 @@
 # Conformance testing
 
-KubeVirt releases a `kubevirt/conformance:<release>` binary starting from
-`v0.33.0`. It can be executed as a [Sonobuoy](https://sonobuoy.io/) plugin to
-verify if the underlying cluster meets the basic needs to run KubeVirt.
+KubeVirt releases a `kubevirt/conformance:<release>` image and
+`conformance.yaml` manifest starting from `v0.33.0`. It can be executed as a
+[Sonobuoy](https://sonobuoy.io/) plugin to verify if the underlying cluster
+meets the basic needs to run KubeVirt.
 
 By default tests with a `[Conformance]` tag will be executed and tests with a
-`[Disruptive]` tag will be skipped. Therefore the tests will not destroy or
-modify anything outside of the explicitly created test namespaces by the
-binary.
+`[Disruptive]` tag will be skipped. These tests will not destroy or modify
+anything outside of the explicitly created test namespaces by the binary.
 
 ## Executing conformance tests for a specific release
 
-To execute the conformance tests for a released conformance test suite, run
+To execute the conformance tests for a released conformance test suite, run:
 
 ```bash
-$ sonobuoy gen plugin --name kubevirt-conformance --cmd /usr/bin/conformance --image kubevirt/conformance:<tag> -f junit > kubevirt.yaml
-```
-Replace `<tag>` with the kubevirt version which you have installed.
-
-Then launch the suite:
-
-```bash
-$ sonobuoy run --plugin kubevirt.yaml
+VERSION=v0.33.0
+sonobuoy run --plugin https://github.com/kubevirt/kubevirt/releases/download/${VERSION}/conformance.yaml
 ```
 
-## Executing conformace tests in the development environment
-
-Here a full flow in the development environment (note the `registry:500` prefix and the `:devel` tag:
+The execution can be monitored using the `status` command:
 
 ```bash
-$ sonobuoy gen plugin --name kubevirt-conformance --cmd /usr/bin/conformance --image registry:5000/kubevirt/conformance:devel -f junit > conformance.yaml
-sonobuoy gen plugin --name kubevirt-conformance --cmd /usr/bin/conformance --image registry:5000/kubevirt/conformance:devel -f junit > conformance.yaml
-$ sonobuoy retrieve
+sonobuoy status
+```
+
+```
+                 PLUGIN     STATUS   RESULT   COUNT
+   kubevirt-conformance   complete   passed       1
+
+Sonobuoy has completed. Use `sonobuoy retrieve` to get results.
+```
+
+Once the test run finishes, the result can be fetched:
+
+```bash
+sonobuoy retrieve
+```
+
+```
 202008201609_sonobuoy_8f8d0b0e-1d37-485a-b61d-bf7185198fbf.tar.gz
-$ sonobuoy results 202008201609_sonobuoy_8f8d0b0e-1d37-485a-b61d-bf7185198fbf.tar.gz
+```
+
+And interpreted:
+
+```bash
+sonobuoy results 202008201609_sonobuoy_8f8d0b0e-1d37-485a-b61d-bf7185198fbf.tar.gz
+```
+
+```
 Plugin: kubevirt-conformance
 Status: passed
 Total: 580
 Passed: 1
 Failed: 0
 Skipped: 579
+```
+
+## Executing conformace tests in the development environment
+
+```bash
+make conformance
+```
+
+## Generate manifests
+
+Conformance tests plugin manifest template under
+`manifests/release/conformance.yaml` was generated with following commands:
+
+```bash
+sonobuoy gen plugin --name kubevirt-conformance --cmd /usr/bin/conformance --image IMAGE -f junit > manifests/release/conformance.yaml.in
+sed -i 's#IMAGE#{{.DockerPrefix}}/conformance:{{.DockerTag}}#' manifests/release/conformance.yaml.in
 ```

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -92,6 +92,13 @@ RUN set -x && \
 
 RUN pip3 install j2cli operator-courier==1.3.0
 
+ENV SONOBUOY_VERSION=0.19.0
+RUN set -x && \
+    wget https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz && \
+    tar xvf sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz && \
+    chmod +x sonobuoy && \
+    mv sonobuoy /usr/bin
+
 COPY rsyncd.conf /etc/rsyncd.conf
 
 COPY entrypoint.sh /entrypoint.sh

--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# This script should be executed through the makefile via `make conformance`.
+
+set -eExuo pipefail
+
+echo 'Preparing directory for artifacts'
+export ARTIFACTS=_out/artifacts/conformance
+mkdir -p ${ARTIFACTS}
+
+echo 'Obtaining KUBECONFIG of the development cluster'
+export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
+
+echo 'Executing conformance tests and wait for them to finish'
+sonobuoy run --wait --plugin _out/manifests/release/conformance.yaml
+
+trap "{ echo 'Cleaning up after the test execution'; sonobuoy delete --wait; }" EXIT SIGINT SIGTERM SIGQUIT
+
+echo 'Downloading report about the test execution'
+results_archive=${ARTIFACTS}/$(cd ${ARTIFACTS} && sonobuoy retrieve)
+
+echo 'Results:'
+sonobuoy results ${results_archive}
+
+echo "Extracting the full report and keep it under ${ARTIFACTS}"
+tar xf ${results_archive} -C ${ARTIFACTS}
+cp ${ARTIFACTS}/plugins/kubevirt-conformance/results/global/junit.xml ${ARTIFACTS}/junit.conformance.xml
+
+echo 'Evaluating success of the test run'
+sonobuoy results ${results_archive} | grep -q 'Status: passed' || {
+    echo 'Conformance suite has failed'
+    exit 1
+}
+echo 'Conformance suite has successfully completed'

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:1f521ae568f4bdbcb41f02f9f11a7b5234120cf7c6a673df4f42b6fdfe4c35d3"
+KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:d5dce6c29362025b69fd4c3fe77fcde5fd2ab95f92452c3d08113ecc0d395e90"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/manifests/release/conformance.yaml.in
+++ b/manifests/release/conformance.yaml.in
@@ -1,0 +1,13 @@
+sonobuoy-config:
+  driver: Job
+  plugin-name: kubevirt-conformance
+  result-format: junit
+spec:
+  command:
+  - /usr/bin/conformance
+  image: {{.DockerPrefix}}/conformance:{{.DockerTag}}
+  name: plugin
+  resources: {}
+  volumeMounts:
+  - mountPath: /tmp/results
+    name: results


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this patch, sonobuoy conformance manifest will be published as part of released artifacts.

This patch also introduce a new makefile target to execute conformance tests against the development cluster.

Finally, this patch adds a new automation script to exercise conformance suite on CI.

Nightly prow job exercising this suite: https://github.com/kubevirt/project-infra/pull/623

**Special notes for your reviewer**:

/hold

This patch updates the builder image. We need to publish a new version of it to our registry before merging this PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add conformance automation and manifest publishing
```
