### PR TITLE
MacvtapPodInterface.setCachedInterface: fix arg name

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1227,8 +1227,8 @@ func (m *MacvtapPodInterface) loadCachedInterface(uid, name string) (bool, error
 	return false, nil
 }
 
-func (m *MacvtapPodInterface) setCachedInterface(uid, name string) error {
-	err := writeToCachedFile(m.virtIface, interfaceCacheFile, uid, name)
+func (m *MacvtapPodInterface) setCachedInterface(pid, name string) error {
+	err := writeToCachedFile(m.virtIface, interfaceCacheFile, pid, name)
 	return err
 }
 


### PR DESCRIPTION
setCachedInterface() expects a *pid* string on all other PodInterface
subclasses. There is nothing special aobut MacvtapPodInterface, let us
use the same argument name.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

-->
```release-note
NONE
```