### PR TITLE
Fixing colisions in openapi.

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -25,7 +25,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.RootPaths"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.RootPaths"
        }
       },
       "401": {
@@ -51,7 +51,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroupList"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIGroupList"
        }
       },
       "401": {
@@ -77,7 +77,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -103,7 +103,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -416,7 +416,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -527,7 +527,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -556,7 +556,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -583,7 +583,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -836,7 +836,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -947,7 +947,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -976,7 +976,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -1003,7 +1003,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -1256,7 +1256,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -1367,7 +1367,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -1396,7 +1396,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -1423,7 +1423,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -1676,7 +1676,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -1787,7 +1787,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -1816,7 +1816,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -1843,7 +1843,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -2096,7 +2096,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -2207,7 +2207,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -2236,7 +2236,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -2263,7 +2263,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -2516,7 +2516,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -2627,7 +2627,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -2656,7 +2656,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -2683,7 +2683,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -3147,7 +3147,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3228,7 +3228,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3317,7 +3317,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3406,7 +3406,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3495,7 +3495,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3584,7 +3584,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3673,7 +3673,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3762,7 +3762,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3843,7 +3843,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -3924,7 +3924,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -4005,7 +4005,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -4086,7 +4086,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -4167,7 +4167,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -4193,7 +4193,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -4423,7 +4423,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -4534,7 +4534,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -4563,7 +4563,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -4590,7 +4590,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -4843,7 +4843,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -4954,7 +4954,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -4983,7 +4983,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -5010,7 +5010,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -5263,7 +5263,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -5374,7 +5374,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.DeleteOptions"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions"
        }
       },
       {
@@ -5403,7 +5403,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Status"
        }
       },
       "401": {
@@ -5430,7 +5430,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Patch"
        }
       }
      ],
@@ -5728,7 +5728,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -5817,7 +5817,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -5906,7 +5906,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -5995,7 +5995,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -6076,7 +6076,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -6157,7 +6157,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.WatchEvent"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent"
        }
       },
       "401": {
@@ -6238,7 +6238,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -6264,7 +6264,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -6868,20 +6868,553 @@
    }
   },
   "definitions": {
-   "intstr.IntOrString": {
-    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
-    "type": "string",
-    "format": "int-or-string"
+   "k8s.io.api.core.v1.Affinity": {
+    "description": "Affinity is a group of affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "nodeAffinity": {
+      "description": "Describes node affinity scheduling rules for the pod.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.NodeAffinity"
+     },
+     "podAffinity": {
+      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+      "$ref": "#/definitions/k8s.io.api.core.v1.PodAffinity"
+     },
+     "podAntiAffinity": {
+      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+      "$ref": "#/definitions/k8s.io.api.core.v1.PodAntiAffinity"
+     }
+    }
    },
