### PR TITLE
tests, sriov: XFail IPv6 connectivity test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -195,6 +195,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
+        "//tests/assert:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",

--- a/tests/assert/BUILD.bazel
+++ b/tests/assert/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["xfail.go"],
+    importpath = "kubevirt.io/kubevirt/tests/assert",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/tests/assert/xfail.go
+++ b/tests/assert/xfail.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package assert
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// XFail replaces the default Fail handler with a XFail for one occurrence.
+// XFail skips the test once it fails and leaves a XFAIL label on the message.
+// It is useful to mark tests as XFail when one wants them to run even though they fail,
+// monitoring and collecting information.
+func XFail(reason string) {
+	RegisterFailHandler(func(m string, offset ...int) {
+		defer RegisterFailHandler(Fail)
+		depth := 0
+		if len(offset) > 0 {
+			depth = offset[0]
+		}
+		Skip(fmt.Sprintf("[XFAIL] %s, failure: %s", reason, m), depth+1)
+	})
+}

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -44,6 +44,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -866,6 +867,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			cidrA := "192.168.1.1/24"
 			cidrB := "192.168.1.2/24"
 			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
+
 			Eventually(func() error {
 				return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
 			}, 15*time.Second, time.Second).Should(Succeed())
@@ -878,6 +880,8 @@ var _ = Describe("[Serial]SRIOV", func() {
 			cidrA := "fc00::1/64"
 			cidrB := "fc00::2/64"
 			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
+
+			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642")
 			Eventually(func() error {
 				return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
 			}, 15*time.Second, time.Second).Should(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

The SRIOV connectivity check between SRIOV vnic/s is failing from time
to time [1].

This test is set to XFAIL, i.e. it is left running and in case of
failure, a skip is raised (instead of a failure).
This enables further investigation of the problem.

1. https://github.com/kubevirt/kubevirt/issues/4642

**Release note**:
```release-note
NONE
```
