### PR TITLE
fix wrong logic in SetDriverCacheMode log message

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -170,7 +170,9 @@ func SetDriverCacheMode(disk *Disk) error {
 		if backingFile := disk.BackingStore; backingFile != nil {
 			backingFilePath := backingFile.Source.File
 			backFileDirectIOSupport := checkDirectIOFlag(backingFilePath)
-			log.Log.Infof("%s backing file system does not support direct I/O", backingFilePath)
+			if !backFileDirectIOSupport {
+				log.Log.Infof("%s backing file system does not support direct I/O", backingFilePath)
+			}
 			supportDirectIO = supportDirectIO && backFileDirectIOSupport
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Ezra Silvera <ezra@il.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is a missing condition, and therefore we always get the message `"backing file system does not support direct I/O"`, even when the file system does support direct I/O

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
