### PR TITLE
virt-launcher, libvirt: Free (all) domain resources (fix leaks)

### DIFF
--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -476,7 +476,11 @@ func (l *AccessCredentialManager) reportAccessCredentialResult(vmi *v1.VirtualMa
 		return nil
 	}
 
-	_, err = util.SetDomainSpecStrWithHooks(l.virConn, vmi, domainSpec)
+	d, err := util.SetDomainSpecStrWithHooks(l.virConn, vmi, domainSpec)
+	if err != nil {
+		return err
+	}
+	defer d.Free()
 	return err
 }
 

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -229,6 +229,7 @@ func (l *LibvirtConnection) QemuAgentCommand(command string, domainName string) 
 	if err != nil {
 		return "", err
 	}
+	defer domain.Free()
 	result, err := domain.QemuAgentCommand(command, libvirt.DOMAIN_QEMU_AGENT_COMMAND_DEFAULT, uint32(0))
 	return result, err
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -210,10 +210,11 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 		StartTimestamp: &now,
 		Mode:           migrationMode,
 	}
-	_, err = l.setDomainSpecWithHooks(vmi, domainSpec)
+	d, err := l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return false, err
 	}
+	defer d.Free()
 	return false, nil
 }
 
@@ -305,10 +306,11 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 		domainSpec.Metadata.KubeVirt.Migration.Completed = true
 		domainSpec.Metadata.KubeVirt.Migration.EndTimestamp = &now
 	}
-	_, err = l.setDomainSpecWithHooks(vmi, domainSpec)
+	d, err := l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return err
 	}
+	defer d.Free()
 	return nil
 
 }
@@ -463,6 +465,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 			l.setMigrationResult(vmi, true, fmt.Sprintf("%v", err), "")
 			return
 		}
+		defer dom.Free()
 
 		migrateFlags := prepareMigrationFlags(isBlockMigration, options.UnsafeMigration, options.AllowAutoConverge, options.AllowPostCopy)
 		if options.UnsafeMigration {
@@ -489,7 +492,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		// start live migration tracking
 		migrationErrorChan := make(chan error, 1)
 		defer close(migrationErrorChan)
-		go liveMigrationMonitor(vmi, dom, l, options, migrationErrorChan)
+		go liveMigrationMonitor(vmi, l, options, migrationErrorChan)
 
 		err = dom.MigrateToURI3(dstURI, params, migrateFlags)
 		if err != nil {
@@ -516,30 +519,11 @@ func (l *LibvirtDomainManager) SetGuestTime(vmi *v1.VirtualMachineInstance) erro
 		log.Log.Object(vmi).Reason(err).Error("failed to sync guest time")
 		return err
 	}
-	// try setting the guest time. Fail early if agent is not configured.
-	l.setGuestTime(vmi, dom)
-	return nil
-}
 
-func (l *LibvirtDomainManager) getGuestTimeContext() context.Context {
-	l.setGuestTimeLock.Lock()
-	defer l.setGuestTimeLock.Unlock()
+	go func() {
+		defer dom.Free()
 
-	// cancel the already running setGuestTime go-routine if such exist
-	if l.setGuestTimeContextPtr != nil {
-		l.setGuestTimeContextPtr.cancel()
-	}
-	// create a new context and store it
-	ctx, cancel := context.WithCancel(context.Background())
-	l.setGuestTimeContextPtr = &contextStore{ctx: ctx, cancel: cancel}
-	return ctx
-}
-
-func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance, dom cli.VirDomain) {
-	// get new context
-	ctx := l.getGuestTimeContext()
-
-	go func(ctx context.Context, vmi *v1.VirtualMachineInstance, dom cli.VirDomain) {
+		ctx := l.getGuestTimeContext()
 		timeout := time.After(60 * time.Second)
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
@@ -581,7 +565,23 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance, dom 
 				}
 			}
 		}
-	}(ctx, vmi, dom)
+	}()
+
+	return nil
+}
+
+func (l *LibvirtDomainManager) getGuestTimeContext() context.Context {
+	l.setGuestTimeLock.Lock()
+	defer l.setGuestTimeLock.Unlock()
+
+	// cancel the already running setGuestTime go-routine if such exist
+	if l.setGuestTimeContextPtr != nil {
+		l.setGuestTimeContextPtr.cancel()
+	}
+	// create a new context and store it
+	ctx, cancel := context.WithCancel(context.Background())
+	l.setGuestTimeContextPtr = &contextStore{ctx: ctx, cancel: cancel}
+	return ctx
 }
 
 func getVMIEphemeralDisksTotalSize() *resource.Quantity {
@@ -621,9 +621,19 @@ func getVMIMigrationDataSize(vmi *v1.VirtualMachineInstance) int64 {
 	return memory.ScaledValue(resource.Giga)
 }
 
-func liveMigrationMonitor(vmi *v1.VirtualMachineInstance, dom cli.VirDomain, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationErr chan error) {
+func liveMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationErr chan error) {
 
 	logger := log.Log.Object(vmi)
+
+	domName := api.VMINamespaceKeyFunc(vmi)
+	dom, err := l.virConn.LookupDomainByName(domName)
+	if err != nil {
+		logger.Reason(err).Error("Live migration failed.")
+		l.setMigrationResult(vmi, true, fmt.Sprintf("%v", err), "")
+		return
+	}
+	defer dom.Free()
+
 	start := time.Now().UTC().Unix()
 	lastProgressUpdate := start
 	progressWatermark := int64(0)
@@ -784,6 +794,7 @@ func (l *LibvirtDomainManager) asyncMigrationAbort(vmi *v1.VirtualMachineInstanc
 			log.Log.Object(vmi).Reason(err).Warning("failed to cancel migration, domain not found ")
 			return
 		}
+		defer dom.Free()
 		stats, err := dom.GetJobInfo()
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Error("failed to get domain job info")
@@ -1340,6 +1351,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 			if err != nil {
 				return nil, err
 			}
+			defer dom.Free()
 			logger.Info("Domain defined.")
 		} else {
 			logger.Reason(err).Error("Getting the domain failed.")
@@ -1360,6 +1372,7 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 		if err != nil {
 			return nil, err
 		}
+		defer dom.Free()
 	}
 
 	// TODO Suspend, Pause, ..., for now we only support reaching the running state
@@ -1646,7 +1659,9 @@ func (l *LibvirtDomainManager) UnpauseVMI(vmi *v1.VirtualMachineInstance) error 
 		l.paused.remove(vmi.UID)
 		// Try to set guest time after this commands execution.
 		// This operation is not disruptive.
-		l.setGuestTime(vmi, dom)
+		if err := l.SetGuestTime(vmi); err != nil {
+			return err
+		}
 
 	} else {
 		logger.Infof("Domain is not paused for %s", vmi.GetObjectMeta().GetName())
@@ -1686,10 +1701,11 @@ func (l *LibvirtDomainManager) MarkGracefulShutdownVMI(vmi *v1.VirtualMachineIns
 		domainSpec.Metadata.KubeVirt.GracePeriod.MarkedForGracefulShutdown = &t
 	}
 
-	_, err = l.setDomainSpecWithHooks(vmi, domainSpec)
+	d, err := l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return err
 	}
