### PR TITLE
WIP / DNM: net_admin: remove this capability

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1135,7 +1135,6 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability 
 	if (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
 		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true) {
-		res = append(res, CAP_NET_ADMIN)
 		// The DHCP server needs the ability to use raw sockets. This
 		// capability is available by default in some clusters, but not
 		// a given.

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -486,6 +486,12 @@ func (h *NetworkUtilsHandler) BindTapDeviceToBridge(tapName string, bridgeName s
 		return fmt.Errorf("failed to set tap device %s up; %v", tapName, err)
 	}
 
+	// turn TX offload checksum because it causes dhcp failures
+	if err := dhcp.EthtoolTXOff(bridgeName); err != nil {
+		log.Log.Reason(err).Errorf("Failed to set tx offload for interface %s off", bridgeName)
+		return err
+	}
+
 	log.Log.Infof("Successfully configured tap device: %s", tapName)
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -81,12 +81,6 @@ func SingleClientDHCPServer(
 		options:       options,
 	}
 
-	// turn TX offload checksum because it causes dhcp failures
-	if err := EthtoolTXOff(serverIface); err != nil {
-		log.Log.Reason(err).Errorf("Failed to set tx offload for interface %s off", serverIface)
-		return err
-	}
-
 	l, err := dhcpConn.NewUDP4BoundListener(serverIface, ":67")
 	if err != nil {
 		return err

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -478,7 +478,7 @@ func (b *BridgePodInterface) decorateConfig() error {
 	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
 		if iface.Alias.Name == b.iface.Name {
-			ifaces[i].MTU = b.virtIface.MTU
+			//ifaces[i].MTU = b.virtIface.MTU
 			ifaces[i].MAC = &api.MAC{MAC: b.vif.MAC.String()}
 			ifaces[i].Target = b.virtIface.Target
 			break
@@ -787,7 +787,7 @@ func (p *MasqueradePodInterface) decorateConfig() error {
 	ifaces := p.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
 		if iface.Alias.Name == p.iface.Name {
-			ifaces[i].MTU = p.virtIface.MTU
+			//ifaces[i].MTU = p.virtIface.MTU
 			ifaces[i].MAC = &api.MAC{MAC: p.vif.MAC.String()}
 			ifaces[i].Target = p.virtIface.Target
 			break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
see what breaks when we remove the capability and work from there ...

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
**THIS IS NOT WORKING**
**NO ETA ON HAVING THIS WORKING**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Issue list:
  - mtu configuration on the tap creation (netlink bug - open one; address it)
  - dhcp disables eth tx offload - moving this into the first part of pod networking setup seems to appease the launcher
  - cap_net_admin required when the users (tap creator & tap consumer) mismatch. Is this the issue we're facing ? ....