### PR TITLE
Disable service links on virt-launcher Pod

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1118,6 +1118,9 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 
 	pod.Spec.SchedulerName = vmi.Spec.SchedulerName
 
+	enableServiceLinks := false
+	pod.Spec.EnableServiceLinks = &enableServiceLinks
+
 	if len(serviceAccountName) > 0 {
 		pod.Spec.ServiceAccountName = serviceAccountName
 		automount := true


### PR DESCRIPTION
Service Links are considered a legacy feature. Service links are not used by Kubevirt and cause slower initialization in namespaces with many services. 

**What this PR does / why we need it**:

Fixes #4391

**Special notes for your reviewer**:
I have not updated any tests, not sure if one should be updated.

**Release note**:
```release-note
Disable legacy service links in `virt-launcher` Pods to speed up Pod instantiation and decrease Kubelet load in namespaces with many services.
```