+	defer d.Free()
 	return nil
 
 }
@@ -1734,11 +1750,12 @@ func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance)
 
 			now := metav1.Now()
 			domSpec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp = &now
-			_, err = l.setDomainSpecWithHooks(vmi, domSpec)
+			d, err := l.setDomainSpecWithHooks(vmi, domSpec)
 			if err != nil {
 				log.Log.Object(vmi).Reason(err).Error("Unable to update grace period start time on domain xml")
 				return err
 			}
+			defer d.Free()
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -125,6 +125,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -147,6 +148,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -168,6 +170,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -201,6 +204,7 @@ var _ = Describe("Manager", func() {
 				mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 				mockDomain.EXPECT().Create().Return(nil)
 				mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
+				mockDomain.EXPECT().Free()
 				manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 				newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 				Expect(err).To(BeNil())
@@ -292,6 +296,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().SetTime(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(interface{}, interface{}, interface{}) {
 				isSetTimeCalled <- true
 			})
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 
 			err := manager.UnpauseVMI(vmi)
@@ -444,6 +449,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().AttachDevice(strings.ToLower(string(attachBytes)))
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -555,6 +561,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().DetachDevice(strings.ToLower(string(detachBytes)))
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -635,6 +642,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -738,6 +746,7 @@ var _ = Describe("Manager", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockDomain.EXPECT().Create().Return(nil)
 			mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xmlDomain2), nil)
+			mockDomain.EXPECT().Free()
 			manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).To(BeNil())
@@ -807,6 +816,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetJobInfo().AnyTimes().Return(fake_jobinfo, nil)
 			mockDomain.EXPECT().AbortJob()
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(xml), nil)
@@ -815,7 +825,7 @@ var _ = Describe("Manager", func() {
 				AnyTimes().
 				Return("<kubevirt></kubevirt>", nil)
 
-			liveMigrationMonitor(vmi, mockDomain, manager, options, migrationErrorChan)
+			liveMigrationMonitor(vmi, manager, options, migrationErrorChan)
 		})
 		It("migration should be canceled if timeout has been reached", func() {
 			migrationErrorChan := make(chan error)
@@ -852,6 +862,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetJobInfo().AnyTimes().Return(fake_jobinfo, nil)
 			mockDomain.EXPECT().AbortJob()
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(xml), nil)
@@ -860,7 +871,7 @@ var _ = Describe("Manager", func() {
 				AnyTimes().
 				Return("<kubevirt></kubevirt>", nil)
 
-			liveMigrationMonitor(vmi, mockDomain, manager, options, migrationErrorChan)
+			liveMigrationMonitor(vmi, manager, options, migrationErrorChan)
 		})
 		It("migration should switch to PostCopy", func() {
 			migrationErrorChan := make(chan error)
@@ -904,6 +915,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockDomain.EXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetJobInfo().AnyTimes().DoAndReturn(func() (*libvirt.DomainJobInfo, error) {
 				return fake_jobinfo(), nil
 			})
@@ -930,7 +942,7 @@ var _ = Describe("Manager", func() {
 				return mockDomain, nil
 			})
 
-			liveMigrationMonitor(vmi, mockDomain, manager, options, migrationErrorChan)
+			liveMigrationMonitor(vmi, manager, options, migrationErrorChan)
 		})
 		It("migration should be canceled when requested", func() {
 			// Make sure that we always free the domain after use

--- a/pkg/virt-launcher/virtwrap/postcopy.go
+++ b/pkg/virt-launcher/virtwrap/postcopy.go
@@ -18,10 +18,11 @@ func (l *LibvirtDomainManager) updateVMIMigrationMode(dom cli.VirDomain, vmi *v1
 
 	domainSpec.Metadata.KubeVirt.Migration.Mode = mode
 
-	_, err = l.setDomainSpecWithHooks(vmi, domainSpec)
+	d, err := l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return err
 	}
+	defer d.Free()
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Not all instances of the libvirt domain are released (free).
In turn, this causes memory leaks during the lifetime of the
virt-launcher.

Whenever a domain is retrieved from the libvirt-go package
successfully, it is now freed using a "defer".

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
