### PR TITLE
openapi: fix the swagger file

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8106,8 +8106,21 @@
     }
    },
    "v1.Patch": {
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
-    "type": "object"
+    "type": "object",
+    "properties": {
+     "patch": {
+      "type": "string"
+     },
+     "resourceName": {
+      "type": "string"
+     },
+     "resourceType": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
    },
    "v1.PersistentVolumeClaim": {
     "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Somehow, the swagger file is not up to date, which causes the CI test ` pull-kubevirt-generate ` to fail.

Check the following failures for examples:
  - https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4035/pull-kubevirt-generate/1303231357811429376
  - https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4131/pull-kubevirt-generate/1303004615326830595
...

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
