### PR TITLE
tests, network: Remove vmi Status ip normalization

### DIFF
--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -20,7 +20,6 @@
 package network
 
 import (
-	"net"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -106,8 +105,8 @@ var _ = SIGDescribe("[Serial]Primary Pod Network", func() {
 
 				It("should report PodIP/s IPv4 as its own on interface status", func() {
 					vmiPod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-					Eventually(vmiIP).Should(WithTransform(removeCIDR, Equal(vmiPod.Status.PodIP)), "should contain VMI Status IP as Pod status ip")
-					Eventually(vmiIPs).Should(WithTransform(removeCIDRs, ContainElement(vmiPod.Status.PodIP)), "should contain IPv4 reported by guest agent")
+					Eventually(vmiIP).Should(Equal(vmiPod.Status.PodIP), "should contain VMI Status IP as Pod status ip")
+					Eventually(vmiIPs).Should(ContainElement(vmiPod.Status.PodIP), "should contain IPv4 reported by guest agent")
 				})
 
 				It("should report VMIs static IPv6 at interface status", func() {
@@ -237,20 +236,4 @@ func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.Virtual
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)
 	return vmi, nil
-}
-
-func removeCIDRs(ips []string) []string {
-	ipAddresses := []string{}
-	for _, ip := range ips {
-		ipAddresses = append(ipAddresses, removeCIDR(ip))
-	}
-	return ipAddresses
-}
-
-func removeCIDR(ip string) string {
-	ipAddr, _, err := net.ParseCIDR(ip)
-	if err != nil {
-		return ip
-	}
-	return ipAddr.String()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Now that the CIDR is not included at the VMI Status IPs (https://github.com/kubevirt/kubevirt/pull/4217) we don't need to
remove it before compare it with the pod Ips.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
