### PR TITLE
Networkpolicy ignore warnings

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,7 +36,6 @@ goimports(
     exclude_paths = [
         "./vendor/*",
         "./.history/*",
-        "./.git/*",
     ],
     local = ["kubevirt.io"],
     prefix = "kubevirt.io/kubevirt",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ goimports(
     exclude_paths = [
         "./vendor/*",
         "./.history/*",
+        "./.git/*",
     ],
     local = ["kubevirt.io"],
     prefix = "kubevirt.io/kubevirt",

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -61,9 +61,9 @@ var _ = Describe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][leve
 			clientVMI = createVMICirros(virtClient, tests.NamespaceTestDefault, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 			clientVMIAlternativeNamespace = createVMICirros(virtClient, tests.NamespaceTestAlternative, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 
-			serverVMI = tests.WaitUntilVMIReady(serverVMI, tests.LoggedInCirrosExpecter)
-			clientVMI = tests.WaitUntilVMIReady(clientVMI, tests.LoggedInCirrosExpecter)
-			clientVMIAlternativeNamespace = tests.WaitUntilVMIReady(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
+			serverVMI = tests.WaitUntilVMIReadyAndIgnoreWarnings(serverVMI, tests.LoggedInCirrosExpecter)
+			clientVMI = tests.WaitUntilVMIReadyAndIgnoreWarnings(clientVMI, tests.LoggedInCirrosExpecter)
+			clientVMIAlternativeNamespace = tests.WaitUntilVMIReadyAndIgnoreWarnings(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
 
 			By("Start HTTP server at serverVMI on ports 80 and 81")
 			tests.HTTPServer.Start(serverVMI, 80)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2710,9 +2710,21 @@ func WaitForSuccessfulVMIStart(vmi runtime.Object) string {
 	return waitForVMIStart(vmi, 360, false)
 }
 
+func waitForSuccessfulVMIStartWithIgnoreWarnings(vmi runtime.Object, ignoreWarnings bool) string {
+	return waitForVMIStart(vmi, 360, ignoreWarnings)
+}
+
 func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) *v1.VirtualMachineInstance {
+	return waitUntilVMIReadyWithIgnoreWarnings(vmi, expecterFactory, false)
+}
+
+func WaitUntilVMIReadyAndIgnoreWarnings(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) *v1.VirtualMachineInstance {
+	return waitUntilVMIReadyWithIgnoreWarnings(vmi, expecterFactory, true)
+}
+
+func waitUntilVMIReadyWithIgnoreWarnings(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory, ignoreWarnings bool) *v1.VirtualMachineInstance {
 	// Wait for VirtualMachineInstance start
-	WaitForSuccessfulVMIStart(vmi)
+	waitForSuccessfulVMIStartWithIgnoreWarnings(vmi, ignoreWarnings)
 
 	// Fetch the new VirtualMachineInstance with updated status
 	virtClient, err := kubecli.GetKubevirtClient()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
At k8s-1.19 provider if we start to watch at a resource with old resourceVersion we
receive a event with error to prevent that we are going to just ignore warnings so
we don't have to start the watcher at the networkpolicy tests
    
Also watcher `startType` has being removed since there is no tests using the helpers that were setting it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4239

**Special notes for your reviewer**:
We have see this issue at networkpolicy but it may appear at other test suite.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
