### PR TITLE
Improve memory overhead accounting

### DIFF
--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -82,7 +82,7 @@ func (mutator *VMIsMutator) Mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 		mutator.setDefaultCPUModel(newVMI)
 		mutator.setDefaultMachineType(newVMI)
 		mutator.setDefaultResourceRequests(newVMI)
-        mutator.setDefaultGuestCPUTopology(newVMI)
+		mutator.setDefaultGuestCPUTopology(newVMI)
 		mutator.setDefaultPullPoliciesOnContainerDisks(newVMI)
 		err = mutator.setDefaultNetworkInterface(newVMI)
 		if err != nil {
@@ -200,23 +200,23 @@ func (mutator *VMIsMutator) setDefaultGuestCPUTopology(vmi *v1.VirtualMachineIns
 	sockets := uint32(1)
 	vmiCPU := vmi.Spec.Domain.CPU
 	if vmiCPU == nil || (vmiCPU.Cores == 0 && vmiCPU.Sockets == 0 && vmiCPU.Threads == 0) {
-        // create cpu topology struct
-        if vmi.Spec.Domain.CPU == nil {
-            vmi.Spec.Domain.CPU = &v1.CPU{}
-        }
-        //if cores, sockets, threads are not set, take value from domain resources request or limits and
-        //set value into sockets, which have best performance (https://bugzilla.redhat.com/show_bug.cgi?id=1653453)
-        resources := vmi.Spec.Domain.Resources
-        if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
-            sockets = uint32(cpuLimit.Value())
-        } else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
-            sockets = uint32(cpuRequests.Value())
-        }
-
-        vmi.Spec.Domain.CPU.Sockets = sockets
-        vmi.Spec.Domain.CPU.Cores = cores
-        vmi.Spec.Domain.CPU.Threads = threads
+		// create cpu topology struct
+		if vmi.Spec.Domain.CPU == nil {
+			vmi.Spec.Domain.CPU = &v1.CPU{}
 		}
+		//if cores, sockets, threads are not set, take value from domain resources request or limits and
+		//set value into sockets, which have best performance (https://bugzilla.redhat.com/show_bug.cgi?id=1653453)
+		resources := vmi.Spec.Domain.Resources
+		if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
+			sockets = uint32(cpuLimit.Value())
+		} else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
+			sockets = uint32(cpuRequests.Value())
+		}
+
+		vmi.Spec.Domain.CPU.Sockets = sockets
+		vmi.Spec.Domain.CPU.Cores = cores
+		vmi.Spec.Domain.CPU.Threads = threads
+	}
 }
 
 func (mutator *VMIsMutator) setDefaultMachineType(vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -82,6 +82,7 @@ func (mutator *VMIsMutator) Mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 		mutator.setDefaultCPUModel(newVMI)
 		mutator.setDefaultMachineType(newVMI)
 		mutator.setDefaultResourceRequests(newVMI)
+        mutator.setDefaultGuestCPUTopology(newVMI)
 		mutator.setDefaultPullPoliciesOnContainerDisks(newVMI)
 		err = mutator.setDefaultNetworkInterface(newVMI)
 		if err != nil {
@@ -191,6 +192,31 @@ func (mutator *VMIsMutator) setDefaultCPUModel(vmi *v1.VirtualMachineInstance) {
 			vmi.Spec.Domain.CPU.Model = defaultCPUModel
 		}
 	}
+}
+
+func (mutator *VMIsMutator) setDefaultGuestCPUTopology(vmi *v1.VirtualMachineInstance) {
+	cores := uint32(1)
+	threads := uint32(1)
+	sockets := uint32(1)
+	vmiCPU := vmi.Spec.Domain.CPU
+	if vmiCPU == nil || (vmiCPU.Cores == 0 && vmiCPU.Sockets == 0 && vmiCPU.Threads == 0) {
+        // create cpu topology struct
+        if vmi.Spec.Domain.CPU == nil {
+            vmi.Spec.Domain.CPU = &v1.CPU{}
+        }
+        //if cores, sockets, threads are not set, take value from domain resources request or limits and
+        //set value into sockets, which have best performance (https://bugzilla.redhat.com/show_bug.cgi?id=1653453)
+        resources := vmi.Spec.Domain.Resources
+        if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
+            sockets = uint32(cpuLimit.Value())
+        } else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
+            sockets = uint32(cpuRequests.Value())
+        }
+
+        vmi.Spec.Domain.CPU.Sockets = sockets
+        vmi.Spec.Domain.CPU.Cores = cores
+        vmi.Spec.Domain.CPU.Threads = threads
+		}
 }
 
 func (mutator *VMIsMutator) setDefaultMachineType(vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -482,29 +482,29 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(vmiSpec.Domain.Resources.Requests.Memory()).To(Equal(vmi.Spec.Domain.Resources.Requests.Memory()))
 	})
 
