### PR TITLE
Fix support for camelCase userData and networkData labels in secret-based cloud init volumes

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -149,12 +149,12 @@ func resolveNoCloudSecrets(vmi *v1.VirtualMachineInstance, secretSourceDir strin
 	baseDir := filepath.Join(secretSourceDir, volume.Name)
 	userData, userDataError := readFileFromDir(baseDir, "userdata")
 	// If "userdata" was not found, try "userData"
-	if userDataError != nil && os.IsNotExist(userDataError) {
+	if userDataError != nil {
 		userData, userDataError = readFileFromDir(baseDir, "userData")
 	}
 	networkData, networkDataError := readFileFromDir(baseDir, "networkdata")
 	// If "networkdata" was not found, try "networkData"
-	if networkDataError != nil && os.IsNotExist(networkDataError) {
+	if networkDataError != nil {
 		networkData, networkDataError = readFileFromDir(baseDir, "networkData")
 	}
 	if userDataError != nil && networkDataError != nil {
@@ -227,12 +227,12 @@ func resolveConfigDriveSecrets(vmi *v1.VirtualMachineInstance, secretSourceDir s
 	baseDir := filepath.Join(secretSourceDir, volume.Name)
 	userData, userDataError := readFileFromDir(baseDir, "userdata")
 	// If "userdata" was not found, try "userData"
-	if userDataError != nil && os.IsNotExist(userDataError) {
+	if userDataError != nil {
 		userData, userDataError = readFileFromDir(baseDir, "userData")
 	}
 	networkData, networkDataError := readFileFromDir(baseDir, "networkdata")
 	// If "networkdata" was not found, try "networkData"
-	if networkDataError != nil && os.IsNotExist(networkDataError) {
+	if networkDataError != nil {
 		networkData, networkDataError = readFileFromDir(baseDir, "networkData")
 	}
 	if userDataError != nil && networkDataError != nil {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -550,6 +550,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 					SubPath:   "userdata",
 					ReadOnly:  true,
 				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userData"),
+					SubPath:   "userData",
+					ReadOnly:  true,
+				})
 			}
 			if volume.CloudInitNoCloud.NetworkDataSecretRef != nil {
 				// attach a secret referenced by the networkdata
@@ -566,6 +572,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 					Name:      volumeName,
 					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkdata"),
 					SubPath:   "networkdata",
+					ReadOnly:  true,
+				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkData"),
+					SubPath:   "networkData",
 					ReadOnly:  true,
 				})
 			}
@@ -589,6 +601,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 					SubPath:   "userdata",
 					ReadOnly:  true,
 				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "userData"),
+					SubPath:   "userData",
+					ReadOnly:  true,
+				})
 			}
 			if volume.CloudInitConfigDrive.NetworkDataSecretRef != nil {
 				// attach a secret referenced by the networkdata
@@ -605,6 +623,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 					Name:      volumeName,
 					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkdata"),
 					SubPath:   "networkdata",
+					ReadOnly:  true,
+				})
+				volumeMounts = append(volumeMounts, k8sv1.VolumeMount{
+					Name:      volumeName,
+					MountPath: filepath.Join(config.SecretSourceDir, volume.Name, "networkData"),
+					SubPath:   "networkData",
 					ReadOnly:  true,
 				})
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds missing volume mounts for camelCase versions of secret-based userData and networkData.
It also fixes error checking since a broken mount (missing source) will actually create an empty directory instead of doing nothing.
Finally, it adds a functional test to ensure secret-based camelCase userData and networkData work correctly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1862997

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
