### PR TITLE
Reject --access-mode ReadOnlyMany when uploading an image.

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -173,6 +173,10 @@ func parseArgs(args []string) error {
 		size = pvcSize
 	}
 
+	if accessMode == string(v1.ReadOnlyMany) {
+		return fmt.Errorf("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported")
+	}
+
 	// check deprecated invocation
 	if name != "" {
 		if len(args) != 0 {

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -447,6 +447,16 @@ var _ = Describe("ImageUpload", func() {
 			Entry("PVC without upload annotation and no annotation map", pvcSpecNoAnnotationMap()),
 		)
 
+		It("Show error when uploading to ReadOnly volume", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--insecure", "--image-path", imagePath, "--access-mode", string(v1.ReadOnlyMany))
+			err := cmd()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported"))
+			Expect(dvCreateCalled).To(BeFalse())
+		})
+
 		AfterEach(func() {
 			testDone()
 		})


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Disallow uploading while specifying ReadOnlyMany access mode. This would create a readonly volume, and CDI will be unable to write the image to it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4624

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtctl upload now shows error when specifying access mode of ReadOnlyMany
```
