### PR TITLE
Don't discard bazel platform cache on virtctl cross-compilation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -359,6 +359,36 @@ genrule(
 )
 
 genrule(
+    name = "build-virtctl-amd64",
+    srcs = [
+        "//cmd/virtctl:virtctl-amd64",
+    ],
+    outs = ["virtctl-copier-amd64"],
+    cmd = "echo '#!/bin/sh\n\ncp $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
+    name = "build-virtctl-darwin",
+    srcs = [
+        "//cmd/virtctl:virtctl-darwin",
+    ],
+    outs = ["virtctl-copier-darwin"],
+    cmd = "echo '#!/bin/sh\n\ncp $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
+    name = "build-virtctl-windows",
+    srcs = [
+        "//cmd/virtctl:virtctl-windows",
+    ],
+    outs = ["virtctl-copier-windows"],
+    cmd = "echo '#!/bin/sh\n\ncp $(SRCS) $$1' > \"$@\"",
+    executable = 1,
+)
+
+genrule(
     name = "build-ginkgo",
     srcs = [
         "//vendor/github.com/onsi/ginkgo/ginkgo",

--- a/cmd/virtctl/BUILD.bazel
+++ b/cmd/virtctl/BUILD.bazel
@@ -19,3 +19,30 @@ go_binary(
     visibility = ["//visibility:public"],
     x_defs = version_x_defs(),
 )
+
+go_binary(
+    name = "virtctl-amd64",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
+)
+
+go_binary(
+    name = "virtctl-darwin",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "darwin",
+    visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
+)
+
+go_binary(
+    name = "virtctl-windows",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "windows",
+    visibility = ["//visibility:public"],
+    x_defs = version_x_defs(),
+)

--- a/hack/bazel-build.sh
+++ b/hack/bazel-build.sh
@@ -34,11 +34,13 @@ bazel build \
 
 # Copy dump binary to a reachable place outside of the build container
 bazel run \
+    --config=${ARCHITECTURE} \
     --stamp \
     :build-dump -- ${CMD_OUT_DIR}/dump/dump
 
 # build platform native virtctl explicitly
 bazel run \
+    --config=${ARCHITECTURE} \
     --stamp \
     :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl
 
@@ -46,18 +48,18 @@ bazel run \
 
 # linux
 bazel run \
-    --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+    --config=${ARCHITECTURE} \
     --stamp \
-    :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-amd64
+    :build-virtctl-amd64 -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-linux-amd64
 
 # darwin
 bazel run \
-    --platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64 \
+    --config=${ARCHITECTURE} \
     --stamp \
-    :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-amd64
+    :build-virtctl-darwin -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-darwin-amd64
 
 # windows
 bazel run \
-    --platforms=@io_bazel_rules_go//go/toolchain:windows_amd64 \
+    --config=${ARCHITECTURE} \
     --stamp \
-    :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-windows-amd64.exe
+    :build-virtctl-windows -- ${CMD_OUT_DIR}/virtctl/virtctl-${KUBEVIRT_VERSION}-windows-amd64.exe


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to keep the current cache and not build the whole project for
another architecture. Therefore, introducing explicit cross-compile
targets for the virtctl binary, instead of changing the whole target
platform for bazel.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
