### PR TITLE
Remove FSGroup from Pod spec to allow non-root guest usage of Virtio-FS

### DIFF
--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -75,6 +75,11 @@ func ReplacePVCByHostDisk(vmi *v1.VirtualMachineInstance, clientset kubecli.Kube
 			}
 			// PersistenVolumeClaim is replaced by HostDisk
 			volumeSource.PersistentVolumeClaim = nil
+			// Set ownership of the disk.img to qemu
+			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(file); err != nil && !os.IsNotExist(err) {
+				log.Log.Reason(err).Errorf("Couldn't set Ownership on %s: %v", file, err)
+				return err
+			}
 		}
 	}
 	return nil
@@ -176,6 +181,7 @@ func (hdc DiskImgCreator) Create(vmi *v1.VirtualMachineInstance) error {
 			} else if err != nil {
 				return err
 			}
+			// Change file ownership to the qemu user.
 			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(diskPath); err != nil {
 				log.Log.Reason(err).Errorf("Couldn't set Ownership on %s: %v", diskPath, err)
 				return err

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1163,7 +1163,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 			Subdomain: vmi.Spec.Subdomain,
 			SecurityContext: &k8sv1.PodSecurityContext{
 				RunAsUser: &userId,
-				FSGroup:   &t.launcherSubGid,
 			},
 			TerminationGracePeriodSeconds: &gracePeriodKillAfter,
 			RestartPolicy:                 k8sv1.RestartPolicyNever,

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -75,20 +75,22 @@ var _ = Describe("Storage", func() {
 
 	Describe("Starting a VirtualMachineInstance", func() {
 		var vmi *v1.VirtualMachineInstance
+		var targetImagePath string
 
 		BeforeEach(func() {
 			vmi = nil
+			targetImagePath = tests.HostPathAlpine
 		})
 
-		initNFS := func() *k8sv1.Pod {
+		initNFS := func(targetImage string) *k8sv1.Pod {
 			tests.SkipNFSTestIfRunnigOnKindInfra()
 
 			// Prepare a NFS backed PV
 			By("Starting an NFS POD")
-			nfsPod := storageframework.RenderNFSServer("nfsserver", tests.HostPathAlpine)
+			nfsPod := storageframework.RenderNFSServer("nfsserver", targetImage)
 			nfsPod, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(nfsPod)
 			Expect(err).ToNot(HaveOccurred())
-			Eventually(ThisPod(nfsPod), 120).Should(BeInPhase(k8sv1.PodRunning))
+			Eventually(ThisPod(nfsPod), 180).Should(BeInPhase(k8sv1.PodRunning))
 			nfsPod, err = ThisPod(nfsPod)()
 			Expect(err).ToNot(HaveOccurred())
 			return nfsPod
@@ -106,13 +108,53 @@ var _ = Describe("Storage", func() {
 			return pvName
 		}
 
+		runHostPathJobAndExpectCompletion := func(pod *k8sv1.Pod) {
+			pod, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(pod)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(ThisPod(pod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
+			_, err = ThisPod(pod)()
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		copyAlpineWithNonQEMUPermissions := func() string {
+
+			dstPath := tests.HostPathAlpine + "-nopriv"
+
+			hostPathType := k8sv1.HostPathDirectoryOrCreate
+
+			args := []string{fmt.Sprintf(`mkdir -p %[1]s-nopriv && cp %[1]s/disk.img %[1]s-nopriv/ && chmod 644 %[1]s-nopriv/disk.img`, tests.HostPathAlpine)}
+
+			By("creating an image with without qemu permissions")
+			pod := tests.RenderHostPathPod("tmp-image-create-job", tests.HostPathBase, hostPathType, k8sv1.MountPropagationNone, []string{"/bin/bash", "-c"}, args)
+
+			runHostPathJobAndExpectCompletion(pod)
+			return dstPath
+		}
+
+		deleteAlpineWithNonQEMUPermissions := func() {
+
+			dst := tests.HostPathAlpine + "-nopriv"
+
+			hostPathType := k8sv1.HostPathDirectoryOrCreate
+
+			args := []string{fmt.Sprintf(`rm -rf %s`, dst)}
+
+			pod := tests.RenderHostPathPod("remove-tmp-image-job", tests.HostPathBase, hostPathType, k8sv1.MountPropagationNone, []string{"/bin/bash", "-c"}, args)
+
+			runHostPathJobAndExpectCompletion(pod)
+		}
+
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]with Alpine PVC", func() {
 
 			Context("should be successfully", func() {
 				var pvName string
 				var nfsPod *k8sv1.Pod
-
-				table.DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily) {
+				AfterEach(func() {
+					if targetImagePath != tests.HostPathAlpine {
+						deleteAlpineWithNonQEMUPermissions()
+					}
+				})
+				table.DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily, imageOwnedByQEMU bool) {
 					tests.SkipPVCTestIfRunnigOnKindInfra()
 					if family == k8sv1.IPv6Protocol {
 						libnet.SkipWhenNotDualStackCluster(virtClient)
@@ -121,7 +163,11 @@ var _ = Describe("Storage", func() {
 					var ignoreWarnings bool
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {
-						nfsPod = initNFS()
+						targetImage := targetImagePath
+						if !imageOwnedByQEMU {
+							targetImage = copyAlpineWithNonQEMUPermissions()
+						}
+						nfsPod = initNFS(targetImage)
 						pvName = createNFSPvAndPvc(family, nfsPod)
 						ignoreWarnings = true
 					} else {
@@ -129,15 +175,16 @@ var _ = Describe("Storage", func() {
 					}
 					vmi = newVMI(pvName)
 
-					tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 120, ignoreWarnings)
+					tests.RunVMIAndExpectLaunchWithIgnoreWarningArg(vmi, 180, ignoreWarnings)
 
 					By("Checking that the VirtualMachineInstance console has expected output")
 					Expect(console.LoginToAlpine(vmi)).To(Succeed())
 				},
-					table.Entry("[test_id:3130]with Disk PVC", tests.NewRandomVMIWithPVC, "", nil),
-					table.Entry("[test_id:3131]with CDRom PVC", tests.NewRandomVMIWithCDRom, "", nil),
-					table.Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol),
-					table.Entry("with NFS Disk PVC using ipv6 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol),
+					table.Entry("[test_id:3130]with Disk PVC", tests.NewRandomVMIWithPVC, "", nil, true),
+					table.Entry("[test_id:3131]with CDRom PVC", tests.NewRandomVMIWithCDRom, "", nil, true),
+					table.Entry("[test_id:4618]with NFS Disk PVC using ipv4 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, true),
+					table.Entry("with NFS Disk PVC using ipv6 address of the NFS pod", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv6Protocol, true),
+					table.Entry("with NFS Disk PVC using ipv4 address of the NFS pod not owned by qemu", tests.NewRandomVMIWithPVC, "nfs", k8sv1.IPv4Protocol, false),
 				)
 			})
 
@@ -347,7 +394,7 @@ var _ = Describe("Storage", func() {
 					var ignoreWarnings bool
 					// Start the VirtualMachineInstance with the PVC attached
 					if storageEngine == "nfs" {
-						nfsPod = initNFS()
+						nfsPod = initNFS(tests.HostPathAlpine)
 						pvName = createNFSPvAndPvc(family, nfsPod)
 						ignoreWarnings = true
 					} else {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1554,44 +1554,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			Expect(event).To(BeNil(), "virt-handler tried to sync on a VirtualMachineInstance in final state")
 		})
 	})
-
-	Describe("Defaults", func() {
-		Context("FSGroup", func() {
-			It("[test_id:4120]Should run with qemu as supplemental group", func() {
-				By("Starting VirtualMachineInstance")
-				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
-				Expect(err).To(BeNil(), "Create VMI successfully")
-				tests.WaitForSuccessfulVMIStart(vmi)
-
-				By("Checking supplemental groups of PID 1")
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, vmi.Namespace)
-				Expect(pod).NotTo(BeNil())
-				output, err := tests.ExecuteCommandOnPod(
-					virtClient,
-					pod,
-					pod.Spec.Containers[0].Name,
-					[]string{"ps", "-o", "supgrp", "1"},
-				)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(output).To(ContainSubstring("qemu"))
-
-				By("Looking up qemu's UID")
-				output, err = tests.ExecuteCommandOnPod(
-					virtClient,
-					pod,
-					pod.Spec.Containers[0].Name,
-					[]string{"id", "-g", "qemu"},
-				)
-				Expect(err).ToNot(HaveOccurred())
-
-				qemuGroup, err := strconv.Atoi(strings.TrimSpace(output))
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(pod.Spec.SecurityContext.FSGroup).ToNot(BeNil())
-				Expect(int(*pod.Spec.SecurityContext.FSGroup)).To(Equal(qemuGroup))
-			})
-		})
-	})
 })
 
 func renderPkillAllPod(processName string) *k8sv1.Pod {


### PR DESCRIPTION
Currently, Virtio-FS is horribly broken when trying to do file operations as a non root user inside a guest.

Trying to write to a file leads to a very strange behavior:
```
open("test5", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
write(3, "data\n", 5)                   = -1 EPERM
```

The file descriptor opens, but the actual write fails with a permission error. Not very POSIX compliant. The source of this is the `fsGroup` that gets set in the security context of the virt-launcher Pod. As the `runAsUser` is root, I do not see the point of setting `fsGroup` and have simply removed it. Another option would be to just disable it when there are `Filesystems` attached, but introducing such subtle behavior changes can lead to more headaches down the line.

Is there a good reason to keep `fsGroup`?

**Special notes for your reviewer**:

```release-note
Fixed an issue where non-root users inside a guest could not write to a Virtio-FS mount.
```
