### PR TITLE
Remove domain label from kubevirt_vmi_memory_unused_bytes

### DIFF
--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -122,7 +122,7 @@ func (metrics *vmiMetrics) updateMemory(vmStats *stats.DomainStats) {
 	}
 
 	if vmStats.Memory.UnusedSet {
-		memoryUnusedLabels := []string{"node", "namespace", "name", "domain"}
+		memoryUnusedLabels := []string{"node", "namespace", "name"}
 		memoryUnusedLabels = append(memoryUnusedLabels, metrics.k8sLabels...)
 		memoryUnusedDesc := prometheus.NewDesc(
 			"kubevirt_vmi_memory_unused_bytes",
@@ -131,7 +131,7 @@ func (metrics *vmiMetrics) updateMemory(vmStats *stats.DomainStats) {
 			nil,
 		)
 
-		memoryUnusedLabelValues := []string{metrics.vmi.Status.NodeName, metrics.vmi.Namespace, metrics.vmi.Name, vmStats.Name}
+		memoryUnusedLabelValues := []string{metrics.vmi.Status.NodeName, metrics.vmi.Namespace, metrics.vmi.Name}
 		memoryUnusedLabelValues = append(memoryUnusedLabelValues, metrics.k8sLabelValues...)
 		mv, err := prometheus.NewConstMetric(
 			memoryUnusedDesc, prometheus.GaugeValue,


### PR DESCRIPTION
Signed-off-by: arthursens <arthursens2005@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Removes the `domain` label from the `kubevirt_vmi_memory_unused_bytes` metric.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
#3927 was created before #3845 got merged, so it was created with the domain label. There was plenty of time to fix the PR before getting #3927 merged, but due to my lack of attention it got merged with the extra label.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`domain` label removed from metric `kubevirt_vmi_memory_unused_bytes`
```
