### PR TITLE
tests: move ping to libnet and move expecter helpers to a new console package

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
-        "expecter.go",
         "job.go",
         "login.go",
         "ping.go",
@@ -31,6 +30,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/libnet:go_default_library",
@@ -196,6 +196,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
+        "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/libnet:go_default_library",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
         "config.go",
         "job.go",
         "login.go",
-        "ping.go",
         "pod_servers.go",
         "test.go",
         "utils.go",

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -32,6 +32,7 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -105,7 +106,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					// mount iso ConfigMap image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -199,7 +200,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					// mount iso Secret image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutput},
 				}, 200*time.Second)
@@ -282,7 +283,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				// mount service account iso image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0")},
+				&expect.BExp{R: console.RetValue("0")},
 				&expect.BSnd{S: "cat /mnt/namespace\n"},
 				&expect.BExp{R: tests.NamespaceTestDefault},
 				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
@@ -377,7 +378,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: "#"},
 					&expect.BSnd{S: "mount /dev/vdc /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
 					&expect.BExp{R: expectedOutputCfgMap},
 				}, 200*time.Second)
@@ -403,7 +404,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					// mount Secret image
 					&expect.BSnd{S: "mount /dev/vdd /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutputSecret},
 				}, 200*time.Second)
@@ -501,13 +502,13 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: "\\#"},
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "grep \"PRIVATE KEY\" /mnt/ssh-privatekey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "grep ssh-rsa /mnt/ssh-publickey\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 200*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/console/BUILD.bazel
+++ b/tests/console/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["console.go"],
+    importpath = "kubevirt.io/kubevirt/tests/console",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/google/goexpect:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+    ],
+)

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -17,7 +17,7 @@
  *
  */
 
-package tests
+package console
 
 import (
 	"fmt"
@@ -74,7 +74,9 @@ func VmiConsoleExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Bat
 // NOTE: This functions heritage limitations from `ExpectBatchWithValidatedSend` refer to it to check them.
 func CheckForTextExpecter(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
 	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
+	if err != nil {
+		panic(err)
+	}
 	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 	if err != nil {
 		return err
@@ -119,7 +121,9 @@ func VmiConsoleRunCommand(vmi *v1.VirtualMachineInstance, command string, timeou
 // It will parse the kernel output (dmesg) and succeed if it finds that Secure boot is enabled
 func SecureBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
+	if err != nil {
+		return nil, err
+	}
 	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
@@ -141,7 +145,9 @@ func SecureBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error)
 // It will parse the SeaBIOS output and succeed if it finds the string "iPXE"
 func NetBootExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
-	PanicOnError(err)
+	if err != nil {
+		return nil, err
+	}
 	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -33,6 +33,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -59,7 +60,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 
 	ExpectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {
 		By("Expecting the VirtualMachineInstance console")
-		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+		expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			By("Closing the opened expecter")
@@ -67,7 +68,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 		}()
 
 		By("Checking that the console output equals to expected one")
-		_, err = tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+		_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: expected},
 		}, 120*time.Second)
@@ -76,7 +77,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 
 	OpenConsole := func(vmi *v1.VirtualMachineInstance) (expect.Expecter, <-chan error) {
 		By("Expecting the VirtualMachineInstance console")
-		expecter, errChan, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+		expecter, errChan, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		return expecter, errChan
 	}
@@ -229,7 +230,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
 
 				By("Expecting the VirtualMachineInstance console")
-				_, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+				_, _, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
 			})

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -60,7 +60,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 
 	ExpectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {
 		By("Expecting the VirtualMachineInstance console")
-		expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+		expecter, _, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		defer func() {
 			By("Closing the opened expecter")
@@ -77,7 +77,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 
 	OpenConsole := func(vmi *v1.VirtualMachineInstance) (expect.Expecter, <-chan error) {
 		By("Expecting the VirtualMachineInstance console")
-		expecter, errChan, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+		expecter, errChan, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		return expecter, errChan
 	}
@@ -230,7 +230,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				Expect(virtClient.RestClient().Post().Resource("virtualmachineinstances").Namespace(tests.NamespaceTestDefault).Body(vmi).Do().Error()).To(Succeed())
 
 				By("Expecting the VirtualMachineInstance console")
-				_, _, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+				_, _, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Timeout trying to connect to the virtual machine instance"))
 			})

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -36,6 +36,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -211,11 +212,11 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cd /media/cdrom\n"},
 					&expect.BSnd{S: "ls virtio-win_license.txt guest-agent\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "expected virtio files to be mounted properly")
 			})

--- a/tests/libnet/BUILD.bazel
+++ b/tests/libnet/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cluster.go",
         "dns.go",
         "ipaddress.go",
+        "ping.go",
         "skips.go",
         "validation.go",
     ],
