### PR TITLE
Serialize `make cluster-sync` build + deploy steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,9 @@ cluster-clean:
 cluster-deploy: cluster-clean
 	./hack/cluster-deploy.sh
 
-cluster-sync: cluster-build cluster-deploy
+cluster-sync:
+	$(MAKE) cluster-build
+	$(MAKE) cluster-deploy
 
 builder-build:
 	./hack/builder/build.sh

--- a/hack/cluster-build.sh
+++ b/hack/cluster-build.sh
@@ -97,4 +97,4 @@ for node in ${nodes[@]}; do
     done
 done
 
-echo "Done"
+echo "Done $0"

--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -135,4 +135,4 @@ done
 
 sleep 2
 
-echo "Done"
+echo "Done $0"

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -128,4 +128,4 @@ until _kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 
     sleep 1m
 done
 
-echo "Done"
+echo "Done $0"


### PR DESCRIPTION
The way the `make cluster-sync` build + deploy steps are referenced means that `make` will try to parallelize them if -j > 1 is specfied (like I have via MAKEFLAGS in my .bashrc). `cluster-sync` was never working for me after a fresh checkout for example, I needed to invoke it twice

This fixes the rule to explicitly serialize the  `cluster-build` and `cluster-deploy` invocations