### PR TITLE
Add flag volumeMode and deprecate block-volume for virtctl image-upload

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -402,7 +402,7 @@ var _ = Describe("ImageUpload", func() {
 			validateDataVolume()
 		})
 
-		It("Create a VolumeMode=Block PVC", func() {
+		It("Create a VolumeMode=Block PVC by specifying block-vloume", func() {
 			testInit(http.StatusOK)
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath, "--block-volume")
@@ -410,6 +410,46 @@ var _ = Describe("ImageUpload", func() {
 			Expect(dvCreateCalled).To(BeTrue())
 			validateBlockPVC()
 			validateBlockDataVolume()
+		})
+
+		It("Create a VolumeMode=Block PVC by specifying volume-mode", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--insecure", "--image-path", imagePath, "--volume-mode", string(v1.PersistentVolumeBlock))
+			Expect(cmd()).To(BeNil())
+			Expect(dvCreateCalled).To(BeTrue())
+			validateBlockPVC()
+			validateBlockDataVolume()
+		})
+
+		It("Create a VolumeMode=Block PVC by specifying both block-volume and volume-mode", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--insecure", "--image-path", imagePath, "--block-volume", "--volume-mode", string(v1.PersistentVolumeBlock))
+			Expect(cmd()).To(BeNil())
+			Expect(dvCreateCalled).To(BeTrue())
+			validateBlockPVC()
+			validateBlockDataVolume()
+		})
+
+		It("Create a VolumeMode=Filesystem PVC by specifying volume-mode", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--insecure", "--image-path", imagePath, "--volume-mode", string(v1.PersistentVolumeFilesystem))
+			Expect(cmd()).To(BeNil())
+			Expect(dvCreateCalled).To(BeTrue())
+			validatePVC()
+			validateDataVolume()
+		})
+
+		It("Create a VolumeMode=Filesystem PVC by specifying both block-volume and volume-mode", func() {
+			testInit(http.StatusOK)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--insecure", "--image-path", imagePath, "--block-volume", "--volume-mode", string(v1.PersistentVolumeFilesystem))
+			Expect(cmd()).To(BeNil())
+			Expect(dvCreateCalled).To(BeTrue())
+			validatePVC()
+			validateDataVolume()
 		})
 
 		It("Create a non-default storage class PVC", func() {

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -422,30 +422,10 @@ var _ = Describe("ImageUpload", func() {
 			validateBlockDataVolume()
 		})
 
-		It("Create a VolumeMode=Block PVC by specifying both block-volume and volume-mode", func() {
-			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
-				"--insecure", "--image-path", imagePath, "--block-volume", "--volume-mode", string(v1.PersistentVolumeBlock))
-			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
-			validateBlockPVC()
-			validateBlockDataVolume()
-		})
-
 		It("Create a VolumeMode=Filesystem PVC by specifying volume-mode", func() {
 			testInit(http.StatusOK)
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath, "--volume-mode", string(v1.PersistentVolumeFilesystem))
-			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
-			validatePVC()
-			validateDataVolume()
-		})
-
-		It("Create a VolumeMode=Filesystem PVC by specifying both block-volume and volume-mode", func() {
-			testInit(http.StatusOK)
-			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
-				"--insecure", "--image-path", imagePath, "--block-volume", "--volume-mode", string(v1.PersistentVolumeFilesystem))
 			Expect(cmd()).To(BeNil())
 			Expect(dvCreateCalled).To(BeTrue())
 			validatePVC()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add volumeMode and deprecate block-volume for virtctl image-upload.

'block-volume'  is not a proper name for volumeMode and it's possible to mislead users as it shows in #4707, hence change it to more native name 'volue-mode' as it's easy to understand what it does.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4707

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
A new flag 'volume-mode' is added as a replacement of 'block-volume' for the PVC volumeMode in virtctl image-upload, the flag 'block-volume' is deprecated now.

```
