### PR TITLE
test, sriov: Configure ip addresses using cloud init network data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	k8s.io/utils v0.0.0-20200720150651-0bdb4ca86cbc
 	kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer v1.26.1
+	kubevirt.io/controller-lifecycle-operator-sdk v0.1.1
 	kubevirt.io/qe-tools v0.1.6
 	libvirt.org/libvirt-go v6.5.0+incompatible
 	sigs.k8s.io/yaml v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	k8s.io/utils v0.0.0-20200720150651-0bdb4ca86cbc
 	kubevirt.io/client-go v0.0.0-00010101000000-000000000000
 	kubevirt.io/containerized-data-importer v1.26.1
-	kubevirt.io/controller-lifecycle-operator-sdk v0.1.1
 	kubevirt.io/qe-tools v0.1.6
 	libvirt.org/libvirt-go v6.5.0+incompatible
 	sigs.k8s.io/yaml v1.2.0

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -34,6 +34,20 @@ const (
 // NewFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options.
 func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	return newFedora(cd.ContainerDiskFedora, opts...)
+}
+
+// NewSriovFedora instantiates a new Fedora based VMI configuration,
+// building its extra properties based on the specified With* options, the
+// image used include Guest Agent and some moduled needed by SRIOV.
+func NewSriovFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	return newFedora(cd.ContainerDiskFedoraSRIOVLane, opts...)
+}
+
+// NewFedora instantiates a new Fedora based VMI configuration with specified
+// containerDisk, building its extra properties based on the specified With*
+// options.
+func newFedora(containerDisk cd.ContainerDisk, opts ...Option) *kvirtv1.VirtualMachineInstance {
 	configurePassword := `#!/bin/bash
 	echo "fedora" |passwd fedora --stdin
 	echo `
@@ -42,7 +56,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory("512M"),
 		WithRng(),
-		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedora)),
+		WithContainerImage(cd.ContainerDiskFor(containerDisk)),
 		WithCloudInitNoCloudUserData(configurePassword, false),
 	}
 	opts = append(fedoraOptions, opts...)

--- a/tests/libvmi/network.go
+++ b/tests/libvmi/network.go
@@ -60,9 +60,19 @@ func InterfaceDeviceWithBridgeBinding() kvirtv1.Interface {
 	}
 }
 
+// InterfaceDeviceWithSRIOVBinding returns an Interface with SRIOV binding.
+func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
+	return kvirtv1.Interface{
+		Name: name,
+		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
+			SRIOV: &kvirtv1.InterfaceSRIOV{},
+		},
+	}
+}
+
 // MultusNetwork returns a Network with the given name
