### PR TITLE
Issue 3512: To limit kubevirt-controller service ccount from modifying CRs

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -177,7 +177,6 @@ spec:
           - watch
           - patch
           - update
-          - patch
         - apiGroups:
           - ""
           resources:
@@ -498,7 +497,26 @@ spec:
           resources:
           - '*'
           verbs:
-          - '*'
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - kubevirts
+          - virtualmachines
+          - virtualmachineinstancemigrations
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+          - update
+          - create
+          - delete
         - apiGroups:
           - cdi.kubevirt.io
           resources:

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -503,11 +503,15 @@ spec:
           - patch
           - update
           - create
+          - delete
         - apiGroups:
           - kubevirt.io
           resources:
           - kubevirts
           - virtualmachines
+          - virtualmachineinstances
+          - virtualmachineinstancereplicasets
+          - virtualmachineinstancepresets
           - virtualmachineinstancemigrations
           verbs:
           - get

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -497,13 +497,7 @@ spec:
           resources:
           - '*'
           verbs:
-          - get
-          - list
-          - watch
-          - patch
-          - update
-          - create
-          - delete
+          - '*'
         - apiGroups:
           - kubevirt.io
           resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -79,7 +79,6 @@ rules:
   - watch
   - patch
   - update
-  - patch
 - apiGroups:
   - ""
   resources:
@@ -400,7 +399,26 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - kubevirts
+  - virtualmachines
+  - virtualmachineinstancemigrations
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create
+  - delete
 - apiGroups:
   - cdi.kubevirt.io
   resources:

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -405,11 +405,15 @@ rules:
   - patch
   - update
   - create
+  - delete
 - apiGroups:
   - kubevirt.io
   resources:
   - kubevirts
   - virtualmachines
+  - virtualmachineinstances
+  - virtualmachineinstancereplicasets
+  - virtualmachineinstancepresets
   - virtualmachineinstancemigrations
   verbs:
   - get

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -399,13 +399,7 @@ rules:
   resources:
   - '*'
   verbs:
-  - get
-  - list
-  - watch
-  - patch
-  - update
-  - create
-  - delete
+  - '*'
 - apiGroups:
   - kubevirt.io
   resources:

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -147,45 +147,23 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"kubevirt.io",
 				},
 				Resources: []string{
+					"*",
+				},
+				Verbs: []string{
+					"get", "list", "watch", "patch", "update", "create",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
 					"kubevirts",
-				},
-				Verbs: []string{
-					"get", "list", "watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"kubevirt.io",
-				},
-				Resources: []string{
 					"virtualmachines",
-					"virtualmachineinstances",
-					"virtualmachineinstancereplicasets",
-				},
-				Verbs: []string{
-					"get", "list", "watch", "patch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"kubevirt.io",
-				},
-				Resources: []string{
-					"virtualmachineinstancepresets",
-				},
-				Verbs: []string{
-					"watch", "list",
-				},
-			},
-			{
-				APIGroups: []string{
-					"kubevirt.io",
-				},
-				Resources: []string{
 					"virtualmachineinstancemigrations",
 				},
 				Verbs: []string{
-					"create", "get", "list", "watch", "patch",
+					"get", "list", "watch", "patch", "update", "create", "delete",
 				},
 			},
 			{

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -150,7 +150,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"*",
 				},
 				Verbs: []string{
-					"get", "list", "watch", "patch", "update", "create", "delete",
+					"*",
 				},
 			},
 			{

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -150,7 +150,7 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"*",
 				},
 				Verbs: []string{
-					"get", "list", "watch", "patch", "update", "create",
+					"get", "list", "watch", "patch", "update", "create", "delete",
 				},
 			},
 			{
@@ -160,6 +160,9 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 				Resources: []string{
 					"kubevirts",
 					"virtualmachines",
+					"virtualmachineinstances",
+					"virtualmachineinstancereplicasets",
+					"virtualmachineinstancepresets",
 					"virtualmachineinstancemigrations",
 				},
 				Verbs: []string{

--- a/pkg/virt-operator/creation/rbac/controller.go
+++ b/pkg/virt-operator/creation/rbac/controller.go
@@ -147,10 +147,45 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 					"kubevirt.io",
 				},
 				Resources: []string{
-					"*",
+					"kubevirts",
 				},
 				Verbs: []string{
-					"*",
+					"get", "list", "watch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachines",
+					"virtualmachineinstances",
+					"virtualmachineinstancereplicasets",
+				},
+				Verbs: []string{
+					"get", "list", "watch", "patch",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachineinstancepresets",
+				},
+				Verbs: []string{
+					"watch", "list",
+				},
+			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"virtualmachineinstancemigrations",
+				},
+				Verbs: []string{
+					"create", "get", "list", "watch", "patch",
 				},
 			},
 			{

--- a/pkg/virt-operator/creation/rbac/operator.go
+++ b/pkg/virt-operator/creation/rbac/operator.go
@@ -105,7 +105,6 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 					"watch",
 					"patch",
 					"update",
-					"patch",
 				},
 			},
 			{
@@ -249,8 +248,8 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 					"securitycontextconstraints",
 				},
 				ResourceNames: []string{
-					"kubevirt-handler",
-					"kubevirt-controller",
+					HandlerServiceAccountName,
+					ControllerServiceAccountName,
 				},
 				Verbs: []string{
 					"get",
@@ -441,7 +440,7 @@ func newOperatorRoleBinding(namespace string) *rbacv1.RoleBinding {
 	}
 }
 
