### PR TITLE
Reduce to the minimum the helpers that return an expecter

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -97,11 +97,9 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutput).To(Equal(expectedOutput))
 
 				By("Checking mounted iso image")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount iso ConfigMap image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -109,8 +107,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/option1 /mnt/option2 /mnt/option3\n"},
 					&expect.BExp{R: expectedOutput},
-				}, 200*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				}, 200)).To(Succeed())
 			})
 		})
 
@@ -192,11 +189,9 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutput).To(Equal(expectedOutput))
 
 				By("Checking mounted iso image")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount iso Secret image
 					&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -204,8 +199,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutput},
-				}, 200*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				}, 200)).To(Succeed())
 			})
 		})
 
@@ -276,11 +270,9 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			)
 
 			By("Checking mounted iso image")
-			expecter, err := tests.LoggedInAlpineExpecter(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
+			Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
-			_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				// mount service account iso image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 				&expect.BExp{R: console.PromptExpression},
@@ -290,8 +282,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				&expect.BExp{R: tests.NamespaceTestDefault},
 				&expect.BSnd{S: "tail -c 20 /mnt/token\n"},
 				&expect.BExp{R: token},
-			}, 200*time.Second)
-			Expect(err).ToNot(HaveOccurred())
+			}, 200)).To(Succeed())
 		})
 
 	})
@@ -545,19 +536,16 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			Expect(podOutput).To(Equal(expectedOutput + "\n"))
 
 			By("Checking mounted iso image")
-			expecter, err := tests.LoggedInAlpineExpecter(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
+			Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
-			_, err = expecter.ExpectBatch([]expect.Batcher{
+			Expect(console.ExpectBatch(vmi, []expect.Batcher{
 				// mount iso DownwardAPI image
 				&expect.BSnd{S: "mount /dev/sda /mnt\n"},
 				&expect.BSnd{S: "echo $?\n"},
 				&expect.BExp{R: console.RetValue("0")},
 				&expect.BSnd{S: "grep " + testLabelKey + " /mnt/labels\n"},
 				&expect.BExp{R: expectedOutput},
-			}, 200*time.Second)
-			Expect(err).ToNot(HaveOccurred())
+			}, 200*time.Second)).To(Succeed())
 		})
 	})
 })

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -29,7 +29,6 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/config"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -371,11 +370,9 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutputCfgMap).To(Equal(expectedOutputCfgMap), "Expected %s to Equal value1value2value3", podOutputCfgMap)
 
 				By("Checking mounted ConfigMap image")
-				expecter, err := tests.LoggedInFedoraExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToFedora(vmi)).To(Succeed())
 
-				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount ConfigMap image
 					&expect.BSnd{S: "sudo su -\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -385,9 +382,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/config1 /mnt/config2 /mnt/config3\n"},
 					&expect.BExp{R: expectedOutputCfgMap},
-				}, 200*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 200)).To(Succeed())
 
 				By("Checking if Secret has also been attached to the same pod")
 				podOutputSecret, err := tests.ExecuteCommandOnPod(
@@ -404,7 +399,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 
 				By("Checking mounted secret image")
 
-				res, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount Secret image
 					&expect.BSnd{S: "mount /dev/vdd /mnt\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -412,12 +407,10 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: console.RetValue("0")},
 					&expect.BSnd{S: "cat /mnt/user /mnt/password\n"},
 					&expect.BExp{R: expectedOutputSecret},
-				}, 200*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 200)).To(Succeed())
 
 				By("checking that all disk labels match the expectations")
-				res, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdc\n"},
 					&expect.BExp{R: "cfgdata"}, // default value
 					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdd\n"},
@@ -426,9 +419,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: "configlabel"}, // custom value
 					&expect.BSnd{S: "blkid -s LABEL -o value /dev/vdf\n"},
 					&expect.BExp{R: "secretlabel"}, // custom value
-				}, 200*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 200)).To(Succeed())
 			})
 		})
 	})
@@ -497,11 +488,9 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(podOutput2).To(Equal(expectedPublicKey), "Expected pod output of public key to match genereated one.")
 
 				By("Checking mounted secrets sshkeys image")
-				expecter, err := tests.LoggedInFedoraExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToFedora(vmi)).To(Succeed())
 
-				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount iso Secret image
 					&expect.BSnd{S: "sudo su -\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -513,9 +502,7 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 					&expect.BExp{R: console.RetValue(`[1-9]\d*`)},
 					&expect.BSnd{S: "grep -c ssh-rsa /mnt/ssh-publickey\n"},
 					&expect.BExp{R: console.RetValue(`[1-9]\d*`)},
-				}, 200*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 200)).To(Succeed())
 			})
 		})
 	})

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -73,13 +73,22 @@ func ExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, time
 // wait `timeout` for the batch to return, it also check that the sended commands arrives to console checking.
 // NOTE: This functions heritage limitations from `ExpectBatchWithValidatedSend` refer to it to check them.
 func SafeExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
+	_, err := SafeExpectBatchWithResponse(vmi, expected, wait)
+	return err
+}
+
+// SafeExpectBatchWithResponse runs the batch from `expected` connecting to a VMI's console and
+// wait `timeout` for the batch to return with a response.
+// It includes a safety check which validates that the commands arrive to the console.
+// NOTE: This functions inherits limitations from `ExpectBatchWithValidatedSend`, refer to it for more information.
+func SafeExpectBatchWithResponse(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) ([]expect.BatchRes, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		panic(err)
 	}
 	expecter, _, err := NewExpecter(virtClient, vmi, 30*time.Second)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer expecter.Close()
 
@@ -87,7 +96,7 @@ func SafeExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, 
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("%v", resp)
 	}
