### PR TITLE
automation: remove ipv6 lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -298,8 +298,6 @@ elif [[ $TARGET =~ gpu.* ]]; then
   export KUBEVIRT_E2E_FOCUS=GPU
 elif [[ $TARGET =~ (okd|ocp).* ]]; then
   export KUBEVIRT_E2E_SKIP="SRIOV|GPU"
-elif [[ $TARGET =~ ipv6.* ]]; then
-  export KUBEVIRT_E2E_SKIP="Multus|SRIOV|GPU|.*slirp.*|.*bridge.*"
 else
   export KUBEVIRT_E2E_SKIP="Multus|SRIOV|GPU"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As the ipv6 lane no longer exists, it can be removed from automation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
