### PR TITLE
deployment scripts: Increase CDI deployment timeout

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -58,7 +58,7 @@ EOF
         # Ensure that cdi insecure registries are set
         count=0
         until _kubectl get configmap -n ${cdi_namespace} cdi-insecure-registries; do
-            ((count++)) && ((count == 30)) && echo "cdi-insecure-registries config-map not found" && exit 1
+            ((count++)) && ((count == 120)) && echo "cdi-insecure-registries config-map not found" && exit 1
             echo "waiting for cdi-insecure-registries configmap to be created"
             sleep 1
         done


### PR DESCRIPTION
CDI is being deployed as part of our testing infrastructure bring up.
Increase the timeout for watching the CDI CM to 120 secs.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
If using external container registry the image pull latency 
may affect the deployment time and then we hit the CDI timeout 
while watching the creation of the CDI configmaps.

**Release note**:

```release-note
NONE
```
