### PR TITLE
tests, Fix SRIOV UpdateCDIConfigMap panic

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4330,7 +4330,10 @@ func resetToDefaultConfig() {
 	}
 
 	UpdateKubeVirtConfigValueAndWait(KubeVirtDefaultConfig)
-	UpdateCDIConfigMap(CDIInsecureRegistryConfig)
+
+	if HasCDI() {
+		UpdateCDIConfigMap(CDIInsecureRegistryConfig)
+	}
 }
 
 type compare func(string, string) bool


### PR DESCRIPTION
On SRIOV lane, we dont have CDI, nor CDI insecure registries
so we dont need to restore config of CDI insecure registries,
else a panic of a nil ptr deref will occur.

Fixes: https://github.com/kubevirt/kubevirt/issues/4468

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
