### PR TITLE
dual-stack, virtctl: expose ipv6 services

### DIFF
--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -238,6 +238,25 @@ var _ = Describe("Expose", func() {
 				Expect(err()).To(BeNil())
 			})
 		})
+		Context("With parametrized IPFamily", func() {
+			It("should succeed with IPv4", func() {
+				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+					"--port", "9999", "--target-port", "http", "--ip-family", "ipv4")
+				Expect(cmd()).To(Succeed(), "should succeed on an valid IP family - ipv4 is valid")
+			})
+
+			It("should succeed with IPv6", func() {
+				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+					"--port", "9999", "--target-port", "http", "--ip-family", "ipv6")
+				Expect(cmd()).To(Succeed(), "should succeed on an valid IP family - ipv6 is valid")
+			})
+
+			It("should fail with an invalid IPFamily", func() {
+				cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+					"--port", "9999", "--target-port", "http", "--ip-family", "ipv14")
+				Expect(cmd()).To(HaveOccurred(), "should fail on an invalid IP family")
+			})
+		})
 	})
 })
 

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -55,22 +56,37 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	})
 
 	runHelloWorldJob := func(host, port, namespace string) *batchv1.Job {
-		job := tests.NewHelloWorldJob(host, port)
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(job)
+		var job *batchv1.Job
+		if net.IsIPv6String(host) {
+			job = tests.NewHelloWorldJobv6(host, port)
+		} else {
+			job = tests.NewHelloWorldJob(host, port)
+		}
+		job, err = virtClient.BatchV1().Jobs(namespace).Create(job)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return job
 	}
 
 	runHelloWorldJobUDP := func(host, port, namespace string) *batchv1.Job {
-		job := tests.NewHelloWorldJobUDP(host, port)
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(job)
+		var job *batchv1.Job
+		if net.IsIPv6String(host) {
+			job = tests.NewHelloWorldJobUDPv6(host, port)
+		} else {
+			job = tests.NewHelloWorldJobUDP(host, port)
+		}
+		job, err = virtClient.BatchV1().Jobs(namespace).Create(job)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return job
 	}
 
 	runHelloWorldJobHttp := func(host, port, namespace string) *batchv1.Job {
-		job := tests.NewHelloWorldJobHTTP(host, port)
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(job)
+		var job *batchv1.Job
+		if net.IsIPv6String(host) {
+			job = tests.NewHelloWorldJobHTTPv6(host, port)
+		} else {
+			job = tests.NewHelloWorldJobHTTP(host, port)
+		}
+		job, err = virtClient.BatchV1().Jobs(namespace).Create(job)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return job
 	}

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -124,6 +124,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should expose a Cluster IP service on a VMI and connect to it", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmiExposeArgs = append(vmiExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -166,6 +167,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("Should expose a ClusterIP service and connect to the vm on port 80", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmiExposeArgs = append(vmiExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -211,6 +213,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("Should expose a ClusterIP service and connect to all ports defined on the vmi", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmiExposeArgs = append(vmiExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -260,6 +263,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmiExposeArgs = append(vmiExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -333,6 +337,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should expose a ClusterIP service on a VMI and connect to it", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmiExposeArgs = append(vmiExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -376,6 +381,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should expose a NodePort service on a VMI and connect to it", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmiExposeArgs = append(vmiExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -482,11 +488,13 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should create a ClusterIP service on VMRS and connect to it", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmirsExposeArgs = append(vmirsExposeArgs, "--ip-family", "ipv6")
 				}
 
-				By("Exposing the service via virtctl command")
+				By("Expose a service on the VMRS using virtctl")
 				virtctl := tests.NewRepeatableVirtctlCommand(vmirsExposeArgs...)
+
 				Expect(virtctl()).To(Succeed(), "should succeed exposing a service via `virtctl expose ...`")
 
 				By("Getting back the cluster IP given for the service")
@@ -578,6 +586,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Connect to ClusterIP service that was set when VM was offline.", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmExposeArgs = append(vmExposeArgs, "--ip-family", "ipv6")
 				}
 
