### PR TITLE
tests, console: Remove VMIExpecterFactory

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -273,5 +273,3 @@ func ExpectBatchWithValidatedSend(expecter expect.Expecter, batch []expect.Batch
 func RetValue(retcode string) string {
 	return "\n" + retcode + CRLF + ".*" + PromptExpression
 }
-
-type VMIExpecterFactory func(*v1.VirtualMachineInstance) (expect.Expecter, error)


### PR DESCRIPTION
**What this PR does / why we need it**:

VMIExpecterFactory is a leftover from the expector refactoring.
It was replaced by LoginToFactory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
