### PR TITLE
Let VMIRS detect VMIs in unknown state

### DIFF
--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -100,6 +100,11 @@ func (d *VirtualMachineInstanceConditionManager) HasConditionWithStatus(vmi *v1.
 	return c != nil && c.Status == status
 }
 
+func (d *VirtualMachineInstanceConditionManager) HasConditionWithStatusAndReason(vmi *v1.VirtualMachineInstance, cond v1.VirtualMachineInstanceConditionType, status k8sv1.ConditionStatus, reason string) bool {
+	c := d.GetCondition(vmi, cond)
+	return c != nil && c.Status == status && c.Reason == reason
+}
+
 func (d *VirtualMachineInstanceConditionManager) RemoveCondition(vmi *v1.VirtualMachineInstance, cond v1.VirtualMachineInstanceConditionType) {
 	var conds []v1.VirtualMachineInstanceCondition
 	for _, c := range vmi.Status.Conditions {

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/go-openapi/errors:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -398,6 +398,19 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		if !podExists {
 			// Remove PodScheduling condition from the VM
 			conditionManager.RemoveCondition(vmiCopy, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+		} else if isPodDownOrGoingDown(pod) {
+			cond := conditionManager.GetPodCondition(pod, k8sv1.PodReady)
+			if cond == nil || cond.Reason != virtv1.PodTerminatingReason {
+				conditionManager.RemoveCondition(vmiCopy, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+				conditionManager.AddPodCondition(vmiCopy, &k8sv1.PodCondition{
+					Type:               k8sv1.PodReady,
+					Status:             k8sv1.ConditionFalse,
+					LastProbeTime:      v1.Now(),
+					LastTransitionTime: v1.Now(),
+					Reason:             virtv1.PodTerminatingReason,
+					Message:            "The Pod is terminating",
+				})
+			}
 		} else if cond := conditionManager.GetPodCondition(pod, k8sv1.PodReady); cond != nil {
 			conditionManager.RemoveCondition(vmiCopy, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
 			conditionManager.AddPodCondition(vmiCopy, cond)

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -410,6 +410,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 					Reason:             virtv1.PodTerminatingReason,
 					Message:            "The Pod is terminating",
 				})
+				c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, virtv1.PodTerminatingReason, "Pod %s is terminating, marking VMI as not ready.", pod.Name)
 			}
 		} else if cond := conditionManager.GetPodCondition(pod, k8sv1.PodReady); cond != nil {
 			conditionManager.RemoveCondition(vmiCopy, virtv1.VirtualMachineInstanceConditionType(k8sv1.PodReady))

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1101,6 +1101,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				return patchedVMI, nil
 			})
 			controller.Execute()
+			testutils.ExpectEvent(recorder, v1.PodTerminatingReason)
 		})
 
 		It("should add active pods to status if VMI is in running state", func() {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -275,6 +275,11 @@ const (
 	VirtualMachineInstanceReasonInterfaceNotMigratable = "InterfaceNotLiveMigratable"
 )
 
+const (
+	// PodTerminatingReason indicates on the PodReady condition on the VMI if the underlying pod is terminating
+	PodTerminatingReason = "PodTerminating"
+)
+
 // +k8s:openapi-gen=true
 type VirtualMachineInstanceMigrationConditionType string
 

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	autov1 "k8s.io/api/autoscaling/v1"
+	v13 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -37,6 +38,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/tests"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
@@ -133,13 +135,17 @@ var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][le
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}
 
-	newReplicaSet := func() *v1.VirtualMachineInstanceReplicaSet {
-		By("Create a new VirtualMachineInstance replica set")
-		template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+	newReplicaSetWithTemplate := func(template *v1.VirtualMachineInstance) *v1.VirtualMachineInstanceReplicaSet {
 		newRS := tests.NewRandomReplicaSetFromVMI(template, int32(0))
 		newRS, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Create(newRS)
 		Expect(err).ToNot(HaveOccurred())
 		return newRS
+	}
+
+	newReplicaSet := func() *v1.VirtualMachineInstanceReplicaSet {
+		By("Create a new VirtualMachineInstance replica set")
+		template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+		return newReplicaSetWithTemplate(template)
 	}
 
 	table.DescribeTable("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]should scale", func(startScale int, stopScale int) {
@@ -387,7 +393,7 @@ var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][le
 		}, 10*time.Second, 1*time.Second).Should(Equal(int32(2)))
 	})
 
