### PR TITLE
selinux: always build KubeVirt with selinux support

### DIFF
--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -108,7 +108,7 @@ for arg in $args; do
             LINUX_NAME=${ARCH_BASENAME}-linux-amd64
 
             echo "building dynamic binary $BIN_NAME"
-            GOOS=linux GOARCH=amd64 go_build -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
+            GOOS=linux GOARCH=amd64 go_build -tags selinux -i -o ${CMD_OUT_DIR}/${BIN_NAME}/${LINUX_NAME} -ldflags "$(kubevirt::version::ldflags)" $(pkg_dir linux amd64)
 
             (cd ${CMD_OUT_DIR}/${BIN_NAME} && ln -sf ${LINUX_NAME} ${BIN_NAME})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On KubeVirt, we rely on bazel to set the selinux tag - [0]; on
Openshift, we do not use bazel, which causes KubeVirt to be
compiled without selinux support, which ultimately causes the
selinux library used in [1] to use the stub instead of the proper
linux binding. This will indeed make the selinux do nothing when
attempting to read labels / set execution labels.

This change is harmless on nodes without selinux (or with it
disabled) since all runtime calls to this library only happen *if*
selinux is enabled.

[0] - https://github.com/kubevirt/kubevirt/blob/master/.bazelrc#L18
[1] - https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-launcher/virtwrap/network/common.go#L36

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
always compile KubeVirt with selinux support on pure go builds.
```
