### PR TITLE
SRIOV lane: skip flaky tests

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -880,10 +880,12 @@ var _ = Describe("[Serial]SRIOV", func() {
 		}
 
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {
+			Skip("Skip until https://github.com/kubevirt/kubevirt/issues/3774 fixed")
 			pingThroughSriov("192.168.1.1/24", "192.168.1.2/24")
 		})
 
 		It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
+			Skip("Skip until https://github.com/kubevirt/kubevirt/issues/3747 is fixed")
 			pingThroughSriov("fc00::1/64", "fc00::2/64")
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In order to enable sriov lane back and save CI resources  and developers time
skip flaky tests on sriov lane until their issues are resolved:
https://github.com/kubevirt/kubevirt/issues/3840
https://github.com/kubevirt/kubevirt/issues/3774
https://github.com/kubevirt/kubevirt/issues/3747
https://github.com/kubevirt/kubevirt/issues/4432

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
