### PR TITLE
Add Subject Key Id field to CA certificate

### DIFF
--- a/pkg/certificates/triple/BUILD.bazel
+++ b/pkg/certificates/triple/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,4 +6,18 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/certificates/triple",
     visibility = ["//visibility:public"],
     deps = ["//pkg/certificates/triple/cert:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "triple_suite_test.go",
+        "triple_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/reporters:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/pkg/certificates/triple/triple_suite_test.go
+++ b/pkg/certificates/triple/triple_suite_test.go
@@ -1,0 +1,15 @@
+package triple
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+)
+
+func TestTriple(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.triple_suite_test.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Certificate Test Suite", []Reporter{junitReporter})
+}

--- a/pkg/certificates/triple/triple_test.go
+++ b/pkg/certificates/triple/triple_test.go
@@ -1,0 +1,44 @@
+package triple
+
+import (
+	"crypto/x509"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cert library", func() {
+	Context("when NewCA is called", func() {
+		var (
+			name     string
+			duration time.Duration
+			now      time.Time
+		)
+		BeforeEach(func() {
+			now = time.Now()
+			name = "foo-bar-name"
+			duration = time.Minute
+		})
+		It("should generate key and CA cert with expected fields", func() {
+
+			keyAndCert, err := NewCA(name, duration)
+			Expect(err).ToNot(HaveOccurred(), "should succeed generating CA")
+
+			privateKey := keyAndCert.Key
+			caCert := keyAndCert.Cert
+
+			Expect(privateKey).ToNot(BeNil(), "should generate a private key")
+			Expect(caCert).ToNot(BeNil(), "should generate a CA certificate")
+			Expect(caCert.SerialNumber.Int64()).To(Equal(int64(0)), "should have zero as serial number")
+			Expect(caCert.Subject.CommonName).To(Equal(name), "should take CommonName from name field")
+			Expect(caCert.NotBefore).To(BeTemporally("~", now.UTC(), time.Second), "should set NotBefore to now")
+			Expect(caCert.NotAfter).To(BeTemporally("~", now.Add(duration).UTC(), time.Second), "should  set NotAfter to now + duration")
+			Expect(caCert.KeyUsage).To(Equal(x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign), "should set proper KeyUsage")
+			Expect(caCert.BasicConstraintsValid).To(BeTrue(), "should mark it as BasicConstraintsValid")
+			Expect(caCert.IsCA).To(BeTrue(), "should mark it as CA")
+			Expect(caCert.SubjectKeyId).ToNot(BeEmpty(), "should include a SKI")
+		})
+
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The SKI field is mandatory for CA certificates, but Go crypto library for versions < 1.15
is not filling in the SKI field for CAs [1] this PR replicate the golang >= 1.15 fix [2].

Replicated from https://github.com/qinqon/kube-admission-webhook/pull/42

[1] golang/go#26676
[2] https://go-review.googlesource.com/c/go/+/227098/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add SKI field to CA certificate
```
