### PR TITLE
cloud-init: Allow populate networkData alone

### DIFF
--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -323,6 +323,14 @@ var _ = Describe("CloudInit", func() {
 					verifyCloudInitNoCloudIso(cloudInitData)
 				})
 
+				It("should succeed to verify networkData if there is no userData", func() {
+					networkData := "fake\nnetwork\ndata\n"
+					cloudInitData := &v1.CloudInitNoCloudSource{
+						NetworkData: networkData,
+					}
+					verifyCloudInitNoCloudIso(cloudInitData)
+				})
+
 				It("should fail to verify bad cloudInitNoCloud UserDataBase64", func() {
 					source := &v1.CloudInitNoCloudSource{
 						UserDataBase64: "#######garbage******",
@@ -340,13 +348,10 @@ var _ = Describe("CloudInit", func() {
 					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
 				})
 
-				It("should fail to verify networkData without userData", func() {
-					networkData := "FakeNetwork"
-					source := &v1.CloudInitNoCloudSource{
-						NetworkData: networkData,
-					}
+				It("should fail to verify if there is no userData nor networkData", func() {
+					source := &v1.CloudInitNoCloudSource{}
 					_, err := readCloudInitNoCloudSource(source)
-					Expect(err).Should(MatchError("userDataBase64 or userData is required for a cloud-init data source"))
+					Expect(err).Should(MatchError("userDataBase64, userData, networkDataBase64 or networkData is required for a cloud-init data source"))
 				})
 
 				Context("with secretRefs", func() {
@@ -462,15 +467,6 @@ var _ = Describe("CloudInit", func() {
 					}
 					_, err := readCloudInitConfigDriveSource(source)
 					Expect(err.Error()).Should(Equal("illegal base64 data at input byte 0"))
-				})
-
-				It("should fail to verify networkData without userData", func() {
-					networkData := "FakeNetwork"
-					source := &v1.CloudInitConfigDriveSource{
-						NetworkData: networkData,
-					}
-					_, err := readCloudInitConfigDriveSource(source)
-					Expect(err).Should(MatchError("userDataBase64 or userData is required for a cloud-init data source"))
 				})
 
 				Context("with secretRefs", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1475,10 +1475,10 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 				userDataLen = len(userData)
 			}
 
-			if userDataSourceCount != 1 {
+			if userDataSourceCount > 1 {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("%s must have one exactly one userdata source set.", field.Index(idx).Child(dataSourceType).String()),
+					Message: fmt.Sprintf("%s must have only one userdatasource set.", field.Index(idx).Child(dataSourceType).String()),
 					Field:   field.Index(idx).Child(dataSourceType).String(),
 				})
 			}
@@ -1523,6 +1523,14 @@ func validateVolumes(field *k8sfield.Path, volumes []v1.Volume, config *virtconf
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: fmt.Sprintf("%s networkdata exceeds %d byte limit. Should use NetworkDataSecretRef for larger data.", field.Index(idx).Child(dataSourceType).String(), cloudInitNetworkMaxLen),
+					Field:   field.Index(idx).Child(dataSourceType).String(),
+				})
+			}
+
+			if userDataSourceCount == 0 && networkDataSourceCount == 0 {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("%s must have at least one userdatasource or one networkdatasource set.", field.Index(idx).Child(dataSourceType).String()),
 					Field:   field.Index(idx).Child(dataSourceType).String(),
 				})
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is an issue with cloudInit noData and networkData. KubeVirt does not
allow you to set networkData alone, you always must pass userData with it,
even if it is just an empty echo. This change allow to populate at
cloud-init either networkData or userData, removing the dependency
between networkData and userData.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow configure cloud-init with networkData only.
```