-   "resource.Quantity": {
+   "k8s.io.api.core.v1.HTTPGetAction": {
+    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+    "type": "object",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "host": {
+      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+      "type": "string"
+     },
+     "httpHeaders": {
+      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.HTTPHeader"
+      }
+     },
+     "path": {
+      "description": "Path to access on the HTTP server.",
+      "type": "string"
+     },
+     "port": {
+      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+      "type": [
+       "string",
+       "number"
+      ]
+     },
+     "scheme": {
+      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.HTTPHeader": {
+    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+    "type": "object",
+    "required": [
+     "name",
+     "value"
+    ],
+    "properties": {
+     "name": {
+      "description": "The header field name",
+      "type": "string"
+     },
+     "value": {
+      "description": "The header field value",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.LocalObjectReference": {
+    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+    "type": "object",
+    "properties": {
+     "name": {
+      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.NodeAffinity": {
+    "description": "Node affinity is a group of node affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "preferredDuringSchedulingIgnoredDuringExecution": {
+      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.PreferredSchedulingTerm"
+      }
+     },
+     "requiredDuringSchedulingIgnoredDuringExecution": {
+      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.NodeSelector"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.NodeSelector": {
+    "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+    "type": "object",
+    "required": [
+     "nodeSelectorTerms"
+    ],
+    "properties": {
+     "nodeSelectorTerms": {
+      "description": "Required. A list of node selector terms. The terms are ORed.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.NodeSelectorTerm"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.NodeSelectorRequirement": {
+    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "type": "object",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "description": "The label key that the selector applies to.",
+      "type": "string"
+     },
+     "operator": {
+      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+      "type": "string"
+     },
+     "values": {
+      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.NodeSelectorTerm": {
+    "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+    "type": "object",
+    "properties": {
+     "matchExpressions": {
+      "description": "A list of node selector requirements by node's labels.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.NodeSelectorRequirement"
+      }
+     },
+     "matchFields": {
+      "description": "A list of node selector requirements by node's fields.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.NodeSelectorRequirement"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PersistentVolumeClaim": {
+    "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
+    "type": "object",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimSpec"
+     },
+     "status": {
+      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimStatus"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PersistentVolumeClaimCondition": {
+    "description": "PersistentVolumeClaimCondition contails details about state of pvc",
+    "type": "object",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastProbeTime": {
+      "description": "Last time we probed the condition.",
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "lastTransitionTime": {
+      "description": "Last time the condition transitioned from one status to another.",
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "message": {
+      "description": "Human-readable message indicating details about last transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports \"ResizeStarted\" that means the underlying persistent volume is being resized.",
+      "type": "string"
+     },
+     "status": {
+      "type": "string"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PersistentVolumeClaimSpec": {
+    "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+    "type": "object",
+    "properties": {
+     "accessModes": {
+      "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "dataSource": {
+      "description": "This field requires the VolumeSnapshotDataSource alpha feature gate to be enabled and currently VolumeSnapshot is the only supported data source. If the provisioner can support VolumeSnapshot data source, it will create a new volume and data will be restored to the volume at the same time. If the provisioner does not support VolumeSnapshot data source, volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
+     },
+     "resources": {
+      "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+      "$ref": "#/definitions/k8s.io.api.core.v1.ResourceRequirements"
+     },
+     "selector": {
+      "description": "A label query over volumes to consider for binding.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector"
+     },
+     "storageClassName": {
+      "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+      "type": "string"
+     },
+     "volumeMode": {
+      "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec. This is a beta feature.",
+      "type": "string"
+     },
+     "volumeName": {
+      "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PersistentVolumeClaimStatus": {
+    "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
+    "type": "object",
+    "nullable": true,
+    "properties": {
+     "accessModes": {
+      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "capacity": {
+      "description": "Represents the actual resources of the underlying volume.",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
+     },
+     "conditions": {
+      "description": "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimCondition"
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
+     },
+     "phase": {
+      "description": "Phase represents the current phase of PersistentVolumeClaim.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PersistentVolumeClaimVolumeSource": {
+    "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+    "type": "object",
+    "required": [
+     "claimName"
+    ],
+    "properties": {
+     "claimName": {
+      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+      "type": "string"
+     },
+     "readOnly": {
+      "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PodAffinity": {
+    "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "preferredDuringSchedulingIgnoredDuringExecution": {
+      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.WeightedPodAffinityTerm"
+      }
+     },
+     "requiredDuringSchedulingIgnoredDuringExecution": {
+      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.PodAffinityTerm"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PodAffinityTerm": {
+    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+    "type": "object",
+    "required": [
+     "topologyKey"
+    ],
+    "properties": {
+     "labelSelector": {
+      "description": "A label query over a set of resources, in this case pods.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector"
+     },
+     "namespaces": {
+      "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "topologyKey": {
+      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PodAntiAffinity": {
+    "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+    "type": "object",
+    "properties": {
+     "preferredDuringSchedulingIgnoredDuringExecution": {
+      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.WeightedPodAffinityTerm"
+      }
+     },
+     "requiredDuringSchedulingIgnoredDuringExecution": {
+      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.PodAffinityTerm"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PodDNSConfig": {
+    "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+    "type": "object",
+    "properties": {
+     "nameservers": {
+      "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "options": {
+      "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.api.core.v1.PodDNSConfigOption"
+      }
+     },
+     "searches": {
+      "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PodDNSConfigOption": {
+    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "type": "object",
+    "properties": {
+     "name": {
+      "description": "Required.",
+      "type": "string"
+     },
+     "value": {
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.PreferredSchedulingTerm": {
+    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+    "type": "object",
+    "required": [
+     "weight",
+     "preference"
+    ],
+    "properties": {
+     "preference": {
+      "description": "A node selector term, associated with the corresponding weight.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.NodeSelectorTerm"
+     },
+     "weight": {
+      "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.ResourceRequirements": {
+    "description": "ResourceRequirements describes the compute resource requirements.",
+    "type": "object",
+    "properties": {
+     "limits": {
+      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
+     },
+     "requests": {
+      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
+      }
+     }
+    }
+   },
+   "k8s.io.api.core.v1.TCPSocketAction": {
+    "description": "TCPSocketAction describes an action based on opening a socket",
+    "type": "object",
+    "required": [
+     "port"
+    ],
+    "properties": {
+     "host": {
+      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+      "type": "string"
+     },
+     "port": {
+      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+      "type": [
+       "string",
+       "number"
+      ]
+     }
+    }
+   },
+   "k8s.io.api.core.v1.Toleration": {
+    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+    "type": "object",
+    "properties": {
+     "effect": {
+      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+      "type": "string"
+     },
+     "key": {
+      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+      "type": "string"
+     },
+     "operator": {
+      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+      "type": "string"
+     },
+     "tolerationSeconds": {
+      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "value": {
+      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.TypedLocalObjectReference": {
+    "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+    "type": "object",
+    "required": [
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "apiGroup": {
+      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is the type of resource being referenced",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name is the name of resource being referenced",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.api.core.v1.WeightedPodAffinityTerm": {
+    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+    "type": "object",
+    "required": [
+     "weight",
+     "podAffinityTerm"
+    ],
+    "properties": {
+     "podAffinityTerm": {
+      "description": "Required. A pod affinity term, associated with the corresponding weight.",
+      "$ref": "#/definitions/k8s.io.api.core.v1.PodAffinityTerm"
+     },
+     "weight": {
+      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.api.resource.Quantity": {
     "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n\u003cquantity\u003e        ::= \u003csignedNumber\u003e\u003csuffix\u003e\n  (Note that \u003csuffix\u003e may be empty, from the \"\" case in \u003cdecimalSI\u003e.)\n\u003cdigit\u003e           ::= 0 | 1 | ... | 9 \u003cdigits\u003e          ::= \u003cdigit\u003e | \u003cdigit\u003e\u003cdigits\u003e \u003cnumber\u003e          ::= \u003cdigits\u003e | \u003cdigits\u003e.\u003cdigits\u003e | \u003cdigits\u003e. | .\u003cdigits\u003e \u003csign\u003e            ::= \"+\" | \"-\" \u003csignedNumber\u003e    ::= \u003cnumber\u003e | \u003csign\u003e\u003cnumber\u003e \u003csuffix\u003e          ::= \u003cbinarySI\u003e | \u003cdecimalExponent\u003e | \u003cdecimalSI\u003e \u003cbinarySI\u003e        ::= Ki | Mi | Gi | Ti | Pi | Ei\n  (International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\u003cdecimalSI\u003e       ::= m | \"\" | k | M | G | T | P | E\n  (Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\u003cdecimalExponent\u003e ::= \"e\" \u003csignedNumber\u003e | \"E\" \u003csignedNumber\u003e\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n  a. No precision is lost\n  b. No fractional digits will be emitted\n  c. The exponent (or suffix) is as large as possible.\nThe sign will be omitted unless the number is negative.\n\nExamples:\n  1.5 will be serialized as \"1500m\"\n  1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
     "type": "string"
    },
-   "runtime.RawExtension": {
-    "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
-    "type": "object"
-   },
-   "v1.APIGroup": {
+   "k8s.io.apimachinery.pkg.apis.meta.v1.APIGroup": {
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "type": "object",
     "required": [
@@ -6903,25 +7436,25 @@
      },
      "preferredVersion": {
       "description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
-      "$ref": "#/definitions/v1.GroupVersionForDiscovery"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
      },
      "serverAddressByClientCIDRs": {
       "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.ServerAddressByClientCIDR"
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR"
       }
      },
      "versions": {
       "description": "versions are the versions supported in this group.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.GroupVersionForDiscovery"
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery"
       }
      }
     }
    },
-   "v1.APIGroupList": {
+   "k8s.io.apimachinery.pkg.apis.meta.v1.APIGroupList": {
     "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
     "type": "object",
     "required": [
@@ -6936,7 +7469,7 @@
       "description": "groups is a list of APIGroup.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.APIGroup"
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIGroup"
       }
      },
      "kind": {
@@ -6945,7 +7478,7 @@
      }
     }
    },
-   "v1.APIResource": {
+   "k8s.io.apimachinery.pkg.apis.meta.v1.APIResource": {
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "type": "object",
     "required": [
@@ -7007,7 +7540,7 @@
      }
     }
    },
-   "v1.APIResourceList": {
+   "k8s.io.apimachinery.pkg.apis.meta.v1.APIResourceList": {
     "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
     "type": "object",
     "required": [
@@ -7031,28 +7564,477 @@
       "description": "resources contains the name of the resources and if they are namespaced.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.APIResource"
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResource"
       }
      }
     }
    },
-   "v1.Affinity": {
-    "description": "Affinity is a group of affinity scheduling rules.",
+   "k8s.io.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
+    "description": "DeleteOptions may be provided when deleting an API object.",
     "type": "object",
     "properties": {
-     "nodeAffinity": {
-      "description": "Describes node affinity scheduling rules for the pod.",
-      "$ref": "#/definitions/v1.NodeAffinity"
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
      },
-     "podAffinity": {
-      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
-      "$ref": "#/definitions/v1.PodAffinity"
+     "dryRun": {
+      "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
      },
-     "podAntiAffinity": {
-      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
-      "$ref": "#/definitions/v1.PodAntiAffinity"
+     "gracePeriodSeconds": {
+      "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "orphanDependents": {
+      "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+      "type": "boolean"
+     },
+     "preconditions": {
+      "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Preconditions"
+     },
+     "propagationPolicy": {
+      "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+      "type": "string"
      }
     }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.Duration": {
+    "description": "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
+    "type": "string"
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+    "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+    "type": "object"
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "type": "object",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "description": "groupVersion specifies the API group and version in the form \"group/version\"",
+      "type": "string"
+     },
+     "version": {
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "type": "object",
+    "properties": {
+     "matchExpressions": {
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+      }
+     },
+     "matchLabels": {
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "type": "object",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "description": "key is the label key that the selector applies to.",
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
+     },
+     "operator": {
+      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+      "type": "string"
+     },
+     "values": {
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta": {
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "type": "object",
+    "properties": {
+     "continue": {
+      "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
+      "type": "string"
+     },
+     "remainingItemCount": {
+      "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "resourceVersion": {
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+      "type": "string"
+     },
+     "selfLink": {
+      "description": "selfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+    "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+    "type": "object",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+      "type": "string"
+     },
+     "fieldsType": {
+      "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+      "type": "string"
+     },
+     "fieldsV1": {
+      "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.FieldsV1"
+     },
+     "manager": {
+      "description": "Manager is an identifier of the workflow managing these fields.",
+      "type": "string"
+     },
+     "operation": {
+      "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+      "type": "string"
+     },
+     "time": {
+      "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+    "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+    "type": "object",
+    "properties": {
+     "annotations": {
+      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "clusterName": {
+      "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+      "type": "string"
+     },
+     "creationTimestamp": {
+      "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "deletionGracePeriodSeconds": {
+      "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "deletionTimestamp": {
+      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
+     },
+     "finalizers": {
+      "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-patch-strategy": "merge"
+     },
+     "generateName": {
+      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+      "type": "string"
+     },
+     "generation": {
+      "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "labels": {
+      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "managedFields": {
+      "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+      }
+     },
+     "name": {
+      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+      "type": "string"
+     },
+     "namespace": {
+      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+      "type": "string"
+     },
+     "ownerReferences": {
+      "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference"
+      },
+      "x-kubernetes-patch-merge-key": "uid",
+      "x-kubernetes-patch-strategy": "merge"
+     },
+     "resourceVersion": {
+      "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+      "type": "string"
+     },
+     "selfLink": {
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+      "type": "string"
+     },
+     "uid": {
+      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+    "type": "object",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "API version of the referent.",
+      "type": "string"
+     },
+     "blockOwnerDeletion": {
+      "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+      "type": "boolean"
+     },
+     "controller": {
+      "description": "If true, this reference points to the managing controller.",
+      "type": "boolean"
+     },
+     "kind": {
+      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+      "type": "string"
+     },
+     "uid": {
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.Patch": {
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "type": "object"
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.Preconditions": {
+    "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+    "type": "object",
+    "properties": {
+     "resourceVersion": {
+      "description": "Specifies the target ResourceVersion",
+      "type": "string"
+     },
+     "uid": {
+      "description": "Specifies the target UID.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.RootPaths": {
+    "description": "RootPaths lists the paths available at root. For example: \"/healthz\", \"/apis\".",
+    "type": "object",
+    "required": [
+     "paths"
+    ],
+    "properties": {
+     "paths": {
+      "description": "paths are the paths available at root.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+    "type": "object",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+      "type": "string"
+     },
+     "serverAddress": {
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.Status": {
+    "description": "Status is a return value for calls that don't return other objects.",
+    "type": "object",
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+     },
+     "code": {
+      "description": "Suggested HTTP return code for this status, 0 if not set.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "details": {
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.StatusDetails"
+     },
+     "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "message": {
+      "description": "A human-readable description of the status of this operation.",
+      "type": "string"
+     },
+     "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
+     },
+     "reason": {
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.StatusCause": {
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "type": "object",
+    "properties": {
+     "field": {
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+      "type": "string"
+     },
+     "message": {
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.StatusDetails": {
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "type": "object",
+    "properties": {
+     "causes": {
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.StatusCause"
+      }
+     },
+     "group": {
+      "description": "The group attribute of the resource associated with the status StatusReason.",
+      "type": "string"
+     },
+     "kind": {
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "name": {
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+      "type": "string"
+     },
+     "retryAfterSeconds": {
+      "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "uid": {
+      "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.Time": {
+    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+    "type": "string",
+    "format": "date-time"
+   },
+   "k8s.io.apimachinery.pkg.apis.meta.v1.WatchEvent": {
+    "description": "Event represents a single event to a watched resource.",
+    "type": "object",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "object": {
+      "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.runtime.RawExtension"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "k8s.io.apimachinery.pkg.runtime.RawExtension": {
+    "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+    "type": "object"
+   },
+   "k8s.io.apimachinery.pkg.util.intstr.IntOrString": {
+    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+    "type": "string",
+    "format": "int-or-string"
    },
    "v1.BIOS": {
     "description": "If set (default), BIOS will be used.",
@@ -7210,11 +8192,11 @@
      },
      "networkDataSecretRef": {
       "description": "NetworkDataSecretRef references a k8s secret that contains config drive networkdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.LocalObjectReference"
      },
      "secretRef": {
       "description": "UserDataSecretRef references a k8s secret that contains config drive userdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.LocalObjectReference"
      },
      "userData": {
       "description": "UserData contains config drive inline cloud-init userdata.",
@@ -7240,11 +8222,11 @@
      },
      "networkDataSecretRef": {
       "description": "NetworkDataSecretRef references a k8s secret that contains NoCloud networkdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.LocalObjectReference"
      },
      "secretRef": {
       "description": "UserDataSecretRef references a k8s secret that contains NoCloud userdata.",
-      "$ref": "#/definitions/v1.LocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.LocalObjectReference"
      },
      "userData": {
       "description": "UserData contains NoCloud inline cloud-init userdata.",
@@ -7383,44 +8365,6 @@
     "properties": {
      "name": {
       "description": "Name represents the name of the DataVolume in the same namespace",
-      "type": "string"
-     }
-    }
-   },
-   "v1.DeleteOptions": {
-    "description": "DeleteOptions may be provided when deleting an API object.",
-    "type": "object",
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "dryRun": {
-      "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "gracePeriodSeconds": {
-      "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "orphanDependents": {
-      "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
-      "type": "boolean"
-     },
-     "preconditions": {
-      "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned.",
-      "$ref": "#/definitions/v1.Preconditions"
-     },
-     "propagationPolicy": {
-      "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
       "type": "string"
      }
     }
@@ -7635,10 +8579,6 @@
      }
     }
    },
-   "v1.Duration": {
-    "description": "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
-    "type": "string"
-   },
    "v1.EFI": {
     "description": "If set, EFI will be used instead of BIOS.",
     "type": "object",
@@ -7658,7 +8598,7 @@
     "properties": {
      "capacity": {
       "description": "Capacity of the sparse disk.",
-      "$ref": "#/definitions/resource.Quantity"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      }
     }
    },
@@ -7667,7 +8607,7 @@
     "properties": {
      "persistentVolumeClaim": {
       "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
+      "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimVolumeSource"
      }
     }
    },
@@ -7804,10 +8744,6 @@
      }
     }
    },
-   "v1.FieldsV1": {
-    "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:\u003cname\u003e', where \u003cname\u003e is the name of a field in a struct, or key in a map 'v:\u003cvalue\u003e', where \u003cvalue\u003e is the exact json formatted value of a list item 'i:\u003cindex\u003e', where \u003cindex\u003e is position of a item in a list 'k:\u003ckeys\u003e', where \u003ckeys\u003e is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
-    "type": "object"
-   },
    "v1.Firmware": {
     "type": "object",
     "properties": {
@@ -7854,24 +8790,6 @@
      }
     }
    },
-   "v1.GroupVersionForDiscovery": {
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
-    "type": "object",
-    "required": [
-     "groupVersion",
-     "version"
-    ],
-    "properties": {
-     "groupVersion": {
-      "description": "groupVersion specifies the API group and version in the form \"group/version\"",
-      "type": "string"
-     },
-     "version": {
-      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
-      "type": "string"
-     }
-    }
-   },
    "v1.HPETTimer": {
     "type": "object",
     "properties": {
@@ -7881,59 +8799,6 @@
      },
      "tickPolicy": {
       "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"merge\", \"discard\".",
-      "type": "string"
-     }
-    }
-   },
-   "v1.HTTPGetAction": {
-    "description": "HTTPGetAction describes an action based on HTTP Get requests.",
-    "type": "object",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "host": {
-      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
-      "type": "string"
-     },
-     "httpHeaders": {
-      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.HTTPHeader"
-      }
-     },
-     "path": {
-      "description": "Path to access on the HTTP server.",
-      "type": "string"
-     },
-     "port": {
-      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-      "type": [
-       "string",
-       "number"
-      ]
-     },
-     "scheme": {
-      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.HTTPHeader": {
-    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
-    "type": "object",
-    "required": [
-     "name",
-     "value"
-    ],
-    "properties": {
-     "name": {
-      "description": "The header field name",
-      "type": "string"
-     },
-     "value": {
-      "description": "The header field value",
       "type": "string"
      }
     }
@@ -7948,7 +8813,7 @@
     "properties": {
      "capacity": {
       "description": "Capacity of the sparse disk",
-      "$ref": "#/definitions/resource.Quantity"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      },
      "path": {
       "description": "The path to HostDisk image located on the cluster",
@@ -8107,7 +8972,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "$ref": "#/definitions/v1.KubeVirtSpec"
@@ -8233,7 +9098,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -8241,13 +9106,13 @@
     "type": "object",
     "properties": {
      "caOverlapInterval": {
-      "$ref": "#/definitions/v1.Duration"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Duration"
      },
      "caRotateInterval": {
-      "$ref": "#/definitions/v1.Duration"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Duration"
      },
      "certRotateInterval": {
-      "$ref": "#/definitions/v1.Duration"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Duration"
      }
     }
    },
@@ -8341,86 +9206,6 @@
      }
     }
    },
-   "v1.LabelSelector": {
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
-    "type": "object",
-    "properties": {
-     "matchExpressions": {
-      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.LabelSelectorRequirement"
-      }
-     },
-     "matchLabels": {
-      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.LabelSelectorRequirement": {
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-    "type": "object",
-    "required": [
-     "key",
-     "operator"
-    ],
-    "properties": {
-     "key": {
-      "description": "key is the label key that the selector applies to.",
-      "type": "string",
-      "x-kubernetes-patch-merge-key": "key",
-      "x-kubernetes-patch-strategy": "merge"
-     },
-     "operator": {
-      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
-      "type": "string"
-     },
-     "values": {
-      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.ListMeta": {
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
-    "type": "object",
-    "properties": {
-     "continue": {
-      "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.",
-      "type": "string"
-     },
-     "remainingItemCount": {
-      "description": "remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "resourceVersion": {
-      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
-      "type": "string"
-     },
-     "selfLink": {
-      "description": "selfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.LocalObjectReference": {
-    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
-    "type": "object",
-    "properties": {
-     "name": {
-      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-      "type": "string"
-     }
-    }
-   },
    "v1.LunTarget": {
     "type": "object",
     "properties": {
@@ -8446,43 +9231,13 @@
      }
     }
    },
-   "v1.ManagedFieldsEntry": {
-    "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
-    "type": "object",
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
-      "type": "string"
-     },
-     "fieldsType": {
-      "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
-      "type": "string"
-     },
-     "fieldsV1": {
-      "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type.",
-      "$ref": "#/definitions/v1.FieldsV1"
-     },
-     "manager": {
-      "description": "Manager is an identifier of the workflow managing these fields.",
-      "type": "string"
-     },
-     "operation": {
-      "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
-      "type": "string"
-     },
-     "time": {
-      "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'",
-      "$ref": "#/definitions/v1.Time"
-     }
-    }
-   },
    "v1.Memory": {
     "description": "Memory allows specifying the VirtualMachineInstance memory features.",
     "type": "object",
     "properties": {
      "guest": {
       "description": "Guest allows to specifying the amount of memory which is visible inside the Guest OS. The Guest must lie between Requests and Limits from the resources section. Defaults to the requested memory in the resources section if not specified.",
-      "$ref": "#/definitions/resource.Quantity"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      },
      "hugepages": {
       "description": "Hugepages allow to use hugepages for the VirtualMachineInstance instead of regular memory.",
@@ -8502,7 +9257,7 @@
       "type": "string"
      },
      "bandwidthPerMigration": {
-      "$ref": "#/definitions/resource.Quantity"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      },
      "completionTimeoutPerGiB": {
       "type": "string"
@@ -8575,213 +9330,6 @@
      }
     }
    },
-   "v1.NodeAffinity": {
-    "description": "Node affinity is a group of node affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "preferredDuringSchedulingIgnoredDuringExecution": {
-      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PreferredSchedulingTerm"
-      }
-     },
-     "requiredDuringSchedulingIgnoredDuringExecution": {
-      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
-      "$ref": "#/definitions/v1.NodeSelector"
-     }
-    }
-   },
-   "v1.NodeSelector": {
-    "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
-    "type": "object",
-    "required": [
-     "nodeSelectorTerms"
-    ],
-    "properties": {
-     "nodeSelectorTerms": {
-      "description": "Required. A list of node selector terms. The terms are ORed.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.NodeSelectorTerm"
-      }
-     }
-    }
-   },
-   "v1.NodeSelectorRequirement": {
-    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-    "type": "object",
-    "required": [
-     "key",
-     "operator"
-    ],
-    "properties": {
-     "key": {
-      "description": "The label key that the selector applies to.",
-      "type": "string"
-     },
-     "operator": {
-      "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
-      "type": "string"
-     },
-     "values": {
-      "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.NodeSelectorTerm": {
-    "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
-    "type": "object",
-    "properties": {
-     "matchExpressions": {
-      "description": "A list of node selector requirements by node's labels.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.NodeSelectorRequirement"
-      }
-     },
-     "matchFields": {
-      "description": "A list of node selector requirements by node's fields.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.NodeSelectorRequirement"
-      }
-     }
-    }
-   },
-   "v1.ObjectMeta": {
-    "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
-    "type": "object",
-    "properties": {
-     "annotations": {
-      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     },
-     "clusterName": {
-      "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
-      "type": "string"
-     },
-     "creationTimestamp": {
-      "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "deletionGracePeriodSeconds": {
-      "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "deletionTimestamp": {
-      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "finalizers": {
-      "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      },
-      "x-kubernetes-patch-strategy": "merge"
-     },
-     "generateName": {
-      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
-      "type": "string"
-     },
-     "generation": {
-      "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "labels": {
-      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     },
-     "managedFields": {
-      "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.ManagedFieldsEntry"
-      }
-     },
-     "name": {
-      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-      "type": "string"
-     },
-     "namespace": {
-      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
-      "type": "string"
-     },
-     "ownerReferences": {
-      "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.OwnerReference"
-      },
-      "x-kubernetes-patch-merge-key": "uid",
-      "x-kubernetes-patch-strategy": "merge"
-     },
-     "resourceVersion": {
-      "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
-      "type": "string"
-     },
-     "selfLink": {
-      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
-      "type": "string"
-     },
-     "uid": {
-      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-      "type": "string"
-     }
-    }
-   },
-   "v1.OwnerReference": {
-    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
-    "type": "object",
-    "required": [
-     "apiVersion",
-     "kind",
-     "name",
-     "uid"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "API version of the referent.",
-      "type": "string"
-     },
-     "blockOwnerDeletion": {
-      "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
-      "type": "boolean"
-     },
-     "controller": {
-      "description": "If true, this reference points to the managing controller.",
-      "type": "boolean"
-     },
-     "kind": {
-      "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-      "type": "string"
-     },
-     "uid": {
-      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-      "type": "string"
-     }
-    }
-   },
    "v1.PITTimer": {
     "type": "object",
     "properties": {
@@ -8791,266 +9339,6 @@
      },
      "tickPolicy": {
       "description": "TickPolicy determines what happens when QEMU misses a deadline for injecting a tick to the guest. One of \"delay\", \"catchup\", \"discard\".",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Patch": {
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
-    "type": "object"
-   },
-   "v1.PersistentVolumeClaim": {
-    "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
-    "type": "object",
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "metadata": {
-      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimSpec"
-     },
-     "status": {
-      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimStatus"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimCondition": {
-    "description": "PersistentVolumeClaimCondition contails details about state of pvc",
-    "type": "object",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastProbeTime": {
-      "description": "Last time we probed the condition.",
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "lastTransitionTime": {
-      "description": "Last time the condition transitioned from one status to another.",
-      "type": [
-       "string",
-       "null"
-      ]
-     },
-     "message": {
-      "description": "Human-readable message indicating details about last transition.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports \"ResizeStarted\" that means the underlying persistent volume is being resized.",
-      "type": "string"
-     },
-     "status": {
-      "type": "string"
-     },
-     "type": {
-      "type": "string"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimSpec": {
-    "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
-    "type": "object",
-    "properties": {
-     "accessModes": {
-      "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "dataSource": {
-      "description": "This field requires the VolumeSnapshotDataSource alpha feature gate to be enabled and currently VolumeSnapshot is the only supported data source. If the provisioner can support VolumeSnapshot data source, it will create a new volume and data will be restored to the volume at the same time. If the provisioner does not support VolumeSnapshot data source, volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.",
-      "$ref": "#/definitions/v1.TypedLocalObjectReference"
-     },
-     "resources": {
-      "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
-      "$ref": "#/definitions/v1.ResourceRequirements"
-     },
-     "selector": {
-      "description": "A label query over volumes to consider for binding.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "storageClassName": {
-      "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
-      "type": "string"
-     },
-     "volumeMode": {
-      "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec. This is a beta feature.",
-      "type": "string"
-     },
-     "volumeName": {
-      "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimStatus": {
-    "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
-    "type": "object",
-    "nullable": true,
-    "properties": {
-     "accessModes": {
-      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "capacity": {
-      "description": "Represents the actual resources of the underlying volume.",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
-      }
-     },
-     "conditions": {
-      "description": "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PersistentVolumeClaimCondition"
-      },
-      "x-kubernetes-patch-merge-key": "type",
-      "x-kubernetes-patch-strategy": "merge"
-     },
-     "phase": {
-      "description": "Phase represents the current phase of PersistentVolumeClaim.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PersistentVolumeClaimVolumeSource": {
-    "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
-    "type": "object",
-    "required": [
-     "claimName"
-    ],
-    "properties": {
-     "claimName": {
-      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "type": "string"
-     },
-     "readOnly": {
-      "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v1.PodAffinity": {
-    "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "preferredDuringSchedulingIgnoredDuringExecution": {
-      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.WeightedPodAffinityTerm"
-      }
-     },
-     "requiredDuringSchedulingIgnoredDuringExecution": {
-      "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PodAffinityTerm"
-      }
-     }
-    }
-   },
-   "v1.PodAffinityTerm": {
-    "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
-    "type": "object",
-    "required": [
-     "topologyKey"
-    ],
-    "properties": {
-     "labelSelector": {
-      "description": "A label query over a set of resources, in this case pods.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "namespaces": {
-      "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means \"this pod's namespace\"",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "topologyKey": {
-      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PodAntiAffinity": {
-    "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
-    "type": "object",
-    "properties": {
-     "preferredDuringSchedulingIgnoredDuringExecution": {
-      "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.WeightedPodAffinityTerm"
-      }
-     },
-     "requiredDuringSchedulingIgnoredDuringExecution": {
-      "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PodAffinityTerm"
-      }
-     }
-    }
-   },
-   "v1.PodDNSConfig": {
-    "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
-    "type": "object",
-    "properties": {
-     "nameservers": {
-      "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "options": {
-      "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PodDNSConfigOption"
-      }
-     },
-     "searches": {
-      "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.PodDNSConfigOption": {
-    "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
-    "type": "object",
-    "properties": {
-     "name": {
-      "description": "Required.",
-      "type": "string"
-     },
-     "value": {
       "type": "string"
      }
     }
@@ -9087,39 +9375,6 @@
      }
     }
    },
-   "v1.Preconditions": {
-    "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
-    "type": "object",
-    "properties": {
-     "resourceVersion": {
-      "description": "Specifies the target ResourceVersion",
-      "type": "string"
-     },
-     "uid": {
-      "description": "Specifies the target UID.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.PreferredSchedulingTerm": {
-    "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
-    "type": "object",
-    "required": [
-     "weight",
-     "preference"
-    ],
-    "properties": {
-     "preference": {
-      "description": "A node selector term, associated with the corresponding weight.",
-      "$ref": "#/definitions/v1.NodeSelectorTerm"
-     },
-     "weight": {
-      "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
    "v1.Probe": {
     "description": "Probe describes a health check to be performed against a VirtualMachineInstance to determine whether it is alive or ready to receive traffic.",
     "type": "object",
@@ -9131,7 +9386,7 @@
      },
      "httpGet": {
       "description": "HTTPGet specifies the http request to perform.",
-      "$ref": "#/definitions/v1.HTTPGetAction"
+      "$ref": "#/definitions/k8s.io.api.core.v1.HTTPGetAction"
      },
      "initialDelaySeconds": {
       "description": "Number of seconds after the VirtualMachineInstance has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
@@ -9150,7 +9405,7 @@
      },
      "tcpSocket": {
       "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported",
-      "$ref": "#/definitions/v1.TCPSocketAction"
+      "$ref": "#/definitions/k8s.io.api.core.v1.TCPSocketAction"
      },
      "timeoutSeconds": {
       "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
@@ -9183,7 +9438,7 @@
       "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
       }
      },
      "overcommitGuestOverhead": {
@@ -9194,7 +9449,7 @@
       "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
       }
      }
     }
@@ -9221,22 +9476,6 @@
    "v1.Rng": {
     "description": "Rng represents the random device passed from host",
     "type": "object"
-   },
-   "v1.RootPaths": {
-    "description": "RootPaths lists the paths available at root. For example: \"/healthz\", \"/apis\".",
-    "type": "object",
-    "required": [
-     "paths"
-    ],
-    "properties": {
-     "paths": {
-      "description": "paths are the paths available at root.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
    },
    "v1.SMBiosConfiguration": {
     "type": "object",
@@ -9276,24 +9515,6 @@
      }
     }
    },
-   "v1.ServerAddressByClientCIDR": {
-    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
-    "type": "object",
-    "required": [
-     "clientCIDR",
-     "serverAddress"
-    ],
-    "properties": {
-     "clientCIDR": {
-      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
-      "type": "string"
-     },
-     "serverAddress": {
-      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
-      "type": "string"
-     }
-    }
-   },
    "v1.ServiceAccountVolumeSource": {
     "description": "ServiceAccountVolumeSource adapts a ServiceAccount into a volume.",
     "type": "object",
@@ -9303,122 +9524,6 @@
       "type": "string"
      }
     }
-   },
-   "v1.Status": {
-    "description": "Status is a return value for calls that don't return other objects.",
-    "type": "object",
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
-      "type": "string"
-     },
-     "code": {
-      "description": "Suggested HTTP return code for this status, 0 if not set.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "details": {
-      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-      "$ref": "#/definitions/v1.StatusDetails"
-     },
-     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "message": {
-      "description": "A human-readable description of the status of this operation.",
-      "type": "string"
-     },
-     "metadata": {
-      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
-     },
-     "reason": {
-      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
-      "type": "string"
-     },
-     "status": {
-      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
-      "type": "string"
-     }
-    }
-   },
-   "v1.StatusCause": {
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
-    "type": "object",
-    "properties": {
-     "field": {
-      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
-      "type": "string"
-     },
-     "message": {
-      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.StatusDetails": {
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
-    "type": "object",
-    "properties": {
-     "causes": {
-      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.StatusCause"
-      }
-     },
-     "group": {
-      "description": "The group attribute of the resource associated with the status StatusReason.",
-      "type": "string"
-     },
-     "kind": {
-      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "name": {
-      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
-      "type": "string"
-     },
-     "retryAfterSeconds": {
-      "description": "If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "uid": {
-      "description": "UID of the resource. (when there is a single resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-      "type": "string"
-     }
-    }
-   },
-   "v1.TCPSocketAction": {
-    "description": "TCPSocketAction describes an action based on opening a socket",
-    "type": "object",
-    "required": [
-     "port"
-    ],
-    "properties": {
-     "host": {
-      "description": "Optional: Host name to connect to, defaults to the pod IP.",
-      "type": "string"
-     },
-     "port": {
-      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-      "type": [
-       "string",
-       "number"
-      ]
-     }
-    }
-   },
-   "v1.Time": {
-    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
-    "type": "string",
-    "format": "date-time"
    },
    "v1.Timer": {
     "description": "Represents all available timers in a vmi.",
@@ -9446,55 +9551,6 @@
      }
     }
    },
-   "v1.Toleration": {
-    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
-    "type": "object",
-    "properties": {
-     "effect": {
-      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
-      "type": "string"
-     },
-     "key": {
-      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-      "type": "string"
-     },
-     "operator": {
-      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
-      "type": "string"
-     },
-     "tolerationSeconds": {
-      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "value": {
-      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.TypedLocalObjectReference": {
-    "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
-    "type": "object",
-    "required": [
-     "kind",
-     "name"
-    ],
-    "properties": {
-     "apiGroup": {
-      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is the type of resource being referenced",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name is the name of resource being referenced",
-      "type": "string"
-     }
-    }
-   },
    "v1.VirtualMachine": {
     "description": "VirtualMachine handles the VirtualMachines that are not running or are in a stopped state The VirtualMachine contains the template to create the VirtualMachineInstance. It also mirrors the running state of the created VirtualMachineInstance in its status.",
     "type": "object",
@@ -9511,7 +9567,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "description": "Spec contains the specification of VirtualMachineInstance created",
@@ -9573,7 +9629,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
@@ -9685,7 +9741,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -9808,7 +9864,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -9834,7 +9890,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -9854,7 +9910,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "$ref": "#/definitions/v1.VirtualMachineInstanceMigrationSpec"
@@ -9919,7 +9975,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -9949,7 +10005,7 @@
      },
      "endTimestamp": {
       "description": "The time the migration action ended",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "failed": {
       "description": "Indicates that the migration failed",
@@ -9965,7 +10021,7 @@
      },
      "startTimestamp": {
       "description": "The time the migration action began",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "targetDirectMigrationNodePorts": {
       "description": "The list of ports opened for live migration on the destination node",
@@ -10049,7 +10105,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
@@ -10079,7 +10135,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -10095,7 +10151,7 @@
      },
      "selector": {
       "description": "Selector is a label query over a set of VMIs. Required.",
-      "$ref": "#/definitions/v1.LabelSelector"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector"
      }
     }
    },
@@ -10115,7 +10171,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
@@ -10182,7 +10238,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -10204,7 +10260,7 @@
      },
      "selector": {
       "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-      "$ref": "#/definitions/v1.LabelSelector"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector"
      },
      "template": {
       "description": "Template describes the pods that will be created.",
@@ -10247,11 +10303,11 @@
     "properties": {
      "affinity": {
       "description": "If affinity is specifies, obey all the affinity rules",
-      "$ref": "#/definitions/v1.Affinity"
+      "$ref": "#/definitions/k8s.io.api.core.v1.Affinity"
      },
      "dnsConfig": {
       "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
-      "$ref": "#/definitions/v1.PodDNSConfig"
+      "$ref": "#/definitions/k8s.io.api.core.v1.PodDNSConfig"
      },
      "dnsPolicy": {
       "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
@@ -10312,7 +10368,7 @@
       "description": "If toleration is specified, obey all the toleration rules.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.Toleration"
+       "$ref": "#/definitions/k8s.io.api.core.v1.Toleration"
       }
      },
      "volumes": {
@@ -10384,7 +10440,7 @@
     "type": "object",
     "properties": {
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "description": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
@@ -10414,7 +10470,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -10547,7 +10603,7 @@
      },
      "persistentVolumeClaim": {
       "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
+      "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimVolumeSource"
      },
      "secret": {
       "description": "SecretVolumeSource represents a reference to a secret data in the same namespace. More info: https://kubernetes.io/docs/concepts/configuration/secret/",
@@ -10556,23 +10612,6 @@
      "serviceAccount": {
       "description": "ServiceAccountVolumeSource represents a reference to a service account. There can only be one volume of this type! More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
       "$ref": "#/definitions/v1.ServiceAccountVolumeSource"
-     }
-    }
-   },
-   "v1.WatchEvent": {
-    "description": "Event represents a single event to a watched resource.",
-    "type": "object",
-    "required": [
-     "type",
-     "object"
-    ],
-    "properties": {
-     "object": {
-      "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
-      "$ref": "#/definitions/runtime.RawExtension"
-     },
-     "type": {
-      "type": "string"
      }
     }
    },
@@ -10590,25 +10629,6 @@
      "name": {
       "description": "Name of the watchdog.",
       "type": "string"
-     }
-    }
-   },
-   "v1.WeightedPodAffinityTerm": {
-    "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
-    "type": "object",
-    "required": [
-     "weight",
-     "podAffinityTerm"
-    ],
-    "properties": {
-     "podAffinityTerm": {
-      "description": "Required. A pod affinity term, associated with the corresponding weight.",
-      "$ref": "#/definitions/v1.PodAffinityTerm"
-     },
-     "weight": {
-      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
-      "type": "integer",
-      "format": "int32"
      }
     }
    },
@@ -10662,7 +10682,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "$ref": "#/definitions/v1alpha1.DataVolumeSpec"
@@ -10685,7 +10705,7 @@
     ],
     "properties": {
      "lastHeartbeatTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "lastProbeTime": {
       "type": [
@@ -10861,7 +10881,7 @@
      },
      "pvc": {
       "description": "PVC is the PVC specification",
-      "$ref": "#/definitions/v1.PersistentVolumeClaimSpec"
+      "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaimSpec"
      },
      "source": {
       "description": "Source is the src of the data for the requested DataVolume",
@@ -10902,7 +10922,7 @@
       "type": "string"
      },
      "time": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      }
     }
    },
@@ -10931,7 +10951,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "$ref": "#/definitions/v1alpha1.VirtualMachineRestoreSpec"
@@ -10964,7 +10984,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -10978,7 +10998,7 @@
     "properties": {
      "target": {
       "description": "initially only VirtualMachine type supported",
-      "$ref": "#/definitions/v1.TypedLocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
      },
      "virtualMachineSnapshotName": {
       "type": "string"
@@ -11006,7 +11026,7 @@
       }
      },
      "restoreTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "restores": {
       "type": "array",
@@ -11032,7 +11052,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotSpec"
@@ -11058,7 +11078,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
       "$ref": "#/definitions/v1alpha1.VirtualMachineSnapshotContentSpec"
@@ -11091,7 +11111,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -11122,7 +11142,7 @@
     "nullable": true,
     "properties": {
      "creationTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "error": {
       "$ref": "#/definitions/v1alpha1.Error"
@@ -11161,7 +11181,7 @@
       "type": "string"
      },
      "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
      }
     }
    },
@@ -11176,7 +11196,7 @@
       "type": "string"
      },
      "source": {
-      "$ref": "#/definitions/v1.TypedLocalObjectReference"
+      "$ref": "#/definitions/k8s.io.api.core.v1.TypedLocalObjectReference"
      }
     }
    },
@@ -11192,7 +11212,7 @@
       }
      },
      "creationTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "error": {
       "$ref": "#/definitions/v1alpha1.Error"
@@ -11217,7 +11237,7 @@
     ],
     "properties": {
      "persistentVolumeClaim": {
-      "$ref": "#/definitions/v1.PersistentVolumeClaim"
+      "$ref": "#/definitions/k8s.io.api.core.v1.PersistentVolumeClaim"
      },
      "volumeName": {
       "type": "string"
@@ -11258,7 +11278,7 @@
     ],
     "properties": {
      "creationTime": {
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
      "error": {
       "$ref": "#/definitions/v1alpha1.Error"

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.0-20181218000649-703b5e6b11ae // indirect
 	github.com/mfranczy/crd-rest-coverage v0.1.0
 	github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b
+	github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/opencontainers/selinux v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNl
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b h1:9+ke9YJ9KGWw5ANXK6ozjoK47uI3uNbXv4YVINBnGm8=
 github.com/mitchellh/go-ps v0.0.0-20190716172923-621e5597135b/go.mod h1:r1VsdOzOPt1ZSrGZWFoNhsAedKnEd6r9Np1+5blZCWk=
+github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed h1:FI2NIv6fpef6BQl2u3IZX/Cj20tfypRF4yd+uaHOMtI=
+github.com/mitchellh/go-vnc v0.0.0-20150629162542-723ed9867aed/go.mod h1:3rdaFaCv4AyBgu5ALFM0+tSuHrBh6v692nyQe3ikrq0=
 github.com/mitchellh/hashstructure v0.0.0-20170609045927-2bca23e0e452/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
By default kube-openapi takes only the last part of type/model definition.
So type "`kubevirt.io/client-go/api/v1.Patch`" ends up -> "`v1.Patch`" &
"`k8s.io/apimachinery/pkg/apis/meta/v1.Patch`" -> "`v1.Patch`".

This PR changes our config and takes full name(in case of non-kubevirt type) so no conflict should be possible.
Kubevirt types are left with shorten names to support our validation without needing to rework it.

This should prevent us from hitting conflicts in the future.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
