### PR TITLE
tests, multus, sriov: Fix checking for the same network twice

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -808,13 +808,14 @@ var _ = Describe("[Serial]SRIOV", func() {
 		})
 
 		It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
-			vmi := getSriovVmi([]string{"sriov", "sriov2"})
+			sriovNetworks := []string{"sriov", "sriov2"}
+			vmi := getSriovVmi(sriovNetworks)
 			startVmi(vmi)
 			waitVmi(vmi)
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variables are defined in pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-			for _, name := range []string{"sriov", "sriov"} {
+			for _, name := range sriovNetworks {
 				out, err := tests.ExecuteCommandOnPod(
 					virtClient,
 					vmiPod,

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -749,6 +749,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			checkInterfacesInGuest(vmi, []string{"eth0", "eth1"})
 
 			domSpec, err := tests.GetRunningVMIDomainSpec(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			rootPortController := []api.Controller{}
 			for _, c := range domSpec.Devices.Controllers {
 				if c.Model == "pcie-root-port" {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -701,16 +701,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-			out, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				"compute",
-				[]string{"sh", "-c", "echo $KUBEVIRT_RESOURCE_NAME_sriov"},
-			)
-			Expect(err).ToNot(HaveOccurred())
-
-			expectedSriovResourceName := fmt.Sprintf("%s\n", sriovResourceName)
-			Expect(out).To(Equal(expectedSriovResourceName))
+			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, "sriov", sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
 
@@ -732,16 +723,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-			out, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				"compute",
-				[]string{"sh", "-c", "echo $KUBEVIRT_RESOURCE_NAME_sriov"},
-			)
-			Expect(err).ToNot(HaveOccurred())
-
-			expectedSriovResourceName := fmt.Sprintf("%s\n", sriovResourceName)
-			Expect(out).To(Equal(expectedSriovResourceName))
+			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, "sriov", sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
 
@@ -772,16 +754,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variable is defined in pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
-			out, err := tests.ExecuteCommandOnPod(
-				virtClient,
-				vmiPod,
-				"compute",
-				[]string{"sh", "-c", "echo $KUBEVIRT_RESOURCE_NAME_sriov"},
-			)
-			Expect(err).ToNot(HaveOccurred())
-
-			expectedSriovResourceName := fmt.Sprintf("%s\n", sriovResourceName)
-			Expect(out).To(Equal(expectedSriovResourceName))
+			Expect(validatePodKubevirtResourceName(virtClient, vmiPod, "sriov", sriovResourceName)).To(Succeed())
 
 			checkDefaultInterfaceInPod(vmi)
 
@@ -817,16 +790,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			By("checking KUBEVIRT_RESOURCE_NAME_<networkName> variables are defined in pod")
 			vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
 			for _, name := range sriovNetworks {
-				out, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					vmiPod,
-					"compute",
-					[]string{"sh", "-c", fmt.Sprintf("echo $KUBEVIRT_RESOURCE_NAME_%s", name)},
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedSriovResourceName := fmt.Sprintf("%s\n", sriovResourceName)
-				Expect(out).To(Equal(expectedSriovResourceName))
+				Expect(validatePodKubevirtResourceName(virtClient, vmiPod, name, sriovResourceName)).To(Succeed())
 			}
 
 			checkDefaultInterfaceInPod(vmi)
@@ -1234,4 +1198,23 @@ func checkSriovEnabled(virtClient kubecli.KubevirtClient, sriovResourceName stri
 		}
 	}
 	return false
+}
+
+func validatePodKubevirtResourceName(virtClient kubecli.KubevirtClient, vmiPod *k8sv1.Pod, networkName, sriovResourceName string) error {
+	out, err := tests.ExecuteCommandOnPod(
+		virtClient,
+		vmiPod,
+		"compute",
+		[]string{"sh", "-c", fmt.Sprintf("echo $KUBEVIRT_RESOURCE_NAME_%s", networkName)},
+	)
+	if err != nil {
+		return err
+	}
+
+	out = strings.TrimSuffix(out, "\n")
+	if out != sriovResourceName {
+		return fmt.Errorf("env settings %s didnt match %s", out, sriovResourceName)
+	}
+
+	return nil
 }


### PR DESCRIPTION
The test checks if the virt-launcher pod got the SRIOV interfaces, via the env vars that
the CNI propagates. It checked the same name twice, instead of
checking both.

* Add an array declaration, in order to reuse the info.
* Add `validatePodKubevirtResourceName` wrapper to remove code duplication.
* Add missing error check

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
