### PR TITLE
Append default KUBEVIRT_POSTINBOUND chain rule

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -924,8 +924,19 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables(protocol iptables.P
 			"-j",
 			"DNAT",
 			"--to-destination", p.getVifIpByProtocol(protocol))
+		if err != nil {
+			return err
+		}
 
-		return err
+		err = Handler.IptablesAppendRule(protocol, "nat", "KUBEVIRT_POSTINBOUND",
+			"-j",
+			"SNAT",
+			"--to", p.getGatewayByProtocol(protocol))
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	for _, port := range p.iface.Ports {
@@ -1028,8 +1039,17 @@ func (p *MasqueradePodInterface) createNatRulesUsingNftables(proto iptables.Prot
 	if len(p.iface.Ports) == 0 {
 		err = Handler.NftablesAppendRule(proto, "nat", "KUBEVIRT_PREINBOUND",
 			"counter", "dnat", "to", p.getVifIpByProtocol(proto))
+		if err != nil {
+			return err
+		}
 
-		return err
+		err = Handler.NftablesAppendRule(proto, "nat", "KUBEVIRT_POSTINBOUND",
+			"counter", "snat", "to", p.getGatewayByProtocol(proto))
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 
 	for _, port := range p.iface.Ports {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Signed-off-by: Guangbo Chen steven.guangbo.chen@gmail.com

**What this PR does / why we need it**:
Append default KUBEVIRT_POSTINBOUND chain rule when no ports are specified in the `spec::domain::interfaces` subtree with masquerade mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/4188

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Append default KUBEVIRT_POSTINBOUND chain rule to the masqueraded network.
```