-	return err
+	return resp, err
 }
 
 // RunCommand runs the command line from `command connecting to an already logged in console at vmi

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -142,7 +142,7 @@ func SecureBootExpecter(vmi *v1.VirtualMachineInstance) error {
 	b := append([]expect.Batcher{
 		&expect.BExp{R: "secureboot: Secure boot enabled"},
 	})
-	res, err := ExpectBatchWithValidatedSend(expecter, b, 180*time.Second)
+	res, err := expecter.ExpectBatch(b, 180*time.Second)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("Kernel: %+v", res)
 		return err
@@ -229,6 +229,11 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 	sendFlag := false
 	expectFlag := false
 	previousSend := ""
+
+	if len(batch) < 2 {
+		return nil, fmt.Errorf("ExpectBatchWithValidatedSend requires at least 2 batchers, supplied %v", batch)
+	}
+
 	for i, batcher := range batch {
 		switch batcher.Cmd() {
 		case expect.BatchExpect:

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -59,20 +59,11 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 	}
 
 	ExpectConsoleOutput := func(vmi *v1.VirtualMachineInstance, expected string) {
-		By("Expecting the VirtualMachineInstance console")
-		expecter, _, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
-		Expect(err).ToNot(HaveOccurred())
-		defer func() {
-			By("Closing the opened expecter")
-			expecter.Close()
-		}()
-
 		By("Checking that the console output equals to expected one")
-		_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: expected},
-		}, 120*time.Second)
-		Expect(err).ToNot(HaveOccurred())
+		}, 120)).To(Succeed())
 	}
 
 	OpenConsole := func(vmi *v1.VirtualMachineInstance) (expect.Expecter, <-chan error) {

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
@@ -204,11 +203,9 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				tests.WaitForSuccessfulVMIStart(obj)
 
 				By("Checking whether the second disk really contains virtio drivers")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "expected alpine to login properly")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed(), "expected alpine to login properly")
 
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					// mount virtio cdrom and check files are there
 					&expect.BSnd{S: "mount -t iso9600 /dev/cdrom\n"},
 					&expect.BExp{R: console.PromptExpression},
