### PR TITLE
Fix double migration during node drain

### DIFF
--- a/pkg/util/migrations/BUILD.bazel
+++ b/pkg/util/migrations/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -1,6 +1,7 @@
 package migrations
 
 import (
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -26,4 +27,24 @@ func FilterRunningMigrations(migrations []v1.VirtualMachineInstanceMigration) []
 		}
 	}
 	return runningMigrations
+}
+
+// IsMigrating returns true if a given VMI is still migrating and false otherwise.
+func IsMigrating(vmi *v1.VirtualMachineInstance) bool {
+
+	now := v12.Now()
+
+	running := false
+	if vmi.Status.MigrationState != nil {
+		start := vmi.Status.MigrationState.StartTimestamp
+		stop := vmi.Status.MigrationState.EndTimestamp
+		if start != nil && (now.After(start.Time) || now.Equal(start)) {
+			running = true
+		}
+
+		if stop != nil && (now.After(stop.Time) || now.Equal(stop)) {
+			running = false
+		}
+	}
+	return running
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/pod-eviction-admitter.go
@@ -49,7 +49,7 @@ func (admitter *PodEvictionAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1beta1
 			"VMI %s is configured with an eviction strategy but is not live-migratable", vmi.Name))
 	}
 
-	if !vmi.IsMarkedForEviction() {
+	if !vmi.IsMarkedForEviction() && vmi.Status.NodeName == launcher.Spec.NodeName {
 		dryRun := ar.Request.DryRun != nil && *ar.Request.DryRun == true
 		err := admitter.markVMI(ar, vmi, dryRun)
 		if err != nil {

--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/host-disk:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/cluster:go_default_library",
+        "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",


### PR DESCRIPTION
This bug originates from a race condition between the time we finish a
migration and remove the PDB that used to protect the original launcher
and the eviction requests that are issued by the client every 5 seconds.

To fix the issue, a check was added in the eviction webhook that
prevents it from operating on a VMI that was already migrated to another
node.

This PR also includes closing of loose ends on the evacuation
controller to prevent a race between the time we mark the VMI's
migration as completed and the time the evacuation sync loop runs.

https://bugzilla.redhat.com/show_bug.cgi?id=1888790

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>

```release-note
Fix double migration on node evacuation
```
