### PR TITLE
virt-launcher: drop CAP_NET_RAW from compute container

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -853,7 +853,8 @@ func (t *templateService) RenderLaunchManifest(vmi *v1.VirtualMachineInstance) (
 			RunAsUser:  &userId,
 			Privileged: &privileged,
 			Capabilities: &k8sv1.Capabilities{
-				Add: capabilities,
+				Add:  capabilities,
+				Drop: []k8sv1.Capability{CAP_NET_RAW},
 			},
 		},
 		Command:       command,
@@ -1149,10 +1150,6 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability 
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
 		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true) {
 		res = append(res, CAP_NET_ADMIN)
-		// The DHCP server needs the ability to use raw sockets. This
-		// capability is available by default in some clusters, but not
-		// a given.
-		res = append(res, CAP_NET_RAW)
 	}
 	// add a CAP_SYS_NICE capability to allow setting cpu affinity
 	res = append(res, CAP_SYS_NICE)

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1827,7 +1827,7 @@ var _ = Describe("Template", func() {
 				caps := pod.Spec.Containers[0].SecurityContext.Capabilities
 
 				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_ADMIN)), "Expected compute container to be granted NET_ADMIN capability")
-				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to be granted NET_RAW capability")
+				Expect(caps.Drop).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to drop NET_RAW capability")
 			})
 
 			It("Should require tun device if explicitly requested", func() {
@@ -1851,7 +1851,7 @@ var _ = Describe("Template", func() {
 				caps := pod.Spec.Containers[0].SecurityContext.Capabilities
 
 				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_ADMIN)), "Expected compute container to be granted NET_ADMIN capability")
-				Expect(caps.Add).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to be granted NET_RAW capability")
+				Expect(caps.Drop).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to drop NET_RAW capability")
 			})
 
 			It("Should not require tun device if explicitly rejected", func() {
@@ -1874,7 +1874,7 @@ var _ = Describe("Template", func() {
 				caps := pod.Spec.Containers[0].SecurityContext.Capabilities
 
 				Expect(caps.Add).To(Not(ContainElement(kubev1.Capability(CAP_NET_ADMIN))), "Expected compute container not to be granted NET_ADMIN capability")
-				Expect(caps.Add).To(Not(ContainElement(kubev1.Capability(CAP_NET_RAW))), "Expected compute container not to be granted NET_RAW capability")
+				Expect(caps.Drop).To(ContainElement(kubev1.Capability(CAP_NET_RAW)), "Expected compute container to drop NET_RAW capability")
 			})
 		})
 

--- a/pkg/virt-launcher/virtwrap/network/dhcp/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dhcp.go",
         "ethtool.go",
+        "socket_listener.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network/dhcp",
     visibility = ["//visibility:public"],
@@ -14,6 +15,7 @@ go_library(
         "//vendor/github.com/krolaw/dhcp4:go_default_library",
         "//vendor/github.com/krolaw/dhcp4/conn:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
+        "//vendor/golang.org/x/net/ipv4:go_default_library",
     ],
 )
 

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	dhcp "github.com/krolaw/dhcp4"
-	dhcpConn "github.com/krolaw/dhcp4/conn"
 	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -87,7 +86,7 @@ func SingleClientDHCPServer(
 		return err
 	}
 
-	l, err := dhcpConn.NewUDP4BoundListener(serverIface, ":67")
+	l, err := NewUDP4FilterListener(serverIface, ":67")
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/dhcp/socket_listener.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/socket_listener.go
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+package dhcp
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	dhcpConn "github.com/krolaw/dhcp4/conn"
+
+	"golang.org/x/net/ipv4"
+)
+
+// Creates listener on all interfaces and then filters packets not received by interfaceName
+func NewUDP4FilterListener(interfaceName, laddr string) (c ServeIfConn, e error) {
+	iface, err := net.InterfaceByName(interfaceName)
+	if err != nil {
+		return nil, err
+	}
+	lc := CreateListenConfig()
+	l, err := lc.ListenPacket(context.Background(), "udp4", laddr)
+
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if e != nil {
+			l.Close()
+		}
+	}()
+	p := ipv4.NewPacketConn(l)
+	if err := p.SetControlMessage(ipv4.FlagInterface, true); err != nil {
+		return nil, err
+	}
+	return dhcpConn.NewServeIf(iface.Index, p), nil
+}
+
+func CreateListenConfig() net.ListenConfig {
+	return net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var opErr error
+			err := c.Control(func(fd uintptr) {
+				opErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+			})
+			if err != nil {
+				return err
+			}
+			return opErr
+		},
+	}
+}
+
+type ServeIfConn interface {
+	ReadFrom(b []byte) (n int, addr net.Addr, err error)
+	WriteTo(b []byte, addr net.Addr) (n int, err error)
+	Close() error
+}

