### PR TITLE
Reduce the cluster size a little to see if flakiness reduces

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -51,7 +51,7 @@ fi
 
 export KUBEVIRT_NUM_NODES=2
 # Give the nodes enough memory to run tests in parallel, including tests which involve fedora
-export KUBEVIRT_MEMORY_SIZE=10240M
+export KUBEVIRT_MEMORY_SIZE=9216M
 
 export RHEL_NFS_DIR=${RHEL_NFS_DIR:-/var/lib/stdci/shared/kubevirt-images/rhel7}
 export RHEL_LOCK_PATH=${RHEL_LOCK_PATH:-/var/lib/stdci/shared/download_rhel_image.lock}


### PR DESCRIPTION
Take 1 GB away from the clusters. Even with running three fedora VMs in
tests in parallel it should be enough and we experience some flakes in
CI which may be related to the increased memory assigned to the cluster
nodes. Intially they had 8GB, then 10GB, now 9.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
