### PR TITLE
Do not create Host Disks for Virtio-FS PVCs

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -875,12 +875,6 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 	isBlockDVMap := make(map[string]bool)
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
-		for i := range vmi.Spec.Domain.Devices.Filesystems {
-			if vmi.Spec.Domain.Devices.Filesystems[i].Name == volume.Name {
-				volume.VolumeSource.PersistentVolumeClaim = nil
-				break
-			}
-		}
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
 			isBlockPVC, err := isBlockDeviceVolume(volume.Name)
 			if err != nil {
@@ -1241,12 +1235,6 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 	isBlockDVMap := make(map[string]bool)
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
-		for i := range vmi.Spec.Domain.Devices.Filesystems {
-			if vmi.Spec.Domain.Devices.Filesystems[i].Name == volume.Name {
-				volume.VolumeSource.PersistentVolumeClaim = nil
-				break
-			}
-		}
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
 			isBlockPVC := false
 			if _, ok := hotplugVolumes[volume.Name]; ok {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -875,6 +875,12 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 	isBlockDVMap := make(map[string]bool)
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
+		for i := range vmi.Spec.Domain.Devices.Filesystems {
+			if vmi.Spec.Domain.Devices.Filesystems[i].Name == volume.Name {
+				volume.VolumeSource.PersistentVolumeClaim = nil
+				break
+			}
+		}
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
 			isBlockPVC, err := isBlockDeviceVolume(volume.Name)
 			if err != nil {
@@ -1235,6 +1241,12 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 	isBlockDVMap := make(map[string]bool)
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
+		for i := range vmi.Spec.Domain.Devices.Filesystems {
+			if vmi.Spec.Domain.Devices.Filesystems[i].Name == volume.Name {
+				volume.VolumeSource.PersistentVolumeClaim = nil
+				break
+			}
+		}
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
 			isBlockPVC := false
 			if _, ok := hotplugVolumes[volume.Name]; ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
`host-disk.go` assumes that all PVCs mounted into the Pod will be used to mount a Block Volume to the VM. Therefor it converts the PVCs to a `HostDisk` and later on creates a `disk.img` in there. This fix checks to see if the PVC is used in a `Filesystem`. If it is, it does not convert the PVC to a `HostDisk` and no disk image is created.

Fixes #4440

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where a disk.img file was created on filesystems mounted via Virtio-FS
```
