### PR TITLE
Fix virtctl image-upload ignoring custom storage class argument

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -535,6 +535,10 @@ func createPVCSpec(size, storageClass, accessMode string, blockVolume bool) (*v1
 		},
 	}
 
+	if storageClass != "" {
+		spec.StorageClassName = &storageClass
+	}
+
 	if accessMode != "" {
 		spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.PersistentVolumeAccessMode(accessMode)}
 	}

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -123,8 +123,9 @@ var _ = Describe("ImageUpload", func() {
 		Expect(errors.IsNotFound(err)).To(BeTrue())
 
 		By("Get PVC")
-		_, err = virtClient.CoreV1().PersistentVolumeClaims(namespace).Get(targetName, metav1.GetOptions{})
+		pvc, err := virtClient.CoreV1().PersistentVolumeClaims(namespace).Get(targetName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
+		Expect(*pvc.Spec.StorageClassName).To(Equal(tests.Config.StorageClassLocal))
 	}
 
 	Context("Upload an image and start a VMI with PVC", func() {


### PR DESCRIPTION
- image-upload currently ignores the --storage-class that is passed by user,
  adding processing of this argument
- add unit test to verify custom storage class was set in PVC spec
- validate storage class in functional test

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1876559

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
