### PR TITLE
Add readiness and health probes to virt-handler

### DIFF
--- a/pkg/virt-operator/creation/components/deployments.go
+++ b/pkg/virt-operator/creation/components/deployments.go
@@ -455,6 +455,37 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 	container.Env = append(container.Env, containerEnv...)
 
 	container.VolumeMounts = []corev1.VolumeMount{}
+
+	container.LivenessProbe = &corev1.Probe{
+		FailureThreshold: 8,
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Scheme: corev1.URISchemeHTTPS,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8443,
+				},
+				Path: "/healthz",
+			},
+		},
+		InitialDelaySeconds: 15,
+		TimeoutSeconds:      10,
+	}
+	container.ReadinessProbe = &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Scheme: corev1.URISchemeHTTPS,
+				Port: intstr.IntOrString{
+					Type:   intstr.Int,
+					IntVal: 8443,
+				},
+				Path: "/healthz",
+			},
+		},
+		InitialDelaySeconds: 15,
+		TimeoutSeconds:      10,
+	}
+
 	pod.Volumes = []corev1.Volume{}
 
 	type volume struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

virt-handler startup can take some time. Ensure that we clearly indicate
when it is ready, to avoid strange temporary side-effects in tests or
during production when virt-handler gets restarted.

One example in our tests is, that if operator tests restore the kubevirt installation, follow-up tests assume that virt-handler is fully reachable if it reports ready. In practice it was sometimes still starting up. That made especially the config-propagation checks flaky.

Fixes #4262 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Add readiness and liveness probes to virt-handler, to clearly indicate readiness
```
