### PR TITLE
virt-api/webhooks: simplify, rename and test ServiceAccount-matching function

### DIFF
--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -21,5 +21,19 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "utils_test.go",
+        "webhooks_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -125,8 +125,7 @@ func (mutator *VMIsMutator) Mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admissi
 		// TODO: As soon as CRDs support field selectors we can remove this and just enable
 		// the status subresource. Until then we need to update Status and Metadata labels in parallel for e.g. Migrations.
 		if !reflect.DeepEqual(newVMI.Status, oldVMI.Status) {
-			allowed := webhooks.GetAllowedServiceAccounts()
-			if _, ok := allowed[ar.Request.UserInfo.Username]; !ok {
+			if !webhooks.IsKubeVirtServiceAccount(ar.Request.UserInfo.Username) {
 				patch = append(patch, patchOperation{
 					Op:    "replace",
 					Path:  "/status",

--- a/pkg/virt-api/webhooks/utils.go
+++ b/pkg/virt-api/webhooks/utils.go
@@ -123,7 +123,7 @@ func newInformers() *Informers {
 	}
 }
 
-func GetAllowedServiceAccounts() map[string]struct{} {
+func IsKubeVirtServiceAccount(serviceAccount string) bool {
 	ns, err := clientutil.GetNamespace()
 	logger := log.DefaultLogger()
 
@@ -132,11 +132,8 @@ func GetAllowedServiceAccounts() map[string]struct{} {
 		ns = "kubevirt"
 	}
 
-	// system:serviceaccount:{namespace}:{kubevirt-component}
-	prefix := fmt.Sprintf("%s:%s:%s", "system", "serviceaccount", ns)
-	return map[string]struct{}{
-		fmt.Sprintf("%s:%s", prefix, rbac.ApiServiceAccountName):        {},
-		fmt.Sprintf("%s:%s", prefix, rbac.HandlerServiceAccountName):    {},
-		fmt.Sprintf("%s:%s", prefix, rbac.ControllerServiceAccountName): {},
-	}
+	prefix := fmt.Sprintf("system:serviceaccount:%s", ns)
+	return serviceAccount == fmt.Sprintf("%s:%s", prefix, rbac.ApiServiceAccountName) ||
+		serviceAccount == fmt.Sprintf("%s:%s", prefix, rbac.HandlerServiceAccountName) ||
+		serviceAccount == fmt.Sprintf("%s:%s", prefix, rbac.ControllerServiceAccountName)
 }

--- a/pkg/virt-api/webhooks/utils_test.go
+++ b/pkg/virt-api/webhooks/utils_test.go
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package webhooks_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+)
+
+var _ = Describe("IsKubeVirtServiceAccount", func() {
+	It("rejects an invalid service account", func() {
+		Expect(webhooks.IsKubeVirtServiceAccount("invalid:service:account")).To(BeFalse())
+	})
+	It("recognizes all KubeVirt service accounts", func() {
+		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:kubevirt-apiserver")).To(BeTrue())
+		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:kubevirt-controller")).To(BeTrue())
+		Expect(webhooks.IsKubeVirtServiceAccount("system:serviceaccount:kubevirt:kubevirt-handler")).To(BeTrue())
+	})
+})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1034,8 +1034,7 @@ func ValidateVirtualMachineInstanceMetadata(field *k8sfield.Path, metadata *meta
 	labels := metadata.Labels
 	// Validate kubevirt.io labels presence. Restricted labels allowed
 	// to be created only by known service accounts
-	allowed := webhooks.GetAllowedServiceAccounts()
-	if _, ok := allowed[accountName]; !ok {
+	if !webhooks.IsKubeVirtServiceAccount(accountName) {
 		if len(filterKubevirtLabels(labels)) > 0 {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotSupported,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -52,8 +52,7 @@ func (admitter *VMIUpdateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1beta1.A
 	// Reject VMI update if VMI spec changed
 	if !reflect.DeepEqual(newVMI.Spec, oldVMI.Spec) {
 		// Only allow the KubeVirt SA to modify the VMI spec, since that means it went through the sub resource.
-		allowed := webhooks.GetAllowedServiceAccounts()
-		if _, ok := allowed[ar.Request.UserInfo.Username]; ok {
+		if webhooks.IsKubeVirtServiceAccount(ar.Request.UserInfo.Username) {
 			hotplugResponse := admitHotplug(newVMI.Spec.Volumes, oldVMI.Spec.Volumes, newVMI.Spec.Domain.Devices.Disks, oldVMI.Spec.Domain.Devices.Disks, oldVMI.Status.VolumeStatus, newVMI, admitter.ClusterConfig)
 			if hotplugResponse != nil {
 				return hotplugResponse
@@ -264,9 +263,7 @@ func admitVMILabelsUpdate(
 	oldVMI *v1.VirtualMachineInstance,
 	ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 
-	// Skip admission for internal components
-	allowed := webhooks.GetAllowedServiceAccounts()
-	if _, ok := allowed[ar.Request.UserInfo.Username]; ok {
+	if webhooks.IsKubeVirtServiceAccount(ar.Request.UserInfo.Username) {
 		return nil
 	}
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -469,8 +469,7 @@ func validateStateChangeRequests(ar *v1beta1.AdmissionRequest, vm *v1.VirtualMac
 		}
 
 		if getRenameRequest(existingVM) != nil {
-			allowed := webhooks.GetAllowedServiceAccounts()
-			if _, ok := allowed[ar.UserInfo.Username]; ok {
+			if webhooks.IsKubeVirtServiceAccount(ar.UserInfo.Username) {
 				if !reflect.DeepEqual(existingVM.Spec, vm.Spec) {
 					return []metav1.StatusCause{{
 						Type:    metav1.CauseTypeFieldValueNotSupported,

--- a/pkg/virt-api/webhooks/webhooks_suite_test.go
+++ b/pkg/virt-api/webhooks/webhooks_suite_test.go
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package webhooks_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/log"
+)
+
+func TestWebhooks(t *testing.T) {
+	log.Log.SetIOWriter(GinkgoWriter)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhooks Suite")
+}


### PR DESCRIPTION
None of the callers of GetAllowedServiceAccounts() actually need a list
of all service account. Actually, they need to tell if a specific
ServiceAccount is a KubeVirt-internal one. This commit simplifies the 
function and its caller by renaming it to a clearer
IsKubeVirtServiceAccount().

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
