### PR TITLE
Fix gosec issue: Use of unsafe calls (go pointers)

### DIFF
--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -144,7 +144,7 @@ func prLimit(pid int, limit uintptr, rlimit *unix.Rlimit) error {
 	_, _, errno := unix.RawSyscall6(unix.SYS_PRLIMIT64,
 		uintptr(pid),
 		limit,
-		uintptr(unsafe.Pointer(rlimit)),
+		uintptr(unsafe.Pointer(rlimit)), // #nosec used in unix RawSyscall6
 		0, 0, 0)
 	if errno != 0 {
 		return fmt.Errorf("Error setting prlimit: %v", errno)

--- a/pkg/virt-launcher/virtwrap/network/dhcp/ethtool.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/ethtool.go
@@ -49,10 +49,10 @@ func EthtoolTXOff(name string) error {
 
 	// Request current value
 	value := EthtoolValue{Cmd: ETHTOOL_GTXCSUM}
-	request := IFReqData{Data: uintptr(unsafe.Pointer(&value))}
+	request := IFReqData{Data: uintptr(unsafe.Pointer(&value))} // #nosec Used for a RawSyscall
 	copy(request.Name[:], name)
 
-	if err := ioctlEthtool(socket, uintptr(unsafe.Pointer(&request))); err != nil {
+	if err := ioctlEthtool(socket, uintptr(unsafe.Pointer(&request))); err != nil { // #nosec Used for a RawSyscall
 		return err
 	}
 	if value.Data == 0 { // if already off, don't try to change
@@ -60,5 +60,5 @@ func EthtoolTXOff(name string) error {
 	}
 
 	value = EthtoolValue{ETHTOOL_STXCSUM, 0}
-	return ioctlEthtool(socket, uintptr(unsafe.Pointer(&request)))
+	return ioctlEthtool(socket, uintptr(unsafe.Pointer(&request))) // #nosec Used for a RawSyscall
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Review the usage of unsafe pointers in code. Unsafe pointers can introduce security risks as they expose C-like pointers. 
In some cases (e.g., direct syscalls and ioctl ) it is required to use unsafe pointers but the usage need to be carefully reviewed. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
