### PR TITLE
Fix flaky timezone test

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1488,9 +1488,9 @@ var _ = Describe("Configurations", func() {
 				loc, err := time.LoadLocation(timezone)
 				Expect(err).ToNot(HaveOccurred())
 				now := time.Now().In(loc)
-
+				plusone := now.Add(time.Minute)
 				By("Checking hardware clock time")
-				expected := fmt.Sprintf("%02d:%02d:", now.Hour(), now.Minute())
+				expected := fmt.Sprintf("(%02d:%02d:|%02d:%02d:)", now.Hour(), now.Minute(), plusone.Hour(), plusone.Minute())
 				_, err = console.ExpectBatchWithValidatedSend(expecter, []expect.Batcher{
 					&expect.BSnd{S: "sudo hwclock --localtime \n"},
 					&expect.BExp{R: expected},


### PR DESCRIPTION
It can happen that we ask for time at 1:57:59 and don't match 1:58:*

**What this PR does / why we need it**:
Fix flaky test

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4096

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
