### PR TITLE
Fix infra-test nodes update logic

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -228,20 +228,25 @@ var _ = Describe("[Serial]Infrastructure", func() {
 			AfterEach(func() {
 				if selectedNode != nil {
 					By("removing the taint from the tainted node")
-					var taints []k8sv1.Taint
-
-					for _, taint := range selectedNode.Spec.Taints {
-						if taint.Key != "CriticalAddonsOnly" {
-							taints = append(taints, taint)
-						}
-					}
-
-					nodeCopy := selectedNode.DeepCopy()
-					nodeCopy.ResourceVersion = ""
-					nodeCopy.Spec.Taints = taints
-
 					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						_, err := virtClient.CoreV1().Nodes().Update(nodeCopy)
+						var err error
+						selectedNode, err = virtClient.CoreV1().Nodes().Get(selectedNode.Name, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+
+						var taints []k8sv1.Taint
+						for _, taint := range selectedNode.Spec.Taints {
+							if taint.Key != "CriticalAddonsOnly" {
+								taints = append(taints, taint)
+							}
+						}
+
+						nodeCopy := selectedNode.DeepCopy()
+						nodeCopy.ResourceVersion = ""
+						nodeCopy.Spec.Taints = taints
+
+						_, err = virtClient.CoreV1().Nodes().Update(nodeCopy)
 						return err
 					})
 					Expect(err).ShouldNot(HaveOccurred())
@@ -310,15 +315,21 @@ var _ = Describe("[Serial]Infrastructure", func() {
 				go signalTerminatedPods(stopCn, lw.ResultChan(), terminatedPodsCn)
 
 				By("tainting the selected node")
-				selectedNodeCopy := selectedNode.DeepCopy()
-				selectedNodeCopy.Spec.Taints = append(selectedNodeCopy.Spec.Taints, k8sv1.Taint{
-					Key:    "CriticalAddonsOnly",
-					Value:  "",
-					Effect: k8sv1.TaintEffectNoExecute,
-				})
-
 				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					_, err := virtClient.CoreV1().Nodes().Update(selectedNodeCopy)
+					var err error
+					selectedNode, err = virtClient.CoreV1().Nodes().Get(selectedNode.Name, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+
+					selectedNodeCopy := selectedNode.DeepCopy()
+					selectedNodeCopy.Spec.Taints = append(selectedNodeCopy.Spec.Taints, k8sv1.Taint{
+						Key:    "CriticalAddonsOnly",
+						Value:  "",
+						Effect: k8sv1.TaintEffectNoExecute,
+					})
+
+					_, err = virtClient.CoreV1().Nodes().Update(selectedNodeCopy)
 					return err
 				})
 				Expect(err).ShouldNot(HaveOccurred())

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -237,6 +237,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 
 				nodeCopy := selectedNode.DeepCopy()
 				nodeCopy.ResourceVersion = ""
+				nodeCopy.Spec.Taints = taints
 
 				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					_, err := virtClient.CoreV1().Nodes().Update(nodeCopy)

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -219,18 +219,17 @@ var _ = Describe("[Serial]Infrastructure", func() {
 
 		Context("CriticalAddonsOnly taint set on a node", func() {
 
-			var selectedNode *k8sv1.Node
+			var selectedNodeName string
 
 			BeforeEach(func() {
-				selectedNode = nil
+				selectedNodeName = ""
 			})
 
 			AfterEach(func() {
-				if selectedNode != nil {
+				if selectedNodeName != "" {
 					By("removing the taint from the tainted node")
 					err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						var err error
-						selectedNode, err = virtClient.CoreV1().Nodes().Get(selectedNode.Name, metav1.GetOptions{})
+						selectedNode, err := virtClient.CoreV1().Nodes().Get(selectedNodeName, metav1.GetOptions{})
 						if err != nil {
 							return err
 						}
@@ -276,7 +275,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 					if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
 						continue
 					}
-					selectedNode = node.DeepCopy()
+					selectedNodeName = node.Name
 					break
 				}
 
@@ -316,8 +315,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 
 				By("tainting the selected node")
 				err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-					var err error
-					selectedNode, err = virtClient.CoreV1().Nodes().Get(selectedNode.Name, metav1.GetOptions{})
+					selectedNode, err := virtClient.CoreV1().Nodes().Get(selectedNodeName, metav1.GetOptions{})
 					if err != nil {
 						return err
 					}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -272,6 +272,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 						continue
 					}
 					selectedNode = node.DeepCopy()
+					break
 				}
 
 				By("setting up a watch for terminated pods")


### PR DESCRIPTION
Fix few infra-test errors:

* Cleanup of node taints, missed the actual update of the taints
because the updated taint slice wasn't assigned before the API update call.
* Add missing check in AfterEach that the node variable isn't nil before using it.
* Add missing break when select a node, in order to improve the search logic,
which just need the first schedulable worker, no need to iterate all nodes and reassign
the same variable, once one is found.
* Fix RetryOnConflict logic, which should refetch the node scheme in case of a retry,
in order to get a fresh status and update only the desired fields.
* Refactor node selection to capture only the name, since we just need the name in order
to fetch a fresh scheme before updating the node.
 
```release-note
None
```
