### PR TITLE
Automatically set disk I/O mode to the optimal value (native/threads) 

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -21,10 +21,12 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -32,9 +34,6 @@ import (
 
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"encoding/json"
-	"os/exec"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
@@ -198,23 +197,19 @@ func SetDriverCacheMode(disk *Disk) error {
 }
 
 func isPreAllocated(path string) bool {
-
-	preAlloc := false
 	diskInf, err := GetImageInfo(path)
 	if err != nil {
 		return false
 	}
-	if diskInf.VirtualSize > diskInf.ActualSize {
-		preAlloc = true
-	}
-	log.Log.Infof("XXXXX VirtualSize=%d ActualSize=%d", diskInf.VirtualSize, diskInf.ActualSize)
-	return preAlloc
+	// ActualSize can be a little larger then VirtualSize for qcow2
+	return diskInf.VirtualSize < diskInf.ActualSize
 }
 
+// Set optimal io mode automatically
 func SetOptimalIOMode(disk *Disk) error {
 	var path string
 
-	// If the user explicitly set the io mmode do nothing
+	// If the user explicitly set the io mode do nothing
 	if v1.DriverIO(disk.Driver.IO) != "" {
 		return nil
 	}
@@ -234,7 +229,8 @@ func SetOptimalIOMode(disk *Disk) error {
 			disk.Driver.IO = string(v1.IONative)
 		}
 	}
-
+	// For now we don't explicitly set io=threads even for sparse files as it's
+	// not clear it's better for all use-cases
 	if v1.DriverIO(disk.Driver.IO) != "" {
 		log.Log.Infof("Driver IO mode for %s set to %s", path, disk.Driver.IO)
 	}

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -202,7 +202,7 @@ func isPreAllocated(path string) bool {
 		return false
 	}
 	// ActualSize can be a little larger then VirtualSize for qcow2
-	return diskInf.VirtualSize < diskInf.ActualSize
+	return diskInf.VirtualSize <= diskInf.ActualSize
 }
 
 // Set optimal io mode automatically

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -200,14 +200,14 @@ func SetDriverCacheMode(disk *Disk) error {
 func isPreAllocated(path string) bool {
 
 	preAlloc := false
-	diskInf, err := xxGetImageInfo(path)
+	diskInf, err := GetImageInfo(path)
 	if err != nil {
 		return false
 	}
-	if diskInf.VirtualSize > (1024 * diskInf.ActualSize) {
+	if diskInf.VirtualSize > diskInf.ActualSize {
 		preAlloc = true
 	}
-	log.Log.Infof("XXXXX VirtualSize=%d ActualSize=%d", diskInf.VirtualSize, 1024*diskInf.ActualSize)
+	log.Log.Infof("XXXXX VirtualSize=%d ActualSize=%d", diskInf.VirtualSize, diskInf.ActualSize)
 	return preAlloc
 }
 
@@ -1801,7 +1801,7 @@ func createHostDevicesFromMdevUUIDList(mdevUuidList []string) ([]HostDevice, err
 	return hds, nil
 }
 
-func xxGetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
+func GetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
 
 	out, err := exec.Command(
 		"/usr/bin/qemu-img", "info", imagePath, "--output", "json",
@@ -1811,7 +1811,6 @@ func xxGetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
 	}
 	info := &containerdisk.DiskInfo{}
 	err = json.Unmarshal(out, info)
-	log.Log.Infof("XXXX out:%#v", info)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse disk info: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1071,6 +1071,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		if err != nil {
 			return domain, err
 		}
+		api.SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
 	}
 
 	return domain, err

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -27,12 +27,10 @@ package virtwrap
 
 import (
 	"context"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -863,7 +861,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 			if err != nil {
 				return err
 			}
-			info, err := GetImageInfo(image)
+			info, err := api.GetImageInfo(image)
 			if err != nil {
 				return err
 			}
@@ -1206,7 +1204,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 			if err != nil {
 				return nil, err
 			}
-			info, err := GetImageInfo(image)
+			info, err := api.GetImageInfo(image)
 			if err != nil {
 				return nil, err
 			}
@@ -1697,22 +1695,6 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 	}
 	return devicesMetadata, nil
 
-}
-
-func GetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
-
-	out, err := exec.Command(
-		"/usr/bin/qemu-img", "info", imagePath, "--output", "json",
-	).Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to invoke qemu-img: %v", err)
-	}
-	info := &containerdisk.DiskInfo{}
-	err = json.Unmarshal(out, info)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse disk info: %v", err)
-	}
-	return info, err
 }
 
 // GetGuestInfo queries the agent store and return the aggregated data from Guest agent

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -965,6 +965,7 @@ func addCloudInitDisk(vmi *v1.VirtualMachineInstance, userData string, networkDa
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name:  "cloudinit",
 		Cache: v1.CacheNone,
+		IO:    v1.IONative,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
 				Bus: "virtio",

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1784,7 +1784,7 @@ var _ = Describe("Configurations", func() {
 		})
 	})
 
