### PR TITLE
ephemeral-disk-utils: add few harmless tests and rename RemoveFile

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -521,10 +521,10 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		networkData = []byte(data.NetworkData)
 	}
 
-	diskutils.RemoveFile(userFile)
-	diskutils.RemoveFile(metaFile)
-	diskutils.RemoveFile(networkFile)
-	diskutils.RemoveFile(isoStaging)
+	diskutils.RemoveFilesIfExist(userFile)
+	diskutils.RemoveFilesIfExist(metaFile)
+	diskutils.RemoveFilesIfExist(networkFile)
+	diskutils.RemoveFilesIfExist(isoStaging)
 
 	err = ioutil.WriteFile(userFile, userData, 0644)
 	if err != nil {

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -521,10 +521,10 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		networkData = []byte(data.NetworkData)
 	}
 
-	diskutils.RemoveFilesIfExist(userFile)
-	diskutils.RemoveFilesIfExist(metaFile)
-	diskutils.RemoveFilesIfExist(networkFile)
-	diskutils.RemoveFilesIfExist(isoStaging)
+	err = diskutils.RemoveFilesIfExist(userFile, metaFile, networkFile, isoStaging)
+	if err != nil {
+		return err
+	}
 
 	err = ioutil.WriteFile(userFile, userData, 0644)
 	if err != nil {

--- a/pkg/ephemeral-disk-utils/BUILD.bazel
+++ b/pkg/ephemeral-disk-utils/BUILD.bazel
@@ -5,10 +5,7 @@ go_library(
     srcs = ["utils.go"],
     importpath = "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils",
     visibility = ["//visibility:public"],
-    deps = [
-        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
-    ],
+    deps = ["//staging/src/kubevirt.io/client-go/api/v1:go_default_library"],
 )
 
 go_test(

--- a/pkg/ephemeral-disk-utils/BUILD.bazel
+++ b/pkg/ephemeral-disk-utils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -8,5 +8,19 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "utils_suite_test.go",
+        "utils_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	v1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/log"
 )
 
 // TODO this should be part of structs, instead of a global
@@ -66,13 +65,13 @@ func (om *OwnershipManager) SetFileOwnership(file string) error {
 	return os.Chown(file, uid, gid)
 }
 
-func RemoveFile(path string) error {
-	err := os.RemoveAll(path)
-	if err != nil && os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		log.Log.Reason(err).Errorf("failed to remove %s", path)
-		return err
+func RemoveFilesIfExist(paths ...string) error {
+	var err error
+	for _, path := range paths {
+		err = os.Remove(path)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/ephemeral-disk-utils/utils_suite_test.go
+++ b/pkg/ephemeral-disk-utils/utils_suite_test.go
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package ephemeraldiskutils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/log"
+)
+
+func TestEphemeralDiskUtils(t *testing.T) {
+	log.Log.SetIOWriter(GinkgoWriter)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EphemeralDiskUtils Suite")
+}

--- a/pkg/ephemeral-disk-utils/utils_test.go
+++ b/pkg/ephemeral-disk-utils/utils_test.go
@@ -34,18 +34,27 @@ var _ = Describe("FileExists", func() {
 		Expect(FileExists("no one would ever have this file")).To(BeFalse())
 	})
 })
-var _ = Describe("RemoveFile", func() {
+var _ = Describe("RemoveFilesIfExist", func() {
 	It("silently ignores non-existing file", func() {
-		// Ingnoring missing files is typically a sloppy behavior. This test
-		// documents it, not aproves of its usage.
-		Expect(RemoveFile("no one would ever have this file")).To(BeNil())
+		Expect(RemoveFilesIfExist("no one would ever have this file")).To(BeNil())
 	})
 	It("removes a file", func() {
 		tmpfile, err := ioutil.TempFile("", "file_to_remove")
 		Expect(err).To(BeNil())
 		defer tmpfile.Close()
 		Expect(FileExists(tmpfile.Name())).To(BeTrue())
-		Expect(RemoveFile(tmpfile.Name())).To(BeNil())
+		Expect(RemoveFilesIfExist(tmpfile.Name())).To(BeNil())
 		Expect(FileExists(tmpfile.Name())).To(BeFalse())
+	})
+	It("removes multiple files", func() {
+		tmpfile1, err := ioutil.TempFile("", "file_to_remove1")
+		Expect(err).To(BeNil())
+		defer tmpfile1.Close()
+		tmpfile2, err := ioutil.TempFile("", "file_to_remove2")
+		Expect(err).To(BeNil())
+		defer tmpfile2.Close()
+		Expect(RemoveFilesIfExist(tmpfile1.Name(), tmpfile2.Name())).To(BeNil())
+		Expect(FileExists(tmpfile1.Name())).To(BeFalse())
+		Expect(FileExists(tmpfile2.Name())).To(BeFalse())
 	})
 })

--- a/pkg/ephemeral-disk-utils/utils_test.go
+++ b/pkg/ephemeral-disk-utils/utils_test.go
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package ephemeraldiskutils
+
+import (
+	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FileExists", func() {
+	It("recognizes am existing file", func() {
+		Expect(FileExists("/etc/passwd")).To(BeTrue())
+	})
+	It("recognizes non-existing file", func() {
+		Expect(FileExists("no one would ever have this file")).To(BeFalse())
+	})
+})
+var _ = Describe("RemoveFile", func() {
+	It("silently ignores non-existing file", func() {
+		// Ingnoring missing files is typically a sloppy behavior. This test
+		// documents it, not aproves of its usage.
+		Expect(RemoveFile("no one would ever have this file")).To(BeNil())
+	})
+	It("removes a file", func() {
+		tmpfile, err := ioutil.TempFile("", "file_to_remove")
+		Expect(err).To(BeNil())
+		defer tmpfile.Close()
+		Expect(FileExists(tmpfile.Name())).To(BeTrue())
+		Expect(RemoveFile(tmpfile.Name())).To(BeNil())
+		Expect(FileExists(tmpfile.Name())).To(BeFalse())
+	})
+})

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1259,7 +1259,7 @@ func gracefulShutdownTriggerFromNamespaceName(baseDir string, namespace string, 
 // VMIs running with the old graceful shutdown trigger logic
 func vmGracefulShutdownTriggerClear(baseDir string, vmi *v1.VirtualMachineInstance) error {
 	triggerFile := gracefulShutdownTriggerFromNamespaceName(baseDir, vmi.Namespace, vmi.Name)
-	return diskutils.RemoveFile(triggerFile)
+	return diskutils.RemoveFilesIfExist(triggerFile)
 }
 
 // Legacy, remove once we're certain we are no longer supporting

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -65,7 +65,7 @@ func WatchdogFileRemove(baseDir string, vmi *v1.VirtualMachineInstance) error {
 	file := WatchdogFileFromNamespaceName(baseDir, namespace, domain)
 
 	log.Log.V(3).Infof("Remove watchdog file %s", file)
-	return diskutils.RemoveFile(file)
+	return diskutils.RemoveFilesIfExist(file)
 }
 
 func WatchdogFileUpdate(watchdogFile string, uid string) error {


### PR DESCRIPTION
Introduce a few tests to document RemoveFile and FileExists; simplify RemoveFile and rename it.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
