### PR TITLE
tests, infra-test, Solve CI flakiness due to update conflict

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -237,7 +237,11 @@ var _ = Describe("[Serial]Infrastructure", func() {
 
 				nodeCopy := selectedNode.DeepCopy()
 				nodeCopy.ResourceVersion = ""
-				_, err = virtClient.CoreV1().Nodes().Update(nodeCopy)
+
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					_, err := virtClient.CoreV1().Nodes().Update(nodeCopy)
+					return err
+				})
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 
@@ -308,7 +312,11 @@ var _ = Describe("[Serial]Infrastructure", func() {
 					Value:  "",
 					Effect: k8sv1.TaintEffectNoExecute,
 				})
-				_, err = virtClient.CoreV1().Nodes().Update(selectedNodeCopy)
+
+				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					_, err := virtClient.CoreV1().Nodes().Update(selectedNodeCopy)
+					return err
+				})
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Consistently(terminatedPodsCn, 5*time.Second).ShouldNot(Receive(), "pods should not terminate")


### PR DESCRIPTION
Add `RetryOnConflict` in order to fix
`the object has been modified; please apply your changes to the latest version and try again.`
which can be caused by a legitimate k8s node update operation,
and require a reconcile retry.
    
Its important to add it also to the AfterEach,
else a conflict there might break the cluster
for the rests of the tests.

Signed-off-by: Or Shoval <oshoval@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: https://github.com/kubevirt/kubevirt/issues/4286

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
