### PR TITLE
virt-launcher/handler- use VIF cache only for dhcp server

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -65,7 +65,6 @@ type VIF struct {
 	Routes       *[]netlink.Route
 	Mtu          uint16
 	IPAMDisabled bool
-	TapDevice    string
 }
 
 type CriticalNetworkError struct {
@@ -76,7 +75,7 @@ func (e *CriticalNetworkError) Error() string { return e.Msg }
 
 func (vif VIF) String() string {
 	return fmt.Sprintf(
-		"VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: %t, TapDevice: %s}",
+		"VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: %t}",
 		vif.Name,
 		vif.IP.IP,
 		vif.IP.Mask,
@@ -85,7 +84,6 @@ func (vif VIF) String() string {
 		vif.Gateway,
 		vif.Mtu,
 		vif.IPAMDisabled,
-		vif.TapDevice,
 	)
 }
 

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -117,32 +117,30 @@ var _ = Describe("VIF", func() {
 	const mac = "de:ad:00:00:be:ef"
 	const ipv4Gateway = "10.0.0.1"
 	const mtu = 1450
-	const tapName = "myTap0"
 	const vifName = "test-vif"
 
 	Context("String", func() {
 		It("returns correct string representation", func() {
-			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac, tapName, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false, TapDevice: %s}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway, mtu, tapName)))
+			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
+			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway, mtu)))
 		})
 		It("returns correct string representation with ipv6", func() {
-			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, tapName, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false, TapDevice: %s}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu, tapName)))
+			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
+			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu)))
 		})
 	})
 })
 
-func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr, tapName string, mtu uint16) *VIF {
+func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *VIF {
 	addr, _ := netlink.ParseAddr(ipv4cidr)
 	mac, _ := net.ParseMAC(macStr)
 	gw := net.ParseIP(ipv4gateway)
 	vif := &VIF{
-		Name:      vifName,
-		IP:        *addr,
-		MAC:       mac,
-		Gateway:   gw,
-		Mtu:       mtu,
-		TapDevice: tapName,
+		Name:    vifName,
+		IP:      *addr,
+		MAC:     mac,
+		Gateway: gw,
+		Mtu:     mtu,
 	}
 	if ipv6cidr != "" {
 		ipv6Addr, _ := netlink.ParseAddr(ipv6cidr)

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -455,7 +455,7 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, lau
 	}
 
 	tapDeviceName := generateTapDeviceName(podInterfaceName)
-	err := createAndBindTapToBridge(b.vif, tapDeviceName, b.bridgeInterfaceName, queueNumber, launcherPID, int(b.vif.Mtu))
+	err := createAndBindTapToBridge(tapDeviceName, b.bridgeInterfaceName, queueNumber, launcherPID, int(b.vif.Mtu))
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err
@@ -479,7 +479,7 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, lau
 	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}
 	b.virtIface.MAC = &api.MAC{MAC: b.vif.MAC.String()}
 	b.virtIface.Target = &api.InterfaceTarget{
-		Device:  b.vif.TapDevice,
+		Device:  tapDeviceName,
 		Managed: "no",
 	}
 
@@ -746,7 +746,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 	}
 
 	tapDeviceName := generateTapDeviceName(podInterfaceName)
-	err = createAndBindTapToBridge(p.vif, tapDeviceName, p.bridgeInterfaceName, queueNumber, launcherPID, int(p.vif.Mtu))
+	err = createAndBindTapToBridge(tapDeviceName, p.bridgeInterfaceName, queueNumber, launcherPID, int(p.vif.Mtu))
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err
@@ -788,7 +788,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 	p.virtIface.MTU = &api.MTU{Size: strconv.Itoa(p.podNicLink.Attrs().MTU)}
 	p.virtIface.MAC = &api.MAC{MAC: p.vif.MAC.String()}
 	p.virtIface.Target = &api.InterfaceTarget{
-		Device:  p.vif.TapDevice,
+		Device:  tapDeviceName,
 		Managed: "no",
 	}
 
