### PR TITLE
Test dual-stack network configuration unless explicitly told to skip it

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -37,4 +37,10 @@ if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* 
     oc=${kubectl}
 fi
 
-${TESTS_OUT_DIR}/tests.test -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra}
+test_options="-kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -test.timeout 420m ${FUNC_TEST_ARGS} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra}"
+if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|k8s-sriov.* ]]; then
+    echo "Will skip test asserting the cluster is in dual-stack mode."
+    test_options="$test_options -skip-dual-stack-test"
+fi
+
+${TESTS_OUT_DIR}/tests.test ${test_options}

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -41,6 +41,7 @@ var PreviousReleaseTag = ""
 var PreviousReleaseRegistry = ""
 var ConfigFile = ""
 var SkipShasumCheck bool
+var SkipDualStackTests bool
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -65,6 +66,7 @@ func init() {
 	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "index.docker.io/kubevirt", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
+	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presense of IPv6 address in the cluster pods.")
 }
 
 func NormalizeFlags() {

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cluster.go"],
+    importpath = "kubevirt.io/kubevirt/tests/libnet",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/flags:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
+)

--- a/tests/libnet/cluster.go
+++ b/tests/libnet/cluster.go
@@ -1,0 +1,46 @@
+package libnet
+
+import (
+	"fmt"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netutils "k8s.io/utils/net"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/flags"
+)
+
+func IsClusterDualStack(virtClient kubecli.KubevirtClient) (bool, error) {
+	// grab us some neat kubevirt pod; let's say virt-handler is our target.
+	targetPodType := "virt-handler"
+	virtHandlerPod, err := getPodByKubeVirtRole(virtClient, targetPodType)
+	if err != nil {
+		return false, err
+	}
+
+	hasMultipleIPAddrs := len(virtHandlerPod.Status.PodIPs) > 1
+	if !hasMultipleIPAddrs {
+		return false, nil
+	}
+
+	for _, ip := range virtHandlerPod.Status.PodIPs {
+		if netutils.IsIPv6String(ip.IP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func getPodByKubeVirtRole(virtClient kubecli.KubevirtClient, kubevirtPodRole string) (*k8sv1.Pod, error) {
+	labelSelectorValue := fmt.Sprintf("%s = %s", v1.AppLabel, kubevirtPodRole)
+	pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(metav1.ListOptions{LabelSelector: labelSelectorValue})
+	if err != nil {
+		return nil, fmt.Errorf("could not filter virt-handler pods: %v", err)
+	}
+	if len(pods.Items) <= 0 {
+		return nil, fmt.Errorf("could not find virt-handler pods on the system")
+	}
+	return &pods.Items[0], nil
+}

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "dual_stack_cluster.go",
         "framework.go",
         "primary_pod_network.go",
         "validation.go",
@@ -14,6 +15,8 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",
         "//tests/containerdisk:go_default_library",
+        "//tests/flags:go_default_library",
+        "//tests/libnet:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/tests/network/dual_stack_cluster.go
+++ b/tests/network/dual_stack_cluster.go
@@ -1,0 +1,32 @@
+package network
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/libnet"
+)
+
+var _ = SIGDescribe("Dual stack cluster network configuration", func() {
+	var virtClient kubecli.KubevirtClient
+
+	BeforeEach(func() {
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).NotTo(HaveOccurred(), "Should successfully initialize an API client")
+	})
+
+	Context("when dual stack cluster configuration is enabled", func() {
+		Specify("the cluster must be dual stack", func() {
+			if flags.SkipDualStackTests {
+				Skip("user requested the dual stack check on the live cluster to be skipped")
+			}
+
+			isClusterDualStack, err := libnet.IsClusterDualStack(virtClient)
+			Expect(err).NotTo(HaveOccurred(), "must be able to infer the dual stack configuration from the live cluster")
+			Expect(isClusterDualStack).To(BeTrue(), "the live cluster should be in dual stack mode")
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This test adds a flag the user can provide to indicate the intention of **not** running the tests against a dual-stack cluster.

When this flag is provided, the test that explicitly checks if the cluster is configured in dual stack mode is not executed.

The test assures a well-known pod (virt-handler) features at least one IPv6 address in it's primary pod interface. Since we do not support IPv6 only setups, the check can be this simple.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