-    It("should convert CPU requests to sockets", func() {
+	It("should convert CPU requests to sockets", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Model: "EPYC"}
 		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-			k8sv1.ResourceCPU:    resource.MustParse("2200m"),
-        }
-        vmiSpec, _ := getVMISpecMetaFromResponse()
+			k8sv1.ResourceCPU: resource.MustParse("2200m"),
+		}
+		vmiSpec, _ := getVMISpecMetaFromResponse()
 
-        Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
-        Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
-        Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
-    })
+		Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
+		Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
+		Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
+	})
 
 	It("should convert CPU limits to sockets", func() {
 		vmi.Spec.Domain.CPU = &v1.CPU{Model: "EPYC"}
 		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
-			k8sv1.ResourceCPU:    resource.MustParse("2.3"),
-        }
-        vmiSpec, _ := getVMISpecMetaFromResponse()
+			k8sv1.ResourceCPU: resource.MustParse("2.3"),
+		}
+		vmiSpec, _ := getVMISpecMetaFromResponse()
 
-        Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
-        Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
-        Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
-    })
+		Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
+		Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
+		Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
+	})
 
 	It("should apply memory-overcommit when guest-memory is set and memory-request is not set", func() {
 		// no limits wanted on this test, to not copy the limit to requests

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -482,6 +482,30 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		Expect(vmiSpec.Domain.Resources.Requests.Memory()).To(Equal(vmi.Spec.Domain.Resources.Requests.Memory()))
 	})
 
