### PR TITLE
Disable Virtio-FS Metadata Cache

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1013,7 +1013,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 				Path:  "/usr/libexec/virtiofsd",
 				Xattr: "on",
 				Cache: &FilesystemBinaryCache{
-					Mode: "always",
+					Mode: "none",
 				},
 				Lock: &FilesystemBinaryLock{
 					Posix: "on",


### PR DESCRIPTION
**What this PR does / why we need it**:
With Virtio-FS metadata cache set to "always" or undefined (should default to auto) the memory usage of virtiofsd will grow larger than memory allocated to the Pod. The memory overhead allocated to the Pod over the guest VM is pretty small, and virtiofsd can easily take up 200Mb itself with a directory structure that has a lot of files in it. This leads to the Pod getting OOM killed as it hits the memory limit.

It seems as even when leaving the cache mode undefined, which should default to auto, the memory usage grows and never decreases. `none` is the only setting where Pods are not at risk of getting killed.

**Special notes for your reviewer**:
Even if we add a larger memory limit when filesystems are in used, it will be hard to find a good default. Making the cache mode configurable from the VMI would be the best, however I see that as a second step after setting the default to a value that will not risk the Pod to OOM.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable Virtio-FS metadata cache to prevent OOM conditions on the host.
```
