### PR TITLE
tests, Fix potential deref of nil ptr at resetToDefaultConfig

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4335,10 +4335,7 @@ func resetToDefaultConfig() {
 	}
 
 	UpdateKubeVirtConfigValueAndWait(KubeVirtDefaultConfig)
-
-	if HasCDI() {
-		UpdateCDIConfigMap(CDIInsecureRegistryConfig)
-	}
+	UpdateCDIConfigMap(CDIInsecureRegistryConfig)
 }
 
 type compare func(string, string) bool

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -805,8 +805,13 @@ func AdjustKubeVirtResource() {
 	PanicOnError(err)
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
 	CDIInsecureRegistryConfig, err = virtClient.CoreV1().ConfigMaps(flags.ContainerizedDataImporterNamespace).Get(insecureRegistryConfigName, metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
-		PanicOnError(err)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// force it to nil, independent of what the client returned
+			CDIInsecureRegistryConfig = nil
+		} else {
+			PanicOnError(err)
+		}
 	}
 }
 


### PR DESCRIPTION
In case CDI insecure registries wasnt found,
the Get command still returns a non nil ptr.
The logic would then panic when it wont find
this config map on UpdateCDIConfigMap.

It also fixes SRIOV lane where no CDI and no
CDI insecure registries exists.

Fixes: https://github.com/kubevirt/kubevirt/issues/4468

See also https://github.com/kubevirt/kubevirt/pull/4470#discussion_r515619817

```release-note
None
```