@@ -220,8 +217,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
-				}, 200*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "expected virtio files to be mounted properly")
+				}, 200)).To(Succeed(), "expected virtio files to be mounted properly")
 			})
 		})
 	})

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -237,7 +237,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Ensuring VMI is running by logging in")
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
 				pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -97,9 +97,7 @@ var _ = Describe("[Serial]DataVolume Integration", func() {
 					// after being restarted multiple times
 					if i == num {
 						By("Checking that the VirtualMachineInstance console has expected output")
-						expecter, err := tests.LoggedInAlpineExpecter(vmi)
-						Expect(err).To(BeNil())
-						expecter.Close()
+						Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 					}
 
 					err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
@@ -121,9 +119,7 @@ var _ = Describe("[Serial]DataVolume Integration", func() {
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).To(BeNil())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
@@ -548,9 +544,7 @@ var _ = Describe("[Serial]DataVolume Integration", func() {
 						By("Checking that the VirtualMachineInstance console has expected output")
 						vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
 						Expect(err).ToNot(HaveOccurred())
-						expecter, err := tests.LoggedInAlpineExpecter(vmi)
-						Expect(err).To(BeNil())
-						expecter.Close()
+						Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 					}
 					vm = tests.StopVirtualMachine(vm)
 				}

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -39,7 +39,7 @@ func newLabeledVMI(label string, virtClient kubecli.KubevirtClient, createVMI bo
 		tests.WaitForSuccessfulVMIStartIgnoreWarnings(vmi)
 		vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.ObjectMeta.Name, &k8smetav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+		tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 	}
 	return
 }

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -170,9 +170,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			By("checking that we can still start virtual machines and connect to the VMI")
 			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			vmi = tests.RunVMI(vmi, 60)
-			expecter, err := tests.LoggedInAlpineExpecter(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
+			Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 		})
 
 		It("[test_id:4100] should be valid during the whole rotation process", func() {
@@ -188,9 +186,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			Eventually(func() (rotated bool) {
 				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 				vmi = tests.RunVMI(vmi, 60)
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 				err = virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				newAPICert, _, err := tests.GetPodsCertIfSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-api"), flags.KubeVirtInstallNamespace, "8443")
@@ -564,18 +560,15 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			By("Expecting the VirtualMachineInstance console")
 			// This also serves as a sync point to make sure the VM completed the boot
 			// (and reduce the risk of false negatives)
-			expecter, err := tests.LoggedInAlpineExpecter(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
+			Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 			By("Writing some data to the disk")
-			_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "dd if=/dev/zero of=/dev/vdb bs=1M count=1\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: "sync\n"},
 				&expect.BExp{R: console.PromptExpression},
-			}, 10*time.Second)
-			Expect(err).ToNot(HaveOccurred())
+			}, 10)).To(Succeed())
 
 			preparedVMIs = append(preparedVMIs, vmi)
 			return nodeName

--- a/tests/login.go
+++ b/tests/login.go
@@ -16,7 +16,10 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-// LoginToCirros call LoggedInFedoraExpecter but does not return the expecter
+// LoginToFactory represents the LogIn* functions signature
+type LoginToFactory func(*v1.VirtualMachineInstance) error
+
+// LoginToCirros performs a console login to a Cirros base VM
 func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 	expecter, err := LoggedInCirrosExpecter(vmi)
 	if err == nil {
@@ -73,6 +76,13 @@ func LoggedInCirrosExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 	return expecter, configureIPv6OnVMI(vmi, expecter, virtClient)
 }
 
+// LoginToAlpine performs a console login to an Alpine base VM
+func LoginToAlpine(vmi *v1.VirtualMachineInstance) error {
+	expecter, err := LoggedInAlpineExpecter(vmi)
+	defer expecter.Close()
+	return err
+}
+
 // LoggedInAlpineExpecter return prepared and ready to use console expecter for
 // Alpine test VM
 func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, error) {
@@ -101,6 +111,13 @@ func LoggedInAlpineExpecter(vmi *v1.VirtualMachineInstance) (expect.Expecter, er
 		return nil, err
 	}
 	return expecter, err
+}
+
+// LoginToFedora performs a console login to a Fedora base VM
+func LoginToFedora(vmi *v1.VirtualMachineInstance) error {
+	expecter, err := LoggedInFedoraExpecter(vmi)
+	defer expecter.Close()
+	return err
 }
 
 // LoggedInFedoraExpecter return prepared and ready to use console expecter for

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -375,9 +375,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 				// after being restarted multiple times
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				for _, c := range vmi.Status.Conditions {
 					if c.Type == v1.VirtualMachineInstanceIsMigratable {
@@ -684,9 +682,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 				// after being restarted multiple times
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				// execute a migration, wait for finalized state
 				By("Starting the Migration")
@@ -728,9 +724,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				// Verify console on last iteration to verify the VirtualMachineInstance is still booting properly
 				// after being restarted multiple times
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				for _, c := range vmi.Status.Conditions {
 					if c.Type == v1.VirtualMachineInstanceIsMigratable {
@@ -763,9 +757,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 300)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Starting a Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -811,9 +803,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Starting a Migration")
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
@@ -835,9 +825,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				// execute a migration, wait for finalized state
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -413,9 +413,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				// execute a migration, wait for finalized state
 				By("starting the migration")
@@ -452,9 +450,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				num := 4
 
@@ -498,9 +494,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				pods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(metav1.ListOptions{
 					LabelSelector: v1.CreatedByLabel + "=" + string(vmi.GetUID()),
@@ -887,10 +881,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-
-				expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking that MigrationMethod is set to BlockMigration")
 				Expect(vmi.Status.MigrationMethod).To(Equal(v1.BlockMigration))
@@ -1319,9 +1310,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				vmi = runVMIAndExpectLaunch(vmi, 180)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				for _, c := range vmi.Status.Conditions {
 					if c.Type == v1.VirtualMachineInstanceIsMigratable {

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -93,7 +93,7 @@ var _ = SIGDescribe("[Serial]Primary Pod Network", func() {
 
 					tmpVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(tmpVmi)
 					Expect(err).NotTo(HaveOccurred())
-					vmi = tests.WaitUntilVMIReady(tmpVmi, tests.LoggedInFedoraExpecter)
+					vmi = tests.WaitUntilVMIReady(tmpVmi, tests.LoginToFedora)
 
 					tests.WaitAgentConnected(virtClient, vmi)
 				})
@@ -139,7 +139,7 @@ func setupVMI(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance)
 	Expect(err).NotTo(HaveOccurred(), "VMI should be successfully created")
 
 	By("Waiting until the VMI gets ready")
-	vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+	vmi = tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 	return vmi
 }

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -66,7 +66,7 @@ var _ = SIGDescribe("[Serial]Services", func() {
 		createdVMI, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 		Expect(err).ToNot(HaveOccurred())
 
-		return tests.WaitUntilVMIReady(createdVMI, tests.LoggedInCirrosExpecter)
+		return tests.WaitUntilVMIReady(createdVMI, tests.LoginToCirros)
 	}
 
 	cleanupVMI := func(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {

--- a/tests/networkpolicy_test.go
+++ b/tests/networkpolicy_test.go
@@ -66,9 +66,9 @@ var _ = Describe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][leve
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			serverVMIFuture := tests.WaitUntilVMIReadyAsync(ctx, serverVMI, tests.LoggedInCirrosExpecter)
-			clientVMIFuture := tests.WaitUntilVMIReadyAsync(ctx, clientVMI, tests.LoggedInCirrosExpecter)
-			clientVMIAlternativeNamespaceFuture := tests.WaitUntilVMIReadyAsync(ctx, clientVMIAlternativeNamespace, tests.LoggedInCirrosExpecter)
+			serverVMIFuture := tests.WaitUntilVMIReadyAsync(ctx, serverVMI, tests.LoginToCirros)
+			clientVMIFuture := tests.WaitUntilVMIReadyAsync(ctx, clientVMI, tests.LoginToCirros)
+			clientVMIAlternativeNamespaceFuture := tests.WaitUntilVMIReadyAsync(ctx, clientVMIAlternativeNamespace, tests.LoginToCirros)
 
 			serverVMI = serverVMIFuture()
 			clientVMI = clientVMIFuture()

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -938,11 +938,9 @@ spec:
 				Eventually(func() error {
 					vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmYaml.vmName, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					expecter, err := tests.LoggedInCirrosExpecter(vmi)
-					if err != nil {
+					if err := tests.LoginToCirros(vmi); err != nil {
 						return err
 					}
-					expecter.Close()
 					return nil
 				}, 60*time.Second, 1*time.Second).Should(BeNil())
 

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -400,8 +400,9 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			vmi = tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 240, false)
 
 			By("Checking that the VirtualMachineInstance console has expected output")
-			expecter, expecterErr := tests.LoggedInCirrosExpecter(vmi)
-			Expect(expecterErr).ToNot(HaveOccurred(), "should successfully create expecter")
+			Expect(tests.LoginToCirros(vmi)).To(Succeed())
+			expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred(), "should successfully create expecter")
 			defer expecter.Close()
 
 			By("checking uptime difference between guest and host")

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -27,8 +27,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"kubevirt.io/client-go/log"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -376,12 +374,11 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			uptimeDiffBeforePausing float64
 		)
 
-		grepGuestUptime := func(expecter expect.Expecter) float64 {
-			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+		grepGuestUptime := func(vmi *v1.VirtualMachineInstance) float64 {
+			res, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
 				&expect.BSnd{S: `cat /proc/uptime | awk '{print $1;}'` + "\n"},
 				&expect.BExp{R: console.RetValue("[0-9\\.]+")}, // guest uptime
-			}, 15*time.Second)
-			log.DefaultLogger().Infof("a:%+v\n", res)
+			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 			re := regexp.MustCompile("\r\n[0-9\\.]+\r\n")
 			guestUptime, err := strconv.ParseFloat(strings.TrimSpace(re.FindString(res[0].Match[0])), 64)
@@ -401,12 +398,9 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			By("Checking that the VirtualMachineInstance console has expected output")
 			Expect(tests.LoginToCirros(vmi)).To(Succeed())
-			expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
-			Expect(err).ToNot(HaveOccurred(), "should successfully create expecter")
-			defer expecter.Close()
 
 			By("checking uptime difference between guest and host")
-			uptimeDiffBeforePausing = hostUptime() - grepGuestUptime(expecter)
+			uptimeDiffBeforePausing = hostUptime() - grepGuestUptime(vmi)
 		})
 
 		It("[test_id:3090]should be less than uptime difference after pause", func() {
@@ -421,12 +415,8 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(command()).To(Succeed(), "should successfully unpause tthe vmi")
 			tests.WaitForVMIConditionRemovedOrFalse(virtClient, vmi, v1.VirtualMachineInstancePaused, 30)
 
-			expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
-			Expect(err).ToNot(HaveOccurred(), "should successfully create expecter")
-			defer expecter.Close()
-
 			By("Verifying VMI was indeed Paused")
-			uptimeDiffAfterPausing := hostUptime() - grepGuestUptime(expecter)
+			uptimeDiffAfterPausing := hostUptime() - grepGuestUptime(vmi)
 			Expect(uptimeDiffAfterPausing).To(BeNumerically(">", uptimeDiffBeforePausing+10), "uptime diff after pausing should be greater by at least 10 than before pausing")
 		})
 	})

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -20,7 +20,6 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	snapshotv1 "kubevirt.io/client-go/apis/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -379,8 +378,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 
 			doRestore := func(device string) {
 				By("creating 'message with initial value")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				var batch []expect.Batcher
 				if device != "" {
@@ -419,10 +417,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 					&expect.BExp{R: console.PromptExpression},
 				}...)
 
-				res, err := console.ExpectBatchWithValidatedSend(expecter, batch, 20*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				expecter.Close()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 
 				By("Stopping VM")
 				vm = tests.StopVirtualMachine(vm)
@@ -436,8 +431,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("updating message")
-				expecter, err = tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				batch = nil
 
@@ -475,10 +469,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 					&expect.BExp{R: console.PromptExpression},
 				}...)
 
-				res, err = console.ExpectBatchWithValidatedSend(expecter, batch, 20*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				expecter.Close()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 
 				By("Stopping VM")
 				vm = tests.StopVirtualMachine(vm)
@@ -497,8 +488,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Verifying original file contents")
-				expecter, err = tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				batch = nil
 
@@ -526,10 +516,7 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 					&expect.BExp{R: string(vm.UID)},
 				}...)
 
-				res, err = console.ExpectBatchWithValidatedSend(expecter, batch, 20*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				expecter.Close()
-				Expect(err).ToNot(HaveOccurred())
+				Expect(console.SafeExpectBatch(vmi, batch, 20)).To(Succeed())
 			}
 
 			It("[test_id:5259]should restore a vm multiple from the same snapshot", func() {

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -147,7 +147,7 @@ var _ = Describe("[Serial]SecurityFeatures", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Ensuring VMI is running by logging in")
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
 				pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -177,7 +177,7 @@ var _ = Describe("[Serial]SecurityFeatures", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Ensuring VMI is running by logging in")
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 				By("Fetching virt-launcher Pod")
 				pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
@@ -216,7 +216,7 @@ var _ = Describe("[Serial]SecurityFeatures", func() {
 			tests.WaitForSuccessfulVMIStart(vmi)
 
 			By("Ensuring VMI is running by logging in")
-			tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 			By("Fetching virt-launcher Pod")
 			pod := tests.GetPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -222,27 +222,21 @@ var _ = Describe("[Serial]Storage", func() {
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking that /dev/vdc has a capacity of 2Gi")
-				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo blockdev --getsize64 /dev/vdc\n"},
 					&expect.BExp{R: "2147483648"}, // 2Gi in bytes
-				}, 10*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 10)).To(Succeed())
 
 				By("Checking if we can write to /dev/vdc")
-				res, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo mkfs.ext4 /dev/vdc\n"},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
-				}, 20*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 20)).To(Succeed())
 			})
 
 		})
