### PR TITLE
fix: change url and label name for "good-first-issue" on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ relevant Issues.
 
 To make yourself comfortable with the code, you might want to work on some
 Issues marked with one or more of the following labels:
-[good first issue](https://github.com/kubevirt/kubevirt/labels/good%20first%20issue),
+[good-first-issue](https://github.com/kubevirt/kubevirt/labels/good-first-issue),
 [help wanted](https://github.com/kubevirt/kubevirt/labels/help%20wanted)
 or [kind/bug](https://github.com/kubevirt/kubevirt/labels/kind%2Fbug).
 Any help is highly appreciated.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
It seems that there isn't a label named `good first issue` but named `good-first-issue` on this repo. 
So I fixed the link on CONTRIBUTING.md.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
