### PR TITLE
Infra test made invalid assumptions about cluster composition

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -299,12 +299,22 @@ var _ = Describe("[Serial]Infrastructure", func() {
 				// tolerate this taint because it is meant to be used on compute nodes only. If we set this taint
 				// on a master node, we risk in breaking the test cluster.
 				for _, pod := range pods.Items {
-					node := schedulableNodes[pod.Spec.NodeName]
+					node, ok := schedulableNodes[pod.Spec.NodeName]
+					if !ok {
+						// Pod is running on a non-schedulable node?
+						continue
+					}
 					if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
 						continue
 					}
 					selectedNodeName = node.Name
 					break
+				}
+
+				// It is possible to run this test on a cluster that simply does not have worker nodes.
+				// Since KubeVirt can't control that, the only correct action is to halt the test.
+				if selectedNodeName == "" {
+					Skip("Could nould determine a node to safely taint")
 				}
 
 				By("setting up a watch for terminated pods")


### PR DESCRIPTION
Fixes a panic in infra tests when an appropriate node to taint could not be determined.

**Release note**:
```release-note
NONE
```
