### PR TITLE
fix gosec issue: Subprocess launched with variable

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -306,6 +306,7 @@ func defaultIsoFunc(isoOutFile, volumeID string, inDir string) error {
 	args = append(args, "-rock")
 	args = append(args, inDir)
 
+	// #nosec No risk for attacket injection. Parameters are predefined strings
 	cmd := exec.Command("genisoimage", args...)
 
 	err := cmd.Start()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,7 @@ func defaultCreateIsoImage(output string, volID string, files []string) error {
 	args = append(args, "-graft-points")
 	args = append(args, files...)
 
+	// #nosec No risk for attacket injection. Parameters are predefined strings
 	cmd := exec.Command("genisoimage", args...)
 	err := cmd.Run()
 	if err != nil {

--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -24,6 +24,7 @@ func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
 				return err
 			}
 			if _, err := os.Stat(file); os.IsNotExist(err) {
+				// #nosec No risk for attacket injection. Parameters are predefined strings
 				if err := exec.Command("qemu-img", "create", "-f", "qcow2", file, size).Run(); err != nil {
 					return err
 				}

--- a/pkg/ephemeral-disk/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/ephemeral-disk.go
@@ -94,6 +94,7 @@ func CreateBackedImageForVolume(volume v1.Volume, backingFile string) error {
 	args = append(args, backingFile)
 	args = append(args, imagePath)
 
+	// #nosec No risk for attacket injection. Parameters are predefined strings
 	cmd := exec.Command("qemu-img", args...)
 	output, err := cmd.CombinedOutput()
 

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -290,6 +290,7 @@ func (m *mounter) legacyUnmount(vmi *v1.VirtualMachineInstance) error {
 			if mounted, err := isolation.NodeIsolationResult().IsMounted(path); err != nil {
 				return fmt.Errorf("failed to check mount point for containerDisk %v: %v", path, err)
 			} else if mounted {
+				// #nosec No risk for attacket injection. Parameters are predefined strings
 				out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "umount", path).CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to unmount containerDisk %v: %v : %v", path, string(out), err)
@@ -333,6 +334,7 @@ func (m *mounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 				return fmt.Errorf("failed to check mount point for containerDisk %v: %v", path, err)
 			} else if mounted {
 				log.DefaultLogger().Object(vmi).Infof("unmounting container disk at path %s", path)
+				// #nosec No risk for attacket injection. Parameters are predefined strings
 				out, err := exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "umount", path).CombinedOutput()
 				if err != nil {
 					return fmt.Errorf("failed to unmount containerDisk %v: %v : %v", path, string(out), err)

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -17,6 +17,7 @@ type execFunc = func(binary string, args ...string) ([]byte, error)
 type copyPolicy = func(policyName string, dir string) (err error)
 
 func defaultExecFunc(binary string, args ...string) ([]byte, error) {
+	// #nosec No risk for attacket injection. args get specific selinux exec parameters
 	return exec.Command(binary, args...).CombinedOutput()
 }
 

--- a/pkg/virt-launcher/virtwrap/api/converter.go
+++ b/pkg/virt-launcher/virtwrap/api/converter.go
@@ -1917,6 +1917,7 @@ func createHostDevicesFromMdevUUIDList(mdevUuidList []string) ([]HostDevice, err
 
 func GetImageInfo(imagePath string) (*containerdisk.DiskInfo, error) {
 
+	// #nosec No risk for attacket injection. Only get information about an image
 	out, err := exec.Command(
 		"/usr/bin/qemu-img", "info", imagePath, "--output", "json",
 	).Output()

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -236,6 +236,7 @@ func (h *NetworkUtilsHandler) NftablesNewChain(proto iptables.Protocol, table, c
 
 func (h *NetworkUtilsHandler) NftablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error {
 	cmd := append([]string{"add", "rule", Handler.GetNFTIPString(proto), table, chain}, rulespec...)
+	// #nosec No risk for attacket injection. CMD variables are predefined strings
 	output, err := exec.Command("nft", cmd...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to apped new nfrule error %s", string(output))
@@ -401,6 +402,7 @@ func buildTapDeviceMaker(tapName string, queueNumber uint32, virtLauncherPID int
 		"--queue-number", fmt.Sprintf("%d", queueNumber),
 		"--mtu", fmt.Sprintf("%d", mtu),
 	}
+	// #nosec No risk for attacket injection. createTapDeviceArgs includes predefined strings
 	cmd := exec.Command("virt-chroot", createTapDeviceArgs...)
 
 	return &tapDeviceMaker{

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -239,6 +239,7 @@ func StartVirtlog(stopChan chan struct{}, domainName string) {
 			var args []string
 			args = append(args, "-f")
 			args = append(args, "/etc/libvirt/virtlogd.conf")
+			// #nosec No risk for attacket injection. Args  are predefined strings
 			cmd := exec.Command("/usr/sbin/virtlogd", args...)
 
 			exitChan := make(chan struct{})

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -272,6 +272,7 @@ func checkAndRunVNCViewer(doneChan chan struct{}, viewResChan chan error, port i
 		if glog.V(4) {
 			glog.Infof("Executing commandline: '%s %v'", vncBin, args)
 		}
+		// #nosec No risk for attacket injection. vncBin and args include predefined strings
 		cmnd := exec.Command(vncBin, args...)
 		output, err := cmnd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Ezra Silvera <ezra@il.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix warnings coming from the gosec static analysis.  Audit the code to make sure no injection command attack  can be performed through exec.Command() launched with variable

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
