### PR TITLE
[masquerade-binding] Set the pod iface mtu on the bridge

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -706,6 +706,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 	bridgeNic := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: bridgeNicName,
+			MTU:  int(p.vif.Mtu),
 		},
 	}
 	err := Handler.LinkAdd(bridgeNic)
@@ -851,6 +852,7 @@ func (p *MasqueradePodInterface) createBridge() error {
 	bridge := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: p.bridgeInterfaceName,
+			MTU:  int(p.vif.Mtu),
 		},
 	}
 	err = Handler.LinkAdd(bridge)

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Pod Network", func() {
 	var fakeAddr netlink.Addr
 	var updateFakeMac net.HardwareAddr
 	var bridgeTest *netlink.Bridge
+	var masqueradeBridgeTest *netlink.Bridge
 	var bridgeAddr *netlink.Addr
 	var testNic *VIF
 	var tmpDir string
@@ -106,6 +107,13 @@ var _ = Describe("Pod Network", func() {
 			},
 		}
 
+		masqueradeBridgeTest = &netlink.Bridge{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: api.DefaultBridgeName,
+				MTU:  1410,
+			},
+		}
+
 		bridgeAddr, _ = netlink.ParseAddr(fmt.Sprintf(bridgeFakeIP, 0))
 		tapDeviceName = "tap0"
 		testNic = &VIF{Name: podInterface,
@@ -129,7 +137,7 @@ var _ = Describe("Pod Network", func() {
 		masqueradeIpv6VmAddr, _ = netlink.ParseAddr(masqueradeIpv6VmStr)
 		masqueradeVmIpv6 = masqueradeIpv6VmAddr.IP.String()
 		masqueradeDummyName = fmt.Sprintf("%s-nic", api.DefaultBridgeName)
-		masqueradeDummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: masqueradeDummyName}}
+		masqueradeDummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: masqueradeDummyName, MTU: 1410}}
 		masqueradeTestNic = &VIF{Name: podInterface,
 			IP:          *masqueradeVmAddr,
 			IPv6:        *masqueradeIpv6VmAddr,
@@ -201,9 +209,11 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkByName(masqueradeDummyName).Return(masqueradeDummy, nil)
 		mockNetwork.EXPECT().LinkSetUp(masqueradeDummy).Return(nil)
 		mockNetwork.EXPECT().GenerateRandomMac().Return(fakeMac, nil)
-		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, bridgeTest).Return(nil)
-		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeGwAddr).Return(nil)
-		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeIpv6GwAddr).Return(nil)
+		mockNetwork.EXPECT().LinkAdd(masqueradeBridgeTest).Return(nil)
+		mockNetwork.EXPECT().LinkSetUp(masqueradeBridgeTest).Return(nil)
+		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, masqueradeBridgeTest).Return(nil)
+		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeGwAddr).Return(nil)
+		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeIpv6GwAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return(masqueradeGwStr, masqueradeVmStr, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return(masqueradeIpv6GwStr, masqueradeIpv6VmStr, nil)

--- a/tests/libnet/ipaddress.go
+++ b/tests/libnet/ipaddress.go
@@ -1,11 +1,13 @@
 package libnet
 
 import (
-	v1 "k8s.io/api/core/v1"
+	k8sv1 "k8s.io/api/core/v1"
 	netutils "k8s.io/utils/net"
+
+	v1 "kubevirt.io/client-go/api/v1"
 )
 
-func GetPodIpByFamily(pod *v1.Pod, family v1.IPFamily) string {
+func GetPodIpByFamily(pod *k8sv1.Pod, family k8sv1.IPFamily) string {
 	var ips []string
 	for _, ip := range pod.Status.PodIPs {
 		ips = append(ips, ip.IP)
@@ -13,7 +15,11 @@ func GetPodIpByFamily(pod *v1.Pod, family v1.IPFamily) string {
 	return getIp(ips, family)
 }
 
-func getIp(ips []string, family v1.IPFamily) string {
+func GetVmiPrimaryIpByFamily(vmi *v1.VirtualMachineInstance, family k8sv1.IPFamily) string {
+	return getIp(vmi.Status.Interfaces[0].IPs, family)
+}
+
+func getIp(ips []string, family k8sv1.IPFamily) string {
 	for _, ip := range ips {
 		if family == getFamily(ip) {
 			return ip
@@ -22,9 +28,9 @@ func getIp(ips []string, family v1.IPFamily) string {
 	return ""
 }
 
-func getFamily(ip string) v1.IPFamily {
+func getFamily(ip string) k8sv1.IPFamily {
 	if netutils.IsIPv6String(ip) {
-		return v1.IPv6Protocol
+		return k8sv1.IPv6Protocol
 	}
-	return v1.IPv4Protocol
+	return k8sv1.IPv4Protocol
 }

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -47,6 +47,8 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", func() {
@@ -790,6 +792,107 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 					return nil
 				}, 120*time.Second).Should(Succeed())
 			})
+		})
+
+		Context("MTU verification", func() {
+			var vmi *v1.VirtualMachineInstance
+			var anotherVmi *v1.VirtualMachineInstance
+
+			getMtu := func(pod *k8sv1.Pod, ifaceName string) int {
+				output, err := tests.ExecuteCommandOnPod(
+					virtClient,
+					pod,
+					"compute",
+					[]string{"cat", fmt.Sprintf("/sys/class/net/%s/mtu", ifaceName)},
+				)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+				output = strings.TrimSuffix(output, "\n")
+				mtu, err := strconv.Atoi(output)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+				return mtu
+			}
+
+			BeforeEach(func() {
+				var err error
+
+				By("Create VMI")
+				vmi = libvmi.NewFedora()
+
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Create another VMI")
+				anotherVmi = masqueradeVMI([]v1.Port{}, "")
+				anotherVmi, err = virtClient.VirtualMachineInstance(anotherVmi.Namespace).Create(anotherVmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Wait for VMIs to be ready")
+				tests.WaitUntilVMIReady(anotherVmi, tests.LoggedInCirrosExpecter)
+				anotherVmi, err = virtClient.VirtualMachineInstance(anotherVmi.Namespace).Get(anotherVmi.Name, &v13.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				tests.WaitUntilVMIReady(vmi, tests.LoggedInFedoraExpecter)
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				if vmi != nil {
+					By("Delete VMI")
+					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &v13.DeleteOptions{})).To(Succeed())
+				}
+			})
+
+			AfterEach(func() {
+				if anotherVmi != nil {
+					By("Delete another VMI")
+					Expect(virtClient.VirtualMachineInstance(anotherVmi.Namespace).Delete(anotherVmi.Name, &v13.DeleteOptions{})).To(Succeed())
+				}
+			})
+
+			table.DescribeTable("should have the correct MTU", func(ipFamily k8sv1.IPFamily) {
+				if ipFamily == k8sv1.IPv6Protocol {
+					libnet.SkipWhenNotDualStackCluster(virtClient)
+				}
+
+				By("checking k6t-eth0 MTU inside the pod")
+				vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
+				bridgeMtu := getMtu(vmiPod, "k6t-eth0")
+				primaryIfaceMtu := getMtu(vmiPod, "eth0")
+
+				Expect(bridgeMtu).To(Equal(primaryIfaceMtu), "k6t-eth0 bridge mtu should equal eth0 interface mtu")
+
+				By("checking k6t-eth0-nic MTU inside the pod")
+				bridgePrimaryNicMtu := getMtu(vmiPod, "k6t-eth0-nic")
+				Expect(bridgePrimaryNicMtu).To(Equal(primaryIfaceMtu), "k6t-eth0-nic mtu should equal eth0 interface mtu")
+
+				By("checking eth0 MTU inside the VirtualMachineInstance")
+				showMtu := "cat /sys/class/net/eth0/mtu\n"
+				err = tests.CheckForTextExpecter(vmi, []expect.Batcher{
+					&expect.BSnd{S: showMtu},
+					&expect.BExp{R: tests.RetValue(strconv.Itoa(bridgeMtu))},
+				}, 180)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
+				icmpHeaderSize := 8
+				var ipHeaderSize int
+				if ipFamily == k8sv1.IPv4Protocol {
+					ipHeaderSize = 20
+				} else {
+					ipHeaderSize = 40
+				}
+				payloadSize := primaryIfaceMtu - ipHeaderSize - icmpHeaderSize
+				addr := libnet.GetVmiPrimaryIpByFamily(anotherVmi, ipFamily)
+				Expect(tests.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize), "-M do")).To(Succeed())
+
+				By("checking the VirtualMachineInstance cannot send bigger than MTU sized frames to another VirtualMachineInstance")
+				Expect(tests.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize+1), "-M do")).ToNot(Succeed())
+			},
+				table.Entry("IPv4", k8sv1.IPv4Protocol),
+				table.Entry("IPv6", k8sv1.IPv6Protocol),
+			)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since on masquerade binding the bridge is not the master of pod interface,
it doesn't automatically get the mtu of the interface.
This PR copies the mtu from the pod interface and sets it on the bridge.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Masquerade binding - set the virt-launcher pod interface MTU on the bridge.
```