@@ -272,17 +266,13 @@ var _ = Describe("[Serial]Storage", func() {
 				})
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				By("Checking for the specified serial number")
-				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo find /sys -type f -regex \".*/block/.*/serial\" | xargs cat\n"},
 					&expect.BExp{R: diskSerial},
-				}, 10*time.Second)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 10)).To(Succeed())
 			})
 
 		})
@@ -878,9 +868,7 @@ var _ = Describe("[Serial]Storage", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 90)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Cirros login successfully")
-				expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 			})
 		})
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -339,17 +339,14 @@ var _ = Describe("[Serial]Storage", func() {
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				expecter, err := tests.LoggedInFedoraExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "Should be able to login to the Fedora VM")
-				defer expecter.Close()
+				Expect(tests.LoginToFedora(vmi)).To(Succeed(), "Should be able to login to the Fedora VM")
 
 				By("Checking that virtio-fs is mounted")
 				listVirtioFSDisk := fmt.Sprintf("ls -l %s/*disk* | wc -l\n", virtiofsMountPath)
-				_, err = expecter.ExpectBatch([]expect.Batcher{
+				Expect(console.ExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: listVirtioFSDisk},
 					&expect.BExp{R: console.RetValue("1")},
-				}, 30*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "Should be able to access the mounted virtiofs file")
+				}, 30*time.Second)).To(Succeed(), "Should be able to access the mounted virtiofs file")
 
 				virtioFsFileTestCmd := fmt.Sprintf("test -f /run/kubevirt-private/vmi-disks/%s/virtiofs_test && echo exist", fs.Name)
 				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -938,6 +938,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
+						&expect.BExp{R: console.PromptExpression},
 					}, 10)).To(Succeed())
 
 					By("Getting VM's UUID")
@@ -1092,6 +1093,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
+						&expect.BExp{R: console.PromptExpression},
 					}, 10)).To(Succeed())
 
 					By("Ensuring the VirtualMachineInstance enters Succeeded phase")
@@ -1329,6 +1331,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					By("Issuing a poweroff command from inside VM")
 					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
+						&expect.BExp{R: console.PromptExpression},
 					}, 10)).To(Succeed())
 
 					By("Ensuring the VirtualMachineInstance enters Succeeded phase")

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -682,16 +682,13 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}, 240*time.Second, 1*time.Second).Should(BeTrue())
 
 				By("Obtaining the serial console")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 				By("Guest shutdown")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo poweroff\n"},
 					&expect.BExp{R: "The system is going down NOW!"},
-				}, 240*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				}, 240)).To(Succeed())
 
 				By("waiting for the controller to replace the shut-down vmi with a new instance")
 				Eventually(func() bool {
@@ -936,15 +933,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &v12.GetOptions{})
 
-					expecter, err := tests.LoggedInCirrosExpecter(vmi)
-					Expect(err).ToNot(HaveOccurred())
-					defer expecter.Close()
+					Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
-					_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
-					}, 10*time.Second)
-					Expect(err).ToNot(HaveOccurred())
+					}, 10)).To(Succeed())
 
 					By("Getting VM's UUID")
 					virtualMachine, err = virtClient.VirtualMachine(virtualMachine.Namespace).Get(virtualMachine.Name, &v12.GetOptions{})
@@ -1093,15 +1087,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &v12.GetOptions{})
 
