### PR TITLE
Remove 'string' from json tag to preserve type information in our API

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8484,7 +8484,8 @@
     "type": "object",
     "properties": {
      "cpuAllocationRatio": {
-      "type": "string"
+      "type": "integer",
+      "format": "int32"
      },
      "featureGates": {
       "type": "array",
@@ -8493,7 +8494,8 @@
       }
      },
      "memoryOvercommit": {
-      "type": "string"
+      "type": "integer",
+      "format": "int32"
      },
      "nodeSelectors": {
       "type": "object",
@@ -8502,10 +8504,11 @@
       }
      },
      "pvcTolerateLessSpaceUpToPercent": {
-      "type": "string"
+      "type": "integer",
+      "format": "int32"
      },
      "useEmulation": {
-      "type": "string"
+      "type": "boolean"
      }
     }
    },
@@ -9434,31 +9437,35 @@
     "type": "object",
     "properties": {
      "allowAutoConverge": {
-      "type": "string"
+      "type": "boolean"
      },
      "allowPostCopy": {
-      "type": "string"
+      "type": "boolean"
      },
      "bandwidthPerMigration": {
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      },
      "completionTimeoutPerGiB": {
-      "type": "string"
+      "type": "integer",
+      "format": "int64"
      },
      "nodeDrainTaintKey": {
       "type": "string"
      },
      "parallelMigrationsPerCluster": {
-      "type": "string"
+      "type": "integer",
+      "format": "int64"
      },
      "parallelOutboundMigrationsPerNode": {
-      "type": "string"
+      "type": "integer",
+      "format": "int64"
      },
      "progressTimeout": {
-      "type": "string"
+      "type": "integer",
+      "format": "int64"
      },
      "unsafeMigrationOverride": {
-      "type": "string"
+      "type": "boolean"
      }
     }
    },
@@ -9506,10 +9513,10 @@
       "type": "string"
      },
      "permitBridgeInterfaceOnPodNetwork": {
-      "type": "string"
+      "type": "boolean"
      },
      "permitSlirpInterface": {
-      "type": "string"
+      "type": "boolean"
      }
     }
    },

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -228,17 +228,33 @@ func (c *ClusterConfig) SetConfigModifiedCallback(cb ConfigModifiedFn) {
 	go c.configModifiedCallback()
 }
 
+// This struct is for backward compatibility and is deprecated, no new fields should be added
+type migrationConfiguration struct {
+	NodeDrainTaintKey                 *string            `json:"nodeDrainTaintKey,omitempty"`
+	ParallelOutboundMigrationsPerNode *uint32            `json:"parallelOutboundMigrationsPerNode,string,omitempty"`
+	ParallelMigrationsPerCluster      *uint32            `json:"parallelMigrationsPerCluster,string,omitempty"`
+	AllowAutoConverge                 *bool              `json:"allowAutoConverge,string,omitempty"`
+	BandwidthPerMigration             *resource.Quantity `json:"bandwidthPerMigration,omitempty"`
+	CompletionTimeoutPerGiB           *int64             `json:"completionTimeoutPerGiB,string,omitempty"`
+	ProgressTimeout                   *int64             `json:"progressTimeout,string,omitempty"`
+	UnsafeMigrationOverride           *bool              `json:"unsafeMigrationOverride,string,omitempty"`
+	AllowPostCopy                     *bool              `json:"allowPostCopy,string,omitempty"`
+}
+
 // setConfigFromConfigMap parses the provided config map and updates the provided config.
 // Default values in the provided config stay in tact.
 func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.ConfigMap) error {
 	// set migration options
 	rawConfig := strings.TrimSpace(configMap.Data[MigrationsConfigKey])
 	if rawConfig != "" {
+		migrationConfig := migrationConfiguration(*config.MigrationConfiguration)
 		// only sets values if they were specified, default values stay intact
-		err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(rawConfig), 1024).Decode(config.MigrationConfiguration)
+		err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(rawConfig), 1024).Decode(&migrationConfig)
 		if err != nil {
 			return fmt.Errorf("failed to parse migration config: %v", err)
 		}
+		converted := v1.MigrationConfiguration(migrationConfig)
+		config.MigrationConfiguration = &converted
 	}
 
 	// set smbios values if they exist