-	It("[test_id:1418]should remove the finished VM", func() {
+	It("[test_id:1418]should replace finished VMIs", func() {
 		By("Creating new replica set")
 		rs := newReplicaSet()
 		doScale(rs.ObjectMeta.Name, int32(2))
@@ -415,10 +421,65 @@ var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][le
 			return false
 		}, 120*time.Second, time.Second).Should(BeTrue())
 
-		By("Checking number of RS VM's")
+		By("Checking number of RS VM's to see that we got a replacement")
 		vmis, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(vmis.Items)).Should(Equal(2))
+	})
+
+	It("should replace a VMI immediately when a virt-launcher pod gets deleted", func() {
+		By("Creating new replica set")
+		template := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+		var gracePeriod int64 = 200
+		template.Spec.TerminationGracePeriodSeconds = &gracePeriod
+		rs := newReplicaSetWithTemplate(template)
+
+		// ensure that the shutdown will take as long as possible
+
+		doScale(rs.ObjectMeta.Name, int32(2))
+
+		vmis, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmis.Items).ToNot(BeEmpty())
+
+		By("Waiting until the VMIs are running")
+		Eventually(func() int {
+			vmis, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return len(tests.Running(vmis))
+		}, 40*time.Second, time.Second).Should(Equal(2))
+
+		vmi := &vmis.Items[0]
+		pods, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).List(tests.UnfinishedVMIPodSelector(vmi))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(pods.Items)).To(Equal(1))
+		pod := pods.Items[0]
+
+		By("Deleting one of the RS VMS pods, which will take some time to really stop the VMI")
+		err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(pod.Name, &v12.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Checking that then number of VMIs increases to three")
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(func() int {
+			vmis, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).List(&v12.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return len(vmis.Items)
+		}, 20*time.Second, time.Second).Should(Equal(3))
+
+		By("Checking that the shutting donw VMI is still running, reporting the pod deletion and being marked for deletion")
+		vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &v12.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmi.Status.Phase).To(Equal(v1.Running))
+		Expect(controller.NewVirtualMachineInstanceConditionManager().
+			HasConditionWithStatusAndReason(
+				vmi,
+				v1.VirtualMachineInstanceConditionType(v13.PodReady),
+				v13.ConditionFalse,
+				v1.PodTerminatingReason,
+			),
+		).To(BeTrue())
+		Expect(vmi.DeletionTimestamp).ToNot(BeNil())
 	})
 
 	It("[test_id:4121]should create and verify kubectl/oc output for vm replicaset", func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -47,12 +47,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/onsi/ginkgo/config"
-	netutils "k8s.io/utils/net"
-
 	expect "github.com/google/goexpect"
 	covreport "github.com/mfranczy/crd-rest-coverage/pkg/report"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -81,6 +79,7 @@ import (
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
+	netutils "k8s.io/utils/net"
 
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
@@ -1673,7 +1672,15 @@ func cleanNamespaces() {
 		}
 
 		// Remove all Pods
-		PanicOnError(virtCli.CoreV1().RESTClient().Delete().Namespace(namespace).Resource("pods").Do().Error())
+		podList, err := virtCli.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+		var gracePeriod int64 = 0
+		for _, pod := range podList.Items {
+			err := virtCli.CoreV1().Pods(namespace).Delete(pod.Name, &metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+			if errors.IsNotFound(err) {
+				continue
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
 
 		// Remove all Services
 		svcList, err := virtCli.CoreV1().Services(namespace).List(metav1.ListOptions{})
@@ -3373,6 +3380,15 @@ func NotDeleted(vmis *v1.VirtualMachineInstanceList) (notDeleted []v1.VirtualMac
 	for _, vmi := range vmis.Items {
 		if vmi.DeletionTimestamp == nil {
 			notDeleted = append(notDeleted, vmi)
+		}
+	}
+	return
+}
+
+func Running(vmis *v1.VirtualMachineInstanceList) (running []v1.VirtualMachineInstance) {
+	for _, vmi := range vmis.Items {
+		if vmi.DeletionTimestamp == nil && vmi.Status.Phase == v1.Running {
+			running = append(running, vmi)
 		}
 	}
 	return


### PR DESCRIPTION
**What this PR does / why we need it**:

If nodes become unreachable, the node controller will put a non-responsive taint on the node. As a consequence pods on that node will be terminated after some time. However, it is not directly visible in the container status that they are in an unknown state. From a user and controller perspective it looks like the pod is fine, except that it is being deleted. If a delete hangs for a long time (which it does in this case), controllers like VMIRs can't see on the VMI that the VMI is going down.

With this PR, the VMI controller will indicate on the Ready condition that the pod is going down by setting the Ready condition to false and applying the reason `PodTerminating`. The VMIRs can directly look for that condition and react by deleting the VMI and creating a replacement.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3332

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMIs reflect deleted stuck virt-launcher pods with the "PodTerminating" Reason in the ready condition. The VMIRS detects this reason and immediately creates replacement VMIs.
```