### PR TITLE
Fix failing CI test - loosen requirements in a too demanding test

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -483,6 +483,7 @@ func (vca *VirtControllerApp) initSnapshotController() {
 		PVCInformer:               vca.persistentVolumeClaimInformer,
 		CRDInformer:               vca.crdInformer,
 		PodInformer:               vca.allPodInformer,
+		DVInformer:                vca.dataVolumeInformer,
 		Recorder:                  recorder,
 		ResyncPeriod:              vca.snapshotControllerResyncPeriod,
 	}

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -87,6 +87,7 @@ var _ = Describe("Application", func() {
 		storageClassInformer, _ := testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 		crdInformer, _ := testutils.NewFakeInformerFor(&extv1beta1.CustomResourceDefinition{})
 		vmRestoreInformer, _ := testutils.NewFakeInformerFor(&snapshotv1.VirtualMachineRestore{})
+		dvInformer, _ := testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 
 		var qemuGid int64 = 107
 
@@ -122,6 +123,7 @@ var _ = Describe("Application", func() {
 			StorageClassInformer:      storageClassInformer,
 			PVCInformer:               pvcInformer,
 			CRDInformer:               crdInformer,
+			DVInformer:                dvInformer,
 			Recorder:                  recorder,
 			ResyncPeriod:              60 * time.Second,
 		}

--- a/pkg/virt-controller/watch/snapshot/BUILD.bazel
+++ b/pkg/virt-controller/watch/snapshot/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The failing test suggest a better way to get DV's StorageClass. This PR makes the VolumeSnapshotStatus to be calculated without waiting for the underlying PVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
