### PR TITLE
tests, Use RandName for creating random VMI names

### DIFF
--- a/tests/libvmi/vmi.go
+++ b/tests/libvmi/vmi.go
@@ -43,9 +43,9 @@ func New(name string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return vmi
 }
 
-// RandName returns a random name by concatanating the given name with a random string.
+// RandName returns a random name by concatenating the given name with a hyphen and a random string.
 func RandName(name string) string {
-	return name + rand.String(5)
+	return name + "-" + rand.String(5)
 }
 
 // WithTerminationGracePeriod specifies the termination grace period in seconds.

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1904,7 +1904,7 @@ func NewRandomVMI() *v1.VirtualMachineInstance {
 }
 
 func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
-	vmi := v1.NewMinimalVMIWithNS(namespace, "testvmi-"+rand.String(12))
+	vmi := v1.NewMinimalVMIWithNS(namespace, libvmi.RandName(libvmi.DefaultVmiName))
 
 	t := defaultTestGracePeriod
 	vmi.Spec.TerminationGracePeriodSeconds = &t

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/rand"
 	netutils "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 
@@ -949,7 +948,7 @@ sockfd = None`})
 		})
 		It("[test_id:2964]should reject VMIs with bridge interface when it's not permitted on pod network", func() {
 			var t int64 = 0
-			vmi := v1.NewMinimalVMIWithNS(tests.NamespaceTestDefault, "testvmi"+rand.String(48))
+			vmi := v1.NewMinimalVMIWithNS(tests.NamespaceTestDefault, libvmi.RandName(libvmi.DefaultVmiName))
 			vmi.Spec.TerminationGracePeriodSeconds = &t
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 			tests.AddEphemeralDisk(vmi, "disk0", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -37,6 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
 var _ = Describe("[Serial]Slirp Networking", func() {
@@ -163,7 +163,7 @@ var _ = Describe("[Serial]Slirp Networking", func() {
 		})
 		It("should reject VMIs with default interface slirp when it's not permitted", func() {
 			var t int64 = 0
-			vmi := v1.NewMinimalVMIWithNS(tests.NamespaceTestDefault, "testvmi"+rand.String(48))
+			vmi := v1.NewMinimalVMIWithNS(tests.NamespaceTestDefault, libvmi.RandName(libvmi.DefaultVmiName))
 			vmi.Spec.TerminationGracePeriodSeconds = &t
 			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 			tests.AddEphemeralDisk(vmi, "disk0", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))


### PR DESCRIPTION
Following the work done at
https://github.com/kubevirt/kubevirt/pull/4605 https://github.com/kubevirt/kubevirt/pull/4609
which updated tests to use a shorter random VMI suffix, in order to ease logs readability,

Use `libvmi.RandName(baseName)` in tests which create a random VMI name,
in order to unify the interface and the VMI name pattern in the logs
for those tests.

**Special notes for your reviewer**:
* On a follow PR, it might worth to check if the tests which use a fixed VMI name `"testvmi"`,
are running in a `[Serial]` mode due to this fact, or might collide in case they run in a parallel mode,
and adapt them (in one way or another).

**Release notes**:
```release-note
None
```
