### PR TITLE
Generate release manifests using quay images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
     branch: master
     condition: $TRAVIS_CPU_ARCH = amd64
 - provider: script
-  script: docker login -u="$DOCKER_USER" -p="$DOCKER_PASS" && DOCKER_PREFIX="index.docker.io/kubevirt"
+  script: docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" quay.io && DOCKER_PREFIX="quay.io/kubevirt"
     DOCKER_TAG="$TRAVIS_TAG" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub"
     sh -c 'make bazel-push-images && make manifests'
   skip_cleanup: true


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We are in the process of migrating from DockerHub to Quay.io, after verifying that the prow jobs for publishing images to Quay.io worked well for 0.36 this PR introduces the required changes to reference the artifact images published to quay in the release manifests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
