### PR TITLE
virt-handler, Add missing network name for SRIOV interfaces in case MAC is presented in the VMI spec

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2094,6 +2094,57 @@ var _ = Describe("VirtualMachineInstance", func() {
 			controller.Execute()
 		})
 	})
+
+	Context("with SRIOV configuration", func() {
+		It("should report interface with MAC and network name", func() {
+			vmi := v1.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			const sriovInterfaceName = "sriov_network"
+			const MAC = "1C:CE:C0:01:BE:E7"
+
+			vmi.Spec.Networks = []v1.Network{
+				{
+					Name: sriovInterfaceName,
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.MultusNetwork{
+							NetworkName: sriovInterfaceName,
+						},
+					},
+				},
+			}
+			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+				{
+					Name: sriovInterfaceName,
+					InterfaceBindingMethod: v1.InterfaceBindingMethod{
+						SRIOV: &v1.InterfaceSRIOV{},
+					},
+					MacAddress: MAC,
+				},
+			}
+
+			mockWatchdog.CreateFile(vmi)
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Running
+			domain.Status.Interfaces = []api.InterfaceStatus{
+				{
+					Mac:           MAC,
+					InterfaceName: "eth1",
+				},
+			}
+
+			vmiFeeder.Add(vmi)
+			domainFeeder.Add(domain)
+
+			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].MAC).To(Equal(MAC))
+				Expect(arg.(*v1.VirtualMachineInstance).Status.Interfaces[0].Name).To(Equal(sriovInterfaceName))
+			}).Return(vmi, nil)
+
+			controller.Execute()
+		})
+	})
 })
 
 var _ = Describe("DomainNotifyServerRestarts", func() {


### PR DESCRIPTION
Since SRIOV interfaces are HostDev, they don't appear on `domain.Spec.Devices.Interfaces`
but just on `domain.Status.Interfaces` (based on guest agent report),
and on `domain.Spec.Devices.HostDevices`.
For non HostDev we have a mapping between the mac and the network name for each interface
that was declared in the spec.
For HostDev SRIOV, the VFIO device type
doesn't support getting the mac address at the current stage,
so we cannot create such mapping, hence we cannot match between the report of guest agent
MAC and the network name.

Add logic that in case the `vmi.Spec.Domain.Devices.Interfaces`
has a MAC address for the SRIOV interface, it would be used to find
the matching interface of domain.Status.Interfaces and report back the
network name according the `vmi.Spec.Domain.Devices.Interfaces` network name field.

Notes:

* In case there isn't a matching MAC (if the mac wasn't set explicitly in the Spec), a name won't be reported.
* In case there are two entries with the same MAC on `vmi.Spec.Domain.Devices.Interfaces`
which match the one reported by the guest agent on domain.Status.Interfaces,
one of them will be reported as network name.

SRIOV tests:
* Validate that the network name is set in the VMI scheme,
and matched the expected interface.
* Added SRIOV unit test, which also includes checking of network name logic.

2nd Phase would either include MAC generating in case the MAC isn't set in the VMI spec,
or reading the actual configured MAC, in case it would be supported for VFIO devices.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1856347

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
VMI status displays SRIOV interfaces with their network name only when they have originally
been defined with an explicit MAC address in the VMI spec.
```
