### PR TITLE
 Use "json" annotation instead of "yaml"

### DIFF
--- a/tests/libnet/cloudinit.go
+++ b/tests/libnet/cloudinit.go
@@ -24,38 +24,38 @@ import (
 )
 
 type CloudInitNetworkData struct {
-	Version   int                           `yaml:"version"`
-	Ethernets map[string]CloudInitInterface `yaml:"ethernets,omitempty"`
+	Version   int                           `json:"version"`
+	Ethernets map[string]CloudInitInterface `json:"ethernets,omitempty"`
 }
 
 type CloudInitInterface struct {
-	AcceptRA       *bool                `yaml:"accept-ra,omitempty"`
-	Addresses      []string             `yaml:"addresses,omitempty"`
-	DHCP4          *bool                `yaml:"dhcp4,omitempty"`
-	DHCP6          *bool                `yaml:"dhcp6,omitempty"`
-	DHCPIdentifier string               `yaml:"dhcp-identifier,omitempty"` // "duid" or  "mac"
-	Gateway4       string               `yaml:"gateway4,omitempty"`
-	Gateway6       string               `yaml:"gateway6,omitempty"`
-	Nameservers    CloudInitNameservers `yaml:"nameservers,omitempty"`
-	MACAddress     string               `yaml:"macaddress,omitempty"`
-	MTU            int                  `yaml:"mtu,omitempty"`
-	Routes         []CloudInitRoute     `yaml:"routes,omitempty"`
+	AcceptRA       *bool                `json:"accept-ra,omitempty"`
+	Addresses      []string             `json:"addresses,omitempty"`
+	DHCP4          *bool                `json:"dhcp4,omitempty"`
+	DHCP6          *bool                `json:"dhcp6,omitempty"`
+	DHCPIdentifier string               `json:"dhcp-identifier,omitempty"` // "duid" or  "mac"
+	Gateway4       string               `json:"gateway4,omitempty"`
+	Gateway6       string               `json:"gateway6,omitempty"`
+	Nameservers    CloudInitNameservers `json:"nameservers,omitempty"`
+	MACAddress     string               `json:"macaddress,omitempty"`
+	MTU            int                  `json:"mtu,omitempty"`
+	Routes         []CloudInitRoute     `json:"routes,omitempty"`
 }
 
 type CloudInitNameservers struct {
-	Search    []string `yaml:"search,omitempty,flow"`
-	Addresses []string `yaml:"addresses,omitempty,flow"`
+	Search    []string `json:"search,omitempty,flow"`
+	Addresses []string `json:"addresses,omitempty,flow"`
 }
 
 type CloudInitRoute struct {
-	From   string `yaml:"from,omitempty"`
-	OnLink *bool  `yaml:"on-link,omitempty"`
-	Scope  string `yaml:"scope,omitempty"`
-	Table  *int   `yaml:"table,omitempty"`
-	To     string `yaml:"to,omitempty"`
-	Type   string `yaml:"type,omitempty"`
-	Via    string `yaml:"via,omitempty"`
-	Metric *int   `yaml:"metric,omitempty"`
+	From   string `json:"from,omitempty"`
+	OnLink *bool  `json:"on-link,omitempty"`
+	Scope  string `json:"scope,omitempty"`
+	Table  *int   `json:"table,omitempty"`
+	To     string `json:"to,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Via    string `json:"via,omitempty"`
+	Metric *int   `json:"metric,omitempty"`
 }
 
 const (

--- a/tests/libnet/cloudinit.go
+++ b/tests/libnet/cloudinit.go
@@ -59,8 +59,8 @@ type CloudInitRoute struct {
 }
 
 const (
-	ipv6MasqueradeAddress = "fd10:0:2::2/120"
-	ipv6MasqueradeGateway = "fd10:0:2::1"
+	DefaultIPv6Address = "fd10:0:2::2/120"
+	DefaultIPv6Gateway = "fd10:0:2::1"
 )
 
 // CreateDefaultCloudInitNetworkData generates a default configuration
@@ -79,9 +79,9 @@ func CreateDefaultCloudInitNetworkData() (string, error) {
 			Version: 2,
 			Ethernets: map[string]CloudInitInterface{
 				"eth0": {
-					Addresses: []string{ipv6MasqueradeAddress},
+					Addresses: []string{DefaultIPv6Address},
 					DHCP4:     &enabled,
-					Gateway6:  ipv6MasqueradeGateway,
+					Gateway6:  DefaultIPv6Gateway,
 					Nameservers: CloudInitNameservers{
 						Addresses: []string{dnsServerIP},
 						Search:    SearchDomains(),

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -27,7 +27,6 @@ import (
 
 // Default VMI values
 const (
-	DefaultResourceMemory        = "8192Ki"
 	DefaultTestGracePeriod int64 = 0
 	DefaultVmiName               = "testvmi"
 )
@@ -39,13 +38,13 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	echo "fedora" |passwd fedora --stdin
 	echo `
 
-	fedoraOptions := append(
-		defaultOptions(),
+	fedoraOptions := []Option{
+		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory("512M"),
 		WithRng(),
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskFedora)),
 		WithCloudInitNoCloudUserData(configurePassword, false),
-	)
+	}
 	opts = append(fedoraOptions, opts...)
 	return New(RandName(DefaultVmiName), opts...)
 }
@@ -60,14 +59,4 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	}
 	cirrosOpts = append(cirrosOpts, opts...)
 	return New(RandName(DefaultVmiName), cirrosOpts...)
-}
-
-// defaultOptions returns a list of "default" options.
-func defaultOptions() []Option {
-	return []Option{
-		WithInterface(InterfaceDeviceWithMasqueradeBinding()),
-		WithNetwork(kvirtv1.DefaultPodNetwork()),
-		WithTerminationGracePeriod(DefaultTestGracePeriod),
-		WithResourceMemory(DefaultResourceMemory),
-	}
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2159,6 +2159,8 @@ func NewRandomFedoraVMIWitGuestAgent() *v1.VirtualMachineInstance {
 	Expect(err).NotTo(HaveOccurred())
 
 	return libvmi.NewFedora(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithCloudInitNoCloudUserData(GetGuestAgentUserData(), false),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -817,8 +817,11 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			BeforeEach(func() {
 				var err error
 
-				By("Create VMI")
-				vmi = libvmi.NewFedora()
+				By("Create masquerade VMI")
+				vmi = libvmi.NewFedora(
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
 
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The networkData from cloud init is being rendered wrongly [1] since the actual yaml
parser that we use sigs.k8s.io/yaml don't understand the "yaml" annotation [2], using
"json" annotation fix the issue.

Added a new test for pod networking + guest agent + bridge binding to verify that cloud-init network data is working fine now.    

[1] :
```yaml
cloudInitNoCloud:
            networkData: |
              Ethernets:
                eth0:
                  AcceptRA: null
                  Addresses:
                  - fd10:0:2::2/120
                  DHCP4: true
                  DHCP6: null
                  DHCPIdentifier: ""
                  Gateway4: ""
                  Gateway6: fd10:0:2::1
                  MACAddress: ""
                  MTU: 0
                  Nameservers:
                    Addresses:
                    - 10.96.0.10
                    Search:
                    - default.svc.cluster.local
                    - svc.cluster.local
                    - cluster.local
                  Routes: null
              Version: 2
```

    [2] https://play.golang.org/p/S0Pok-gGeQH

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
