### PR TITLE
Validate network interface name

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -623,6 +623,16 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			})
 		}
 
+		// Check if the interface name has correct format
+		isValid := regexp.MustCompile(`^[A-Za-z0-9-_]+$`).MatchString
+		if !isValid(iface.Name) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "Network interface name can only contain alphabetical characters, numbers, dashes (-) or underscores (_)",
+				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("name").String(),
+			})
+		}
+
 		networkInterfaceMap[iface.Name] = struct{}{}
 
 		// Check only ports configured on interfaces connected to a pod network


### PR DESCRIPTION
Virtual Machine with Network interface that contains "." in its name fails to boot
despite k8s allowing "." in object names. Adding a validation to refuse VMs with
NICs containing "." in their name.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
PR fixes issue with VM not booting up due to a network interface containing dot (".") in its name.

**Special notes for your reviewer**:

**Release note**:
```release-note
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1853911
```
