### PR TITLE
 tests, utils: Add early exit for wait-for-vmi-phase

### DIFF
--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -61,13 +61,9 @@ var _ = Describe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][leve
 			clientVMI = createVMICirros(virtClient, tests.NamespaceTestDefault, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 			clientVMIAlternativeNamespace = createVMICirros(virtClient, tests.NamespaceTestAlternative, map[string]string{}, libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()))
 
-			serverVMIFuture := tests.WaitUntilVMIReadyAsync(serverVMI, tests.LoggedInCirrosExpecter)
-			clientVMIFuture := tests.WaitUntilVMIReadyAsync(clientVMI, tests.LoggedInCirrosExpecter)
-			clientVMIAlternativeNamespaceFuture := tests.WaitUntilVMIReadyAsync(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
-
-			serverVMI = serverVMIFuture()
-			clientVMI = clientVMIFuture()
-			clientVMIAlternativeNamespace = clientVMIAlternativeNamespaceFuture()
+			serverVMI = tests.WaitUntilVMIReady(serverVMI, tests.LoggedInCirrosExpecter)
+			clientVMI = tests.WaitUntilVMIReady(clientVMI, tests.LoggedInCirrosExpecter)
+			clientVMIAlternativeNamespace = tests.WaitUntilVMIReady(clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
 
 			By("Start HTTP server at serverVMI on ports 80 and 81")
 			tests.HTTPServer.Start(serverVMI, 80)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2688,16 +2688,15 @@ func waitForVMIPhase(phases []v1.VirtualMachineInstancePhase, obj runtime.Object
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
+	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	if isPhaseIncludedIn(vmi.Status.Phase, phases) {
+		return vmi.Status.NodeName
+	}
+
 	// In case we don't want errors, start an event watcher and  check in parallel if we receive some warnings
 	if ignoreWarnings != true {
-
-		// Fetch the VirtualMachineInstance, to make sure we have a resourceVersion as a starting point for the watch
-		// FIXME: This may start watching too late and we may miss some warnings
-		if vmi.ResourceVersion == "" {
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		}
-
 		objectEventWatcher := NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(seconds+2) * time.Second)
 		objectEventWatcher.FailOnWarnings()
 
@@ -2721,6 +2720,15 @@ func waitForVMIPhase(phases []v1.VirtualMachineInstancePhase, obj runtime.Object
 	}, time.Duration(seconds)*time.Second, 1*time.Second).Should(BeElementOf(phases), timeoutMsg)
 
 	return
+}
+
+func isPhaseIncludedIn(phase v1.VirtualMachineInstancePhase, phases []v1.VirtualMachineInstancePhase) bool {
+	for _, p := range phases {
+		if p == phase {
+			return true
+		}
+	}
+	return false
 }
 
 func WaitForSuccessfulVMIStartIgnoreWarnings(vmi runtime.Object) string {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2766,23 +2766,6 @@ func WaitForSuccessfulVMIStart(vmi runtime.Object) string {
 	return waitForVMIStart(vmi, 360, false)
 }
 
-func WaitUntilVMIReadyAsync(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) func() *v1.VirtualMachineInstance {
-	var (
-		wg       sync.WaitGroup
-		readyVMI *v1.VirtualMachineInstance
-	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		readyVMI = WaitUntilVMIReady(vmi, expecterFactory)
-	}()
-
-	return func() *v1.VirtualMachineInstance {
-		wg.Wait()
-		return readyVMI
-	}
-}
-
 func WaitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory VMIExpecterFactory) *v1.VirtualMachineInstance {
 	// Wait for VirtualMachineInstance start
 	WaitForSuccessfulVMIStart(vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

In case the VMI is already in the expected phase, return early as there
is no need to wait for anything.

Revert the async wait implementation. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
