### PR TITLE
Don't override the e2e kubevirt config by default in the e2e tests

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -40,6 +40,7 @@ rm -rf $ARTIFACTS
 mkdir -p $ARTIFACTS
 
 function functest() {
+    extra_args="${extra_args} -apply-default-e2e-configuration"
     if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|k8s-sriov.* ]]; then
         echo "Will skip test asserting the cluster is in dual-stack mode."
         extra_args="${extra_args} -skip-dual-stack-test"

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -44,6 +44,7 @@ var ConfigFile = ""
 var SkipShasumCheck bool
 var SkipDualStackTests bool
 var ArtifactsDir string
+var ApplyDefaulte2eConfiguration bool
 
 var DeployTestingInfrastructureFlag = false
 var PathToTestingInfrastrucureManifests = ""
@@ -70,6 +71,7 @@ func init() {
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presence of IPv6 address in the cluster pods.")
+	flag.BoolVar(&ApplyDefaulte2eConfiguration, "apply-default-e2e-configuration", false, "Apply the default e2e test configuration (feature gates, selinux contexts, ...)")
 }
 
 func NormalizeFlags() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -794,7 +794,12 @@ func AdjustKubeVirtResource() {
 	PanicOnError(err)
 
 	kv := GetCurrentKv(virtClient)
+
 	originalKV = kv.DeepCopy()
+
+	if !flags.ApplyDefaulte2eConfiguration {
+		return
+	}
 
 	// Rotate very often during the tests to ensure that things are working
 	kv.Spec.CertificateRotationStrategy = v1.KubeVirtCertificateRotateStrategy{SelfSigned: &v1.KubeVirtSelfSignConfiguration{


### PR DESCRIPTION
**What this PR does / why we need it**:

Our e2e tests in our CI want to set a specific config to run the tests.
That is not in general the case. Our tests should in general adjust to
the cluster shape. This restores the config-map configuration behaviour
which we had before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4317

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