-func MultusNetwork(networkName string) kvirtv1.Network {
-	return kvirtv1.Network{
+func MultusNetwork(networkName string) *kvirtv1.Network {
+	return &kvirtv1.Network{
 		Name: networkName,
 		NetworkSource: kvirtv1.NetworkSource{
 			Multus: &kvirtv1.MultusNetwork{

--- a/tests/libvmi/status.go
+++ b/tests/libvmi/status.go
@@ -38,3 +38,11 @@ func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, namespace st
 
 	return controlledPod
 }
+
+func IndexInterfaceStatusByName(vmi *v1.VirtualMachineInstance) map[string]v1.VirtualMachineInstanceNetworkInterface {
+	interfaceStatusByName := map[string]v1.VirtualMachineInstanceNetworkInterface{}
+	for _, interfaceStatus := range vmi.Status.Interfaces {
+		interfaceStatusByName[interfaceStatus.Name] = interfaceStatus
+	}
+	return interfaceStatusByName
+}

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -405,7 +405,7 @@ var _ = Describe("[Serial]Multus", func() {
 
 				By("Verifying the desired custom MAC is the one that were actually configured on the interface.")
 				vmiIfaceStatusByName := libvmi.IndexInterfaceStatusByName(vmiOne)
-				Expect(vmiIfaceStatusByName).To(ContainElement(linuxBridgeInterfaceWithCustomMac.Name), "should set linux bridge interface with the custom MAC address at VMI Status")
+				Expect(vmiIfaceStatusByName).To(HaveKey(linuxBridgeInterfaceWithCustomMac.Name), "should set linux bridge interface with the custom MAC address at VMI Status")
 				Expect(vmiIfaceStatusByName[linuxBridgeInterfaceWithCustomMac.Name].MAC).To(Equal(customMacAddress), "should set linux bridge interface with the custom MAC address at VMI")
 
 				By("Verifying the desired custom MAC is not configured inside the pod namespace.")
@@ -640,49 +640,42 @@ var _ = Describe("[Serial]SRIOV", func() {
 	})
 
 	Context("VirtualMachineInstance with sriov plugin interface", func() {
-		getSriovVmi := func(networks []string) *v1.VirtualMachineInstance {
-			// Pre-configured container-disk image for sriov-lane
-			vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskFedoraSRIOVLane))
 
-			// fedora requires some more memory to boot without kernel panics
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceName("memory")] = resource.MustParse("1024M")
+		getSriovVmi := func(networks []string, cloudInitNetworkData string) *v1.VirtualMachineInstance {
 
-			// newer fedora kernels may require hardware RNG to boot
-			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
-
-			// pod network interface
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{Name: "default", Ports: []v1.Port{}, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}}
-			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-
+			withVmiOptions := []libvmi.Option{
+				libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkData, false),
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			}
 			// sriov network interfaces
 			for _, name := range networks {
-				iface := v1.Interface{Name: name, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}
-				network := v1.Network{Name: name, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: name}}}
-				vmi.Spec.Domain.Devices.Interfaces = append(vmi.Spec.Domain.Devices.Interfaces, iface)
-				vmi.Spec.Networks = append(vmi.Spec.Networks, network)
+				withVmiOptions = append(withVmiOptions,
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(name)),
+					libvmi.WithNetwork(libvmi.MultusNetwork(name)),
+				)
 			}
+			return libvmi.NewSriovFedora(withVmiOptions...)
+		}
 
+		startVmi := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
+			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			return vmi
 		}
 
-		startVmi := func(vmi *v1.VirtualMachineInstance) {
-			_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			return
-		}
-
-		waitVmi := func(vmi *v1.VirtualMachineInstance) {
+		waitVmi := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 			// Need to wait for cloud init to finish and start the agent inside the vmi.
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToFedora))
 			tests.WaitAgentConnected(virtClient, vmi)