-	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache settings and PVC", func() {
+	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache and io settings and PVC", func() {
 		var originalConfig v1.KubeVirtConfiguration
 
 		BeforeEach(func() {
@@ -1866,6 +1866,66 @@ var _ = Describe("Configurations", func() {
 			By("checking if default cache 'writethrough' has been set to fs which does not support direct I/O")
 			Expect(disks[6].Alias.Name).To(Equal("hostdisk"))
 			Expect(disks[6].Driver.Cache).To(Equal(cacheWritethrough))
+		})
+
+		It("[test_id:1683]should set appropriate IO modes", func() {
+			tests.SkipPVCTestIfRunnigOnKindInfra()
+
+			vmi := tests.NewRandomVMI()
+			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
+
+			By("adding disks to a VMI")
+			// disk[0]:  File, sparsed, no user-input, cache=none
+			tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			vmi.Spec.Domain.Devices.Disks[0].Cache = v1.CacheNone
+
+			// disk[1]:  Block, no user-input, cache=none
+			tests.AddPVCDisk(vmi, "block-pvc", "virtio", tests.BlockDiskForTest)
+
+			// disk[2]: File, not-sparsed, no user-input, cache=none
+			tests.AddPVCDisk(vmi, "hostpath-pvc", "virtio", tests.DiskAlpineHostPath)
+
+			// disk[3]:  File, sparsed, user-input=threads, cache=none
+			tests.AddEphemeralDisk(vmi, "ephemeral-disk2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
+			vmi.Spec.Domain.Devices.Disks[3].Cache = v1.CacheNone
+			vmi.Spec.Domain.Devices.Disks[3].IO = v1.IOThreads
+
+			tests.RunVMIAndExpectLaunch(vmi, 60)
+			runningVMISpec, err := tests.GetRunningVMIDomainSpec(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			disks := runningVMISpec.Devices.Disks
+			By("checking if number of attached disks is equal to real disks number")
+			Expect(len(vmi.Spec.Domain.Devices.Disks)).To(Equal(len(disks)))
+
+			ioNative := string(v1.IONative)
+			ioThreads := string(v1.IOThreads)
+			ioNone := ""
+
+			By("checking if default io has not been seti for sparsed file")
+			Expect(disks[0].Alias.Name).To(Equal("ephemeral-disk1"))
+			Expect(disks[0].Driver.IO).To(Equal(ioNone))
+
+			By("checking if default io mode has been set to 'native' for block device")
+			Expect(disks[1].Alias.Name).To(Equal("block-pvc"))
+			Expect(disks[1].Driver.IO).To(Equal(ioNative))
+
+			By("checking if default cache 'none' has been set to pvc disk")
+			Expect(disks[2].Alias.Name).To(Equal("hostpath-pvc"))
+			// PVC is mounted as tmpfs on kind, which does not support direct I/O.
+			// As such, it behaves as plugging in a hostDisk - check disks[6].
+			if tests.IsRunningOnKindInfra() {
+				// The chache mode is set to cacheWritethrough
+				Expect(disks[2].Driver.IO).To(Equal(ioNone))
+			} else {
+				// The chache mode is set to cacheNone
+				Expect(disks[2].Driver.IO).To(Equal(ioNative))
+			}
+
+			By("checking if requested io mode 'threads' has been set")
+			Expect(disks[3].Alias.Name).To(Equal("ephemeral-disk2"))
+			Expect(disks[3].Driver.IO).To(Equal(ioThreads))
+
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
KubeVirt supports setting a disk I/O mode for disk devices.  There are currently two possible modes 
1.  io=native:  Using kernel async-io. 
1. io=threads: Using user-space threads to achieve (semi) async-I/O

Several investigations showed that on most cases the `native` option results in better I/O performance regardless of the workload and I/O pattern (i.e., requests/sec, size of requests, etc..). 
The only exception was in the case of file based disk with sparse file image. 

This means we can set an optimal disk I/O for the user within KubeVirt independently on the user future usage. 
We will set this mode automatically only in case the user didn't explicitly set that mode himself (we still allow the user to set it up directly)
The logic we take (to make sure we are on the safe side) is:  For block devices, and pre-allocated image disks - use `native`, for everything else don't set the mode explicitly. 

We don't set explicitly `thread` mode for sparse files because there might be use cases in which `native` will out-perform `threads` even for sparse files.

[1] https://web.archive.org/web/20180815010524/http://turlucode.com/qemu-disk-io-performance-comparison-native-or-threads-windows-10-version/
[2] http://docshare02.docshare.tips/files/17877/178771133.pdf
[3] https://www.slideshare.net/pradeepkumarsuvce/qemu-disk-io-which-performs-better-native-or-threads

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4077

**Special notes for your reviewer**:
Not to be confused with `iothreads` which can be orthogonal to this mode
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
