### PR TITLE
dual stack, services: provide more explicit info on test execution

### DIFF
--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -19,12 +19,12 @@ go_library(
         "//tests/libnet:go_default_library",
         "//tests/libvmi:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -259,17 +259,22 @@ var _ = SIGDescribe("[Serial]Services", func() {
 
 			table.DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
-				if ipFamily == k8sv1.IPv6Protocol {
-					libnet.SkipWhenNotDualStackCluster(virtClient)
+				By("setting up resources to expose the VMI via a service", func() {
+					if ipFamily == k8sv1.IPv6Protocol {
+						libnet.SkipWhenNotDualStackCluster(virtClient)
 
-					serviceName = serviceName + "v6"
-					service = buildIPv6ServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
-				} else {
-					service = buildServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
-				}
+						serviceName = serviceName + "v6"
+						service = buildIPv6ServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
+					} else {
+						service = buildServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
+					}
 
-				_, err := virtClient.CoreV1().Services(inboundVMI.Namespace).Create(service)
-				Expect(err).NotTo(HaveOccurred(), "the k8sv1.Service entity should have been created.")
+					_, err := virtClient.CoreV1().Services(inboundVMI.Namespace).Create(service)
+					Expect(err).NotTo(HaveOccurred(), "the k8sv1.Service entity should have been created.")
+				})
+
+				By("checking connectivity the the exposed service")
+				var err error
 
 				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort)
 				Expect(err).NotTo(HaveOccurred(), "connectivity is expected to the exposed service")

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -37,6 +37,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -250,6 +251,8 @@ var _ = SIGDescribe("[Serial]Services", func() {
 			table.DescribeTable("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func(ipFamily k8sv1.IPFamily) {
 				serviceName := "myservice"
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
+
 					serviceName = serviceName + "v6"
 					service = buildIPv6ServiceSpec(serviceName, servicePort, servicePort, selectorLabelKey, selectorLabelValue)
 				} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Change our current approach from having a single test that checks
one service per each reported IP on the VMI for a more explicit
one, where a test exists for each individual scenario.

This implies that our current approach of using test setup,
test execution, test teardown had to be dropped, in favor in
performing all those steps inside the table entry description.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
