### PR TITLE
Slow down the certificate and CA rotate intervall in the tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -785,9 +785,9 @@ func AdjustKubeVirtResource() {
 
 	// Rotate very often during the tests to ensure that things are working
 	kv.Spec.CertificateRotationStrategy = v1.KubeVirtCertificateRotateStrategy{SelfSigned: &v1.KubeVirtSelfSignConfiguration{
-		CARotateInterval:   &metav1.Duration{Duration: 10 * time.Minute},
-		CertRotateInterval: &metav1.Duration{Duration: 7 * time.Minute},
-		CAOverlapInterval:  &metav1.Duration{Duration: 4 * time.Minute},
+		CARotateInterval:   &metav1.Duration{Duration: 20 * time.Minute},
+		CertRotateInterval: &metav1.Duration{Duration: 14 * time.Minute},
+		CAOverlapInterval:  &metav1.Duration{Duration: 8 * time.Minute},
 	}}
 
 	// match default kubevirt-config testing resource


### PR DESCRIPTION
The ceritificate disitribution is done via secrets which ware mounted to our components. It looks like it can sometimes take a very long time until they are synchronized. Slow down the rotation slightly, so that the CAs can be kept for a longer time period.

This solves flakyness during normal rotations during the test executions. The certificate-rotation test explicitly suffers from that too, but it will require a dedicated fix.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
