### PR TITLE
docs: Fix the ginkgo flags usage example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,7 +173,7 @@ If you'd like to run specific functional tests only, you can leverage `ginkgo`
 command line options as follows (run a specified suite):
 
 ```
-    FUNC_TEST_ARGS='-ginkgo.focus=vmi_networking_test -ginkgo.regexScansFilePath' make functest
+    FUNC_TEST_ARGS='-focus=vmi_networking_test -regexScansFilePath' make functest
 ```
 
 In addition, if you want to run a specific test or tests you can prepend any `Describe`,


### PR DESCRIPTION
Signed-off-by: Ezra Silvera <ezra@il.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The example on how to run a specific functional tests uses a wrong format causing the `make functest` to fail with printout of the ginkco help

The error we get is `flag provided but not defined: -ginco.focus`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
