### PR TITLE
WIP infra_test, Adapt tests to be dual stack compatible

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	netURL "net/url"
 	"reflect"
 	"sort"
 	"strconv"
@@ -696,6 +697,9 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			for ix := 0; ix < concurrency; ix++ {
 				err := <-errors
 				if err != nil {
+					urlErr, ok := err.(*netURL.Error)
+					Expect(ok).To(BeTrue())
+					Expect(urlErr.Err.Error()).To(ContainSubstring("Client.Timeout exceeded while awaiting headers"))
 					errorCount += 1
 				}
 			}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -860,9 +860,11 @@ var _ = Describe("[Serial]Infrastructure", func() {
 		})
 
 		It("[test_id:4556]should include unused memory metric for running VM", func() {
-			metrics := collectMetrics("kubevirt_vmi_memory_unused_bytes")
-			for _, v := range metrics {
-				Expect(v).To(BeNumerically(">=", float64(0.0)))
+			for _, url := range metricsURLs {
+				metrics := collectMetrics(url, "kubevirt_vmi_memory_unused_bytes")
+				for _, v := range metrics {
+					Expect(v).To(BeNumerically(">=", float64(0.0)))
+				}
 			}
 		})
 	})

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -744,50 +744,23 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			}
 		})
 
-		It("[test_id:4143]should include the network metrics for a running VM", func() {
+		table.DescribeTable("should include metrics for a running VM", func(metricSubstring, operator string) {
 			for _, url := range metricsURLs {
-				metrics := collectMetrics(url, "kubevirt_vmi_network_")
+				metrics := collectMetrics(url, metricSubstring)
 				By("Checking the collected metrics")
 				keys := getKeysFromMetrics(metrics)
 				for _, key := range keys {
 					value := metrics[key]
-					Expect(value).To(BeNumerically(">=", float64(0.0)))
+					fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
+					Expect(value).To(BeNumerically(operator, float64(0.0)))
 				}
 			}
-		})
-
-		It("[test_id:4144]should include the memory metrics for a running VM", func() {
-			for _, url := range metricsURLs {
-				metrics := collectMetrics(url, "kubevirt_vmi_memory")
-				By("Checking the collected metrics")
-				keys := getKeysFromMetrics(metrics)
-				for _, key := range keys {
-					value := metrics[key]
-					// swap metrics may (and should) be actually zero
-					Expect(value).To(BeNumerically(">=", float64(0.0)))
-				}
-			}
-		})
-
-		It("[test_id:4553]should include the vcpu wait metrics for running VM", func() {
-			for _, url := range metricsURLs {
-				metrics := collectMetrics(url, "kubevirt_vmi_vcpu_wait")
-				for _, v := range metrics {
-					fmt.Fprintf(GinkgoWriter, "vcpu wait was %f", v)
-					Expect(v).To(BeNumerically("==", float64(0.0)))
-				}
-			}
-		})
-
-		It("[test_id:4554]should include the vcpu seconds metrics for running VM", func() {
-			for _, url := range metricsURLs {
-				metrics := collectMetrics(url, "kubevirt_vmi_vcpu_seconds")
-				for _, v := range metrics {
-					fmt.Fprintf(GinkgoWriter, "vcpu seconds was %f", v)
-					Expect(v).To(BeNumerically(">=", float64(0.0)))
-				}
-			}
-		})
+		},
+			table.Entry("[test_id:4143] network metrics", "kubevirt_vmi_network_", ">="),
+			table.Entry("[test_id:4144] memory metrics", "kubevirt_vmi_memory", ">="),
+			table.Entry("[test_id:4553] vcpu wait", "kubevirt_vmi_vcpu_wait", "=="),
+			table.Entry("[test_id:4554] vcpu seconds", "kubevirt_vmi_vcpu_seconds", ">="),
+		)
 
 		It("[test_id:4145]should include VMI infos for a running VM", func() {
 			for _, url := range metricsURLs {


### PR DESCRIPTION
Adapt tests to be dual stack compatible.
Refactor some tests to use DescribeTable.

Notes:
1. Test 4140 checks metrics access throttling
which is expected to raise errors,
but it didn't distinct between a connectivity error
and other errors.
Add a validation that the error is only an expected error
and not due connectivity (network unreachable)
for example.
Skip it for IPv6, it will be taken care of in another PR.
See: https://github.com/kubevirt/kubevirt/issues/4145
2. Endpoints tests would be taken care of in another PR.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