-					expecter, err := tests.LoggedInCirrosExpecter(vmi)
-					Expect(err).ToNot(HaveOccurred())
-					defer expecter.Close()
+					Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
-					_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
-					}, 10*time.Second)
-					Expect(err).ToNot(HaveOccurred())
+					}, 10)).To(Succeed())
 
 					By("Ensuring the VirtualMachineInstance enters Succeeded phase")
 					Eventually(func() v1.VirtualMachineInstancePhase {
@@ -1333,15 +1324,12 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					vmi, err := virtClient.VirtualMachineInstance(virtualMachine.Namespace).Get(virtualMachine.Name, &v12.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					expecter, err := tests.LoggedInCirrosExpecter(vmi)
-					Expect(err).ToNot(HaveOccurred())
-					defer expecter.Close()
+					Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
 					By("Issuing a poweroff command from inside VM")
-					_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+					Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "sudo poweroff\n"},
-					}, 10*time.Second)
-					Expect(err).ToNot(HaveOccurred())
+					}, 10)).To(Succeed())
 
 					By("Ensuring the VirtualMachineInstance enters Succeeded phase")
 					Eventually(func() v1.VirtualMachineInstancePhase {

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -123,7 +123,7 @@ var _ = Describe("CloudInitHookSidecars", func() {
 			It("[test_id:3169]should have cloud-init user-data from sidecar", func() {
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 				By("mouting cloudinit iso")
 				MountCloudInit(vmi)
 				By("checking cloudinit user-data")

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -234,16 +234,12 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, time.Second*120)
 
 				By("applying the hostname from meta-data")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
-				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
 					&expect.BExp{R: dns.SanitizeHostname(vmi)},
-				}, time.Second*10)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 10)).To(Succeed())
 			})
 		})
 
@@ -261,16 +257,12 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, time.Second*120)
 
 				By("applying the hostname from meta-data")
-				expecter, err := tests.LoggedInCirrosExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToCirros(vmi)).To(Succeed())
 
-				res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
 					&expect.BExp{R: dns.SanitizeHostname(vmi)},
-				}, time.Second*10)
-				log.DefaultLogger().Object(vmi).Infof("%v", res)
-				Expect(err).ToNot(HaveOccurred())
+				}, 10)).To(Succeed())
 			})
 		})
 

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -326,7 +326,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), testUserData, testNetworkData, false)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mouting cloudinit iso")
 				MountCloudInitNoCloud(vmi)
@@ -341,7 +341,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), testUserData, testNetworkData, true)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mouting cloudinit iso")
 				MountCloudInitNoCloud(vmi)
@@ -392,7 +392,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mouting cloudinit iso")
 				MountCloudInitNoCloud(vmi)
@@ -420,7 +420,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), testUserData, testNetworkData, false)
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mouting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)
@@ -437,7 +437,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", Tag: "specialNet", InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}}
 				vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -483,7 +483,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndConfigDriveUserdataNetworkData(
 					cd.ContainerDiskFor(cd.ContainerDiskCirros), testUserData, testNetworkData, true)
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mouting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)
@@ -534,7 +534,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mouting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)
@@ -613,7 +613,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}
 
 				LaunchVMI(vmi)
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("mounting cloudinit iso")
 				MountCloudInitConfigDrive(vmi)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -34,7 +34,6 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
 	cloudinit "kubevirt.io/kubevirt/pkg/cloud-init"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -82,15 +81,8 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		}
 
 		VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
-			By("Expecting the VirtualMachineInstance console")
-			expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
-
 			By("Checking that the VirtualMachineInstance serial console output equals to expected one")
-			resp, err := console.ExpectBatchWithValidatedSend(expecter, commands, timeout)
-			log.DefaultLogger().Object(vmi).Infof("%v", resp)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(console.SafeExpectBatch(vmi, commands, int(timeout.Seconds()))).To(Succeed())
 		}
 
 		mountCloudInitFunc := func(devName string) func(*v1.VirtualMachineInstance) {

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -115,18 +115,12 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		}
 		CheckCloudInitMetaData = func(vmi *v1.VirtualMachineInstance, testFile, testData string) {
 			cmdCheck := "cat /mnt/" + testFile + "\n"
-			virtClient, err := kubecli.GetKubevirtClient()
-			tests.PanicOnError(err)
-			expecter, _, err := console.NewExpecter(virtClient, vmi, 30*time.Second)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
-
-			res, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			res, err := console.SafeExpectBatchWithResponse(vmi, []expect.Batcher{
 				&expect.BSnd{S: "sudo su -\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: cmdCheck},
 				&expect.BExp{R: testData},
-			}, 15*time.Second)
+			}, 15)
 			if err != nil {
 				Expect(res[1].Output).To(ContainSubstring(testData))
 			}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -200,16 +200,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of CPU cores under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: console.RetValue("3")},
-				}, 15*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of cores")
+				}, 15)).To(Succeed(), "should report number of cores")
 
 				By("Checking the requested amount of memory allocated for a guest")
 				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("64M"))
@@ -265,16 +262,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of sockets under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
 					&expect.BExp{R: console.RetValue("3")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of sockets")
+				}, 60)).To(Succeed(), "should report number of sockets")
 			})
 
 			It("[test_id:1661]should report 2 sockets from spec.domain.resources.requests under guest OS ", func() {
@@ -292,16 +286,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of sockets under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
 					&expect.BExp{R: console.RetValue("2")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of sockets")
+				}, 60)).To(Succeed(), "should report number of sockets")
 			})
 
 			It("[test_id:1662]should report 2 sockets from spec.domain.resources.limits under guest OS ", func() {
@@ -321,16 +312,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of sockets under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep '^physical id' /proc/cpuinfo | uniq | wc -l\n"},
 					&expect.BExp{R: console.RetValue("2")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of sockets")
+				}, 60)).To(Succeed(), "should report number of sockets")
 			})
 
 			It("[test_id:1663]should report 4 vCPUs under guest OS", func() {
@@ -351,16 +339,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of vCPUs under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^processor /proc/cpuinfo\n"},
 					&expect.BExp{R: console.RetValue("4")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of threads")
+				}, 60)).To(Succeed(), "should report number of threads")
 			})
 
 			It("[Serial][test_id:1664]should map cores to virtio block queues", func() {
@@ -687,16 +672,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should get console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of usb under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
 					&expect.BExp{R: console.RetValue("2")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
+				}, 60)).To(Succeed(), "should report number of usb")
 			})
 
 			It("[test_id:3117]should start the VMI with usb controller when input device doesn't have bus", func() {
@@ -713,16 +695,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should get console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the number of usb under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* | wc -l\n"},
 					&expect.BExp{R: console.RetValue("2")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
+				}, 60)).To(Succeed(), "should report number of usb")
 			})
 
 			It("[test_id:3118]should start the VMI without usb controller", func() {
@@ -734,15 +713,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
+
 				By("Checking the number of usb under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "ls -l /sys/bus/usb/devices/usb* 2>/dev/null | wc -l\n"},
 					&expect.BExp{R: console.RetValue("0")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report number of usb")
+				}, 60)).To(Succeed(), "should report number of usb")
 			})
 		})
 
