### PR TITLE
docs/devel/networking: no NET_ADMIN, NET_RAW

### DIFF
--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -56,6 +56,8 @@ the following operations, in this order:
 The virt-launcher is an untrusted component of KubeVirt (since it wraps the
 libvirt process that will run third party workloads). As a result, it must be
 run with as little privileges as required.
+In particular, it should not assume having `CAP_NET_ADMIN` or `CAP_NET_RAW`
+capabilites.
 
 In this second phase, virt-launcher also has to select the correct
 `BindMechanism`, and afterwards will uses it to retrieve the configuration


### PR DESCRIPTION
"as little privileges" is a true guideline, but it sounds a bit vague.
We should specifically discourage virt-launcher from ever making any
use of CAP_NET_ADMIN  and CAP_NET_RAW.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add specificity to network developer doc

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
/cc @AlonaKaplan @maiqueb 