### PR TITLE
cloud-init, GenerateLocalData:  simplify iso staging

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -573,7 +573,6 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 	if isEqual {
 		diskutils.RemoveFile(isoStaging)
 	} else {
-		diskutils.RemoveFile(iso)
 		err = os.Rename(isoStaging, iso)
 		if err != nil {
 			log.Log.Reason(err).Errorf("Cloud-init failed to rename file %s to %s", isoStaging, iso)

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -576,7 +576,6 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		diskutils.RemoveFile(iso)
 		err = os.Rename(isoStaging, iso)
 		if err != nil {
-			// This error is not something we need to block iso creation for.
 			log.Log.Reason(err).Errorf("Cloud-init failed to rename file %s to %s", isoStaging, iso)
 			return err
 		}

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -564,20 +564,10 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		return err
 	}
 
-	isEqual, err := diskutils.FilesAreEqual(iso, isoStaging)
+	err = os.Rename(isoStaging, iso)
 	if err != nil {
+		log.Log.Reason(err).Errorf("Cloud-init failed to rename file %s to %s", isoStaging, iso)
 		return err
-	}
-
-	// Only replace the dynamically generated iso if it has a different checksum
-	if isEqual {
-		diskutils.RemoveFile(isoStaging)
-	} else {
-		err = os.Rename(isoStaging, iso)
-		if err != nil {
-			log.Log.Reason(err).Errorf("Cloud-init failed to rename file %s to %s", isoStaging, iso)
-			return err
-		}
 	}
 
 	log.Log.V(2).Infof("generated nocloud iso file %s", iso)

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -537,4 +537,21 @@ var _ = Describe("CloudInit", func() {
 			})
 		})
 	})
+	Describe("GenerateLocalData", func() {
+		It("should cleanly run twice", func() {
+			namespace := "fake-namespace"
+			domain := "fake-domain"
+			userData := "fake\nuser\ndata\n"
+			source := &v1.CloudInitNoCloudSource{
+				UserDataBase64: base64.StdEncoding.EncodeToString([]byte(userData)),
+			}
+			cloudInitData, err := readCloudInitNoCloudSource(source)
+			Expect(err).NotTo(HaveOccurred())
+			err = GenerateLocalData(domain, namespace, cloudInitData)
+			Expect(err).NotTo(HaveOccurred())
+			err = GenerateLocalData(domain, namespace, cloudInitData)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
 })

--- a/pkg/ephemeral-disk-utils/BUILD.bazel
+++ b/pkg/ephemeral-disk-utils/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -20,11 +20,7 @@
 package ephemeraldiskutils
 
 import (
-	"bytes"
-	// #nosec md5 here is used only as hash to compare files and not for cryptographic
-	"crypto/md5"
 	"fmt"
-	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -33,7 +29,6 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
-	"kubevirt.io/kubevirt/pkg/util"
 )
 
 // TODO this should be part of structs, instead of a global
@@ -91,57 +86,6 @@ func FileExists(path string) (bool, error) {
 		err = nil
 	}
 	return exists, err
-}
-func Md5CheckSum(filePath string) ([]byte, error) {
-
-	file, err := os.Open(filepath.Clean(filePath))
-	if err != nil {
-		return nil, err
-	}
-	defer util.CloseIOAndCheckErr(file, nil)
-
-	// #nosec CWE: 326 - Use of weak cryptographic primitive (http://cwe.mitre.org/data/definitions/326.html)
-	// reason: sha1 is not used for encryption but for creating a hash value
-	hash := md5.New()
-	_, err = io.Copy(hash, file)
-
-	if err != nil {
-		return nil, err
-	}
-
-	result := hash.Sum(nil)
-	return result, nil
-}
-
-func FilesAreEqual(path1 string, path2 string) (bool, error) {
-	exists, err := FileExists(path1)
-	if err != nil {
-		log.Log.Reason(err).Errorf("unexpected error encountered while attempting to determine if %s exists", path1)
-		return false, err
-	} else if exists == false {
-		return false, nil
-	}
-
-	exists, err = FileExists(path2)
-	if err != nil {
-		log.Log.Reason(err).Errorf("unexpected error encountered while attempting to determine if %s exists", path2)
-		return false, err
-	} else if exists == false {
-		return false, nil
-	}
-
-	sum1, err := Md5CheckSum(path1)
-	if err != nil {
-		log.Log.Reason(err).Errorf("calculating md5 checksum failed for %s", path1)
-		return false, err
-	}
-	sum2, err := Md5CheckSum(path2)
-	if err != nil {
-		log.Log.Reason(err).Errorf("calculating md5 checksum failed for %s", path2)
-		return false, err
-	}
-
-	return bytes.Equal(sum1, sum2), nil
 }
 
 // Lists all vmis ephemeral disk has local data for


### PR DESCRIPTION
**What this PR does / why we need it**:    
GenerateLocalData creates a staging iso file, compares it to the production one, and replaces the production iso if their MD5 checksums are not equal.

The comparison take time in production, introduces code and complexity and opens the door to possible errors due to MD5 collisions. The cost of os.Rename is negligible. It is one of the quickest and safest file-related syscalls. This PR suggests to call os.Rename without comparison.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
