### PR TITLE
Adapt conformance tests to support migration.

### DIFF
--- a/automation/conformance.sh
+++ b/automation/conformance.sh
@@ -8,6 +8,8 @@ mkdir -p "$ARTIFACTS_PATH"
 
 trap "{ make cluster-down; cp -r _out/artifacts/conformance/* ${ARTIFACTS_PATH}; }" EXIT SIGINT SIGTERM SIGQUIT
 
+export KUBEVIRT_NUM_NODES=2
+
 make cluster-up
 make cluster-sync
 make conformance


### PR DESCRIPTION
Since conformance tests include a migration tests,
we must set `KUBEVIRT_NUM_NODES` to 2, (as the default is 1 node)
in the cluster we create, because libvirt doesn't allow
migrating to the same host.

(unless we want also to add validation of number of nodes, 
but we usually dont do it in the migration tests).

Fixes: https://github.com/kubevirt/kubevirt/issues/4345

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
