### PR TITLE
add snapshot APIGroup to aggregate cluster rules

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -646,6 +646,21 @@ spec:
           - watch
           - deletecollection
         - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+          - deletecollection
+        - apiGroups:
           - subresources.kubevirt.io
           resources:
           - virtualmachineinstances/console
@@ -679,6 +694,20 @@ spec:
           - list
           - watch
         - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
+          verbs:
+          - get
+          - delete
+          - create
+          - update
+          - patch
+          - list
+          - watch
+        - apiGroups:
           - kubevirt.io
           resources:
           - virtualmachines
@@ -686,6 +715,16 @@ spec:
           - virtualmachineinstancepresets
           - virtualmachineinstancereplicasets
           - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.kubevirt.io
+          resources:
+          - virtualmachinesnapshots
+          - virtualmachinesnapshotcontents
+          - virtualmachinerestores
           verbs:
           - get
           - list

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -548,6 +548,21 @@ rules:
   - watch
   - deletecollection
 - apiGroups:
+  - snapshot.kubevirt.io
+  resources:
+  - virtualmachinesnapshots
+  - virtualmachinesnapshotcontents
+  - virtualmachinerestores
+  verbs:
+  - get
+  - delete
+  - create
+  - update
+  - patch
+  - list
+  - watch
+  - deletecollection
+- apiGroups:
   - subresources.kubevirt.io
   resources:
   - virtualmachineinstances/console
@@ -581,6 +596,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - snapshot.kubevirt.io
+  resources:
+  - virtualmachinesnapshots
+  - virtualmachinesnapshotcontents
+  - virtualmachinerestores
+  verbs:
+  - get
+  - delete
+  - create
+  - update
+  - patch
+  - list
+  - watch
+- apiGroups:
   - kubevirt.io
   resources:
   - virtualmachines
@@ -588,6 +617,16 @@ rules:
   - virtualmachineinstancepresets
   - virtualmachineinstancereplicasets
   - virtualmachineinstancemigrations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.kubevirt.io
+  resources:
+  - virtualmachinesnapshots
+  - virtualmachinesnapshotcontents
+  - virtualmachinerestores
   verbs:
   - get
   - list

--- a/pkg/virt-operator/creation/rbac/cluster.go
+++ b/pkg/virt-operator/creation/rbac/cluster.go
@@ -158,6 +158,19 @@ func newAdminClusterRole() *rbacv1.ClusterRole {
 					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
 				},
 			},
+			{
+				APIGroups: []string{
+					"snapshot.kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachinesnapshots",
+					"virtualmachinesnapshotcontents",
+					"virtualmachinerestores",
+				},
+				Verbs: []string{
+					"get", "delete", "create", "update", "patch", "list", "watch", "deletecollection",
+				},
+			},
 		},
 	}
 }
@@ -218,6 +231,19 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"get", "delete", "create", "update", "patch", "list", "watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"snapshot.kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachinesnapshots",
+					"virtualmachinesnapshotcontents",
+					"virtualmachinerestores",
+				},
+				Verbs: []string{
+					"get", "delete", "create", "update", "patch", "list", "watch",
+				},
+			},
 		},
 	}
 }
@@ -246,6 +272,19 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					"virtualmachineinstancepresets",
 					"virtualmachineinstancereplicasets",
 					"virtualmachineinstancemigrations",
+				},
+				Verbs: []string{
+					"get", "list", "watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"snapshot.kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachinesnapshots",
+					"virtualmachinesnapshotcontents",
+					"virtualmachinerestores",
 				},
 				Verbs: []string{
 					"get", "list", "watch",

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -134,6 +134,9 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			table.Entry("[test_id:528]given a vmi preset", "virtualmachineinstancepresets"),
 			table.Entry("[test_id:529][crit:low]given a vmi replica set", "virtualmachineinstancereplicasets"),
 			table.Entry("[test_id:3230]given a vmi migration", "virtualmachineinstancemigrations"),
+			table.Entry("given a vmsnapshot", "virtualmachinesnapshots"),
+			table.Entry("given a vmsnapshotcontent", "virtualmachinesnapshotcontents"),
+			table.Entry("given a vmsrestore", "virtualmachinerestores"),
 		)
 
 		var authClient *authClientV1.AuthorizationV1Client
@@ -285,6 +288,9 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				table.Entry("[test_id:2917]given a vmi preset", "virtualmachineinstancepresets"),
 				table.Entry("[test_id:2919]given a vmi replica set", "virtualmachineinstancereplicasets"),
 				table.Entry("[test_id:3235]given a vmi migration", "virtualmachineinstancemigrations"),
+				table.Entry("given a vmsnapshot", "virtualmachinesnapshots"),
+				table.Entry("given a vmsnapshotcontent", "virtualmachinesnapshotcontents"),
+				table.Entry("given a vmsrestore", "virtualmachinerestores"),
 			)
 		})
 
@@ -316,6 +322,9 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				table.Entry("[test_id:2916]given a vmi preset", "virtualmachineinstancepresets"),
 				table.Entry("[test_id:2918][crit:low]given a vmi replica set", "virtualmachineinstancereplicasets"),
 				table.Entry("[test_id:2837]given a vmi migration", "virtualmachineinstancemigrations"),
+				table.Entry("given a vmsnapshot", "virtualmachinesnapshots"),
+				table.Entry("given a vmsnapshotcontent", "virtualmachinesnapshotcontents"),
+				table.Entry("given a vmsrestore", "virtualmachinerestores"),
 			)
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Neglected to add the snapshot APIGroup to aggregate cluster roles

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add snapshot.kubevirt.io to admin/edit/view roles
```
