### PR TITLE
Parallel datavolume tests

### DIFF
--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "existence.go",
         "getter.go",
+        "owner.go",
         "phase.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/framework/matcher",
@@ -28,6 +29,7 @@ go_test(
     srcs = [
         "existence_test.go",
         "matcher_suite_test.go",
+        "owner_test.go",
         "phase_test.go",
     ],
     embed = [":go_default_library"],
@@ -37,5 +39,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/framework/matcher/getter.go
+++ b/tests/framework/matcher/getter.go
@@ -14,12 +14,17 @@ import (
 
 // ThisPod fetches the latest state of the pod. If the object does not exist, nil is returned.
 func ThisPod(pod *v1.Pod) func() (*v1.Pod, error) {
+	return ThisPodWith(pod.Namespace, pod.Name)
+}
+
+// ThisPodWith fetches the latest state of the pod based on namespace and name. If the object does not exist, nil is returned.
+func ThisPodWith(namespace string, name string) func() (*v1.Pod, error) {
 	return func() (p *v1.Pod, err error) {
 		virtClient, err := kubecli.GetKubevirtClient()
 		if err != nil {
 			return nil, err
 		}
-		p, err = virtClient.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, k8smetav1.GetOptions{})
+		p, err = virtClient.CoreV1().Pods(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -27,14 +32,19 @@ func ThisPod(pod *v1.Pod) func() (*v1.Pod, error) {
 	}
 }
 
-// ThisVMI fetches the latest state of the pod. If the object does not exist, nil is returned.
+// ThisVMI fetches the latest state of the VirtualMachineInstance. If the object does not exist, nil is returned.
 func ThisVMI(vmi *virtv1.VirtualMachineInstance) func() (*virtv1.VirtualMachineInstance, error) {
+	return ThisVMIWith(vmi.Namespace, vmi.Name)
+}
+
+// ThisVMIWith fetches the latest state of the VirtualMachineInstance based on namespace and name. If the object does not exist, nil is returned.
+func ThisVMIWith(namespace string, name string) func() (*virtv1.VirtualMachineInstance, error) {
 	return func() (p *virtv1.VirtualMachineInstance, err error) {
 		virtClient, err := kubecli.GetKubevirtClient()
 		if err != nil {
 			return nil, err
 		}
-		p, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &k8smetav1.GetOptions{})
+		p, err = virtClient.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -42,7 +52,27 @@ func ThisVMI(vmi *virtv1.VirtualMachineInstance) func() (*virtv1.VirtualMachineI
 	}
 }
 
-// AllVMI fetches the latest state of the pod. If the object does not exist, nil is returned.
+// ThisVM fetches the latest state of the VirtualMachine. If the object does not exist, nil is returned.
+func ThisVM(vm *virtv1.VirtualMachine) func() (*virtv1.VirtualMachine, error) {
+	return ThisVMWith(vm.Namespace, vm.Name)
+}
+
+// ThisVMWith fetches the latest state of the VirtualMachine based on namespace and name. If the object does not exist, nil is returned.
+func ThisVMWith(namespace string, name string) func() (*virtv1.VirtualMachine, error) {
+	return func() (p *virtv1.VirtualMachine, err error) {
+		virtClient, err := kubecli.GetKubevirtClient()
+		if err != nil {
+			return nil, err
+		}
+		p, err = virtClient.VirtualMachine(namespace).Get(name, &k8smetav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return
+	}
+}
+
+// AllVMI fetches the latest state of all VMIs in a namespace.
 func AllVMIs(namespace string) func() ([]virtv1.VirtualMachineInstance, error) {
 	return func() (p []virtv1.VirtualMachineInstance, err error) {
 		virtClient, err := kubecli.GetKubevirtClient()
@@ -54,14 +84,39 @@ func AllVMIs(namespace string) func() ([]virtv1.VirtualMachineInstance, error) {
 	}
 }
 
-// ThisDV fetches the latest state of the pod. If the object does not exist, nil is returned.
+// ThisDV fetches the latest state of the DataVolume. If the object does not exist, nil is returned.
 func ThisDV(dv *v1beta1.DataVolume) func() (*v1beta1.DataVolume, error) {
+	return ThisDVWith(dv.Namespace, dv.Name)
+}
+
+// ThisDVWith fetches the latest state of the DataVolume based on namespace and name. If the object does not exist, nil is returned.
+func ThisDVWith(namespace string, name string) func() (*v1beta1.DataVolume, error) {
 	return func() (p *v1beta1.DataVolume, err error) {
 		virtClient, err := kubecli.GetKubevirtClient()
 		if err != nil {
 			return nil, err
 		}
-		p, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(dv.Namespace).Get(context.Background(), dv.Name, k8smetav1.GetOptions{})
+		p, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return
+	}
+}
+
+// ThisPVC fetches the latest state of the PVC. If the object does not exist, nil is returned.
+func ThisPVC(pvc *v1.PersistentVolumeClaim) func() (*v1.PersistentVolumeClaim, error) {
+	return ThisPVCWith(pvc.Namespace, pvc.Name)
+}
+
+// ThisPVCWith fetches the latest state of the PersistentVolumeClaim based on namespace and name. If the object does not exist, nil is returned.
+func ThisPVCWith(namespace string, name string) func() (*v1.PersistentVolumeClaim, error) {
+	return func() (p *v1.PersistentVolumeClaim, err error) {
+		virtClient, err := kubecli.GetKubevirtClient()
+		if err != nil {
+			return nil, err
+		}
+		p, err = virtClient.CoreV1().PersistentVolumeClaims(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/tests/framework/matcher/owner.go
+++ b/tests/framework/matcher/owner.go
@@ -1,0 +1,58 @@
+package matcher
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func BeOwned() types.GomegaMatcher {
+	return ownedMatcher{}
+}
+
+func HaveOwners() types.GomegaMatcher {
+	return ownedMatcher{}
+}
+
+type ownedMatcher struct {
+}
+
+func (o ownedMatcher) Match(actual interface{}) (success bool, err error) {
+	u, err := toUnstructured(actual)
+	if err != nil {
+		return false, nil
+	}
+	if len(u.GetOwnerReferences()) > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (o ownedMatcher) FailureMessage(actual interface{}) (message string) {
+	u, err := toUnstructured(actual)
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("Expected owner references to not be empty, but got '%v'", u)
+}
+
+func (o ownedMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	u, err := toUnstructured(actual)
+	if err != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("Expected owner references to be empty, but got '%v'", u)
+}
+
+func toUnstructured(actual interface{}) (*unstructured.Unstructured, error) {
+	if isNil(actual) {
+		return nil, fmt.Errorf("object does not exist")
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(actual)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
+}

--- a/tests/framework/matcher/owner.go
+++ b/tests/framework/matcher/owner.go
@@ -6,6 +6,8 @@ import (
 	"github.com/onsi/gomega/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
 )
 
 func BeOwned() types.GomegaMatcher {
@@ -47,7 +49,7 @@ func (o ownedMatcher) NegatedFailureMessage(actual interface{}) (message string)
 }
 
 func toUnstructured(actual interface{}) (*unstructured.Unstructured, error) {
-	if isNil(actual) {
+	if helper.IsNil(actual) {
 		return nil, fmt.Errorf("object does not exist")
 	}
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(actual)

--- a/tests/framework/matcher/owner_test.go
+++ b/tests/framework/matcher/owner_test.go
@@ -1,0 +1,36 @@
+package matcher
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Owner", func() {
+
+	var toNilPointer *v1.Pod = nil
+
+	var ownedPod = func(ownerReferences []metav1.OwnerReference) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: ownerReferences,
+			},
+		}
+	}
+
+	table.DescribeTable("should", func(pod interface{}, match bool) {
+		success, err := HaveOwners().Match(pod)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(success).To(Equal(match))
+		Expect(HaveOwners().FailureMessage(pod)).ToNot(BeEmpty())
+		Expect(HaveOwners().NegatedFailureMessage(pod)).ToNot(BeEmpty())
+	},
+		table.Entry("with an owner present report it as present", ownedPod([]metav1.OwnerReference{{}}), true),
+		table.Entry("with no owner present report it as missing", ownedPod([]metav1.OwnerReference{}), false),
+		table.Entry("cope with a nil pod", nil, false),
+		table.Entry("cope with an object pointing to nil", toNilPointer, false),
+		table.Entry("cope with an object which has nil as owners array", ownedPod(nil), false),
+	)
+})

--- a/tests/framework/matcher/phase.go
+++ b/tests/framework/matcher/phase.go
@@ -11,6 +11,18 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher/helper"
 )
 
+func BeRunning() types.GomegaMatcher {
+	return phaseMatcher{
+		expectedPhase: "Running",
+	}
+}
+
+func HaveSucceeded() types.GomegaMatcher {
+	return phaseMatcher{
+		expectedPhase: "Succeeded",
+	}
+}
+
 func BeInPhase(phase interface{}) types.GomegaMatcher {
 	return phaseMatcher{
 		expectedPhase: phase,
@@ -65,7 +77,7 @@ func (p phaseMatcher) FailureMessage(actual interface{}) (message string) {
 	if err != nil {
 		return err.Error()
 	}
-	return fmt.Sprintf("expected phase is %v but got %v", expectedPhase, phase)
+	return fmt.Sprintf("expected phase is '%v' but got '%v'", expectedPhase, phase)
 }
 
 func (p phaseMatcher) NegatedFailureMessage(actual interface{}) (message string) {
@@ -80,7 +92,7 @@ func (p phaseMatcher) NegatedFailureMessage(actual interface{}) (message string)
 	if err != nil {
 		return err.Error()
 	}
-	return fmt.Sprintf("expected phase %v to not match %v", expectedPhase, phase)
+	return fmt.Sprintf("expected phase '%v' to not match '%v'", expectedPhase, phase)
 }
 
 func getCurrentPhase(actual interface{}) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:


Follow up of #4616. Making datavolume test work in parallel and refactor them with more custom ginkgo matchers to make them more maintainable.

***New Matchers***
Add some convenience functions for Running and Succeeded phase which is pretty common to match against:

```go
Expect(ThisDV(dv)).To(HaveSucceeded())
Expect(ThisVMI(vmi)).To(BeRunning())
```

Add matchers which can check for owner refereces in a convenient way:

```go
Expect(ThisVMI(vmi)).To(BeOwned())
Expect(ThisDV(dv)).ToNot(HaveOwners())
```

Checking for object states when just having the `name` and `namespace` at hand is pretty common. To avoid extre pre-pulls to pass in an object to the matchers, add a new set of getters which take `namespace` and `name` directly. They all have a `With` suffix.

Therfore instead of

```go
Expect(ThisVMI(vmi).To(Exist())
```

one can now also do

```go
Expect(ThisVMIWith(namespace, name).To(Exist())
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Seems to roughly save 6-10 minutes per run.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