+    It("should convert CPU requests to sockets", func() {
+		vmi.Spec.Domain.CPU = &v1.CPU{Model: "EPYC"}
+		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+			k8sv1.ResourceCPU:    resource.MustParse("2200m"),
+        }
+        vmiSpec, _ := getVMISpecMetaFromResponse()
+
+        Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
+        Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
+        Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
+    })
+
+	It("should convert CPU limits to sockets", func() {
+		vmi.Spec.Domain.CPU = &v1.CPU{Model: "EPYC"}
+		vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+			k8sv1.ResourceCPU:    resource.MustParse("2.3"),
+        }
+        vmiSpec, _ := getVMISpecMetaFromResponse()
+
+        Expect(vmiSpec.Domain.CPU.Cores).To(Equal(uint32(1)), "Expect cores")
+        Expect(vmiSpec.Domain.CPU.Sockets).To(Equal(uint32(3)), "Expect sockets")
+        Expect(vmiSpec.Domain.CPU.Threads).To(Equal(uint32(1)), "Expect threads")
+    })
+
 	It("should apply memory-overcommit when guest-memory is set and memory-request is not set", func() {
 		// no limits wanted on this test, to not copy the limit to requests
 		namespaceLimitInformer, _ = testutils.NewFakeInformerFor(&k8sv1.LimitRange{})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1209,11 +1209,27 @@ func getMemoryOverhead(vmi *v1.VirtualMachineInstance) *resource.Quantity {
 	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
 	// overhead per vcpu in MiB
 	coresMemory := resource.MustParse("8Mi")
+	var vcpus int64
 	if domain.CPU != nil {
-		vcpus := hardware.GetNumberOfVCPUs(domain.CPU)
-		value := coresMemory.Value() * vcpus
-		coresMemory = *resource.NewQuantity(value, coresMemory.Format)
+		vcpus = hardware.GetNumberOfVCPUs(domain.CPU)
+	} else {
+		// Currently, a default guest CPU topology is set by the API webhook mutator, if not set by a user.
+		// However, this wasn't always the case.
+		// In case when the guest topology isn't set, take value from resources request or limits.
+		resources := vmi.Spec.Domain.Resources
+		if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
+			vcpus = cpuLimit.Value()
+		} else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
+			vcpus = cpuRequests.Value()
+		}
 	}
+
+	// if neither CPU topology nor request or limits provided, set vcpus to 1
+	if vcpus < 1 {
+		vcpus = 1
+	}
+	value := coresMemory.Value() * vcpus
+	coresMemory = *resource.NewQuantity(value, coresMemory.Format)
 	overhead.Add(coresMemory)
 
 	// static overhead for IOThread

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1204,7 +1204,7 @@ func getMemoryOverhead(vmi *v1.VirtualMachineInstance) *resource.Quantity {
 
 	// Add fixed overhead for shared libraries and such
 	// TODO account for the overhead of kubevirt components running in the pod
-	overhead.Add(resource.MustParse("128M"))
+	overhead.Add(resource.MustParse("138Mi"))
 
 	// Add CPU table overhead (8 MiB per vCPU and 8 MiB per IO thread)
 	// overhead per vcpu in MiB
@@ -1228,7 +1228,7 @@ func getMemoryOverhead(vmi *v1.VirtualMachineInstance) *resource.Quantity {
 	// in addition to MMIO memory space to allow DMA. 1G is often the size of reserved MMIO space on x86 systems.
 	// Additial information can be found here: https://www.redhat.com/archives/libvir-list/2015-November/msg00329.html
 	if util.IsSRIOVVmi(vmi) || util.IsGPUVMI(vmi) {
-		overhead.Add(resource.MustParse("1G"))
+		overhead.Add(resource.MustParse("1Gi"))
 	}
 
 	return overhead

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1117,8 +1117,8 @@ var _ = Describe("Template", func() {
 
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1m"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("2m"))
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1163507557"))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2163507557"))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1180211045"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2180211045"))
 			})
 			It("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func() {
 
@@ -1147,7 +1147,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2163507557"))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("2180211045"))
 			})
 			It("should not add unset resources", func() {
 
@@ -1175,7 +1175,7 @@ var _ = Describe("Template", func() {
 
 				Expect(vmi.Spec.Domain.Resources.Requests.Memory().String()).To(Equal("64M"))
 				Expect(pod.Spec.Containers[0].Resources.Requests.Cpu().String()).To(Equal("1m"))
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(243)))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(260)))
 
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
@@ -1210,9 +1210,9 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				table.Entry("and consider graphics overhead if it is not set", nil, 243),
-				table.Entry("and consider graphics overhead if it is set to true", True(), 243),
-				table.Entry("and not consider graphics overhead if it is set to false", False(), 226),
+				table.Entry("and consider graphics overhead if it is not set", nil, 260),
+				table.Entry("and consider graphics overhead if it is set to true", True(), 260),
+				table.Entry("and not consider graphics overhead if it is set to false", False(), 243),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 
@@ -1344,8 +1344,8 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(162)))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(162)))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179)))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179)))
 
 				hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + value)
 				hugepagesRequest := pod.Spec.Containers[0].Resources.Requests[hugepageType]
@@ -1396,8 +1396,8 @@ var _ = Describe("Template", func() {
 				guestRequestMemDiff := vmi.Spec.Domain.Resources.Requests.Memory()
 				guestRequestMemDiff.Sub(guestMem)
 
-				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(162) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
-				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(162) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
+				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
+				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(179) + guestRequestMemDiff.ToDec().ScaledValue(resource.Mega)))
 
 				hugepageType := kubev1.ResourceName(kubev1.ResourceHugePagesPrefix + "1Gi")
 				hugepagesRequest := pod.Spec.Containers[0].Resources.Requests[hugepageType]

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1449,17 +1449,6 @@ func getCPUTopology(vmi *v1.VirtualMachineInstance) *CPUTopology {
 		}
 	}
 
-	if vmiCPU == nil || (vmiCPU.Cores == 0 && vmiCPU.Sockets == 0 && vmiCPU.Threads == 0) {
-		//if cores, sockets, threads are not set, take value from domain resources request or limits and
-		//set value into sockets, which have best performance (https://bugzilla.redhat.com/show_bug.cgi?id=1653453)
-		resources := vmi.Spec.Domain.Resources
-		if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
-			sockets = uint32(cpuLimit.Value())
-		} else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
-			sockets = uint32(cpuRequests.Value())
-		}
-	}
-
 	return &CPUTopology{
 		Sockets: sockets,
 		Cores:   cores,

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1448,6 +1448,18 @@ func getCPUTopology(vmi *v1.VirtualMachineInstance) *CPUTopology {
 			sockets = vmiCPU.Sockets
 		}
 	}
