### PR TITLE
Allow PVC as volume source with a DV populating the PVC.

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -215,9 +215,11 @@ func ValidateVirtualMachineSpec(field *k8sfield.Path, spec *v1.VirtualMachineSpe
 
 			dataVolumeRefFound := false
 			for _, volume := range spec.Template.Spec.Volumes {
-				if volume.VolumeSource.DataVolume == nil {
-					continue
-				} else if volume.VolumeSource.DataVolume.Name == dataVolume.Name {
+				// TODO: Assuming here that PVC name == DV name which might not be the case in the future
+				if volume.VolumeSource.PersistentVolumeClaim != nil && volume.VolumeSource.PersistentVolumeClaim.ClaimName == dataVolume.Name {
+					dataVolumeRefFound = true
+					break
+				} else if volume.VolumeSource.DataVolume != nil && volume.VolumeSource.DataVolume.Name == dataVolume.Name {
 					dataVolumeRefFound = true
 					break
 				}

--- a/pkg/virt-controller/watch/util.go
+++ b/pkg/virt-controller/watch/util.go
@@ -23,13 +23,9 @@ import (
 	"fmt"
 	"time"
 
-	k8sv1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 )
 
@@ -72,68 +68,4 @@ func processWorkItem(queue workqueue.RateLimitingInterface, handler func(string)
 	}
 
 	return true
-}
-
-func handlePVCMisuseInVM(pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder, vm *v1.VirtualMachine) error {
-	logger := log.Log.Object(vm)
-
-	volumeName, err := handlePVCMisuse(pvcInformer, recorder, vm.Namespace, vm.Spec.Template.Spec.Volumes, logger)
-	if err != nil && volumeName != nil {
-		recorder.Eventf(vm,
-			k8sv1.EventTypeWarning,
-			FailedPVCVolumeSourceMisusedReason,
-			"PVC '%s' used as volume source where Data Volume should be used",
-			*volumeName)
-	}
-
-	return err
-}
-
-func handlePVCMisuseInVMI(pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder, vmi *v1.VirtualMachineInstance) error {
-	logger := log.Log.Object(vmi)
-
-	volumeName, err := handlePVCMisuse(pvcInformer, recorder, vmi.Namespace, vmi.Spec.Volumes, logger)
-	if err != nil && volumeName != nil {
-		recorder.Eventf(vmi,
-			k8sv1.EventTypeWarning,
-			FailedPVCVolumeSourceMisusedReason,
-			"PVC '%s' used as volume source where Data Volume should be used",
-			*volumeName)
-	}
-
-	return err
-}
-
-// Checks if PVC used in VolumeSource is owned by a DataVolume.
-// If so, the DV should be used instead and this is an error
-func handlePVCMisuse(pvcInformer cache.SharedIndexInformer, recorder record.EventRecorder, namespace string, volumes []v1.Volume, logger *log.FilteredLogger) (*string, error) {
-
-	for _, volume := range volumes {
-		if volume.VolumeSource.PersistentVolumeClaim == nil {
-			continue
-		}
-
-		key := fmt.Sprintf("%s/%s", namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName)
-		obj, exists, err := pvcInformer.GetStore().GetByKey(key)
-		if err != nil {
-			logger.Reason(err).Warning("failed to fetch PVC for namespace from cache")
-			return nil, err
-		} else if !exists {
-			continue
-		}
-
-		pvc := obj.(*k8sv1.PersistentVolumeClaim)
-		for _, or := range pvc.ObjectMeta.OwnerReferences {
-			if or.Kind != "DataVolume" {
-				continue
-			}
-
-			err := fmt.Errorf("PVC %v owned by DataVolume %v cannot be used as a volume source. Use DataVolume instead",
-				key, or.Name)
-			logger.Reason(err).Error("Invalid VM spec")
-			return &volume.VolumeSource.PersistentVolumeClaim.ClaimName, err
-		}
-	}
-
-	return nil, nil
 }

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -669,11 +669,6 @@ func (c *VMController) startVMI(vm *virtv1.VirtualMachine) error {
 		return nil
 	}
 
-	// Check that PVCs are not used when DataVolmes should
-	if err := handlePVCMisuseInVM(c.pvcInformer, c.recorder, vm); err != nil {
-		return err
-	}
-
 	// start it
 	vmi := c.setupVMIFromVM(vm)
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -875,14 +875,10 @@ func (c *VMIController) listVMIsMatchingDataVolume(namespace string, dataVolumeN
 			// VolumeSource.PersistentVolumeClaim doesn't list any ownerRef for the PVC. So in order to detect
 			// if the PVC is owned by a DV, I would have to look up the PVC, and find the ownerRef and determine if
 			// it is a DV. TODO: determine if it is slower to do the above or run through a reconcile of a VMI.
-			if volume.VolumeSource.PersistentVolumeClaim == nil {
-				if volume.VolumeSource.DataVolume == nil {
-					continue
-				} else if volume.VolumeSource.DataVolume.Name != dataVolumeName {
-					continue
-				}
+			if volume.VolumeSource.PersistentVolumeClaim != nil ||
+				volume.VolumeSource.DataVolume != nil && volume.VolumeSource.DataVolume.Name == dataVolumeName {
+				vmis = append(vmis, vmi)
 			}
-			vmis = append(vmis, vmi)
 		}
 	}
 	return vmis, nil

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -97,8 +97,6 @@ const (
 	SuccessfulAbortMigrationReason = "SuccessfulAbortMigration"
 	// FailedAbortMigrationReason is added when an attempt to abort migration fails
 	FailedAbortMigrationReason = "FailedAbortMigration"
-	// FailedPVCVolumeSourceMisusedReason is added when PVC volume source is used where Data Volume should be used
-	FailedPVCVolumeSourceMisusedReason = "PVCVolumeSourceMisused"
 )
 
 func NewVMIController(templateService services.TemplateService,
@@ -553,10 +551,6 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		return nil
 	}
 
-	if err := handlePVCMisuseInVMI(c.pvcInformer, c.recorder, vmi); err != nil {
-		return &syncErrorImpl{err, FailedPVCVolumeSourceMisusedReason}
-	}
-
 	if !podExists(pod) {
 		// If we came ever that far to detect that we already created a pod, we don't create it again
 		if !vmi.IsUnprocessed() {
@@ -599,29 +593,43 @@ func (c *VMIController) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance
 	ready := true
 
 	for _, volume := range vmi.Spec.Volumes {
-		if volume.VolumeSource.DataVolume == nil {
-			continue
-		}
-
-		exists := false
-		for _, dataVolume := range dataVolumes {
-			if dataVolume.Name == volume.VolumeSource.DataVolume.Name {
-				exists = true
-				if dataVolume.Status.Phase != cdiv1.Succeeded {
-					log.Log.V(3).Object(vmi).Infof("DataVolume %s not ready. Phase=%s", dataVolume.Name, dataVolume.Status.Phase)
-					ready = false
-					if dataVolume.Status.Phase == cdiv1.Failed {
-						c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedDataVolumeImportReason, "DataVolume %s failed", dataVolume.Name)
-						return ready, &syncErrorImpl{fmt.Errorf("DataVolume %s for volume %s failed", dataVolume.Name, volume.Name), FailedDataVolumeImportReason}
+		// Check both DVs and PVCs
+		if volume.VolumeSource.DataVolume != nil {
+			for _, dataVolume := range dataVolumes {
+				if dataVolume.Name == volume.VolumeSource.DataVolume.Name {
+					if dataVolume.Status.Phase != cdiv1.Succeeded {
+						log.Log.V(3).Object(vmi).Infof("DataVolume %s not ready. Phase=%s", dataVolume.Name, dataVolume.Status.Phase)
+						ready = false
+						// This isn't needed anymore because datavolumes are eventually consistent.
+						if dataVolume.Status.Phase == cdiv1.Failed {
+							c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedDataVolumeImportReason, "DataVolume %s failed", dataVolume.Name)
+							return ready, &syncErrorImpl{fmt.Errorf("DataVolume %s for volume %s failed", dataVolume.Name, volume.Name), FailedDataVolumeImportReason}
+						}
 					}
+					break
 				}
-				break
 			}
 		}
-
-		if !exists {
-			log.Log.V(3).Object(vmi).Infof("DataVolume %s not found", volume.VolumeSource.DataVolume.Name)
-			ready = false
+		if volume.VolumeSource.PersistentVolumeClaim != nil {
+			// err is always nil
+			pvcInterface, pvcExists, _ := c.pvcInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", vmi.Namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName))
+			if pvcExists {
+				pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)
+				populated, err := cdiv1.IsPopulated(pvc, func(name, namespace string) (*cdiv1.DataVolume, error) {
+					dv, exists, _ := c.dataVolumeInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+					if !exists {
+						return nil, fmt.Errorf("Unable to find datavolume %s/%s", namespace, name)
+					}
+					return dv.(*cdiv1.DataVolume), nil
+				})
+				if err != nil {
+					return false, &syncErrorImpl{fmt.Errorf("Error determining if PVC %s is ready %v", pvc.Name, err), FailedDataVolumeImportReason}
+				}
+				if !populated {
+					log.Log.V(3).Object(vmi).Infof("PVC %s not ready.", pvc.Name)
+					ready = false
+				}
+			}
 		}
 	}
 
@@ -863,10 +871,16 @@ func (c *VMIController) listVMIsMatchingDataVolume(namespace string, dataVolumeN
 	for _, obj := range objs {
 		vmi := obj.(*virtv1.VirtualMachineInstance)
 		for _, volume := range vmi.Spec.Volumes {
-			if volume.VolumeSource.DataVolume == nil {
-				continue
-			} else if volume.VolumeSource.DataVolume.Name != dataVolumeName {
-				continue
+			// Always check persistent volume claims to see if they match a DV, can't filter any more since
+			// VolumeSource.PersistentVolumeClaim doesn't list any ownerRef for the PVC. So in order to detect
+			// if the PVC is owned by a DV, I would have to look up the PVC, and find the ownerRef and determine if
+			// it is a DV. TODO: determine if it is slower to do the above or run through a reconcile of a VMI.
+			if volume.VolumeSource.PersistentVolumeClaim == nil {
+				if volume.VolumeSource.DataVolume == nil {
+					continue
+				} else if volume.VolumeSource.DataVolume.Name != dataVolumeName {
+					continue
+				}
 			}
 			vmis = append(vmis, vmi)
 		}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -280,6 +280,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 
 		It("VMI should fail if DataVolume fails to import", func() {
+			// TODO: Remove this test, Datavolumes are now eventually consistent, and cannot enter into failed state.
 			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
@@ -312,26 +313,46 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
 		})
 
-		It("should not start VMI if it mistakenly uses PVC instead of DV that owns it", func() {
-			vmi := v1.NewMinimalVMI("testvm")
+	})
 
-			annotations := map[string]string{}
-			annotations[v1.ControllerAPILatestVersionObservedAnnotation] = v1.ApiLatestVersion
-			annotations[v1.ControllerAPIStorageVersionObservedAnnotation] = v1.ApiStorageVersion
-			vmi.SetAnnotations(annotations)
+	Context("On valid VirtualMachineInstance given with PVC source, ownedRef of DataVolume", func() {
+		controllerOf := true
+
+		It("should create a corresponding Pod on VMI creation when DataVolume is ready", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
 
 			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "dv1",
+				Name: "test1",
 				VolumeSource: v1.VolumeSource{
 					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "dv1",
+						ClaimName: "test1",
 					},
 				},
 			})
 
-			dv := &cdiv1.DataVolume{
+			dvPVC := &k8sv1.PersistentVolumeClaim{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolumeClaim",
+					APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dv1",
+					Namespace: vmi.Namespace,
+					Name:      "test1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "DataVolume",
+							Name:       "test1",
+							Controller: &controllerOf,
+						},
+					},
+				},
+			}
+			// we are mocking a successful DataVolume. we expect the PVC to
+			// be available in the store if DV is successful.
+			pvcInformer.GetIndexer().Add(dvPVC)
+
+			dataVolume := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
 					Namespace: vmi.Namespace,
 				},
 				Status: cdiv1.DataVolumeStatus{
@@ -339,27 +360,94 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 			}
 
-			pvcInformer.GetStore().Add(&k8sv1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "dv1",
-					Namespace: vmi.Namespace,
-					OwnerReferences: []metav1.OwnerReference{
-						metav1.OwnerReference{
-							Name: "dv1",
-							Kind: "DataVolume",
-						},
+			addVirtualMachine(vmi)
+			dataVolumeFeeder.Add(dataVolume)
+			shouldExpectPodCreation(vmi.UID)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+		})
+
+		It("should not create a corresponding Pod on VMI creation when DataVolume is pending", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "test1",
 					},
 				},
 			})
 
-			addVirtualMachine(vmi)
-			dataVolumeInformer.GetStore().Add(dv)
+			dvPVC := &k8sv1.PersistentVolumeClaim{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolumeClaim",
+					APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: vmi.Namespace,
+					Name:      "test1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "DataVolume",
+							Name:       "test1",
+							Controller: &controllerOf,
+						},
+					},
+				},
+			}
+			// we are mocking a successful DataVolume. we expect the PVC to
+			// be available in the store if DV is successful.
+			pvcInformer.GetIndexer().Add(dvPVC)
 
