### PR TITLE
Fix display of virtctl help text for other usages

### DIFF
--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -21,5 +21,19 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "root_suite_test.go",
+        "root_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -22,19 +22,9 @@ import (
 
 var programName string
 
-const symlinkAsKrewPlugin = "kubectl-virt"
-
 func NewVirtctlCommand() *cobra.Command {
 
-	// if `virtctl` is installed via krew to be used as a kubectl plugin, it's run via a symlink, so the basename then
-	// is `kubectl-virt`. In this case we want to accomodate the user by adjusting the help text (usage, examples and
-	// the like) by displaying `kubectl virt <command>` instead of `virtctl <command>`.
-	// see https://github.com/kubevirt/kubevirt/issues/2356 for more details
-	// see also templates.go
-	programName = "virtctl"
-	if filepath.Base(os.Args[0]) == symlinkAsKrewPlugin {
-		programName = "kubectl virt"
-	}
+	programName := GetProgramName(filepath.Base(os.Args[0]))
 
 	// used in cobra templates to display either `kubectl virt` or `virtctl`
 	cobra.AddTemplateFunc(
@@ -94,6 +84,19 @@ func NewVirtctlCommand() *cobra.Command {
 		optionsCmd,
 	)
 	return rootCmd
+}
+
+// GetProgramName returns the commmand name to display in help texts.
+// If `virtctl` is installed via krew to be used as a kubectl plugin, it's run via a symlink, so the basename then
+// is `kubectl-virt`. In this case we want to accomodate the user by adjusting the help text (usage, examples and
+// the like) by displaying `kubectl virt <command>` instead of `virtctl <command>`.
+// see https://github.com/kubevirt/kubevirt/issues/2356 for more details
+// see also templates.go
+func GetProgramName(binary string) string {
+	if strings.HasSuffix(binary, "-virt") {
+		return fmt.Sprintf("%s virt", strings.TrimSuffix(binary, "-virt"))
+	}
+	return "virtctl"
 }
 
 func Execute() {

--- a/pkg/virtctl/root_suite_test.go
+++ b/pkg/virtctl/root_suite_test.go
@@ -1,0 +1,16 @@
+package virtctl_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/log"
+)
+
+func TestRoot(t *testing.T) {
+	log.Log.SetIOWriter(GinkgoWriter)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "root Suite")
+}

--- a/pkg/virtctl/root_test.go
+++ b/pkg/virtctl/root_test.go
@@ -1,0 +1,28 @@
+package virtctl_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virtctl"
+)
+
+var _ = Describe("Root", func() {
+
+	It("returns virtctl", func() {
+		Expect(virtctl.GetProgramName("virtctl")).To(BeEquivalentTo("virtctl"))
+	})
+
+	It("returns virtctl as default", func() {
+		Expect(virtctl.GetProgramName("42")).To(BeEquivalentTo("virtctl"))
+	})
+
+	It("returns kubectl", func() {
+		Expect(virtctl.GetProgramName("kubectl-virt")).To(BeEquivalentTo("kubectl virt"))
+	})
+
+	It("returns oc", func() {
+		Expect(virtctl.GetProgramName("oc-virt")).To(BeEquivalentTo("oc virt"))
+	})
+
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In the case where either the virtctl binary or the symlink does not exactly
match the expectation the name virtctl is displayed in the help text.
This is now generalized by only looking for the suffix `-virt` and then
displaying `... virt` in the help text.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix virtctl help text when running as a plugin
```
