### PR TITLE
infra-test, Add Assertion

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -292,6 +292,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 
 				By("finding all schedulable nodes")
 				schedulableNodesList := tests.GetAllSchedulableNodes(virtClient)
+				Expect(schedulableNodesList.Items).NotTo(BeEmpty())
 				schedulableNodes := map[string]*k8sv1.Node{}
 				for _, node := range schedulableNodesList.Items {
 					schedulableNodes[node.Name] = node.DeepCopy()
@@ -303,21 +304,12 @@ var _ = Describe("[Serial]Infrastructure", func() {
 				// on a master node, we risk in breaking the test cluster.
 				for _, pod := range pods.Items {
 					node, ok := schedulableNodes[pod.Spec.NodeName]
-					if !ok {
-						// Pod is running on a non-schedulable node?
-						continue
-					}
+					Expect(ok).To(BeTrue())
 					if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
 						continue
 					}
 					selectedNodeName = node.Name
 					break
-				}
-
-				// It is possible to run this test on a cluster that simply does not have worker nodes.
-				// Since KubeVirt can't control that, the only correct action is to halt the test.
-				if selectedNodeName == "" {
-					Skip("Could nould determine a node to safely taint")
 				}
 
 				By("setting up a watch for terminated pods")


### PR DESCRIPTION
Sometimes the node list doesnt have the expected workers,
we should correlate when it happens with etcd log,
to see if there was a timeout.
And fix the root cause (for example select without filter
assert the list and then filter).
As the root cause can imply the cluster is not actually ready
or suffer from flakiness.

See https://github.com/kubevirt/kubevirt/issues/4158

Signed-off-by: Or Shoval <oshoval@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
