### PR TITLE
Prepend kubevirt_ to recording rules and metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,8 +9,8 @@ Sometimes the Help text on `/metrics` endpoint just isn't enough to explain what
 Kubevirt's version information
 
 Labels:
-* `goversion` - GO version used to compile this version of KubeVirt 
-* `kubeversion` - Git commit refspec that created this version of KubeVirt 
+* `goversion` - GO version used to compile this version of KubeVirt
+* `kubeversion` - Git commit refspec that created this version of KubeVirt
 
 ## Node Metric
 
@@ -20,7 +20,7 @@ Labels:
 The total amount of VMIs per node and phase.
 
 Labels:
-* `phase` - Phase of the VMI. It can be one of [Virtual Machine Instance Phases](https://github.com/kubevirt/kubevirt/blob/master/staging/src/kubevirt.io/client-go/api/v1/types.go#L415) 
+* `phase` - Phase of the VMI. It can be one of [Virtual Machine Instance Phases](https://github.com/kubevirt/kubevirt/blob/master/staging/src/kubevirt.io/client-go/api/v1/types.go#L415)
 * `node` - Node where the VMI is running on.
 
 ## VMI Metrics
@@ -34,7 +34,7 @@ All VMI metrics listed below contain, but are not limited to, these three labels
 #### kubevirt_vmi_memory_resident_bytes
 #### HELP kubevirt_vmi_memory_resident_bytes resident set size of the process running the domain.
 
-Total resident memory of the process running the VMI. 
+Total resident memory of the process running the VMI.
 
 #### kubevirt_vmi_memory_available_bytes
 #### HELP kubevirt_vmi_memory_available_bytes amount of usable memory as seen by the domain.
@@ -52,7 +52,7 @@ The total amount of unused memory as seen by the domain.
 The amount of traffic that is being read and written in swap memory.
 
 Extra labels:
-* `type` - Whether the data is being transmitted or received. `in` when transmitting and `out` when receiving. 
+* `type` - Whether the data is being transmitted or received. `in` when transmitting and `out` when receiving.
 
 #### kubevirt_vmi_network_errors_total
 #### HELP kubevirt_vmi_network_errors_total network errors.
@@ -115,7 +115,7 @@ The total amount of time spent in each vcpu state
 
 Extra labels:
 * `id` - Identifier to a single Virtual CPU.
-* `state` - Identify the Virtual CPU state. It can be one of libvirt vcpu's states: `OFFLINE`, `RUNNING` or `BLOCKED` 
+* `state` - Identify the Virtual CPU state. It can be one of libvirt vcpu's states: `OFFLINE`, `RUNNING` or `BLOCKED`
 
 
 
@@ -125,7 +125,7 @@ Improving Kubevirt's Observability is a important topic and we are currently wor
 
 A design proposal and its implementation history can be seen [here](https://docs.google.com/document/d/1bEwrnZZkVsCtz0PSyzlxOdhupL6GTurkUYcz7TXFM1g/edit)
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_vcpu_wait_seconds
 #### HELP kubevirt_vmi_vcpu_wait_seconds vcpu time spent by waiting on I/O.
 ## leading_virt_controller
@@ -133,11 +133,11 @@ A design proposal and its implementation history can be seen [here](https://docs
 ## ready_virt_controller
 #### HELP ready_virt_controller Indication for a virt-controller that is ready to take the lead.
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_outdated_count
 #### HELP kubevirt_vmi_outdated_count Indication for the number of VirtualMachineInstance workloads that are not running within the most up-to-date version of the virt-launcher environment.
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_network_receive_bytes_total
 #### HELP kubevirt_vmi_network_receive_bytes_total Network traffic receive in bytes
 ## kubevirt_vmi_network_receive_errors_total
@@ -154,3 +154,9 @@ A design proposal and its implementation history can be seen [here](https://docs
 #### HELP kubevirt_vmi_network_transmit_packets_dropped_total The number of tx packets dropped on vNIC interfaces.
 ## kubevirt_vmi_network_transmit_packets_total
 #### HELP kubevirt_vmi_network_transmit_packets_total Network traffic transmit packets
+
+ # Other Metrics 
+## kubevirt_leading_virt_controller
+#### HELP kubevirt_leading_virt_controller Indication for an operating virt-controller.
+## kubevirt_ready_virt_controller
+#### HELP kubevirt_ready_virt_controller Indication for a virt-controller that is ready to take the lead.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -36,9 +36,9 @@ tests:
   # Some virt controllers are not ready
   - interval: 1m
     input_series:
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kubevirt_ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
         values: "1 1 1 1 1 1"
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-2"}'
+      - series: 'kubevirt_ready_virt_controller{namespace="ci", pod="virt-controller-2"}'
         values: "0 0 0 0 0 0"
       - series: 'up{namespace="ci", pod="virt-controller-1"}'
         values: "1 1 1 1 1 1"
@@ -55,7 +55,7 @@ tests:
   # All virt controllers are not ready
   - interval: 1m
     input_series:
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kubevirt_ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
         values: "0 0 0 0 0 0"
 
     alert_rule_test:
@@ -67,7 +67,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kubevirt_ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
         values: "0 0 0 0 0 0"
 
     alert_rule_test:

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -91,14 +91,14 @@ var (
 
 	leaderGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "leading_virt_controller",
+			Name: "kubevirt_leading_virt_controller",
 			Help: "Indication for an operating virt-controller.",
 		},
 	)
 
 	readyGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "ready_virt_controller",
+			Name: "kubevirt_ready_virt_controller",
 			Help: "Indication for a virt-controller that is ready to take the lead.",
 		},
 	)

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -99,14 +99,14 @@ var (
 
 	leaderGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "leading_virt_operator",
+			Name: "kubevirt_leading_virt_operator",
 			Help: "Indication for an operating virt-operator.",
 		},
 	)
 
 	readyGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "ready_virt_operator",
+			Name: "kubevirt_ready_virt_operator",
 			Help: "Indication for a virt-operator that is ready to take the lead.",
 		},
 	)

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -488,14 +488,14 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 				Name: "kubevirt.rules",
 				Rules: []promv1.Rule{
 					{
-						Record: "num_of_running_virt_api_servers",
+						Record: "kubevirt_up_virt_api_servers_total",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-api-.*'})", ns),
 						),
 					},
 					{
 						Alert: "VirtAPIDown",
-						Expr:  intstr.FromString("num_of_running_virt_api_servers == 0"),
+						Expr:  intstr.FromString("kubevirt_up_virt_api_servers_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "All virt-api servers are down.",
@@ -507,7 +507,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "LowVirtAPICount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_running_virt_api_servers < 2)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_up_virt_api_servers_total < 2)"),
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-api should be running if more than one worker nodes exist.",
@@ -530,20 +530,20 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
-						Record: "num_of_running_virt_controllers",
+						Record: "kubevirt_up_virt_controllers_total",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'})", ns),
 						),
 					},
 					{
-						Record: "num_of_ready_virt_controllers",
+						Record: "kubevirt_ready_virt_controllers_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(ready_virt_controller{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_ready_virt_controller{namespace='%s'})", ns),
 						),
 					},
 					{
 						Alert: "LowReadyVirtControllersCount",
-						Expr:  intstr.FromString("num_of_ready_virt_controllers <  num_of_running_virt_controllers"),
+						Expr:  intstr.FromString("kubevirt_ready_virt_controllers_total <  kubevirt_up_virt_controllers_total"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "Some virt controllers are running but not ready.",
@@ -551,7 +551,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "NoReadyVirtController",
-						Expr:  intstr.FromString("num_of_ready_virt_controllers == 0"),
+						Expr:  intstr.FromString("kubevirt_ready_virt_controllers_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No ready virt-controller was detected for the last 5 min.",
@@ -559,7 +559,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "VirtControllerDown",
-						Expr:  intstr.FromString("num_of_running_virt_controllers == 0"),
+						Expr:  intstr.FromString("kubevirt_up_virt_controllers_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No running virt-controller was detected for the last 5 min.",
@@ -567,7 +567,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "LowVirtControllersCount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_ready_virt_controllers < 2)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_ready_virt_controllers_total < 2)"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-controller should be ready if more than one worker node.",
@@ -614,14 +614,14 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
-						Record: "num_of_running_virt_operators",
+						Record: "kubevirt_up_virt_operators_total",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-operator-.*'})", ns),
 						),
 					},
 					{
 						Alert: "VirtOperatorDown",
-						Expr:  intstr.FromString("num_of_running_virt_operators == 0"),
+						Expr:  intstr.FromString("kubevirt_up_virt_operators_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "All virt-operator servers are down.",
@@ -629,7 +629,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "LowVirtOperatorCount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_running_virt_operators < 2)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_up_virt_operators_total < 2)"),
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-operator should be running if more than one worker nodes exist.",
@@ -676,20 +676,20 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
-						Record: "num_of_ready_virt_operators",
+						Record: "kubevirt_ready_virt_operators_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(ready_virt_operator{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_ready_virt_operator{namespace='%s'})", ns),
 						),
 					},
 					{
-						Record: "num_of_leading_virt_operators",
+						Record: "kubevirt_leading_virt_operators_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(ready_virt_operator{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_leading_virt_operator{namespace='%s'})", ns),
 						),
 					},
 					{
 						Alert: "LowReadyVirtOperatorsCount",
-						Expr:  intstr.FromString("num_of_ready_virt_operators <  num_of_running_virt_operators"),
+						Expr:  intstr.FromString("kubevirt_ready_virt_operators_total <  kubevirt_up_virt_operators_total"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "Some virt-operators are running but not ready.",
@@ -697,7 +697,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "NoReadyVirtOperator",
-						Expr:  intstr.FromString("num_of_running_virt_operators == 0"),
+						Expr:  intstr.FromString("kubevirt_up_virt_operators_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No ready virt-operator was detected for the last 5 min.",
@@ -705,14 +705,14 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "NoLeadingVirtOperator",
-						Expr:  intstr.FromString("num_of_leading_virt_operators == 0"),
+						Expr:  intstr.FromString("kubevirt_leading_virt_operators_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No leading virt-operator was detected for the last 5 min.",
 						},
 					},
 					{
-						Record: "num_of_running_virt_handlers",
+						Record: "kubevirt_up_virt_handlers_total",
 						Expr:   intstr.FromString(fmt.Sprintf("sum(up{pod=~'virt-handler-.*', namespace='%s'})", ns)),
 					},
 					{

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -624,9 +624,9 @@ var _ = Describe("[Serial]Infrastructure", func() {
 						continue
 					}
 					switch data {
-					case "leading_virt_controller 1":
+					case "kubevirt_leading_virt_controller 1":
 						foundMetrics["leading"]++
-					case "ready_virt_controller 1":
+					case "kubevirt_ready_virt_controller 1":
 						foundMetrics["ready"]++
 					}
 				}
@@ -663,9 +663,9 @@ var _ = Describe("[Serial]Infrastructure", func() {
 						continue
 					}
 					switch data {
-					case "leading_virt_operator 1":
+					case "kubevirt_leading_virt_operator 1":
 						foundMetrics["leading"]++
-					case "ready_virt_operator 1":
+					case "kubevirt_ready_virt_operator 1":
 						foundMetrics["ready"]++
 					}
 				}


### PR DESCRIPTION
Some metrics and recording rules are difficult to find, this patch will
add a kubevirt_ prefix to those, making them more visible.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Generally, every component that ships metrics/alerts, names them with a common prefix, this helps the user search for those in the monitoring UI.
This PR renames and adds the kubevirt_ prefix to the following recording rules and metrics:
num_of_running_virt_api_servers -> kubevirt_up_virt_api_servers_total
num_of_running_virt_operators -> kubevirt_up_virt_operators_total
num_of_running_virt_handlers -> kubevirt_up_virt_handlers_total
num_of_running_virt_controllers -> kubevirt_up_virt_controllers_total
num_of_ready_virt_controllers -> kubevirt_ready_virt_controllers_total
num_of_ready_virt_operators -> kubevirt_ready_virt_operators_total
num_of_leading_virt_operators -> kubevirt_leading_virt_operators_total
leading_virt_controller -> kubevirt_leading_virt_controller
ready_virt_controller -> kubevirt_ready_virt_controller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a kubevirt_ prefix to several recording rules and metrics
```
