### PR TITLE
Fix coexistance of scsi and sata drives

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -192,9 +192,6 @@ func SetDriverCacheMode(disk *Disk) error {
 }
 
 func makeDeviceName(bus string, devicePerBus map[string]int) string {
-	index := devicePerBus[bus]
-	devicePerBus[bus] += 1
-
 	prefix := ""
 	switch bus {
 	case "virtio":
@@ -207,6 +204,10 @@ func makeDeviceName(bus string, devicePerBus map[string]int) string {
 		log.Log.Errorf("Unrecognized bus '%s'", bus)
 		return ""
 	}
+
+	index := devicePerBus[prefix]
+	devicePerBus[prefix] += 1
+
 	return formatDeviceName(prefix, index)
 }
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -802,5 +802,68 @@ var _ = Describe("Storage", func() {
 
 			})
 		})
+
+		Context("With both SCSI and SATA devices", func() {
+			It("should successfully start with distinct device names", func() {
+
+				// Start the VirtualMachineInstance with two empty disks attached, one per bus
+				vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
+				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+					Name: "emptydisk1",
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{
+							Bus: "scsi",
+						},
+					},
+				})
+				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+					Name: "emptydisk2",
+					DiskDevice: v1.DiskDevice{
+						Disk: &v1.DiskTarget{
+							Bus: "sata",
+						},
+					},
+				})
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+					Name: "emptydisk1",
+					VolumeSource: v1.VolumeSource{
+						EmptyDisk: &v1.EmptyDiskSource{
+							Capacity: resource.MustParse("1Gi"),
+						},
+					},
+				})
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+					Name: "emptydisk2",
+					VolumeSource: v1.VolumeSource{
+						EmptyDisk: &v1.EmptyDiskSource{
+							Capacity: resource.MustParse("1Gi"),
+						},
+					},
+				})
+				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
+
+				expecter, err := tests.LoggedInAlpineExpecter(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				defer expecter.Close()
+
+				By("Checking that /dev/sda has a capacity of 1Gi")
+				res, err := expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: "blockdev --getsize64 /dev/sda\n"},
+					&expect.BExp{R: "1073741824"}, // 2Gi in bytes
+				}, 10*time.Second)
+				log.DefaultLogger().Object(vmi).Infof("%v", res)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking that /dev/sdb has a capacity of 1Gi")
+				res, err = expecter.ExpectBatch([]expect.Batcher{
+					&expect.BSnd{S: "blockdev --getsize64 /dev/sdb\n"},
+					&expect.BExp{R: "1073741824"}, // 1Gi in bytes
+				}, 10*time.Second)
+				log.DefaultLogger().Object(vmi).Infof("%v", res)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+		})
+
 	})
 })


### PR DESCRIPTION
makeDeviceName() counted device indices by bus. But SCSI and SATA
devices share the 'sd' prefix so adding both resulted in duplicate
names.
This fixes it by counting per prefix instead of bus.

Use case: Installing Windows with a SCSI disk and SATA CDROMs for
Install medium, virtio drivers, and unattended config.

Signed-off-by: Malte Starostik <github@xodtsoq.de>

**What this PR does / why we need it**:

This makes it possible to attach both SCSI and SATA drives to a single machine.
Major use case for this is installing virtio-scsi drivers on Windows, both at setup time as well as into an imported or converted 
VM. 

Without this, such a setup fails to start with:
```server error. command SyncVMI failed: "LibvirtError(Code=27, Domain=20, Message='XML error: target 'sda' duplicated for disk sources '/var/run/kubevirt-private/vmi-disks/system/win10.img' and '/var/run/kubevirt-ephemeral-disks/disk-data/drivers/disk.qcow2'')"```

**Release note**:
```release-note
fixes a bug that prevented unique device name allocation when configuring both scsi and sata drives
```
