### PR TITLE
tests: Render test utils pod in the test namespace

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2836,6 +2836,7 @@ func RenderPod(name string, cmd []string, args []string) *k8sv1.Pod {
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
+			Namespace:    NamespaceTestDefault,
 			Labels: map[string]string{
 				v1.AppLabel: "test",
 			},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Explicitly render test utils pods in the default testing namespace. By
doing this, we make sure that all the helper objects created by our
tests are removed when the test namespace is deleted.

Signed-off-by: Petr Horacek <phoracek@redhat.com>

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
