### PR TITLE
virt-operator: remove Kubevirt service accounts from default privileged SCC upon upgrade

### DIFF
--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -19,6 +19,7 @@
 package rbac
 
 import (
+	"fmt"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -485,5 +486,14 @@ func NewOperatorRole(namespace string) *rbacv1.Role {
 				},
 			},
 		},
+	}
+}
+
+func GetKubevirtComponentsServiceAccounts(namespace string) []string {
+	prefix := "system:serviceaccount"
+	return []string{
+		fmt.Sprintf("%s:%s:%s", prefix, namespace, HandlerServiceAccountName),
+		fmt.Sprintf("%s:%s:%s", prefix, namespace, ApiServiceAccountName),
+		fmt.Sprintf("%s:%s:%s", prefix, namespace, ControllerServiceAccountName),
 	}
 }

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -20,12 +20,15 @@ package rbac
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
+
+const OperatorServiceAccountName = "kubevirt-operator"
 
 // Used for manifest generation only, not by the operator itself
 func GetAllOperator(namespace string) []interface{} {
@@ -46,7 +49,7 @@ func newOperatorServiceAccount(namespace string) *corev1.ServiceAccount {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "kubevirt-operator",
+			Name:      OperatorServiceAccountName,
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
 			},
@@ -66,7 +69,7 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt-operator",
+			Name: OperatorServiceAccountName,
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
 			},
@@ -390,7 +393,7 @@ func newOperatorClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding 
 			Kind:       "ClusterRoleBinding",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt-operator",
+			Name: OperatorServiceAccountName,
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
 			},
@@ -398,13 +401,13 @@ func newOperatorClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding 
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "kubevirt-operator",
+			Name:     OperatorServiceAccountName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Namespace: namespace,
-				Name:      "kubevirt-operator",
+				Name:      OperatorServiceAccountName,
 			},
 		},
 	}
@@ -426,13 +429,13 @@ func newOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     "kubevirt-operator",
+			Name:     OperatorServiceAccountName,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Namespace: namespace,
-				Name:      "kubevirt-operator",
+				Name:      OperatorServiceAccountName,
 			},
 		},
 	}
@@ -446,7 +449,7 @@ func NewOperatorRole(namespace string) *rbacv1.Role {
 			Kind:       "Role",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubevirt-operator",
+			Name:      OperatorServiceAccountName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				virtv1.AppLabel: "",
@@ -489,11 +492,14 @@ func NewOperatorRole(namespace string) *rbacv1.Role {
 	}
 }
 
-func GetKubevirtComponentsServiceAccounts(namespace string) []string {
+func GetKubevirtComponentsServiceAccounts(namespace string) map[string]bool {
+	usermap := make(map[string]bool)
+
 	prefix := "system:serviceaccount"
-	return []string{
-		fmt.Sprintf("%s:%s:%s", prefix, namespace, HandlerServiceAccountName),
-		fmt.Sprintf("%s:%s:%s", prefix, namespace, ApiServiceAccountName),
-		fmt.Sprintf("%s:%s:%s", prefix, namespace, ControllerServiceAccountName),
-	}
+	usermap[fmt.Sprintf("%s:%s:%s", prefix, namespace, HandlerServiceAccountName)] = true
+	usermap[fmt.Sprintf("%s:%s:%s", prefix, namespace, ApiServiceAccountName)] = true
+	usermap[fmt.Sprintf("%s:%s:%s", prefix, namespace, ControllerServiceAccountName)] = true
+	usermap[fmt.Sprintf("%s:%s:%s", prefix, namespace, OperatorServiceAccountName)] = true
+
+	return usermap
 }

--- a/pkg/virt-operator/install-strategy/BUILD.bazel
+++ b/pkg/virt-operator/install-strategy/BUILD.bazel
@@ -56,7 +56,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller:go_default_library",
+        "//pkg/testutils:go_default_library",
         "//pkg/virt-operator/creation/components:go_default_library",
+        "//pkg/virt-operator/creation/rbac:go_default_library",
         "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -66,6 +68,8 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/openshift/api/security/v1:go_default_library",
+        "//vendor/github.com/openshift/client-go/security/clientset/versioned/typed/security/v1/fake:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",

--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -321,6 +321,14 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	strategy.certificateSecrets = append(strategy.certificateSecrets, components.NewCACertSecret(operatorNamespace))
 	strategy.configMaps = append(strategy.configMaps, components.NewKubeVirtCAConfigMap(operatorNamespace))
 
+	strategy.customSCCPrivileges = append(strategy.customSCCPrivileges, &customSCCPrivilegedAccounts{
+		TypeMeta: metav1.TypeMeta{
+			Kind: customSCCPrivilegedAccountsType,
+		},
+		TargetSCC:       "privileged",
+		ServiceAccounts: []string{},
+	})
+
 	return strategy, nil
 }
 

