### PR TITLE
Extract an IP address from CIDR reported by Qemu guest

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1923,8 +1923,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			interfaceName := "interface_name"
 			mac := "C0:01:BE:E7:15:G0:0D"
-			ip := "2.2.2.2/24"
-			ips := []string{"2.2.2.2/24", "3.3.3.3/16"}
+			ip := "2.2.2.2"
+			ips := []string{"2.2.2.2", "3.3.3.3"}
 
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
 				{

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -2,7 +2,6 @@ package agentpoller
 
 import (
 	"encoding/json"
-	"fmt"
 	"regexp"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -269,7 +268,7 @@ func extractIPs(ipAddresses []IP) (string, []string) {
 	interfaceIPs := []string{}
 	var interfaceIP string
 	for _, ipAddr := range ipAddresses {
-		ip := fmt.Sprintf("%s/%d", ipAddr.IP, ipAddr.Prefix)
+		ip := ipAddr.IP
 		// Prefer ipv4 as the main interface IP
 		if ipAddr.Type == "ipv4" && interfaceIP == "" {
 			interfaceIP = ip

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -128,23 +128,23 @@ var _ = Describe("Qemu agent poller", func() {
 				api.InterfaceStatus{
 					Name:          "",
 					Mac:           "0a:58:0a:f4:00:51",
-					Ip:            "10.244.0.81/24",
-					IPs:           []string{"10.244.0.81/24", "fe80::858:aff:fef4:51/64"},
+					Ip:            "10.244.0.81",
+					IPs:           []string{"10.244.0.81", "fe80::858:aff:fef4:51"},
 					InterfaceName: "eth0",
 				})
 			expectedStatuses = append(expectedStatuses,
 				api.InterfaceStatus{
 					Name:          "",
 					Mac:           "02:00:00:b0:17:66",
-					Ip:            "fe80::ff:feb0:1766/64",
-					IPs:           []string{"fe80::ff:feb0:1766/64"},
+					Ip:            "fe80::ff:feb0:1766",
+					IPs:           []string{"fe80::ff:feb0:1766"},
 					InterfaceName: "eth1",
 				})
 			expectedStatuses = append(expectedStatuses,
 				api.InterfaceStatus{
 					Mac:           "02:00:00:22:11:11",
-					Ip:            "1.2.3.4/24",
-					IPs:           []string{"1.2.3.4/24", "fe80::ff:1111:2222/64"},
+					Ip:            "1.2.3.4",
+					IPs:           []string{"1.2.3.4", "fe80::ff:1111:2222"},
 					InterfaceName: "eth5",
 				})
 			Expect(interfaceStatuses).To(Equal(expectedStatuses))
@@ -188,23 +188,23 @@ var _ = Describe("Qemu agent poller", func() {
 				api.InterfaceStatus{
 					Name:          "ovs",
 					Mac:           "0a:58:0a:f4:00:51",
-					Ip:            "10.244.0.81/24",
-					IPs:           []string{"10.244.0.81/24", "fe80::858:aff:fef4:51/64"},
+					Ip:            "10.244.0.81",
+					IPs:           []string{"10.244.0.81", "fe80::858:aff:fef4:51"},
 					InterfaceName: "eth0",
 				})
 			expectedStatuses = append(expectedStatuses,
 				api.InterfaceStatus{
 					Name:          "net1",
 					Mac:           "02:00:00:b0:17:66",
-					Ip:            "fe80::ff:feb0:1766/64",
-					IPs:           []string{"fe80::ff:feb0:1766/64"},
+					Ip:            "fe80::ff:feb0:1766",
+					IPs:           []string{"fe80::ff:feb0:1766"},
 					InterfaceName: "eth1",
 				})
 			expectedStatuses = append(expectedStatuses,
 				api.InterfaceStatus{
 					Mac:           "02:00:00:22:11:11",
-					Ip:            "1.2.3.4/24",
-					IPs:           []string{"1.2.3.4/24", "fe80::ff:1111:2222/64"},
+					Ip:            "1.2.3.4",
+					IPs:           []string{"1.2.3.4", "fe80::ff:1111:2222"},
 					InterfaceName: "eth5",
 				})
 			expectedStatuses = append(expectedStatuses,

--- a/tests/libnet/cloudinit.go
+++ b/tests/libnet/cloudinit.go
@@ -59,7 +59,8 @@ type CloudInitRoute struct {
 }
 
 const (
-	DefaultIPv6Address = "fd10:0:2::2/120"
+	DefaultIPv6Address = "fd10:0:2::2"
+	DefaultIPv6CIDR    = DefaultIPv6Address + "/120"
 	DefaultIPv6Gateway = "fd10:0:2::1"
 )
 
@@ -79,7 +80,7 @@ func CreateDefaultCloudInitNetworkData() (string, error) {
 			Version: 2,
 			Ethernets: map[string]CloudInitInterface{
 				"eth0": {
-					Addresses: []string{DefaultIPv6Address},
+					Addresses: []string{DefaultIPv6CIDR},
 					DHCP4:     &enabled,
 					Gateway6:  DefaultIPv6Gateway,
 					Nameservers: CloudInitNameservers{

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -499,10 +499,18 @@ var _ = Describe("[Serial]Multus", func() {
 					linuxBridgeNetwork,
 				}
 
-				ep1Ip := "1.0.0.10/24"
-				ep2Ip := "1.0.0.11/24"
-				ep1IpV6 := "fe80::ce3d:82ff:fe52:24c0/64"
-				ep2IpV6 := "fe80::ce3d:82ff:fe52:24c1/64"
+				v4Mask := "/24"
+				ep1Ip := "1.0.0.10"
+				ep2Ip := "1.0.0.11"
+				ep1Cidr := ep1Ip + v4Mask
+				ep2Cidr := ep2Ip + v4Mask
+
+				v6Mask := "/64"
+				ep1IpV6 := "fe80::ce3d:82ff:fe52:24c0"
+				ep2IpV6 := "fe80::ce3d:82ff:fe52:24c1"
+				ep1CidrV6 := ep1IpV6 + v6Mask
+				ep2CidrV6 := ep2IpV6 + v6Mask
+
 				userdata := fmt.Sprintf(`#!/bin/bash
                     echo "fedora" |passwd fedora --stdin
                     setenforce 0
@@ -516,7 +524,7 @@ var _ = Describe("[Serial]Multus", func() {
                     chmod +x /usr/local/bin/qemu-ga
 		    curl %s > /lib64/libpixman-1.so.0
                     systemd-run --unit=guestagent /usr/local/bin/qemu-ga
-                `, ep1Ip, ep2Ip, ep1IpV6, ep2IpV6, tests.GetUrl(tests.GuestAgentHttpUrl), tests.GetUrl(tests.PixmanUrl))
+                `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6, tests.GetUrl(tests.GuestAgentHttpUrl), tests.GetUrl(tests.PixmanUrl))
 				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedora), userdata)
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
qemu-guest-agent reports ip addresses of VMI with mask, like x.x.x.x/mask, this breaks 3rd party components which expect to get IP address in x.x.x.x format. This is visible when you use multus and have qemu-guest-agent installed.

We treat VMs created by KubeVirt as worker nodes for another k8s cluster and during network initialization we realized that calico has a problem with issue described above, for instance:
```
Error from server: failed to construct request for https://10.x.x.106%2F32:10250/containerLogs/kube-system/calico-node-lvcgj/calico-node, got parse https://10.225.128.106%2F32:10250/containerLogs/kube-system/calico-node-lvcgj/calico-node: invalid URL escape "%2F"
```

for more details look at the issue attached below:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/gardener/gardener-extension-provider-kubevirt/issues/33

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set only an IP address for interfaces reported by qemu-guest-agent. Previously that was CIDR.
```
