### PR TITLE
[release-0.30] Fix MTU assignment on the masquerade binding

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -587,6 +587,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces() error {
 	bridgeNic := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: bridgeNicName,
+			MTU:  int(p.vif.Mtu),
 		},
 	}
 	err := Handler.LinkAdd(bridgeNic)
@@ -708,6 +709,7 @@ func (p *MasqueradePodInterface) createBridge() error {
 	bridge := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: p.bridgeInterfaceName,
+			MTU:  int(p.vif.Mtu),
 		},
 	}
 	err = Handler.LinkAdd(bridge)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This fix is needed so VMs connected to a network supporting jumbo frames via the masquerade binding can be used with jumbo frames themselves.

**Special notes for your reviewer**:

Backport of: https://github.com/kubevirt/kubevirt/pull/4289 (https://github.com/kubevirt/kubevirt/pull/4329)

The first commit is a clean cherry-pick. The second commit introducing the test needed some adjustments to fit in the old codebase which is missing some of the test helpers.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix MTU configuration on the masquerade binding
```
