### PR TITLE
Update stale references in documentation (kubevirt-config ConfigMap, cluster/ scripts)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,14 +19,14 @@ to libvirt domains based on the state of those resources.
 
 ### Scripts
 
- * `cluster/kubectl.sh`: This is a wrapper around Kubernetes' kubectl command so
+ * `cluster-up/kubectl.sh`: This is a wrapper around Kubernetes' kubectl command so
    that it can be run directly from this checkout without logging into a node.
- * `cluster/virtctl.sh` is a wrapper around `virtctl`. `virtctl` brings all
+ * `cluster-up/virtctl.sh` is a wrapper around `virtctl`. `virtctl` brings all
    virtual machine specific commands with it. It is supplement to `kubectl`.
-   e.g. `cluster/virtctl.sh console testvm`.
- * `cluster/cli.sh` helps you creating ephemeral kubernetes and openshift
+   e.g. `cluster-up/virtctl.sh console testvm`.
+ * `cluster-up/cli.sh` helps you creating ephemeral kubernetes and openshift
    clusters for testing. This is helpful when direct management or access to
-   cluster nodes is necessary. e.g. `cluster/cli.sh ssh node01`.
+   cluster nodes is necessary. e.g. `cluster-up/cli.sh ssh node01`.
 
 ### Makefile Commands
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,7 +1,7 @@
 # Debugging
 
 ```bash
-cluster/kubectl.sh version
+cluster-up/kubectl.sh version
 ```
 
 will try to connect to the apiserver.
@@ -9,10 +9,10 @@ will try to connect to the apiserver.
 ## Retrieving Logs
 
 To investigate the logs of a pod, you can view the logs via
-`cluster/kubectl.sh logs`. To view the logs of `virt-api`, type
+`cluster-up/kubectl.sh logs`. To view the logs of `virt-api`, type
 
 ```bash
-cluster/kubectl.sh logs virt-api -f
+cluster-up/kubectl.sh logs virt-api -f
 ```
 
 Sometimes a container in a pod is crashlooping because of an application error
@@ -22,7 +22,7 @@ attempt, the `--previous` flag can be used. To view the logs of the container
 `virt-api` in the pod `virt-api` from the previous run, type
 
 ```bash
-cluster/kubectl.sh logs virt-api -f -c virt-api -p
+cluster-up/kubectl.sh logs virt-api -f -c virt-api -p
 ```
 
 Note that you always have to select a container inside a pod for fetching old
@@ -33,7 +33,7 @@ logs with the `--previous` flag.
 Both, Kubernetes and KubeVirt are creating events, which can be viewed via
 
 ```bash
-cluster/kubectl.sh get events --all-namespaces --watch
+cluster-up/kubectl.sh get events --all-namespaces --watch
 ```
 
 This way it is pretty easy to detect if a Pod or a VMI got started.
@@ -45,7 +45,7 @@ to see what is going wrong. In this case the kubectl `exec` command can be
 used. To enter `virt-api` with an interactive shell, type
 
 ```bash
-cluster/kubectl.sh exec virt-api -c virt-api -i -t -- sh
+cluster-up/kubectl.sh exec virt-api -c virt-api -i -t -- sh
 ```
 
 ## Kubelet Logs

--- a/docs/devel/storage.md
+++ b/docs/devel/storage.md
@@ -11,7 +11,7 @@ In order to use disk images one must configure an appropriate storage. In this d
 The hostPath provisioner needs to write to a directory on the node, we will need to create this directory before installing the hostPath provisioner
 
 ```bash
-cluster/cli.sh ssh node01 -- sudo mkdir /var/run/kubevirt/hostpath
+cluster-up/cli.sh ssh node01 -- sudo mkdir /var/run/kubevirt/hostpath
 ```
 
 ## Deploy hostPath PVC provisioner