@@ -790,16 +767,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the tablet input under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep -rs '^QEMU Virtio Tablet' /sys/devices | wc -l\n"},
 					&expect.BExp{R: console.RetValue("1")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report input device")
+				}, 60)).To(Succeed(), "should report input device")
 			})
 
 			It("[test_id:3073]should start the VMI with tablet input device with usb bus", func() {
@@ -817,16 +791,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "should start console")
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Checking the tablet input under guest OS")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "grep -rs '^QEMU USB Tablet' /sys/devices | wc -l\n"},
 					&expect.BExp{R: console.RetValue("1")},
-				}, 60*time.Second)
-				Expect(err).ToNot(HaveOccurred(), "should report input device")
+				}, 60)).To(Succeed(), "should report input device")
 			})
 		})
 
@@ -1128,16 +1099,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(rngVmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(rngVmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(rngVmi)).To(Succeed())
 
 				By("Checking the virtio rng presence")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(rngVmi, []expect.Batcher{
 					&expect.BSnd{S: "grep -c ^virtio /sys/devices/virtual/misc/hw_random/rng_available\n"},
 					&expect.BExp{R: console.RetValue("1")},
-				}, 400*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				}, 400)).To(Succeed())
 			})
 
 			It("[test_id:1675]should not have the virtio rng device when not present", func() {
@@ -1147,16 +1115,13 @@ var _ = Describe("Configurations", func() {
 				tests.WaitForSuccessfulVMIStart(rngVmi)
 
 				By("Expecting the VirtualMachineInstance console")
-				expecter, err := tests.LoggedInAlpineExpecter(rngVmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(rngVmi)).To(Succeed())
 
 				By("Checking the virtio rng presence")
-				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+				Expect(console.SafeExpectBatch(rngVmi, []expect.Batcher{
 					&expect.BSnd{S: "[[ ! -e /sys/devices/virtual/misc/hw_random/rng_available ]] && echo non\n"},
 					&expect.BExp{R: console.RetValue("non")},
-				}, 400*time.Second)
-				Expect(err).ToNot(HaveOccurred())
+				}, 400)).To(Succeed())
 			})
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -469,9 +469,8 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Expecting no bootable NIC")
-				_, err = console.NetBootExpecter(vmi)
+				Expect(console.NetBootExpecter(vmi)).NotTo(Succeed())
 				// The expecter *should* have error-ed since the network interface is not marked bootable
-				Expect(err).To(HaveOccurred())
 			})
 
 			It("[test_id:5266]should boot to NIC rom if a boot order was set on a network interface", func() {
@@ -497,8 +496,7 @@ var _ = Describe("Configurations", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Expecting a bootable NIC")
-				_, err = console.NetBootExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(console.NetBootExpecter(vmi)).To(Succeed())
 			})
 		})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -527,7 +527,7 @@ var _ = Describe("Configurations", func() {
 				By("Starting a VirtualMachineInstance")
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 				By("Checking if UEFI is enabled")
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
@@ -1920,7 +1920,7 @@ var _ = Describe("Configurations", func() {
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = "virtio"
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+			tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
 		})
@@ -2668,7 +2668,7 @@ var _ = Describe("Configurations", func() {
 			}
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(vmi, tests.LoggedInFedoraExpecter)
+			tests.WaitUntilVMIReady(vmi, tests.LoginToFedora)
 			Expect(len(vmi.Spec.Domain.Devices.Disks)).Should(BeNumerically("==", numOfDevices))
 
 			err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -128,9 +128,7 @@ var _ = Describe("[rfe_id:609]VMIheadless", func() {
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 30)
 
 				By("checking that console works")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred())
-				defer expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed())
 			})
 
 		})

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -2,7 +2,6 @@ package tests_test
 
 import (
 	"strings"
-	"time"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
@@ -56,15 +55,13 @@ var _ = Describe("[Serial]HostDevices", func() {
 			vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(randomVMI)
 			Expect(err).ToNot(HaveOccurred())
 			tests.WaitForSuccessfulVMIStart(vmi)
-			expecter, err := tests.LoggedInFedoraExpecter(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(tests.LoginToFedora(vmi)).To(Succeed())
 
 			By("Making sure the sound card is present inside the VMI")
-			_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "grep -c " + strings.Replace(deviceIDs, ":", "", 1) + " /proc/bus/pci/devices\n"},
 				&expect.BExp{R: console.RetValue("1")},
-			}, 15*time.Second)
-			Expect(err).ToNot(HaveOccurred(), "Device not found")
+			}, 15)).To(Succeed(), "Device not found")
 		})
 	})
 })

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -279,9 +279,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred(), "cannot fetch VirtualMachineInstance %q: %v", vmi.Name, err)
 
 				By("Obtaining serial console")
-				expecter, err := tests.LoggedInAlpineExpecter(vmi)
-				Expect(err).ToNot(HaveOccurred(), "VirtualMachineInstance %q console is not accessible: %v", vmi.Name, err)
-				expecter.Close()
+				Expect(tests.LoginToAlpine(vmi)).To(Succeed(), "VirtualMachineInstance %q console is not accessible: %v", vmi.Name, err)
 			})
 		})
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1395,7 +1395,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
 				// wait until booted
-				vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				vmi = tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("Deleting the VirtualMachineInstance")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")
@@ -1424,7 +1424,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
 				// wait until booted
