### PR TITLE
Add 2.x QEMU Guest Agents to the list of supported versions

### DIFF
--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -58,7 +58,7 @@ const (
 	SmbiosConfigDefaultProduct                      = "None"
 	DefaultPermitBridgeInterfaceOnPodNetwork        = true
 	DefaultSELinuxLauncherType                      = "virt_launcher.process"
-	SupportedGuestAgentVersions                     = "3.*,4.*"
+	SupportedGuestAgentVersions                     = "2.*,3.*,4.*"
 	DefaultOVMFPath                                 = "/usr/share/OVMF"
 	DefaultMemBalloonStatsPeriod             uint32 = 10
 	DefaultCPUAllocationRatio                       = 10.0


### PR DESCRIPTION
**What this PR does / why we need it**:

After inspecting the guest agent API and our code, there's no reason we can't support Older QEMU Guest agents. As far back as 2.x

**Which issue(s) this PR fixes**
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1883857

**Release note**:
```release-note
Version 2.x QEMU guest agents are supported.
```
