### PR TITLE
Add cluster-up *.cert to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tools/vms-generator/vms-generator
 .coverprofile*
 coverage.html
 manifests/**/*.tmp
+cluster-up/**/kind-k8s-sriov*/**/*.cert
 /bazel-*
 /ci.bazelrc
 _ci-configs/


### PR DESCRIPTION
SRIOV provider creates cert files
```
cluster-up/cluster/kind-k8s-sriov-1.17.0/csrcreator/network-resources-injector.cert
cluster-up/cluster/kind-k8s-sriov-1.17.0/csrcreator/operator-webhook.cert
```
which appear as untracked files and shouldn't be visible.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
