### PR TITLE
Consume nightly build images from quay

### DIFF
--- a/hack/ci/entrypoint.sh
+++ b/hack/ci/entrypoint.sh
@@ -36,7 +36,7 @@ function deploy_release() {
 }
 
 function test_kubevirt_nightly() {
-    export DOCKER_PREFIX='kubevirtnightlybuilds'
+    export DOCKER_PREFIX='quay.io/kubevirt'
     local release_url
     release_date=$(get_latest_release_date_for_kubevirt_nightly)
     release_url="$(get_release_url_for_kubevirt_nightly "$release_date")"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We now publish the nightly build images to quay.io (see https://github.com/kubevirt/project-infra/pull/756), so we need to change the nightly job to consume them from there.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fgimenez @rmohr 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
