### PR TITLE
sriov tests, Fix flakiness due to race between guest agent and test

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -797,11 +797,14 @@ var _ = Describe("[Serial]SRIOV", func() {
 			startVmi(vmi)
 			waitVmi(vmi)
 
-			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			interfaceName, err := getInterfaceNameByMAC(vmi, mac)
-			Expect(err).NotTo(HaveOccurred())
+			var interfaceName string
+			Eventually(func() error {
+				var err error
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				interfaceName, err = getInterfaceNameByMAC(vmi, mac)
+				return err
+			}, 140*time.Second, 5*time.Second).Should(Succeed())
 
 			By("checking virtual machine instance has an interface with the requested MAC address")
 			Expect(checkMacAddress(vmi, interfaceName, mac)).To(Succeed())


### PR DESCRIPTION
Waiting for guest agent connected event, doesnt mean
the guest agent reported already the information
or that the vmi spec is already updated.
Test should give some time to the status to be updated,
else a race between the test and kubevirt might occur.

Fixes: https://github.com/kubevirt/kubevirt/issues/4490

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
