### PR TITLE
tests, sriov: Fix the helper that waits for a vmi to start

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -658,8 +658,11 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 		waitVmi := func(vmi *v1.VirtualMachineInstance) {
 			// Need to wait for cloud init to finish and start the agent inside the vmi.
-			tests.WaitAgentConnected(virtClient, vmi)
+			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
 			tests.WaitUntilVMIReady(vmi, tests.LoggedInFedoraExpecter)
+			tests.WaitAgentConnected(virtClient, vmi)
 			return
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A VMI needs first to start and then we need to wait for the Guest Agent
condition to appear (and not the other way around).

In addition, the VMI object needs to be populated with the content from
the api-server and not with the data created.

This should reduce flakiness seen while running SRIOV tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
