### PR TITLE
dev guide, networking: Update the doc net_admin is still required

### DIFF
--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -55,9 +55,8 @@ the following operations, in this order:
 ### Unprivileged VMI networking configuration
 The virt-launcher is an untrusted component of KubeVirt (since it wraps the
 libvirt process that will run third party workloads). As a result, it must be
-run with as little privileges as required. As of now, the only capabilities
-required by virt-launcher to configure networking is the `CAP_NET_ADMIN` and
-the `CAP_NET_RAW` capabilites.
+run with as little privileges as required. As of now, the only capability
+required by virt-launcher to configure networking is the `CAP_NET_ADMIN`.
 
 In this second phase, virt-launcher also has to select the correct
 `BindMechanism`, and afterwards will uses it to retrieve the configuration

--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -55,7 +55,9 @@ the following operations, in this order:
 ### Unprivileged VMI networking configuration
 The virt-launcher is an untrusted component of KubeVirt (since it wraps the
 libvirt process that will run third party workloads). As a result, it must be
-run with as little privileges as required.
+run with as little privileges as required. As of now, the only capabilities
+required by virt-launcher to configure networking is the `CAP_NET_ADMIN` and
+the `CAP_NET_RAW` capabilites.
 
 In this second phase, virt-launcher also has to select the correct
 `BindMechanism`, and afterwards will uses it to retrieve the configuration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
net_admin capability was [re-introduced](https://github.com/kubevirt/kubevirt/pull/4645) to virt-launcher.
Update the dev guide accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