--- a/pkg/virt-operator/install-strategy/strategy.go
+++ b/pkg/virt-operator/install-strategy/strategy.go
@@ -51,19 +51,6 @@ import (
 
 const customSCCPrivilegedAccountsType = "KubevirtCustomSCCRule"
 
-type customSCCPrivilegedAccounts struct {
-	// this isn't a real k8s object. We use the meta type
-	// because it gives a consistent way to separate k8s
-	// objects from our custom actions
-	metav1.TypeMeta `json:",inline"`
-
-	// this is the target scc we're adding service accounts to
-	TargetSCC string `json:"TargetSCC"`
-
-	// these are the service accounts being added to the scc
-	ServiceAccounts []string `json:"serviceAccounts"`
-}
-
 type InstallStrategy struct {
 	serviceAccounts []*corev1.ServiceAccount
 
@@ -82,14 +69,10 @@ type InstallStrategy struct {
 	mutatingWebhookConfigurations   []*v1beta1.MutatingWebhookConfiguration
 	apiServices                     []*v1beta12.APIService
 	certificateSecrets              []*corev1.Secret
-
-	// deprecated, keep it for backwards compatibility
-	customSCCPrivileges []*customSCCPrivilegedAccounts
-
-	sccs            []*secv1.SecurityContextConstraints
-	serviceMonitors []*promv1.ServiceMonitor
-	prometheusRules []*promv1.PrometheusRule
-	configMaps      []*corev1.ConfigMap
+	sccs                            []*secv1.SecurityContextConstraints
+	serviceMonitors                 []*promv1.ServiceMonitor
+	prometheusRules                 []*promv1.PrometheusRule
+	configMaps                      []*corev1.ConfigMap
 }
 
 func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, addMonitorServiceResources bool, operatorNamespace string) (*corev1.ConfigMap, error) {
@@ -196,9 +179,6 @@ func dumpInstallStrategyToBytes(strategy *InstallStrategy) []byte {
 		marshalutil.MarshallObject(entry, writer)
 	}
 	for _, entry := range strategy.daemonSets {
-		marshalutil.MarshallObject(entry, writer)
-	}
-	for _, entry := range strategy.customSCCPrivileges {
 		marshalutil.MarshallObject(entry, writer)
 	}
 	for _, entry := range strategy.sccs {
@@ -320,14 +300,6 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	strategy.certificateSecrets = components.NewCertSecrets(config.GetNamespace(), operatorNamespace)
 	strategy.certificateSecrets = append(strategy.certificateSecrets, components.NewCACertSecret(operatorNamespace))
 	strategy.configMaps = append(strategy.configMaps, components.NewKubeVirtCAConfigMap(operatorNamespace))
-
-	strategy.customSCCPrivileges = append(strategy.customSCCPrivileges, &customSCCPrivilegedAccounts{
-		TypeMeta: metav1.TypeMeta{
-			Kind: customSCCPrivilegedAccountsType,
-		},
-		TargetSCC:       "privileged",
-		ServiceAccounts: []string{},
-	})
 
 	return strategy, nil
 }
@@ -488,12 +460,6 @@ func loadInstallStrategyFromBytes(data string) (*InstallStrategy, error) {
 				return nil, err
 			}
 			strategy.crds = append(strategy.crds, crd)
-		case customSCCPrivilegedAccountsType:
-			priv := &customSCCPrivilegedAccounts{}
-			if err := yaml.Unmarshal([]byte(entry), &priv); err != nil {
-				return nil, err
-			}
-			strategy.customSCCPrivileges = append(strategy.customSCCPrivileges, priv)
 		case "SecurityContextConstraints":
 			s := &secv1.SecurityContextConstraints{}
 			if err := yaml.Unmarshal([]byte(entry), &s); err != nil {

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -827,7 +827,7 @@ func (c *KubeVirtController) getInstallStrategyJob(config *operatorutil.KubeVirt
 
 // Loads install strategies into memory, and generates jobs to
 // create install strategies that don't exist yet.
-func (c *KubeVirtController) loadInstallStrategy(kv *v1.KubeVirt, loadObservedVersion bool) (*installstrategy.InstallStrategy, bool, error) {
+func (c *KubeVirtController) loadInstallStrategy(kv *v1.KubeVirt) (*installstrategy.InstallStrategy, bool, error) {
 
 	kvkey, err := controller.KeyFunc(kv)
 	if err != nil {
@@ -835,13 +835,6 @@ func (c *KubeVirtController) loadInstallStrategy(kv *v1.KubeVirt, loadObservedVe
 	}
 
 	config := operatorutil.GetTargetConfigFromKV(kv)
-	if loadObservedVersion {
-		config, err = operatorutil.GetObservedConfigFromKV(kv)
-		if err != nil {
-			return nil, true, err
-		}
-	}
-
 	// 1. see if we already loaded the install strategy
 	strategy, ok := c.getInstallStrategyFromMap(config, kv.Generation)
 	if ok {
@@ -962,9 +955,7 @@ func isUpdating(kv *v1.KubeVirt) bool {
 }
 
 func (c *KubeVirtController) syncDeployment(kv *v1.KubeVirt) error {
-	var prevStrategy *installstrategy.InstallStrategy
 	var targetStrategy *installstrategy.InstallStrategy
-	var prevPending bool
 	var targetPending bool
 	var err error
 
@@ -991,25 +982,17 @@ func (c *KubeVirtController) syncDeployment(kv *v1.KubeVirt) error {
 
 	if isUpdating(kv) {
 		util.UpdateConditionsUpdating(kv)
-		// If this is an update, we need to retrieve the install strategy of the
-		// previous version. This is only necessary because there are settings
-		// related to SCC privileges that we can't infere without the previous
-		// strategy.
-		prevStrategy, prevPending, err = c.loadInstallStrategy(kv, true)
-		if err != nil {
-			return err
-		}
 	} else {
 		util.UpdateConditionsDeploying(kv)
 	}
 
-	targetStrategy, targetPending, err = c.loadInstallStrategy(kv, false)
+	targetStrategy, targetPending, err = c.loadInstallStrategy(kv)
 	if err != nil {
 		return err
 	}
 
 	// we're waiting on a job to finish and the config map to be created
-	if prevPending || targetPending {
+	if targetPending {
 		return nil
 	}
 
@@ -1024,7 +1007,7 @@ func (c *KubeVirtController) syncDeployment(kv *v1.KubeVirt) error {
 	}
 
 	// deploy
-	synced, err := installstrategy.SyncAll(c.queue, kv, prevStrategy, targetStrategy, c.stores, c.clientset, c.aggregatorClient, &c.kubeVirtExpectations)
+	synced, err := installstrategy.SyncAll(c.queue, kv, targetStrategy, c.stores, c.clientset, c.aggregatorClient, &c.kubeVirtExpectations)
 
 	if err != nil {
 		// deployment failed
@@ -1095,7 +1078,7 @@ func (c *KubeVirtController) syncDeletion(kv *v1.KubeVirt) error {
 
 	// If we still have cached objects around, more deletions need to take place.
 	if !c.stores.AllEmpty() {
-		strategy, pending, err := c.loadInstallStrategy(kv, false)
+		strategy, pending, err := c.loadInstallStrategy(kv)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -138,25 +138,6 @@ func GetTargetConfigFromKV(kv *v1.KubeVirt) *KubeVirtDeploymentConfig {
 	return getConfig(kv.Spec.ImageRegistry, kv.Spec.ImageTag, kv.Namespace, getKVMapFromSpec(kv.Spec))
 }
 
-func GetObservedConfigFromKV(kv *v1.KubeVirt) (*KubeVirtDeploymentConfig, error) {
-	additionalProperties := getKVMapFromSpec(kv.Spec)
-
-	imagePrefix, _, err := getImagePrefixFromDeploymentConfig(kv.Status.ObservedDeploymentConfig)
-
-	if err != nil {
-		return nil, fmt.Errorf("unable to load observed config from kubevirt custom resource: %v", err)
-	}
-	additionalProperties[ImagePrefixKey] = imagePrefix
-	if kv.Spec.ProductName != "" {
-		additionalProperties[ProductNameKey] = kv.Spec.ProductName
-	}
-	if kv.Spec.ProductVersion != "" {
-		additionalProperties[ProductVersionKey] = kv.Spec.ProductVersion
-	}
-
-	return getConfig(kv.Status.ObservedKubeVirtRegistry, kv.Status.ObservedKubeVirtVersion, kv.Namespace, additionalProperties), nil
-}
-
 // retrieve imagePrefix from an existing deployment config (which is stored as JSON)
 func getImagePrefixFromDeploymentConfig(deploymentConfig string) (string, bool, error) {
 	var obj interface{}


### PR DESCRIPTION
During an upgrade the virt-operator will delete Kubevirt service accounts from the 
default Security Context Constraint called "privileged". That will occur if the 
cluster provider is Openshift.

 Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
When running in Openshift we create our own Security Context Constraints and add our service accounts there.
No need to use Openshift default SCCs such as the privileged SCC which was used in prior Kubevirt releases.
Moreover, it can introduce a security issue since the default privileged SCC may have more relaxed policy 
than needed.

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=1860992

**Release note**:
```release-note
NONE
```
