### PR TITLE
backporting release-0.33 blocker fix

### DIFF
--- a/pkg/virt-operator/install-strategy/create_test.go
+++ b/pkg/virt-operator/install-strategy/create_test.go
@@ -296,4 +296,42 @@ var _ = Describe("Create", func() {
 			table.Entry("should allow empty strings", "", true),
 		)
 	})
+
+	Context("Injecting Metadata", func() {
+
+		It("should set expected values", func() {
+
+			kv := &v1.KubeVirt{}
+			kv.Status.TargetKubeVirtRegistry = Registry
+			kv.Status.TargetKubeVirtVersion = Version
+			kv.Status.TargetDeploymentID = Id
+
+			deployment := appsv1.Deployment{}
+			injectOperatorMetadata(kv, &deployment.ObjectMeta, "fakeversion", "fakeregistry", "fakeid")
+
+			// NOTE we are purposfully not using the defined constant values
+			// in types.go here. This test is explicitly verifying that those
+			// values in types.go that we depend on for virt-operator updates
+			// do not change. This is meant to preserve backwards and forwards
+			// compatibility
+
+			managedBy, ok := deployment.Labels["app.kubernetes.io/managed-by"]
+
+			Expect(ok).To(BeTrue())
+			Expect(managedBy).To(Equal("kubevirt-operator"))
+
+			version, ok := deployment.Annotations["kubevirt.io/install-strategy-version"]
+			Expect(ok).To(BeTrue())
+			Expect(version).To(Equal("fakeversion"))
+
+			registry, ok := deployment.Annotations["kubevirt.io/install-strategy-registry"]
+			Expect(ok).To(BeTrue())
+			Expect(registry).To(Equal("fakeregistry"))
+
+			id, ok := deployment.Annotations["kubevirt.io/install-strategy-identifier"]
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal("fakeid"))
+
+		})
+	})
 })

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -644,10 +644,15 @@ func (c *KubeVirtController) execute(key string) error {
 	operatorutil.SetConditionTimestamps(kv, kvCopy)
 
 	// If we detect a change on KubeVirt we update it
-	if !reflect.DeepEqual(kv.Status, kvCopy.Status) ||
-		!reflect.DeepEqual(kv.Finalizers, kvCopy.Finalizers) {
-
+	if !reflect.DeepEqual(kv.Status, kvCopy.Status) {
 		if err := c.statusUpdater.UpdateStatus(kvCopy); err != nil {
+			logger.Reason(err).Errorf("Could not update the KubeVirt resource status.")
+			return err
+		}
+	}
+
+	if !reflect.DeepEqual(kv.Finalizers, kvCopy.Finalizers) {
+		if _, err := c.clientset.KubeVirt(kvCopy.ObjectMeta.Namespace).Update(kvCopy); err != nil {
 			logger.Reason(err).Errorf("Could not update the KubeVirt resource.")
 			return err
 		}

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -485,7 +485,7 @@ const (
 	AppComponent = "kubevirt"
 	// This label will be set on all resources created by the operator
 	ManagedByLabel              = AppLabelPrefix + "/managed-by"
-	ManagedByLabelOperatorValue = "virt-operator"
+	ManagedByLabelOperatorValue = "kubevirt-operator"
 	// This annotation represents the kubevirt version for an install strategy configmap.
 	InstallStrategyVersionAnnotation = "kubevirt.io/install-strategy-version"
 	// This annotation represents the kubevirt registry used for an install strategy configmap.


### PR DESCRIPTION
This is a backport of PR #4113 which addresses the update issues identified in issue #4108

We need this before we can cut the official v0.33.0 release.

```release-note
NONE
```
