### PR TITLE
virt-launcher: Remove unused arg from GetDomainSpecWithRuntimeInfo

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -224,7 +224,7 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 			domain.SetState(util.ConvState(status), util.ConvReason(status, reason))
 		}
 
-		spec, err := util.GetDomainSpecWithRuntimeInfo(status, d)
+		spec, err := util.GetDomainSpecWithRuntimeInfo(d)
 		if err != nil {
 			// NOTE: Getting domain metadata for a live-migrating VM isn't allowed
 			if !domainerrors.IsNotFound(err) && !domainerrors.IsInvalidOperation(err) {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1555,15 +1555,14 @@ func isBlockDeviceVolumeFunc(volumeName string) (bool, error) {
 }
 
 func (l *LibvirtDomainManager) getDomainSpec(dom cli.VirDomain) (*api.DomainSpec, error) {
-	state, _, err := dom.GetState()
-	if err != nil {
-		return nil, err
-	}
-
-	domainSpec, err := util.GetDomainSpecWithRuntimeInfo(state, dom)
+	domainSpec, err := util.GetDomainSpecWithRuntimeInfo(dom)
 	if err != nil {
 		// Return without runtime info only for cases we know for sure it's not supposed to be there
 		if domainerrors.IsNotFound(err) || domainerrors.IsInvalidOperation(err) {
+			state, _, err := dom.GetState()
+			if err != nil {
+				return nil, err
+			}
 			return util.GetDomainSpec(state, dom)
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1105,7 +1105,6 @@ var _ = Describe("Manager", func() {
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
-			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 
 			domainXml, err := xml.MarshalIndent(domainSpec, "", "\t")
 			Expect(err).To(BeNil())

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -117,7 +117,7 @@ func SetDomainSpecStrWithHooks(virConn cli.Connection, vmi *v1.VirtualMachineIns
 }
 
 // GetDomainSpecWithRuntimeInfo return the active domain XML with runtime information embedded
-func GetDomainSpecWithRuntimeInfo(status libvirt.DomainState, dom cli.VirDomain) (*api.DomainSpec, error) {
+func GetDomainSpecWithRuntimeInfo(dom cli.VirDomain) (*api.DomainSpec, error) {
 
 	// get libvirt xml with runtime status
 	activeSpec, err := GetDomainSpecWithFlags(dom, 0)


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes an unused argument from the `GetDomainSpecWithRuntimeInfo` function.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