+	// A default guest CPU topology is being set in API mutator webhook, if nothing provided by a user.
+	// However this setting is still required to handle situations when the webhook fails to set a default topology.
+	if vmiCPU == nil || (vmiCPU.Cores == 0 && vmiCPU.Sockets == 0 && vmiCPU.Threads == 0) {
+		//if cores, sockets, threads are not set, take value from domain resources request or limits and
+		//set value into sockets, which have best performance (https://bugzilla.redhat.com/show_bug.cgi?id=1653453)
+		resources := vmi.Spec.Domain.Resources
+		if cpuLimit, ok := resources.Limits[k8sv1.ResourceCPU]; ok {
+			sockets = uint32(cpuLimit.Value())
+		} else if cpuRequests, ok := resources.Requests[k8sv1.ResourceCPU]; ok {
+			sockets = uint32(cpuRequests.Value())
+		}
+	}
 
 	return &CPUTopology{
 		Sockets: sockets,

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -2134,7 +2134,7 @@ var _ = Describe("Converter", func() {
 		It("should honor multiQueue setting", func() {
 			var expectedQueues uint = 2
 			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores:   2,
+				Cores: 2,
 			}
 
 			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true, SMBios: &cmdv1.SMBios{}})
@@ -2236,7 +2236,7 @@ var _ = Describe("Converter", func() {
 		It("should assign queues to a device if requested", func() {
 			var expectedQueues uint = 2
 			vmi.Spec.Domain.CPU = &v1.CPU{
-				Cores:   2,
+				Cores: 2,
 			}
 
 			domain := vmiToDomain(vmi, &ConverterContext{UseEmulation: true})

--- a/pkg/virt-launcher/virtwrap/api/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/api/converter_test.go
@@ -1184,6 +1184,30 @@ var _ = Describe("Converter", func() {
 				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
 			})
 
+			It("should convert CPU requests to sockets", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = nil
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2200m")
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
+			It("should convert CPU limits to sockets", func() {
+				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+				vmi.Spec.Domain.CPU = nil
+				vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse("2.3")
+				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+
+				Expect(domainSpec.CPU.Topology.Cores).To(Equal(uint32(1)), "Expect cores")
+				Expect(domainSpec.CPU.Topology.Sockets).To(Equal(uint32(3)), "Expect sockets")
+				Expect(domainSpec.CPU.Topology.Threads).To(Equal(uint32(1)), "Expect threads")
+				Expect(domainSpec.VCPU.CPUs).To(Equal(uint32(3)), "Expect vcpus")
+			})
+
 			It("should prefer CPU spec instead of CPU requests", func() {
 				v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 				vmi.Spec.Domain.CPU = &v1.CPU{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Configurations", func() {
 				if computeContainer == nil {
 					tests.PanicOnError(fmt.Errorf("could not find the compute container"))
 				}
-				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(243)))
+				Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(260)))
 
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -843,7 +843,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-				Expect(curVMI.Spec.Domain.CPU).To(BeNil(), "Expected CPU to be nil")
+				Expect(curVMI.Spec.Domain.CPU.Model).To(BeEmpty(), "Expected CPU model to be nil")
 			})
 		})
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -287,7 +287,7 @@ var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 			Expect(ok).To(BeFalse(), "Preset should not have been applied due to exclusion")
 
 			// check a setting from the preset itself to show it was applied
-			Expect(newVMI.Spec.Domain.CPU).To(BeNil(),
+			Expect(newVMI.Spec.Domain.CPU.Cores).NotTo(Equal(newPreset.Spec.Domain.CPU.Cores),
 				"CPU should still have been the default value (not defined in spec)")
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
In some cases, when the is not an explicit guest CPU topology set, the amount of guests vCPUs is derived from resource requests or limits.
However, currently, this is being done late in the VMI creation stage, and the newly assigned number of vCPUs is not being accounted for in the memory overhead calculation.
This PR moves the assignment of a default guest CPU topology to the mutator webhook.

This PR also adjusts the static memory overhead reservation by 10Mi. 
This is being done as a response to users' reports about the current overhead not being enough.
After running multiple different scenarios, it appears that a static overhead of 5Mi would be sufficient to avoid OOM situations. This PR double this amount as a first step to address this issue.


**Release note**:
```release-note
Increase the static memory overhead by 10Mi
```