@@ -1257,12 +1257,11 @@ func (m *MacvtapPodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func createAndBindTapToBridge(virtualInterface *VIF, deviceName string, bridgeIfaceName string, queueNumber uint32, launcherPID int, mtu int) error {
+func createAndBindTapToBridge(deviceName string, bridgeIfaceName string, queueNumber uint32, launcherPID int, mtu int) error {
 	err := Handler.CreateTapDevice(deviceName, queueNumber, launcherPID, mtu)
 	if err != nil {
 		return err
 	}
-	virtualInterface.TapDevice = deviceName
 	return Handler.BindTapDeviceToBridge(deviceName, bridgeIfaceName)
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -297,20 +297,26 @@ func getPhase1Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 }
 
 func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) (BindMechanism, error) {
-	populateMacAddress := func(vif *VIF, iface *v1.Interface) error {
+	retrieveMacAddress := func(iface *v1.Interface) (*net.HardwareAddr, error) {
 		if iface.MacAddress != "" {
 			macAddress, err := net.ParseMAC(iface.MacAddress)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			vif.MAC = macAddress
+			return &macAddress, nil
 		}
-		return nil
+		return nil, nil
 	}
 
 	if iface.Bridge != nil {
+		mac, err := retrieveMacAddress(iface)
+		if err != nil {
+			return nil, err
+		}
 		vif := &VIF{Name: podInterfaceName}
-		populateMacAddress(vif, iface)
+		if mac != nil {
+			vif.MAC = *mac
+		}
 		return &BridgePodInterface{iface: iface,
 			virtIface:           &api.Interface{},
 			vmi:                 vmi,
@@ -320,8 +326,14 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 			bridgeInterfaceName: fmt.Sprintf("k6t-%s", podInterfaceName)}, nil
 	}
 	if iface.Masquerade != nil {
+		mac, err := retrieveMacAddress(iface)
+		if err != nil {
+			return nil, err
+		}
 		vif := &VIF{Name: podInterfaceName}
-		populateMacAddress(vif, iface)
+		if mac != nil {
+			vif.MAC = *mac
+		}
 		return &MasqueradePodInterface{iface: iface,
 			virtIface:           &api.Interface{},
 			vmi:                 vmi,
@@ -336,13 +348,18 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		return &SlirpPodInterface{vmi: vmi, iface: iface, domain: domain}, nil
 	}
 	if iface.Macvtap != nil {
-		vif := &VIF{Name: podInterfaceName}
-		populateMacAddress(vif, iface)
+		mac, err := retrieveMacAddress(iface)
+		if err != nil {
+			return nil, err
+		}
+		virtIface := &api.Interface{}
+		if mac != nil {
+			virtIface.MAC = &api.MAC{MAC: mac.String()}
+		}
 		return &MacvtapPodInterface{
 			vmi:              vmi,
-			vif:              vif,
 			iface:            iface,
-			virtIface:        &api.Interface{},
+			virtIface:        virtIface,
 			domain:           domain,
 			podInterfaceName: podInterfaceName,
 		}, nil
@@ -1159,7 +1176,6 @@ func (s *SlirpPodInterface) setCachedInterface(pid, name string) error {
 
 type MacvtapPodInterface struct {
 	vmi              *v1.VirtualMachineInstance
-	vif              *VIF
 	iface            *v1.Interface
 	virtIface        *api.Interface
 	domain           *api.Domain
@@ -1175,21 +1191,20 @@ func (m *MacvtapPodInterface) discoverPodNetworkInterface() error {
 	}
 	m.podNicLink = link
 
-	if len(m.vif.MAC) == 0 {
+	if m.virtIface.MAC == nil {
 		// Get interface MAC address
 		mac, err := Handler.GetMacDetails(m.podInterfaceName)
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to get MAC for %s", m.podInterfaceName)
 			return err
 		}
-		m.vif.MAC = mac
+		m.virtIface.MAC = &api.MAC{MAC: mac.String()}
 	}
 
 	return nil
 }
 
 func (m *MacvtapPodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
-	m.virtIface.MAC = &api.MAC{MAC: m.vif.MAC.String()}
 	m.virtIface.MTU = &api.MTU{Size: strconv.Itoa(m.podNicLink.Attrs().MTU)}
 	m.virtIface.Target = &api.InterfaceTarget{
 		Device:  m.podInterfaceName,
@@ -1203,7 +1218,7 @@ func (m *MacvtapPodInterface) decorateConfig() error {
 	for i, iface := range ifaces {
 		if iface.Alias.Name == m.iface.Name {
 			ifaces[i].MTU = m.virtIface.MTU
-			ifaces[i].MAC = &api.MAC{MAC: m.vif.MAC.String()}
+			ifaces[i].MAC = m.virtIface.MAC
 			ifaces[i].Target = m.virtIface.Target
 			break
 		}
@@ -1233,23 +1248,11 @@ func (m *MacvtapPodInterface) setCachedInterface(uid, name string) error {
 }
 
 func (m *MacvtapPodInterface) loadCachedVIF(pid, name string) (bool, error) {
-	buf, err := ioutil.ReadFile(getVifFilePath(pid, name))
-	if err != nil {
-		return false, err
-	}
-	err = json.Unmarshal(buf, &m.vif)
-	if err != nil {
-		return false, err
-	}
 	return true, nil
 }
 
 func (m *MacvtapPodInterface) setCachedVIF(pid, name string) error {
-	buf, err := json.MarshalIndent(&m.vif, "", "  ")
-	if err != nil {
-		return fmt.Errorf("error marshaling vif object: %v", err)
-	}
-	return writeVifFile(buf, pid, name)
+	return nil
 }
 
 func (m *MacvtapPodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1201,15 +1201,16 @@ func (m *MacvtapPodInterface) discoverPodNetworkInterface() error {
 		m.virtIface.MAC = &api.MAC{MAC: mac.String()}
 	}
 
-	return nil
-}
-
-func (m *MacvtapPodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
 	m.virtIface.MTU = &api.MTU{Size: strconv.Itoa(m.podNicLink.Attrs().MTU)}
 	m.virtIface.Target = &api.InterfaceTarget{
 		Device:  m.podInterfaceName,
 		Managed: "no",
 	}
+
+	return nil
+}
+
+func (m *MacvtapPodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -119,11 +119,10 @@ var _ = Describe("Pod Network", func() {
 		bridgeAddr, _ = netlink.ParseAddr(fmt.Sprintf(bridgeFakeIP, 0))
 		tapDeviceName = "tap0"
 		testNic = &VIF{Name: podInterface,
-			IP:        fakeAddr,
-			MAC:       fakeMac,
-			Mtu:       uint16(mtu),
-			Gateway:   gw,
-			TapDevice: tapDeviceName,
+			IP:      fakeAddr,
+			MAC:     fakeMac,
+			Mtu:     uint16(mtu),
+			Gateway: gw,
 		}
 
 		masqueradeGwStr = "10.0.2.1/30"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

virt-launcher/handler podInterface.phase1 is storing values in the VIF cache to be use by phase2 for the dhcp server.
This PR removes any other values that were store in the VIF cache by phase1 but never used in phase2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
