### PR TITLE
WORKSPACE: Update libvirt container

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -334,10 +334,10 @@ container_pull(
 # Pull base image libvirt
 container_pull(
     name = "libvirt",
-    digest = "sha256:6a817da0fa85d6698e93594ef9d1d084358d62c93ed1b1237f3d147f77f92b58",
+    digest = "sha256:340da2900571f7c5124abfd7d58f488fc3e7e60f72fb780b8f5d8988a87a1b16",
     registry = "index.docker.io",
     repository = "kubevirt/libvirt",
-    #tag = "av-8.2-20200629-e049c89",
+    #tag = "20201111-ed64fb3",
 )
 
 # TODO: Update this once we have PPC builds of the base image available

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -322,7 +322,7 @@ func main() {
 	log.InitializeLogging("virt-launcher")
 
 	if !*noFork {
-		exitCode, err := ForkAndMonitor("qemu-kvm", *ephemeralDiskDir, *containerDiskDir)
+		exitCode, err := ForkAndMonitor(*containerDiskDir)
 		if err != nil {
 			log.Log.Reason(err).Error("monitoring virt-launcher failed")
 			os.Exit(1)
@@ -449,7 +449,7 @@ func main() {
 
 // ForkAndMonitor itself to give qemu an extra grace period to properly terminate
 // in case of virt-launcher crashes
-func ForkAndMonitor(qemuProcessCommandPrefix string, ephemeralDiskDir string, containerDiskDir string) (int, error) {
+func ForkAndMonitor(containerDiskDir string) (int, error) {
 	defer cleanupContainerDiskDirectory(containerDiskDir)
 	cmd := exec.Command(os.Args[0], append(os.Args[1:], "--no-fork", "true")...)
 	cmd.Stdout = os.Stdout
@@ -514,8 +514,10 @@ func ForkAndMonitor(qemuProcessCommandPrefix string, ephemeralDiskDir string, co
 	// are not everywhere available where libvirt and qemu are. There we usually call qemu-kvm
 	// which resides in /usr/libexec/qemu-kvm
 	pid, _ := virtlauncher.FindPid("qemu-system")
+	qemuProcessCommandPrefix := "qemu-system"
 	if pid <= 0 {
 		pid, _ = virtlauncher.FindPid("qemu-kvm")
+		qemuProcessCommandPrefix = "qemu-kvm"
 	}
 	if pid > 0 {
 		p, err := os.FindProcess(pid)

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1192,6 +1192,14 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		})
 	}
 
+	if needsSCSIControler(vmi) {
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, Controller{
+			Type:  "scsi",
+			Index: "0",
+			Model: "virtio-scsi",
+		})
+	}
+
 	if vmi.Spec.Domain.Clock != nil {
 		clock := vmi.Spec.Domain.Clock
 		newClock := &Clock{}
@@ -1921,4 +1929,19 @@ func GetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
 		return nil, fmt.Errorf("failed to parse disk info: %v", err)
 	}
 	return info, err
+}
+
+func needsSCSIControler(vmi *v1.VirtualMachineInstance) bool {
+	for _, disk := range vmi.Spec.Domain.Devices.Disks {
+		if disk.LUN != nil && disk.LUN.Bus == "scsi" {
+			return true
+		}
+		if disk.Disk != nil && disk.Disk.Bus == "scsi" {
+			return true
+		}
+		if disk.CDRom != nil && disk.CDRom.Bus == "scsi" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This brings in newer versions of libvirt and QEMU, which are now installed from upstream builds taken from Fedora instead of rebuilt RHEL packages. Tracking upstream releases allows us to take advantage of improvements and bug fixes earlier.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

None.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
This version of KubeVirt includes upgraded virtualization technology based on libvirt 6.6.0 and QEMU 5.1.0.
Each new release of libvirt and QEMU contains numerous improvements and bug fixes.
```