### PR TITLE
Cleanup k8s jobs from test namespaces

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1588,6 +1588,8 @@ func cleanNamespaces() {
 			continue
 		}
 
+		//Remove all Jobs
+		PanicOnError(virtCli.BatchV1().RESTClient().Delete().Namespace(namespace).Resource("jobs").Do().Error())
 		//Remove all HPA
 		PanicOnError(virtCli.AutoscalingV1().RESTClient().Delete().Namespace(namespace).Resource("horizontalpodautoscalers").Do().Error())
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some tests create one-off jobs not directly with pods, but by really
starting a k8s jobs. Delete them in our cleanup paths.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
