### PR TITLE
update listType markers for kubevirt pci host devices

### DIFF
--- a/api/api-rule-violations-known.list
+++ b/api/api-rule-violations-known.list
@@ -153,8 +153,6 @@ API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,KubeVirtConfi
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,KubeVirtList,Items
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,KubeVirtStatus,Conditions
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,NodePlacement,Tolerations
-API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,PermittedHostDevices,MediatedDevices
-API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,PermittedHostDevices,PciHostDevices
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,VirtualMachineInstanceFileSystemInfo,Filesystems
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,VirtualMachineInstanceFileSystemList,Items
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,VirtualMachineInstanceGuestAgentInfo,UserList

--- a/api/api-rule-violations.list
+++ b/api/api-rule-violations.list
@@ -153,8 +153,6 @@ API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,KubeVirtConfi
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,KubeVirtList,Items
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,KubeVirtStatus,Conditions
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,NodePlacement,Tolerations
-API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,PermittedHostDevices,MediatedDevices
-API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,PermittedHostDevices,PciHostDevices
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,VirtualMachineInstanceFileSystemInfo,Filesystems
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,VirtualMachineInstanceFileSystemList,Items
 API rule violation: list_type_missing,kubevirt.io/client-go/api/v1,VirtualMachineInstanceGuestAgentInfo,UserList

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9782,13 +9782,15 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/v1.MediatedHostDevice"
-      }
+      },
+      "x-kubernetes-list-type": "atomic"
      },
      "pciHostDevices": {
       "type": "array",
       "items": {
        "$ref": "#/definitions/v1.PciHostDevice"
-      }
+      },
+      "x-kubernetes-list-type": "atomic"
      }
     }
    },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -156,6 +156,7 @@ spec:
                         - resourceName
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                     pciHostDevices:
                       items:
                         description: PciHostDevice represents a host PCI device allowed for passthrough
@@ -171,6 +172,7 @@ spec:
                         - resourceName
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
                 selinuxLauncherType:
                   type: string

--- a/pkg/virt-operator/creation/components/validations_generated.go
+++ b/pkg/virt-operator/creation/components/validations_generated.go
@@ -352,6 +352,7 @@ var CRDsValidation map[string]string = map[string]string{
                     - resourceName
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
                 pciHostDevices:
                   items:
                     description: PciHostDevice represents a host PCI device allowed for passthrough
@@ -367,6 +368,7 @@ var CRDsValidation map[string]string = map[string]string{
                     - resourceName
                     type: object
                   type: array
+                  x-kubernetes-list-type: atomic
               type: object
             selinuxLauncherType:
               type: string

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -16641,6 +16641,11 @@ func schema_kubevirtio_client_go_api_v1_PermittedHostDevices(ref common.Referenc
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"pciHostDevices": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -16653,6 +16658,11 @@ func schema_kubevirtio_client_go_api_v1_PermittedHostDevices(ref common.Referenc
 						},
 					},
 					"mediatedDevices": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1608,7 +1608,9 @@ type DeveloperConfiguration struct {
 // PermittedHostDevices holds inforamtion about devices allowed for passthrough
 // +k8s:openapi-gen=true
 type PermittedHostDevices struct {
-	PciHostDevices  []PciHostDevice      `json:"pciHostDevices,omitempty"`
+	// +listType=atomic
+	PciHostDevices []PciHostDevice `json:"pciHostDevices,omitempty"`
+	// +listType=atomic
 	MediatedDevices []MediatedHostDevice `json:"mediatedDevices,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -508,7 +508,9 @@ func (DeveloperConfiguration) SwaggerDoc() map[string]string {
 
 func (PermittedHostDevices) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "PermittedHostDevices holds inforamtion about devices allowed for passthrough\n+k8s:openapi-gen=true",
+		"":                "PermittedHostDevices holds inforamtion about devices allowed for passthrough\n+k8s:openapi-gen=true",
+		"pciHostDevices":  "+listType=atomic",
+		"mediatedDevices": "+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -16496,6 +16496,11 @@ func schema_kubevirtio_client_go_api_v1_PermittedHostDevices(ref common.Referenc
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"pciHostDevices": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -16508,6 +16513,11 @@ func schema_kubevirtio_client_go_api_v1_PermittedHostDevices(ref common.Referenc
 						},
 					},
 					"mediatedDevices": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{


### PR DESCRIPTION
listType=set is used for string lists. We need to use atomic or map for structs. 

```release-note
NONE
```
