### PR TITLE
Add creation of bazelrc for running unnested in prow

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -7,6 +7,8 @@ ENV LIBVIRT_VERSION 5.0.0
 
 ENV BAZEL_VERSION 1.2.1
 
+ENV KUBEVIRT_CREATE_BAZELRCS false
+
 # Install packages
 RUN dnf install -y dnf-plugins-core && \
     dnf copr enable -y vbatts/bazel && \
@@ -95,5 +97,7 @@ RUN pip3 install j2cli operator-courier==1.3.0
 COPY rsyncd.conf /etc/rsyncd.conf
 
 COPY entrypoint.sh /entrypoint.sh
+
+COPY create_bazel_cache_rcs.sh /create_bazel_cache_rcs.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 SCRIPT_DIR="$(
-    cd "$(dirname "$BASH_SOURCE[0]")"
+    cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd
 )"
 
@@ -10,18 +10,19 @@ trap 'cleanup' EXIT
 
 cleanup() {
     docker rm -f dummy-qemu-user-static >/dev/null || true
-    rm ${SCRIPT_DIR}/qemu-ppc64le-static || true
+    rm "${SCRIPT_DIR}/qemu-ppc64le-static" || true
 }
 
-. ${SCRIPT_DIR}/version.sh
+# shellcheck source=hack/builder/version.sh
+. "${SCRIPT_DIR}/version.sh"
 
 cleanup
 
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 docker create -ti --name dummy-qemu-user-static multiarch/qemu-user-static
-docker cp dummy-qemu-user-static:/usr/bin/qemu-ppc64le-static ${SCRIPT_DIR}/qemu-ppc64le-static
+docker cp dummy-qemu-user-static:/usr/bin/qemu-ppc64le-static "${SCRIPT_DIR}/qemu-ppc64le-static"
 
 for ARCH in ${ARCHITECTURES}; do
-    docker build -t kubevirt/builder:${VERSION}-${ARCH} --build-arg ARCH=${ARCH} -f ${SCRIPT_DIR}/Dockerfile ${SCRIPT_DIR}
+    docker build -t "kubevirt/builder:${VERSION}-${ARCH}" --build-arg ARCH="${ARCH}" -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
     TMP_IMAGES="${TMP_IMAGES} kubevirt/builder:${VERSION}-${ARCH}"
 done

--- a/hack/builder/create_bazel_cache_rcs.sh
+++ b/hack/builder/create_bazel_cache_rcs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# heavily borrowed from https://raw.githubusercontent.com/kubernetes/test-infra/5489305c550e250f7d9053528c725656d5b5ff20/images/bootstrap/create_bazel_cache_rcs.sh
+
+CACHE_HOST="${CACHE_HOST:-bazel-cache.default.svc.cluster.local.}"
+CACHE_PORT="${CACHE_PORT:-8080}"
+
+get_workspace() {
+    # get org/repo from prow, otherwise use $PWD
+    if [[ -n "${REPO_NAME}" ]] && [[ -n "${REPO_OWNER}" ]]; then
+        echo "${REPO_OWNER}/${REPO_NAME}"
+    else
+        echo "$(basename "$(dirname "$PWD")")/$(basename "$PWD")"
+    fi
+}
+
+make_bazel_rc() {
+    # this is the default for recent releases but we set it explicitly
+    # since this is the only hash our cache supports
+    echo "startup --host_jvm_args=-Dbazel.DigestFunction=sha256"
+    # don't fail if the cache is unavailable
+    echo "build --remote_local_fallback"
+    # point bazel at our http cache ...
+    # NOTE our caches are versioned by all path segments up until the last two
+    # IE PUT /foo/bar/baz/cas/asdf -> is in cache "/foo/bar/baz"
+    local cache_id
+    cache_id="$(get_workspace)"
+    local cache_url
+    cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
+    echo "build --remote_http_cache=${cache_url}"
+}
+
+bazel_rc_contents=$(make_bazel_rc)
+echo "create_bazel_cache_rcs.sh: Configuring './ci.bazelrc' with"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}" >>"./ci.bazelrc"

--- a/hack/builder/entrypoint.sh
+++ b/hack/builder/entrypoint.sh
@@ -2,6 +2,10 @@
 set -e
 set -o pipefail
 
+if [[ "$KUBEVIRT_CREATE_BAZELRCS" == "true" ]]; then
+    /create_bazel_cache_rcs.sh
+fi
+
 source /etc/profile.d/gimme.sh
 export GOPATH="/root/go"
 eval "$@"

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,3 @@
-VERSION=30-6.0.0
+VERSION=30-7.0.0
 # TODO: reenable ppc64le when new builds are available
 ARCHITECTURES="amd64"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
bootstrap image from test-infra creates the bazelrc for us which we copy at the moment into `ci.bazelrc` to have it available for the build. When using kubevirt/builder with `KUBEVIRT_RUN_UNNESTED=true` we don't have it any more.

Therefore we borrow parts of `create_bazel_cache_rcs.sh` from test-infra/bootstrap, which now creates `ci.bazelrc` so that we have a bazel config when running in prow. Also we add KUBEVIRT_CREATE_BAZELRCS env var to selectively enable it on prow builds when using KUBEVIRT_RUN_UNNESTED.

Fix some shellcheck errors BTW.

First time usage is here: https://github.com/kubevirt/project-infra/pull/630

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