@@ -19,7 +19,7 @@ cluster/cli.sh ssh node01 -- sudo mkdir /var/run/kubevirt/hostpath
 We are using the hostPath provisioner from [here](https://github.com/MaZderMind/hostpath-provisioner). Simply run from :
 
 ```bash
-cluster/kubectl.sh apply -f docs/devel/hostpath-provisioner.yaml
+cluster-up/kubectl.sh apply -f docs/devel/hostpath-provisioner.yaml
 ```
 
 This will create
@@ -36,7 +36,7 @@ After a few moments the hostpath-provisioner pod should be running, we are now r
 The Containerized Data Importer controller is a controller that watches for PVCs with a specific annotation. If that annotation is detected, it will use the 'storage.image.endpoint' URL to download the image, convert it if needed and write it to the requested PVC. One can then use the PVC to start a VM using the image in it. To deploy the CDI controller run this:
 
 ```bash
-cluster/kubectl.sh apply -f https://raw.githubusercontent.com/kubevirt/containerized-data-importer/master/manifests/controller/cdi-controller-deployment.yaml
+cluster-up/kubectl.sh apply -f https://raw.githubusercontent.com/kubevirt/containerized-data-importer/master/manifests/controller/cdi-controller-deployment.yaml
 ```
 
 This will create

--- a/docs/env-providers.md
+++ b/docs/env-providers.md
@@ -8,7 +8,7 @@ All following providers allow a common workflow:
  * `make cluster-deploy` to (re)deploy the code (no provider support needed)
  * `make cluster-sync` to build and (re)deploy the code
  * `make functests` to run the functional tests against KubeVirt
- * `cluster/kubectl.sh` to talk to the k8s installation
+ * `cluster-up/kubectl.sh` to talk to the k8s installation
 
 It is recommended to export the `KUBEVIRT_PROVIDER` variable as part of your `.bashrc`
 file.

--- a/docs/env-providers.md
+++ b/docs/env-providers.md
@@ -63,7 +63,9 @@ make cluster-up
 ```
 ## New Providers
 
- * Create a `cluster/$KUBEVIRT_PROVIDER` directory
- * Create a `cluster/$KUBEVIRT_PROVIDER/provider.sh` files
- * This file has to contain the functions `up`, `build`, `down` and `_kubectl`
- * Have a look at `cluster/k8s-1.10.11/provider.sh` for a reference implementation
+First add your provider in the [kubevirtci](https://github.com/kubevirt/kubevirtci) repository.
+After this provider is merged, update our copy of this repository with the following command:
+
+```bash
+make bump-kubevirtci
+```

--- a/docs/software-emulation.md
+++ b/docs/software-emulation.md
@@ -17,34 +17,20 @@ If `useEmulation` is enabled,
 
 # Configuration
 
-Enabling software emulation is a cluster-wide setting, and is activated using a
-ConfigMap in the `kubevirt` namespace. It can be enabled with the following
-command:
+Enabling software emulation is a cluster-wide setting, and is activated by
+editing the kubevirt-config as follows:
 
 ```bash
-cluster/kubectl.sh --namespace kubevirt create configmap kubevirt-config \
-    --from-literal debug.useEmulation=true
+cluster-up/kubectl.sh --namespace kubevirt edit kubevirt kubevirt
 ```
 
-If the `kubevirt/kubevirt-config` ConfigMap already exists, the above entry
-can be added using:
-
-```bash
-cluster/kubectl.sh --namespace kubevirt edit configmap kubevirt-config
-```
-
-In this case, add the `debug.useEmulation: "true"` setting to `data`:
+Add the following snippet to the spec:
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kubevirt-config
-  namespace: kubevirt
-data:
-  debug.useEmulation: "true"
-
+spec:
+  developerConfiguration:
+    useEmulation: "true"
 ```
 
-**NOTE**: The values of `ConfigMap.data` are **strings**. Yaml requires the use of
+**NOTE**: The values of `KubeVirt.spec` are **strings**. Yaml requires the use of
 quotes around `"true"` to distinguish the value from a boolean.

--- a/docs/sriov.md
+++ b/docs/sriov.md
@@ -216,8 +216,8 @@ $ go get -u -d github.com/intel/multus-cni
 $ cd $GOPATH/src/github.com/intel/multus-cni/
 $ mkdir -p /etc/cni/net.d
 $ cp images/70-multus.conf /etc/cni/net.d/
-$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/images/multus-daemonset.yml
-$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/images/flannel-daemonset.yml
+$ ./cluster-up/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/images/multus-daemonset.yml
+$ ./cluster-up/kubectl.sh create -f $GOPATH/src/github.com/intel/multus-cni/images/flannel-daemonset.yml
 ```
 
 Now, deploy SR-IOV device plugin. Adjust config.json file for your particular
@@ -239,20 +239,20 @@ $ cat <<EOF > /etc/pcidp/config.json
     ]
 }
 EOF
-$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-network-device-plugin/images/sriovdp-daemonset.yaml
+$ ./cluster-up/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-network-device-plugin/images/sriovdp-daemonset.yaml
 ```
 
 Deploy SR-IOV CNI plugin.
 
 ```
 $ go get -u -d github.com/intel/sriov-cni/
-$ ./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-cni/images/sriov-cni-daemonset.yaml
+$ ./cluster-up/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-cni/images/sriov-cni-daemonset.yaml
 ```
 
 Finally, create a new SR-IOV network CRD that will use SR-IOV device plugin to allocate devices.
 
 ```
-./cluster/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-network-device-plugin/deployments/sriov-crd.yaml
+./cluster-up/kubectl.sh create -f $GOPATH/src/github.com/intel/sriov-network-device-plugin/deployments/sriov-crd.yaml
 ```
 
 Just make sure that the network spec refers to the right resource name for


### PR DESCRIPTION
**What this PR does / why we need it**:
First I went looking for kubevirt-config configmap references, then I found the command is using cluster/... as a path for things that are on cluster-up, so I touched the related documentation.

Since the section on new providers was also referring to this directory, I've updated it with slightly more relevant information.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
