### PR TITLE
keep original pod ip on a dummy interface

### DIFF
--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -17,6 +17,7 @@ Originally copied from https://github.com/kubernetes/kubernetes/blob/d8695d06b71
 package sysctl
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path"
 	"strconv"
@@ -34,6 +35,8 @@ type Interface interface {
 	GetSysctl(sysctl string) (int, error)
 	// SetSysctl modifies the specified sysctl flag to the new value
 	SetSysctl(sysctl string, newVal int) error
+	// GetIpv4ArpIgnoreAll returns the interface's path to set arp_ignore
+	GetIpv4ArpIgnoreAll() string
 }
 
 // New returns a new Interface for accessing sysctl
@@ -43,6 +46,11 @@ func New() Interface {
 
 // procSysctl implements Interface by reading and writing files under /proc/sys
 type procSysctl struct {
+}
+
+// GetIpv4ArpIgnoreAll returns a path to set arp_ignore on all interfaces
+func (*procSysctl) GetIpv4ArpIgnoreAll() string {
+	return fmt.Sprintf("net/ipv4/conf/all/arp_ignore")
 }
 
 // GetSysctl returns the value for the specified sysctl setting

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -17,7 +17,6 @@ Originally copied from https://github.com/kubernetes/kubernetes/blob/d8695d06b71
 package sysctl
 
 import (
-	"fmt"
 	"io/ioutil"
 	"path"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 const (
 	sysctlBase        = "/proc/sys"
 	NetIPv6Forwarding = "net/ipv6/conf/all/forwarding"
+	Ipv4ArpIgnoreAll  = "net/ipv4/conf/all/arp_ignore"
 )
 
 // Interface is an injectable interface for running sysctl commands.
@@ -35,8 +35,6 @@ type Interface interface {
 	GetSysctl(sysctl string) (int, error)
 	// SetSysctl modifies the specified sysctl flag to the new value
 	SetSysctl(sysctl string, newVal int) error
-	// GetIpv4ArpIgnoreAll returns the interface's path to set arp_ignore
-	GetIpv4ArpIgnoreAll() string
 }
 
 // New returns a new Interface for accessing sysctl
@@ -46,11 +44,6 @@ func New() Interface {
 
 // procSysctl implements Interface by reading and writing files under /proc/sys
 type procSysctl struct {
-}
-
-// GetIpv4ArpIgnoreAll returns a path to set arp_ignore on all interfaces
-func (*procSysctl) GetIpv4ArpIgnoreAll() string {
-	return fmt.Sprintf("net/ipv4/conf/all/arp_ignore")
 }
 
 // GetSysctl returns the value for the specified sysctl setting

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -190,7 +190,7 @@ func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 }
 
 func (h *NetworkUtilsHandler) ConfigureIpv4ArpIgnore() error {
-	err := sysctl.New().SetSysctl(sysctl.New().GetIpv4ArpIgnoreAll(), 1)
+	err := sysctl.New().SetSysctl(sysctl.Ipv4ArpIgnoreAll, 1)
 	return err
 }
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -94,8 +94,10 @@ type NetworkHandler interface {
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)
 	AddrDel(link netlink.Link, addr *netlink.Addr) error
 	AddrAdd(link netlink.Link, addr *netlink.Addr) error
+	AddrReplace(link netlink.Link, addr *netlink.Addr) error
 	LinkSetDown(link netlink.Link) error
 	LinkSetUp(link netlink.Link) error
+	LinkSetName(link netlink.Link, name string) error
 	LinkAdd(link netlink.Link) error
 	LinkSetLearningOff(link netlink.Link) error
 	ParseAddr(s string) (*netlink.Addr, error)
@@ -109,6 +111,7 @@ type NetworkHandler interface {
 	IsIpv6Enabled(interfaceName string) (bool, error)
 	IsIpv4Primary() (bool, error)
 	ConfigureIpv6Forwarding() error
+	ConfigureIpv4ArpIgnore() error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
 	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
 	NftablesNewChain(proto iptables.Protocol, table, chain string) error
@@ -140,6 +143,9 @@ func (h *NetworkUtilsHandler) AddrList(link netlink.Link, family int) ([]netlink
 func (h *NetworkUtilsHandler) RouteList(link netlink.Link, family int) ([]netlink.Route, error) {
 	return netlink.RouteList(link, family)
 }
+func (h *NetworkUtilsHandler) AddrReplace(link netlink.Link, addr *netlink.Addr) error {
+	return netlink.AddrReplace(link, addr)
+}
 func (h *NetworkUtilsHandler) AddrDel(link netlink.Link, addr *netlink.Addr) error {
 	return netlink.AddrDel(link, addr)
 }
@@ -148,6 +154,9 @@ func (h *NetworkUtilsHandler) LinkSetDown(link netlink.Link) error {
 }
 func (h *NetworkUtilsHandler) LinkSetUp(link netlink.Link) error {
 	return netlink.LinkSetUp(link)
+}
+func (h *NetworkUtilsHandler) LinkSetName(link netlink.Link, name string) error {
+	return netlink.LinkSetName(link, name)
 }
 func (h *NetworkUtilsHandler) LinkAdd(link netlink.Link) error {
 	return netlink.LinkAdd(link)
@@ -178,6 +187,11 @@ func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 	}
 
 	return true
+}
+
+func (h *NetworkUtilsHandler) ConfigureIpv4ArpIgnore() error {
+	err := sysctl.New().SetSysctl(sysctl.New().GetIpv4ArpIgnoreAll(), 1)
+	return err
 }
 
 func (h *NetworkUtilsHandler) ConfigureIpv6Forwarding() error {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -87,6 +87,16 @@ func (_mr *_MockNetworkHandlerRecorder) AddrAdd(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddrAdd", arg0, arg1)
 }
 
+func (_m *MockNetworkHandler) AddrReplace(link netlink.Link, addr *netlink.Addr) error {
+	ret := _m.ctrl.Call(_m, "AddrReplace", link, addr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) AddrReplace(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddrReplace", arg0, arg1)
+}
+
 func (_m *MockNetworkHandler) LinkSetDown(link netlink.Link) error {
 	ret := _m.ctrl.Call(_m, "LinkSetDown", link)
 	ret0, _ := ret[0].(error)
@@ -105,6 +115,16 @@ func (_m *MockNetworkHandler) LinkSetUp(link netlink.Link) error {
 
 func (_mr *_MockNetworkHandlerRecorder) LinkSetUp(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetUp", arg0)
+}
+
+func (_m *MockNetworkHandler) LinkSetName(link netlink.Link, name string) error {
+	ret := _m.ctrl.Call(_m, "LinkSetName", link, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) LinkSetName(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetName", arg0, arg1)
 }
 
 func (_m *MockNetworkHandler) LinkAdd(link netlink.Link) error {
@@ -243,6 +263,16 @@ func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {
 
 func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv6Forwarding() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv6Forwarding")
+}
+
+func (_m *MockNetworkHandler) ConfigureIpv4ArpIgnore() error {
+	ret := _m.ctrl.Call(_m, "ConfigureIpv4ArpIgnore")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv4ArpIgnore() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv4ArpIgnore")
 }
 
 func (_m *MockNetworkHandler) IptablesNewChain(proto iptables.Protocol, table string, chain string) error {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1468,6 +1468,16 @@ func DeletePV(os string) {
 	}
 }
 
+func VerifyDummyNicForBridgeNetwork(vmi *v1.VirtualMachineInstance) {
+	output := RunCommandOnVmiPod(vmi, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep DOWN|grep -c eth0"})
+	ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("1"))
+
+	output = RunCommandOnVmiPod(vmi, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep UP|grep -c eth0-nic"})
+	ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("1"))
+
+	return
+}
+
 func RunVMI(vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstance {
 	By("Starting a VirtualMachineInstance")
 	virtCli, err := kubecli.GetKubevirtClient()

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -247,6 +247,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				By("applying the hostname from meta-data")
 				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
 					&expect.BExp{R: dns.SanitizeHostname(vmi)},

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -247,7 +247,6 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				By("applying the hostname from meta-data")
 				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
-
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "hostname\n"},
 					&expect.BExp{R: dns.SanitizeHostname(vmi)},

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -591,7 +591,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				By("restarting kubelet")
 				pod := renderPkillAllPod("kubelet")
 				pod.Spec.NodeName = nodeName
-				_, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(pod)
+				_, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("starting another VMI on the same node, to verify kubelet is running again")

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -570,6 +570,76 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				tests.WaitForSuccessfulVMIStart(newVMI)
 			})
+
+			It("VMIs with Bridge Networking shouldn't fail after the kubelet restarts", func() {
+				bridgeVMI := vmi
+				// Remove the masquerade interface to use the default bridge one
+				bridgeVMI.Spec.Domain.Devices.Interfaces = nil
+				bridgeVMI.Spec.Networks = nil
+				v1.SetDefaults_NetworkInterface(bridgeVMI)
+				Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
+
+				By("starting a VMI with bridged network on a node")
+				bridgeVMI, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(bridgeVMI)
+				Expect(err).To(BeNil(), "Should submit VMI successfully")
+
+				// Start a VirtualMachineInstance with bridged networking
+				nodeName := tests.WaitForSuccessfulVMIStart(bridgeVMI)
+
+				tests.VerifyDummyNicForBridgeNetwork(bridgeVMI)
+
+				By("restarting kubelet")
+				pod := renderPkillAllPod("kubelet")
+				pod.Spec.NodeName = nodeName
+				_, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(pod)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("starting another VMI on the same node, to verify kubelet is running again")
+				newVMI := newCirrosVMI()
+				newVMI.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+				Eventually(func() error {
+					newVMI, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(newVMI)
+					Expect(err).To(BeNil())
+					return nil
+				}, 100, 10).Should(Succeed(), "Should be able to start a new VM")
+
+				By("checking if the VMI with bridged networking is still running, it will verify the CNI didn't cause the pod to be killed")
+				tests.WaitForSuccessfulVMIStart(bridgeVMI)
+			})
+
+			It("VMIs with Bridge Networking should work with Duplicate Address Detection (DAD)", func() {
+				bridgeVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
+				// Remove the masquerade interface to use the default bridge one
+				bridgeVMI.Spec.Domain.Devices.Interfaces = nil
+				bridgeVMI.Spec.Networks = nil
+				v1.SetDefaults_NetworkInterface(bridgeVMI)
+				Expect(bridgeVMI.Spec.Domain.Devices.Interfaces).NotTo(BeEmpty())
+
+				By("starting a VMI with bridged network on a node")
+				bridgeVMI, err = virtClient.VirtualMachineInstance(vmi.Namespace).Create(bridgeVMI)
+				Expect(err).To(BeNil(), "Should submit VMI successfully")
+
+				// Start a VirtualMachineInstance with bridged networking
+				By("Waiting the VirtualMachineInstance start")
+				tests.WaitUntilVMIReady(bridgeVMI, console.LoginToCirros)
+				tests.VerifyDummyNicForBridgeNetwork(bridgeVMI)
+
+				// Update the VMI object so we get the IP address
+				bridgeVMI, err = virtClient.VirtualMachineInstance(bridgeVMI.Namespace).Get(bridgeVMI.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				vmIP := libnet.GetVmiPrimaryIpByFamily(bridgeVMI, k8sv1.IPv4Protocol)
+				dadCommand := fmt.Sprintf("sudo /usr/sbin/arping -D -I eth0 -c 2 %s | grep Received | cut -d ' ' -f 2\n", vmIP)
+
+				Expect(console.SafeExpectBatch(bridgeVMI, []expect.Batcher{
+					&expect.BSnd{S: "\n"},
+					&expect.BExp{R: console.PromptExpression},
+
+					&expect.BSnd{S: dadCommand},
+					&expect.BExp{R: "0"},
+				}, 600)).To(Succeed())
+			})
+
 		})
 
 		Context("[Serial]when virt-handler is not responsive", func() {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -270,7 +270,7 @@ var _ = Describe("[Serial]Multus", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("checking pod has only one interface")
-				// lo0, eth0, k6t-eth0, vnet0
+				// lo0, eth0-nic, k6t-eth0, vnet0
 				output := tests.RunCommandOnVmiPod(detachedVMI, []string{"/bin/bash", "-c", "/usr/sbin/ip link show|grep -c UP"})
 				ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal("4"))
 			})

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -95,7 +95,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 	}
 
 	checkLearningState := func(vmi *v1.VirtualMachineInstance, expectedValue string) {
-		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0/brport/learning"})
+		output := tests.RunCommandOnVmiPod(vmi, []string{"cat", "/sys/class/net/eth0-nic/brport/learning"})
 		ExpectWithOffset(1, strings.TrimSpace(output)).To(Equal(expectedValue))
 	}
 


### PR DESCRIPTION
When kubelet is restarted, it goes over all pods, peeks in their
respective network namespaces and tries to detect their IP in order
to update their Pod objects.

However, with the bridge binding mode, we move this IP address to VM
and the pod interface is left IP-less. That causes kubelet's IP check
to fail and results in pod removal.

With this patch, we use a dummy interface named after the pod interface
to keep the pod IP address. When kubelet performs the check, it sees
interface with expected name (eth0) and reports its IP address on
Pod object.

Fixes: #2076

Authored-by: Petr Horacek <phoracek@redhat.com>
Authored-by: Ryan Hallisey <rhallisey@nvidia.com>

**Release note**:
```release-note
VMs using bridged networking will survive a kubelet restart by having kubevirt create a dummy interface on the virt-launcher pods, so that some Kubernetes CNIs, that have implemented the `CHECK` RPC call, will not cause VMI pods to enter a failed state.
```
