### PR TITLE
wrong apiVersion used for VirtualMachineRestore owner references

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore.go
+++ b/pkg/virt-controller/watch/snapshot/restore.go
@@ -463,7 +463,7 @@ func (t *vmRestoreTarget) Own(obj metav1.Object) {
 	b := true
 	obj.SetOwnerReferences([]metav1.OwnerReference{
 		{
-			APIVersion:         snapshotv1.SchemeGroupVersion.String(),
+			APIVersion:         kubevirtv1.GroupVersion.String(),
 			Kind:               "VirtualMachine",
 			Name:               t.vm.Name,
 			UID:                t.vm.UID,

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -17,6 +17,7 @@ import (
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
 
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	v1 "kubevirt.io/client-go/api/v1"
 	snapshotv1 "kubevirt.io/client-go/apis/snapshot/v1alpha1"
 	cdifake "kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake"
@@ -52,7 +53,7 @@ var _ = Describe("Restore controlleer", func() {
 				UID:       uid,
 				OwnerReferences: []metav1.OwnerReference{
 					{
-						APIVersion:         snapshotv1.SchemeGroupVersion.String(),
+						APIVersion:         kubevirtv1.GroupVersion.String(),
 						Kind:               "VirtualMachine",
 						Name:               vmName,
 						UID:                vmUID,

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -107,6 +107,8 @@ var _ = Describe("VirtualMachineRestore Tests", func() {
 			return r.Status != nil && r.Status.Complete != nil && *r.Status.Complete
 		}, 180*time.Second, time.Second).Should(BeTrue())
 		Expect(r.OwnerReferences).To(HaveLen(1))
+		Expect(r.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
+		Expect(r.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
 		Expect(r.OwnerReferences[0].Name).To(Equal(vm.Name))
 		Expect(r.OwnerReferences[0].UID).To(Equal(vm.UID))
 		Expect(r.Status.RestoreTime).ToNot(BeNil())
@@ -565,6 +567,8 @@ var _ = Describe("VirtualMachineRestore Tests", func() {
 						Expect(v.PersistentVolumeClaim.ClaimName).ToNot(Equal(originalPVCName))
 						pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(v.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
+						Expect(pvc.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
+						Expect(pvc.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
 						Expect(pvc.OwnerReferences[0].Name).To(Equal(vm.Name))
 						Expect(pvc.OwnerReferences[0].UID).To(Equal(vm.UID))
 					}
@@ -616,6 +620,8 @@ var _ = Describe("VirtualMachineRestore Tests", func() {
 						Expect(v.PersistentVolumeClaim.ClaimName).ToNot(Equal(originalPVCName))
 						pvc, err := virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Get(v.PersistentVolumeClaim.ClaimName, metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
+						Expect(pvc.OwnerReferences[0].APIVersion).To(Equal(v1.GroupVersion.String()))
+						Expect(pvc.OwnerReferences[0].Kind).To(Equal("VirtualMachine"))
 						Expect(pvc.OwnerReferences[0].Name).To(Equal(vm.Name))
 						Expect(pvc.OwnerReferences[0].UID).To(Equal(vm.UID))
 					}


### PR DESCRIPTION
interestengly, only an issue on ocp

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Issue discovered in OCP testing.  Interesting wasn't an issue upstream.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
