### PR TITLE
Dynamically extend and shrink launcher's PDB

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10140,6 +10140,10 @@
       "description": "Lets us know if the vmi is currenly running pre or post copy migration",
       "type": "string"
      },
+     "pending": {
+      "description": "Indicates that the migration was accepted to the system and is now being processed",
+      "type": "boolean"
+     },
      "sourceNode": {
       "description": "The source node that the VMI originated on",
       "type": "string"

--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -125,6 +125,12 @@ func (d *VirtualMachineInstanceConditionManager) AddPodCondition(vmi *v1.Virtual
 	}
 }
 
+func (d *VirtualMachineInstanceConditionManager) AddCondition(vmi *v1.VirtualMachineInstance, cond *v1.VirtualMachineInstanceCondition) {
+	if !d.HasCondition(vmi, cond.Type) {
+		vmi.Status.Conditions = append(vmi.Status.Conditions, *cond)
+	}
+}
+
 func (d *VirtualMachineInstanceConditionManager) PodHasCondition(pod *k8sv1.Pod, conditionType k8sv1.PodConditionType, status k8sv1.ConditionStatus) bool {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == conditionType {

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -228,6 +228,7 @@ var _ = Describe("Migration watcher", func() {
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
+			vmiInterface.EXPECT().Update(gomock.Any())
 
 			controller.Execute()
 
@@ -263,6 +264,7 @@ var _ = Describe("Migration watcher", func() {
 			}
 
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
+			vmiInterface.EXPECT().Update(gomock.Any())
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 		})
@@ -284,6 +286,7 @@ var _ = Describe("Migration watcher", func() {
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
 			}
+			vmiInterface.EXPECT().Update(gomock.Any())
 
 			controller.Execute()
 		})
@@ -317,6 +320,7 @@ var _ = Describe("Migration watcher", func() {
 				addVirtualMachineInstance(vmi)
 				podInformer.GetStore().Add(pod)
 			}
+			vmiInterface.EXPECT().Update(gomock.Any())
 
 			controller.Execute()
 		})
@@ -339,6 +343,8 @@ var _ = Describe("Migration watcher", func() {
 			}
 
 			shouldExpectPodCreation(vmi.UID, migration.UID, 1, 0, 0)
+			vmiInterface.EXPECT().Update(gomock.Any())
+
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
 		})
@@ -359,6 +365,7 @@ var _ = Describe("Migration watcher", func() {
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
 			}
+			vmiInterface.EXPECT().Update(gomock.Any())
 
 			controller.Execute()
 		})
@@ -415,6 +422,7 @@ var _ = Describe("Migration watcher", func() {
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			shouldExpectPodCreation(vmi.UID, migration.UID, 2, 1, 1)
+			vmiInterface.EXPECT().Update(gomock.Any())
 
 			controller.Execute()
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -17459,6 +17459,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceMigrationState(ref
 							Format:      "",
 						},
 					},
+					"pending": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicates that the migration was accepted to the system and is now being processed",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"completed": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Indicates the migration completed",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -273,6 +273,10 @@ const (
 	VirtualMachineInstanceReasonDisksNotMigratable = "DisksNotLiveMigratable"
 	// Reason means that VMI is not live migratioable because of it's network interfaces collection
 	VirtualMachineInstanceReasonInterfaceNotMigratable = "InterfaceNotLiveMigratable"
+
+	// VirtualMachineInstanceMigrationIsProtected indicates that both the current VMI pod and the target migration pod
+	// are protected by a PDB.
+	VirtualMachineInstanceMigrationIsProtected VirtualMachineInstanceConditionType = "LiveMigrationIsProtected"
 )
 
 // +k8s:openapi-gen=true
@@ -392,6 +396,8 @@ type VirtualMachineInstanceMigrationState struct {
 	TargetPod string `json:"targetPod,omitempty"`
 	// The source node that the VMI originated on
 	SourceNode string `json:"sourceNode,omitempty"`
+	// Indicates that the migration was accepted to the system and is now being processed
+	Pending bool `json:"pending,omitempty"`
 	// Indicates the migration completed
 	Completed bool `json:"completed,omitempty"`
 	// Indicates that the migration failed

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -107,6 +107,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"targetNode":                     "The target node that the VMI is moving to",
 		"targetPod":                      "The target pod that the VMI is moving to",
 		"sourceNode":                     "The source node that the VMI originated on",
+		"pending":                        "Indicates that the migration was accepted to the system and is now being processed",
 		"completed":                      "Indicates the migration completed",
 		"failed":                         "Indicates that the migration failed",
 		"abortRequested":                 "Indicates that the migration has been requested to abort",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -17313,6 +17313,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceMigrationState(ref
 							Format:      "",
 						},
 					},
+					"pending": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicates that the migration was accepted to the system and is now being processed",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"completed": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Indicates the migration completed",


### PR DESCRIPTION
In order to protect VMI pods from evictions, we create a PDB for every
VMI that has eviction strategy set to live-migrate. This PDB was set to
require min available VMI pods to 2. The problem with this approach is
that systems that monitor pod disrubtion budgets are triggering an alert
because we require at least 2 available pods for each VMI, but create
only one. The second pod is created only in case of a migration.

This patch solves the problem my dynamically extending and shrinking the
availability config on the PDB. During a regular operation, we require
just 1 pod and during the migration process, we extend it to 2, when the
migration ends, we shrink it back to 1. Since PDBs are immutable, we
create a new one and delete the old PDB every time.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
pdb that protects vmi pods from evictions now sets maxUnavailable instead of minAvailable to relax some alerting systems
```
