### PR TITLE
tests, utils: shorten name of random VMs

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1866,7 +1866,7 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 }
 
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
-	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi"+rand.String(48))
+	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi-"+rand.String(12))
 
 	t := defaultTestGracePeriod
 	vmi.Spec.TerminationGracePeriodSeconds = &t


### PR DESCRIPTION
I find it very hard to sift through CI logs with VM names that include 48 pseudorandom consonants. Moreover, kubevirt prepends "virt-launcher-" to the 55-chars-long VMI name and uses this as a generateName for the virt-launcher Pod. Apparently, when Kubernetes generates the Pod name, it keeps only 58 chars of the generateName, which makes matching virt-launcher pods even harder.

This commit shortens the VMI name length to a more humanly comprehensible length of 12 consonants. The probability of collision is still quite low (27^12 ~ 10^17). If we keep creating one VMI per second, we are likely to see a collision after a few billion years. The number 12 was chosen without a very good reason. 6 consonants would be safe enough. A dash is introduced between the `testvmi` prefix and the random string for readability.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>


**Special notes for your reviewer**:
This would hopefully ease review of flaky test logs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
