### PR TITLE
tests, multus: Fix SRIOV link and IP address configuration

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -1342,11 +1342,10 @@ func defaultCloudInitNetworkData() string {
 	return networkData
 }
 
-func cloudInitNetworkDataWithStaticIPsByMac(nicName, macAddress, ipv4Address string) string {
+func cloudInitNetworkDataWithStaticIPsByMac(nicName, macAddress, ipAddress string) string {
 	networkData, err := libnet.NewNetworkData(
 		libnet.WithEthernet(nicName,
-			libnet.WithAddresses(ipv4Address, libnet.DefaultIPv6CIDR),
-			libnet.WithGateway6(libnet.DefaultIPv6Gateway),
+			libnet.WithAddresses(ipAddress),
 			libnet.WithNameserverFromCluster(),
 			libnet.WithMatchingMAC(macAddress),
 		),
@@ -1355,12 +1354,10 @@ func cloudInitNetworkDataWithStaticIPsByMac(nicName, macAddress, ipv4Address str
 	return networkData
 }
 
-func cloudInitNetworkDataWithStaticIPsByDevice(deviceName, ipv4Address string) string {
+func cloudInitNetworkDataWithStaticIPsByDevice(deviceName, ipAddress string) string {
 	networkData, err := libnet.NewNetworkData(
 		libnet.WithEthernet(deviceName,
-			libnet.WithAddresses(ipv4Address, libnet.DefaultIPv6CIDR),
-			libnet.WithGateway6(libnet.DefaultIPv6Gateway),
-			libnet.WithAddresses(ipv4Address),
+			libnet.WithAddresses(ipAddress),
 			libnet.WithNameserverFromCluster(),
 		),
 	)

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -63,7 +63,7 @@ const (
 const (
 	sriovnet1 = "sriov"
 	sriovnet2 = "sriov2"
-	sriovnet3 = "sriov-link-enabled"
+	sriovnet3 = "sriov3"
 )
 
 var _ = Describe("[Serial]Multus", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed the network name used in the SRIOV configuration to fit a valid ifname.
It caused errors during could-init configuration.

Avoid implicit IPv6 configuration of an address and gateway.
It caused duplication to exist on the LAN.

Fixes: #4621 

```release-note
NONE
```
