### PR TITLE
tests, probes: Test dual stack

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "job.go",
         "login.go",
         "ping.go",
+        "server.go"
         "test.go",
         "utils.go",
     ],

--- a/tests/server.go
+++ b/tests/server.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+func NewHTTPServerPod(port int) *corev1.Pod {
+	serverCommand := fmt.Sprintf(`echo -e "HTTP/1.1 200 OK\nContent-Length: 11\n\nHello World!" | nc -kvlp %d`, port)
+	return RenderPod("http-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
+}
+
+func NewTCPServerPod(port int) *corev1.Pod {
+	serverCommand := fmt.Sprintf("nc -klp %d --sh-exec 'echo \"Hello World!\"'", port)
+	return RenderPod("tcp-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
+}
+
+func CreatePodAndWaitUntil(pod *corev1.Pod, phaseToWait corev1.PodPhase) *corev1.Pod {
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	pod, err = virtClient.CoreV1().Pods(NamespaceTestDefault).Create(pod)
+	Expect(err).ToNot(HaveOccurred(), "should succeed creating pod")
+
+	getStatus := func() corev1.PodPhase {
+		pod, err = virtClient.CoreV1().Pods(NamespaceTestDefault).Get(pod.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		return pod.Status.Phase
+	}
+	Eventually(getStatus, 30, 1).Should(Equal(phaseToWait), "should reach %s phase", phaseToWait)
+	return pod
+}
+
+func StartTCPServerPod(port int) *corev1.Pod {
+	By(fmt.Sprintf("Start TCP Server pod at port %d", port))
+	return CreatePodAndWaitUntil(NewTCPServerPod(port), corev1.PodRunning)
+}
+
+func StartHTTPServerPod(port int) *corev1.Pod {
+	By(fmt.Sprintf("Start HTTP Server pod at port %d", port))
+	return CreatePodAndWaitUntil(NewHTTPServerPod(port), corev1.PodRunning)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This add new tests that will start up a pod that acts as probe backend (tcp or http) and use
the field `Host` from probes to point there, this way we have the probe IP before creating the
VMI and we can exercise whatever IP we want from dual stack.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Only readiness is implemented and only TCP is working, we have to debug why HTTP is not working.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
