### PR TITLE
virt-launcher: make sure dev nodes can be opened before starting libvirtd

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -185,7 +185,7 @@ func StartLibvirt(stopChan chan struct{}) {
 	go func() {
 		// libvirtd needs access to /dev/null and /dev/urandom
 		// Ensure both are there and ready to be used, panic if they are still not after 1 second
-		devNodes := []string{"/dev/null", "/dev/urandom"}
+		devNodes := []string{"/dev/null", "/dev/urandom", "/dev/kvm"}
 		for i := 1; i <= 10; i++ {
 			var err error
 			var fd *os.File


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure /dev/null and /dev/urandom can be opened before starting libvirtd.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
May fix https://github.com/kubevirt/kubevirt/issues/2566

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