@@ -15,6 +16,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/console:go_default_library",
         "//tests/flags:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -17,7 +17,7 @@
  *
  */
 
-package tests
+package libnet
 
 import (
 	"fmt"

--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -48,7 +48,7 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 	args = append([]string{pingString, ipAddr}, args...)
 	cmdCheck := strings.Join(args, " ")
 
-	err := console.VmiConsoleRunCommand(vmi, cmdCheck, maxCommandTimeout)
+	err := console.RunCommand(vmi, cmdCheck, maxCommandTimeout)
 	if err != nil {
 		return fmt.Errorf("Failed to ping VMI %s, error: %v", vmi.Name, err)
 	}

--- a/tests/login.go
+++ b/tests/login.go
@@ -13,6 +13,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
+	"kubevirt.io/kubevirt/tests/console"
 )
 
 // LoginToCirros call LoggedInFedoraExpecter but does not return the expecter
@@ -27,7 +28,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +77,7 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +108,7 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -188,11 +189,11 @@ func configureConsole(expecter expect.Expecter, prompt string, shouldSudo bool) 
 		&expect.BSnd{S: "stty cols 500 rows 500\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")},
+		&expect.BExp{R: console.RetValue("0")},
 		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: RetValue("0")}})
+		&expect.BExp{R: console.RetValue("0")}})
 	resp, err := expecter.ExpectBatch(batch, 30*time.Second)
 	if err != nil {
 		log.DefaultLogger().Infof("%v", resp)

--- a/tests/login.go
+++ b/tests/login.go
@@ -28,7 +28,7 @@ func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func LoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 func ReLoggedInFedoraExpecter(vmi *v1.VirtualMachineInstance, timeout int) (expect.Expecter, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+	expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -369,7 +369,7 @@ func checkHTTPPing(vmi *v1.VirtualMachineInstance, ip string, port int) error {
 	const curlCheckCmd = "curl --head %s --connect-timeout 5\n"
 	url := fmt.Sprintf("http://%s", net.JoinHostPort(ip, strconv.Itoa(port)))
 	curlCheck := fmt.Sprintf(curlCheckCmd, url)
-	err := console.VmiConsoleRunCommand(vmi, curlCheck, 10*time.Second)
+	err := console.RunCommand(vmi, curlCheck, 10*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed HTTP ping from vmi(%s/%s) to url(%s): %v", vmi.Namespace, vmi.Name, url, err)
 	}

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
@@ -367,7 +368,7 @@ func checkHTTPPing(vmi *v1.VirtualMachineInstance, ip string, port int) error {
 	const curlCheckCmd = "curl --head %s --connect-timeout 5\n"
 	url := fmt.Sprintf("http://%s", net.JoinHostPort(ip, strconv.Itoa(port)))
 	curlCheck := fmt.Sprintf(curlCheckCmd, url)
-	err := tests.VmiConsoleRunCommand(vmi, curlCheck, 10*time.Second)
+	err := console.VmiConsoleRunCommand(vmi, curlCheck, 10*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed HTTP ping from vmi(%s/%s) to url(%s): %v", vmi.Namespace, vmi.Name, url, err)
 	}

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -263,7 +264,7 @@ func createVMICirros(virtClient kubecli.KubevirtClient, namespace string, labels
 func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
 	ConsistentlyWithOffset(1, func() error {
 		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
-			if err := tests.PingFromVMConsole(fromVmi, toIp); err != nil {
+			if err := libnet.PingFromVMConsole(fromVmi, toIp); err != nil {
 				return err
 			}
 		}
@@ -276,7 +277,7 @@ func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
 	EventuallyWithOffset(1, func() error {
 		var err error
 		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
-			if err = tests.PingFromVMConsole(fromVmi, toIp); err == nil {
+			if err = libnet.PingFromVMConsole(fromVmi, toIp); err == nil {
 				return nil
 			}
 		}
@@ -286,7 +287,7 @@ func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
 	ConsistentlyWithOffset(1, func() error {
 		var err error
 		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
-			if err = tests.PingFromVMConsole(fromVmi, toIp); err == nil {
+			if err = libnet.PingFromVMConsole(fromVmi, toIp); err == nil {
 				return nil
 			}
 		}

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -41,6 +41,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -371,9 +372,9 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 	Context("A long running process", func() {
 
 		grepSleepPid := func(expecter expect.Expecter) string {
-			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: `pgrep -f "sleep 8"` + "\n"},
-				&expect.BExp{R: tests.RetValue("[0-9]+")}, // pid
+				&expect.BExp{R: console.RetValue("[0-9]+")}, // pid
 			}, 15*time.Second)
 			log.DefaultLogger().Infof("a:%+v\n", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -383,7 +384,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 		startProcess := func(expecter expect.Expecter) string {
 			By("Start a long running process")
-			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "sleep 8&\n"},
 				&expect.BExp{R: "\\# "},     // prompt
 				&expect.BSnd{S: "disown\n"}, // avoid "garbage" print in terminal on completion

--- a/tests/ping.go
+++ b/tests/ping.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/tests/console"
 )
 
 // PingFromVMConsole performs a ping through the provided VMI console.
@@ -47,7 +48,7 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 	args = append([]string{pingString, ipAddr}, args...)
 	cmdCheck := strings.Join(args, " ")
 
-	err := VmiConsoleRunCommand(vmi, cmdCheck, maxCommandTimeout)
+	err := console.VmiConsoleRunCommand(vmi, cmdCheck, maxCommandTimeout)
 	if err != nil {
 		return fmt.Errorf("Failed to ping VMI %s, error: %v", vmi.Name, err)
 	}

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -387,13 +388,13 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 						&expect.BSnd{S: fmt.Sprintf("sudo mkfs.ext4 %s\n", device)},
 						&expect.BExp{R: "\\$ "},
 						&expect.BSnd{S: "echo $?\n"},
-						&expect.BExp{R: tests.RetValue("0")},
+						&expect.BExp{R: console.RetValue("0")},
 						&expect.BSnd{S: "sudo mkdir -p /test\n"},
 						&expect.BExp{R: "\\$ "},
 						&expect.BSnd{S: fmt.Sprintf("sudo mount %s /test \n", device)},
 						&expect.BExp{R: "\\$ "},
 						&expect.BSnd{S: "echo $?\n"},
-						&expect.BExp{R: tests.RetValue("0")},
+						&expect.BExp{R: console.RetValue("0")},
 					}...)
 				}
 
@@ -441,7 +442,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 						&expect.BSnd{S: fmt.Sprintf("sudo mount %s /test \n", device)},
 						&expect.BExp{R: "\\$ "},
 						&expect.BSnd{S: "echo $?\n"},
-						&expect.BExp{R: tests.RetValue("0")},
+						&expect.BExp{R: console.RetValue("0")},
 					}...)
 				}
 
@@ -496,7 +497,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 						&expect.BSnd{S: fmt.Sprintf("sudo mount %s /test \n", device)},
 						&expect.BExp{R: "\\$ "},
 						&expect.BSnd{S: "echo $?\n"},
-						&expect.BExp{R: tests.RetValue("0")},
+						&expect.BExp{R: console.RetValue("0")},
 					}...)
 				}
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/client-go/log"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
 )
@@ -237,7 +238,7 @@ var _ = Describe("[Serial]Storage", func() {
 					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 20*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -345,7 +346,7 @@ var _ = Describe("[Serial]Storage", func() {
 				listVirtioFSDisk := fmt.Sprintf("ls -l %s/*disk* | wc -l\n", virtiofsMountPath)
 				_, err = expecter.ExpectBatch([]expect.Batcher{
 					&expect.BSnd{S: listVirtioFSDisk},
-					&expect.BExp{R: tests.RetValue("1")},
+					&expect.BExp{R: console.RetValue("1")},
 				}, 30*time.Second)
 				Expect(err).ToNot(HaveOccurred(), "Should be able to access the mounted virtiofs file")
 
@@ -456,7 +457,7 @@ var _ = Describe("[Serial]Storage", func() {
 					// Because "/" is mounted on tmpfs, we need something that normally persists writes - /dev/sda2 is the EFI partition formatted as vFAT.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "echo content > /mnt/checkpoint\n"},
 					// The QEMU process will be killed, therefore the write must be flushed to the disk.
 					&expect.BSnd{S: "sync\n"},
@@ -484,10 +485,10 @@ var _ = Describe("[Serial]Storage", func() {
 					// Same story as when first starting the VirtualMachineInstance - the checkpoint, if persisted, is located at /dev/sda2.
 					&expect.BSnd{S: "mount /dev/sda2 /mnt\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/checkpoint &> /dev/null\n"},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("1")},
+					&expect.BExp{R: console.RetValue("1")},
 				}, 200*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -31,6 +31,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 )
@@ -62,20 +63,20 @@ var _ = Describe("CloudInitHookSidecars", func() {
 	}
 	MountCloudInit := func(vmi *v1.VirtualMachineInstance, prompt string) {
 		cmdCheck := "mount $(blkid  -L cidata) /mnt/\n"
-		err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+		err := console.CheckForTextExpecter(vmi, []expect.Batcher{
 			&expect.BSnd{S: "sudo su -\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: cmdCheck},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "echo $?\n"},
-			&expect.BExp{R: tests.RetValue("0")},
+			&expect.BExp{R: console.RetValue("0")},
 		}, 15)
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	CheckCloudInitFile := func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
 		cmdCheck := "cat /mnt/" + testFile + "\n"
-		err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+		err := console.CheckForTextExpecter(vmi, []expect.Batcher{
 			&expect.BSnd{S: "sudo su -\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: cmdCheck},

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -63,7 +63,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 	}
 	MountCloudInit := func(vmi *v1.VirtualMachineInstance, prompt string) {
 		cmdCheck := "mount $(blkid  -L cidata) /mnt/\n"
-		err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+		err := console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "sudo su -\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: cmdCheck},
@@ -76,7 +76,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 
 	CheckCloudInitFile := func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
 		cmdCheck := "cat /mnt/" + testFile + "\n"
-		err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+		err := console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "sudo su -\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: cmdCheck},

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -83,7 +83,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
 			By("Expecting the VirtualMachineInstance console")
-			expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+			expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 
@@ -96,7 +96,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		mountCloudInitFunc := func(devName string) func(*v1.VirtualMachineInstance, string) {
 			return func(vmi *v1.VirtualMachineInstance, prompt string) {
 				cmdCheck := fmt.Sprintf("mount $(blkid  -L %s) /mnt/\n", devName)
-				err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+				err := console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo su -\n"},
 					&expect.BExp{R: prompt},
 					&expect.BSnd{S: cmdCheck},
@@ -113,7 +113,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		CheckCloudInitFile = func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
 			cmdCheck := "cat /mnt/" + testFile + "\n"
-			err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "sudo su -\n"},
 				&expect.BExp{R: prompt},
 				&expect.BSnd{S: cmdCheck},
@@ -125,7 +125,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			cmdCheck := "cat /mnt/" + testFile + "\n"
 			virtClient, err := kubecli.GetKubevirtClient()
 			tests.PanicOnError(err)
-			expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+			expecter, _, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -82,7 +83,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
 			By("Expecting the VirtualMachineInstance console")
-			expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+			expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 
@@ -95,13 +96,13 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		mountCloudInitFunc := func(devName string) func(*v1.VirtualMachineInstance, string) {
 			return func(vmi *v1.VirtualMachineInstance, prompt string) {
 				cmdCheck := fmt.Sprintf("mount $(blkid  -L %s) /mnt/\n", devName)
-				err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+				err := console.CheckForTextExpecter(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo su -\n"},
 					&expect.BExp{R: prompt},
 					&expect.BSnd{S: cmdCheck},
 					&expect.BExp{R: prompt},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 15)
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -112,7 +113,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		CheckCloudInitFile = func(vmi *v1.VirtualMachineInstance, prompt, testFile, testData string) {
 			cmdCheck := "cat /mnt/" + testFile + "\n"
-			err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+			err := console.CheckForTextExpecter(vmi, []expect.Batcher{
 				&expect.BSnd{S: "sudo su -\n"},
 				&expect.BExp{R: prompt},
 				&expect.BSnd{S: cmdCheck},
@@ -124,7 +125,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			cmdCheck := "cat /mnt/" + testFile + "\n"
 			virtClient, err := kubecli.GetKubevirtClient()
 			tests.PanicOnError(err)
-			expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
+			expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 30*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -49,6 +49,7 @@ import (
 	hw_utils "kubevirt.io/kubevirt/pkg/util/hardware"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -484,7 +485,7 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Expecting no bootable NIC")
-				_, err = tests.NetBootExpecter(vmi)
+				_, err = console.NetBootExpecter(vmi)
 				// The expecter *should* have error-ed since the network interface is not marked bootable
 				Expect(err).To(HaveOccurred())
 			})
@@ -512,7 +513,7 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Expecting a bootable NIC")
-				_, err = tests.NetBootExpecter(vmi)
+				_, err = console.NetBootExpecter(vmi)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -541,7 +542,7 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Checking if SecureBoot is enabled in Linux")
-				tests.WaitUntilVMIReady(vmi, tests.SecureBootExpecter)
+				tests.WaitUntilVMIReady(vmi, console.SecureBootExpecter)
 
 				By("Checking if SecureBoot is enabled in the libvirt XML")
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
@@ -620,13 +621,13 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.RetValue("pass")},
+					&expect.BExp{R: console.RetValue("pass")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -678,9 +679,9 @@ var _ = Describe("Configurations", func() {
 				defer expecter.Close()
 
 				// Check on the VM, if the Free memory is roughly what we expected
-				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 95 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.RetValue("pass")},
+					&expect.BExp{R: console.RetValue("pass")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -1878,7 +1879,7 @@ var _ = Describe("Configurations", func() {
 			// NOTE: we have one disk per bus, so we expect vda, sda
 		})
 		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string, prompt string) {
-			err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+			err := console.CheckForTextExpecter(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: prompt},
 				&expect.BSnd{S: "grep DEVNAME /sys/bus/pci/devices/" + expectedPciAddress + "/*/block/vda/uevent|awk -F= '{ print $2 }'\n"},
@@ -2116,13 +2117,13 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 				defer expecter.Close()
 
-				res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -lt 80 ] && echo 'pass'\n"},
-					&expect.BExp{R: tests.RetValue("pass")},
+					&expect.BExp{R: console.RetValue("pass")},
 					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "echo $?\n"},
-					&expect.BExp{R: tests.RetValue("0")},
+					&expect.BExp{R: console.RetValue("0")},
 				}, 15*time.Second)
 				log.DefaultLogger().Object(vmi).Infof("%v", res)
 				Expect(err).ToNot(HaveOccurred())
@@ -2465,9 +2466,9 @@ var _ = Describe("Configurations", func() {
 
 			By("Check value in VM with dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
-			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') = Test-123 ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2511,13 +2512,13 @@ var _ = Describe("Configurations", func() {
 
 			By("Check values in dmidecode")
 			// Check on the VM, if expected values are there with dmidecode
-			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = KubeVirt ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2552,13 +2553,13 @@ var _ = Describe("Configurations", func() {
 			By("Check values in dmidecode")
 
 			// Check on the VM, if expected values are there with dmidecode
-			res, err := tests.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-family | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-product-name | tr -s ' ') = test ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 				&expect.BSnd{S: "[ $(sudo dmidecode -s system-manufacturer | tr -s ' ') = None ] && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2772,9 +2773,9 @@ var _ = Describe("Configurations", func() {
 			By("Check virt-what-cpuid-helper does not match KVM")
 			res, err := expecter.ExpectBatch([]expect.Batcher{
 				&expect.BSnd{S: "virt-what-cpuid-helper > /dev/null 2>&1 && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 				&expect.BSnd{S: "$(sudo virt-what-cpuid-helper | grep -q KVMKVMKVM) || echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())
@@ -2794,9 +2795,9 @@ var _ = Describe("Configurations", func() {
 			By("Check virt-what-cpuid-helper matches KVM")
 			res, err := expecter.ExpectBatch([]expect.Batcher{
 				&expect.BSnd{S: "virt-what-cpuid-helper > /dev/null 2>&1 && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 				&expect.BSnd{S: "$(sudo virt-what-cpuid-helper | grep -q KVMKVMKVM) && echo 'pass'\n"},
-				&expect.BExp{R: tests.RetValue("pass")},
+				&expect.BExp{R: console.RetValue("pass")},
 			}, 1*time.Second)
 			log.DefaultLogger().Object(vmi).Infof("%v", res)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1879,7 +1879,7 @@ var _ = Describe("Configurations", func() {
 			// NOTE: we have one disk per bus, so we expect vda, sda
 		})
 		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string, prompt string) {
-			err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: prompt},
 				&expect.BSnd{S: "grep DEVNAME /sys/bus/pci/devices/" + expectedPciAddress + "/*/block/vda/uevent|awk -F= '{ print $2 }'\n"},

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -18,6 +18,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -38,13 +39,13 @@ func parseDeviceAddress(addrString string) []string {
 
 func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt string) {
 	cmdCheck := fmt.Sprintf("lspci -m %s\n", gpuName)
-	err := tests.CheckForTextExpecter(vmi, []expect.Batcher{
+	err := console.CheckForTextExpecter(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: cmdCheck},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: "echo $?\n"},
-		&expect.BExp{R: tests.RetValue("0")},
+		&expect.BExp{R: console.RetValue("0")},
 	}, 15)
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -39,7 +39,7 @@ func parseDeviceAddress(addrString string) []string {
 
 func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string, prompt string) {
 	cmdCheck := fmt.Sprintf("lspci -m %s\n", gpuName)
-	err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: cmdCheck},

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -59,7 +59,7 @@ var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][leve
 
 		VerifyIgnitionDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
 			By("Expecting the VirtualMachineInstance console")
-			expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+			expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -30,6 +30,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -58,7 +59,7 @@ var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][leve
 
 		VerifyIgnitionDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
 			By("Expecting the VirtualMachineInstance console")
-			expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+			expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 			defer expecter.Close()
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -319,7 +319,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Checking console text")
-				err = console.CheckForTextExpecter(vmi, []expect.Batcher{
+				err = console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: consoleText},
 				}, wait)

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -47,6 +47,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 )
@@ -318,7 +319,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Checking console text")
-				err = tests.CheckForTextExpecter(vmi, []expect.Batcher{
+				err = console.CheckForTextExpecter(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: consoleText},
 				}, wait)

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -30,6 +30,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 )
 
 var _ = Describe("Health Monitoring", func() {
@@ -60,7 +61,7 @@ var _ = Describe("Health Monitoring", func() {
 				&expect.BSnd{S: "watchdog -t 2000ms -T 4000ms /dev/watchdog && sleep 5 && killall -9 watchdog\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "echo $?\n"},
-				&expect.BExp{R: tests.RetValue("0")},
+				&expect.BExp{R: console.RetValue("0")},
 			}, 250*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/libnet"
 )
 
 const (
@@ -169,7 +170,7 @@ var _ = Describe("[Serial]Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
 
 			It("[test_id:1752]should create a virtual machine with one interface with network definition from different namespace", func() {
@@ -187,7 +188,7 @@ var _ = Describe("[Serial]Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
 
 			It("[test_id:1753]should create a virtual machine with two interfaces", func() {
@@ -223,7 +224,7 @@ var _ = Describe("[Serial]Multus", func() {
 				checkInterface(detachedVMI, "eth0", "\\$ ")
 				checkInterface(detachedVMI, "eth1", "\\$ ")
 
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
 		})
 
@@ -245,7 +246,7 @@ var _ = Describe("[Serial]Multus", func() {
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
-				Expect(tests.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 
 				By("checking virtual machine instance only has one interface")
 				// lo0, eth0
@@ -337,7 +338,7 @@ var _ = Describe("[Serial]Multus", func() {
 				checkInterface(vmiTwo, "eth0", "localhost:~#")
 
 				By("ping between virtual machines")
-				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 
 			It("[test_id:1578]should create two virtual machines with two interfaces", func() {
@@ -366,7 +367,7 @@ var _ = Describe("[Serial]Multus", func() {
 				checkInterface(vmiTwo, "eth1", "localhost:~#")
 
 				By("ping between virtual machines")
-				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 		})
 
@@ -410,7 +411,7 @@ var _ = Describe("[Serial]Multus", func() {
 				Expect(strings.Contains(out, customMacAddress)).To(BeFalse())
 
 				By("Ping from the VM with the custom MAC to the other VM.")
-				Expect(tests.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmiOne, "10.1.1.2")).To(Succeed())
 			})
 		})
 		Context("Single VirtualMachineInstance with Linux bridge CNI plugin interface", func() {
@@ -861,8 +862,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 			configInterface(vmi2, "eth1", cidrB, "#")
 
 			// now check ICMP goes both ways
-			Expect(tests.PingFromVMConsole(vmi1, cidrToIP(cidrB))).To(Succeed())
-			Expect(tests.PingFromVMConsole(vmi2, cidrToIP(cidrA))).To(Succeed())
+			Expect(libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))).To(Succeed())
+			Expect(libnet.PingFromVMConsole(vmi2, cidrToIP(cidrA))).To(Succeed())
 		}
 
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -210,7 +210,7 @@ var _ = Describe("[Serial]Multus", func() {
 				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
 				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
-				err = console.CheckForTextExpecter(detachedVMI, []expect.Batcher{
+				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: cmdCheck},
@@ -250,7 +250,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				By("checking virtual machine instance only has one interface")
 				// lo0, eth0
-				err = console.CheckForTextExpecter(detachedVMI, []expect.Batcher{
+				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: "\\$ "},
 					&expect.BSnd{S: "ip link show | grep -c UP\n"},
@@ -297,7 +297,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				By("Verifying the desired custom MAC is the one that was actually configured on the interface.")
 				ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
-				err = console.CheckForTextExpecter(vmiOne, []expect.Batcher{
+				err = console.SafeExpectBatch(vmiOne, []expect.Batcher{
 					&expect.BSnd{S: ipLinkShow},
 					&expect.BExp{R: "1"},
 				}, 15)
@@ -393,7 +393,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				By("Verifying the desired custom MAC is the one that were actually configured on the interface.")
 				ipLinkShow := fmt.Sprintf("ip link show eth0 | grep -i \"%s\" | wc -l\n", customMacAddress)
-				err = console.CheckForTextExpecter(vmiOne, []expect.Batcher{
+				err = console.SafeExpectBatch(vmiOne, []expect.Batcher{
 					&expect.BSnd{S: ipLinkShow},
 					&expect.BExp{R: "1"},
 				}, 15)
@@ -446,11 +446,11 @@ var _ = Describe("[Serial]Multus", func() {
 				}
 				Expect(interfacesByName["default"].MAC).To(Not(Equal(interfacesByName["linux-bridge"].MAC)))
 
-				err = console.CheckForTextExpecter(updatedVmi, []expect.Batcher{
+				err = console.SafeExpectBatch(updatedVmi, []expect.Batcher{
 					&expect.BSnd{S: fmt.Sprintf("ip addr show eth0 | grep %s | wc -l", interfacesByName["default"].MAC)},
 					&expect.BExp{R: "1"},
 				}, 15)
-				err = console.CheckForTextExpecter(updatedVmi, []expect.Batcher{
+				err = console.SafeExpectBatch(updatedVmi, []expect.Batcher{
 					&expect.BSnd{S: fmt.Sprintf("ip addr show eth1 | grep %s | wc -l", interfacesByName["linux-bridge"].MAC)},
 					&expect.BExp{R: "1"},
 				}, 15)
@@ -884,7 +884,7 @@ func cidrToIP(cidr string) string {
 
 func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAddress, prompt string) {
 	cmdCheck := fmt.Sprintf("ip addr add %s dev %s\n", interfaceAddress, interfaceName)
-	err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: cmdCheck},
@@ -895,7 +895,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 	Expect(err).ToNot(HaveOccurred(), "Failed to configure address %s for interface %s on VMI %s", interfaceAddress, interfaceName, vmi.Name)
 
 	cmdCheck = fmt.Sprintf("ip link set %s up\n", interfaceName)
-	err = console.CheckForTextExpecter(vmi, []expect.Batcher{
+	err = console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: cmdCheck},
@@ -908,7 +908,7 @@ func configInterface(vmi *v1.VirtualMachineInstance, interfaceName, interfaceAdd
 
 func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string) {
 	cmdCheck := fmt.Sprintf("ip link show %s\n", interfaceName)
-	err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: prompt},
 		&expect.BSnd{S: cmdCheck},
@@ -921,7 +921,7 @@ func checkInterface(vmi *v1.VirtualMachineInstance, interfaceName, prompt string
 
 func checkMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress string) {
 	cmdCheck := fmt.Sprintf("ip link show %s\n", interfaceName)
-	err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+	err := console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: console.PromptExpression},
 		&expect.BSnd{S: cmdCheck},

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -74,7 +74,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 	})
 
 	checkMacAddress := func(vmi *v1.VirtualMachineInstance, expectedMacAddress string, prompt string) {
-		err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+		err := console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "cat /sys/class/net/eth0/address\n"},
@@ -84,7 +84,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 	}
 
 	checkNetworkVendor := func(vmi *v1.VirtualMachineInstance, expectedVendor string, prompt string) {
-		err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+		err := console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: prompt},
 			&expect.BSnd{S: "cat /sys/class/net/eth0/device/vendor\n"},
@@ -224,7 +224,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			// NOTE: cirros ping doesn't support -M do that could be used to
 			// validate end-to-end connectivity with Don't Fragment flag set
 			cmdCheck = fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
-			err = console.CheckForTextExpecter(outboundVMI, []expect.Batcher{
+			err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: cmdCheck},
@@ -235,7 +235,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking the VirtualMachineInstance can fetch via HTTP")
-			err = console.CheckForTextExpecter(outboundVMI, []expect.Batcher{
+			err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "curl --silent http://kubevirt.io > /dev/null\n"},
@@ -428,7 +428,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
 
-			err := console.CheckForTextExpecter(detachedVMI, []expect.Batcher{
+			err := console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$ "},
 				&expect.BSnd{S: "ls /sys/class/net/ | wc -l\n"},
@@ -487,7 +487,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 		})
 
 		checkPciAddress := func(vmi *v1.VirtualMachineInstance, expectedPciAddress string, prompt string) {
-			err := console.CheckForTextExpecter(vmi, []expect.Batcher{
+			err := console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: prompt},
 				&expect.BSnd{S: "grep INTERFACE /sys/bus/pci/devices/" + expectedPciAddress + "/*/net/eth0/uevent|awk -F= '{ print $2 }'\n"},
@@ -551,7 +551,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 			tests.WaitUntilVMIReady(dhcpVMI, tests.LoggedInFedoraExpecter)
 
-			err = console.CheckForTextExpecter(dhcpVMI, []expect.Batcher{
+			err = console.SafeExpectBatch(dhcpVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\#"},
 				&expect.BSnd{S: "dhclient -1 -r -d eth0\n"},
@@ -588,7 +588,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(dnsVMI)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitUntilVMIReady(dnsVMI, tests.LoggedInCirrosExpecter)
-			err = console.CheckForTextExpecter(dnsVMI, []expect.Batcher{
+			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: "\\$"},
 				&expect.BSnd{S: "cat /etc/resolv.conf\n"},
@@ -681,11 +681,11 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
 
 				By("Connecting from the client vm")
-				err = console.CheckForTextExpecter(clientVMI, createExpectConnectToServer(serverIP, tcpPort, true), 30)
+				err = console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort, true), 30)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Rejecting the connection from the client to unregistered port")
-				err = console.CheckForTextExpecter(clientVMI, createExpectConnectToServer(serverIP, tcpPort+1, false), 30)
+				err = console.SafeExpectBatch(clientVMI, createExpectConnectToServer(serverIP, tcpPort+1, false), 30)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -870,7 +870,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 				By("checking eth0 MTU inside the VirtualMachineInstance")
 				showMtu := "cat /sys/class/net/eth0/mtu\n"
-				err = console.CheckForTextExpecter(vmi, []expect.Batcher{
+				err = console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: showMtu},
 					&expect.BExp{R: console.RetValue(strconv.Itoa(bridgeMtu))},
 				}, 180)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -664,21 +664,21 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 					// Cluster nodes subnet (docker network gateway)
 					// Docker network subnet cidr definition:
 					// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-					Expect(tests.PingFromVMConsole(serverVMI, "2001:db8:1::1")).To(Succeed())
+					Expect(libnet.PingFromVMConsole(serverVMI, "2001:db8:1::1")).To(Succeed())
 				} else {
 					if ipv4NetworkCIDR == "" {
 						ipv4NetworkCIDR = api.DefaultVMCIDR
 					}
 					By("Checking ping (IPv4) to gateway")
 					ipAddr := gatewayIPFromCIDR(ipv4NetworkCIDR)
-					Expect(tests.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
+					Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
 
 					By("Checking ping (IPv4) to google")
-					Expect(tests.PingFromVMConsole(serverVMI, "8.8.8.8")).To(Succeed())
-					Expect(tests.PingFromVMConsole(clientVMI, "google.com")).To(Succeed())
+					Expect(libnet.PingFromVMConsole(serverVMI, "8.8.8.8")).To(Succeed())
+					Expect(libnet.PingFromVMConsole(clientVMI, "google.com")).To(Succeed())
 				}
 
-				Expect(tests.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
+				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
 
 				By("Connecting from the client vm")
 				err = console.CheckForTextExpecter(clientVMI, createExpectConnectToServer(serverIP, tcpPort, true), 30)
@@ -701,7 +701,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			var virtHandlerIPs []k8sv1.PodIP
 
 			ping := func(ipAddr string) error {
-				return tests.PingFromVMConsole(vmi, ipAddr, "-c 1", "-w 2")
+				return libnet.PingFromVMConsole(vmi, ipAddr, "-c 1", "-w 2")
 			}
 
 			getVirtHandlerPod := func() (*k8sv1.Pod, error) {
@@ -886,10 +886,10 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				}
 				payloadSize := primaryIfaceMtu - ipHeaderSize - icmpHeaderSize
 				addr := libnet.GetVmiPrimaryIpByFamily(anotherVmi, ipFamily)
-				Expect(tests.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize), "-M do")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize), "-M do")).To(Succeed())
 
 				By("checking the VirtualMachineInstance cannot send bigger than MTU sized frames to another VirtualMachineInstance")
-				Expect(tests.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize+1), "-M do")).ToNot(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, addr, "-c 1", "-w 5", fmt.Sprintf("-s %d", payloadSize+1), "-M do")).ToNot(Succeed())
 			},
 				table.Entry("IPv4", k8sv1.IPv4Protocol),
 				table.Entry("IPv6", k8sv1.IPv6Protocol),

--- a/tests/vmi_servers.go
+++ b/tests/vmi_servers.go
@@ -32,5 +32,5 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int) {
 }
 
 func (s server) Start(vmi *v1.VirtualMachineInstance, port int) {
-	Expect(console.VmiConsoleRunCommand(vmi, s.composeNetcatServerCommand(port), 60*time.Second)).To(Succeed())
+	Expect(console.RunCommand(vmi, s.composeNetcatServerCommand(port), 60*time.Second)).To(Succeed())
 }

--- a/tests/vmi_servers.go
+++ b/tests/vmi_servers.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/tests/console"
 )
 
 type server string
@@ -31,5 +32,5 @@ func StartHTTPServer(vmi *v1.VirtualMachineInstance, port int) {
 }
 
 func (s server) Start(vmi *v1.VirtualMachineInstance, port int) {
-	Expect(VmiConsoleRunCommand(vmi, s.composeNetcatServerCommand(port), 60*time.Second)).To(Succeed())
+	Expect(console.VmiConsoleRunCommand(vmi, s.composeNetcatServerCommand(port), 60*time.Second)).To(Succeed())
 }

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -142,7 +142,7 @@ var _ = Describe("[Serial]Slirp Networking", func() {
 		Expect(err).To(HaveOccurred())
 
 		By("communicate with the outside world")
-		expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+		expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
 		defer expecter.Close()
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -36,6 +36,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
@@ -141,7 +142,7 @@ var _ = Describe("[Serial]Slirp Networking", func() {
 		Expect(err).To(HaveOccurred())
 
 		By("communicate with the outside world")
-		expecter, _, err := tests.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
+		expecter, _, err := console.NewConsoleExpecter(virtClient, vmi, 10*time.Second)
 		defer expecter.Close()
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the ping helpers to the libnet package.

As a pre-requirement, the expecter helpers have been extracted to the "console" package, allowing the use of them in helpers like libnet (to avoid dependency loops).
The function names in the console package have been updated to reflect the package naming context.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
