### PR TITLE
Fix flaky rename test

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1729,9 +1729,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					return err
 				}, 10*time.Second, 1*time.Second).Should(BeNil())
 
-				_, err = cli.Get(vm1.Name, &v12.GetOptions{})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("not found"))
+				Eventually(func() error {
+					_, err = cli.Get(vm1.Name, &v12.GetOptions{})
+
+					return err
+				}, 10*time.Second, 1*time.Second).Should(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

If the controller needs a little bit longer than usual to delete the old
VM, one can still observe the olf VM for some time until it is finally
gone. Retry a few times to see if the old VM will disappear as expected.

Resolves issues like this:

```

[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachine VM rename VM update [test_id:4659]should succeed expand_less | 5s
-- | --
tests/vm_test.go:1736 Expected an error to have occurred.  Got:     <nil>: nil tests/vm_test.go:1747
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

An example can be found here: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4249/pull-kubevirt-e2e-k8s-1.18/1309972904657555456

Also created #4294 to follow up on the feature, since it does not seem to be save to use in general.

**Release note**:

```release-note
NONE
```
