### PR TITLE
Don't mutate container disk permissions

### DIFF
--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -11,6 +11,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@alpine_image_ppc64le//file"],
         "//conditions:default": ["@alpine_image//file"],
     }),
+    mode = "444",
     visibility = ["//visibility:public"],
 )
 
@@ -25,6 +26,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@cirros_image_ppc64le//file"],
         "//conditions:default": ["@cirros_image//file"],
     }),
+    mode = "444",
     visibility = ["//visibility:public"],
 )
 
@@ -40,6 +42,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@cirros_image_ppc64le//file"],
         "//conditions:default": ["@cirros_image//file"],
     }),
+    mode = "444",
     visibility = ["//visibility:public"],
 )
 
@@ -54,6 +57,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@fedora_image_ppc64le//file"],
         "//conditions:default": ["@fedora_image//file"],
     }),
+    mode = "444",
     visibility = ["//visibility:public"],
 )
 
@@ -64,6 +68,7 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_ppc64le": ["@microlivecd_image_ppc64le//file"],
         "//conditions:default": ["@microlivecd_image//file"],
     }),
+    mode = "444",
     visibility = ["//visibility:public"],
 )
 
@@ -75,6 +80,7 @@ container_image(
     }),
     directory = "/disk",
     files = ["@virtio_win_image//file"],
+    mode = "444",
     visibility = ["//visibility:public"],
 )
 
@@ -88,5 +94,6 @@ container_image(
         "@io_bazel_rules_go//go/platform:linux_ppc64le": "@fedora_sriov_lane_ppc64le//image",
         "//conditions:default": "@fedora_sriov_lane//image",
     }),
+    mode = "444",
     visibility = ["//visibility:public"],
 )

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -245,10 +245,6 @@ func (m *mounter) Mount(vmi *v1.VirtualMachineInstance, verify bool) error {
 				}
 				f.Close()
 
-				if err = os.Chmod(sourceFile, 0444); err != nil {
-					return fmt.Errorf("failed to change permisions on %s", sourceFile)
-				}
-
 				log.DefaultLogger().Object(vmi).Infof("Bind mounting container disk at %s to %s", strings.TrimPrefix(sourceFile, nodeRes.MountRoot()), targetFile)
 				out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "mount", "-o", "ro,bind", strings.TrimPrefix(sourceFile, nodeRes.MountRoot()), targetFile).CombinedOutput()
 				if err != nil {

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -250,17 +250,6 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Checking the writable Image Octal mode")
 				Expect(strings.Trim(writableImageOctalMode, "\n")).To(Equal("640"), "Octal Mode of writable Image should be 640")
-
-				readonlyImageOctalMode, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					pod,
-					"compute",
-					[]string{"/usr/bin/bash", "-c", "stat -c %a /var/run/kubevirt/container-disks/disk_0.img"},
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				By("Checking the read-only Image Octal mode")
-				Expect(strings.Trim(readonlyImageOctalMode, "\n")).To(Equal("444"), "Octal Mode of read-only Image should be 444")
 			})
 		})
 	})

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -250,6 +250,18 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 				By("Checking the writable Image Octal mode")
 				Expect(strings.Trim(writableImageOctalMode, "\n")).To(Equal("640"), "Octal Mode of writable Image should be 640")
+
+				readonlyImageOctalMode, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					pod,
+					"compute",
+					[]string{"/usr/bin/bash", "-c", "stat -c %a /var/run/kubevirt/container-disks/disk_0.img"},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking the read-only Image Octal mode")
+				Expect(strings.Trim(readonlyImageOctalMode, "\n")).To(Equal("444"), "Octal Mode of read-only Image should be 444")
+
 			})
 		})
 	})


### PR DESCRIPTION
If we mutate the permissions of the disk, then we cause the disk to be copied due to the container's layered filesystem. A container disk should never be altered. 

The disk either has the correct permissions necessary for qemu to access it, or it doesn't. If it doesn't, then the vmi will fail to boot. There's no action we can take to change or modify that on our end. 

```release-note
NONE
```
