### PR TITLE
Fix sync of generated client-go to master

### DIFF
--- a/hack/publish-staging.sh
+++ b/hack/publish-staging.sh
@@ -51,7 +51,7 @@ if [ -n "$(git status --porcelain)" ]; then
 
     # we only push branch changes on master
     if [ "${TARGET_BRANCH}" == "master" ]; then
-        git push origin ${TARGET_BRANCH}
+        git push origin ${TARGET_BRANCH}-local:${TARGET_BRANCH}
         echo "client-go updated for ${TARGET_BRANCH}."
     fi
 else


### PR DESCRIPTION


Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In the current state, we never update the master branch of
kubevirt/client-go repository. Even we try to push there with `git push
origin master`, the push is never applied and exits with:

+git push origin master
Everything up-to-date

The reason for that is, that our chenges are checked out on branch
"master-local" while the aforemenetioned command tries to push from the
checked out master branch.

With this change, we explicitly push from the currently checked-out
branch to master.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