-			vmiInterface.EXPECT().Update(gomock.Any()).Return(vmi, nil)
+			dataVolume := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test1",
+					Namespace: vmi.Namespace,
+				},
+				Status: cdiv1.DataVolumeStatus{
+					Phase: cdiv1.Pending,
+				},
+			}
+
+			addVirtualMachine(vmi)
+			dataVolumeFeeder.Add(dataVolume)
 
 			controller.Execute()
-			testutils.ExpectEvent(recorder, FailedPVCVolumeSourceMisusedReason)
 		})
+
+		It("should create a corresponding Pod on VMI creation when PVC is not controlled by a DataVolume", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "test1",
+					},
+				},
+			})
+
+			pvc := &k8sv1.PersistentVolumeClaim{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "PersistentVolumeClaim",
+					APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: vmi.Namespace,
+					Name:      "test1",
+				},
+			}
+			// we are mocking a successful DataVolume. we expect the PVC to
+			// be available in the store if DV is successful.
+			pvcInformer.GetIndexer().Add(pvc)
+
+			addVirtualMachine(vmi)
+			shouldExpectPodCreation(vmi.UID)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
+		})
+
 	})
 
 	Context("On valid VirtualMachineInstance given", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -111,7 +111,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(len(reviewResponse.Details.Causes)).To(Equal(1))
 			Expect(reviewResponse.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[2].name"))
 		})
-		It("[test_id:4643]should be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", func() {
+		It("[test_id:4643]should NOT be rejected when VM template lists a DataVolume, but VM lists PVC VolumeSource", func() {
 			dv := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 			_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
 			Expect(err).To(BeNil())
@@ -154,7 +154,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			}
 			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, *dvt)
 			_, err = virtClient.VirtualMachine(tests.NamespaceTestDefault).Create(vm)
-			Expect(err).Should(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("[Serial][test_id:4644]should fail to start when a volume is backed by PVC created by DataVolume instead of the DataVolume itself", func() {
 			dv := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)


### PR DESCRIPTION

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR verifies the PVC is fully populated before allowing the VM to start. Before this was not allowed because we could not be sure that the PVC was fully populated. This PR checks the DV to ensure the PVC is fully populated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
PVCs populated by DVs are now allowed as volumes.
```
