### PR TITLE
Fix patches empty handling

### DIFF
--- a/pkg/virt-operator/install-strategy/patches.go
+++ b/pkg/virt-operator/install-strategy/patches.go
@@ -147,7 +147,7 @@ func (c *Customizer) GetPatchesForResource(resourceType, name string) []v1.Custo
 	patches := make([]v1.CustomizeComponentsPatch, 0)
 
 	for _, p := range allPatches {
-		if strings.EqualFold(p.ResourceType, resourceType) && strings.EqualFold(p.ResourceName, name) {
+		if (p.ResourceType == "" || strings.EqualFold(p.ResourceType, resourceType)) && (p.ResourceName == "" || strings.EqualFold(p.ResourceName, name)) {
 			patches = append(patches, p)
 		}
 	}

--- a/pkg/virt-operator/install-strategy/patches_test.go
+++ b/pkg/virt-operator/install-strategy/patches_test.go
@@ -57,6 +57,12 @@ var _ = Describe("Patches", func() {
 					Patch:        `{"metadata":{"labels":{"new-key":"added-this-label"}}}`,
 					Type:         v1.StrategicMergePatchType,
 				},
+				{
+					ResourceName: "",
+					ResourceType: "Deployment",
+					Patch:        `{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"image-pull"}]}}}}`,
+					Type:         v1.StrategicMergePatchType,
+				},
 			},
 		})
 
@@ -75,6 +81,7 @@ var _ = Describe("Patches", func() {
 			err := config.GenericApplyPatches(deployments)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(deployment.ObjectMeta.Labels["new-key"]).To(Equal("added-this-label"))
+			Expect(deployment.Spec.Template.Spec.ImagePullSecrets[0].Name).To(Equal("image-pull"))
 
 			err = config.GenericApplyPatches([]string{"string"})
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION

Signed-off-by: Andrew DeMaria <ademaria@cloudflare.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
If patches resourceType/resourceName are empty they should match all
types/names.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change customizeComponents.patches such that empty resourceName or resourceType matches all.
```
