### PR TITLE
Release func tests on release-0.33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ deploy:
   script: make build-functests
   skip_cleanup: true
   on:
-    branch: master
+    tags: true
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: releases
   skip_cleanup: true


### PR DESCRIPTION
We want the func tests to be released on all branches, not just the
master branch.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>