-// NewOperatorRole creates a Role object for kubevirt-operator.
+// NewOperatorRole creates a Role object for OperatorServiceAccountName (kubevirt-operator).
 func NewOperatorRole(namespace string) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -71,9 +71,9 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			// The test id is temporary, appearing unique
 			table.Entry("given a kv", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "kubevirt"),
 			table.Entry("given a vm", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachines"),
-			table.Entry("given a vmi", []string{"yes", "yes", "yes", "yes", "yes", "yes", "no", "no"}, "virtualmachineinstances"),
-			table.Entry("given a vmi replica set", []string{"yes", "yes", "yes", "yes", "yes", "yes", "no", "no"}, "virtualmachineinstancereplicasets"),
-			table.Entry("given a vmi preset", []string{"yes", "yes", "yes", "yes", "yes", "yes", "no", "no"}, "virtualmachineinstancepresets"),
+			table.Entry("given a vmi", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstances"),
+			table.Entry("given a vmi replica set", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstancereplicasets"),
+			table.Entry("given a vmi preset", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstancepresets"),
 			table.Entry("given a vmi migration", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstancemigrations"),
 		)
 	})

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -69,12 +69,12 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			}
 		},
 			// The test id is temporary, appearing unique
-			table.Entry("given a kv", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "kubevirt"),
-			table.Entry("given a vm", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachines"),
-			table.Entry("given a vmi", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstances"),
-			table.Entry("given a vmi replica set", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstancereplicasets"),
-			table.Entry("given a vmi preset", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstancepresets"),
-			table.Entry("given a vmi migration", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "no"}, "virtualmachineinstancemigrations"),
+			table.Entry("given a kv", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "yes"}, "kubevirt"),
+			table.Entry("given a vm", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "yes"}, "virtualmachines"),
+			table.Entry("given a vmi", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "yes"}, "virtualmachineinstances"),
+			table.Entry("given a vmi replica set", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "yes"}, "virtualmachineinstancereplicasets"),
+			table.Entry("given a vmi preset", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "yes"}, "virtualmachineinstancepresets"),
+			table.Entry("given a vmi migration", []string{"yes", "yes", "yes", "yes", "yes", "yes", "yes", "yes"}, "virtualmachineinstancemigrations"),
 		)
 	})
 

--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -38,6 +38,7 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	view := tests.ViewServiceAccountName
 	edit := tests.EditServiceAccountName
 	admin := tests.AdminServiceAccountName
+	controller := tests.ControllerServiceAccountName
 
 	var k8sClient string
 	var authClient *authClientV1.AuthorizationV1Client
@@ -51,6 +52,51 @@ var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Expect(err).ToNot(HaveOccurred())
 
 		tests.BeforeTestCleanup()
