### PR TITLE
[virt-handler] restrict migration for specific CPU modes

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -37,6 +37,10 @@ const (
 	HostDiskGate          = "HostDisk"
 	VirtIOFSGate          = "ExperimentalVirtiofsSupport"
 	MacvtapGate           = "Macvtap"
+	// 	MigratableHostModelCPU allows migration of VMs with host-model CPU
+	MigratableHostModelCPU = "WithHostModelCPU"
+	// MigratableHostPassthroughCPU allows migration of VMs with host-passthrough CPU
+	MigratableHostPassthroughCPU = "WithHostPassthroughCPU"
 )
 
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -98,4 +102,12 @@ func (config *ClusterConfig) MacvtapEnabled() bool {
 
 func (config *ClusterConfig) HostDevicesPassthroughEnabled() bool {
 	return config.isFeatureGateEnabled(HostDevicesGate)
+}
+
+func (config *ClusterConfig) MigrationOfHostPassthroughCPUEnabled() bool {
+	return config.isFeatureGateEnabled(MigratableHostPassthroughCPU)
+}
+
+func (config *ClusterConfig) MigrationOfHostModelCPUEnabled() bool {
+	return config.isFeatureGateEnabled(MigratableHostModelCPU)
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -332,12 +332,14 @@ const (
 
 	// Indicates whether the VMI is live migratable
 	VirtualMachineInstanceIsMigratable VirtualMachineInstanceConditionType = "LiveMigratable"
-	// Reason means that VMI is not live migratioable because of it's disks collection
+	// Reason means that VMI is not live migratable because of it's disks collection
 	VirtualMachineInstanceReasonDisksNotMigratable = "DisksNotLiveMigratable"
-	// Reason means that VMI is not live migratioable because of it's network interfaces collection
+	// Reason means that VMI is not live migratable because of it's network interfaces collection
 	VirtualMachineInstanceReasonInterfaceNotMigratable = "InterfaceNotLiveMigratable"
-	// Reason means that VMI is not live migratioable because of it's network interfaces collection
+	// Reason means that VMI is not live migratable because of disk hot-plug support
 	VirtualMachineInstanceReasonHotplugNotMigratable = "HotplugNotLiveMigratable"
+	// Reason means that VMI is not live migratable because of it's CPU model configuration
+	VirtualMachineInstanceReasonCPUModelNotMigratable = "CPUModelNotMigratable"
 )
 
 const (


### PR DESCRIPTION
A cluster administrator will be able to restrict VM live migrations when the CPU mode is host-model or host-passthrough.

This management will be possible via the Kubevirt CR. If [HCO](https://github.com/kubevirt/hyperconverged-cluster-operator) is being deployed then it can be [managed](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1063) via the HCO CR.

**HCO CR**

Allow migration with host-model CPU:
```yaml
apiVersion: hco.kubevirt.io/v1beta1
kind: HyperConverged
metadata:
  name: kubevirt-hyperconverged
spec:
  infra: {}
  workloads: {}
  featureGates:
    withHostModelCPU: true
``` 
Allow migration with host-passthrough CPU:

```yaml
apiVersion: hco.kubevirt.io/v1beta1
kind: HyperConverged
metadata:
  name: kubevirt-hyperconverged
spec:
  infra: {}
  workloads: {}
  featureGates:
    withHostPassthroughCPU: true
```
Combination of both can be used as well

**Kubevirt CR**

Allow migration with host-model CPU:
```yaml
---
apiVersion: kubevirt.io/v1
kind: KubeVirt
metadata:
  name: kubevirt
  namespace: kubevirt
spec:
  certificateRotateStrategy: {}
  configuration: 
    developerConfiguration:
      featureGates:
      - "LiveMigration"
      - "withHostModelCPU"
  customizeComponents: {}
  imagePullPolicy: IfNotPresent
```

Allow migration with host-passthrough CPU:
```yaml
---
apiVersion: kubevirt.io/v1
kind: KubeVirt
metadata:
  name: kubevirt
  namespace: kubevirt
spec:
  certificateRotateStrategy: {}
  configuration: 
    developerConfiguration:
      featureGates:
      - "LiveMigration"
      - "withHostPassthroughCPU"
  customizeComponents: {}
  imagePullPolicy: IfNotPresent
```
Combination of both can be used as well

**What this PR does / why we need it**:
By default, when a user configures a specific CPU model in the VM spec, it does not affect the scheduling of the virt-launcher pod itself since the CPU model isn't been considered as a criteria for node match (nodeSelector, node affinity, etc.).
However, in order to match node CPU capabilities with these defined in the VM spec it is required to set
```feature-gate: "CPUNodeDiscovery"``` In such case CPU specifics will be copied to the virt-launcher pod NodeSelector section.
The problem with host-model and host-passthrough modes is that CPU model is unknown at the scheduling stage, but 
only after the launch of the VM.
Long term solution (depends on #3498) will be to perform auto-translation of the host-model CPU into a selector at the VMI pod scheduling phase.

**Which issue(s) this PR fixes** 
https://bugzilla.redhat.com/show_bug.cgi?id=1760028

**Special notes for your reviewer**:

**Release note**:
```release-note
restrict host-model and host-passthrough migrations via feature gate
```
