### PR TITLE
add webhook to validate kubevirt CR updates

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -598,6 +598,9 @@ func (app *virtAPIApp) prepareCertManager() {
 }
 
 func (app *virtAPIApp) registerValidatingWebhooks() {
+	http.HandleFunc(components.KubeVirtUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
+		validating_webhook.ServeKubeVirtUpdate(w, r, app.virtCli)
+	})
 	http.HandleFunc(components.VMICreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMICreate(w, r, app.clusterConfig)
 	})

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -73,6 +73,12 @@ var MigrationGroupVersionResource = metav1.GroupVersionResource{
 	Resource: "virtualmachineinstancemigrations",
 }
 
+var KubeVirtGroupVersionResource = metav1.GroupVersionResource{
+	Group:    v1.KubeVirtGroupVersionKind.Group,
+	Version:  v1.KubeVirtGroupVersionKind.Version,
+	Resource: "kubevirts",
+}
+
 type Informers struct {
 	VMIPresetInformer       cache.SharedIndexInformer
 	NamespaceLimitsInformer cache.SharedIndexInformer

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -3,6 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "kubevirt-update-admitter.go",
+        "kubevirt-update-admitter-test.go",
         "migration-create-admitter.go",
         "migration-update-admitter.go",
         "pod-eviction-admitter.go",
@@ -28,6 +30,9 @@ go_library(
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -36,6 +41,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/kubevirt-update-admitter-test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/kubevirt-update-admitter-test.go
@@ -1,0 +1,164 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package admitters
+
+import (
+	"encoding/json"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+)
+
+var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
+
+	getAdmitter := func(needsVMIMock bool, vmi *v1.VirtualMachineInstance) *KubeVirtUpdateAdmitter {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+
+		if needsVMIMock {
+			vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+			virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(vmiInterface).AnyTimes()
+
+			items := []v1.VirtualMachineInstance{}
+			if vmi != nil {
+				items = append(items, *vmi)
+			}
+
+			vmiInterface.EXPECT().List(gomock.Any()).Return(&v1.VirtualMachineInstanceList{
+				Items: items,
+			}, nil)
+		}
+
+		return NewKubeVirtUpdateAdmitter(virtClient)
+	}
+
+	getKV := func() v1.KubeVirt {
+		return v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+			},
+			Spec: v1.KubeVirtSpec{
+				Workloads: nil,
+			},
+		}
+	}
+
+	getComponentConfig := func() v1.ComponentConfig {
+		return v1.ComponentConfig{
+			NodePlacement: &v1.NodePlacement{
+				NodeSelector: map[string]string{
+					"kubernetes.io/hostname": "node01",
+				},
+			},
+		}
+	}
+
+	It("should accept workload update when no VMIS are running", func() {
+		kvAdmitter := getAdmitter(true, nil)
+		kv := getKV()
+		kvBytes, _ := json.Marshal(&kv)
+
+		cc := getComponentConfig()
+		kv.Spec.Workloads = &cc
+		kvUpdateBytes, _ := json.Marshal(&kv)
+
+		ar := &v1beta1.AdmissionReview{
+			Request: &v1beta1.AdmissionRequest{
+				Resource: webhooks.KubeVirtGroupVersionResource,
+				Object: runtime.RawExtension{
+					Raw: kvUpdateBytes,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: kvBytes,
+				},
+				Operation: v1beta1.Update,
+			},
+		}
+
+		resp := kvAdmitter.Admit(ar)
+		Expect(resp.Allowed).To(BeTrue())
+	})
+
+	It("should reject workload update when VMIS are running", func() {
+		vmi := v1.NewMinimalVMI("testmigratevmiupdate")
+		kvAdmitter := getAdmitter(true, vmi)
+		kv := getKV()
+		kvBytes, _ := json.Marshal(&kv)
+
+		cc := getComponentConfig()
+		kv.Spec.Workloads = &cc
+		kvUpdateBytes, _ := json.Marshal(&kv)
+
+		ar := &v1beta1.AdmissionReview{
+			Request: &v1beta1.AdmissionRequest{
+				Resource: webhooks.KubeVirtGroupVersionResource,
+				Object: runtime.RawExtension{
+					Raw: kvUpdateBytes,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: kvBytes,
+				},
+				Operation: v1beta1.Update,
+			},
+		}
+
+		resp := kvAdmitter.Admit(ar)
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+	})
+
+	It("should accept KV update with VMIS running if workloads object is not changed", func() {
+		kvAdmitter := getAdmitter(false, nil)
+		kv := getKV()
+		cc := getComponentConfig()
+		kv.Spec.Workloads = &cc
+
+		kvBytes, _ := json.Marshal(&kv)
+
+		kv.ObjectMeta.Labels = map[string]string{
+			"kubevirt.io": "new-label",
+		}
+		kvUpdateBytes, _ := json.Marshal(&kv)
+
+		ar := &v1beta1.AdmissionReview{
+			Request: &v1beta1.AdmissionRequest{
+				Resource: webhooks.KubeVirtGroupVersionResource,
+				Object: runtime.RawExtension{
+					Raw: kvUpdateBytes,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: kvBytes,
+				},
+				Operation: v1beta1.Update,
+			},
+		}
+
+		resp := kvAdmitter.Admit(ar)
+		Expect(resp.Allowed).To(BeTrue())
+	})
+})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/kubevirt-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/kubevirt-update-admitter.go
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2018 Red Hat, Inc.
+ *
+ */
+
+package admitters
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+)
+
+// KubeVirtUpdateAdmitter validates KubeVirt updates
+type KubeVirtUpdateAdmitter struct {
+	Client kubecli.KubevirtClient
+}
+
+// NewKubeVirtUpdateAdmitter creates a KubeVirtUpdateAdmitter
+func NewKubeVirtUpdateAdmitter(client kubecli.KubevirtClient) *KubeVirtUpdateAdmitter {
+	return &KubeVirtUpdateAdmitter{
+		Client: client,
+	}
+}
+
+func (admitter *KubeVirtUpdateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	// Get new and old KubeVirt from admission response
+	newKV, oldKV, err := getAdmissionReviewKubeVirt(ar)
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	if resp := webhookutils.ValidateSchema(v1.KubeVirtGroupVersionKind, ar.Request.Object.Raw); resp != nil {
+		return resp
+	}
+
+	if reflect.DeepEqual(newKV.Spec.Workloads, oldKV.Spec.Workloads) {
+		return allowed()
+	}
+
+	// reject update if it will move a virt-handler pod from a node that has
+	// a vmi running on it
+	causes, err := admitter.validateWorkloadPlacementUpdate()
+	if err != nil {
+		return webhookutils.ToAdmissionResponseError(err)
+	}
+
+	if len(causes) > 0 {
+		return webhookutils.ToAdmissionResponse(causes)
+	}
+
+	return allowed()
+}
+
+func (admitter *KubeVirtUpdateAdmitter) validateWorkloadPlacementUpdate() ([]metav1.StatusCause, error) {
+	vmis, err := admitter.Client.VirtualMachineInstance(corev1.NamespaceAll).List(&metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(vmis.Items) > 0 {
+		return []metav1.StatusCause{
+			{
+				Type:    metav1.CauseTypeFieldValueNotSupported,
+				Message: "can't placement of workload pods while there are running vms",
+			},
+		}, nil
+	}
+
+	return []metav1.StatusCause{}, nil
+}
+
+func getAdmissionReviewKubeVirt(ar *v1beta1.AdmissionReview) (new *v1.KubeVirt, old *v1.KubeVirt, err error) {
+	if !webhookutils.ValidateRequestResource(ar.Request.Resource, webhooks.KubeVirtGroupVersionResource.Group, webhooks.KubeVirtGroupVersionResource.Resource) {
+		return nil, nil, fmt.Errorf("expect resource to be '%s'", webhooks.KubeVirtGroupVersionResource)
+	}
+
+	raw := ar.Request.Object.Raw
+	newKV := v1.KubeVirt{}
+
+	err = json.Unmarshal(raw, &newKV)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if ar.Request.Operation == v1beta1.Update {
+		raw := ar.Request.OldObject.Raw
+		oldKV := v1.KubeVirt{}
+		err = json.Unmarshal(raw, &oldKV)
+		if err != nil {
+			return nil, nil, err
+		}
+		return &newKV, &oldKV, nil
+	}
+
+	return &newKV, nil, nil
+}

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -28,6 +28,10 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
+func ServeKubeVirtUpdate(resp http.ResponseWriter, req *http.Request, virtCli kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewKubeVirtUpdateAdmitter(virtCli))
+}
+
 func ServeVMICreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
 	validating_webhooks.Serve(resp, req, &admitters.VMICreateAdmitter{ClusterConfig: clusterConfig})
 }

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -365,6 +365,7 @@ var _ = Describe("[Serial]Operator", func() {
 
 		patchKvNodePlacement = func(name string, path string, verb string, componentConfig *v1.ComponentConfig) {
 			var data []byte
+
 			componentConfigData, _ := json.Marshal(componentConfig)
 
 			data = []byte(fmt.Sprintf(`[{"op": "%s", "path": "/spec/%s", "value": %s}]`, verb, path, string(componentConfigData)))
@@ -383,6 +384,9 @@ var _ = Describe("[Serial]Operator", func() {
 			if kv.Spec.Infra != nil {
 				verb = "replace"
 			}
+			if infra == nil {
+				verb = "remove"
+			}
 
 			patchKvNodePlacement(name, "infra", verb, infra)
 		}
@@ -392,6 +396,9 @@ var _ = Describe("[Serial]Operator", func() {
 			verb := "add"
 			if kv.Spec.Workloads != nil {
 				verb = "replace"
+			}
+			if workloads == nil {
+				verb = "remove"
 			}
 
 			patchKvNodePlacement(name, "workloads", verb, workloads)


### PR DESCRIPTION
only allow updates to workloads key if no vmis are running

Signed-off-by: Ashley Schuett <ashleyns1992@gmail.com>

**What this PR does / why we need it**:

If the KubeVirt CR is updated to change or restrict the nodes that the workload pods are running on and there are running VMIs we will reject the update. 

This is needed because the update will migrated the workload related components managed by the operator but will not migrate existing VMIs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1895414

**Special notes for your reviewer**:

I think this can be refined to either not apply the workload placement update to the workloads until migrations have happened or check if the update moves the workloads from a node with a running vmi. If it doesn't it could still be allowed. However these other options will take discussion and this change fixes the bug and is the current proposed solution. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
