### PR TITLE
tests: fix LoginToCirros panic

### DIFF
--- a/tests/login.go
+++ b/tests/login.go
@@ -19,7 +19,9 @@ import (
 // LoginToCirros call LoggedInFedoraExpecter but does not return the expecter
 func LoginToCirros(vmi *v1.VirtualMachineInstance) error {
 	expecter, err := LoggedInCirrosExpecter(vmi)
-	defer expecter.Close()
+	if err == nil {
+		expecter.Close()
+	}
 	return err
 }
 


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <federico.gimenez@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

`LoggedInCirrosExpecter` can return a nil expecter in case of error, with these changes we call `Close` on the returned expecter if it is not nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4456

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
