### PR TITLE
tests, sriov: Do not mount /sys/devices/ for SRIOV devices

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -357,7 +357,7 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 		},
 	})
 
-	if util.IsSRIOVVmi(vmi) || util.IsGPUVMI(vmi) {
+	if util.IsGPUVMI(vmi) {
 		// libvirt needs this volume to access PCI device config;
 		// note that the volume should not be read-only because libvirt
 		// opens the config for writing

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1631,7 +1631,7 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
 				Expect(*pod.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
 			})
-			It("should mount pci related host directories", func() {
+			It("should not mount pci related host directories", func() {
 				sriovInterface := v1.InterfaceSRIOV{}
 				domain := v1.DomainSpec{}
 				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
@@ -1646,9 +1646,16 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
-				// Skip first four mounts that are generic for all launcher pods
-				Expect(pod.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/sys/devices/"))
-				Expect(pod.Spec.Volumes[1].HostPath.Path).To(Equal("/sys/devices/"))
+
+				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
+					Expect(volumeMount.MountPath).ToNot(Equal("/sys/devices/"))
+				}
+
+				for _, volume := range pod.Spec.Volumes {
+					if volume.HostPath != nil {
+						Expect(volume.HostPath.Path).ToNot(Equal("/sys/devices/"))
+					}
+				}
 			})
 			It("should add 1G of memory overhead", func() {
 				sriovInterface := v1.InterfaceSRIOV{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Libvirt required a Read/Write access to the hostdev devices representation,
on sysfs in older versions (< 5.6).
Since libvirt 5.6.0-10 [1] this is no longer the case and Read-Only access is sufficient.
Therefore, there is no longer a need for kubevirt to explicitly mount
/sys/devices with RW access on the virt-launcher.

This change removes the sysfs /sys/devices mount for VMI/s which contain SRIOV interfaces.

It does not change the logic for VMI/s which contain GPU devices,
as those need to be examined and tested separately to see that no degradation exists.
A following change should handle GPU/s.

1.https://bugzilla.redhat.com/show_bug.cgi?id=1758330

Signed-off-by: alonSadan <asadan@redhat.com>

colaborated with @ormergi  on this one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
