### PR TITLE
WIP / DNM => jumbo-frames: activate jumbo frames on one lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -324,6 +324,14 @@ spec:
 EOF
 fi
 
+# Enable jumbo-frames for a selected lane
+if [[ $TARGET == "k8s-1.19" ]]; then
+  echo "Enabling jumbo frames."
+  kubectl patch configmap/calico-config -n kube-system --type merge \
+    -p '{"data":{"veth_mtu": "8000"}}'
+
+  kubectl rollout restart daemonset calico-node -n kube-system
+fi
 
 # Run functional tests
 FUNC_TEST_ARGS=$ginko_params make functest

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -223,6 +223,10 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			// NOTE: cirros ping doesn't support -M do that could be used to
 			// validate end-to-end connectivity with Don't Fragment flag set
 			cmdCheck = fmt.Sprintf("ping %s -c 1 -w 5 -s %d\n", addr, payloadSize)
+			// pinging over the internet w/ a jumbo frame is not a good idea. Far from it.
+			if destination == "Internet" {
+				cmdCheck = fmt.Sprintf("ping %s -c 1 -w 5\n", addr)
+			}
 			err = console.SafeExpectBatch(outboundVMI, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: console.PromptExpression},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Configure the MTU of one of the lanes to use jumbo frames.

This solution cannot be used to reach over the internet; as such
all tests that do it need to be adapted.

**Special notes for your reviewer**:
This is just to get the ball running, see what tests explode, and start a discussion about the best / simplest way to configure the MTU.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
