### PR TITLE
Mark networking conformance tests

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -92,7 +92,7 @@ var _ = SIGDescribe("[Serial]Primary Pod Network", func() {
 				cleanupVMI(virtClient, vmi)
 			})
 
-			It("should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
+			It("[Conformance] should report PodIP as its own on interface status", func() { AssertReportedIP(vmi) })
 		})
 	})
 })

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -282,7 +282,7 @@ var _ = SIGDescribe("[Serial]Services", func() {
 				cleanupJobs(jobsToCleanup)
 			})
 
-			It("should be able to reach the vmi based on labels specified on the vmi", func() {
+			It("[Conformance] should be able to reach the vmi based on labels specified on the vmi", func() {
 				for _, exposedService := range serviceManager.services {
 					jobCleanupFunc := assertConnectivityToService(exposedService.Name, inboundVMI.Namespace, servicePort)
 					jobsToCleanup = append(jobsToCleanup, jobCleanupFunc)

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -127,11 +127,11 @@ var _ = Describe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][leve
 				waitForNetworkPolicyDeletion(policy)
 			})
 
-			It("[test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
+			It("[Conformance][test_id:1513] should succeed pinging between two VMI/s in the same namespace", func() {
 				assertPingSucceed(clientVMI, serverVMI)
 			})
 
-			It("[test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
+			It("[Conformance][test_id:1514] should fail pinging between two VMI/s each on different namespaces", func() {
 				assertPingFail(clientVMIAlternativeNamespace, serverVMI)
 			})
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -607,7 +607,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			return vmi
 		}
 
-		table.DescribeTable("[test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", func(ports []v1.Port, withCustomCIDR bool) {
+		table.DescribeTable("[Conformance][test_id:1780][label:masquerade_binding_connectivity]should allow regular network connection", func(ports []v1.Port, withCustomCIDR bool) {
 			var ipv4NetworkCIDR string
 
 			if withCustomCIDR {
@@ -710,6 +710,10 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			}
 
 			BeforeEach(func() {
+				if !tests.HasLiveMigration() {
+					Skip("LiveMigration feature gate is not enabled in kubevirt-config")
+				}
+
 				var err error
 
 				By("Create VMI")
@@ -754,7 +758,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				}
 			})
 
-			It("preserves connectivity", func() {
+			It("[Conformance] preserves connectivity", func() {
 				Eventually(func() error {
 					for _, podIP := range virtHandlerIPs {
 						err := ping(podIP.IP)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

These tests should assert basic networking functionality of KubeVirt on
the cluster.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
