### PR TITLE
vmi, sriov: Enable to set the PCI address on a SRIOV iface

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1290,6 +1290,15 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				Type:    "pci",
 				Managed: "yes",
 			}
+
+			if iface.PciAddress != "" {
+				addr, err := decoratePciAddressField(iface.PciAddress)
+				if err != nil {
+					return fmt.Errorf("failed to configure SRIOV %s: %v", iface.Name, err)
+				}
+				hostDev.Address = addr
+			}
+
 			if iface.BootOrder != nil {
 				hostDev.BootOrder = &BootOrder{Order: *iface.BootOrder}
 			}

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1360,18 +1360,38 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].Rom.Enabled).To(Equal("no"))
 		})
 
-		It("should set nic pci address when specified", func() {
-			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
-			vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:81:01.0"
-			test_address := Address{
+		When("NIC PCI address is specified on VMI", func() {
+			expectedPCIAddress := Address{
 				Type:     "pci",
 				Domain:   "0x0000",
 				Bus:      "0x81",
 				Slot:     "0x01",
 				Function: "0x0",
 			}
-			domain := vmiToDomain(vmi, c)
-			Expect(*domain.Spec.Devices.Interfaces[0].Address).To(Equal(test_address))
+
+			BeforeEach(func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = "0000:81:01.0"
+			})
+
+			It("should be set on the domain spec for a non-SRIOV nic", func() {
+				domain := vmiToDomain(vmi, c)
+				Expect(*domain.Spec.Devices.Interfaces[0].Address).To(Equal(expectedPCIAddress))
+
+			})
+			It("should be set on the domain spec for a SRIOV nic", func() {
+				iface := &vmi.Spec.Domain.Devices.Interfaces[0]
+				iface.SRIOV = &v1.InterfaceSRIOV{}
+				c := &ConverterContext{
+					VirtualMachine: vmi,
+					UseEmulation:   true,
+					SRIOVDevices:   map[string][]string{iface.Name: []string{"0000:81:11.1"}},
+				}
+
+				domain := vmiToDomain(vmi, c)
+				Expect(*domain.Spec.Devices.HostDevices[0].Address).To(Equal(expectedPCIAddress))
+			})
+
 		})
 
 		It("should calculate mebibyte from a quantity", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

SRIOV interfaces are defined through libvirt domxml using the hostdev
device.
It is now possible to set the guest PCI address on which this SRIOV VF
interface will be mapped to.

The need for this has been raised while debugging an issue of libvirt in
detecting the SRIOV VF PCI capabilities. Failure to detect the device as
PCIe, causes it to be added to the guest as a conventional PCI slot
(which in turn messes up the addresses).
Allowing to set the PCI address at configuration is a dirty workaround
to the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Tested manually on a dedicated SRIOV setup.

**Release note**:
```release-note
NONE
```
