### PR TITLE
Lift the e2e parallel test restriction for fedora guests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -49,15 +49,9 @@ if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
   exit 1
 fi
 
-if [[ $TARGET =~ os-.* ]]; then
-  # when testing on slow CI system cleanup sometimes takes very long.
-  # openshift clusters are more memory demanding. If the cleanup
-  # of old vms does not go fast enough they run out of memory.
-  # To still allow continuing with the tests, give more memory in CI.
-  export KUBEVIRT_MEMORY_SIZE=6144M
-fi
-
 export KUBEVIRT_NUM_NODES=2
+# Give the nodes enough memory to run tests in parallel, including tests which involve fedora
+export KUBEVIRT_MEMORY_SIZE=10240M
 
 export RHEL_NFS_DIR=${RHEL_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/rhel7}
 export RHEL_LOCK_PATH=${RHEL_LOCK_PATH:-/var/lib/stdci/shared/download_rhel_image.lock}

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,6 @@ We aim to run e2e tests in parallel by default. As such the following rules shou
 The following types of tests need to be marked as `[Serial]` right now:
 
  * Tests which use PVCs or DataVolumes (parallelizing these is on the way).
- * Tests which use Fedora or a lot of memory for other reasons.
  * Tests which use `BeforeAll`.
 
 Additional suggestions:

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -102,7 +102,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 				})
 			})
 
-			Context("[Serial]with a fedora image", func() {
+			Context("with a fedora image", func() {
 				It("[test_id:1589]should return that we are running fedora", func() {
 					vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedora))
 					RunVMIAndWaitForStart(vmi)

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -400,7 +400,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			return grepSleepPid(expecter)
 		}
 
-		It("[Serial][test_id:3090]should be continued after the VMI is unpaused", func() {
+		It("[test_id:3090]should be continued after the VMI is unpaused", func() {
 			By("Starting a Fedora VMI")
 			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -802,7 +802,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				Expect(err.Error()).To(Equal(fmt.Sprintf(`Error stopping VirtualMachine Operation cannot be fulfilled on virtualmachine.kubevirt.io "%s": VM is not running`, newVM.Name)))
 			})
 
-			It("[Serial][test_id:3007]Should force restart a VM with terminationGracePeriodSeconds>0", func() {
+			It("[test_id:3007]Should force restart a VM with terminationGracePeriodSeconds>0", func() {
 
 				By("getting a VM with high TerminationGracePeriod")
 				newVMI := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskFedora))

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -158,7 +158,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			Context("with injected ssh-key", func() {
-				It("[Serial][test_id:1616]should have ssh-key under authorized keys", func() {
+				It("[test_id:1616]should have ssh-key under authorized keys", func() {
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,
@@ -196,7 +196,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			Context("with injected ssh-key", func() {
-				It("[Serial][test_id:3178]should have ssh-key under authorized keys", func() {
+				It("[test_id:3178]should have ssh-key under authorized keys", func() {
 					userData := fmt.Sprintf(
 						"#cloud-config\npassword: %s\nchpasswd: { expire: False }\nssh_authorized_keys:\n  - %s",
 						fedoraPassword,

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -791,7 +791,7 @@ var _ = Describe("Configurations", func() {
 				Expect(err).To(HaveOccurred(), "should not start vmi")
 			})
 
-			It("[Serial][test_id:3072]should start the VMI with tablet input device with virtio bus", func() {
+			It("[test_id:3072]should start the VMI with tablet input device with virtio bus", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi.Spec.Domain.Devices.Inputs = []v1.Input{
 					{
@@ -2565,7 +2565,7 @@ var _ = Describe("Configurations", func() {
 		})
 	})
 
-	Context("[Serial]With ephemeral CD-ROM", func() {
+	Context("With ephemeral CD-ROM", func() {
 		var vmi *v1.VirtualMachineInstance
 
 		BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

 * Give the CI nodes enough memory to execute 3 fedora guest tests in parallel
 * Remove the `[Serial]` tag from tests wich involve fedora and were only excluded due to that

This is possible, since we have already much more reserved memory for the test cluster than we actually used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
