### PR TITLE
Fix generating of swagger

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -25,7 +25,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.RootPaths"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.RootPaths"
        }
       },
       "401": {
@@ -51,7 +51,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroupList"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIGroupList"
        }
       },
       "401": {
@@ -77,7 +77,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIGroup"
        }
       },
       "401": {
@@ -103,7 +103,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIResourceList"
        }
       },
       "401": {
@@ -131,7 +131,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirtList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtList"
        }
       },
       "401": {
@@ -280,7 +280,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirtList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtList"
        }
       },
       "401": {
@@ -308,7 +308,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       {
@@ -324,19 +324,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "401": {
@@ -416,7 +416,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -457,7 +457,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "401": {
@@ -485,7 +485,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       }
      ],
@@ -493,13 +493,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "401": {
@@ -527,7 +527,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -556,7 +556,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -583,7 +583,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -591,7 +591,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.KubeVirt"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
        }
       },
       "401": {
@@ -700,7 +700,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationList"
        }
       },
       "401": {
@@ -728,7 +728,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       {
@@ -744,19 +744,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "401": {
@@ -836,7 +836,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -877,7 +877,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "401": {
@@ -905,7 +905,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       }
      ],
@@ -913,13 +913,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "401": {
@@ -947,7 +947,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -976,7 +976,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -1003,7 +1003,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -1011,7 +1011,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
        }
       },
       "401": {
@@ -1120,7 +1120,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePresetList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePresetList"
        }
       },
       "401": {
@@ -1148,7 +1148,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       {
@@ -1164,19 +1164,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "401": {
@@ -1256,7 +1256,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -1297,7 +1297,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "401": {
@@ -1325,7 +1325,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       }
      ],
@@ -1333,13 +1333,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "401": {
@@ -1367,7 +1367,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -1396,7 +1396,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -1423,7 +1423,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -1431,7 +1431,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
        }
       },
       "401": {
@@ -1540,7 +1540,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSetList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSetList"
        }
       },
       "401": {
@@ -1568,7 +1568,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       {
@@ -1584,19 +1584,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "401": {
@@ -1676,7 +1676,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -1717,7 +1717,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "401": {
@@ -1745,7 +1745,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       }
      ],
@@ -1753,13 +1753,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "401": {
@@ -1787,7 +1787,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -1816,7 +1816,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -1843,7 +1843,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -1851,7 +1851,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
        }
       },
       "401": {
@@ -1960,7 +1960,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceList"
        }
       },
       "401": {
@@ -1988,7 +1988,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       {
@@ -2004,19 +2004,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "401": {
@@ -2096,7 +2096,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -2137,7 +2137,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "401": {
@@ -2165,7 +2165,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       }
      ],
@@ -2173,13 +2173,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "401": {
@@ -2207,7 +2207,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -2236,7 +2236,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -2263,7 +2263,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -2271,7 +2271,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstance"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
        }
       },
       "401": {
@@ -2380,7 +2380,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineList"
        }
       },
       "401": {
@@ -2408,7 +2408,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       {
@@ -2424,19 +2424,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "401": {
@@ -2516,7 +2516,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -2557,7 +2557,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "401": {
@@ -2585,7 +2585,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       }
      ],
@@ -2593,13 +2593,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "401": {
@@ -2627,7 +2627,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -2656,7 +2656,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -2683,7 +2683,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -2691,7 +2691,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachine"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
        }
       },
       "401": {
@@ -2734,7 +2734,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationList"
        }
       },
       "401": {
@@ -2817,7 +2817,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstancePresetList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePresetList"
        }
       },
       "401": {
@@ -2900,7 +2900,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSetList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSetList"
        }
       },
       "401": {
@@ -2983,7 +2983,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceList"
        }
       },
       "401": {
@@ -3066,7 +3066,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineList"
        }
       },
       "401": {
@@ -3147,7 +3147,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3228,7 +3228,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3317,7 +3317,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3406,7 +3406,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3495,7 +3495,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3584,7 +3584,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3673,7 +3673,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3762,7 +3762,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3843,7 +3843,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -3924,7 +3924,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -4005,7 +4005,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -4086,7 +4086,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -4167,7 +4167,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIGroup"
        }
       },
       "401": {
@@ -4193,7 +4193,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIResourceList"
        }
       },
       "401": {
@@ -4287,7 +4287,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContentList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContentList"
        }
       },
       "401": {
@@ -4315,7 +4315,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       {
@@ -4331,19 +4331,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "401": {
@@ -4423,7 +4423,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -4464,7 +4464,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "401": {
@@ -4492,7 +4492,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       }
      ],
@@ -4500,13 +4500,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "401": {
@@ -4534,7 +4534,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -4563,7 +4563,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -4590,7 +4590,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -4598,7 +4598,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
        }
       },
       "401": {
@@ -4707,7 +4707,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotList"
        }
       },
       "401": {
@@ -4735,7 +4735,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       {
@@ -4751,19 +4751,19 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "201": {
        "description": "Created",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "202": {
        "description": "Accepted",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "401": {
@@ -4843,7 +4843,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -4884,7 +4884,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "401": {
@@ -4912,7 +4912,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       }
      ],
@@ -4920,13 +4920,13 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "201": {
        "description": "Create",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "401": {
@@ -4954,7 +4954,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.DeleteOptions"
        }
       },
       {
@@ -4983,7 +4983,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Status"
        }
       },
       "401": {
@@ -5010,7 +5010,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Patch"
        }
       }
      ],
@@ -5018,7 +5018,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
        }
       },
       "401": {
@@ -5061,7 +5061,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContentList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContentList"
        }
       },
       "401": {
@@ -5144,7 +5144,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotList"
        }
       },
       "401": {
@@ -5225,7 +5225,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -5314,7 +5314,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -5403,7 +5403,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -5484,7 +5484,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.WatchEvent"
        }
       },
       "401": {
@@ -5565,7 +5565,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIGroup"
        }
       },
       "401": {
@@ -5591,7 +5591,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIResourceList"
        }
       },
       "401": {
@@ -5678,7 +5678,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceFileSystemList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceFileSystemList"
        }
       },
       "401": {
@@ -5701,7 +5701,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceGuestAgentInfo"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceGuestAgentInfo"
        }
       },
       "401": {
@@ -5865,7 +5865,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.VirtualMachineInstanceGuestOSUserList"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceGuestOSUserList"
        }
       },
       "401": {
@@ -6012,7 +6012,7 @@
        "name": "body",
        "in": "body",
        "schema": {
-        "$ref": "#/definitions/v1.RestartOptions"
+        "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.RestartOptions"
        }
       }
      ],
@@ -6195,20 +6195,546 @@
    }
   },
   "definitions": {
-   "intstr.IntOrString": {
-    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
-    "type": "string",
-    "format": "int-or-string"
+   "k8s.io/api/core/v1.Affinity": {
+    "description": "Affinity is a group of affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "nodeAffinity": {
+      "description": "Describes node affinity scheduling rules for the pod.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.NodeAffinity"
+     },
+     "podAffinity": {
+      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodAffinity"
+     },
+     "podAntiAffinity": {
+      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodAntiAffinity"
+     }
+    }
    },
