### PR TITLE
Failure detection and handling when EFI without SB is not available

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1302,6 +1302,10 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 		}
 		c.MemBalloonStatsPeriod = uint(options.MemBalloonStatsPeriod)
 	}
+	if err := api.CheckEFI_OVMFRoms(vmi, c); err != nil {
+		logger.Error("EFI OVMF roms missing")
+		return nil, err
+	}
 
 	if err := api.Convert_v1_VirtualMachine_To_api_Domain(vmi, domain, c); err != nil {
 		logger.Error("Conversion failed.")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2695,19 +2695,26 @@ func waitForSuccessfulDataVolumeImport(namespace, name string, seconds int) {
 	}, time.Duration(seconds)*time.Second, 1*time.Second).Should(Equal(cdiv1.Succeeded), "Timed out waiting for DataVolume to enter Succeeded phase")
 }
 
+// Block until the specified VirtualMachineInstance reached either Failed or Running states
+func WaitForVMIStartOrFailed(obj runtime.Object, seconds int, ignoreWarnings bool) (nodeName string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Running, v1.Failed}, obj, seconds, ignoreWarnings, true)
+}
+
 // Block until the specified VirtualMachineInstance started and return the target node name.
 func waitForVMIStart(ctx context.Context, obj runtime.Object, seconds int, ignoreWarnings bool) (nodeName string) {
-	return waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Running}, obj, seconds, ignoreWarnings)
+	return waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Running}, obj, seconds, ignoreWarnings, false)
 }
 
 // Block until the specified VirtualMachineInstance scheduled and return the target node name.
 func waitForVMIScheduling(obj runtime.Object, seconds int, ignoreWarnings bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Scheduling, v1.Scheduled, v1.Running}, obj, seconds, ignoreWarnings)
+	waitForVMIPhase(ctx, []v1.VirtualMachineInstancePhase{v1.Scheduling, v1.Scheduled, v1.Running}, obj, seconds, ignoreWarnings, false)
 }
 
-func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhase, obj runtime.Object, seconds int, ignoreWarnings bool) (nodeName string) {
+func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhase, obj runtime.Object, seconds int, ignoreWarnings bool, waitForFail bool) (nodeName string) {
 	vmi, ok := obj.(*v1.VirtualMachineInstance)
 	ExpectWithOffset(1, ok).To(BeTrue(), "Object is not of type *v1.VMI")
 
@@ -2740,7 +2747,11 @@ func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhas
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
 		nodeName = vmi.Status.NodeName
-		Expect(vmi.IsFinal()).To(BeFalse(), "VMI %s unexpectedly stopped. State: %s", vmi.Name, vmi.Status.Phase)
+		Expect(vmi.Status.Phase == v1.Succeeded).To(BeFalse(), "VMI %s unexpectedly stopped. State: %s", vmi.Name, vmi.Status.Phase)
+		// May need to wait for Failed state
+		if !waitForFail {
+			Expect(vmi.Status.Phase == v1.Failed).To(BeFalse(), "VMI %s unexpectedly stopped. State: %s", vmi.Name, vmi.Status.Phase)
+		}
 		return vmi.Status.Phase
 	}, time.Duration(seconds)*time.Second, 1*time.Second).Should(BeElementOf(phases), timeoutMsg)
 


### PR DESCRIPTION
Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
In certain downstream KubeVirt build, only EFI with Secure Boot is enabled. In such environment, a virtual machine (instance) with a specification of EFI with Insecure Boot will not boot successfully and the KubeVirt admin will not be aware of this crash without accessing the console. This caused the failure of the test for *EFI insecure boot* in the `vmi_configuration_test`.

The PR implements a fast and graceful way to fail out before trying to boot the virtual machine. It has two key aspects:
1) The virt-launcher's `SyncVMI` code path generates a specific error when it detects, at the earliest occasion during VMI creation, that the VMI specification contains EFI with Insecure Boot and the virt-launcher OS does not contain the needed EFI firmware. 
2) The virt-handler catches the specific error and move the VMI to `Failed` state.

The final state of the `virt-launcher` is `Completed`; the final state of the `vmi` is `Failed`. 

The function test is piggy-backed to the test for *EFI insecure boot* in the `vmi_configuration_test`, to avoid to introduce new cluster-wide configuration. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes

**Special notes for your reviewer**:
In the function test code, to wait for a VMI for the `Failed` state, I had to refactor a heavily used function, `waitForVMIPhase`, which is a change to watch out.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Failure detection and handling for VM with EFI Insecure Boot in KubeVirt environments where EFI Insecure Boot is not supported by design.
```
