### PR TITLE
Keep conformance artifacts on the top level

### DIFF
--- a/automation/conformance.sh
+++ b/automation/conformance.sh
@@ -6,7 +6,7 @@ export WORKSPACE="${WORKSPACE:-$PWD}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 mkdir -p "$ARTIFACTS_PATH"
 
-trap "{ make cluster-down; cp -r _out/artifacts/conformance ${ARTIFACTS_PATH}; }" EXIT SIGINT SIGTERM SIGQUIT
+trap "{ make cluster-down; cp -r _out/artifacts/conformance/* ${ARTIFACTS_PATH}; }" EXIT SIGINT SIGTERM SIGQUIT
 
 make cluster-up
 make cluster-sync


### PR DESCRIPTION


Signed-off-by: Petr Horacek <phoracek@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Without this change, artifacts are kept under actifacts/conformance
directory which prevents junit files from being exposed and introduces
an unneeded subdirectory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Artifacts in the current state: https://gcsweb.apps.ovirt.org/gcs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-conformance/1308001288461488128/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
