### PR TITLE
virt-chroot: use sysfs node for getenforce instead of less-reliable go-selinux

### DIFF
--- a/cmd/virt-chroot/selinux.go
+++ b/cmd/virt-chroot/selinux.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/spf13/cobra"
@@ -14,17 +16,13 @@ func NewGetEnforceCommand() *cobra.Command {
 		Short: "determine if selinux is present",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if selinux.GetEnabled() {
-				mode := selinux.EnforceMode()
-				if mode == selinux.Enforcing {
-					fmt.Println("enforcing")
-				} else if mode == selinux.Permissive {
-					fmt.Println("permissive")
-				} else {
-					fmt.Println("disabled")
-				}
-			} else {
+			enforcing, err := ioutil.ReadFile("/sys/fs/selinux/enforce")
+			if err != nil {
 				fmt.Println("disabled")
+			} else if bytes.Compare(enforcing, []byte("1")) == 0 {
+				fmt.Println("enforcing")
+			} else {
+				fmt.Println("permissive")
 			}
 			return nil
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
In some environments, `virt-chroot selinux getenforce` fails to detect the presence of SELinux.
Maybe it is due to the way it is compiled or something...
Switching to reading the sysfs as a simpler method.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
