### PR TITLE
WIP: Configure the tap device MTU at tap creation time

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8497,7 +8497,7 @@
       }
      },
      "networkInterfaceMultiqueue": {
-      "description": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature",
+      "description": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.",
       "type": "boolean"
      },
      "rng": {

--- a/cmd/virt-chroot/tap-device-maker.go
+++ b/cmd/virt-chroot/tap-device-maker.go
@@ -9,10 +9,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func createTapDevice(name string, owner uint, group uint, queueNumber int) error {
+func createTapDevice(name string, owner uint, group uint, queueNumber int, mtu int) error {
 	var err error = nil
 	tapDevice := &netlink.Tuntap{
-		LinkAttrs:  netlink.LinkAttrs{Name: name},
+		LinkAttrs:  netlink.LinkAttrs{Name: name, MTU: mtu},
 		Mode:       unix.IFF_TAP,
 		NonPersist: false,
 		Queues:     queueNumber,
@@ -47,6 +47,10 @@ func NewCreateTapCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not access queue-number parameter: %v", err)
 			}
+			mtu, err := cmd.Flags().GetUint32("mtu")
+			if err != nil {
+				return fmt.Errorf("could not access mtu parameter: %v", err)
+			}
 
 			uid, err := strconv.ParseUint(uidStr, 10, 32)
 			if err != nil {
@@ -57,7 +61,7 @@ func NewCreateTapCommand() *cobra.Command {
 				return fmt.Errorf("could not parse tap device group: %v", err)
 			}
 
-			if err := createTapDevice(tapName, uint(uid), uint(gid), int(queueNumber)); err != nil {
+			if err := createTapDevice(tapName, uint(uid), uint(gid), int(queueNumber), int(mtu)); err != nil {
 				return fmt.Errorf("failed to create tap device named %s. Reason: %v", tapName, err)
 			}
 

--- a/cmd/virt-chroot/tap-device-maker.go
+++ b/cmd/virt-chroot/tap-device-maker.go
@@ -20,6 +20,14 @@ func createTapDevice(name string, owner uint, group uint, queueNumber int) error
 		Group:      uint32(group),
 	}
 
+	// when netlink receives a request for a tap device with 1 queue, it uses
+	// the MULTI_QUEUE flag, which differs from libvirt; as such, we need to
+	// manually request the single queue flags, enabling libvirt to consume
+	// the tap device.
+	// See https://github.com/vishvananda/netlink/issues/574
+	if queueNumber == 1 {
+		tapDevice.Flags = netlink.TUNTAP_DEFAULTS
+	}
 	if err := netlink.LinkAdd(tapDevice); err != nil {
 		return fmt.Errorf("failed to create tap device named %s. Reason: %v", name, err)
 	}

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -2188,6 +2188,17 @@ var _ = Describe("Converter", func() {
 			Expect(domain.Spec.Devices.Interfaces[0].Driver).To(BeNil(),
 				"queues should not be set for models other than virtio")
 		})
+
+		It("should cap the maximum number of queues", func() {
+			vmi.Spec.Domain.CPU = &v1.CPU{
+				Cores:   512,
+				Sockets: 1,
+				Threads: 2,
+			}
+			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})
+			Expect(*(domain.Spec.Devices.Interfaces[0].Driver.Queues)).To(Equal(multiQueueMaxQueues),
+				"should be capped to the maximum number of queues on tap devices")
+		})
 	})
 
 	Context("sriov", func() {

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -112,7 +112,7 @@ type NetworkHandler interface {
 	NftablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
 	NftablesLoad(fnName string) error
 	GetNFTIPString(proto iptables.Protocol) string
-	CreateTapDevice(tapName string, queueNumber uint32, launcherPID int) error
+	CreateTapDevice(tapName string, queueNumber uint32, launcherPID int, mtu int) error
 	BindTapDeviceToBridge(tapName string, bridgeName string) error
 }
 
@@ -375,8 +375,8 @@ func (h *NetworkUtilsHandler) GenerateRandomMac() (net.HardwareAddr, error) {
 	return net.HardwareAddr(append(prefix, suffix...)), nil
 }
 
-func (h *NetworkUtilsHandler) CreateTapDevice(tapName string, queueNumber uint32, launcherPID int) error {
-	tapDeviceMaker, err := buildTapDeviceMaker(tapName, queueNumber, launcherPID)
+func (h *NetworkUtilsHandler) CreateTapDevice(tapName string, queueNumber uint32, launcherPID int, mtu int) error {
+	tapDeviceMaker, err := buildTapDeviceMaker(tapName, queueNumber, launcherPID, mtu)
 	if err != nil {
 		return fmt.Errorf("error creating tap device named %s; %v", tapName, err)
 	}
@@ -389,13 +389,14 @@ func (h *NetworkUtilsHandler) CreateTapDevice(tapName string, queueNumber uint32
 	return nil
 }
 
-func buildTapDeviceMaker(tapName string, queueNumber uint32, virtLauncherPID int) (*tapDeviceMaker, error) {
+func buildTapDeviceMaker(tapName string, queueNumber uint32, virtLauncherPID int, mtu int) (*tapDeviceMaker, error) {
 	createTapDeviceArgs := []string{
 		"create-tap",
 		"--tap-name", tapName,
 		"--uid", qemuUID,
 		"--gid", qemuGID,
 		"--queue-number", fmt.Sprintf("%d", queueNumber),
+		"--mtu", fmt.Sprintf("%d", mtu),
 	}
 	cmd := exec.Command("virt-chroot", createTapDeviceArgs...)
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -444,7 +444,8 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, lau
 	}
 
 	tapDeviceName := generateTapDeviceName(podInterfaceName)
-	err := createAndBindTapToBridge(b.vif, tapDeviceName, b.bridgeInterfaceName, queueNumber, launcherPID)
+	podMTU := b.podNicLink.Attrs().MTU
+	err := createAndBindTapToBridge(b.vif, tapDeviceName, b.bridgeInterfaceName, queueNumber, launcherPID, podMTU)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err
@@ -465,7 +466,6 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, lau
 		return err
 	}
 
-	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}
 	b.virtIface.MAC = &api.MAC{MAC: b.vif.MAC.String()}
 	b.virtIface.Target = &api.InterfaceTarget{
 		Device:  b.vif.TapDevice,
@@ -734,7 +734,8 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 	}
 
 	tapDeviceName := generateTapDeviceName(podInterfaceName)
-	err = createAndBindTapToBridge(p.vif, tapDeviceName, p.bridgeInterfaceName, queueNumber, launcherPID)
+	podMTU := p.podNicLink.Attrs().MTU
+	err = createAndBindTapToBridge(p.vif, tapDeviceName, p.bridgeInterfaceName, queueNumber, launcherPID, podMTU)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err
@@ -773,7 +774,6 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 		}
 	}
 
-	p.virtIface.MTU = &api.MTU{Size: strconv.Itoa(p.podNicLink.Attrs().MTU)}
 	p.virtIface.MAC = &api.MAC{MAC: p.vif.MAC.String()}
 	p.virtIface.Target = &api.InterfaceTarget{
 		Device:  p.vif.TapDevice,
@@ -1138,8 +1138,8 @@ func (s *SlirpPodInterface) setCachedInterface(pid, name string) error {
 	return nil
 }
 
-func createAndBindTapToBridge(virtualInterface *VIF, deviceName string, bridgeIfaceName string, queueNumber uint32, launcherPID int) error {
-	err := Handler.CreateTapDevice(deviceName, queueNumber, launcherPID)
+func createAndBindTapToBridge(virtualInterface *VIF, deviceName string, bridgeIfaceName string, queueNumber uint32, launcherPID int, mtu int) error {
+	err := Handler.CreateTapDevice(deviceName, queueNumber, launcherPID, mtu)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -200,6 +200,7 @@ func (l *PodInterface) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Inte
 		isMultiqueue := (vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue != nil) && (*vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue)
 		if isMultiqueue {
 			queueNumber, _ = api.CalculateNetworkQueueNumberAndGetCPUTopology(vmi)
+			queueNumber = api.CapTapDeviceQueueNumber(uint(queueNumber))
 		}
 		if err := driver.preparePodNetworkInterfaces(queueNumber, pid); err != nil {
 			log.Log.Reason(err).Error("failed to prepare pod networking")

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -14359,7 +14359,7 @@ func schema_kubevirtio_client_go_api_v1_Devices(ref common.ReferenceCallback) co
 					},
 					"networkInterfaceMultiqueue": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature",
+							Description: "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -369,7 +369,7 @@ type Devices struct {
 	// Whether or not to enable virtio multi-queue for block devices
 	// +optional
 	BlockMultiQueue *bool `json:"blockMultiQueue,omitempty"`
-	// If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature
+	// If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.
 	// +optional
 	NetworkInterfaceMultiQueue *bool `json:"networkInterfaceMultiqueue,omitempty"`
 	//Whether to attach a GPU device to the vmi.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -178,7 +178,7 @@ func (Devices) SwaggerDoc() map[string]string {
 		"autoattachMemBalloon":       "Whether to attach the Memory balloon device with default period.\nPeriod can be adjusted in virt-config.\nDefaults to true.\n+optional",
 		"rng":                        "Whether to have random number generator from host\n+optional",
 		"blockMultiQueue":            "Whether or not to enable virtio multi-queue for block devices\n+optional",
-		"networkInterfaceMultiqueue": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature\n+optional",
+		"networkInterfaceMultiqueue": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.\n+optional",
 		"gpus":                       "Whether to attach a GPU device to the vmi.\n+optional",
 		"filesystems":                "Filesystems describes filesystem which is connected to the vmi.\n+optional\n+listType=set",
 	}

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14213,7 +14213,7 @@ func schema_kubevirtio_client_go_api_v1_Devices(ref common.ReferenceCallback) co
 					},
 					"networkInterfaceMultiqueue": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature",
+							Description: "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[Serial]MultiQueue", func() {
@@ -120,6 +121,32 @@ var _ = Describe("[Serial]MultiQueue", func() {
 			By("Ensuring each disk has three queues assigned")
 			for _, disk := range domSpec.Devices.Disks {
 				Expect(int(*disk.Driver.Queues)).To(Equal(numCpus))
+			}
+		})
+
+		It("should be able to create a multi-queue VMI when requesting a single vCPU", func() {
+			vmi := libvmi.NewCirros()
+
+			multiQueue := true
+			vmi.Spec.Domain.CPU = &v1.CPU{Cores: 1, Sockets: 1, Threads: 1}
+			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &multiQueue
+
+			By("Creating and starting the VMI")
+			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
+
+			By("Fetching Domain XML from running pod")
+			domain, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
+			Expect(err).ToNot(HaveOccurred())
+			domSpec := &api.DomainSpec{}
+			Expect(xml.Unmarshal([]byte(domain), domSpec)).To(Succeed())
+
+			for i, iface := range domSpec.Devices.Interfaces {
+				expectedIfaceName := fmt.Sprintf("tap%d", i)
+
+				Expect(iface.Target.Device).To(Equal(expectedIfaceName), fmt.Sprintf("the target name should be %s", expectedIfaceName))
+				Expect(iface.Target.Managed).To(Equal("no"), "we should instruct libvirt not to configure the tap device")
 			}
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
By configuring the MTU at tap creation time, we relieve the tap
consumer of any type of interface configuration, which will allow
us to drop the NET_ADMIN capability from the launcher POD.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends-on:
  - #4300 
  - #4260 

Missing:
  - func tests (must assure it fails first)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the `mtu` parameter to `virt-chroot create-tap` command.
```
