### PR TITLE
tests, gpu: Do not mount /sys/devices/ for SRIOV devices

### DIFF
--- a/cmd/virt-handler/virt_launcher.cil
+++ b/cmd/virt-handler/virt_launcher.cil
@@ -53,8 +53,4 @@
     (allow process nfs_t (dir (mounton)))
     (allow process proc_t (dir (mounton)))
     (allow process proc_t (filesystem (mount unmount)))
-    ;
-    ; Allowing libvirtd to write to /sys files.
-    ; This permission is necessary when using SR-IOV, but is not needed for anything else.
-    (allow process sysfs_t (file (write)))
 )

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -363,23 +363,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		},
 	})
 
-	if util.IsVFIOVMI(vmi) && !util.IsSRIOVVmi(vmi) {
-		// libvirt needs this volume to access PCI device config;
-		// note that the volume should not be read-only because libvirt
-		// opens the config for writing
-		volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
-			Name:      "pci-devices",
-			MountPath: "/sys/devices/",
-		})
-		volumes = append(volumes, k8sv1.Volume{
-			Name: "pci-devices",
-			VolumeSource: k8sv1.VolumeSource{
-				HostPath: &k8sv1.HostPathVolumeSource{
-					Path: "/sys/devices/",
-				},
-			},
-		})
-	}
 	serviceAccountName := ""
 
 	for _, volume := range vmi.Spec.Volumes {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2187,7 +2187,7 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
 				Expect(*pod.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
 			})
-			It("should mount pci related host directories", func() {
+			It("should not mount pci related host directories and should have gpu resource", func() {
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -2211,9 +2211,16 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
-				// Skip first four mounts that are generic for all launcher pods
-				Expect(pod.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/sys/devices/"))
-				Expect(pod.Spec.Volumes[1].HostPath.Path).To(Equal("/sys/devices/"))
+
+				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
+					Expect(volumeMount.MountPath).ToNot(Equal("/sys/devices/"))
+				}
+
+				for _, volume := range pod.Spec.Volumes {
+					if volume.HostPath != nil {
+						Expect(volume.HostPath.Path).ToNot(Equal("/sys/devices/"))
+					}
+				}
 
 				resources := pod.Spec.Containers[0].Resources
 				val, ok := resources.Requests["vendor.com/gpu_name"]
@@ -2253,7 +2260,7 @@ var _ = Describe("Template", func() {
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
 				Expect(*pod.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
 			})
-			It("should mount pci related host directories", func() {
+			It("should not mount pci related host directories", func() {
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -2277,9 +2284,16 @@ var _ = Describe("Template", func() {
 				pod, err := svc.RenderLaunchManifest(&vmi)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
-				// Skip first four mounts that are generic for all launcher pods
-				Expect(pod.Spec.Containers[0].VolumeMounts[4].MountPath).To(Equal("/sys/devices/"))
-				Expect(pod.Spec.Volumes[1].HostPath.Path).To(Equal("/sys/devices/"))
+
+				for _, volumeMount := range pod.Spec.Containers[0].VolumeMounts {
+					Expect(volumeMount.MountPath).ToNot(Equal("/sys/devices/"))
+				}
+
+				for _, volume := range pod.Spec.Volumes {
+					if volume.HostPath != nil {
+						Expect(volume.HostPath.Path).ToNot(Equal("/sys/devices/"))
+					}
+				}
 
 				resources := pod.Spec.Containers[0].Resources
 				val, ok := resources.Requests["vendor.com/dev_name"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

    
Libvirt required a Read/Write access to the hostdev devices representation,
on sysfs in older versions (< 5.6).
Since libvirt 5.6.0-10 [1] this is no longer the case and Read-Only access is sufficient.
Therefore, there is no longer a need for kubevirt to explicitly mount
/sys/devices with RW access on the virt-launcher.
    
This change removes the sysfs /sys/devices mount for VMI/s which contain GPU device.
Also the Read/Write privileges given to  virtLauncher in the SELinux policy (virt_launcher.cil)
were removed as it no longer needed.
    
    Signed-off-by: alonSadan <asadan@redhat.com>


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
