### PR TITLE
tests, networkpolicy: Wait for VMIs readiness in parallel

### DIFF
--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -61,9 +61,13 @@ var _ = Describe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][leve
 			clientVMI = createVMICirros(virtClient, tests.NamespaceTestDefault, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 			clientVMIAlternativeNamespace = createVMICirros(virtClient, tests.NamespaceTestAlternative, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 
-			serverVMI = tests.WaitUntilVMIReady(serverVMI, tests.LoggedInCirrosExpecter)
-			clientVMI = tests.WaitUntilVMIReady(clientVMI, tests.LoggedInCirrosExpecter)
-			clientVMIAlternativeNamespace = tests.WaitUntilVMIReady(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
+			serverVMIFuture := tests.WaitUntilVMIReadyAsync(serverVMI, tests.LoggedInCirrosExpecter)
+			clientVMIFuture := tests.WaitUntilVMIReadyAsync(clientVMI, tests.LoggedInCirrosExpecter)
+			clientVMIAlternativeNamespaceFuture := tests.WaitUntilVMIReadyAsync(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
+
+			serverVMI = serverVMIFuture()
+			clientVMI = clientVMIFuture()
+			clientVMIAlternativeNamespace = clientVMIAlternativeNamespaceFuture()
 
 			By("Start HTTP server at serverVMI on ports 80 and 81")
 			tests.HTTPServer.Start(serverVMI, 80)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2764,6 +2764,23 @@ func WaitForSuccessfulVMIStart(vmi runtime.Object) string {
 	return waitForVMIStart(vmi, 360, false)
 }
 
+func WaitUntilVMIReadyAsync(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) func() *v1.VirtualMachineInstance {
+	var (
+		wg       sync.WaitGroup
+		readyVMI *v1.VirtualMachineInstance
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		readyVMI = WaitUntilVMIReady(vmi, expecterFactory)
+	}()
+
+	return func() *v1.VirtualMachineInstance {
+		wg.Wait()
+		return readyVMI
+	}
+}
+
 func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) *v1.VirtualMachineInstance {
 	// Wait for VirtualMachineInstance start
 	WaitForSuccessfulVMIStart(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Starting the calls of WaitUntilVMIReady in parallel will also start the events watcher
just after vmis are created so resourceVersion is fresh and the test don't suffer
from non existent resourceVersions.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4239

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