@@ -301,8 +317,8 @@ func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.C
 	}
 
 	if cpuOvercommit := strings.TrimSpace(configMap.Data[CPUAllocationRatio]); cpuOvercommit != "" {
-		if value, err := strconv.ParseFloat(cpuOvercommit, 64); err == nil && value > 0 {
-			config.DeveloperConfiguration.CPUAllocationRatio = value
+		if value, err := strconv.ParseInt(cpuOvercommit, 10, 32); err == nil && value > 0 {
+			config.DeveloperConfiguration.CPUAllocationRatio = int(value)
 		} else {
 			return fmt.Errorf("Invalid cpu allocation ratio in ConfigMap: %s", cpuOvercommit)
 		}

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -61,7 +61,7 @@ const (
 	SupportedGuestAgentVersions                     = "2.*,3.*,4.*"
 	DefaultOVMFPath                                 = "/usr/share/OVMF"
 	DefaultMemBalloonStatsPeriod             uint32 = 10
-	DefaultCPUAllocationRatio                       = 10.0
+	DefaultCPUAllocationRatio                       = 10
 )
 
 // Set default machine type and supported emulated machines based on architecture
@@ -156,6 +156,6 @@ func (c *ClusterConfig) GetOVMFPath() string {
 	return c.GetConfig().OVMFPath
 }
 
-func (c *ClusterConfig) GetCPUAllocationRatio() float64 {
-	return float64(c.GetConfig().DeveloperConfiguration.CPUAllocationRatio)
+func (c *ClusterConfig) GetCPUAllocationRatio() int {
+	return c.GetConfig().DeveloperConfiguration.CPUAllocationRatio
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -643,7 +643,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		}
 		cpuAllocationRatio := t.clusterConfig.GetCPUAllocationRatio()
 		if vcpus != 0 && cpuAllocationRatio > 0 {
-			val := float64(vcpus) / cpuAllocationRatio
+			val := float64(vcpus) / float64(cpuAllocationRatio)
 			vcpusStr := fmt.Sprintf("%g", val)
 			if val < 0 {
 				val *= 1000

--- a/pkg/virt-operator/creation/components/validations_generated.go
+++ b/pkg/virt-operator/creation/components/validations_generated.go
@@ -267,7 +267,7 @@ var CRDsValidation map[string]string = map[string]string{
               description: DeveloperConfiguration holds developer options
               properties:
                 cpuAllocationRatio:
-                  type: number
+                  type: integer
                 featureGates:
                   items:
                     type: string

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -14240,14 +14240,14 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 					},
 					"pvcTolerateLessSpaceUpToPercent": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 					"memoryOvercommit": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 					"nodeSelectors": {
@@ -14266,14 +14266,14 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 					},
 					"useEmulation": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
 					"cpuAllocationRatio": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 				},
@@ -16069,19 +16069,19 @@ func schema_kubevirtio_client_go_api_v1_MigrationConfiguration(ref common.Refere
 					},
 					"parallelOutboundMigrationsPerNode": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"parallelMigrationsPerCluster": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"allowAutoConverge": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -16092,25 +16092,25 @@ func schema_kubevirtio_client_go_api_v1_MigrationConfiguration(ref common.Refere
 					},
 					"completionTimeoutPerGiB": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"progressTimeout": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"unsafeMigrationOverride": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
 					"allowPostCopy": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -16198,13 +16198,13 @@ func schema_kubevirtio_client_go_api_v1_NetworkConfiguration(ref common.Referenc
 					},
 					"permitSlirpInterface": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
 					"permitBridgeInterfaceOnPodNetwork": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1473,31 +1473,31 @@ type SMBiosConfiguration struct {
 // +k8s:openapi-gen=true
 type MigrationConfiguration struct {
 	NodeDrainTaintKey                 *string            `json:"nodeDrainTaintKey,omitempty"`
-	ParallelOutboundMigrationsPerNode *uint32            `json:"parallelOutboundMigrationsPerNode,string,omitempty"`
-	ParallelMigrationsPerCluster      *uint32            `json:"parallelMigrationsPerCluster,string,omitempty"`
-	AllowAutoConverge                 *bool              `json:"allowAutoConverge,string,omitempty"`
+	ParallelOutboundMigrationsPerNode *uint32            `json:"parallelOutboundMigrationsPerNode,omitempty"`
+	ParallelMigrationsPerCluster      *uint32            `json:"parallelMigrationsPerCluster,omitempty"`
+	AllowAutoConverge                 *bool              `json:"allowAutoConverge,omitempty"`
 	BandwidthPerMigration             *resource.Quantity `json:"bandwidthPerMigration,omitempty"`
-	CompletionTimeoutPerGiB           *int64             `json:"completionTimeoutPerGiB,string,omitempty"`
-	ProgressTimeout                   *int64             `json:"progressTimeout,string,omitempty"`
-	UnsafeMigrationOverride           *bool              `json:"unsafeMigrationOverride,string,omitempty"`
-	AllowPostCopy                     *bool              `json:"allowPostCopy,string,omitempty"`
+	CompletionTimeoutPerGiB           *int64             `json:"completionTimeoutPerGiB,omitempty"`
+	ProgressTimeout                   *int64             `json:"progressTimeout,omitempty"`
+	UnsafeMigrationOverride           *bool              `json:"unsafeMigrationOverride,omitempty"`
+	AllowPostCopy                     *bool              `json:"allowPostCopy,omitempty"`
 }
 
 // DeveloperConfiguration holds developer options
 // +k8s:openapi-gen=true
 type DeveloperConfiguration struct {
 	FeatureGates           []string          `json:"featureGates,omitempty"`
-	LessPVCSpaceToleration int               `json:"pvcTolerateLessSpaceUpToPercent,string,omitempty"`
-	MemoryOvercommit       int               `json:"memoryOvercommit,string,omitempty"`
+	LessPVCSpaceToleration int               `json:"pvcTolerateLessSpaceUpToPercent,omitempty"`
+	MemoryOvercommit       int               `json:"memoryOvercommit,omitempty"`
 	NodeSelectors          map[string]string `json:"nodeSelectors,omitempty"`
-	UseEmulation           bool              `json:"useEmulation,string,omitempty"`
-	CPUAllocationRatio     float64           `json:"cpuAllocationRatio,string,omitempty"`
+	UseEmulation           bool              `json:"useEmulation,omitempty"`
+	CPUAllocationRatio     int               `json:"cpuAllocationRatio,omitempty"`
 }
 
 // NetworkConfiguration holds network options
 // +k8s:openapi-gen=true
 type NetworkConfiguration struct {
 	NetworkInterface                  string `json:"defaultNetworkInterface,omitempty"`
-	PermitSlirpInterface              *bool  `json:"permitSlirpInterface,string,omitempty"`
-	PermitBridgeInterfaceOnPodNetwork *bool  `json:"permitBridgeInterfaceOnPodNetwork,string,omitempty"`
+	PermitSlirpInterface              *bool  `json:"permitSlirpInterface,omitempty"`
+	PermitBridgeInterfaceOnPodNetwork *bool  `json:"permitBridgeInterfaceOnPodNetwork,omitempty"`
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14094,14 +14094,14 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 					},
 					"pvcTolerateLessSpaceUpToPercent": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 					"memoryOvercommit": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 					"nodeSelectors": {
@@ -14120,14 +14120,14 @@ func schema_kubevirtio_client_go_api_v1_DeveloperConfiguration(ref common.Refere
 					},
 					"useEmulation": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
 					"cpuAllocationRatio": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 				},
@@ -15923,19 +15923,19 @@ func schema_kubevirtio_client_go_api_v1_MigrationConfiguration(ref common.Refere
 					},
 					"parallelOutboundMigrationsPerNode": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"parallelMigrationsPerCluster": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"allowAutoConverge": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -15946,25 +15946,25 @@ func schema_kubevirtio_client_go_api_v1_MigrationConfiguration(ref common.Refere
 					},
 					"completionTimeoutPerGiB": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"progressTimeout": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Type:   []string{"integer"},
+							Format: "int64",
 						},
 					},
 					"unsafeMigrationOverride": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
 					"allowPostCopy": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -16052,13 +16052,13 @@ func schema_kubevirtio_client_go_api_v1_NetworkConfiguration(ref common.Referenc
 					},
 					"permitSlirpInterface": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
 					"permitBridgeInterfaceOnPodNetwork": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
+							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
We accidentally introduced 'string' to json tags of some fields. This PR removes them.
This PR preserves backward compatibility in configmap.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
