### PR TITLE
tests, sriov: Wait for IPs at Status

### DIFF
--- a/tests/libnet/ipaddress.go
+++ b/tests/libnet/ipaddress.go
@@ -1,6 +1,8 @@
 package libnet
 
 import (
+	"net"
+
 	k8sv1 "k8s.io/api/core/v1"
 	netutils "k8s.io/utils/net"
 
@@ -26,6 +28,14 @@ func GetIp(ips []string, family k8sv1.IPFamily) string {
 		}
 	}
 	return ""
+}
+
+func RemoveCIDR(ipWIthCIDR string) (string, error) {
+	ip, _, err := net.ParseCIDR(ipWIthCIDR)
+	if err != nil {
+		return "", err
+	}
+	return ip.String(), nil
 }
 
 func getFamily(ip string) k8sv1.IPFamily {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When SRIOV VMs configure their IPs using cloud-init networkData waitting
for GuestAgent is not enough since it takes some time for ips to be set
on the VM, this produces some intermitent errors at SRIOV lane, to fix
that polling the VM status until IPs appear there should fix it.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