@@ -612,6 +621,10 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			)
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should verify the exposed service is functional before and after VM restart.", func(ipFamily k8sv1.IPFamily) {
+				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
+				}
+
 				vmObj := vm
 
 				if ipFamily == k8sv1.IPv6Protocol {
@@ -674,6 +687,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 			table.DescribeTable("[label:masquerade_binding_connectivity]Should Verify an exposed service of a VM is not functional after VM deletion.", func(ipFamily k8sv1.IPFamily) {
 				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
 					vmExposeArgs = append(vmExposeArgs, "--ip-family", "ipv6")
 				}
 

--- a/tests/job.go
+++ b/tests/job.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -110,16 +111,8 @@ func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, time
 // NewHelloWorldJob takes a DNS entry or an IP and a port which it will use to create a job
 // which tries to contact the host on the provided port.
 // It expects to receive "Hello World!" to succeed.
-func NewHelloWorldJob(host string, port string) *batchv1.Job {
-	check := fmt.Sprintf(`set -x; x="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, port)
-	return newHelloWorldJob(check)
-}
-
-// NewHelloWorldJobv6 is a workaround to generate `batch.V1` jobs that will access services exposed via IPv6 addresses.
-// It does exactly what NewHelloWorldJob does, but for IPv6.
-func NewHelloWorldJobv6(host string, port string) *batchv1.Job {
-	// TODO - remove this code once https://github.com/kubevirt/kubevirt/issues/4428 is fixed
-	check := fmt.Sprintf(`set -x; ping -c 1 %s; x="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, host, port)
+func NewHelloWorldJob(host string, port string, checkConnectivityCmdPrefixes ...string) *batchv1.Job {
+	check := fmt.Sprintf(`set -x; %sx="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, strings.Join(checkConnectivityCmdPrefixes, ";"), host, port)
 	return newHelloWorldJob(check)
 }
 
@@ -128,7 +121,7 @@ func NewHelloWorldJobv6(host string, port string) *batchv1.Job {
 // Note that in case of UDP, the server will not see the connection unless something is sent over it
 // However, netcat does not work well with UDP and closes before the answer arrives, for that another netcat call is needed,
 // this time as a UDP listener
-func NewHelloWorldJobUDP(host string, port string) *batchv1.Job {
+func NewHelloWorldJobUDP(host string, port string, checkConnectivityCmdPrefixes ...string) *batchv1.Job {
 	localPort, err := strconv.Atoi(port)
 	if err != nil {
 		return nil
@@ -136,25 +129,8 @@ func NewHelloWorldJobUDP(host string, port string) *batchv1.Job {
 	// local port is used to catch the reply - any number can be used
 	// we make it different than the port to be safe if both are running on the same machine
 	localPort--
-	check := fmt.Sprintf(`set -x; trap "kill 0" EXIT; x="$(head -n 1 < <(echo | nc -up %d %s %s -i 3 -w 3 & nc -ul %d))"; echo "$x" ; if [ "$x" = "Hello UDP World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`,
-		localPort, host, port, localPort)
-
-	return newHelloWorldJob(check)
-}
-
-// NewHelloWorldJobUDPv6 is a workaround to generate `batch.V1` jobs that will access services exposed via IPv6 addresses.
-// It does exactly what NewHelloWorldJobUDP does, but for IPv6.
-func NewHelloWorldJobUDPv6(host string, port string) *batchv1.Job {
-	// TODO - remove this code once https://github.com/kubevirt/kubevirt/issues/4428 is fixed
-	localPort, err := strconv.Atoi(port)
-	if err != nil {
-		return nil
-	}
-	// local port is used to catch the reply - any number can be used
-	// we make it different than the port to be safe if both are running on the same machine
-	localPort--
-	check := fmt.Sprintf(`set -x; ping -c 1 %s; trap "kill 0" EXIT; x="$(head -n 1 < <(echo | nc -up %d %s %s -i 3 -w 3 & nc -ul %d))"; echo "$x" ; if [ "$x" = "Hello UDP World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`,
-		host, localPort, host, port, localPort)
+	check := fmt.Sprintf(`set -x; trap "kill 0" EXIT; %sx="$(head -n 1 < <(echo | nc -up %d %s %s -i 3 -w 3 & nc -ul %d))"; echo "$x" ; if [ "$x" = "Hello UDP World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`,
+		strings.Join(checkConnectivityCmdPrefixes, ";"), localPort, host, port, localPort)
 
 	return newHelloWorldJob(check)
 }
@@ -162,16 +138,8 @@ func NewHelloWorldJobUDPv6(host string, port string) *batchv1.Job {
 // NewHelloWorldJobHTTP gets an IP address and a port, which it uses to create a pod.
 // This pod tries to contact the host on the provided port, over HTTP.
 // On success - it expects to receive "Hello World!".
-func NewHelloWorldJobHTTP(host string, port string) *batchv1.Job {
-	check := fmt.Sprintf(`set -x; x="$(head -n 1 < <(curl %s:%s))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, FormatIPForURL(host), port)
-	return newHelloWorldJob(check)
-}
-
-// NewHelloWorldJobHTTPv6 is a workaround to generate `batch.V1` jobs that will access services exposed via IPv6 addresses.
-// It does exactly what NewHelloWorldJobHTTP does, but for IPv6.
-func NewHelloWorldJobHTTPv6(host string, port string) *batchv1.Job {
-	// TODO - remove this code once https://github.com/kubevirt/kubevirt/issues/4428 is fixed
-	check := fmt.Sprintf(`set -x; ping -c 1 %s; x="$(head -n 1 < <(curl %s:%s))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, host, FormatIPForURL(host), port)
+func NewHelloWorldJobHTTP(host string, port string, checkConnectivityCmdPrefixes ...string) *batchv1.Job {
+	check := fmt.Sprintf(`set -x; %sx="$(head -n 1 < <(curl %s:%s))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, strings.Join(checkConnectivityCmdPrefixes, ";"), FormatIPForURL(host), port)
 	return newHelloWorldJob(check)
 }
 

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -45,13 +45,11 @@ var _ = SIGDescribe("[Serial]Services", func() {
 	var virtClient kubecli.KubevirtClient
 
 	runTCPClientExpectingHelloWorldFromServer := func(host, port, namespace string, isIPv6 bool) *batchv1.Job {
-		var job *batchv1.Job
+		var pingCmd string
 		if isIPv6 {
-			job = tests.NewHelloWorldJobv6(host, port)
-		} else {
-			job = tests.NewHelloWorldJob(host, port)
+			pingCmd = fmt.Sprintf("ping -c1 %s;", host)
 		}
-		job, err := virtClient.BatchV1().Jobs(namespace).Create(job)
+		job, err := virtClient.BatchV1().Jobs(namespace).Create(tests.NewHelloWorldJob(host, port, pingCmd))
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return job
 	}

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -44,8 +44,13 @@ import (
 var _ = SIGDescribe("[Serial]Services", func() {
 	var virtClient kubecli.KubevirtClient
 
-	runTCPClientExpectingHelloWorldFromServer := func(host, port, namespace string) *batchv1.Job {
-		job := tests.NewHelloWorldJob(host, port)
+	runTCPClientExpectingHelloWorldFromServer := func(host, port, namespace string, isIPv6 bool) *batchv1.Job {
+		var job *batchv1.Job
+		if isIPv6 {
+			job = tests.NewHelloWorldJobv6(host, port)
+		} else {
+			job = tests.NewHelloWorldJob(host, port)
+		}
 		job, err := virtClient.BatchV1().Jobs(namespace).Create(job)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		return job
@@ -81,11 +86,11 @@ var _ = SIGDescribe("[Serial]Services", func() {
 		return virtClient.CoreV1().Services(namespace).Delete(serviceName, &k8smetav1.DeleteOptions{})
 	}
 
-	assertConnectivityToService := func(serviceName, namespace string, servicePort int) (func() error, error) {
+	assertConnectivityToService := func(serviceName, namespace string, servicePort int, isIPv6 bool) (func() error, error) {
 		serviceFQDN := fmt.Sprintf("%s.%s", serviceName, namespace)
 
 		By(fmt.Sprintf("starting a job which tries to reach the vmi via service %s", serviceFQDN))
-		job := runTCPClientExpectingHelloWorldFromServer(serviceFQDN, strconv.Itoa(servicePort), namespace)
+		job := runTCPClientExpectingHelloWorldFromServer(serviceFQDN, strconv.Itoa(servicePort), namespace, isIPv6)
 
 		By(fmt.Sprintf("waiting for the job to report a SUCCESSFUL connection attempt to service %s on port %d", serviceFQDN, servicePort))
 		err := tests.WaitForJobToSucceed(job, 90*time.Second)
@@ -94,11 +99,11 @@ var _ = SIGDescribe("[Serial]Services", func() {
 		}, err
 	}
 
-	assertNoConnectivityToService := func(serviceName, namespace string, servicePort int) (func() error, error) {
+	assertNoConnectivityToService := func(serviceName, namespace string, servicePort int, isIPv6 bool) (func() error, error) {
 		serviceFQDN := fmt.Sprintf("%s.%s", serviceName, namespace)
 
 		By(fmt.Sprintf("starting a job which tries to reach the vmi via service %s", serviceFQDN))
-		job := runTCPClientExpectingHelloWorldFromServer(serviceFQDN, strconv.Itoa(servicePort), namespace)
+		job := runTCPClientExpectingHelloWorldFromServer(serviceFQDN, strconv.Itoa(servicePort), namespace, isIPv6)
 
 		By(fmt.Sprintf("waiting for the job to report a FAILED connection attempt to service %s on port %d", serviceFQDN, servicePort))
 		err := tests.WaitForJobToFail(job, 90*time.Second)
@@ -172,14 +177,14 @@ var _ = SIGDescribe("[Serial]Services", func() {
 			It("[test_id:1547] should be able to reach the vmi based on labels specified on the vmi", func() {
 				var err error
 
-				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort)
+				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort, false)
 				Expect(err).NotTo(HaveOccurred(), "connectivity is expected to the exposed service")
 			})
 
 			It("[test_id:1548] should fail to reach the vmi if an invalid servicename is used", func() {
 				var err error
 
-				jobCleanup, err = assertNoConnectivityToService("wrongservice", inboundVMI.Namespace, servicePort)
+				jobCleanup, err = assertNoConnectivityToService("wrongservice", inboundVMI.Namespace, servicePort, false)
 				Expect(err).NotTo(HaveOccurred(), "connectivity is *not* expected, since there isn't an exposed service")
 			})
 		})
@@ -207,7 +212,7 @@ var _ = SIGDescribe("[Serial]Services", func() {
 				var err error
 				serviceHostnameWithSubdomain := fmt.Sprintf("%s.%s", inboundVMI.Spec.Hostname, inboundVMI.Spec.Subdomain)
 
-				jobCleanup, err = assertConnectivityToService(serviceHostnameWithSubdomain, inboundVMI.Namespace, servicePort)
+				jobCleanup, err = assertConnectivityToService(serviceHostnameWithSubdomain, inboundVMI.Namespace, servicePort, false)
 				Expect(err).NotTo(HaveOccurred(), "connectivity is expected to the exposed service")
 			})
 		})
@@ -276,7 +281,7 @@ var _ = SIGDescribe("[Serial]Services", func() {
 				By("checking connectivity the the exposed service")
 				var err error
 
-				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort)
+				jobCleanup, err = assertConnectivityToService(serviceName, inboundVMI.Namespace, servicePort, ipFamily == k8sv1.IPv6Protocol)
 				Expect(err).NotTo(HaveOccurred(), "connectivity is expected to the exposed service")
 			},
 				table.Entry("when the service is exposed by an IPv4 address.", k8sv1.IPv4Protocol),
@@ -298,7 +303,7 @@ var _ = SIGDescribe("[Serial]Services", func() {
 				var err error
 				serviceName = "missingservice"
 
-				jobCleanup, err = assertNoConnectivityToService(serviceName, inboundVMI.Namespace, servicePort)
+				jobCleanup, err = assertNoConnectivityToService(serviceName, inboundVMI.Namespace, servicePort, false)
 				Expect(err).NotTo(HaveOccurred(), "connectivity is *not* expected, since there isn't an exposed service")
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adapt the virtctl API to accept the IPFamily of a the service to
be exposed; it accepts 'ipv4' and 'ipv6' as families.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `ip-family` to the `virtctl expose` command. 
```
