### PR TITLE
Catch goroutine panic with GinkgoRecover in tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2809,6 +2809,7 @@ func WaitUntilVMIReadyAsync(vmi *v1.VirtualMachineInstance, expecterFactory cons
 	)
 	wg.Add(1)
 	go func() {
+		defer GinkgoRecover()
 		defer wg.Done()
 		readyVMI = WaitUntilVMIReady(vmi, expecterFactory)
 	}()


### PR DESCRIPTION
Add a missing GinkgoRecover to a test helper, fixing this new error in the test suite:

```
10:12:15: •panic: 
10:12:15: Your test failed.
10:12:15: Ginkgo panics to prevent subsequent assertions from running.
10:12:15: Normally Ginkgo rescues this panic so you shouldn't see it.
10:12:15: 
10:12:15: But, if you make an assertion in a goroutine, Ginkgo can't capture the panic.
10:12:15: To circumvent this, you should call
10:12:15: 
10:12:15: 	defer GinkgoRecover()
10:12:15: 
10:12:15: at the top of the goroutine that caused this panic.
10:12:15: 
10:12:15: 
10:12:15: goroutine 55926 [running]:
10:12:15: kubevirt.io/kubevirt/vendor/github.com/onsi/ginkgo.Fail(0xc002bde240, 0x108, 0xc002fc1f78, 0x1, 0x1)
10:12:15: 	vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:267 +0xc8
10:12:15: kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).match.func1(0x2122e16, 0x9)
10:12:15: 	vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:134 +0x385
10:12:15: kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).match(0xc001ddde40, 0x26f9f20, 0xc0036a1ac0, 0x40e801, 0xc002a8d720, 0x1, 0x1, 0xc002a8d720)
10:12:15: 	vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:156 +0x3fb
10:12:15: kubevirt.io/kubevirt/vendor/github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).Should(0xc001ddde40, 0x26f9f20, 0xc0036a1ac0, 0xc002a8d720, 0x1, 0x1, 0x26cd740)
10:12:15: 	vendor/github.com/onsi/gomega/internal/asyncassertion/async_assertion.go:51 +0x81
10:12:15: kubevirt.io/kubevirt/tests.waitForVMIPhase(0xc002a8d680, 0x1, 0x1, 0x26cbac0, 0xc002e04480, 0x168, 0xc004120800, 0xc003c0c000, 0x430900)
10:12:15: 	tests/utils.go:2757 +0x68f
10:12:15: kubevirt.io/kubevirt/tests.waitForVMIStart(...)
10:12:15: 	tests/utils.go:2712
10:12:15: kubevirt.io/kubevirt/tests.WaitForSuccessfulVMIStart(...)
10:12:15: 	tests/utils.go:2802
10:12:15: kubevirt.io/kubevirt/tests.WaitUntilVMIReady(0xc002e04480, 0x22bddf8, 0x7f62e03e14b8)
10:12:15: 	tests/utils.go:2824 +0xa9
10:12:15: kubevirt.io/kubevirt/tests.WaitUntilVMIReadyAsync.func1(0xc0041a5c80, 0xc002e04480, 0x22bddf8, 0xc0031743b8)
10:12:15: 	tests/utils.go:2813 +0x69
10:12:15: created by kubevirt.io/kubevirt/tests.WaitUntilVMIReadyAsync
10:12:15: 	tests/utils.go:2811 +0xac
```


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