-			return
+			return vmi
 		}
 
 		checkDefaultInterfaceInPod := func(vmi *v1.VirtualMachineInstance) {
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 
 			By("checking default interface is present")
 			_, err = tests.ExecuteCommandOnPod(
@@ -710,12 +703,12 @@ var _ = Describe("[Serial]SRIOV", func() {
 		}
 
 		It("[test_id:1754]should create a virtual machine with sriov interface", func() {
-			vmi := getSriovVmi([]string{"sriov"})
-			startVmi(vmi)
-			waitVmi(vmi)
+			vmi := getSriovVmi([]string{"sriov"}, defaultCloudInitNetworkData())
+			vmi = startVmi(vmi)
+			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, "sriov", sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
@@ -729,15 +722,15 @@ var _ = Describe("[Serial]SRIOV", func() {
 		})
 
 		It("[test_id:1754]should create a virtual machine with sriov interface with all pci devices on the root bus", func() {
-			vmi := getSriovVmi([]string{"sriov"})
+			vmi := getSriovVmi([]string{"sriov"}, defaultCloudInitNetworkData())
 			vmi.Annotations = map[string]string{
 				v1.PlacePCIDevicesOnRootComplex: "true",
 			}
-			startVmi(vmi)
-			waitVmi(vmi)
+			vmi = startVmi(vmi)
+			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, "sriov", sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
@@ -759,16 +752,16 @@ var _ = Describe("[Serial]SRIOV", func() {
 		It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", func() {
 			// In addition to verifying that we can start a VMI with CPU pinning
 			// this also tests if we've correctly calculated the overhead for VFIO devices.
-			vmi := getSriovVmi([]string{"sriov"})
+			vmi := getSriovVmi([]string{"sriov"}, defaultCloudInitNetworkData())
 			vmi.Spec.Domain.CPU = &v1.CPU{
 				Cores:                 2,
 				DedicatedCPUPlacement: true,
 			}
-			startVmi(vmi)
-			waitVmi(vmi)
+			vmi = startVmi(vmi)
+			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, "sriov", sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
@@ -781,11 +774,11 @@ var _ = Describe("[Serial]SRIOV", func() {
 		It("[test_id:3985]should create a virtual machine with sriov interface with custom MAC address", func() {
 			const mac = "de:ad:00:00:be:ef"
 			const sriovNetworkName = "sriov"
-			vmi := getSriovVmi([]string{sriovNetworkName})
+			vmi := getSriovVmi([]string{sriovNetworkName}, defaultCloudInitNetworkData())
 			vmi.Spec.Domain.Devices.Interfaces[1].MacAddress = mac
 
-			startVmi(vmi)
-			waitVmi(vmi)
+			vmi = startVmi(vmi)
+			vmi = waitVmi(vmi)
 
 			var interfaceName string
 			Eventually(func() error {
@@ -804,12 +797,12 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 		It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
 			sriovNetworks := []string{"sriov", "sriov2"}
-			vmi := getSriovVmi(sriovNetworks)
-			startVmi(vmi)
-			waitVmi(vmi)
+			vmi := getSriovVmi(sriovNetworks, defaultCloudInitNetworkData())
+			vmi = startVmi(vmi)
+			vmi = waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variables are defined in pod")
-			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
 			for _, name := range sriovNetworks {
 				Expect(validatePodKubevirtResourceName(virtClient, vmiPod, name, sriovResourceName)).To(Succeed())
 			}
@@ -829,11 +822,6 @@ var _ = Describe("[Serial]SRIOV", func() {
 		// interfaces. It can be achieved either by configuring the external switch
 		// properly, or via in-PF switching for VFs (works for some NIC models)
 		createSriovVMs := func(cidrA, cidrB string) (*v1.VirtualMachineInstance, *v1.VirtualMachineInstance) {
-			const networkName = "sriov-link-enabled"
-			// start peer machines with sriov interfaces from the same resource pool
-			vmi1 := getSriovVmi([]string{networkName})
-			vmi2 := getSriovVmi([]string{networkName})
-
 			// Explicitly choose different random mac addresses instead of relying on kubemacpool to do it:
 			// 1) we don't at the moment deploy kubemacpool in kind providers
 			// 2) even if we would do, it's probably a good idea to have the suite not depend on this fact
@@ -846,29 +834,30 @@ var _ = Describe("[Serial]SRIOV", func() {
 			mac2, err := tests.GenerateRandomMac()
 			Expect(err).ToNot(HaveOccurred())
 
+			// start peer machines with sriov interfaces from the same resource pool
+			// manually configure IP/link on sriov interfaces because there is
+			// no DHCP server to serve the address to the guest
+			const networkName = "sriov-link-enabled"
+			vmi1 := getSriovVmi([]string{networkName}, cloudInitNetworkDataWithStaticIPsByMac(networkName, mac1.String(), cidrA))
+			vmi2 := getSriovVmi([]string{networkName}, cloudInitNetworkDataWithStaticIPsByMac(networkName, mac2.String(), cidrB))
+
 			vmi1.Spec.Domain.Devices.Interfaces[1].MacAddress = mac1.String()
 			vmi2.Spec.Domain.Devices.Interfaces[1].MacAddress = mac2.String()
 
-			startVmi(vmi1)
-			startVmi(vmi2)
-			waitVmi(vmi1)
-			waitVmi(vmi2)
+			vmi1 = startVmi(vmi1)
+			vmi2 = startVmi(vmi2)
+			vmi1 = waitVmi(vmi1)
+			vmi2 = waitVmi(vmi2)
 
 			vmi1, err = virtClient.VirtualMachineInstance(vmi1.Namespace).Get(vmi1.Name, &metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			vmi2, err = virtClient.VirtualMachineInstance(vmi2.Namespace).Get(vmi2.Name, &metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			// manually configure IP/link on sriov interfaces because there is
-			// no DHCP server to serve the address to the guest
-			Expect(configureInterfaceStaticIPByMAC(vmi1, mac1.String(), cidrA)).To(Succeed())
-			Expect(configureInterfaceStaticIPByMAC(vmi2, mac2.String(), cidrB)).To(Succeed())
-
 			return vmi1, vmi2
 		}
 
 		It("[test_id:3956]should connect to another machine with sriov interface over IPv4", func() {
-			Skip("Skip until https://github.com/kubevirt/kubevirt/issues/3774 fixed")
 			cidrA := "192.168.1.1/24"
 			cidrB := "192.168.1.2/24"
 			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
@@ -877,7 +866,6 @@ var _ = Describe("[Serial]SRIOV", func() {
 		})
 
 		It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
-			Skip("Skip until https://github.com/kubevirt/kubevirt/issues/3747 is fixed")
 			cidrA := "fc00::1/64"
 			cidrB := "fc00::2/64"
 			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
@@ -922,11 +910,9 @@ var _ = Describe("[Serial]Macvtap", func() {
 	})
 
 	newCirrosVMIWithMacvtapNetwork := func(macvtapNetworkName string) *v1.VirtualMachineInstance {
-		macvtapMultusNetwork := libvmi.MultusNetwork(macvtapNetworkName)
-
 		return libvmi.NewCirros(
 			libvmi.WithInterface(*v1.DefaultMacvtapNetworkInterface(macvtapNetworkName)),
-			libvmi.WithNetwork(&macvtapMultusNetwork))
+			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName)))
 	}
 
 	createCirrosVMIWithMacvtapDefinedMAC := func(virtClient kubecli.KubevirtClient, networkName string, mac string) *v1.VirtualMachineInstance {
@@ -1256,6 +1242,12 @@ func validatePodKubevirtResourceName(virtClient kubecli.KubevirtClient, vmiPod *
 	return nil
 }
 
+func defaultCloudInitNetworkData() string {
+	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should successfully create default cloud init network data for SRIOV")
+	return networkData
+}
+
 func cloudInitNetworkDataWithStaticIPsByMac(nicName, macAddress, ipv4Address string) string {
 	networkData, err := libnet.NewNetworkData(
 		libnet.WithEthernet(nicName,
@@ -1265,7 +1257,7 @@ func cloudInitNetworkDataWithStaticIPsByMac(nicName, macAddress, ipv4Address str
 			libnet.WithMatchingMAC(macAddress),
 		),
 	)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success creating static IPs by mac address cloud init network data")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should successfully create static IPs by mac address cloud init network data")
 	return networkData
 }
 
@@ -1278,6 +1270,6 @@ func cloudInitNetworkDataWithStaticIPsByDevice(deviceName, ipv4Address string) s
 			libnet.WithNameserverFromCluster(),
 		),
 	)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should success creating static IPs by device name cloud init network data")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "should successfully create static IPs by device name cloud init network data")
 	return networkData
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is an issue with sriov test lane related to NetworkManager overrid ing the ip
configuration set by the tests using 'virtcl console'.
To fix that this PR will configure the ip address at cloud-init network data using
the "match" feature with the "macaddres attribute [1].

[1] https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html#examples

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4432

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