+	})
+
+	Describe("With the kubevirt-controller service account", func() {
+		table.DescribeTable("should verify permissions on resources are correct for kubevirt-controller", func(resource string) {
+
+			controllerVerbs := make(map[string]string)
+			controllerVerbs["get"] = "yes"
+			controllerVerbs["list"] = "yes"
+			controllerVerbs["watch"] = "yes"
+			controllerVerbs["delete"] = "no"
+			controllerVerbs["create"] = "no"
+			controllerVerbs["update"] = "no"
+			controllerVerbs["patch"] = "yes"
+			controllerVerbs["deleteCollection"] = "no"
+
+			// Adjustment for the rule associated with kubevirt, vmipresets, vmim
+			switch resource {
+			case "kubevirt":
+				controllerVerbs["patch"] = "no"
+			case "virtualmachineinstancepresets":
+				controllerVerbs["get"] = "no"
+				controllerVerbs["patch"] = "no"
+			case "virtualmachineinstancemigrations":
+				controllerVerbs["create"] = "yes"
+			}
+
+			namespace := tests.NamespaceKubevirt // Is there an exported var defines kubevirt ns ?
+			verbs := []string{"get", "list", "watch", "delete", "create", "update", "patch", "deletecollection"}
+
+			for _, verb := range verbs {
+				By(fmt.Sprintf("verifying kubevirt-controller for verb %s", verb))
+				expectedRes, _ := controllerVerbs[verb]
+				as := fmt.Sprintf("system:serviceaccount:%s:%s", namespace, controller)
+				result, _, _ := tests.RunCommand(k8sClient, "auth", "can-i", "--as", as, verb, resource)
+				Expect(result).To(ContainSubstring(expectedRes))
+			}
+		},
+			// The test id is temporary, appearing unique
+			table.Entry("[test_id:626]given a kv", "kubevirt"),
+			table.Entry("[test_id:627]given a vm", "virtualmachines"),
+			table.Entry("[test_id:626]given a vmi", "virtualmachineinstances"),
+			table.Entry("[test_id:629][crit:low]given a vmi replica set", "virtualmachineinstancereplicasets"),
+			table.Entry("[test_id:628]given a vmi preset", "virtualmachineinstancepresets"),
+			table.Entry("[test_id:3330]given a vmi migration", "virtualmachineinstancemigrations"),
+		)
 	})
 
 	Describe("With default kubevirt service accounts", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -145,10 +145,12 @@ const (
 	AdminServiceAccountName       = "kubevirt-admin-test-sa"
 	EditServiceAccountName        = "kubevirt-edit-test-sa"
 	ViewServiceAccountName        = "kubevirt-view-test-sa"
+	ControllerServiceAccountName  = "kubevirt-controller"
 )
 
 const SubresourceTestLabel = "subresource-access-test-pod"
 const insecureRegistryConfigName = "cdi-insecure-registries"
+const NamespaceKubevirt = "kubevirt"
 
 // tests.NamespaceTestDefault is the default namespace, to test non-infrastructure related KubeVirt objects.
 var NamespaceTestDefault = "kubevirt-test-default"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The purpose of the PR is to address the problem discussed in issue 3512, i.e. to prevent the service account `kubevirt-controller` from modifying or deleting custom resources in the API Group kubevirt.io.

One reason that the problem existed was that the the RBAC role associated with the service account `kubevirt-controller` can do anything to all the resources in the API Group kubevirt.io.

The solution follows the discussion in the issue: to refactor the RBAC rule associated to the `kubevirt-controller` role by spelling out action verbs to each of the 6 resources in the API group. In this PR, the permission associated with the RBAC role `kubevirt-controller` are summarized as below:

|Resource API   | API Group             | Verbs |
| ----          | ---                   | ---   |
|vm             | kubevirt.io           | get, list, watch, patch       |
|vmi            | kubevirt.io           | get, list, watch, patch       |
|vmim           | kubevirt.io           | create, get, list, watch, patch       |
|vmpreset       | kubevirt.io           | list, watch   |
|kubevirt       | kubevirt.io           | get, list, watch      |

The PR includes an addition of 6 tests to `tests/access_test.go` that essentially runs the command
`kubectl auth can-i delete vm --as system:serviceaccount:kubevirt:kubevirt-controller`
for the 8 verbs against the 6 resource objects.

The PR contains a minor code cleaning up that replaced some recurring string literals by constants in `pkg/virt-operator/creation/rbac/operator.go` to align to the practice of other files under the same directory, e.g. `pkg/virt-operator/creation/rbac/handler.go`. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3512

**Special notes for your reviewer**:
This is a joint effort with @JinjunXiong and authors' first PR to this project and detailed review feedback from all aspects of the PR are highly appreciated. 



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
