### PR TITLE
net admin: disabling tx checksum offloading on virt-handler

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -114,6 +114,7 @@ type NetworkHandler interface {
 	GetNFTIPString(proto iptables.Protocol) string
 	CreateTapDevice(tapName string, queueNumber uint32, launcherPID int) error
 	BindTapDeviceToBridge(tapName string, bridgeName string) error
+	DisableTXOffloadChecksum(ifaceName string) error
 }
 
 type NetworkUtilsHandler struct{}
@@ -487,6 +488,15 @@ func (h *NetworkUtilsHandler) BindTapDeviceToBridge(tapName string, bridgeName s
 	}
 
 	log.Log.Infof("Successfully configured tap device: %s", tapName)
+	return nil
+}
+
+func (h *NetworkUtilsHandler) DisableTXOffloadChecksum(ifaceName string) error {
+	if err := dhcp.EthtoolTXOff(ifaceName); err != nil {
+		log.Log.Reason(err).Errorf("Failed to set tx offload for interface %s off", ifaceName)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -80,12 +80,6 @@ func SingleClientDHCPServer(
 		options:       options,
 	}
 
-	// turn TX offload checksum because it causes dhcp failures
-	if err := EthtoolTXOff(serverIface); err != nil {
-		log.Log.Reason(err).Errorf("Failed to set tx offload for interface %s off", serverIface)
-		return err
-	}
-
 	l, err := NewUDP4FilterListener(serverIface, ":67")
 	if err != nil {
 		return err

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -334,3 +334,13 @@ func (_m *MockNetworkHandler) BindTapDeviceToBridge(tapName string, bridgeName s
 func (_mr *_MockNetworkHandlerRecorder) BindTapDeviceToBridge(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "BindTapDeviceToBridge", arg0, arg1)
 }
+
+func (_m *MockNetworkHandler) DisableTXOffloadChecksum(ifaceName string) error {
+	ret := _m.ctrl.Call(_m, "DisableTXOffloadChecksum", ifaceName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) DisableTXOffloadChecksum(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DisableTXOffloadChecksum", arg0)
+}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -599,6 +599,11 @@ func (b *BridgePodInterface) createBridge() error {
 		return err
 	}
 
+	if err = Handler.DisableTXOffloadChecksum(b.bridgeInterfaceName); err != nil {
+		log.Log.Reason(err).Error("failed to disable TX offload checksum on bridge interface")
+		return err
+	}
+
 	return nil
 }
 
@@ -896,6 +901,12 @@ func (p *MasqueradePodInterface) createBridge() error {
 			return err
 		}
 	}
+
+	if err = Handler.DisableTXOffloadChecksum(p.bridgeInterfaceName); err != nil {
+		log.Log.Reason(err).Error("failed to disable TX offload checksum on bridge interface")
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -199,6 +199,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid).Return(nil)
 		mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
+		mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
 
 		// For masquerade tests
 		mockNetwork.EXPECT().LinkByName(podInterface).Return(dummy, nil)
@@ -220,6 +221,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return(masqueradeGwStr, masqueradeVmStr, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return(masqueradeIpv6GwStr, masqueradeIpv6VmStr, nil)
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid).Return(nil)
+		mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
 		// Global nat rules using iptables
 		mockNetwork.EXPECT().ConfigureIpv6Forwarding().Return(nil)
 		mockNetwork.EXPECT().GetNFTIPString(iptables.ProtocolIPv4).Return("ip").AnyTimes()
@@ -324,6 +326,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrDel(dummy, &fakeAddr).Return(errors.New("device is busy"))
 			mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid).Return(nil)
 			mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
+			mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
 			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			err := SetupPodNetworkPhase1(vm, pid)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This ioctl requires NET_ADMIN, and is the first DHCP related code
to break once the NET_ADMIN linux capability is removed from the
virt-launcher pod.

Moving into the pod networking setup stage 1 - which happens on
virt-handler - fixes this.

**Special notes for your reviewer**:
There's a test for this behavior (assert TX offload is disabled) in:

https://github.com/kubevirt/kubevirt/blob/0f0d715fb42fdf81bc9eb33ba6031dfc604953fe/tests/vmi_networking_test.go#L905

This change alone does not allow NET_ADMIN to be removed; more info in draft PR #4413 .

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
