### PR TITLE
macvtap, migration, tests: add a test w/ traffic

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -239,6 +239,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -70,6 +70,12 @@ func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
 	}
 }
 
+// InterfaceWithMac decorates an existing Interface with a MAC address.
+func InterfaceWithMac(iface *kvirtv1.Interface, macAddress string) *kvirtv1.Interface {
+	iface.MacAddress = macAddress
+	return iface
+}
+
 // MultusNetwork returns a Network with the given name
 func MultusNetwork(networkName string) *kvirtv1.Network {
 	return &kvirtv1.Network{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Test the VM has connectivity before and after VM migration.

We rely on guest agent to learn the IP addresses of the instantiated VMs; as such, we needed to use a fedora VM for the
migration test with traffic.

The CirrOS VMIs used throughout the tests *only* have a single network interface, and as such, are not connected to the pod
network.

The Fedora VMI - which is used only in the migration test with traffic - on the other hand, has 2 network interfaces:
  - a masquerade iface, to connect the VMI to the k8s services
  - a macvtap iface, to connect the VMI to the host's subnet

The masquerade interface, on the Fedora VMI (pod interface) is required to reach the `cdi-http-importer` k8s service, from where
we install the guest-agent, which, in turn, is required to provide the test framework the VMI IP.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
