### PR TITLE
Append rootfs mount to containerdisk base path

### DIFF
--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -236,7 +236,7 @@ func (m *mounter) Mount(vmi *v1.VirtualMachineInstance, verify bool) error {
 				if err != nil {
 					return fmt.Errorf("failed to detect root mount point of containerDisk %v on the node: %v", volume.Name, err)
 				}
-				sourceFile, err := containerdisk.GetImage(filepath.Join(nodeRes.MountRoot(), nodeMountInfo.Root, nodeMountInfo.MountPoint), volume.ContainerDisk.Path)
+				sourceFile, err := containerdisk.GetImage(filepath.Join(nodeRes.MountRoot(), nodeMountInfo.Root, nodeMountInfo.MountPoint, mountInfo.Root), volume.ContainerDisk.Path)
 				if err != nil {
 					return fmt.Errorf("failed to find a sourceFile in containerDisk %v: %v", volume.Name, err)
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR enables running VMs with containerdisk on the systems with `devicemapper` filesystem backend enabled.

In the scenario when `devicemapper` backend is used, the container filesystem gets mounted at `/var/lib/docker/devicemapper/mnt/<ID>/rootfs`. Previously the last part of the path (i.e. `/rootfs`) was missing and that was causing errors durinng VM startup:

```
open /proc/1/root/var/lib/docker/devicemapper/mnt/f98b595a54f0d1deec6b86c21996eacd3ce7cf3963d123d7dd0af9d59869f40f/disk: no such file or directory
```

`mountInfo.Root`  seems to contain the needed rootfs mount info. Appending it to the base path fixes the issue. The correct path will be `/proc/1/root/var/lib/docker/devicemapper/mnt/f98b595a54f0d1deec6b86c21996eacd3ce7cf3963d123d7dd0af9d59869f40f/rootfs/disk`.

Fixes #4613

**Special notes for your reviewer**:

This is my first PR here. Tested the changes with the default overlay setup as well as with the configured devicemapper.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
