### PR TITLE
expose, tests: fix early shutdown of `nc` TCP connections

### DIFF
--- a/tests/job.go
+++ b/tests/job.go
@@ -112,7 +112,7 @@ func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, time
 // which tries to contact the host on the provided port.
 // It expects to receive "Hello World!" to succeed.
 func NewHelloWorldJob(host string, port string, checkConnectivityCmdPrefixes ...string) *batchv1.Job {
-	check := fmt.Sprintf(`set -x; %sx="$(head -n 1 < <(nc %s %s -i 3 -w 3))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, strings.Join(checkConnectivityCmdPrefixes, ";"), host, port)
+	check := fmt.Sprintf(`set -x; %sx="$(head -n 1 < <(nc %s %s -i 3 -w 3 --no-shutdown))"; echo "$x" ; if [ "$x" = "Hello World!" ]; then echo "succeeded"; exit 0; else echo "failed"; exit 1; fi`, strings.Join(checkConnectivityCmdPrefixes, ";"), host, port)
 	return newHelloWorldJob(check)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Ncat calls shutdown of the opened TCP connection once the `echo`
pipe finishes writting to it. Some servers, close the connection
without responding when they read EOF on their network socket,
which reduces the success rate of this test. It currently fails on
OpenShift tests, as tracked by [0].

By using the `--no-shutdown` flag - as per [1] -  we instruct the
ncat client to keep the connection alive, thus greatly improving
the changes of success of the tests.

[0] - https://bugzilla.redhat.com/show_bug.cgi?id=1893154
[1] - https://github.com/nmap/nmap/issues/1229#issuecomment-397642593

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Bugzilla issue: https://bugzilla.redhat.com/show_bug.cgi?id=1893154

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