-				vmi = tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				vmi = tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				By("Deleting the VirtualMachineInstance")
 				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(obj.Name, &metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -74,9 +74,7 @@ var _ = Describe("[Serial]MultiQueue", func() {
 			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 360)
 
 			By("Checking if we can login")
-			e, err := tests.LoggedInFedoraExpecter(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			e.Close()
+			Expect(tests.LoginToFedora(vmi)).To(Succeed())
 		})
 
 		It("[test_id:959][rfe_id:2065] Should honor multiQueue requests", func() {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -171,7 +171,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(detachedVMI, tests.LoginToCirros)
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
@@ -189,7 +189,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(detachedVMI, tests.LoginToCirros)
 
 				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
 			})
@@ -210,7 +210,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(detachedVMI, tests.LoginToCirros)
 
 				cmdCheck := "sudo /sbin/cirros-dhcpc up eth1 > /dev/null\n"
 				err = console.SafeExpectBatch(detachedVMI, []expect.Batcher{
@@ -246,7 +246,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(detachedVMI)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(detachedVMI, tests.LoginToCirros)
 
 				By("checking virtual machine instance can ping 10.1.1.1 using ptp cni plugin")
 				Expect(libnet.PingFromVMConsole(detachedVMI, "10.1.1.1")).To(Succeed())
@@ -293,7 +293,7 @@ var _ = Describe("[Serial]Multus", func() {
 				By("Creating a VM with custom MAC address on its ptp interface.")
 				interfaces[0].MacAddress = customMacAddress
 				vmiOne := createVMIOnNode(interfaces, networks)
-				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmiOne, tests.LoginToAlpine)
 
 				By("Configuring static IP address to ptp interface.")
 				Expect(configInterface(vmiOne, "eth0", "10.1.1.1/24")).To(Succeed())
@@ -329,8 +329,8 @@ var _ = Describe("[Serial]Multus", func() {
 				vmiOne := createVMIOnNode(interfaces, networks)
 				vmiTwo := createVMIOnNode(interfaces, networks)
 
-				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
-				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmiOne, tests.LoginToAlpine)
+				tests.WaitUntilVMIReady(vmiTwo, tests.LoginToAlpine)
 
 				Expect(configInterface(vmiOne, "eth0", "10.1.1.1/24")).To(Succeed())
 				By("checking virtual machine interface eth0 state")
@@ -358,8 +358,8 @@ var _ = Describe("[Serial]Multus", func() {
 				vmiOne := createVMIOnNode(interfaces, networks)
 				vmiTwo := createVMIOnNode(interfaces, networks)
 
-				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
-				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmiOne, tests.LoginToAlpine)
+				tests.WaitUntilVMIReady(vmiTwo, tests.LoginToAlpine)
 
 				Expect(configInterface(vmiOne, "eth1", "10.1.1.1/24")).To(Succeed())
 				By("checking virtual machine interface eth1 state")
@@ -383,12 +383,12 @@ var _ = Describe("[Serial]Multus", func() {
 			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
 				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
 				vmiTwo := createVMIOnNode(interfaces, networks)
-				tests.WaitUntilVMIReady(vmiTwo, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmiTwo, tests.LoginToAlpine)
 
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				interfaces[linuxBridgeIfIdx].MacAddress = customMacAddress
 				vmiOne := createVMIOnNode(interfaces, networks)
-				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmiOne, tests.LoginToAlpine)
 
 				By("Configuring static IP address to the Linux bridge interface.")
 				Expect(configInterface(vmiOne, "eth0", "10.1.1.1/24")).To(Succeed())
@@ -431,7 +431,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				vmiOne := createVMIOnNode(interfaces, networks)
 
-				tests.WaitUntilVMIReady(vmiOne, tests.LoggedInAlpineExpecter)
+				tests.WaitUntilVMIReady(vmiOne, tests.LoginToAlpine)
 
 				updatedVmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmiOne.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -661,7 +661,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(vmi, tests.LoggedInFedoraExpecter)
+			tests.WaitUntilVMIReady(vmi, tests.LoginToFedora)
 			tests.WaitAgentConnected(virtClient, vmi)
 			return
 		}
@@ -950,7 +950,7 @@ var _ = Describe("[Serial]Macvtap", func() {
 		}
 		vmi = tests.WaitUntilVMIReady(
 			tests.StartVmOnNode(vmi, nodeName),
-			tests.LoggedInCirrosExpecter)
+			tests.LoginToCirros)
 		// configure the client VMI
 		Expect(configVMIInterfaceWithSudo(vmi, ifaceName, ipCIDR)).To(Succeed())
 		return vmi

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -150,10 +150,10 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			}
 
 			// Wait for VMIs to become ready
-			inboundVMI = tests.WaitUntilVMIReady(inboundVMI, tests.LoggedInCirrosExpecter)
-			outboundVMI = tests.WaitUntilVMIReady(outboundVMI, tests.LoggedInCirrosExpecter)
-			inboundVMIWithPodNetworkSet = tests.WaitUntilVMIReady(inboundVMIWithPodNetworkSet, tests.LoggedInCirrosExpecter)
-			inboundVMIWithCustomMacAddress = tests.WaitUntilVMIReady(inboundVMIWithCustomMacAddress, tests.LoggedInCirrosExpecter)
+			inboundVMI = tests.WaitUntilVMIReady(inboundVMI, tests.LoginToCirros)
+			outboundVMI = tests.WaitUntilVMIReady(outboundVMI, tests.LoginToCirros)
+			inboundVMIWithPodNetworkSet = tests.WaitUntilVMIReady(inboundVMIWithPodNetworkSet, tests.LoginToCirros)
+			inboundVMIWithCustomMacAddress = tests.WaitUntilVMIReady(inboundVMIWithCustomMacAddress, tests.LoginToCirros)
 
 			tests.StartTCPServer(inboundVMI, testPort)
 		})
@@ -324,7 +324,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(e1000VMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(e1000VMI, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(e1000VMI, tests.LoginToAlpine)
 			// as defined in https://vendev.org/pci/ven_8086/
 			checkNetworkVendor(e1000VMI, "0x8086")
 		})
@@ -341,7 +341,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(deadbeafVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(deadbeafVMI, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(deadbeafVMI, tests.LoginToAlpine)
 			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
 		})
 	})
@@ -358,7 +358,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(beafdeadVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(beafdeadVMI, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(beafdeadVMI, tests.LoginToAlpine)
 			checkMacAddress(beafdeadVMI, "be:af:00:00:de:ad")
 		})
 	})
@@ -405,7 +405,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(deadbeafVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(deadbeafVMI, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(deadbeafVMI, tests.LoginToAlpine)
 			checkMacAddress(deadbeafVMI, deadbeafVMI.Spec.Domain.Devices.Interfaces[0].MacAddress)
 		})
 	})
@@ -426,7 +426,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(detachedVMI)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(detachedVMI, tests.LoggedInCirrosExpecter)
+			tests.WaitUntilVMIReady(detachedVMI, tests.LoginToCirros)
 
 			err := console.SafeExpectBatch(detachedVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
@@ -448,7 +448,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			waitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+			waitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 			By("Checking that the pod did not request a tun device")
 			virtClient, err := kubecli.GetKubevirtClient()
@@ -504,7 +504,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(testVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(testVMI, tests.LoggedInCirrosExpecter)
+			tests.WaitUntilVMIReady(testVMI, tests.LoginToCirros)
 			checkPciAddress(testVMI, testVMI.Spec.Domain.Devices.Interfaces[0].PciAddress)
 		})
 	})
