### PR TITLE
virt-launcher, converter: Remove vCPU dependency on queue limits

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -199,7 +199,7 @@ func (l *PodInterface) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Inte
 		queueNumber := uint32(0)
 		isMultiqueue := (vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue != nil) && (*vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue)
 		if isMultiqueue {
-			queueNumber, _ = api.CalculateNetworkQueueNumberAndGetCPUTopology(vmi)
+			queueNumber = api.CalculateNetworkQueues(vmi)
 		}
 		if err := driver.preparePodNetworkInterfaces(queueNumber, pid); err != nil {
 			log.Log.Reason(err).Error("failed to prepare pod networking")


### PR DESCRIPTION
**What this PR does / why we need it**:

The number of vCPU is calculated from the CPU topology and the number of
queues for a vNIC based on the vCPU count.

The current implementation limits the number of vCPU/s and
queues based on the vNIC limitation (tap device maximum queues).

While the queue count logic is correct (dependent on the vCPU count and
the tap device limit), the vCPU count is wrongly limited by the queues
limit.
This change drops the vCPU count limit, keeping it dependent only on the CPU
topology.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
