### PR TITLE
Drop references to kubevirt-host-device-plugin-config cfgMap

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -988,7 +988,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			if _, exist := supportedHostDevicesMap[hostDev.DeviceName]; !exist {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("GPU %s is not permitted in kubevirt-host-device-plugin-config", hostDev.DeviceName),
+					Message: fmt.Sprintf("GPU %s is not permitted in permittedHostDevices configuration", hostDev.DeviceName),
 					Field:   field.Child("GPUs").String(),
 				})
 			}
@@ -997,7 +997,7 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 			if _, exist := supportedHostDevicesMap[hostDev.DeviceName]; !exist {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf("HostDevice %s is not permitted in kubevirt-host-device-plugin-config", hostDev.DeviceName),
+					Message: fmt.Sprintf("HostDevice %s is not permitted in permittedHostDevices configuration", hostDev.DeviceName),
 					Field:   field.Child("HostDevices").String(),
 				})
 			}


### PR DESCRIPTION
kubevirt-host-device-plugin-config is merged with kubevirt-config cfgMap
so drop references to kubevirt-host-device-plugin-config cfgMap

Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: `Drop references to kubevirt-host-device-plugin-config cfgMap`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
