### PR TITLE
Fix gosec issue: unhandled errors in delete.go & create.go

### DIFF
--- a/pkg/virt-operator/install-strategy/delete.go
+++ b/pkg/virt-operator/install-strategy/delete.go
@@ -449,7 +449,9 @@ func DeleteAll(kv *v1.KubeVirt,
 		}
 	}
 
-	deleteDummyWebhookValidators(kv, clientset, stores, expectations)
-
+	err = deleteDummyWebhookValidators(kv, clientset, stores, expectations)
+	if err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Removing error from ControllerExpectationsInterface as it is only related to the internal implementation of interface which should be properly used. 

Panics are used to propagate errors in internal implementation. Unit test or reviews should catch this.
**Release note**:

```release-note
NONE
```
