### PR TITLE
Fix flaky unpause tests

### DIFF
--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -301,10 +301,16 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					}
 					Expect(err).ToNot(HaveOccurred())
 					return false
-				}, 300*time.Second, 1*time.Second).Should(BeTrue(), "The VMI did not disappear")
+				}, 60*time.Second, 1*time.Second).Should(BeTrue(), "The VMI did not disappear")
 
 				By("Waiting for for new VMI to start")
-				newVMI := v1.NewMinimalVMIWithNS(vm.Namespace, vm.Name)
+				Eventually(func() error {
+					_, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
+					return err
+				}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred(), "No new VMI appeared")
+
+				newVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &v12.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
 				tests.WaitForSuccessfulVMIStartWithTimeout(newVMI, 300)
 
 				By("Ensuring unpaused state")


### PR DESCRIPTION
**What this PR does / why we need it**:

The test

```
[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component]Pausing A valid VM when paused via virtctl [test_id:3226]should be restarted successfully into unpaused state
```


Sometimes, after a VM restart the new VMI is not yet there when we
expect it to be already present. Wait now explicitly for the
re-creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Here an example run where it failed: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/3837/pull-kubevirt-e2e-k8s-1.17/1311373258406236160

**Release note**:
```release-note
NONE
```
