### PR TITLE
tests, xfail: Change XFail API to wrap the expected failure

### DIFF
--- a/tests/assert/xfail.go
+++ b/tests/assert/xfail.go
@@ -30,13 +30,14 @@ import (
 // XFail skips the test once it fails and leaves a XFAIL label on the message.
 // It is useful to mark tests as XFail when one wants them to run even though they fail,
 // monitoring and collecting information.
-func XFail(reason string) {
+func XFail(reason string, f func()) {
+	defer RegisterFailHandler(Fail)
 	RegisterFailHandler(func(m string, offset ...int) {
-		defer RegisterFailHandler(Fail)
 		depth := 0
 		if len(offset) > 0 {
 			depth = offset[0]
 		}
 		Skip(fmt.Sprintf("[XFAIL] %s, failure: %s", reason, m), depth+1)
 	})
+	f()
 }

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -856,13 +856,14 @@ var _ = Describe("[Serial]SRIOV", func() {
 			//create two vms on the smae sriov network
 			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, cidrA, cidrB)
 
-			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642")
-			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
-			}, 15*time.Second, time.Second).Should(Succeed())
-			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi2, cidrToIP(cidrA))
-			}, 15*time.Second, time.Second).Should(Succeed())
+			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642", func() {
+				Eventually(func() error {
+					return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
+				}, 15*time.Second, time.Second).Should(Succeed())
+				Eventually(func() error {
+					return libnet.PingFromVMConsole(vmi2, cidrToIP(cidrA))
+				}, 15*time.Second, time.Second).Should(Succeed())
+			})
 		})
 
 		It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
@@ -871,13 +872,14 @@ var _ = Describe("[Serial]SRIOV", func() {
 			//create two vms on the smae sriov network
 			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, cidrA, cidrB)
 
-			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642")
-			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
-			}, 15*time.Second, time.Second).Should(Succeed())
-			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi2, cidrToIP(cidrA))
-			}, 15*time.Second, time.Second).Should(Succeed())
+			assert.XFail("suspected cloud-init issue: https://github.com/kubevirt/kubevirt/issues/4642", func() {
+				Eventually(func() error {
+					return libnet.PingFromVMConsole(vmi1, cidrToIP(cidrB))
+				}, 15*time.Second, time.Second).Should(Succeed())
+				Eventually(func() error {
+					return libnet.PingFromVMConsole(vmi2, cidrToIP(cidrA))
+				}, 15*time.Second, time.Second).Should(Succeed())
+			})
 		})
 
 		Context("With VLAN", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

The current XFail implementation incorrectly marked regular tests as
xfail. This has been observed when an xfail test passed but the following
one, which was not marked as xfail, failed as an xfail.

The original implementation reverted to the regular non-xfail handler
only if a failure occurred, which is obviously incorrect.

The XFail API has been adjusted to wrap a body of code that is expected
to fail and revert the fail handler when exiting the body.
This approach is also more accurate, as the area where the expected
failure is covered is limited and managed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
