### PR TITLE
virt-api: relax networkInterfaceMultiqueue semantics

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -574,9 +574,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	// Make sure the port name is unique across all the interfaces
 	portForwardMap := make(map[string]struct{})
 
-	vifMQ := spec.Domain.Devices.NetworkInterfaceMultiQueue
-	isVirtioNicRequested := false
-
 	// Validate that each interface has a matching network
 	for idx, iface := range spec.Domain.Devices.Interfaces {
 
@@ -786,10 +783,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			}
 		}
 
-		if iface.Model == "virtio" || iface.Model == "" {
-			isVirtioNicRequested = true
-		}
-
 		if iface.DHCPOptions != nil {
 			for index, ip := range iface.DHCPOptions.NTPServers {
 				if net.ParseIP(ip).To4() == nil {
@@ -801,16 +794,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 				}
 			}
 		}
-	}
-	// Network interface multiqueue can only be set for a virtio driver
-	if vifMQ != nil && *vifMQ && !isVirtioNicRequested {
-
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "virtio-net multiqueue request, but there are no virtio interfaces defined",
-			Field:   field.Child("domain", "devices", "networkInterfaceMultiqueue").String(),
-		})
-
 	}
 
 	// Validate that every network was assign to an interface

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1834,19 +1834,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should reject vmi with a network multiqueue, without virtio nics", func() {
-			_true := true
-			vmi := v1.NewMinimalVMI("testvm")
-			nic := *v1.DefaultBridgeNetworkInterface()
-			nic.Model = "e1000"
-			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{nic}
-			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
-			vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue = &_true
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.networkInterfaceMultiqueue"))
-		})
-
 		It("should allow BlockMultiQueue with CPU settings", func() {
 			_true := true
 			vmi := v1.NewMinimalVMI("testvm")


### PR DESCRIPTION
As examplified by the discussion about pull #4300,
networkInterfaceMultiqueue should not mean "enable multiqueue at all
costs". It should actually mean "enable multiqueue when it makes sense".
KubeVirt now silently ignores networkInterfaceMultiqueue if the VM has
only one vCPU. With this patch, it would ignore
networkInterfaceMultiqueue also when there the VM has no virtio
interfaces.

This is useful for users who build their VM based on a VM template that
has networkInterfaceMultiqueue enabled, but choose to have no virtio
interfaces in their VM. They want to add interfaces as needed, but not
mangle networkInterfaceMultiqueue.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Special notes for your reviewer**:
The only down side (which I can think of) for this PR is that a user may be able to define an rtl8139 interface, and *think* that networkInterfaceMultiqueue applies to it. The removed validation code protocts against this. However, I don't think it is a strong argument. If the user defines an rtl8139 interface by mistake, but has another virtio interface defined, no protection would be provided. It's good to remove code.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Silently ignore networkInterfaceMultiqueue if no virtio interface is currently defined.
```
