### PR TITLE
Run Travis CI only on master, tag or release branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+if: type != pull_request OR branch =~ /^(release-[0-9\.]+)$/
+
 language: generic
-sudo: required
 dist: xenial
 
 services:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As we have moved the checks to prow presubmits we do not want to run the
Travis builds on PRs against master any more.

Also remove sudo flag as it has no effect for quite a while now:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Should only get merged after https://github.com/kubevirt/project-infra/pull/651 is merged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Only run Travis build for PRs against release branches
```