### PR TITLE
Restore controller in memory corrution

### DIFF
--- a/pkg/virt-controller/watch/snapshot/restore_base.go
+++ b/pkg/virt-controller/watch/snapshot/restore_base.go
@@ -129,7 +129,7 @@ func (ctrl *VMRestoreController) processVMRestoreWorkItem() bool {
 			return 0, fmt.Errorf("unexpected resource %+v", storeObj)
 		}
 
-		return ctrl.updateVMRestore(vmRestore)
+		return ctrl.updateVMRestore(vmRestore.DeepCopy())
 	})
 }
 

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -503,7 +503,7 @@ func (ctrl *VMSnapshotController) getSnapshotPVC(namespace, volumeName string) (
 		return nil, nil
 	}
 
-	pvc := obj.(*corev1.PersistentVolumeClaim)
+	pvc := obj.(*corev1.PersistentVolumeClaim).DeepCopy()
 
 	if pvc.Spec.VolumeName == "" {
 		log.Log.Warningf("Unbound PVC %s/%s", pvc.Namespace, pvc.Name)
@@ -533,7 +533,7 @@ func (ctrl *VMSnapshotController) getVolumeSnapshotClass(storageClassName string
 		return "", err
 	}
 
-	storageClass := obj.(*storagev1.StorageClass)
+	storageClass := obj.(*storagev1.StorageClass).DeepCopy()
 
 	var matches []vsv1beta1.VolumeSnapshotClass
 	volumeSnapshotClasses := ctrl.getVolumeSnapshotClasses()
@@ -648,7 +648,7 @@ func (ctrl *VMSnapshotController) getVM(vmSnapshot *snapshotv1.VirtualMachineSna
 		return nil, nil
 	}
 
-	return obj.(*kubevirtv1.VirtualMachine), nil
+	return obj.(*kubevirtv1.VirtualMachine).DeepCopy(), nil
 }
 
 func (ctrl *VMSnapshotController) getContent(vmSnapshot *snapshotv1.VirtualMachineSnapshot) (*snapshotv1.VirtualMachineSnapshotContent, error) {
@@ -662,7 +662,7 @@ func (ctrl *VMSnapshotController) getContent(vmSnapshot *snapshotv1.VirtualMachi
 		return nil, nil
 	}
 
-	return obj.(*snapshotv1.VirtualMachineSnapshotContent), nil
+	return obj.(*snapshotv1.VirtualMachineSnapshotContent).DeepCopy(), nil
 }
 
 func (s *vmSnapshotSource) UID() types.UID {

--- a/pkg/virt-controller/watch/snapshot/snapshot_base.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_base.go
@@ -208,7 +208,7 @@ func (ctrl *VMSnapshotController) processVMSnapshotWorkItem() bool {
 			return 0, fmt.Errorf("unexpected resource %+v", storeObj)
 		}
 
-		return ctrl.updateVMSnapshot(vmSnapshot)
+		return ctrl.updateVMSnapshot(vmSnapshot.DeepCopy())
 	})
 }
 
@@ -226,7 +226,7 @@ func (ctrl *VMSnapshotController) processVMSnapshotContentWorkItem() bool {
 			return 0, fmt.Errorf("unexpected resource %+v", storeObj)
 		}
 
-		return ctrl.updateVMSnapshotContent(vmSnapshotContent)
+		return ctrl.updateVMSnapshotContent(vmSnapshotContent.DeepCopy())
 	})
 }
 
@@ -384,7 +384,7 @@ func (ctrl *VMSnapshotController) getVolumeSnapshot(namespace, name string) (*vs
 		return nil, err
 	}
 
-	return obj.(*vsv1beta1.VolumeSnapshot), nil
+	return obj.(*vsv1beta1.VolumeSnapshot).DeepCopy(), nil
 }
 
 func (ctrl *VMSnapshotController) getVolumeSnapshotClasses() []vsv1beta1.VolumeSnapshotClass {
@@ -399,7 +399,7 @@ func (ctrl *VMSnapshotController) getVolumeSnapshotClasses() []vsv1beta1.VolumeS
 	var vscs []vsv1beta1.VolumeSnapshotClass
 	objs := di.informer.GetStore().List()
 	for _, obj := range objs {
-		vsc := obj.(*vsv1beta1.VolumeSnapshotClass)
+		vsc := obj.(*vsv1beta1.VolumeSnapshotClass).DeepCopy()
 		vscs = append(vscs, *vsc)
 	}
 


### PR DESCRIPTION
make sure to deep copy resources in informer caches

was mistakenly overwriting VirtualMachineSnapshotContent

kept us from restoring from the same snapshot twice

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
