### PR TITLE
WIP: Add default route to network annotations

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9290,6 +9290,10 @@
       "description": "Select the default network and add it to the multus-cni.io/default-network annotation.",
       "type": "boolean"
      },
+     "gateway": {
+      "description": "Specify the gateway for this multus network. This will compute the default route for this interface and add it to the k8s.v1.cni.cncf.io/networks annotation",
+      "type": "string"
+     },
      "networkName": {
       "description": "References to a NetworkAttachmentDefinition CRD object. Format: \u003cnetworkName\u003e, \u003cnamespace\u003e/\u003cnetworkName\u003e. If namespace is not specified, VMI namespace is assumed.",
       "type": "string"

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -15893,6 +15893,13 @@ func schema_kubevirtio_client_go_api_v1_MultusNetwork(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"gateway": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify the gateway for this multus network. This will compute the default route for this interface and add it to the k8s.v1.cni.cncf.io/networks annotation",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"networkName"},
 			},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -1122,4 +1122,9 @@ type MultusNetwork struct {
 	// Select the default network and add it to the
 	// multus-cni.io/default-network annotation.
 	Default bool `json:"default,omitempty"`
+
+	// Specify the gateway for this multus network.
+	// This will compute the default route for this interface and add it to the
+	// k8s.v1.cni.cncf.io/networks annotation
+	Gateway string `json:"gateway,omitempty"`
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -566,5 +566,6 @@ func (MultusNetwork) SwaggerDoc() map[string]string {
 		"":            "Represents the multus cni network.\n\n+k8s:openapi-gen=true",
 		"networkName": "References to a NetworkAttachmentDefinition CRD object. Format:\n<networkName>, <namespace>/<networkName>. If namespace is not\nspecified, VMI namespace is assumed.",
 		"default":     "Select the default network and add it to the\nmultus-cni.io/default-network annotation.",
+		"gateway":     "Specify the gateway for this multus network.\nThis will compute the default route for this interface and add it to the\nk8s.v1.cni.cncf.io/networks annotation",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -15749,6 +15749,13 @@ func schema_kubevirtio_client_go_api_v1_MultusNetwork(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"gateway": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify the gateway for this multus network. This will compute the default route for this interface and add it to the k8s.v1.cni.cncf.io/networks annotation",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"networkName"},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update the API to support a gateway attribute for multus networks.

Using that attribute, the user can specify the default route of the VMI to something other than the
automatically configured by the pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Missing functional tests ... Will add those ASAP.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds a new "gateway" attribute to the MultusNetwork object, which the can be used
to configure the default route of the VMI.
```
