### PR TITLE
Fix pull-kubevirt-apidocs lane

### DIFF
--- a/hack/gen-swagger-doc/build.gradle
+++ b/hack/gen-swagger-doc/build.gradle
@@ -1,6 +1,8 @@
 buildscript {
     repositories {
         mavenLocal()
+        mavenCentral()
+        google()
         jcenter()
     }
 


### PR DESCRIPTION
`pull-kubevirt-apidocs` had some problems with
classpath and asciidoctor.
`Could not resolve all artifacts for configuration ':classpath'.`

Solution based on https://github.com/flutter/flutter/issues/23553#issuecomment-583104747

See failure on
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4354/pull-kubevirt-apidocs/1315673973295419393

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
