### PR TITLE
Calculate vmipod CPUs requests based on the number of guest vCPU and cluster cpu-allocation-ratio

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8382,6 +8382,9 @@
     "description": "DeveloperConfiguration holds developer options",
     "type": "object",
     "properties": {
+     "cpuAllocationRatio": {
+      "type": "string"
+     },
      "featureGates": {
       "type": "array",
       "items": {

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -58,6 +58,7 @@ const (
 	SupportedGuestAgentVersionsKey    = "supported-guest-agent"
 	OVMFPathKey                       = "ovmfPath"
 	MemBalloonStatsPeriod             = "memBalloonStatsPeriod"
+	CPUAllocationRatio                = "cpu-allocation-ratio"
 )
 
 type ConfigModifiedFn func()
@@ -174,6 +175,7 @@ func defaultClusterConfig() *v1.KubeVirtConfiguration {
 			MemoryOvercommit:       DefaultMemoryOvercommit,
 			LessPVCSpaceToleration: DefaultLessPVCSpaceToleration,
 			NodeSelectors:          nodeSelectorsDefault,
+			CPUAllocationRatio:     DefaultCPUAllocationRatio,
 		},
 		MigrationConfiguration: &v1.MigrationConfiguration{
 			ParallelMigrationsPerCluster:      &parallelMigrationsPerClusterDefault,
@@ -290,6 +292,14 @@ func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.C
 			config.DeveloperConfiguration.MemoryOvercommit = value
 		} else {
 			return fmt.Errorf("Invalid memoryOvercommit in ConfigMap: %s", memoryOvercommit)
+		}
+	}
+
+	if cpuOvercommit := strings.TrimSpace(configMap.Data[CPUAllocationRatio]); cpuOvercommit != "" {
+		if value, err := strconv.ParseFloat(cpuOvercommit, 64); err == nil && value > 0 {
+			config.DeveloperConfiguration.CPUAllocationRatio = value
+		} else {
+			return fmt.Errorf("Invalid cpu allocation ratio in ConfigMap: %s", cpuOvercommit)
 		}
 	}
 

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -60,6 +60,7 @@ const (
 	SupportedGuestAgentVersions                     = "3.*,4.*"
 	DefaultOVMFPath                                 = "/usr/share/OVMF"
 	DefaultMemBalloonStatsPeriod                    = 10
+	DefaultCPUAllocationRatio                       = 10.0
 )
 
 // Set default machine type and supported emulated machines based on architecture
@@ -152,4 +153,8 @@ func (c *ClusterConfig) GetSupportedAgentVersions() []string {
 
 func (c *ClusterConfig) GetOVMFPath() string {
 	return c.GetConfig().OVMFPath
+}
+
+func (c *ClusterConfig) GetCPUAllocationRatio() float64 {
+	return float64(c.GetConfig().DeveloperConfiguration.CPUAllocationRatio)
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -618,6 +618,23 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 	resources.Requests = make(k8sv1.ResourceList)
 	resources.Limits = make(k8sv1.ResourceList)
 
+	// Set Default CPUs request
+	if !vmi.IsCPUDedicated() {
+		vcpus := int64(1)
+		if vmi.Spec.Domain.CPU != nil {
+			vcpus = hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU)
+		}
+		cpuAllocationRatio := t.clusterConfig.GetCPUAllocationRatio()
+		if vcpus != 0 && cpuAllocationRatio > 0 {
+			val := float64(vcpus) / cpuAllocationRatio
+			vcpusStr := fmt.Sprintf("%g", val)
+			if val < 0 {
+				val *= 1000
+				vcpusStr = fmt.Sprintf("%gm", val)
+			}
+			resources.Requests[k8sv1.ResourceCPU] = resource.MustParse(vcpusStr)
+		}
+	}
 	// Copy vmi resources requests to a container
 	for key, value := range vmiResources.Requests {
 		resources.Requests[key] = value

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -14198,6 +14198,12 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 							Format: "",
 						},
 					},
+					"cpuAllocationRatio": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1415,6 +1415,7 @@ type DeveloperConfiguration struct {
 	MemoryOvercommit       int               `json:"memoryOvercommit,string,omitempty"`
 	NodeSelectors          map[string]string `json:"nodeSelectors,omitempty"`
 	UseEmulation           bool              `json:"useEmulation,string,omitempty"`
+	CPUAllocationRatio     float64           `json:"cpuAllocationRatio,string,omitempty"`
 }
 
 // NetworkConfiguration holds network options

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14054,6 +14054,12 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 							Format: "",
 						},
 					},
+					"cpuAllocationRatio": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, a default value of CPUs is being requested by each vmipod regardless of the number of vCPUs the guest will have.
The CPU requested on the pod sets the cgroups `cpu.shares` which is specifying the weight to provide CPU time for a process in this container.
As the number of vCPUs increases, this will reduce the amount of CPU time each vCPU may get when competing with other processes on the node or even with VMIs with a lower amount of vCPUs.

This PR introduces a kubevirt configMap parameter `cpuAllocationRatio` that will normalize the requested compute container CPUs based on the total number of vCPUs *  cpuAllocationRatio
When cpuAllocationRatio is set to 1, a full amount of vCPUs will be requested for the POD.

API users can also request to disable the vCPUs overcommit for the VMI but adding an overcommitVCPUs parameter:
```
spec:
  domain:
    cpu:
      sockets: 2
      cores: 1
      threads: 1
      overcommitVCPUs: false
``` 

Not representing the required amount of vCPU for the k8s scheduler may lead to a high overcommitment of vCPUs. 

**Release note**:
```release-note
introduce a cpuAllocationRatio config parameter to normalize the number of CPUs requested for a pod, based on the number of vCPUs
```
