### PR TITLE
sriov, tests: xfail vlan test

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -895,19 +895,23 @@ var _ = Describe("[Serial]SRIOV", func() {
 			It("should be able to ping between two VMIs with the same VLAN over SRIOV network", func() {
 				_, vlanedVMI2 := createSriovVMs(sriovVlanNetworkName, sriovVlanNetworkName, cidrVlaned1, "192.168.0.2/24")
 
-				By("pinging from vlanedVMI2 and the anonymous vmi over vlan")
-				Eventually(func() error {
-					return libnet.PingFromVMConsole(vlanedVMI2, cidrToIP(cidrVlaned1))
-				}, 15*time.Second, time.Second).ShouldNot(HaveOccurred())
+				assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642", func() {
+					By("pinging from vlanedVMI2 and the anonymous vmi over vlan")
+					Eventually(func() error {
+						return libnet.PingFromVMConsole(vlanedVMI2, cidrToIP(cidrVlaned1))
+					}, 15*time.Second, time.Second).ShouldNot(HaveOccurred())
+				})
 			})
 
 			It("should NOT be able to ping between Vlaned VMI and a non Vlaned VMI", func() {
 				_, nonVlanedVMI := createSriovVMs(sriovVlanNetworkName, sriovnet3, cidrVlaned1, "192.168.0.3/24")
 
-				By("pinging between nonVlanedVMIand the anonymous vmi")
-				Eventually(func() error {
-					return libnet.PingFromVMConsole(nonVlanedVMI, cidrToIP(cidrVlaned1))
-				}, 15*time.Second, time.Second).Should(HaveOccurred())
+				assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642", func() {
+					By("pinging between nonVlanedVMIand the anonymous vmi")
+					Eventually(func() error {
+						return libnet.PingFromVMConsole(nonVlanedVMI, cidrToIP(cidrVlaned1))
+					}, 15*time.Second, time.Second).Should(HaveOccurred())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
Testing sriov+vlan with ping is flaky.
Issue was already seen on ipv4 and ipv6 ping
tests, and it is tracked here:
https://github.com/kubevirt/kubevirt/issues/4642

Until it is solved, this commit xfail vlan+sriov test,
meaning it will fail but won't fail the whole lane.

Signed-off-by: alonSadan <asadan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
