### PR TITLE
flaky pause test: make long-running process longer and quieter

### DIFF
--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -366,7 +366,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		grepSleepPid := func(expecter expect.Expecter) string {
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
-				&expect.BSnd{S: `pgrep -f "sleep 5"` + "\n"},
+				&expect.BSnd{S: `pgrep -f "sleep 8"` + "\n"},
 				&expect.BExp{R: tests.RetValue("[0-9]+")}, // pid
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
@@ -378,8 +378,10 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		startProcess := func(expecter expect.Expecter) string {
 			By("Start a long running process")
 			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
-				&expect.BSnd{S: "sleep 5&\n"},
-				&expect.BExp{R: "\\# "}, // prompt
+				&expect.BSnd{S: "sleep 8&\n"},
+				&expect.BExp{R: "\\# "},     // prompt
+				&expect.BSnd{S: "disown\n"}, // avoid "garbage" print in terminal on completion
+				&expect.BExp{R: "\\# "},     // prompt
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -413,7 +415,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			tests.WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
 			By("Waiting longer than the process normally runs")
-			time.Sleep(7 * time.Second)
+			time.Sleep(10 * time.Second)
 
 			By("Unpausing the VMI")
 			command = tests.NewRepeatableVirtctlCommand("unpause", "vmi", "--namespace", tests.NamespaceTestDefault, vmi.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Expecting a VM to take much less that 5 seconds to pause + unpause might be a bit optimistic.
Bumped to 8 seconds, which should make the test a lot less flaky but only 3 seconds longer to run.
Additionally, silencing the background job with `disown` to avoid unwanted prints in the terminal.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4009 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