-   "resource.Quantity": {
+   "k8s.io/api/core/v1.HTTPGetAction": {
+    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+    "type": "object",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "host": {
+      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+      "type": "string"
+     },
+     "httpHeaders": {
+      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.HTTPHeader"
+      }
+     },
+     "path": {
+      "description": "Path to access on the HTTP server.",
+      "type": "string"
+     },
+     "port": {
+      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1util~1intstr.IntOrString"
+     },
+     "scheme": {
+      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.HTTPHeader": {
+    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+    "type": "object",
+    "required": [
+     "name",
+     "value"
+    ],
+    "properties": {
+     "name": {
+      "description": "The header field name",
+      "type": "string"
+     },
+     "value": {
+      "description": "The header field value",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.LocalObjectReference": {
+    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+    "type": "object",
+    "properties": {
+     "name": {
+      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.NodeAffinity": {
+    "description": "Node affinity is a group of node affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "preferredDuringSchedulingIgnoredDuringExecution": {
+      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.PreferredSchedulingTerm"
+      }
+     },
+     "requiredDuringSchedulingIgnoredDuringExecution": {
+      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.NodeSelector"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.NodeSelector": {
+    "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+    "type": "object",
+    "required": [
+     "nodeSelectorTerms"
+    ],
+    "properties": {
+     "nodeSelectorTerms": {
+      "description": "Required. A list of node selector terms. The terms are ORed.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.NodeSelectorTerm"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.NodeSelectorRequirement": {
+    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "type": "object",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "description": "The label key that the selector applies to.",
+      "type": "string"
+     },
+     "operator": {
+      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      "type": "string"
+     },
+     "values": {
+      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.NodeSelectorTerm": {
+    "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+    "type": "object",
+    "properties": {
+     "matchExpressions": {
+      "description": "A list of node selector requirements by node's labels.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.NodeSelectorRequirement"
+      }
+     },
+     "matchFields": {
+      "description": "A list of node selector requirements by node's fields.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.NodeSelectorRequirement"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PersistentVolumeClaim": {
+    "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
+    "type": "object",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaimSpec"
+     },
+     "status": {
+      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaimStatus"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PersistentVolumeClaimCondition": {
+    "description": "PersistentVolumeClaimCondition contails details about state of pvc",
+    "type": "object",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastProbeTime": {
+      "description": "Last time we probed the condition.",
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "lastTransitionTime": {
+      "description": "Last time the condition transitioned from one status to another.",
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "message": {
+      "description": "Human-readable message indicating details about last transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports \"ResizeStarted\" that means the underlying persistent volume is being resized.",
+      "type": "string"
+     },
+     "status": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PersistentVolumeClaimSpec": {
+    "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+    "type": "object",
+    "properties": {
+     "accessModes": {
+      "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "dataSource": {
+      "description": "This field requires the VolumeSnapshotDataSource alpha feature gate to be enabled and currently VolumeSnapshot is the only supported data source. If the provisioner can support VolumeSnapshot data source, it will create a new volume and data will be restored to the volume at the same time. If the provisioner does not support VolumeSnapshot data source, volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.TypedLocalObjectReference"
+     },
+     "resources": {
+      "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.ResourceRequirements"
+     },
+     "selector": {
+      "description": "A label query over volumes to consider for binding.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.LabelSelector"
+     },
+     "storageClassName": {
+      "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+      "type": "string"
+     },
+     "volumeMode": {
+      "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec. This is a beta feature.",
+      "type": "string"
+     },
+     "volumeName": {
+      "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PersistentVolumeClaimStatus": {
+    "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
+    "type": "object",
+    "properties": {
+     "accessModes": {
+      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "capacity": {
+      "description": "Represents the actual resources of the underlying volume.",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+      }
+     },
+     "conditions": {
+      "description": "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaimCondition"
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
+     },
+     "phase": {
+      "description": "Phase represents the current phase of PersistentVolumeClaim.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource": {
+    "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+    "type": "object",
+    "required": [
+     "claimName"
+    ],
+    "properties": {
+     "claimName": {
+      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "type": "string"
+     },
+     "readOnly": {
+      "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PodAffinity": {
+    "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "preferredDuringSchedulingIgnoredDuringExecution": {
+      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.WeightedPodAffinityTerm"
+      }
+     },
+     "requiredDuringSchedulingIgnoredDuringExecution": {
+      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodAffinityTerm"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PodAffinityTerm": {
+    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+    "type": "object",
+    "required": [
+     "topologyKey"
+    ],
+    "properties": {
+     "labelSelector": {
+      "description": "A label query over a set of resources, in this case pods.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.LabelSelector"
+     },
+     "namespaces": {
+      "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "topologyKey": {
+      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PodAntiAffinity": {
+    "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "preferredDuringSchedulingIgnoredDuringExecution": {
+      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.WeightedPodAffinityTerm"
+      }
+     },
+     "requiredDuringSchedulingIgnoredDuringExecution": {
+      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodAffinityTerm"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PodDNSConfig": {
+    "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+    "type": "object",
+    "properties": {
+     "nameservers": {
+      "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "options": {
+      "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodDNSConfigOption"
+      }
+     },
+     "searches": {
+      "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PodDNSConfigOption": {
+    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "type": "object",
+    "properties": {
+     "name": {
+      "description": "Required.",
+      "type": "string"
+     },
+     "value": {
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.PreferredSchedulingTerm": {
+    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+    "type": "object",
+    "required": [
+     "weight",
+     "preference"
+    ],
+    "properties": {
+     "preference": {
+      "description": "A node selector term, associated with the corresponding weight.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.NodeSelectorTerm"
+     },
+     "weight": {
+      "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.ResourceRequirements": {
+    "description": "ResourceRequirements describes the compute resource requirements.",
+    "type": "object",
+    "properties": {
+     "limits": {
+      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+      }
+     },
+     "requests": {
+      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+      }
+     }
+    }
+   },
+   "k8s.io/api/core/v1.TCPSocketAction": {
+    "description": "TCPSocketAction describes an action based on opening a socket",
+    "type": "object",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "host": {
+      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+      "type": "string"
+     },
+     "port": {
+      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1util~1intstr.IntOrString"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.Toleration": {
+    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+    "type": "object",
+    "properties": {
+     "effect": {
+      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+      "type": "string"
+     },
+     "key": {
+      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+      "type": "string"
+     },
+     "operator": {
+      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+      "type": "string"
+     },
+     "tolerationSeconds": {
+      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "value": {
+      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.TypedLocalObjectReference": {
+    "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+    "type": "object",
+    "required": [
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "apiGroup": {
+      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is the type of resource being referenced",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name is the name of resource being referenced",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/api/core/v1.WeightedPodAffinityTerm": {
+    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+    "type": "object",
+    "required": [
+     "weight",
+     "podAffinityTerm"
+    ],
+    "properties": {
+     "podAffinityTerm": {
+      "description": "Required. A pod affinity term, associated with the corresponding weight.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodAffinityTerm"
+     },
+     "weight": {
+      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "k8s.io/apimachinery/pkg/api/resource.Quantity": {
     "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n\u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n  (Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
     "type": "string"
    },
-   "runtime.RawExtension": {
-    "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
-    "type": "object"
-   },
-   "v1.APIGroup": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup": {
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "type": "object",
     "required": [
@@ -6230,25 +6756,25 @@
      },
      "preferredVersion": {
       "description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
-      "$ref": "#/definitions/v1.GroupVersionForDiscovery"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.GroupVersionForDiscovery"
      },
      "serverAddressByClientCIDRs": {
       "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.ServerAddressByClientCIDR"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ServerAddressByClientCIDR"
       }
      },
      "versions": {
       "description": "versions are the versions supported in this group.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.GroupVersionForDiscovery"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.GroupVersionForDiscovery"
       }
      }
     }
    },
-   "v1.APIGroupList": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList": {
     "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
     "type": "object",
     "required": [
@@ -6263,7 +6789,7 @@
       "description": "groups is a list of APIGroup.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.APIGroup"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIGroup"
       }
      },
      "kind": {
@@ -6272,7 +6798,7 @@
      }
     }
    },
-   "v1.APIResource": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.APIResource": {
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "type": "object",
     "required": [
@@ -6334,7 +6860,7 @@
      }
     }
    },
-   "v1.APIResourceList": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.APIResourceList": {
     "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
     "type": "object",
     "required": [
@@ -6358,346 +6884,12 @@
       "description": "resources contains the name of the resources and if they are namespaced.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.APIResource"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.APIResource"
       }
      }
     }
    },
-   "v1.Affinity": {
-    "description": "Affinity is a group of affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "nodeAffinity": {
-      "description": "Describes node affinity scheduling rules for the pod.",
-      "$ref": "#/definitions/v1.NodeAffinity"
-     },
-     "podAffinity": {
-      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
-      "$ref": "#/definitions/v1.PodAffinity"
-     },
-     "podAntiAffinity": {
-      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
-      "$ref": "#/definitions/v1.PodAntiAffinity"
-     }
-    }
-   },
-   "v1.BIOS": {
-    "description": "If set (default), BIOS will be used.",
-    "type": "object"
-   },
-   "v1.Bootloader": {
-    "description": "Represents the firmware blob used to assist in the domain creation process. Used for setting the QEMU BIOS file path for the libvirt domain.",
-    "type": "object",
-    "properties": {
-     "bios": {
-      "description": "If set (default), BIOS will be used.",
-      "$ref": "#/definitions/v1.BIOS"
-     },
-     "efi": {
-      "description": "If set, EFI will be used instead of BIOS.",
-      "$ref": "#/definitions/v1.EFI"
-     }
-    }
-   },
-   "v1.CDRomTarget": {
-    "type": "object",
-    "properties": {
-     "bus": {
-      "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
-      "type": "string"
-     },
-     "readonly": {
-      "description": "ReadOnly. Defaults to true.",
-      "type": "boolean"
-     },
-     "tray": {
-      "description": "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.CPU": {
-    "description": "CPU allows specifying the CPU topology.",
-    "type": "object",
-    "properties": {
-     "cores": {
-      "description": "Cores specifies the number of cores inside the vmi. Must be a value greater or equal 1.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "dedicatedCpuPlacement": {
-      "description": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node with enough dedicated pCPUs and pin the vCPUs to it.",
-      "type": "boolean"
-     },
-     "features": {
-      "description": "Features specifies the CPU features list inside the VMI.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.CPUFeature"
-      }
-     },
-     "isolateEmulatorThread": {
-      "description": "IsolateEmulatorThread requests one more dedicated pCPU to be allocated for the VMI to place the emulator thread on it.",
-      "type": "boolean"
-     },
-     "model": {
-      "description": "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map. It is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node and \"host-model\" to get CPU closest to the node one. Defaults to host-model.",
-      "type": "string"
-     },
-     "sockets": {
-      "description": "Sockets specifies the number of sockets inside the vmi. Must be a value greater or equal 1.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "threads": {
-      "description": "Threads specifies the number of threads inside the vmi. Must be a value greater or equal 1.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1.CPUFeature": {
-    "description": "CPUFeature allows specifying a CPU feature.",
-    "type": "object",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "description": "Name of the CPU feature",
-      "type": "string"
-     },
-     "policy": {
-      "description": "Policy is the CPU feature attribute which can have the following attributes: force    - The virtual CPU will claim the feature is supported regardless of it being supported by host CPU. require  - Guest creation will fail unless the feature is supported by the host CPU or the hypervisor is able to emulate it. optional - The feature will be supported by virtual CPU if and only if it is supported by host CPU. disable  - The feature will not be supported by virtual CPU. forbid   - Guest creation will fail if the feature is supported by host CPU. Defaults to require",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Chassis": {
-    "description": "Chassis specifies the chassis info passed to the domain.",
-    "type": "object",
-    "properties": {
-     "asset": {
-      "type": "string"
-     },
-     "manufacturer": {
-      "type": "string"
-     },
-     "serial": {
-      "type": "string"
-     },
-     "sku": {
-      "type": "string"
-     },
-     "version": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.Clock": {
-    "description": "Represents the clock and timers of a vmi.",
-    "type": "object",
-    "properties": {
-     "timer": {
-      "description": "Timer specifies whih timers are attached to the vmi.",
-      "$ref": "#/definitions/v1.Timer"
-     },
-     "timezone": {
-      "description": "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
-      "type": "string"
-     },
-     "utc": {
-      "description": "UTC sets the guest clock to UTC on each boot. If an offset is specified, guest changes to the clock will be kept during reboots and are not reset.",
-      "$ref": "#/definitions/v1.ClockOffsetUTC"
-     }
-    }
-   },
-   "v1.ClockOffsetUTC": {
-    "description": "UTC sets the guest clock to UTC on each boot.",
-    "type": "object",
-    "properties": {
-     "offsetSeconds": {
-      "description": "OffsetSeconds specifies an offset in seconds, relative to UTC. If set, guest changes to the clock will be kept during reboots and not reset.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1.CloudInitConfigDriveSource": {
-    "description": "Represents a cloud-init config drive user data source. More info: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html",
-    "type": "object",
-    "properties": {
-     "networkData": {
-      "description": "NetworkData contains config drive inline cloud-init networkdata.",
-      "type": "string"
-     },
-     "networkDataBase64": {
-      "description": "NetworkDataBase64 contains config drive cloud-init networkdata as a base64 encoded string.",
-      "type": "string"
-     },
-     "networkDataSecretRef": {
-      "description": "NetworkDataSecretRef references a k8s secret that contains config drive networkdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
-     },
-     "secretRef": {
-      "description": "UserDataSecretRef references a k8s secret that contains config drive userdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
-     },
-     "userData": {
-      "description": "UserData contains config drive inline cloud-init userdata.",
-      "type": "string"
-     },
-     "userDataBase64": {
-      "description": "UserDataBase64 contains config drive cloud-init userdata as a base64 encoded string.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.CloudInitNoCloudSource": {
-    "description": "Represents a cloud-init nocloud user data source. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
-    "type": "object",
-    "properties": {
-     "networkData": {
-      "description": "NetworkData contains NoCloud inline cloud-init networkdata.",
-      "type": "string"
-     },
-     "networkDataBase64": {
-      "description": "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.",
-      "type": "string"
-     },
-     "networkDataSecretRef": {
-      "description": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
-     },
-     "secretRef": {
-      "description": "UserDataSecretRef references a k8s secret that contains NoCloud userdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
-     },
-     "userData": {
-      "description": "UserData contains NoCloud inline cloud-init userdata.",
-      "type": "string"
-     },
-     "userDataBase64": {
-      "description": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.ConfigMapVolumeSource": {
-    "description": "ConfigMapVolumeSource adapts a ConfigMap into a volume. More info: https://kubernetes.io/docs/concepts/storage/volumes/#configmap",
-    "type": "object",
-    "properties": {
-     "name": {
-      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-      "type": "string"
-     },
-     "optional": {
-      "description": "Specify whether the ConfigMap or it's keys must be defined",
-      "type": "boolean"
-     },
-     "volumeLabel": {
-      "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
-      "type": "string"
-     }
-    }
-   },
-   "v1.ContainerDiskSource": {
-    "description": "Represents a docker image with an embedded disk.",
-    "type": "object",
-    "required": [
-     "image"
-    ],
-    "properties": {
-     "image": {
-      "description": "Image is the name of the image with the embedded disk.",
-      "type": "string"
-     },
-     "imagePullPolicy": {
-      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
-      "type": "string"
-     },
-     "imagePullSecret": {
-      "description": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
-      "type": "string"
-     },
-     "path": {
-      "description": "Path defines the path to disk file in the container",
-      "type": "string"
-     }
-    }
-   },
-   "v1.CustomizeComponents": {
-    "type": "object",
-    "properties": {
-     "patches": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.Patch"
-      },
-      "x-kubernetes-list-type": "atomic"
-     }
-    }
-   },
-   "v1.DHCPOptions": {
-    "description": "Extra DHCP options to use in the interface.",
-    "type": "object",
-    "properties": {
-     "bootFileName": {
-      "description": "If specified will pass option 67 to interface's DHCP server",
-      "type": "string"
-     },
-     "ntpServers": {
-      "description": "If specified will pass the configured NTP server to the VM via DHCP option 042.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "privateOptions": {
-      "description": "If specified will pass extra DHCP options for private use, range: 224-254",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.DHCPPrivateOptions"
-      }
-     },
-     "tftpServerName": {
-      "description": "If specified will pass option 66 to interface's DHCP server",
-      "type": "string"
-     }
-    }
-   },
-   "v1.DHCPPrivateOptions": {
-    "description": "DHCPExtraOptions defines Extra DHCP options for a VM.",
-    "type": "object",
-    "required": [
-     "option",
-     "value"
-    ],
-    "properties": {
-     "option": {
-      "description": "Option is an Integer value from 224-254 Required.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "value": {
-      "description": "Value is a String value for the Option provided Required.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.DataVolumeSource": {
-    "type": "object",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "description": "Name represents the name of the DataVolume in the same namespace",
-      "type": "string"
-     }
-    }
-   },
-   "v1.DeleteOptions": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.DeleteOptions": {
     "description": "DeleteOptions may be provided when deleting an API object.",
     "type": "object",
     "properties": {
@@ -6727,7 +6919,7 @@
      },
      "preconditions": {
       "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
-      "$ref": "#/definitions/v1.Preconditions"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Preconditions"
      },
      "propagationPolicy": {
       "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
@@ -6735,436 +6927,15 @@
      }
     }
    },
-   "v1.DeveloperConfiguration": {
-    "description": "DeveloperConfiguration holds developer options",
-    "type": "object",
-    "properties": {
-     "featureGates": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "memoryOvercommit": {
-      "type": "string"
-     },
-     "nodeSelectors": {
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     },
-     "pvcTolerateLessSpaceUpToPercent": {
-      "type": "string"
-     },
-     "useEmulation": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.Devices": {
-    "type": "object",
-    "properties": {
-     "autoattachGraphicsDevice": {
-      "description": "Whether to attach the default graphics device or not. VNC will not be available if set to false. Defaults to true.",
-      "type": "boolean"
-     },
-     "autoattachMemBalloon": {
-      "description": "Whether to attach the Memory balloon device with default period. Period can be adjusted in virt-config. Defaults to true.",
-      "type": "boolean"
-     },
-     "autoattachPodInterface": {
-      "description": "Whether to attach a pod network interface. Defaults to true.",
-      "type": "boolean"
-     },
-     "autoattachSerialConsole": {
-      "description": "Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.",
-      "type": "boolean"
-     },
-     "blockMultiQueue": {
-      "description": "Whether or not to enable virtio multi-queue for block devices",
-      "type": "boolean"
-     },
-     "disks": {
-      "description": "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.Disk"
-      }
-     },
-     "gpus": {
-      "description": "Whether to attach a GPU device to the vmi.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.GPU"
-      }
-     },
-     "inputs": {
-      "description": "Inputs describe input devices",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.Input"
-      }
-     },
-     "interfaces": {
-      "description": "Interfaces describe network interfaces which are added to the vmi.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.Interface"
-      }
-     },
-     "networkInterfaceMultiqueue": {
-      "description": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature",
-      "type": "boolean"
-     },
-     "rng": {
-      "description": "Whether to have random number generator from host",
-      "$ref": "#/definitions/v1.Rng"
-     },
-     "watchdog": {
-      "description": "Watchdog describes a watchdog device which can be added to the vmi.",
-      "$ref": "#/definitions/v1.Watchdog"
-     }
-    }
-   },
-   "v1.Disk": {
-    "type": "object",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "bootOrder": {
-      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used.",
-      "type": "string"
-     },
-     "cdrom": {
-      "description": "Attach a volume as a cdrom to the vmi.",
-      "$ref": "#/definitions/v1.CDRomTarget"
-     },
-     "dedicatedIOThread": {
-      "description": "dedicatedIOThread indicates this disk should have an exclusive IO Thread. Enabling this implies useIOThreads = true. Defaults to false.",
-      "type": "boolean"
-     },
-     "disk": {
-      "description": "Attach a volume as a disk to the vmi.",
-      "$ref": "#/definitions/v1.DiskTarget"
-     },
-     "floppy": {
-      "description": "Attach a volume as a floppy to the vmi.",
-      "$ref": "#/definitions/v1.FloppyTarget"
-     },
-     "io": {
-      "description": "IO specifies which QEMU disk IO mode should be used. Supported values are: native, default, threads.",
-      "type": "string"
-     },
-     "lun": {
-      "description": "Attach a volume as a LUN to the vmi.",
-      "$ref": "#/definitions/v1.LunTarget"
-     },
-     "name": {
-      "description": "Name is the device name",
-      "type": "string"
-     },
-     "serial": {
-      "description": "Serial provides the ability to specify a serial number for the disk device.",
-      "type": "string"
-     },
-     "tag": {
-      "description": "If specified, disk address and its tag will be provided to the guest via config drive metadata",
-      "type": "string"
-     }
-    }
-   },
-   "v1.DiskTarget": {
-    "type": "object",
-    "properties": {
-     "bus": {
-      "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
-      "type": "string"
-     },
-     "pciAddress": {
-      "description": "If specified, the virtual disk will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10",
-      "type": "string"
-     },
-     "readonly": {
-      "description": "ReadOnly. Defaults to false.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.DomainSpec": {
-    "type": "object",
-    "required": [
-     "devices"
-    ],
-    "properties": {
-     "chassis": {
-      "description": "Chassis specifies the chassis info passed to the domain.",
-      "$ref": "#/definitions/v1.Chassis"
-     },
-     "clock": {
-      "description": "Clock sets the clock and timers of the vmi.",
-      "$ref": "#/definitions/v1.Clock"
-     },
-     "cpu": {
-      "description": "CPU allow specified the detailed CPU topology inside the vmi.",
-      "$ref": "#/definitions/v1.CPU"
-     },
-     "devices": {
-      "description": "Devices allows adding disks, network interfaces, and others",
-      "$ref": "#/definitions/v1.Devices"
-     },
-     "features": {
-      "description": "Features like acpi, apic, hyperv, smm.",
-      "$ref": "#/definitions/v1.Features"
-     },
-     "firmware": {
-      "description": "Firmware.",
-      "$ref": "#/definitions/v1.Firmware"
-     },
-     "ioThreadsPolicy": {
-      "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto",
-      "type": "string"
-     },
-     "machine": {
-      "description": "Machine type.",
-      "$ref": "#/definitions/v1.Machine"
-     },
-     "memory": {
-      "description": "Memory allow specifying the VMI memory features.",
-      "$ref": "#/definitions/v1.Memory"
-     },
-     "resources": {
-      "description": "Resources describes the Compute Resources required by this vmi.",
-      "$ref": "#/definitions/v1.ResourceRequirements"
-     }
-    }
-   },
-   "v1.Duration": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.Duration": {
     "description": "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
     "type": "string"
    },
-   "v1.EFI": {
-    "description": "If set, EFI will be used instead of BIOS.",
-    "type": "object",
-    "properties": {
-     "secureBoot": {
-      "description": "If set, SecureBoot will be enabled and the OVMF roms will be swapped for SecureBoot-enabled ones. Requires SMM to be enabled. Defaults to true",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.EmptyDiskSource": {
-    "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle.",
-    "type": "object",
-    "required": [
-     "capacity"
-    ],
-    "properties": {
-     "capacity": {
-      "description": "Capacity of the sparse disk.",
-      "$ref": "#/definitions/resource.Quantity"
-     }
-    }
-   },
-   "v1.EphemeralVolumeSource": {
-    "type": "object",
-    "properties": {
-     "persistentVolumeClaim": {
-      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
-     }
-    }
-   },
-   "v1.FeatureAPIC": {
-    "type": "object",
-    "properties": {
-     "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
-      "type": "boolean"
-     },
-     "endOfInterrupt": {
-      "description": "EndOfInterrupt enables the end of interrupt notification in the guest. Defaults to false.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.FeatureHyperv": {
-    "description": "Hyperv specific features.",
-    "type": "object",
-    "properties": {
-     "evmcs": {
-      "description": "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "frequencies": {
-      "description": "Frequencies improves the TSC clock source handling for Hyper-V on KVM. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "ipi": {
-      "description": "IPI improves performances in overcommited environments. Requires vpindex. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "reenlightenment": {
-      "description": "Reenlightenment enables the notifications on TSC frequency changes. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "relaxed": {
-      "description": "Relaxed instructs the guest OS to disable watchdog timeouts. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "reset": {
-      "description": "Reset enables Hyperv reboot/reset for the vmi. Requires synic. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "runtime": {
-      "description": "Runtime improves the time accounting to improve scheduling in the guest. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "spinlocks": {
-      "description": "Spinlocks allows to configure the spinlock retry attempts.",
-      "$ref": "#/definitions/v1.FeatureSpinlocks"
-     },
-     "synic": {
-      "description": "SyNIC enables the Synthetic Interrupt Controller. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "synictimer": {
-      "description": "SyNICTimer enables Synthetic Interrupt Controller Timers, reducing CPU load. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "tlbflush": {
-      "description": "TLBFlush improves performances in overcommited environments. Requires vpindex. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "vapic": {
-      "description": "VAPIC improves the paravirtualized handling of interrupts. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "vendorid": {
-      "description": "VendorID allows setting the hypervisor vendor id. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureVendorID"
-     },
-     "vpindex": {
-      "description": "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors. Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureState"
-     }
-    }
-   },
-   "v1.FeatureSpinlocks": {
-    "type": "object",
-    "properties": {
-     "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
-      "type": "boolean"
-     },
-     "spinlocks": {
-      "description": "Retries indicates the number of retries. Must be a value greater or equal 4096. Defaults to 4096.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1.FeatureState": {
-    "description": "Represents if a feature is enabled or disabled.",
-    "type": "object",
-    "properties": {
-     "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.FeatureVendorID": {
-    "type": "object",
-    "properties": {
-     "enabled": {
-      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
-      "type": "boolean"
-     },
-     "vendorid": {
-      "description": "VendorID sets the hypervisor vendor id, visible to the vmi. String up to twelve characters.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Features": {
-    "type": "object",
-    "properties": {
-     "acpi": {
-      "description": "ACPI enables/disables ACPI insidejsondata guest. Defaults to enabled.",
-      "$ref": "#/definitions/v1.FeatureState"
-     },
-     "apic": {
-      "description": "Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureAPIC"
-     },
-     "hyperv": {
-      "description": "Defaults to the machine type setting.",
-      "$ref": "#/definitions/v1.FeatureHyperv"
-     },
-     "smm": {
-      "description": "SMM enables/disables System Management Mode. TSEG not yet implemented.",
-      "$ref": "#/definitions/v1.FeatureState"
-     }
-    }
-   },
-   "v1.FieldsV1": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.FieldsV1": {
     "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
     "type": "object"
    },
-   "v1.Firmware": {
-    "type": "object",
-    "properties": {
-     "bootloader": {
-      "description": "Settings to control the bootloader that is used.",
-      "$ref": "#/definitions/v1.Bootloader"
-     },
-     "serial": {
-      "description": "The system-serial-number in SMBIOS",
-      "type": "string"
-     },
-     "uuid": {
-      "description": "UUID reported by the vmi bios. Defaults to a random generated uid.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.FloppyTarget": {
-    "type": "object",
-    "properties": {
-     "readonly": {
-      "description": "ReadOnly. Defaults to false.",
-      "type": "boolean"
-     },
-     "tray": {
-      "description": "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.GPU": {
-    "type": "object",
-    "required": [
-     "name",
-     "deviceName"
-    ],
-    "properties": {
-     "deviceName": {
-      "type": "string"
-     },
-     "name": {
-      "description": "Name of the GPU device as exposed by a device plugin",
-      "type": "string"
-     }
-    }
-   },
-   "v1.GroupVersionForDiscovery": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery": {
     "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "type": "object",
     "required": [
@@ -7182,476 +6953,7 @@
      }
     }
    },
-   "v1.HPETTimer": {
-    "type": "object",
-    "properties": {
-     "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
-      "type": "boolean"
-     },
-     "tickPolicy": {
-      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"merge\", \"discard\".",
-      "type": "string"
-     }
-    }
-   },
-   "v1.HTTPGetAction": {
-    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
-    "type": "object",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "host": {
-      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
-      "type": "string"
-     },
-     "httpHeaders": {
-      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.HTTPHeader"
-      }
-     },
-     "path": {
-      "description": "Path to access on the HTTP server.",
-      "type": "string"
-     },
-     "port": {
-      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-      "type": [
-       "string",
-       "number"
-      ]
-     },
-     "scheme": {
-      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.HTTPHeader": {
-    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
-    "type": "object",
-    "required": [
-     "name",
-     "value"
-    ],
-    "properties": {
-     "name": {
-      "description": "The header field name",
-      "type": "string"
-     },
-     "value": {
-      "description": "The header field value",
-      "type": "string"
-     }
-    }
-   },
-   "v1.HostDisk": {
-    "description": "Represents a disk created on the cluster level",
-    "type": "object",
-    "required": [
-     "path",
-     "type"
-    ],
-    "properties": {
-     "capacity": {
-      "description": "Capacity of the sparse disk",
-      "$ref": "#/definitions/resource.Quantity"
-     },
-     "path": {
-      "description": "The path to HostDisk image located on the cluster",
-      "type": "string"
-     },
-     "shared": {
-      "description": "Shared indicate whether the path is shared between nodes",
-      "type": "boolean"
-     },
-     "type": {
-      "description": "Contains information if disk.img exists or should be created allowed options are 'Disk' and 'DiskOrCreate'",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Hugepages": {
-    "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
-    "type": "object",
-    "properties": {
-     "pageSize": {
-      "description": "PageSize specifies the hugepage size, for x86_64 architecture valid values are 1Gi and 2Mi.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.HypervTimer": {
-    "type": "object",
-    "properties": {
-     "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.I6300ESBWatchdog": {
-    "description": "i6300esb watchdog device.",
-    "type": "object",
-    "properties": {
-     "action": {
-      "description": "The action to take. Valid values are poweroff, reset, shutdown. Defaults to reset.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Input": {
-    "type": "object",
-    "required": [
-     "type",
-     "name"
-    ],
-    "properties": {
-     "bus": {
-      "description": "Bus indicates the bus of input device to emulate. Supported values: virtio, usb.",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name is the device name",
-      "type": "string"
-     },
-     "type": {
-      "description": "Type indicated the type of input device. Supported values: tablet.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Interface": {
-    "type": "object",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "bootOrder": {
-      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices. Lower values take precedence. Each interface or disk that has a boot order must have a unique value. Interfaces without a boot order are not tried.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "bridge": {
-      "$ref": "#/definitions/v1.InterfaceBridge"
-     },
-     "dhcpOptions": {
-      "description": "If specified the network interface will pass additional DHCP options to the VMI",
-      "$ref": "#/definitions/v1.DHCPOptions"
-     },
-     "macAddress": {
-      "description": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
-      "type": "string"
-     },
-     "masquerade": {
-      "$ref": "#/definitions/v1.InterfaceMasquerade"
-     },
-     "model": {
-      "description": "Interface model. One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
-      "type": "string"
-     },
-     "name": {
-      "description": "Logical name of the interface as well as a reference to the associated networks. Must match the Name of a Network.",
-      "type": "string"
-     },
-     "pciAddress": {
-      "description": "If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10",
-      "type": "string"
-     },
-     "ports": {
-      "description": "List of ports to be forwarded to the virtual machine.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.Port"
-      }
-     },
-     "slirp": {
-      "$ref": "#/definitions/v1.InterfaceSlirp"
-     },
-     "sriov": {
-      "$ref": "#/definitions/v1.InterfaceSRIOV"
-     },
-     "tag": {
-      "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
-      "type": "string"
-     }
-    }
-   },
-   "v1.InterfaceBridge": {
-    "type": "object"
-   },
-   "v1.InterfaceMasquerade": {
-    "type": "object"
-   },
-   "v1.InterfaceSRIOV": {
-    "type": "object"
-   },
-   "v1.InterfaceSlirp": {
-    "type": "object"
-   },
-   "v1.KVMTimer": {
-    "type": "object",
-    "properties": {
-     "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.KubeVirt": {
-    "description": "KubeVirt represents the object deploying all KubeVirt resources",
-    "type": "object",
-    "required": [
-     "spec"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "$ref": "#/definitions/v1.KubeVirtSpec"
-     },
-     "status": {
-      "$ref": "#/definitions/v1.KubeVirtStatus"
-     }
-    }
-   },
-   "v1.KubeVirtCertificateRotateStrategy": {
-    "type": "object",
-    "properties": {
-     "selfSigned": {
-      "$ref": "#/definitions/v1.KubeVirtSelfSignConfiguration"
-     }
-    }
-   },
-   "v1.KubeVirtCondition": {
-    "description": "KubeVirtCondition represents a condition of a KubeVirt deployment",
-    "type": "object",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastProbeTime": {
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "lastTransitionTime": {
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "message": {
-      "type": "string"
-     },
-     "reason": {
-      "type": "string"
-     },
-     "status": {
-      "type": "string"
-     },
-     "type": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.KubeVirtConfiguration": {
-    "description": "KubeVirtConfiguration holds all kubevirt configurations",
-    "type": "object",
-    "properties": {
-     "cpuModel": {
-      "type": "string"
-     },
-     "cpuRequest": {
-      "type": "string"
-     },
-     "developerConfiguration": {
-      "$ref": "#/definitions/v1.DeveloperConfiguration"
-     },
-     "emulatedMachines": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "imagePullPolicy": {
-      "type": "string"
-     },
-     "machineType": {
-      "type": "string"
-     },
-     "memBalloonStatsPeriod": {
-      "type": "integer",
-      "format": "int32"
-     },
-     "migrations": {
-      "$ref": "#/definitions/v1.MigrationConfiguration"
-     },
-     "network": {
-      "$ref": "#/definitions/v1.NetworkConfiguration"
-     },
-     "ovmfPath": {
-      "type": "string"
-     },
-     "selinuxLauncherType": {
-      "type": "string"
-     },
-     "smbios": {
-      "$ref": "#/definitions/v1.SMBiosConfiguration"
-     },
-     "supportedGuestAgentVersions": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.KubeVirtList": {
-    "description": "KubeVirtList is a list of KubeVirts",
-    "type": "object",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "items": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.KubeVirt"
-      }
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1.KubeVirtSelfSignConfiguration": {
-    "type": "object",
-    "properties": {
-     "caOverlapInterval": {
-      "$ref": "#/definitions/v1.Duration"
-     },
-     "caRotateInterval": {
-      "$ref": "#/definitions/v1.Duration"
-     },
-     "certRotateInterval": {
-      "$ref": "#/definitions/v1.Duration"
-     }
-    }
-   },
-   "v1.KubeVirtSpec": {
-    "type": "object",
-    "properties": {
-     "certificateRotateStrategy": {
-      "$ref": "#/definitions/v1.KubeVirtCertificateRotateStrategy"
-     },
-     "configuration": {
-      "description": "holds kubevirt configurations. same as the virt-configMap",
-      "$ref": "#/definitions/v1.KubeVirtConfiguration"
-     },
-     "customizeComponents": {
-      "$ref": "#/definitions/v1.CustomizeComponents"
-     },
-     "imagePullPolicy": {
-      "description": "The ImagePullPolicy to use.",
-      "type": "string"
-     },
-     "imageRegistry": {
-      "description": "The image registry to pull the container images from Defaults to the same registry the operator's container image is pulled from.",
-      "type": "string"
-     },
-     "imageTag": {
-      "description": "The image tag to use for the continer images installed. Defaults to the same tag as the operator's container image.",
-      "type": "string"
-     },
-     "monitorAccount": {
-      "description": "The name of the Prometheus service account that needs read-access to KubeVirt endpoints Defaults to prometheus-k8s",
-      "type": "string"
-     },
-     "monitorNamespace": {
-      "description": "The namespace Prometheus is deployed in Defaults to openshift-monitor",
-      "type": "string"
-     },
-     "productName": {
-      "description": "Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductName is not specified, the part-of label will be omitted.",
-      "type": "string"
-     },
-     "productVersion": {
-      "description": "Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.",
-      "type": "string"
-     },
-     "uninstallStrategy": {
-      "description": "Specifies if kubevirt can be deleted if workloads are still present. This is mainly a precaution to avoid accidental data loss",
-      "type": "string"
-     }
-    }
-   },
-   "v1.KubeVirtStatus": {
-    "description": "KubeVirtStatus represents information pertaining to a KubeVirt deployment.",
-    "type": "object",
-    "nullable": true,
-    "properties": {
-     "conditions": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.KubeVirtCondition"
-      }
-     },
-     "observedDeploymentConfig": {
-      "type": "string"
-     },
-     "observedDeploymentID": {
-      "type": "string"
-     },
-     "observedKubeVirtRegistry": {
-      "type": "string"
-     },
-     "observedKubeVirtVersion": {
-      "type": "string"
-     },
-     "operatorVersion": {
-      "type": "string"
-     },
-     "phase": {
-      "type": "string"
-     },
-     "targetDeploymentConfig": {
-      "type": "string"
-     },
-     "targetDeploymentID": {
-      "type": "string"
-     },
-     "targetKubeVirtRegistry": {
-      "type": "string"
-     },
-     "targetKubeVirtVersion": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.LabelSelector": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector": {
     "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
     "type": "object",
     "properties": {
@@ -7659,7 +6961,7 @@
       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.LabelSelectorRequirement"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.LabelSelectorRequirement"
       }
      },
      "matchLabels": {
@@ -7671,7 +6973,7 @@
      }
     }
    },
-   "v1.LabelSelectorRequirement": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelectorRequirement": {
     "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
     "type": "object",
     "required": [
@@ -7698,7 +7000,7 @@
      }
     }
    },
-   "v1.ListMeta": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta": {
     "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
     "type": "object",
     "properties": {
@@ -7721,42 +7023,7 @@
      }
     }
    },
-   "v1.LocalObjectReference": {
-    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
-    "type": "object",
-    "properties": {
-     "name": {
-      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-      "type": "string"
-     }
-    }
-   },
-   "v1.LunTarget": {
-    "type": "object",
-    "properties": {
-     "bus": {
-      "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
-      "type": "string"
-     },
-     "readonly": {
-      "description": "ReadOnly. Defaults to false.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.Machine": {
-    "type": "object",
-    "required": [
-     "type"
-    ],
-    "properties": {
-     "type": {
-      "description": "QEMU machine type is the actual chipset of the VirtualMachineInstance.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.ManagedFieldsEntry": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry": {
     "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
     "type": "object",
     "properties": {
@@ -7770,7 +7037,7 @@
      },
      "fieldsV1": {
       "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
-      "$ref": "#/definitions/v1.FieldsV1"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.FieldsV1"
      },
      "manager": {
       "description": "Manager is an identifier of the workflow managing these fields.",
@@ -7782,188 +7049,11 @@
      },
      "time": {
       "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      }
     }
    },
-   "v1.Memory": {
-    "description": "Memory allows specifying the VirtualMachineInstance memory features.",
-    "type": "object",
-    "properties": {
-     "guest": {
-      "description": "Guest allows to specifying the amount of memory which is visible inside the Guest OS. The Guest must lie between Requests and Limits from the resources section. Defaults to the requested memory in the resources section if not specified.",
-      "$ref": "#/definitions/resource.Quantity"
-     },
-     "hugepages": {
-      "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
-      "$ref": "#/definitions/v1.Hugepages"
-     }
-    }
-   },
-   "v1.MigrationConfiguration": {
-    "description": "MigrationConfiguration holds migration options",
-    "type": "object",
-    "required": [
-     "allowAutoConverge",
-     "unsafeMigrationOverride"
-    ],
-    "properties": {
-     "allowAutoConverge": {
-      "type": "string"
-     },
-     "bandwidthPerMigration": {
-      "$ref": "#/definitions/resource.Quantity"
-     },
-     "completionTimeoutPerGiB": {
-      "type": "string"
-     },
-     "nodeDrainTaintKey": {
-      "type": "string"
-     },
-     "parallelMigrationsPerCluster": {
-      "type": "string"
-     },
-     "parallelOutboundMigrationsPerNode": {
-      "type": "string"
-     },
-     "progressTimeout": {
-      "type": "string"
-     },
-     "unsafeMigrationOverride": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.MultusNetwork": {
-    "description": "Represents the multus cni network.",
-    "type": "object",
-    "required": [
-     "networkName"
-    ],
-    "properties": {
-     "default": {
-      "description": "Select the default network and add it to the multus-cni.io/default-network annotation.",
-      "type": "boolean"
-     },
-     "networkName": {
-      "description": "References to a NetworkAttachmentDefinition CRD object. Format: \u003cnetworkName\u003e, \u003cnamespace\u003e/\u003cnetworkName\u003e. If namespace is not specified, VMI namespace is assumed.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Network": {
-    "description": "Network represents a network type and a resource that should be connected to the vm.",
-    "type": "object",
-    "required": [
-     "name"
-    ],
-    "properties": {
-     "multus": {
-      "$ref": "#/definitions/v1.MultusNetwork"
-     },
-     "name": {
-      "description": "Network name. Must be a DNS_LABEL and unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-      "type": "string"
-     },
-     "pod": {
-      "$ref": "#/definitions/v1.PodNetwork"
-     }
-    }
-   },
-   "v1.NetworkConfiguration": {
-    "description": "NetworkConfiguration holds network options",
-    "type": "object",
-    "properties": {
-     "defaultNetworkInterface": {
-      "type": "string"
-     },
-     "permitBridgeInterfaceOnPodNetwork": {
-      "type": "string"
-     },
-     "permitSlirpInterface": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.NodeAffinity": {
-    "description": "Node affinity is a group of node affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "preferredDuringSchedulingIgnoredDuringExecution": {
-      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PreferredSchedulingTerm"
-      }
-     },
-     "requiredDuringSchedulingIgnoredDuringExecution": {
-      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-      "$ref": "#/definitions/v1.NodeSelector"
-     }
-    }
-   },
-   "v1.NodeSelector": {
-    "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
-    "type": "object",
-    "required": [
-     "nodeSelectorTerms"
-    ],
-    "properties": {
-     "nodeSelectorTerms": {
-      "description": "Required. A list of node selector terms. The terms are ORed.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.NodeSelectorTerm"
-      }
-     }
-    }
-   },
-   "v1.NodeSelectorRequirement": {
-    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-    "type": "object",
-    "required": [
-     "key",
-     "operator"
-    ],
-    "properties": {
-     "key": {
-      "description": "The label key that the selector applies to.",
-      "type": "string"
-     },
-     "operator": {
-      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-      "type": "string"
-     },
-     "values": {
-      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.NodeSelectorTerm": {
-    "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
-    "type": "object",
-    "properties": {
-     "matchExpressions": {
-      "description": "A list of node selector requirements by node's labels.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.NodeSelectorRequirement"
-      }
-     },
-     "matchFields": {
-      "description": "A list of node selector requirements by node's fields.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.NodeSelectorRequirement"
-      }
-     }
-    }
-   },
-   "v1.ObjectMeta": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta": {
     "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
     "type": "object",
     "properties": {
@@ -7980,10 +7070,7 @@
      },
      "creationTimestamp": {
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "type": [
-       "string",
-       "null"
-      ]
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "deletionGracePeriodSeconds": {
       "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
@@ -7992,7 +7079,7 @@
      },
      "deletionTimestamp": {
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "finalizers": {
       "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
@@ -8022,7 +7109,7 @@
       "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.ManagedFieldsEntry"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ManagedFieldsEntry"
       }
      },
      "name": {
@@ -8037,7 +7124,7 @@
       "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.OwnerReference"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.OwnerReference"
       },
       "x-kubernetes-patch-merge-key": "uid",
       "x-kubernetes-patch-strategy": "merge"
@@ -8056,7 +7143,7 @@
      }
     }
    },
-   "v1.OwnerReference": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference": {
     "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
     "type": "object",
     "required": [
@@ -8092,312 +7179,11 @@
      }
     }
    },
-   "v1.PITTimer": {
-    "type": "object",
-    "properties": {
-     "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
-      "type": "boolean"
-     },
-     "tickPolicy": {
-      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"discard\".",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Patch": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.Patch": {
     "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
     "type": "object"
    },
-   "v1.PersistentVolumeClaim": {
-    "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
-    "type": "object",
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "metadata": {
-      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimSpec"
-     },
-     "status": {
-      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimStatus"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimCondition": {
-    "description": "PersistentVolumeClaimCondition contails details about state of pvc",
-    "type": "object",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastProbeTime": {
-      "description": "Last time we probed the condition.",
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "lastTransitionTime": {
-      "description": "Last time the condition transitioned from one status to another.",
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "message": {
-      "description": "Human-readable message indicating details about last transition.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports \"ResizeStarted\" that means the underlying persistent volume is being resized.",
-      "type": "string"
-     },
-     "status": {
-      "type": "string"
-     },
-     "type": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimSpec": {
-    "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
-    "type": "object",
-    "properties": {
-     "accessModes": {
-      "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "dataSource": {
-      "description": "This field requires the VolumeSnapshotDataSource alpha feature gate to be enabled and currently VolumeSnapshot is the only supported data source. If the provisioner can support VolumeSnapshot data source, it will create a new volume and data will be restored to the volume at the same time. If the provisioner does not support VolumeSnapshot data source, volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.",
-      "$ref": "#/definitions/v1.TypedLocalObjectReference"
-     },
-     "resources": {
-      "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-      "$ref": "#/definitions/v1.ResourceRequirements"
-     },
-     "selector": {
-      "description": "A label query over volumes to consider for binding.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "storageClassName": {
-      "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
-      "type": "string"
-     },
-     "volumeMode": {
-      "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec. This is a beta feature.",
-      "type": "string"
-     },
-     "volumeName": {
-      "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimStatus": {
-    "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
-    "type": "object",
-    "nullable": true,
-    "properties": {
-     "accessModes": {
-      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "capacity": {
-      "description": "Represents the actual resources of the underlying volume.",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
-      }
-     },
-     "conditions": {
-      "description": "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PersistentVolumeClaimCondition"
-      },
-      "x-kubernetes-patch-merge-key": "type",
-      "x-kubernetes-patch-strategy": "merge"
-     },
-     "phase": {
-      "description": "Phase represents the current phase of PersistentVolumeClaim.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimVolumeSource": {
-    "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
-    "type": "object",
-    "required": [
-     "claimName"
-    ],
-    "properties": {
-     "claimName": {
-      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "type": "string"
-     },
-     "readOnly": {
-      "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.PodAffinity": {
-    "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "preferredDuringSchedulingIgnoredDuringExecution": {
-      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.WeightedPodAffinityTerm"
-      }
-     },
-     "requiredDuringSchedulingIgnoredDuringExecution": {
-      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PodAffinityTerm"
-      }
-     }
-    }
-   },
-   "v1.PodAffinityTerm": {
-    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
-    "type": "object",
-    "required": [
-     "topologyKey"
-    ],
-    "properties": {
-     "labelSelector": {
-      "description": "A label query over a set of resources, in this case pods.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "namespaces": {
-      "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "topologyKey": {
-      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PodAntiAffinity": {
-    "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "preferredDuringSchedulingIgnoredDuringExecution": {
-      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.WeightedPodAffinityTerm"
-      }
-     },
-     "requiredDuringSchedulingIgnoredDuringExecution": {
-      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PodAffinityTerm"
-      }
-     }
-    }
-   },
-   "v1.PodDNSConfig": {
-    "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
-    "type": "object",
-    "properties": {
-     "nameservers": {
-      "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "options": {
-      "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PodDNSConfigOption"
-      }
-     },
-     "searches": {
-      "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.PodDNSConfigOption": {
-    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
-    "type": "object",
-    "properties": {
-     "name": {
-      "description": "Required.",
-      "type": "string"
-     },
-     "value": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.PodNetwork": {
-    "description": "Represents the stock pod network interface.",
-    "type": "object",
-    "properties": {
-     "vmNetworkCIDR": {
-      "description": "CIDR for vm network. Default 10.0.2.0/24 if not specified.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Port": {
-    "description": "Port repesents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
-    "type": "object",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "name": {
-      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
-      "type": "string"
-     },
-     "port": {
-      "description": "Number of port to expose for the virtual machine. This must be a valid port number, 0 \u003c x \u003c 65536.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "protocol": {
-      "description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\".",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Preconditions": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.Preconditions": {
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "type": "object",
     "properties": {
@@ -8411,128 +7197,7 @@
      }
     }
    },
-   "v1.PreferredSchedulingTerm": {
-    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-    "type": "object",
-    "required": [
-     "weight",
-     "preference"
-    ],
-    "properties": {
-     "preference": {
-      "description": "A node selector term, associated with the corresponding weight.",
-      "$ref": "#/definitions/v1.NodeSelectorTerm"
-     },
-     "weight": {
-      "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1.Probe": {
-    "description": "Probe describes a health check to be performed against a VirtualMachineInstance to determine whether it is alive or ready to receive traffic.",
-    "type": "object",
-    "properties": {
-     "failureThreshold": {
-      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "httpGet": {
-      "description": "HTTPGet specifies the http request to perform.",
-      "$ref": "#/definitions/v1.HTTPGetAction"
-     },
-     "initialDelaySeconds": {
-      "description": "Number of seconds after the VirtualMachineInstance has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-      "type": "integer",
-      "format": "int32"
-     },
-     "periodSeconds": {
-      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "successThreshold": {
-      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "tcpSocket": {
-      "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
-      "$ref": "#/definitions/v1.TCPSocketAction"
-     },
-     "timeoutSeconds": {
-      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1.RTCTimer": {
-    "type": "object",
-    "properties": {
-     "present": {
-      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
-      "type": "boolean"
-     },
-     "tickPolicy": {
-      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\".",
-      "type": "string"
-     },
-     "track": {
-      "description": "Track the guest or the wall clock.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.ResourceRequirements": {
-    "type": "object",
-    "properties": {
-     "limits": {
-      "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
-      }
-     },
-     "overcommitGuestOverhead": {
-      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
-      "type": "boolean"
-     },
-     "requests": {
-      "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
-      }
-     }
-    }
-   },
-   "v1.RestartOptions": {
-    "description": "RestartOptions may be provided when deleting an API object.",
-    "type": "object",
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "gracePeriodSeconds": {
-      "description": "The duration in seconds before the object should be force-restared. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
-      "type": "integer",
-      "format": "int64"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Rng": {
-    "description": "Rng represents the random device passed from host",
-    "type": "object"
-   },
-   "v1.RootPaths": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.RootPaths": {
     "description": "RootPaths lists the paths available at root. For example: \"/healthz\", \"/apis\".",
     "type": "object",
     "required": [
@@ -8548,45 +7213,7 @@
      }
     }
    },
-   "v1.SMBiosConfiguration": {
-    "type": "object",
-    "properties": {
-     "family": {
-      "type": "string"
-     },
-     "manufacturer": {
-      "type": "string"
-     },
-     "product": {
-      "type": "string"
-     },
-     "sku": {
-      "type": "string"
-     },
-     "version": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.SecretVolumeSource": {
-    "description": "SecretVolumeSource adapts a Secret into a volume.",
-    "type": "object",
-    "properties": {
-     "optional": {
-      "description": "Specify whether the Secret or it's keys must be defined",
-      "type": "boolean"
-     },
-     "secretName": {
-      "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
-      "type": "string"
-     },
-     "volumeLabel": {
-      "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
-      "type": "string"
-     }
-    }
-   },
-   "v1.ServerAddressByClientCIDR": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.ServerAddressByClientCIDR": {
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "type": "object",
     "required": [
@@ -8604,17 +7231,7 @@
      }
     }
    },
-   "v1.ServiceAccountVolumeSource": {
-    "description": "ServiceAccountVolumeSource adapts a ServiceAccount into a volume.",
-    "type": "object",
-    "properties": {
-     "serviceAccountName": {
-      "description": "Name of the service account in the pod's namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Status": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.Status": {
     "description": "Status is a return value for calls that don't return other objects.",
     "type": "object",
     "properties": {
@@ -8629,7 +7246,7 @@
      },
      "details": {
       "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-      "$ref": "#/definitions/v1.StatusDetails"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.StatusDetails"
      },
      "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
@@ -8641,7 +7258,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      },
      "reason": {
       "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
@@ -8653,7 +7270,7 @@
      }
     }
    },
-   "v1.StatusCause": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.StatusCause": {
     "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
     "type": "object",
     "properties": {
@@ -8671,7 +7288,7 @@
      }
     }
    },
-   "v1.StatusDetails": {
+   "k8s.io/apimachinery/pkg/apis/meta/v1.StatusDetails": {
     "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
     "type": "object",
     "properties": {
@@ -8679,7 +7296,7 @@
       "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.StatusCause"
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.StatusCause"
       }
      },
      "group": {
@@ -8705,107 +7322,1555 @@
      }
     }
    },
-   "v1.TCPSocketAction": {
-    "description": "TCPSocketAction describes an action based on opening a socket",
+   "k8s.io/apimachinery/pkg/apis/meta/v1.Time": {
+    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+    "type": "string",
+    "format": "date-time"
+   },
+   "k8s.io/apimachinery/pkg/apis/meta/v1.WatchEvent": {
+    "description": "Event represents a single event to a watched resource.",
+    "type": "object",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "object": {
+      "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1runtime.RawExtension"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io/apimachinery/pkg/runtime.RawExtension": {
+    "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+    "type": "object"
+   },
+   "k8s.io/apimachinery/pkg/util/intstr.IntOrString": {
+    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+    "type": "string",
+    "format": "int-or-string"
+   },
+   "k8s.io~1api~1core~1v1.PersistentVolumeClaimStatus": {
+    "nullable": true
+   },
+   "kubevirt.io/client-go/api/v1.BIOS": {
+    "description": "If set (default), BIOS will be used.",
+    "type": "object"
+   },
+   "kubevirt.io/client-go/api/v1.Bootloader": {
+    "description": "Represents the firmware blob used to assist in the domain creation process. Used for setting the QEMU BIOS file path for the libvirt domain.",
+    "type": "object",
+    "properties": {
+     "bios": {
+      "description": "If set (default), BIOS will be used.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.BIOS"
+     },
+     "efi": {
+      "description": "If set, EFI will be used instead of BIOS.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.EFI"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.CDRomTarget": {
+    "type": "object",
+    "properties": {
+     "bus": {
+      "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
+      "type": "string"
+     },
+     "readonly": {
+      "description": "ReadOnly. Defaults to true.",
+      "type": "boolean"
+     },
+     "tray": {
+      "description": "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.CPU": {
+    "description": "CPU allows specifying the CPU topology.",
+    "type": "object",
+    "properties": {
+     "cores": {
+      "description": "Cores specifies the number of cores inside the vmi. Must be a value greater or equal 1.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "dedicatedCpuPlacement": {
+      "description": "DedicatedCPUPlacement requests the scheduler to place the VirtualMachineInstance on a node with enough dedicated pCPUs and pin the vCPUs to it.",
+      "type": "boolean"
+     },
+     "features": {
+      "description": "Features specifies the CPU features list inside the VMI.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.CPUFeature"
+      }
+     },
+     "isolateEmulatorThread": {
+      "description": "IsolateEmulatorThread requests one more dedicated pCPU to be allocated for the VMI to place the emulator thread on it.",
+      "type": "boolean"
+     },
+     "model": {
+      "description": "Model specifies the CPU model inside the VMI. List of available models https://github.com/libvirt/libvirt/tree/master/src/cpu_map. It is possible to specify special cases like \"host-passthrough\" to get the same CPU as the node and \"host-model\" to get CPU closest to the node one. Defaults to host-model.",
+      "type": "string"
+     },
+     "sockets": {
+      "description": "Sockets specifies the number of sockets inside the vmi. Must be a value greater or equal 1.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "threads": {
+      "description": "Threads specifies the number of threads inside the vmi. Must be a value greater or equal 1.",
+      "type": "integer",
+      "format": "int64"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.CPUFeature": {
+    "description": "CPUFeature allows specifying a CPU feature.",
+    "type": "object",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "description": "Name of the CPU feature",
+      "type": "string"
+     },
+     "policy": {
+      "description": "Policy is the CPU feature attribute which can have the following attributes: force    - The virtual CPU will claim the feature is supported regardless of it being supported by host CPU. require  - Guest creation will fail unless the feature is supported by the host CPU or the hypervisor is able to emulate it. optional - The feature will be supported by virtual CPU if and only if it is supported by host CPU. disable  - The feature will not be supported by virtual CPU. forbid   - Guest creation will fail if the feature is supported by host CPU. Defaults to require",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Chassis": {
+    "description": "Chassis specifies the chassis info passed to the domain.",
+    "type": "object",
+    "properties": {
+     "asset": {
+      "type": "string"
+     },
+     "manufacturer": {
+      "type": "string"
+     },
+     "serial": {
+      "type": "string"
+     },
+     "sku": {
+      "type": "string"
+     },
+     "version": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Clock": {
+    "description": "Represents the clock and timers of a vmi.",
+    "type": "object",
+    "properties": {
+     "timer": {
+      "description": "Timer specifies whih timers are attached to the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Timer"
+     },
+     "timezone": {
+      "description": "Timezone sets the guest clock to the specified timezone. Zone name follows the TZ environment variable format (e.g. 'America/New_York').",
+      "type": "string"
+     },
+     "utc": {
+      "description": "UTC sets the guest clock to UTC on each boot. If an offset is specified, guest changes to the clock will be kept during reboots and are not reset.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.ClockOffsetUTC"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.ClockOffsetUTC": {
+    "description": "UTC sets the guest clock to UTC on each boot.",
+    "type": "object",
+    "properties": {
+     "offsetSeconds": {
+      "description": "OffsetSeconds specifies an offset in seconds, relative to UTC. If set, guest changes to the clock will be kept during reboots and not reset.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.CloudInitConfigDriveSource": {
+    "description": "Represents a cloud-init config drive user data source. More info: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html",
+    "type": "object",
+    "properties": {
+     "networkData": {
+      "description": "NetworkData contains config drive inline cloud-init networkdata.",
+      "type": "string"
+     },
+     "networkDataBase64": {
+      "description": "NetworkDataBase64 contains config drive cloud-init networkdata as a base64 encoded string.",
+      "type": "string"
+     },
+     "networkDataSecretRef": {
+      "description": "NetworkDataSecretRef references a k8s secret that contains config drive networkdata.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.LocalObjectReference"
+     },
+     "secretRef": {
+      "description": "UserDataSecretRef references a k8s secret that contains config drive userdata.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.LocalObjectReference"
+     },
+     "userData": {
+      "description": "UserData contains config drive inline cloud-init userdata.",
+      "type": "string"
+     },
+     "userDataBase64": {
+      "description": "UserDataBase64 contains config drive cloud-init userdata as a base64 encoded string.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.CloudInitNoCloudSource": {
+    "description": "Represents a cloud-init nocloud user data source. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
+    "type": "object",
+    "properties": {
+     "networkData": {
+      "description": "NetworkData contains NoCloud inline cloud-init networkdata.",
+      "type": "string"
+     },
+     "networkDataBase64": {
+      "description": "NetworkDataBase64 contains NoCloud cloud-init networkdata as a base64 encoded string.",
+      "type": "string"
+     },
+     "networkDataSecretRef": {
+      "description": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.LocalObjectReference"
+     },
+     "secretRef": {
+      "description": "UserDataSecretRef references a k8s secret that contains NoCloud userdata.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.LocalObjectReference"
+     },
+     "userData": {
+      "description": "UserData contains NoCloud inline cloud-init userdata.",
+      "type": "string"
+     },
+     "userDataBase64": {
+      "description": "UserDataBase64 contains NoCloud cloud-init userdata as a base64 encoded string.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.ConfigMapVolumeSource": {
+    "description": "ConfigMapVolumeSource adapts a ConfigMap into a volume. More info: https://kubernetes.io/docs/concepts/storage/volumes/#configmap",
+    "type": "object",
+    "properties": {
+     "name": {
+      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+      "type": "string"
+     },
+     "optional": {
+      "description": "Specify whether the ConfigMap or it's keys must be defined",
+      "type": "boolean"
+     },
+     "volumeLabel": {
+      "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.ContainerDiskSource": {
+    "description": "Represents a docker image with an embedded disk.",
+    "type": "object",
+    "required": [
+     "image"
+    ],
+    "properties": {
+     "image": {
+      "description": "Image is the name of the image with the embedded disk.",
+      "type": "string"
+     },
+     "imagePullPolicy": {
+      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+      "type": "string"
+     },
+     "imagePullSecret": {
+      "description": "ImagePullSecret is the name of the Docker registry secret required to pull the image. The secret must already exist.",
+      "type": "string"
+     },
+     "path": {
+      "description": "Path defines the path to disk file in the container",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.CustomizeComponents": {
+    "type": "object",
+    "properties": {
+     "patches": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Patch"
+      },
+      "x-kubernetes-list-type": "atomic"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.DHCPOptions": {
+    "description": "Extra DHCP options to use in the interface.",
+    "type": "object",
+    "properties": {
+     "bootFileName": {
+      "description": "If specified will pass option 67 to interface's DHCP server",
+      "type": "string"
+     },
+     "ntpServers": {
+      "description": "If specified will pass the configured NTP server to the VM via DHCP option 042.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "privateOptions": {
+      "description": "If specified will pass extra DHCP options for private use, range: 224-254",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DHCPPrivateOptions"
+      }
+     },
+     "tftpServerName": {
+      "description": "If specified will pass option 66 to interface's DHCP server",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.DHCPPrivateOptions": {
+    "description": "DHCPExtraOptions defines Extra DHCP options for a VM.",
+    "type": "object",
+    "required": [
+     "option",
+     "value"
+    ],
+    "properties": {
+     "option": {
+      "description": "Option is an Integer value from 224-254 Required.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "value": {
+      "description": "Value is a String value for the Option provided Required.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.DataVolumeSource": {
+    "type": "object",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "description": "Name represents the name of the DataVolume in the same namespace",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.DeveloperConfiguration": {
+    "description": "DeveloperConfiguration holds developer options",
+    "type": "object",
+    "properties": {
+     "featureGates": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "memoryOvercommit": {
+      "type": "string"
+     },
+     "nodeSelectors": {
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "pvcTolerateLessSpaceUpToPercent": {
+      "type": "string"
+     },
+     "useEmulation": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Devices": {
+    "type": "object",
+    "properties": {
+     "autoattachGraphicsDevice": {
+      "description": "Whether to attach the default graphics device or not. VNC will not be available if set to false. Defaults to true.",
+      "type": "boolean"
+     },
+     "autoattachMemBalloon": {
+      "description": "Whether to attach the Memory balloon device with default period. Period can be adjusted in virt-config. Defaults to true.",
+      "type": "boolean"
+     },
+     "autoattachPodInterface": {
+      "description": "Whether to attach a pod network interface. Defaults to true.",
+      "type": "boolean"
+     },
+     "autoattachSerialConsole": {
+      "description": "Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.",
+      "type": "boolean"
+     },
+     "blockMultiQueue": {
+      "description": "Whether or not to enable virtio multi-queue for block devices",
+      "type": "boolean"
+     },
+     "disks": {
+      "description": "Disks describes disks, cdroms, floppy and luns which are connected to the vmi.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Disk"
+      }
+     },
+     "gpus": {
+      "description": "Whether to attach a GPU device to the vmi.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.GPU"
+      }
+     },
+     "inputs": {
+      "description": "Inputs describe input devices",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Input"
+      }
+     },
+     "interfaces": {
+      "description": "Interfaces describe network interfaces which are added to the vmi.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Interface"
+      }
+     },
+     "networkInterfaceMultiqueue": {
+      "description": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature",
+      "type": "boolean"
+     },
+     "rng": {
+      "description": "Whether to have random number generator from host",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Rng"
+     },
+     "watchdog": {
+      "description": "Watchdog describes a watchdog device which can be added to the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Watchdog"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Disk": {
+    "type": "object",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "bootOrder": {
+      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "cache": {
+      "description": "Cache specifies which kvm disk cache mode should be used.",
+      "type": "string"
+     },
+     "cdrom": {
+      "description": "Attach a volume as a cdrom to the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.CDRomTarget"
+     },
+     "dedicatedIOThread": {
+      "description": "dedicatedIOThread indicates this disk should have an exclusive IO Thread. Enabling this implies useIOThreads = true. Defaults to false.",
+      "type": "boolean"
+     },
+     "disk": {
+      "description": "Attach a volume as a disk to the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DiskTarget"
+     },
+     "floppy": {
+      "description": "Attach a volume as a floppy to the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FloppyTarget"
+     },
+     "io": {
+      "description": "IO specifies which QEMU disk IO mode should be used. Supported values are: native, default, threads.",
+      "type": "string"
+     },
+     "lun": {
+      "description": "Attach a volume as a LUN to the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.LunTarget"
+     },
+     "name": {
+      "description": "Name is the device name",
+      "type": "string"
+     },
+     "serial": {
+      "description": "Serial provides the ability to specify a serial number for the disk device.",
+      "type": "string"
+     },
+     "tag": {
+      "description": "If specified, disk address and its tag will be provided to the guest via config drive metadata",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.DiskTarget": {
+    "type": "object",
+    "properties": {
+     "bus": {
+      "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
+      "type": "string"
+     },
+     "pciAddress": {
+      "description": "If specified, the virtual disk will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10",
+      "type": "string"
+     },
+     "readonly": {
+      "description": "ReadOnly. Defaults to false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.DomainSpec": {
+    "type": "object",
+    "required": [
+     "devices"
+    ],
+    "properties": {
+     "chassis": {
+      "description": "Chassis specifies the chassis info passed to the domain.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Chassis"
+     },
+     "clock": {
+      "description": "Clock sets the clock and timers of the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Clock"
+     },
+     "cpu": {
+      "description": "CPU allow specified the detailed CPU topology inside the vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.CPU"
+     },
+     "devices": {
+      "description": "Devices allows adding disks, network interfaces, and others",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Devices"
+     },
+     "features": {
+      "description": "Features like acpi, apic, hyperv, smm.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Features"
+     },
+     "firmware": {
+      "description": "Firmware.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Firmware"
+     },
+     "ioThreadsPolicy": {
+      "description": "Controls whether or not disks will share IOThreads. Omitting IOThreadsPolicy disables use of IOThreads. One of: shared, auto",
+      "type": "string"
+     },
+     "machine": {
+      "description": "Machine type.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Machine"
+     },
+     "memory": {
+      "description": "Memory allow specifying the VMI memory features.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Memory"
+     },
+     "resources": {
+      "description": "Resources describes the Compute Resources required by this vmi.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.ResourceRequirements"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.EFI": {
+    "description": "If set, EFI will be used instead of BIOS.",
+    "type": "object",
+    "properties": {
+     "secureBoot": {
+      "description": "If set, SecureBoot will be enabled and the OVMF roms will be swapped for SecureBoot-enabled ones. Requires SMM to be enabled. Defaults to true",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.EmptyDiskSource": {
+    "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle.",
+    "type": "object",
+    "required": [
+     "capacity"
+    ],
+    "properties": {
+     "capacity": {
+      "description": "Capacity of the sparse disk.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.EphemeralVolumeSource": {
+    "type": "object",
+    "properties": {
+     "persistentVolumeClaim": {
+      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaimVolumeSource"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.FeatureAPIC": {
+    "type": "object",
+    "properties": {
+     "enabled": {
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+      "type": "boolean"
+     },
+     "endOfInterrupt": {
+      "description": "EndOfInterrupt enables the end of interrupt notification in the guest. Defaults to false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.FeatureHyperv": {
+    "description": "Hyperv specific features.",
+    "type": "object",
+    "properties": {
+     "evmcs": {
+      "description": "EVMCS Speeds up L2 vmexits, but disables other virtualization features. Requires vapic. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "frequencies": {
+      "description": "Frequencies improves the TSC clock source handling for Hyper-V on KVM. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "ipi": {
+      "description": "IPI improves performances in overcommited environments. Requires vpindex. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "reenlightenment": {
+      "description": "Reenlightenment enables the notifications on TSC frequency changes. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "relaxed": {
+      "description": "Relaxed instructs the guest OS to disable watchdog timeouts. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "reset": {
+      "description": "Reset enables Hyperv reboot/reset for the vmi. Requires synic. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "runtime": {
+      "description": "Runtime improves the time accounting to improve scheduling in the guest. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "spinlocks": {
+      "description": "Spinlocks allows to configure the spinlock retry attempts.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureSpinlocks"
+     },
+     "synic": {
+      "description": "SyNIC enables the Synthetic Interrupt Controller. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "synictimer": {
+      "description": "SyNICTimer enables Synthetic Interrupt Controller Timers, reducing CPU load. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "tlbflush": {
+      "description": "TLBFlush improves performances in overcommited environments. Requires vpindex. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "vapic": {
+      "description": "VAPIC improves the paravirtualized handling of interrupts. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "vendorid": {
+      "description": "VendorID allows setting the hypervisor vendor id. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureVendorID"
+     },
+     "vpindex": {
+      "description": "VPIndex enables the Virtual Processor Index to help windows identifying virtual processors. Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.FeatureSpinlocks": {
+    "type": "object",
+    "properties": {
+     "enabled": {
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+      "type": "boolean"
+     },
+     "spinlocks": {
+      "description": "Retries indicates the number of retries. Must be a value greater or equal 4096. Defaults to 4096.",
+      "type": "integer",
+      "format": "int64"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.FeatureState": {
+    "description": "Represents if a feature is enabled or disabled.",
+    "type": "object",
+    "properties": {
+     "enabled": {
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.FeatureVendorID": {
+    "type": "object",
+    "properties": {
+     "enabled": {
+      "description": "Enabled determines if the feature should be enabled or disabled on the guest. Defaults to true.",
+      "type": "boolean"
+     },
+     "vendorid": {
+      "description": "VendorID sets the hypervisor vendor id, visible to the vmi. String up to twelve characters.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Features": {
+    "type": "object",
+    "properties": {
+     "acpi": {
+      "description": "ACPI enables/disables ACPI insidejsondata guest. Defaults to enabled.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     },
+     "apic": {
+      "description": "Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureAPIC"
+     },
+     "hyperv": {
+      "description": "Defaults to the machine type setting.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureHyperv"
+     },
+     "smm": {
+      "description": "SMM enables/disables System Management Mode. TSEG not yet implemented.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.FeatureState"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Firmware": {
+    "type": "object",
+    "properties": {
+     "bootloader": {
+      "description": "Settings to control the bootloader that is used.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Bootloader"
+     },
+     "serial": {
+      "description": "The system-serial-number in SMBIOS",
+      "type": "string"
+     },
+     "uuid": {
+      "description": "UUID reported by the vmi bios. Defaults to a random generated uid.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.FloppyTarget": {
+    "type": "object",
+    "properties": {
+     "readonly": {
+      "description": "ReadOnly. Defaults to false.",
+      "type": "boolean"
+     },
+     "tray": {
+      "description": "Tray indicates if the tray of the device is open or closed. Allowed values are \"open\" and \"closed\". Defaults to closed.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.GPU": {
+    "type": "object",
+    "required": [
+     "name",
+     "deviceName"
+    ],
+    "properties": {
+     "deviceName": {
+      "type": "string"
+     },
+     "name": {
+      "description": "Name of the GPU device as exposed by a device plugin",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.HPETTimer": {
+    "type": "object",
+    "properties": {
+     "present": {
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+      "type": "boolean"
+     },
+     "tickPolicy": {
+      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"merge\", \"discard\".",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.HostDisk": {
+    "description": "Represents a disk created on the cluster level",
+    "type": "object",
+    "required": [
+     "path",
+     "type"
+    ],
+    "properties": {
+     "capacity": {
+      "description": "Capacity of the sparse disk",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+     },
+     "path": {
+      "description": "The path to HostDisk image located on the cluster",
+      "type": "string"
+     },
+     "shared": {
+      "description": "Shared indicate whether the path is shared between nodes",
+      "type": "boolean"
+     },
+     "type": {
+      "description": "Contains information if disk.img exists or should be created allowed options are 'Disk' and 'DiskOrCreate'",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Hugepages": {
+    "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
+    "type": "object",
+    "properties": {
+     "pageSize": {
+      "description": "PageSize specifies the hugepage size, for x86_64 architecture valid values are 1Gi and 2Mi.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.HypervTimer": {
+    "type": "object",
+    "properties": {
+     "present": {
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.I6300ESBWatchdog": {
+    "description": "i6300esb watchdog device.",
+    "type": "object",
+    "properties": {
+     "action": {
+      "description": "The action to take. Valid values are poweroff, reset, shutdown. Defaults to reset.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Input": {
+    "type": "object",
+    "required": [
+     "type",
+     "name"
+    ],
+    "properties": {
+     "bus": {
+      "description": "Bus indicates the bus of input device to emulate. Supported values: virtio, usb.",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name is the device name",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type indicated the type of input device. Supported values: tablet.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Interface": {
+    "type": "object",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "bootOrder": {
+      "description": "BootOrder is an integer value \u003e 0, used to determine ordering of boot devices. Lower values take precedence. Each interface or disk that has a boot order must have a unique value. Interfaces without a boot order are not tried.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "bridge": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.InterfaceBridge"
+     },
+     "dhcpOptions": {
+      "description": "If specified the network interface will pass additional DHCP options to the VMI",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DHCPOptions"
+     },
+     "macAddress": {
+      "description": "Interface MAC address. For example: de:ad:00:00:be:af or DE-AD-00-00-BE-AF.",
+      "type": "string"
+     },
+     "masquerade": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.InterfaceMasquerade"
+     },
+     "model": {
+      "description": "Interface model. One of: e1000, e1000e, ne2k_pci, pcnet, rtl8139, virtio. Defaults to virtio.",
+      "type": "string"
+     },
+     "name": {
+      "description": "Logical name of the interface as well as a reference to the associated networks. Must match the Name of a Network.",
+      "type": "string"
+     },
+     "pciAddress": {
+      "description": "If specified, the virtual network interface will be placed on the guests pci address with the specifed PCI address. For example: 0000:81:01.10",
+      "type": "string"
+     },
+     "ports": {
+      "description": "List of ports to be forwarded to the virtual machine.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Port"
+      }
+     },
+     "slirp": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.InterfaceSlirp"
+     },
+     "sriov": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.InterfaceSRIOV"
+     },
+     "tag": {
+      "description": "If specified, the virtual network interface address and its tag will be provided to the guest via config drive",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.InterfaceBridge": {
+    "type": "object"
+   },
+   "kubevirt.io/client-go/api/v1.InterfaceMasquerade": {
+    "type": "object"
+   },
+   "kubevirt.io/client-go/api/v1.InterfaceSRIOV": {
+    "type": "object"
+   },
+   "kubevirt.io/client-go/api/v1.InterfaceSlirp": {
+    "type": "object"
+   },
+   "kubevirt.io/client-go/api/v1.KVMTimer": {
+    "type": "object",
+    "properties": {
+     "present": {
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirt": {
+    "description": "KubeVirt represents the object deploying all KubeVirt resources",
+    "type": "object",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtSpec"
+     },
+     "status": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtStatus"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtCertificateRotateStrategy": {
+    "type": "object",
+    "properties": {
+     "selfSigned": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtSelfSignConfiguration"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtCondition": {
+    "description": "KubeVirtCondition represents a condition of a KubeVirt deployment",
+    "type": "object",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastProbeTime": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "lastTransitionTime": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "message": {
+      "type": "string"
+     },
+     "reason": {
+      "type": "string"
+     },
+     "status": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtConfiguration": {
+    "description": "KubeVirtConfiguration holds all kubevirt configurations",
+    "type": "object",
+    "properties": {
+     "cpuModel": {
+      "type": "string"
+     },
+     "cpuRequest": {
+      "type": "string"
+     },
+     "developerConfiguration": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DeveloperConfiguration"
+     },
+     "emulatedMachines": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "imagePullPolicy": {
+      "type": "string"
+     },
+     "machineType": {
+      "type": "string"
+     },
+     "memBalloonStatsPeriod": {
+      "type": "integer",
+      "format": "int32"
+     },
+     "migrations": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.MigrationConfiguration"
+     },
+     "network": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.NetworkConfiguration"
+     },
+     "ovmfPath": {
+      "type": "string"
+     },
+     "selinuxLauncherType": {
+      "type": "string"
+     },
+     "smbios": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.SMBiosConfiguration"
+     },
+     "supportedGuestAgentVersions": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtList": {
+    "description": "KubeVirtList is a list of KubeVirts",
+    "type": "object",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirt"
+      }
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtSelfSignConfiguration": {
+    "type": "object",
+    "properties": {
+     "caOverlapInterval": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Duration"
+     },
+     "caRotateInterval": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Duration"
+     },
+     "certRotateInterval": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Duration"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtSpec": {
+    "type": "object",
+    "properties": {
+     "certificateRotateStrategy": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtCertificateRotateStrategy"
+     },
+     "configuration": {
+      "description": "holds kubevirt configurations. same as the virt-configMap",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtConfiguration"
+     },
+     "customizeComponents": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.CustomizeComponents"
+     },
+     "imagePullPolicy": {
+      "description": "The ImagePullPolicy to use.",
+      "type": "string"
+     },
+     "imageRegistry": {
+      "description": "The image registry to pull the container images from Defaults to the same registry the operator's container image is pulled from.",
+      "type": "string"
+     },
+     "imageTag": {
+      "description": "The image tag to use for the continer images installed. Defaults to the same tag as the operator's container image.",
+      "type": "string"
+     },
+     "monitorAccount": {
+      "description": "The name of the Prometheus service account that needs read-access to KubeVirt endpoints Defaults to prometheus-k8s",
+      "type": "string"
+     },
+     "monitorNamespace": {
+      "description": "The namespace Prometheus is deployed in Defaults to openshift-monitor",
+      "type": "string"
+     },
+     "productName": {
+      "description": "Designate the apps.kubevirt.io/part-of label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductName is not specified, the part-of label will be omitted.",
+      "type": "string"
+     },
+     "productVersion": {
+      "description": "Designate the apps.kubevirt.io/version label for KubeVirt components. Useful if KubeVirt is included as part of a product. If ProductVersion is not specified, KubeVirt's version will be used.",
+      "type": "string"
+     },
+     "uninstallStrategy": {
+      "description": "Specifies if kubevirt can be deleted if workloads are still present. This is mainly a precaution to avoid accidental data loss",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.KubeVirtStatus": {
+    "description": "KubeVirtStatus represents information pertaining to a KubeVirt deployment.",
+    "type": "object",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KubeVirtCondition"
+      }
+     },
+     "observedDeploymentConfig": {
+      "type": "string"
+     },
+     "observedDeploymentID": {
+      "type": "string"
+     },
+     "observedKubeVirtRegistry": {
+      "type": "string"
+     },
+     "observedKubeVirtVersion": {
+      "type": "string"
+     },
+     "operatorVersion": {
+      "type": "string"
+     },
+     "phase": {
+      "type": "string"
+     },
+     "targetDeploymentConfig": {
+      "type": "string"
+     },
+     "targetDeploymentID": {
+      "type": "string"
+     },
+     "targetKubeVirtRegistry": {
+      "type": "string"
+     },
+     "targetKubeVirtVersion": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.LunTarget": {
+    "type": "object",
+    "properties": {
+     "bus": {
+      "description": "Bus indicates the type of disk device to emulate. supported values: virtio, sata, scsi.",
+      "type": "string"
+     },
+     "readonly": {
+      "description": "ReadOnly. Defaults to false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Machine": {
+    "type": "object",
+    "required": [
+     "type"
+    ],
+    "properties": {
+     "type": {
+      "description": "QEMU machine type is the actual chipset of the VirtualMachineInstance.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Memory": {
+    "description": "Memory allows specifying the VirtualMachineInstance memory features.",
+    "type": "object",
+    "properties": {
+     "guest": {
+      "description": "Guest allows to specifying the amount of memory which is visible inside the Guest OS. The Guest must lie between Requests and Limits from the resources section. Defaults to the requested memory in the resources section if not specified.",
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+     },
+     "hugepages": {
+      "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Hugepages"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.MigrationConfiguration": {
+    "description": "MigrationConfiguration holds migration options",
+    "type": "object",
+    "required": [
+     "allowAutoConverge",
+     "unsafeMigrationOverride"
+    ],
+    "properties": {
+     "allowAutoConverge": {
+      "type": "string"
+     },
+     "bandwidthPerMigration": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+     },
+     "completionTimeoutPerGiB": {
+      "type": "string"
+     },
+     "nodeDrainTaintKey": {
+      "type": "string"
+     },
+     "parallelMigrationsPerCluster": {
+      "type": "string"
+     },
+     "parallelOutboundMigrationsPerNode": {
+      "type": "string"
+     },
+     "progressTimeout": {
+      "type": "string"
+     },
+     "unsafeMigrationOverride": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.MultusNetwork": {
+    "description": "Represents the multus cni network.",
+    "type": "object",
+    "required": [
+     "networkName"
+    ],
+    "properties": {
+     "default": {
+      "description": "Select the default network and add it to the multus-cni.io/default-network annotation.",
+      "type": "boolean"
+     },
+     "networkName": {
+      "description": "References to a NetworkAttachmentDefinition CRD object. Format: \u003cnetworkName\u003e, \u003cnamespace\u003e/\u003cnetworkName\u003e. If namespace is not specified, VMI namespace is assumed.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Network": {
+    "description": "Network represents a network type and a resource that should be connected to the vm.",
+    "type": "object",
+    "required": [
+     "name"
+    ],
+    "properties": {
+     "multus": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.MultusNetwork"
+     },
+     "name": {
+      "description": "Network name. Must be a DNS_LABEL and unique within the vm. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+      "type": "string"
+     },
+     "pod": {
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.PodNetwork"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.NetworkConfiguration": {
+    "description": "NetworkConfiguration holds network options",
+    "type": "object",
+    "properties": {
+     "defaultNetworkInterface": {
+      "type": "string"
+     },
+     "permitBridgeInterfaceOnPodNetwork": {
+      "type": "string"
+     },
+     "permitSlirpInterface": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.PITTimer": {
+    "type": "object",
+    "properties": {
+     "present": {
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+      "type": "boolean"
+     },
+     "tickPolicy": {
+      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"discard\".",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Patch": {
+    "type": "object",
+    "properties": {
+     "patch": {
+      "type": "string"
+     },
+     "resourceName": {
+      "type": "string"
+     },
+     "resourceType": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.PodNetwork": {
+    "description": "Represents the stock pod network interface.",
+    "type": "object",
+    "properties": {
+     "vmNetworkCIDR": {
+      "description": "CIDR for vm network. Default 10.0.2.0/24 if not specified.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Port": {
+    "description": "Port repesents a port to expose from the virtual machine. Default protocol TCP. The port field is mandatory",
     "type": "object",
     "required": [
      "port"
     ],
     "properties": {
-     "host": {
-      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+     "name": {
+      "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
       "type": "string"
      },
      "port": {
-      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-      "type": [
-       "string",
-       "number"
-      ]
+      "description": "Number of port to expose for the virtual machine. This must be a valid port number, 0 \u003c x \u003c 65536.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "protocol": {
+      "description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\".",
+      "type": "string"
      }
     }
    },
-   "v1.Time": {
-    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-    "type": "string",
-    "format": "date-time"
+   "kubevirt.io/client-go/api/v1.Probe": {
+    "description": "Probe describes a health check to be performed against a VirtualMachineInstance to determine whether it is alive or ready to receive traffic.",
+    "type": "object",
+    "properties": {
+     "failureThreshold": {
+      "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "httpGet": {
+      "description": "HTTPGet specifies the http request to perform.",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.HTTPGetAction"
+     },
+     "initialDelaySeconds": {
+      "description": "Number of seconds after the VirtualMachineInstance has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+      "type": "integer",
+      "format": "int32"
+     },
+     "periodSeconds": {
+      "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "successThreshold": {
+      "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "tcpSocket": {
+      "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.TCPSocketAction"
+     },
+     "timeoutSeconds": {
+      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
    },
-   "v1.Timer": {
+   "kubevirt.io/client-go/api/v1.RTCTimer": {
+    "type": "object",
+    "properties": {
+     "present": {
+      "description": "Enabled set to false makes sure that the machine type or a preset can't add the timer. Defaults to true.",
+      "type": "boolean"
+     },
+     "tickPolicy": {
+      "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\".",
+      "type": "string"
+     },
+     "track": {
+      "description": "Track the guest or the wall clock.",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.ResourceRequirements": {
+    "type": "object",
+    "properties": {
+     "limits": {
+      "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+      }
+     },
+     "overcommitGuestOverhead": {
+      "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
+      "type": "boolean"
+     },
+     "requests": {
+      "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1api~1resource.Quantity"
+      }
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.RestartOptions": {
+    "description": "RestartOptions may be provided when deleting an API object.",
+    "type": "object",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "gracePeriodSeconds": {
+      "description": "The duration in seconds before the object should be force-restared. Value must be non-negative integer. The value zero indicates, restart immediately. If this value is nil, the default grace period for deletion of the corresponding VMI for the specified type will be used to determine on how much time to give the VMI to restart. Defaults to a per object value if not specified. zero means restart immediately. Allowed Values: nil and 0",
+      "type": "integer",
+      "format": "int64"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Rng": {
+    "description": "Rng represents the random device passed from host",
+    "type": "object"
+   },
+   "kubevirt.io/client-go/api/v1.SMBiosConfiguration": {
+    "type": "object",
+    "properties": {
+     "family": {
+      "type": "string"
+     },
+     "manufacturer": {
+      "type": "string"
+     },
+     "product": {
+      "type": "string"
+     },
+     "sku": {
+      "type": "string"
+     },
+     "version": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.SecretVolumeSource": {
+    "description": "SecretVolumeSource adapts a Secret into a volume.",
+    "type": "object",
+    "properties": {
+     "optional": {
+      "description": "Specify whether the Secret or it's keys must be defined",
+      "type": "boolean"
+     },
+     "secretName": {
+      "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+      "type": "string"
+     },
+     "volumeLabel": {
+      "description": "The volume label of the resulting disk inside the VMI. Different bootstrapping mechanisms require different values. Typical values are \"cidata\" (cloud-init), \"config-2\" (cloud-init) or \"OEMDRV\" (kickstart).",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.ServiceAccountVolumeSource": {
+    "description": "ServiceAccountVolumeSource adapts a ServiceAccount into a volume.",
+    "type": "object",
+    "properties": {
+     "serviceAccountName": {
+      "description": "Name of the service account in the pod's namespace to use. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/client-go/api/v1.Timer": {
     "description": "Represents all available timers in a vmi.",
     "type": "object",
     "properties": {
      "hpet": {
       "description": "HPET (High Precision Event Timer) - multiple timers with periodic interrupts.",
-      "$ref": "#/definitions/v1.HPETTimer"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.HPETTimer"
      },
      "hyperv": {
       "description": "Hyperv (Hypervclock) - lets guests read the host’s wall clock time (paravirtualized). For windows guests.",
-      "$ref": "#/definitions/v1.HypervTimer"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.HypervTimer"
      },
      "kvm": {
       "description": "KVM \t(KVM clock) - lets guests read the host’s wall clock time (paravirtualized). For linux guests.",
-      "$ref": "#/definitions/v1.KVMTimer"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.KVMTimer"
      },
      "pit": {
       "description": "PIT (Programmable Interval Timer) - a timer with periodic interrupts.",
-      "$ref": "#/definitions/v1.PITTimer"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.PITTimer"
      },
      "rtc": {
       "description": "RTC (Real Time Clock) - a continuously running timer with periodic interrupts.",
-      "$ref": "#/definitions/v1.RTCTimer"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.RTCTimer"
      }
     }
    },
-   "v1.Toleration": {
-    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
-    "type": "object",
-    "properties": {
-     "effect": {
-      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
-      "type": "string"
-     },
-     "key": {
-      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-      "type": "string"
-     },
-     "operator": {
-      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
-      "type": "string"
-     },
-     "tolerationSeconds": {
-      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "value": {
-      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.TypedLocalObjectReference": {
-    "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
-    "type": "object",
-    "required": [
-     "kind",
-     "name"
-    ],
-    "properties": {
-     "apiGroup": {
-      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is the type of resource being referenced",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name is the name of resource being referenced",
-      "type": "string"
-     }
-    }
-   },
-   "v1.VirtualMachine": {
+   "kubevirt.io/client-go/api/v1.VirtualMachine": {
     "description": "VirtualMachine handles the VirtualMachines that are not running or are in a stopped state The VirtualMachine contains the template to create the VirtualMachineInstance. It also mirrors the running state of the created VirtualMachineInstance in its status.",
     "type": "object",
     "required": [
@@ -8821,19 +8886,19 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
       "description": "Spec contains the specification of VirtualMachineInstance created",
-      "$ref": "#/definitions/v1.VirtualMachineSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineSpec"
      },
      "status": {
       "description": "Status holds the current state of the controller and brief information about its associated VirtualMachineInstance",
-      "$ref": "#/definitions/v1.VirtualMachineStatus"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineStatus"
      }
     }
    },
-   "v1.VirtualMachineCondition": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineCondition": {
     "description": "VirtualMachineCondition represents the state of VirtualMachine",
     "type": "object",
     "required": [
@@ -8867,7 +8932,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstance": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstance": {
     "description": "VirtualMachineInstance is *the* VirtualMachineInstance Definition. It represents a virtual machine in the runtime environment of kubernetes.",
     "type": "object",
     "required": [
@@ -8883,19 +8948,19 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceSpec"
      },
      "status": {
       "description": "Status is the high level overview of how the VirtualMachineInstance is doing. It contains information available to controllers and users.",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceStatus"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceStatus"
      }
     }
    },
-   "v1.VirtualMachineInstanceCondition": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceCondition": {
     "type": "object",
     "required": [
      "type",
@@ -8928,7 +8993,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceFileSystem": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceFileSystem": {
     "description": "VirtualMachineInstanceFileSystem represents guest os disk",
     "type": "object",
     "required": [
@@ -8958,7 +9023,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceFileSystemInfo": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceFileSystemInfo": {
     "description": "VirtualMachineInstanceFileSystemInfo represents information regarding single guest os filesystem",
     "type": "object",
     "required": [
@@ -8968,12 +9033,12 @@
      "disks": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceFileSystem"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceFileSystem"
       }
      }
     }
    },
-   "v1.VirtualMachineInstanceFileSystemList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceFileSystemList": {
     "description": "VirtualMachineInstanceFileSystemList comprises the list of all filesystems on guest machine",
     "type": "object",
     "required": [
@@ -8987,7 +9052,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceFileSystem"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceFileSystem"
       }
      },
      "kind": {
@@ -8995,11 +9060,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineInstanceGuestAgentInfo": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceGuestAgentInfo": {
     "description": "VirtualMachineInstanceGuestAgentInfo represents information from the installed guest agent",
     "type": "object",
     "properties": {
@@ -9009,7 +9074,7 @@
      },
      "fsInfo": {
       "description": "FSInfo is a guest os filesystem information containing the disk mapping and disk mounts with usage",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceFileSystemInfo"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceFileSystemInfo"
      },
      "guestAgentVersion": {
       "description": "GAVersion is a version of currently installed guest agent",
@@ -9025,7 +9090,7 @@
      },
      "os": {
       "description": "OS contains the guest operating system information",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceGuestOSInfo"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceGuestOSInfo"
      },
      "timezone": {
       "description": "Timezone is guest os current timezone",
@@ -9035,12 +9100,12 @@
       "description": "UserList is a list of active guest OS users",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceGuestOSUser"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceGuestOSUser"
       }
      }
     }
    },
-   "v1.VirtualMachineInstanceGuestOSInfo": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceGuestOSInfo": {
     "type": "object",
     "properties": {
      "id": {
@@ -9077,7 +9142,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceGuestOSUser": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceGuestOSUser": {
     "description": "VirtualMachineGuestOSUser is the single user of the guest os",
     "type": "object",
     "required": [
@@ -9096,7 +9161,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceGuestOSUserList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceGuestOSUserList": {
     "description": "VirtualMachineInstanceGuestOSUserList comprises the list of all active users on guest machine",
     "type": "object",
     "required": [
@@ -9110,7 +9175,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceGuestOSUser"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceGuestOSUser"
       }
      },
      "kind": {
@@ -9118,11 +9183,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineInstanceList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceList": {
     "description": "VirtualMachineInstanceList is a list of VirtualMachines",
     "type": "object",
     "required": [
@@ -9136,7 +9201,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstance"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstance"
       }
      },
      "kind": {
@@ -9144,11 +9209,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineInstanceMigration": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceMigration": {
     "description": "VirtualMachineInstanceMigration represents the object tracking a VMI's migration to another host in the cluster",
     "type": "object",
     "required": [
@@ -9164,17 +9229,17 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
-      "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationSpec"
      },
      "status": {
-      "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationStatus"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationStatus"
      }
     }
    },
-   "v1.VirtualMachineInstanceMigrationCondition": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceMigrationCondition": {
     "type": "object",
     "required": [
      "type",
@@ -9207,7 +9272,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceMigrationList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceMigrationList": {
     "description": "VirtualMachineInstanceMigrationList is a list of VirtualMachineMigrations",
     "type": "object",
     "required": [
@@ -9221,7 +9286,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceMigration"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigration"
       }
      },
      "kind": {
@@ -9229,11 +9294,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineInstanceMigrationSpec": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceMigrationSpec": {
     "type": "object",
     "properties": {
      "vmiName": {
@@ -9242,7 +9307,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceMigrationState": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceMigrationState": {
     "type": "object",
     "properties": {
      "abortRequested": {
@@ -9259,7 +9324,7 @@
      },
      "endTimestamp": {
       "description": "The time the migration action ended",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "failed": {
       "description": "Indicates that the migration failed",
@@ -9275,7 +9340,7 @@
      },
      "startTimestamp": {
       "description": "The time the migration action began",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "targetDirectMigrationNodePorts": {
       "description": "The list of ports opened for live migration on the destination node",
@@ -9303,15 +9368,14 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceMigrationStatus": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceMigrationStatus": {
     "description": "VirtualMachineInstanceMigration reprents information pertaining to a VMI's migration.",
     "type": "object",
-    "nullable": true,
     "properties": {
      "conditions": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationCondition"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationCondition"
       }
      },
      "phase": {
@@ -9319,7 +9383,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceNetworkInterface": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceNetworkInterface": {
     "type": "object",
     "properties": {
      "interfaceName": {
@@ -9347,7 +9411,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstancePreset": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstancePreset": {
     "type": "object",
     "properties": {
      "apiVersion": {
@@ -9359,15 +9423,15 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
-      "$ref": "#/definitions/v1.VirtualMachineInstancePresetSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePresetSpec"
      }
     }
    },
-   "v1.VirtualMachineInstancePresetList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstancePresetList": {
     "description": "VirtualMachineInstancePresetList is a list of VirtualMachinePresets",
     "type": "object",
     "required": [
@@ -9381,7 +9445,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstancePreset"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstancePreset"
       }
      },
      "kind": {
@@ -9389,11 +9453,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineInstancePresetSpec": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstancePresetSpec": {
     "type": "object",
     "required": [
      "selector"
@@ -9401,15 +9465,15 @@
     "properties": {
      "domain": {
       "description": "Domain is the same object type as contained in VirtualMachineInstanceSpec",
-      "$ref": "#/definitions/v1.DomainSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DomainSpec"
      },
      "selector": {
       "description": "Selector is a label query over a set of VMIs. Required.",
-      "$ref": "#/definitions/v1.LabelSelector"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.LabelSelector"
      }
     }
    },
-   "v1.VirtualMachineInstanceReplicaSet": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceReplicaSet": {
     "description": "VirtualMachineInstance is *the* VirtualMachineInstance Definition. It represents a virtual machine in the runtime environment of kubernetes.",
     "type": "object",
     "required": [
@@ -9425,19 +9489,19 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSetSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSetSpec"
      },
      "status": {
       "description": "Status is the high level overview of how the VirtualMachineInstance is doing. It contains information available to controllers and users.",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSetStatus"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSetStatus"
      }
     }
    },
-   "v1.VirtualMachineInstanceReplicaSetCondition": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceReplicaSetCondition": {
     "type": "object",
     "required": [
      "type",
@@ -9470,7 +9534,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceReplicaSetList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceReplicaSetList": {
     "description": "VMIList is a list of VMIs",
     "type": "object",
     "required": [
@@ -9484,7 +9548,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSet"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSet"
       }
      },
      "kind": {
@@ -9492,11 +9556,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineInstanceReplicaSetSpec": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceReplicaSetSpec": {
     "type": "object",
     "required": [
      "selector",
@@ -9514,22 +9578,21 @@
      },
      "selector": {
       "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-      "$ref": "#/definitions/v1.LabelSelector"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.LabelSelector"
      },
      "template": {
       "description": "Template describes the pods that will be created.",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceTemplateSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceTemplateSpec"
      }
     }
    },
-   "v1.VirtualMachineInstanceReplicaSetStatus": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceReplicaSetStatus": {
     "type": "object",
-    "nullable": true,
     "properties": {
      "conditions": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceReplicaSetCondition"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSetCondition"
       }
      },
      "labelSelector": {
@@ -9548,7 +9611,7 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceSpec": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceSpec": {
     "description": "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
     "type": "object",
     "required": [
@@ -9557,11 +9620,11 @@
     "properties": {
      "affinity": {
       "description": "If affinity is specifies, obey all the affinity rules",
-      "$ref": "#/definitions/v1.Affinity"
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.Affinity"
      },
      "dnsConfig": {
       "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
-      "$ref": "#/definitions/v1.PodDNSConfig"
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PodDNSConfig"
      },
      "dnsPolicy": {
       "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
@@ -9569,7 +9632,7 @@
      },
      "domain": {
       "description": "Specification of the desired behavior of the VirtualMachineInstance on the host.",
-      "$ref": "#/definitions/v1.DomainSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DomainSpec"
      },
      "evictionStrategy": {
       "description": "EvictionStrategy can be set to \"LiveMigrate\" if the VirtualMachineInstance should be migrated instead of shut-off in case of a node drain.",
@@ -9581,13 +9644,13 @@
      },
      "livenessProbe": {
       "description": "Periodic probe of VirtualMachineInstance liveness. VirtualmachineInstances will be stopped if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-      "$ref": "#/definitions/v1.Probe"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Probe"
      },
      "networks": {
       "description": "List of networks that can be attached to a vm's virtual interface.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.Network"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Network"
       }
      },
      "nodeSelector": {
@@ -9603,7 +9666,7 @@
      },
      "readinessProbe": {
       "description": "Periodic probe of VirtualMachineInstance service readiness. VirtualmachineInstances will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
-      "$ref": "#/definitions/v1.Probe"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Probe"
      },
      "schedulerName": {
       "description": "If specified, the VMI will be dispatched by specified scheduler. If not specified, the VMI will be dispatched by default scheduler.",
@@ -9622,22 +9685,21 @@
       "description": "If toleration is specified, obey all the toleration rules.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.Toleration"
+       "$ref": "#/definitions/k8s.io~1api~1core~1v1.Toleration"
       }
      },
      "volumes": {
       "description": "List of volumes that can be mounted by disks belonging to the vmi.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.Volume"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.Volume"
       }
      }
     }
    },
-   "v1.VirtualMachineInstanceStatus": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceStatus": {
     "description": "VirtualMachineInstanceStatus represents information about the status of a VirtualMachineInstance. Status may trail the actual state of a system.",
     "type": "object",
-    "nullable": true,
     "properties": {
      "activePods": {
       "description": "ActivePods is a mapping of pod UID to node name. It is possible for multiple pods to be running for a single VMI during migration.",
@@ -9650,18 +9712,18 @@
       "description": "Conditions are specific points in VirtualMachineInstance's pod runtime.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceCondition"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceCondition"
       }
      },
      "guestOSInfo": {
       "description": "Guest OS Information",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceGuestOSInfo"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceGuestOSInfo"
      },
      "interfaces": {
       "description": "Interfaces represent the details of available network interfaces.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineInstanceNetworkInterface"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceNetworkInterface"
       }
      },
      "migrationMethod": {
@@ -9670,7 +9732,7 @@
      },
      "migrationState": {
       "description": "Represents the status of a live migration",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationState"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationState"
      },
      "nodeName": {
       "description": "NodeName is the name where the VirtualMachineInstance is currently running.",
@@ -9690,19 +9752,19 @@
      }
     }
    },
-   "v1.VirtualMachineInstanceTemplateSpec": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineInstanceTemplateSpec": {
     "type": "object",
     "properties": {
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceSpec"
      }
     }
    },
-   "v1.VirtualMachineList": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineList": {
     "description": "VirtualMachineList is a list of virtualmachines",
     "type": "object",
     "required": [
@@ -9716,7 +9778,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachine"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
       }
      },
      "kind": {
@@ -9724,11 +9786,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1.VirtualMachineSpec": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineSpec": {
     "description": "VirtualMachineSpec describes how the proper VirtualMachine should look like",
     "type": "object",
     "required": [
@@ -9739,7 +9801,7 @@
       "description": "dataVolumeTemplates is a list of dataVolumes that the VirtualMachineInstance template can reference. DataVolumes in this list are dynamically created for the VirtualMachine and are tied to the VirtualMachine's life-cycle.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1alpha1.DataVolume"
+       "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolume"
       }
      },
      "runStrategy": {
@@ -9752,11 +9814,11 @@
      },
      "template": {
       "description": "Template is the direct specification of VirtualMachineInstance",
-      "$ref": "#/definitions/v1.VirtualMachineInstanceTemplateSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceTemplateSpec"
      }
     }
    },
-   "v1.VirtualMachineStateChangeRequest": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineStateChangeRequest": {
     "type": "object",
     "required": [
      "action"
@@ -9779,16 +9841,15 @@
      }
     }
    },
-   "v1.VirtualMachineStatus": {
+   "kubevirt.io/client-go/api/v1.VirtualMachineStatus": {
     "description": "VirtualMachineStatus represents the status returned by the controller to describe how the VirtualMachine is doing",
     "type": "object",
-    "nullable": true,
     "properties": {
      "conditions": {
       "description": "Hold the state information of the VirtualMachine and its VirtualMachineInstance",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineCondition"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineCondition"
       }
      },
      "created": {
@@ -9807,12 +9868,12 @@
       "description": "StateChangeRequests indicates a list of actions that should be taken on a VMI e.g. stop a specific VMI then start a new one.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.VirtualMachineStateChangeRequest"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachineStateChangeRequest"
       }
      }
     }
    },
-   "v1.Volume": {
+   "kubevirt.io/client-go/api/v1.Volume": {
     "description": "Volume represents a named volume in a vmi.",
     "type": "object",
     "required": [
@@ -9821,35 +9882,35 @@
     "properties": {
      "cloudInitConfigDrive": {
       "description": "CloudInitConfigDrive represents a cloud-init Config Drive user-data source. The Config Drive data will be added as a disk to the vmi. A proper cloud-init installation is required inside the guest. More info: https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html",
-      "$ref": "#/definitions/v1.CloudInitConfigDriveSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.CloudInitConfigDriveSource"
      },
      "cloudInitNoCloud": {
       "description": "CloudInitNoCloud represents a cloud-init NoCloud user-data source. The NoCloud data will be added as a disk to the vmi. A proper cloud-init installation is required inside the guest. More info: http://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html",
-      "$ref": "#/definitions/v1.CloudInitNoCloudSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.CloudInitNoCloudSource"
      },
      "configMap": {
       "description": "ConfigMapSource represents a reference to a ConfigMap in the same namespace. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/",
-      "$ref": "#/definitions/v1.ConfigMapVolumeSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.ConfigMapVolumeSource"
      },
      "containerDisk": {
       "description": "ContainerDisk references a docker image, embedding a qcow or raw disk. More info: https://kubevirt.gitbooks.io/user-guide/registry-disk.html",
-      "$ref": "#/definitions/v1.ContainerDiskSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.ContainerDiskSource"
      },
      "dataVolume": {
       "description": "DataVolume represents the dynamic creation a PVC for this volume as well as the process of populating that PVC with a disk image.",
-      "$ref": "#/definitions/v1.DataVolumeSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.DataVolumeSource"
      },
      "emptyDisk": {
       "description": "EmptyDisk represents a temporary disk which shares the vmis lifecycle. More info: https://kubevirt.gitbooks.io/user-guide/disks-and-volumes.html",
-      "$ref": "#/definitions/v1.EmptyDiskSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.EmptyDiskSource"
      },
      "ephemeral": {
       "description": "Ephemeral is a special volume source that \"wraps\" specified source and provides copy-on-write image on top of it.",
-      "$ref": "#/definitions/v1.EphemeralVolumeSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.EphemeralVolumeSource"
      },
      "hostDisk": {
       "description": "HostDisk represents a disk created on the cluster level",
-      "$ref": "#/definitions/v1.HostDisk"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.HostDisk"
      },
      "name": {
       "description": "Volume's name. Must be a DNS_LABEL and unique within the vmi. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -9857,36 +9918,19 @@
      },
      "persistentVolumeClaim": {
       "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaimVolumeSource"
      },
      "secret": {
       "description": "SecretVolumeSource represents a reference to a secret data in the same namespace. More info: https://kubernetes.io/docs/concepts/configuration/secret/",
-      "$ref": "#/definitions/v1.SecretVolumeSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.SecretVolumeSource"
      },
      "serviceAccount": {
       "description": "ServiceAccountVolumeSource represents a reference to a service account. There can only be one volume of this type! More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
-      "$ref": "#/definitions/v1.ServiceAccountVolumeSource"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.ServiceAccountVolumeSource"
      }
     }
    },
-   "v1.WatchEvent": {
-    "description": "Event represents a single event to a watched resource.",
-    "type": "object",
-    "required": [
-     "type",
-     "object"
-    ],
-    "properties": {
-     "object": {
-      "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
-      "$ref": "#/definitions/runtime.RawExtension"
-     },
-     "type": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.Watchdog": {
+   "kubevirt.io/client-go/api/v1.Watchdog": {
     "description": "Named watchdog device.",
     "type": "object",
     "required": [
@@ -9895,7 +9939,7 @@
     "properties": {
      "i6300esb": {
       "description": "i6300esb watchdog device.",
-      "$ref": "#/definitions/v1.I6300ESBWatchdog"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.I6300ESBWatchdog"
      },
      "name": {
       "description": "Name of the watchdog.",
@@ -9903,283 +9947,16 @@
      }
     }
    },
-   "v1.WeightedPodAffinityTerm": {
-    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-    "type": "object",
-    "required": [
-     "weight",
-     "podAffinityTerm"
-    ],
-    "properties": {
-     "podAffinityTerm": {
-      "description": "Required. A pod affinity term, associated with the corresponding weight.",
-      "$ref": "#/definitions/v1.PodAffinityTerm"
-     },
-     "weight": {
-      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1alpha1.DataVolume": {
-    "description": "DataVolume is an abstraction on top of PersistentVolumeClaims to allow easy population of those PersistentVolumeClaims with relation to VirtualMachines",
-    "type": "object",
-    "required": [
-     "spec"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSpec"
-     },
-     "status": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeStatus"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeBlankImage": {
-    "description": "DataVolumeBlankImage provides the parameters to create a new raw blank image for the PVC",
-    "type": "object"
-   },
-   "v1alpha1.DataVolumeCondition": {
-    "description": "DataVolumeCondition represents the state of a data volume condition.",
-    "type": "object",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastHeartbeatTime": {
-      "$ref": "#/definitions/v1.Time"
-     },
-     "lastProbeTime": {
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "lastTransitionTime": {
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "message": {
-      "type": "string"
-     },
-     "reason": {
-      "type": "string"
-     },
-     "status": {
-      "type": "string"
-     },
-     "type": {
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSource": {
-    "description": "DataVolumeSource represents the source for our Data Volume, this can be HTTP, Imageio, S3, Registry or an existing PVC",
-    "type": "object",
-    "properties": {
-     "blank": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeBlankImage"
-     },
-     "http": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSourceHTTP"
-     },
-     "imageio": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSourceImageIO"
-     },
-     "pvc": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSourcePVC"
-     },
-     "registry": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSourceRegistry"
-     },
-     "s3": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSourceS3"
-     },
-     "upload": {
-      "$ref": "#/definitions/v1alpha1.DataVolumeSourceUpload"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSourceHTTP": {
-    "description": "DataVolumeSourceHTTP can be either an http or https endpoint, with an optional basic auth user name and password, and an optional configmap containing additional CAs",
-    "type": "object",
-    "required": [
-     "url"
-    ],
-    "properties": {
-     "certConfigMap": {
-      "description": "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
-      "type": "string"
-     },
-     "secretRef": {
-      "description": "SecretRef A Secret reference, the secret should contain accessKeyId (user name) base64 encoded, and secretKey (password) also base64 encoded",
-      "type": "string"
-     },
-     "url": {
-      "description": "URL is the URL of the http(s) endpoint",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSourceImageIO": {
-    "description": "DataVolumeSourceImageIO provides the parameters to create a Data Volume from an imageio source",
-    "type": "object",
-    "required": [
-     "url",
-     "diskId"
-    ],
-    "properties": {
-     "certConfigMap": {
-      "description": "CertConfigMap provides a reference to the CA cert",
-      "type": "string"
-     },
-     "diskId": {
-      "description": "DiskID provides id of a disk to be imported",
-      "type": "string"
-     },
-     "secretRef": {
-      "description": "SecretRef provides the secret reference needed to access the ovirt-engine",
-      "type": "string"
-     },
-     "url": {
-      "description": "URL is the URL of the ovirt-engine",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSourcePVC": {
-    "description": "DataVolumeSourcePVC provides the parameters to create a Data Volume from an existing PVC",
-    "type": "object",
-    "required": [
-     "namespace",
-     "name"
-    ],
-    "properties": {
-     "name": {
-      "description": "The name of the source PVC",
-      "type": "string"
-     },
-     "namespace": {
-      "description": "The namespace of the source PVC",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSourceRegistry": {
-    "description": "DataVolumeSourceRegistry provides the parameters to create a Data Volume from an registry source",
-    "type": "object",
-    "required": [
-     "url"
-    ],
-    "properties": {
-     "certConfigMap": {
-      "description": "CertConfigMap provides a reference to the Registry certs",
-      "type": "string"
-     },
-     "secretRef": {
-      "description": "SecretRef provides the secret reference needed to access the Registry source",
-      "type": "string"
-     },
-     "url": {
-      "description": "URL is the url of the Docker registry source",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSourceS3": {
-    "description": "DataVolumeSourceS3 provides the parameters to create a Data Volume from an S3 source",
-    "type": "object",
-    "required": [
-     "url"
-    ],
-    "properties": {
-     "secretRef": {
-      "description": "SecretRef provides the secret reference needed to access the S3 source",
-      "type": "string"
-     },
-     "url": {
-      "description": "URL is the url of the S3 source",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeSourceUpload": {
-    "description": "DataVolumeSourceUpload provides the parameters to create a Data Volume by uploading the source",
-    "type": "object"
-   },
-   "v1alpha1.DataVolumeSpec": {
-    "description": "DataVolumeSpec defines the DataVolume type specification",
-    "type": "object",
-    "required": [
-     "source",
-     "pvc"
-    ],
-    "properties": {
-     "contentType": {
-      "description": "DataVolumeContentType options: \"kubevirt\", \"archive\"",
-      "type": "string"
-     },
-     "pvc": {
-      "description": "PVC is the PVC specification",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimSpec"
-     },
-     "source": {
-      "description": "Source is the src of the data for the requested DataVolume",
-      "$ref": "#/definitions/v1alpha1.DataVolumeSource"
-     }
-    }
-   },
-   "v1alpha1.DataVolumeStatus": {
-    "description": "DataVolumeStatus contains the current status of the DataVolume",
-    "type": "object",
-    "nullable": true,
-    "properties": {
-     "conditions": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.DataVolumeCondition"
-      }
-     },
-     "phase": {
-      "description": "Phase is the current phase of the data volume",
-      "type": "string"
-     },
-     "progress": {
-      "type": "string"
-     },
-     "restartCount": {
-      "description": "RestartCount is the number of times the pod populating the DataVolume has restarted",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1alpha1.SourceSpec": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.SourceSpec": {
     "description": "SourceSpec contains the appropriate spec for the resource being snapshotted",
     "type": "object",
     "properties": {
      "virtualMachine": {
-      "$ref": "#/definitions/v1.VirtualMachine"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1api~1v1.VirtualMachine"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshot": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshot": {
     "description": "VirtualMachineSnapshot defines the operation of snapshotting a VM",
     "type": "object",
     "required": [
@@ -10195,17 +9972,17 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotSpec"
      },
      "status": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotStatus"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotStatus"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotCondition": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotCondition": {
     "description": "VirtualMachineSnapshotCondition defines snapshot conditions",
     "type": "object",
     "required": [
@@ -10239,7 +10016,7 @@
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotContent": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotContent": {
     "description": "VirtualMachineSnapshotContent contains the snapshot data",
     "type": "object",
     "required": [
@@ -10255,17 +10032,17 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
      },
      "spec": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContentSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContentSpec"
      },
      "status": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContentStatus"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContentStatus"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotContentList": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotContentList": {
     "description": "VirtualMachineSnapshotContentList is a list of VirtualMachineSnapshot resources",
     "type": "object",
     "required": [
@@ -10280,7 +10057,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContent"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContent"
       }
      },
      "kind": {
@@ -10288,11 +10065,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotContentSpec": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotContentSpec": {
     "description": "VirtualMachineSnapshotContentSpec is the spec for a VirtualMachineSnapshotContent resource",
     "type": "object",
     "required": [
@@ -10300,7 +10077,7 @@
     ],
     "properties": {
      "source": {
-      "$ref": "#/definitions/v1alpha1.SourceSpec"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.SourceSpec"
      },
      "virtualMachineSnapshotName": {
       "type": "string"
@@ -10308,21 +10085,20 @@
      "volumeBackups": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1alpha1.VolumeBackup"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VolumeBackup"
       }
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotContentStatus": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotContentStatus": {
     "description": "VirtualMachineSnapshotContentStatus is the status for a VirtualMachineSnapshotStatus resource",
     "type": "object",
-    "nullable": true,
     "properties": {
      "creationTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "error": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotError"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotError"
      },
      "readyToUse": {
       "type": "boolean"
@@ -10330,12 +10106,12 @@
      "volumeSnapshotStatus": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1alpha1.VolumeSnapshotStatus"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VolumeSnapshotStatus"
       }
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotError": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotError": {
     "description": "VirtualMachineSnapshotError is the last error encountered while creating the snapshot",
     "type": "object",
     "properties": {
@@ -10343,11 +10119,11 @@
       "type": "string"
      },
      "time": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotList": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotList": {
     "description": "VirtualMachineSnapshotList is a list of VirtualMachineSnapshot resources",
     "type": "object",
     "required": [
@@ -10362,7 +10138,7 @@
      "items": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshot"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshot"
       }
      },
      "kind": {
@@ -10370,11 +10146,11 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ListMeta"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotSpec": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotSpec": {
     "description": "VirtualMachineSnapshotSpec is the spec for a VirtualMachineSnapshot resource",
     "type": "object",
     "required": [
@@ -10385,26 +10161,25 @@
       "type": "string"
      },
      "source": {
-      "$ref": "#/definitions/v1.TypedLocalObjectReference"
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.TypedLocalObjectReference"
      }
     }
    },
-   "v1alpha1.VirtualMachineSnapshotStatus": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VirtualMachineSnapshotStatus": {
     "description": "VirtualMachineSnapshotStatus is the status for a VirtualMachineSnapshot resource",
     "type": "object",
-    "nullable": true,
     "properties": {
      "conditions": {
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotCondition"
+       "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotCondition"
       }
      },
      "creationTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "error": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotError"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotError"
      },
      "readyToUse": {
       "type": "boolean"
@@ -10414,7 +10189,7 @@
      }
     }
    },
-   "v1alpha1.VolumeBackup": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VolumeBackup": {
     "description": "VolumeBackup contains the data neeed to restore a PVC",
     "type": "object",
     "required": [
@@ -10426,14 +10201,14 @@
       "type": "string"
      },
      "persistentVolumeClaim": {
-      "$ref": "#/definitions/v1.PersistentVolumeClaim"
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaim"
      },
      "volumeSnapshotName": {
       "type": "string"
      }
     }
    },
-   "v1alpha1.VolumeSnapshotStatus": {
+   "kubevirt.io/client-go/apis/snapshot/v1alpha1.VolumeSnapshotStatus": {
     "description": "VolumeSnapshotStatus is the status of a VolumeSnapshot",
     "type": "object",
     "required": [
@@ -10441,10 +10216,10 @@
     ],
     "properties": {
      "creationTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
      },
      "error": {
-      "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotError"
+      "$ref": "#/definitions/kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotError"
      },
      "readyToUse": {
       "type": "boolean"
@@ -10453,6 +10228,277 @@
       "type": "string"
      }
     }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolume": {
+    "description": "DataVolume is an abstraction on top of PersistentVolumeClaims to allow easy population of those PersistentVolumeClaims with relation to VirtualMachines",
+    "type": "object",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSpec"
+     },
+     "status": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeStatus"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeBlankImage": {
+    "description": "DataVolumeBlankImage provides the parameters to create a new raw blank image for the PVC",
+    "type": "object"
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeCondition": {
+    "description": "DataVolumeCondition represents the state of a data volume condition.",
+    "type": "object",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastHeartbeatTime": {
+      "$ref": "#/definitions/k8s.io~1apimachinery~1pkg~1apis~1meta~1v1.Time"
+     },
+     "lastProbeTime": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "lastTransitionTime": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "message": {
+      "type": "string"
+     },
+     "reason": {
+      "type": "string"
+     },
+     "status": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSource": {
+    "description": "DataVolumeSource represents the source for our Data Volume, this can be HTTP, Imageio, S3, Registry or an existing PVC",
+    "type": "object",
+    "properties": {
+     "blank": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeBlankImage"
+     },
+     "http": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSourceHTTP"
+     },
+     "imageio": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSourceImageIO"
+     },
+     "pvc": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSourcePVC"
+     },
+     "registry": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSourceRegistry"
+     },
+     "s3": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSourceS3"
+     },
+     "upload": {
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSourceUpload"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSourceHTTP": {
+    "description": "DataVolumeSourceHTTP can be either an http or https endpoint, with an optional basic auth user name and password, and an optional configmap containing additional CAs",
+    "type": "object",
+    "required": [
+     "url"
+    ],
+    "properties": {
+     "certConfigMap": {
+      "description": "CertConfigMap is a configmap reference, containing a Certificate Authority(CA) public key, and a base64 encoded pem certificate",
+      "type": "string"
+     },
+     "secretRef": {
+      "description": "SecretRef A Secret reference, the secret should contain accessKeyId (user name) base64 encoded, and secretKey (password) also base64 encoded",
+      "type": "string"
+     },
+     "url": {
+      "description": "URL is the URL of the http(s) endpoint",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSourceImageIO": {
+    "description": "DataVolumeSourceImageIO provides the parameters to create a Data Volume from an imageio source",
+    "type": "object",
+    "required": [
+     "url",
+     "diskId"
+    ],
+    "properties": {
+     "certConfigMap": {
+      "description": "CertConfigMap provides a reference to the CA cert",
+      "type": "string"
+     },
+     "diskId": {
+      "description": "DiskID provides id of a disk to be imported",
+      "type": "string"
+     },
+     "secretRef": {
+      "description": "SecretRef provides the secret reference needed to access the ovirt-engine",
+      "type": "string"
+     },
+     "url": {
+      "description": "URL is the URL of the ovirt-engine",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSourcePVC": {
+    "description": "DataVolumeSourcePVC provides the parameters to create a Data Volume from an existing PVC",
+    "type": "object",
+    "required": [
+     "namespace",
+     "name"
+    ],
+    "properties": {
+     "name": {
+      "description": "The name of the source PVC",
+      "type": "string"
+     },
+     "namespace": {
+      "description": "The namespace of the source PVC",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSourceRegistry": {
+    "description": "DataVolumeSourceRegistry provides the parameters to create a Data Volume from an registry source",
+    "type": "object",
+    "required": [
+     "url"
+    ],
+    "properties": {
+     "certConfigMap": {
+      "description": "CertConfigMap provides a reference to the Registry certs",
+      "type": "string"
+     },
+     "secretRef": {
+      "description": "SecretRef provides the secret reference needed to access the Registry source",
+      "type": "string"
+     },
+     "url": {
+      "description": "URL is the url of the Docker registry source",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSourceS3": {
+    "description": "DataVolumeSourceS3 provides the parameters to create a Data Volume from an S3 source",
+    "type": "object",
+    "required": [
+     "url"
+    ],
+    "properties": {
+     "secretRef": {
+      "description": "SecretRef provides the secret reference needed to access the S3 source",
+      "type": "string"
+     },
+     "url": {
+      "description": "URL is the url of the S3 source",
+      "type": "string"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSourceUpload": {
+    "description": "DataVolumeSourceUpload provides the parameters to create a Data Volume by uploading the source",
+    "type": "object"
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeSpec": {
+    "description": "DataVolumeSpec defines the DataVolume type specification",
+    "type": "object",
+    "required": [
+     "source",
+     "pvc"
+    ],
+    "properties": {
+     "contentType": {
+      "description": "DataVolumeContentType options: \"kubevirt\", \"archive\"",
+      "type": "string"
+     },
+     "pvc": {
+      "description": "PVC is the PVC specification",
+      "$ref": "#/definitions/k8s.io~1api~1core~1v1.PersistentVolumeClaimSpec"
+     },
+     "source": {
+      "description": "Source is the src of the data for the requested DataVolume",
+      "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeSource"
+     }
+    }
+   },
+   "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1.DataVolumeStatus": {
+    "description": "DataVolumeStatus contains the current status of the DataVolume",
+    "type": "object",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeCondition"
+      }
+     },
+     "phase": {
+      "description": "Phase is the current phase of the data volume",
+      "type": "string"
+     },
+     "progress": {
+      "type": "string"
+     },
+     "restartCount": {
+      "description": "RestartCount is the number of times the pod populating the DataVolume has restarted",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotContentStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1client-go~1apis~1snapshot~1v1alpha1.VirtualMachineSnapshotStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1client-go~1api~1v1.KubeVirtStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceMigrationStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceReplicaSetStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1client-go~1api~1v1.VirtualMachineInstanceStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1client-go~1api~1v1.VirtualMachineStatus": {
+    "nullable": true
+   },
+   "kubevirt.io~1containerized-data-importer~1pkg~1apis~1core~1v1alpha1.DataVolumeStatus": {
+    "nullable": true
    }
   },
   "securityDefinitions": {

--- a/pkg/util/openapi/openapi.go
+++ b/pkg/util/openapi/openapi.go
@@ -110,6 +110,10 @@ func createConfig() *common.Config {
 			}
 			return m
 		},
+
+		GetDefinitionName: func(name string) (string, spec.Extensions) {
+			return name, nil
+		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We introduced our `Pach` type which collides with kubernetes type.
By default kube-openapi takes only last part of type/model definition.
So type "`kubevirt.io/client-go/api/v1.Patch`" ends up -> "`v1.Patch`" &
"`k8s.io/apimachinery/pkg/apis/meta/v1.Patch`" -> "`v1.Patch`".

This PR change our config and takes full name so no conflict should be possible.

Signed-off-by: L. Pivarc <lpivarc@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4148 
Should replace https://github.com/kubevirt/kubevirt/pull/4138

**Special notes for your reviewer**:
Fixes master
**Release note**:

```release-note
NONE
```
