### PR TITLE
Fix SRIOV VMI example

### DIFF
--- a/examples/vmi-sriov.yaml
+++ b/examples/vmi-sriov.yaml
@@ -30,16 +30,16 @@ spec:
   - name: default
     pod: {}
   - multus:
-      networkName: sriov/sriov-network
+      networkName: sriov-network-example
     name: sriov-net
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:
-      image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
+      image: registry:5000/kubevirt/fedora-cloud-sriov-lane-container-disk:devel
     name: containerdisk
   - cloudInitNoCloud:
-      userData: |
-        #!/bin/bash
-        echo "fedora" |passwd fedora --stdin
-        dhclient eth1
+      userData: |-
+        #cloud-config
+        password: fedora
+        chpasswd: { expire: False }
     name: cloudinitdisk


### PR DESCRIPTION
Currently creating VMI with example/vmi-sriov.yaml will fail due to missing SriovNetwork.

This PR updates the SRIOV VMI example to use the SRIOV provider example SriovNetwork
and make use of the image [fedora-sriov-lane-container-disk](https://github.com/kubevirt/kubevirt/blob/master/containerimages/container-disk-images.md#kubevirt-container-disk-images).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR should be merged only after the changes https://github.com/kubevirt/kubevirtci/pull/471 are reflects in kubevirt.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix SRIOV example
```
