### PR TITLE
Evacuation controller improvement

### DIFF
--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -339,7 +339,7 @@ func getMarkedForEvictionVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.V
 	return evictionCandidates
 }
 
-func generateNewMigration(vmiName string, key string) *virtv1.VirtualMachineInstanceMigration {
+func GenerateNewMigration(vmiName string, key string) *virtv1.VirtualMachineInstanceMigration {
 
 	annotations := map[string]string{
 		virtv1.EvacuationMigrationAnnotation: key,
@@ -419,7 +419,7 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	for _, vmi := range selectedCandidates {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
-			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(generateNewMigration(vmi.Name, node.Name))
+			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(GenerateNewMigration(vmi.Name, node.Name))
 			if err != nil {
 				c.migrationExpectations.CreationObserved(node.Name)
 				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreateVirtualMachineInstanceMigrationReason, "Error creating a Migration: %v", err)

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -165,16 +165,26 @@ func (c *EvacuationController) nodeFromVMI(obj interface{}) string {
 
 func (c *EvacuationController) addMigration(obj interface{}) {
 	migration := obj.(*virtv1.VirtualMachineInstanceMigration)
-	o, exists, err := c.vmiInformer.GetStore().GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
-	if err != nil {
-		return
-	}
-	if exists {
-		node := c.nodeFromVMI(o)
-		if node != "" {
-			c.migrationExpectations.CreationObserved(node)
-			c.Queue.Add(node)
+
+	node := ""
+
+	// only observe the migration expectation if our controller created it
+	key, ok := migration.Annotations[virtv1.EvacuationMigrationAnnotation]
+	if ok {
+		c.migrationExpectations.CreationObserved(key)
+		node = key
+	} else {
+		o, exists, err := c.vmiInformer.GetStore().GetByKey(migration.Namespace + "/" + migration.Spec.VMIName)
+		if err != nil {
+			return
 		}
+		if exists {
+			node = c.nodeFromVMI(o)
+		}
+	}
+
+	if node != "" {
+		c.Queue.Add(node)
 	}
 }
 
@@ -329,6 +339,22 @@ func getMarkedForEvictionVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.V
 	return evictionCandidates
 }
 
+func generateNewMigration(vmiName string, key string) *virtv1.VirtualMachineInstanceMigration {
+
+	annotations := map[string]string{
+		virtv1.EvacuationMigrationAnnotation: key,
+	}
+	return &virtv1.VirtualMachineInstanceMigration{
+		ObjectMeta: v1.ObjectMeta{
+			Annotations:  annotations,
+			GenerateName: "kubevirt-evacuation-",
+		},
+		Spec: virtv1.VirtualMachineInstanceMigrationSpec{
+			VMIName: vmiName,
+		},
+	}
+}
+
 func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.VirtualMachineInstance, activeMigrations []*virtv1.VirtualMachineInstanceMigration) error {
 	// If the node has no drain taint, we have nothing to do
 	taintKey := *c.clusterConfig.GetMigrationConfiguration().NodeDrainTaintKey
@@ -393,14 +419,7 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	for _, vmi := range selectedCandidates {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
-			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(&virtv1.VirtualMachineInstanceMigration{
-				ObjectMeta: v1.ObjectMeta{
-					GenerateName: "kubevirt-evacuation-",
-				},
-				Spec: virtv1.VirtualMachineInstanceMigrationSpec{
-					VMIName: vmi.Name,
-				},
-			})
+			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(generateNewMigration(vmi.Name, node.Name))
 			if err != nil {
 				c.migrationExpectations.CreationObserved(node.Name)
 				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreateVirtualMachineInstanceMigrationReason, "Error creating a Migration: %v", err)

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -94,6 +94,15 @@ var _ = Describe("Evacuation", func() {
 		syncCaches(stop)
 	})
 
+	Context("migration object creation", func() {
+		It("should have expected values and annotations", func() {
+			migration := evacuation.GenerateNewMigration("my-vmi", "somenode")
+			Expect(migration.Spec.VMIName).To(Equal("my-vmi"))
+			Expect(migration.Annotations[v1.EvacuationMigrationAnnotation]).To(Equal("somenode"))
+		})
+
+	})
+
 	Context("no node eviction in progress", func() {
 
 		It("should do nothing with VMIs", func() {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -567,6 +567,9 @@ const (
 	// Machine Instance migration job. Needed because with CRDs we can't use field
 	// selectors. Used on VirtualMachineInstance.
 	MigrationTargetNodeNameLabel string = "kubevirt.io/migrationTargetNodeName"
+	// This annotation indicates that a migration is the result of an
+	// automated evacuation
+	EvacuationMigrationAnnotation string = "kubevirt.io/evacuationMigration"
 	// This label declares whether a particular node is available for
 	// scheduling virtual machine instances on it. Used on Node.
 	NodeSchedulable string = "kubevirt.io/schedulable"


### PR DESCRIPTION
The evacuation controller uses expectations to observe the creation of new migration objects. There's a oversight in how this expectation logic works though. It counts all migration creations as being counted towards meeting the expected creation count rather than just the migrations generated by the evacuation controller.

The result is the evacuation controller logic runs the risk of issuing duplicate migrations for the same VMI if another controller or person is introducing migrations into the system as well. 

I discovered this while working on a new controller that manages automating migrations to perform workload updates. While the evacuation controller is the only controller doing automation today, it won't be for long. Once the workload update controller is introduced, there's a chance these controllers will collide if the evacuation controller doesn't have it's expectation logic fixed. 

```release-note
NONE
```
