### PR TITLE
tests, libvmi, vmi: shorten random vm names #2

### DIFF
--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -45,7 +45,7 @@ func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 
 // RandName returns a random name by concatanating the given name with a random string.
 func RandName(name string) string {
-	return name + rand.String(48)
+	return name + rand.String(5)
 }
 
 // WithTerminationGracePeriod specifies the termination grace period in seconds.


### PR DESCRIPTION
As mentioned in the review for PR #4605, we have few other places where we generate unusably long VM names. This commit makes RandName behave more like Pod's generateName and add only 5 random consonants. Hopefully, all other places where we generate random VM names can be fixed to use this function.

This commit should not be taken as an advocacy for using randomness in tests. It would be better to have tests with constant meaningful objects names.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
