### PR TITLE
virtctl, imageupload: improve nosec comment

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -210,7 +210,8 @@ func (c *command) run(cmd *cobra.Command, args []string) error {
 	if err := parseArgs(args); err != nil {
 		return err
 	}
-	// #nosec No risk for path injection. This is used only to upload an image not to read info
+	// #nosec G304 No risk for path injection as this funtion exectues with
+	// the same previliges as those of virtctl user who supplies imagePath
 	file, err := os.Open(imagePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
When silencing a gosec warning, we should be specific about which
warning we want to silence, and should be precise why it is safe.

In this case we know that [CWE-22] does not apply, as the run() executes
with the same privileges as those of the caller of virtclt who supplied
the path. We do not expect that run() would ever be moved to execute
in a different, more previliged, context. Thus it should be fine to
silence [G304] and it alone.

[G304] https://securego.io/docs/rules/g304.html
[CWE-22] https://cwe.mitre.org/data/definitions/22.html

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

/cc @ezrasilvera 

```release-note
NONE
```