### PR TITLE
Ensure container disks are pulled before starting virt-launcher

### DIFF
--- a/cmd/container-disk-v2alpha/main.c
+++ b/cmd/container-disk-v2alpha/main.c
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
             /* These options don’t set a flag.
                 We distinguish them by their indices. */
             {"copy-path",    required_argument, 0, 'c'},
+            {"no-op", 0, 0, 'n'},
             {0, 0, 0, 0}
         };
         /* getopt_long stores the option index here. */
@@ -128,6 +129,8 @@ int main(int argc, char **argv) {
                 copy_path_tmp = strndup(copy_path, strlen(copy_path));
                 copy_path_dir = dirname(copy_path_tmp);
                 break;
+            case 'n':
+		exit(0);
             case '?':
                 exit(1);
             default:

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1030,6 +1030,9 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		},
 	}
 
+	// this causes containerDisks to be pre-pulled before virt-launcher starts.
+	initContainers = append(initContainers, containerdisk.GenerateInitContainers(vmi, "container-disks", "virt-bin-share-dir")...)
+
 	// TODO use constants for podLabels
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Virt-launcher has a 3 minute timeout. If no qemu process is started after 3 minutes, the container fails. That's intended to free cluster resources in the event that we schedule a VMI pod that isn't being processed for some reason out of our control. 

Here's the issue.

When a containerdisk is being used, especially a large container disk, it might take longer than 3 minutes to pull. This means the virt-launcher container can start long before the containerDisk container starts, which causes virt-launcher to hit the 3 minute timeout while the containerdisk is being pulled.

To fix this, i've added a no-op init container that ensures every container disk is pulled before virt-launcher starts. The init containers simply start and immediately exit. Since init containers have to execute before normal containers, we've removed the race between pulling a containerDisk and the virt-launcher timeout. 


```release-note
Fixes timeout failure that occurs when pulling large containerDisk images
```
