### PR TITLE
docs: Update for k8s-1.18 as default provider

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ dockerizied environment, clone the KubeVirt repository, `cd` into it, and:
 
 ```bash
 # Build and deploy KubeVirt on Kubernetes in our vms inside containers
-export KUBEVIRT_PROVIDER=k8s-1.15 # this is also the default if no KUBEVIRT_PROVIDER is set
+export KUBEVIRT_PROVIDER=k8s-1.18 # this is also the default if no KUBEVIRT_PROVIDER is set
 make cluster-up
 make cluster-sync
 ```
@@ -121,8 +121,8 @@ You can get the names from following command:
 
 ```bash
 # cluster-up/kubectl.sh get nodes
-NAME    STATUS   ROLES    AGE   VERSION
-node01  Ready    master   11h   v1.15.1
+NAME     STATUS   ROLES           AGE   VERSION
+node01   Ready    master,worker   13s   v1.18.3
 ```
 
 Then you can execute the following command to access the node:


### PR DESCRIPTION
Commit 96376629e343 changed the default provider from k8s-1.15
to k8s-1.18, but the documentation was not updated accordingly.

**What this PR does / why we need it**:

Updates documentation so that it accurately reflects reality.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
