### PR TITLE
tests, ping: increase default amount of packets 

### DIFF
--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -43,7 +43,7 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 	}
 
 	if len(args) == 0 {
-		args = []string{"-c 1", "-w 5"}
+		args = []string{"-c 5", "-w 10"}
 	}
 	args = append([]string{pingString, ipAddr}, args...)
 	cmdCheck := strings.Join(args, " ")


### PR DESCRIPTION
When we tests connectivity , we would like to see
that connection was established, and that it is stable.
When we send one packet, we see the connection was established
but we are less confidant about the connection stability.

This commit increases the default number of packets sent
upon ping, to increase confidence in the stability of the connection.

Signed-off-by: alonSadan <asadan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