@@ -523,7 +523,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(learningDisabledVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(learningDisabledVMI, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(learningDisabledVMI, tests.LoginToAlpine)
 			checkLearningState(learningDisabledVMI, "0")
 		})
 	})
@@ -549,7 +549,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(dhcpVMI)
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(dhcpVMI, tests.LoggedInFedoraExpecter)
+			tests.WaitUntilVMIReady(dhcpVMI, tests.LoginToFedora)
 
 			err = console.SafeExpectBatch(dhcpVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
@@ -587,7 +587,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			}
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(dnsVMI)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(dnsVMI, tests.LoggedInCirrosExpecter)
+			tests.WaitUntilVMIReady(dnsVMI, tests.LoginToCirros)
 			err = console.SafeExpectBatch(dnsVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},
@@ -643,14 +643,14 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				clientVMI = masqueradeVMI([]v1.Port{}, ipv4NetworkCIDR)
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(clientVMI)
 				Expect(err).ToNot(HaveOccurred())
-				clientVMI = tests.WaitUntilVMIReady(clientVMI, tests.LoggedInCirrosExpecter)
+				clientVMI = tests.WaitUntilVMIReady(clientVMI, tests.LoginToCirros)
 			}
 
 			serverVMI = masqueradeVMI(ports, ipv4NetworkCIDR)
 			serverVMI.Labels = map[string]string{"expose": "server"}
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(serverVMI)
 			Expect(err).ToNot(HaveOccurred())
-			serverVMI = tests.WaitUntilVMIReady(serverVMI, tests.LoggedInCirrosExpecter)
+			serverVMI = tests.WaitUntilVMIReady(serverVMI, tests.LoginToCirros)
 			Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
 			Expect(serverVMI.Status.Interfaces[0].IPs).NotTo(BeEmpty())
 
@@ -744,7 +744,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				vmi = masqueradeVMI([]v1.Port{}, "")
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToCirros)
 
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -829,11 +829,11 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Wait for VMIs to be ready")
-				tests.WaitUntilVMIReady(anotherVmi, tests.LoggedInCirrosExpecter)
+				tests.WaitUntilVMIReady(anotherVmi, tests.LoginToCirros)
 				anotherVmi, err = virtClient.VirtualMachineInstance(anotherVmi.Namespace).Get(anotherVmi.Name, &v13.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
-				tests.WaitUntilVMIReady(vmi, tests.LoggedInFedoraExpecter)
+				tests.WaitUntilVMIReady(vmi, tests.LoginToFedora)
 				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &v13.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -908,7 +908,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			tests.WaitUntilVMIReady(vmi, tests.LoggedInAlpineExpecter)
+			tests.WaitUntilVMIReady(vmi, tests.LoginToAlpine)
 
 			output := tests.RunCommandOnVmiPod(vmi, []string{"python3", "-c", `import array
 import fcntl
@@ -950,7 +950,7 @@ sockfd = None`})
 	})
 })
 
-func waitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory console.VMIExpecterFactory) *v1.VirtualMachineInstance {
+func waitUntilVMIReady(vmi *v1.VirtualMachineInstance, loginTo tests.LoginToFactory) *v1.VirtualMachineInstance {
 	// Wait for VirtualMachineInstance start
 	tests.WaitForSuccessfulVMIStart(vmi)
 
@@ -961,9 +961,7 @@ func waitUntilVMIReady(vmi *v1.VirtualMachineInstance, expecterFactory console.V
 	Expect(err).ToNot(HaveOccurred())
 
 	// Lets make sure that the OS is up by waiting until we can login
-	expecter, err := expecterFactory(vmi)
-	Expect(err).ToNot(HaveOccurred())
-	expecter.Close()
+	Expect(loginTo(vmi)).To(Succeed())
 	return vmi
 }
 

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -200,21 +200,17 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			expectedMtuString := fmt.Sprintf("mtu %d", mtu)
 
 			By("checking eth0 MTU inside the VirtualMachineInstance")
-			expecter, err := tests.LoggedInCirrosExpecter(outboundVMI)
-			Expect(err).ToNot(HaveOccurred())
-			defer expecter.Close()
+			Expect(tests.LoginToCirros(outboundVMI)).To(Succeed())
 
 			addrShow = "ip address show eth0\n"
-			resp, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+			Expect(console.SafeExpectBatch(outboundVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},
 				&expect.BSnd{S: addrShow},
 				&expect.BExp{R: fmt.Sprintf(".*%s.*\n", expectedMtuString)},
 				&expect.BSnd{S: "echo $?\n"},
 				&expect.BExp{R: console.RetValue("0")},
-			}, 180*time.Second)
-			log.Log.Infof("%v", resp)
-			Expect(err).ToNot(HaveOccurred())
+			}, 180)).To(Succeed())
 
 			By("checking the VirtualMachineInstance can send MTU sized frames to another VirtualMachineInstance")
 			// NOTE: VirtualMachineInstance is not directly accessible from inside the pod because

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -21,7 +21,6 @@ package tests_test
 
 import (
 	"strings"
-	"time"
 
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo"
@@ -142,18 +141,12 @@ var _ = Describe("[Serial]Slirp Networking", func() {
 		Expect(err).To(HaveOccurred())
 
 		By("communicate with the outside world")
-		expecter, _, err := console.NewExpecter(virtClient, vmi, 10*time.Second)
-		defer expecter.Close()
-		Expect(err).ToNot(HaveOccurred())
-
-		out, err := console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
+		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},
 			&expect.BSnd{S: "curl -o /dev/null -s -w \"%{http_code}\\n\" -k https://google.com\n"},
 			&expect.BExp{R: "301"},
-		}, 180*time.Second)
-		log.Log.Infof("%v", out)
-		Expect(err).ToNot(HaveOccurred())
+		}, 180)).To(Succeed())
 	},
 		table.Entry("VirtualMachineInstance with slirp interface", &genericVmi),
 		table.Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),


### PR DESCRIPTION
**What this PR does / why we need it**:

The helper functions that return an expecter depend on the callers to close them.
In order to reduce the chances of wrongly handling the expecters by test writers, it is preferred to leave their lifecycle handling (creation, execution and teardown) up to the helper functions.

This change aims to reduce to the minimum the helpers and scenarios in which the expecter is returned to the caller.

Only a few cases are left that cannot be removed, specifically when the return value from the expecter run is used in the test and when the channel from a new expecter is asserted on.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
