### PR TITLE
only validate status of vm, vmi, and vmi migration objects

### DIFF
--- a/pkg/virt-operator/creation/components/webhooks.go
+++ b/pkg/virt-operator/creation/components/webhooks.go
@@ -476,7 +476,11 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 					Rule: v1beta1.Rule{
 						APIGroups:   []string{virtv1.GroupName},
 						APIVersions: virtv1.ApiSupportedWebhookVersions,
-						Resources:   []string{"*/status"},
+						Resources: []string{
+							"virtualmachines/status",
+							"virtualmachineinstancereplicasets/status",
+							"virtualmachineinstancemigrations/status",
+						},
 					},
 				}},
 				ClientConfig: v1beta1.WebhookClientConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

We are currently sending any kubvirt.io resource that has it's status updated to the validation webhook when we only need to be sending vms, vmireplicasets, and vmimigrations resource status' according to [this PR](https://github.com/kubevirt/kubevirt/pull/3889)

Right now once this validationwebhookconfiguration` is created if we try to update the KubeVirt CR status it will error which triggers another sync, which makes the resync run a few more times than is needed. I also think it's helpful to understand which resources the validation hook is validating.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
