### PR TITLE
Cap the maximum number of queues on a tap device

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -2188,6 +2188,18 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].Driver).To(BeNil(),
 				"queues should not be set for models other than virtio")
 		})
+
+		It("should cap the maximum number of queues", func() {
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores:   512,
+				Sockets: 1,
+				Threads: 2,
+			}
+			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			expectedNumberQueues := uint(multiQueueMaxQueues)
+			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(expectedNumberQueues),
+				"should be capped to the maximum number of queues on tap devices")
+		})
 	})
 
 	Context("sriov", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The maximum number of queues on a tap device [is currently](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/net/tun.c?id=refs/tags/v4.1.26#n128) 256.

This PR caps the requested number of queues to 256, thus preventing KubeVirt from requesting more than what the kernel will accept.

**Special notes for your reviewer:** 
Depends-on: #4300 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
