### PR TITLE
examples, vmi-masquerade: correct userData script

### DIFF
--- a/examples/vmi-masquerade.yaml
+++ b/examples/vmi-masquerade.yaml
@@ -47,7 +47,6 @@ spec:
       userData: |-
         #!/bin/bash
         echo "fedora" |passwd fedora --stdin
-        for i in {1..20}; do curl -I %s | grep "200 OK" && break || sleep 0.1; done
         yum install -y nginx
         systemctl enable --now nginx
     name: cloudinitdisk

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -435,7 +435,7 @@ func GetVMIMasquerade() *v1.VirtualMachineInstance {
 	vm.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1024M")
 	vm.Spec.Networks = []v1.Network{v1.Network{Name: "testmasquerade", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 	initFedora(&vm.Spec)
-	userData := "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nfor i in {1..20}; do curl -I %s | grep \"200 OK\" && break || sleep 0.1; done\nyum install -y nginx\nsystemctl enable --now nginx"
+	userData := "#!/bin/bash\necho \"fedora\" |passwd fedora --stdin\nyum install -y nginx\nsystemctl enable --now nginx"
 	networkData := "version: 2\nethernets:\n  eth0:\n    addresses: [ fd10:0:2::2/120 ]\n    dhcp4: true\n    gateway6: fd10:0:2::1\n"
 	addNoCloudDiskWitUserDataNetworkData(&vm.Spec, userData, networkData)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The current vmi-masquerade userData script - which was directly
copied from the functional tests - checks connectivity before
attempting to install the nginx package & install it.

This connectivity check is not necessary; since we're not handling
the error, we can directly try to install the package.

This prevents the following errors when booting up the VM, which both pollute the screen and bloat up the VM start up time:
```
[   25.207924] cloud-init[756]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[   25.223814] cloud-init[756]:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: %s
...
[   27.926538] cloud-init[756]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[   27.947862] cloud-init[756]:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: %s

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
