### PR TITLE
virt-launcher: Improve libvirtd debug log filters

### DIFF
--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -401,8 +401,8 @@ func SetupLibvirt() error {
 	}
 
 	if _, ok := os.LookupEnv("LIBVIRT_DEBUG_LOGS"); ok {
-		// see https://wiki.libvirt.org/page/DebugLogs for details
-		_, err = libvirtConf.WriteString("log_filters=\"3:remote 4:event 3:util.json 3:rpc 1:*\"\n")
+		// see https://libvirt.org/kbase/debuglogs.html for details
+		_, err = libvirtConf.WriteString("log_filters=\"3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*\"\n")
 		if err != nil {
 			return err
 		}

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -207,12 +207,8 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			By("Getting virt-launcher logs")
 			logs := func() string { return getVirtLauncherLogs(virtClient, vmi) }
 
-			// there are plenty of strings we can use to identify the debug logs. Here we use something easy to see...
-			Eventually(logs,
-				11*time.Second,
-				500*time.Millisecond).
-				Should(ContainSubstring("OBJECT_REF"))
-			// ...and something we deeply care about when in debug mode.
+			// There are plenty of strings we can use to identify the debug logs.
+			// Here we use something we deeply care about when in debug mode.
 			Eventually(logs,
 				2*time.Second,
 				500*time.Millisecond).


### PR DESCRIPTION
**What this PR does / why we need it**:

The current filters already do a decent enough job at filtering out unnecessary noise from the libvirtd debug log, but they can be improved further: the util.object module, in particular, generates a log entry for each lifecycle event     (new, ref, unref, dispose) of each internal object, which is completely uninteresting to the vast majority of users and not particularly useful even when debugging all but the most peculiar libvirt issues.

To give an idea of the impact of this change, I ran a simple experiment: I started a VM, waited 10 seconds, collected the logs and then stopped it, first without this patch and then with it.  The logs went from 9013 lines to just 5513     lines; of the 3500 lines that were filtered out by the change, 3403 can be attributed to util.object.

The wiki page where the original filter settings were taken from has since been superseded by a "knowledge base" article on the libvirt website, so the reference has been updated as well.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
