### PR TITLE
tests, sriov: XFail IPv4 connectivity test

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -868,6 +868,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			cidrB := "192.168.1.2/24"
 			vmi1, vmi2 := createSriovVMs(cidrA, cidrB)
 
+			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642")
 			Eventually(func() error {
 				return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
 			}, 15*time.Second, time.Second).Should(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:

The SRIOV connectivity check between SRIOV vnic/s is failing from time
to time [1].
This is happening now for IPv4 in addition to the existing IPv6 test
which is already marked as XFail.

This test is set to XFAIL, i.e. it is left running and in case of
failure, a skip is raised (instead of a failure).
This enables further investigation of the problem.

1. https://github.com/kubevirt/kubevirt/issues/4642

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Unfortunately this started to occur too often now to ignore (counting 3 times today).
A following PR will be posted to allow proper debugging of this issue.

**Release note**:
```release-note
NONE
```
