### PR TITLE
Fix eventually and improve watcher

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -153,7 +153,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				Eventually(func() (*corev1.PersistentVolumeClaim, error) {
 					return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(dv.Name, metav1.GetOptions{})
-				}).Should(Not(BeNil()), 30)
+				}, 30).Should(Not(BeNil()))
 
 				vmi := tests.NewRandomVMI()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Two issues are addressed here:

One test tried to pass in a timeout in the description field, leading to this error

```
tests/vm_test.go:143
Test Panicked
GOROOT/src/runtime/iface.go:255

Panic: interface conversion: interface {} is int, not string
```

Sometimes we see tests which are starting the same VMI multiple times failing with this warning

```
vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
Unexpected Warning event received: testvmi-k2wwmf99nxtm,8dbe46b9-564e-4e2f-bb30-53a77f2d82d7: unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded
Expected
    <string>: Warning
not to equal
    <string>: Warning
tests/utils.go:360
```

This happened due to not exact enough registered watchers. Sometimes we still detected the stop of the previous VMI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Pulls out two commits from #4616 since I don't have 100% confidence in it yet but these two fixes are relevant independent of it.

**Release note**:

```release-note
NONE
```
