### PR TITLE
[virt-controller] Remove redundant initcontainer

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1041,12 +1041,12 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			"/init/usr/bin/container-disk",
 		}
 		cpInitContainer := k8sv1.Container{
-				Name:            "container-disk-binary",
-				Image:           t.launcherImage,
-				ImagePullPolicy: imagePullPolicy,
-				Command:         initContainerCommand,
-				VolumeMounts:    initContainerVolumeMounts,
-				Resources:       initContainerResources,
+			Name:            "container-disk-binary",
+			Image:           t.launcherImage,
+			ImagePullPolicy: imagePullPolicy,
+			Command:         initContainerCommand,
+			VolumeMounts:    initContainerVolumeMounts,
+			Resources:       initContainerResources,
 		}
 
 		initContainers = append(initContainers, cpInitContainer)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[1].Image).To(Equal("some-image:v1"))
 				Expect(pod.Spec.Containers[1].ImagePullPolicy).To(Equal(kubev1.PullPolicy("IfNotPresent")))
 				Expect(*pod.Spec.TerminationGracePeriodSeconds).To(Equal(int64(60)))
+				Expect(len(pod.Spec.InitContainers)).To(Equal(0))
 				By("setting the right hostname")
 				Expect(pod.Spec.Hostname).To(Equal("testvmi"))
 				Expect(pod.Spec.Subdomain).To(BeEmpty())


### PR DESCRIPTION
Enhancement #4365

when rendering the POD template for VM, we check whether the ContainerVolume was defined in VM, if not, we add nil initContainer for this POD.