### PR TITLE
virt-launcher, Fix Guest Agent updates causing an event handling deadlock

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -395,7 +395,7 @@ func main() {
 		}
 	}
 
-	events := make(chan watch.Event, 10)
+	events := make(chan watch.Event, 2)
 	// Send domain notifications to virt-handler
 	startDomainEventMonitoring(notifier, *virtShareDir, domainConn, events, vm.UID, domainName, &agentStore, *qemuAgentSysInterval, *qemuAgentFileInterval, *qemuAgentUserInterval, *qemuAgentVersionInterval)
 

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -270,7 +270,6 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 		if interfaceStatus != nil || osInfo != nil {
 			event := watch.Event{Type: watch.Modified, Object: domain}
 			client.SendDomainEvent(event)
-			events <- event
 		}
 		err := client.SendDomainEvent(watch.Event{Type: watch.Modified, Object: domain})
 		if err != nil {

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -267,10 +267,7 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 		if osInfo != nil {
 			domain.Status.OSInfo = *osInfo
 		}
-		if interfaceStatus != nil || osInfo != nil {
-			event := watch.Event{Type: watch.Modified, Object: domain}
-			client.SendDomainEvent(event)
-		}
+
 		err := client.SendDomainEvent(watch.Event{Type: watch.Modified, Object: domain})
 		if err != nil {
 			log.Log.Reason(err).Error("Could not send domain notify event.")

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -260,7 +260,6 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 				events <- event
 			}
 		}
-		log.Log.Infof("7) OSINFO IN EVENT CALLBACK: %v", osInfo)
 		if interfaceStatus != nil {
 			domain.Status.Interfaces = interfaceStatus
 		}


### PR DESCRIPTION
When guest-agent is installed, it will send update events,
which will send events to a channel of virt-launcher.
This channel has two purposes only:
1. Catch the first ADD event.
2. Catch the delete event.

Since this channel is sampled for checking of delete event
only after the qemu PID is gone, this channel can get full, in case wrong events are sent to it.

In such case the event handler (eventCallback) will hang forever
(because it tries to send to a full channel).
Guest agent wont be restarted and events wont be handled.

Since we just need ADD events and DELETE events
we dont need to send events to this channel upon
guest agent updates.

Moreover there was a double send to the virt-handler
which isnt needed as well.

Add mechanism to avoid sending unnecessary events to the channel.

Found as part of working on 
https://bugzilla.redhat.com/show_bug.cgi?id=1874812

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
