### PR TITLE
Set VMI status to pending on creation

### DIFF
--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -275,11 +275,6 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			vmiStatus, err = readNewStatus(stdout, vmiStatus, readTimeout)
 			Expect(err).ToNot(HaveOccurred())
 		}
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex)),
-			"VMI should not have a specified phase yet")
-
-		vmiStatus, err = readNewStatus(stdout, vmiStatus, readTimeout)
-		Expect(err).ToNot(HaveOccurred())
 		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Pending)),
 			"VMI should be in the Pending phase")
 
@@ -332,11 +327,6 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 			return false
 		}, vmCreationTimeout, 1*time.Second).Should(BeTrue())
-
-		vmiStatus, err = readNewStatus(stdout, vmiStatus, readTimeout)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex)),
-			"VMI should not have a specified phase yet")
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, readTimeout)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
When starting a lot of VMIs at once on a given cluster, it can take some time for VMI statuses to go from blank to pending.
That can be confusing to the user, and starting VMIs directly in the pending status should solve that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1903667

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
