### PR TITLE
Remove sysctl binary dependency

### DIFF
--- a/pkg/util/sysctl/BUILD.bazel
+++ b/pkg/util/sysctl/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["sysctl.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/util/sysctl",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+Copyright 2020 The KubeVirt Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Originally copied from https://github.com/kubernetes/kubernetes/blob/d8695d06b7191db56ebbbc0340da263833c9bb6f/pkg/util/sysctl/sysctl.go
+*/
+
+package sysctl
+
+import (
+	"io/ioutil"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const (
+	sysctlBase        = "/proc/sys"
+	NetIPv6Forwarding = "net/ipv6/conf/all/forwarding"
+)
+
+// Interface is an injectable interface for running sysctl commands.
+type Interface interface {
+	// GetSysctl returns the value for the specified sysctl setting
+	GetSysctl(sysctl string) (int, error)
+	// SetSysctl modifies the specified sysctl flag to the new value
+	SetSysctl(sysctl string, newVal int) error
+}
+
+// New returns a new Interface for accessing sysctl
+func New() Interface {
+	return &procSysctl{}
+}
+
+// procSysctl implements Interface by reading and writing files under /proc/sys
+type procSysctl struct {
+}
+
+// GetSysctl returns the value for the specified sysctl setting
+func (*procSysctl) GetSysctl(sysctl string) (int, error) {
+	data, err := ioutil.ReadFile(path.Join(sysctlBase, sysctl))
+	if err != nil {
+		return -1, err
+	}
+	val, err := strconv.Atoi(strings.Trim(string(data), " \n"))
+	if err != nil {
+		return -1, err
+	}
+	return val, nil
+}
+
+// SetSysctl modifies the specified sysctl flag to the new value
+func (*procSysctl) SetSysctl(sysctl string, newVal int) error {
+	return ioutil.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0640)
+}

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util:go_default_library",
+        "//pkg/util/sysctl:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/network/dhcp:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -37,6 +37,8 @@ import (
 	lmf "github.com/subgraph/libmacouflage"
 	"github.com/vishvananda/netlink"
 
+	"kubevirt.io/kubevirt/pkg/util/sysctl"
+
 	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -178,7 +180,7 @@ func (h *NetworkUtilsHandler) HasNatIptables(proto iptables.Protocol) bool {
 }
 
 func (h *NetworkUtilsHandler) ConfigureIpv6Forwarding() error {
-	_, err := exec.Command("sysctl", "net.ipv6.conf.all.forwarding=1").CombinedOutput()
+	err := sysctl.New().SetSysctl(sysctl.NetIPv6Forwarding, 1)
 	return err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since it is so easy to not  use sysctl and every dependency which we don't have is a good dependency, replacing our single sysctl binary call with a golang version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
