### PR TITLE
Update BUILD.bazel goimports ignore list

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -37,7 +37,7 @@ goimports(
         "./vendor/*",
         "./.history/*",
         "./.git/*",
-        "./_ci-configs/*",
+        "./_ci-configs*/*",
     ],
     local = ["kubevirt.io"],
     prefix = "kubevirt.io/kubevirt",


### PR DESCRIPTION
As part of allowing to run clusters side by side
we might use more than one `_ci-configs*` folder.
`make functest` would fail in case its not ignored.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