--- a/pkg/virt-operator/creation/components/scc.go
+++ b/pkg/virt-operator/creation/components/scc.go
@@ -74,7 +74,7 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyRunAsAny,
 	}
-	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "NET_RAW", "SYS_NICE"}
+	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE"}
 	scc.AllowHostDirVolumePlugin = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}
 

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -228,11 +228,16 @@ var _ = Describe("[Serial]SecurityFeatures", func() {
 				}
 			}
 			caps := *container.SecurityContext.Capabilities
-			Expect(len(caps.Add)).To(Equal(3))
+			Expect(len(caps.Add)).To(Equal(2))
 
 			By("Checking virt-launcher Pod's compute container has precisely the documented extra capabilities")
 			for _, cap := range caps.Add {
 				Expect(tests.IsLauncherCapabilityValid(cap)).To(BeTrue(), "Expected compute container of virt_launcher to be granted only specific capabilities")
+			}
+			By("Checking virt-launcher Pod's compute container has precisely the documented dropped capabilities")
+			Expect(len(caps.Drop)).To(Equal(1))
+			for _, cap := range caps.Drop {
+				Expect(tests.IsLauncherCapabilityDropped(cap)).To(BeTrue(), "Expected compute container of virt_launcher to drop only specific capabilities")
 			}
 		})
 	})

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4926,8 +4926,16 @@ func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 	switch capability {
 	case
 		capNetAdmin,
-		capNetRaw,
 		capSysNice:
+		return true
+	}
+	return false
+}
+
+func IsLauncherCapabilityDropped(capability k8sv1.Capability) bool {
+	switch capability {
+	case
+		capNetRaw:
 		return true
 	}
 	return false

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -473,7 +473,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 					caps := container.SecurityContext.Capabilities
 
 					Expect(caps.Add).To(Not(ContainElement(k8sv1.Capability("NET_ADMIN"))), "Compute container should not have NET_ADMIN capability")
-					Expect(caps.Add).To(Not(ContainElement(k8sv1.Capability("NET_RAW"))), "Compute container should not have NET_RAW capability")
+					Expect(caps.Drop).To(ContainElement(k8sv1.Capability("NET_RAW")), "Compute container should drop NET_RAW capability")
 				}
 			}
 


### PR DESCRIPTION
Binding a socket to the pod bridge using SO_BINDTODEVICE requires
CAP_NET_RAW.
However, since the DHCP request is a broadcast message, the dns server is listening on 0.0.0.0.
It means that without SO_BINDTODEVICE  to the bridge we have 2 problems.
1. We may get dhcp requests on any interface of the pod.
2. Even when we get DHCP request from the vm (on the brdige) the response may be sent from another interface of the pod and never get to the vm.

To workaround the issues we set `ipv4.FlagInterface` on the connection (it means the socket will pass [IP_PKT‐INFO.ipi_ifindex](https://linux.die.net/man/7/ip) with the interface index).
1. We filter the received packets by the bridge interface name.
2. Since the `ipi_ifindex` is set, the bridge ip is used as the local source address for the routing table lookup and for setting up IP source route options.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
According to the documentation, SO_BROADCAST has to be set since the dhcp OFFER is sent over broadcast. However, it succeeds to work without SO_BROADCAST.
SO_BROADCAST doesn't require net_admin or net_raw, so we may add it in the future if we find out that it is needed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CAP_NET_RAW removed from virt-launcher.
```
