### PR TITLE
DataVolume containerDisk import test. 

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -80,6 +80,15 @@ spec: {}
 EOF
 fi
 
+# Ensure the cdi insecure registeries is set
+count=0
+until _kubectl get configmap -n ${cdi_namespace} cdi-insecure-registries; do
+    ((count++)) && ((count == 30)) && echo "cdi-insecure-registries config-map not found" && exit 1
+    echo "waiting for cdi-insecure-registries configmap to be created"
+    sleep 1
+done
+_kubectl patch configmap cdi-insecure-registries -n $cdi_namespace --type merge -p '{"data":{"dev-registry": "registry:5000"}}'
+
 # Deploy kubevirt operator
 _kubectl apply -f ${MANIFESTS_OUT_DIR}/release/kubevirt-operator.yaml
 

--- a/manifests/testing/cdi-v1.23.7.yaml.in
+++ b/manifests/testing/cdi-v1.23.7.yaml.in
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     cdi.kubevirt.io: ""
-  name: {{.CDINamespace}}
+  name: cdi
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1981,24 +1981,24 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
-          value: v1.23.5
+          value: v1.23.7
         - name: CONTROLLER_IMAGE
-          value: kubevirt/cdi-controller:v1.23.5
+          value: kubevirt/cdi-controller:v1.23.7
         - name: IMPORTER_IMAGE
-          value: kubevirt/cdi-importer:v1.23.5
+          value: kubevirt/cdi-importer:v1.23.7
         - name: CLONER_IMAGE
-          value: kubevirt/cdi-cloner:v1.23.5
+          value: kubevirt/cdi-cloner:v1.23.7
         - name: APISERVER_IMAGE
-          value: kubevirt/cdi-apiserver:v1.23.5
+          value: kubevirt/cdi-apiserver:v1.23.7
         - name: UPLOAD_SERVER_IMAGE
-          value: kubevirt/cdi-uploadserver:v1.23.5
+          value: kubevirt/cdi-uploadserver:v1.23.7
         - name: UPLOAD_PROXY_IMAGE
-          value: kubevirt/cdi-uploadproxy:v1.23.5
+          value: kubevirt/cdi-uploadproxy:v1.23.7
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
-        image: kubevirt/cdi-operator:v1.23.5
+        image: kubevirt/cdi-operator:v1.23.7
         imagePullPolicy: IfNotPresent
         name: cdi-operator
         ports:

--- a/manifests/testing/cdi-v1.23.7.yaml.in
+++ b/manifests/testing/cdi-v1.23.7.yaml.in
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     cdi.kubevirt.io: ""
-  name: cdi
+  name: {{.CDINamespace}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
This verifies DataVolume registry source works with our upstream  containerDisk images. There were some issues recently (https://github.com/kubevirt/containerized-data-importer/pull/1413) that prevented the demo containerDisks we build in kubevirt/kubevirt repo from being able to import into a PVC using a DataVolume. Now that those issues are resolved, i think it would be wise for us to exercise this import in the kubevirt test suite at least once. 

```release-note
NONE
```
