### PR TITLE
gosec G601: Fix memory aliasing in for loop 

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -461,8 +461,8 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 		}
 	}
 
-	for _, volume := range spec.Volumes {
-		volumeNameMap[volume.Name] = &volume
+	for i, volume := range spec.Volumes {
+		volumeNameMap[volume.Name] = &spec.Volumes[i]
 	}
 
 	// used to validate uniqueness of boot orders among disks and interfaces

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -329,7 +329,8 @@ func (admitter *VMsAdmitter) validateVolumeRequests(ar *v1beta1.AdmissionRequest
 	}
 
 	newSpec := vm.Spec.Template.Spec.DeepCopy()
-	for _, volumeRequest := range vm.Status.VolumeRequests {
+	for _, volumeRequest_ := range vm.Status.VolumeRequests {
+		volumeRequest := volumeRequest_
 		name := ""
 		if volumeRequest.AddVolumeOptions != nil && volumeRequest.RemoveVolumeOptions != nil {
 			return []metav1.StatusCause{{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -329,8 +329,8 @@ func (admitter *VMsAdmitter) validateVolumeRequests(ar *v1beta1.AdmissionRequest
 	}
 
 	newSpec := vm.Spec.Template.Spec.DeepCopy()
-	for _, volumeRequest_ := range vm.Status.VolumeRequests {
-		volumeRequest := volumeRequest_
+	for _, volumeRequest := range vm.Status.VolumeRequests {
+		volumeRequest := volumeRequest
 		name := ""
 		if volumeRequest.AddVolumeOptions != nil && volumeRequest.RemoveVolumeOptions != nil {
 			return []metav1.StatusCause{{

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -637,10 +637,9 @@ func (ctrl *VMSnapshotController) updateVolumeSnapshotStatuses(vm *kubevirtv1.Vi
 
 	vmCopy := vm.DeepCopy()
 	var statuses []kubevirtv1.VolumeSnapshotStatus
-	for _, volume_ := range vmCopy.Spec.Template.Spec.Volumes {
-		volume := volume_
+	for i, volume := range vmCopy.Spec.Template.Spec.Volumes {
 		log.Log.V(3).Infof("Update volume snapshot status for volume [%s]", volume.Name)
-		status := ctrl.getVolumeSnapshotStatus(vmCopy, &volume)
+		status := ctrl.getVolumeSnapshotStatus(vmCopy, &vmCopy.Spec.Template.Spec.Volumes[i])
 		statuses = append(statuses, status)
 	}
 

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -468,8 +468,8 @@ func (ctrl *VMSnapshotController) createContent(vmSnapshot *snapshotv1.VirtualMa
 		},
 		Spec: snapshotv1.VirtualMachineSnapshotContentSpec{
 			VirtualMachineSnapshotName: &vmSnapshot.Name,
-			Source:        source.Spec(),
-			VolumeBackups: volumeBackups,
+			Source:                     source.Spec(),
+			VolumeBackups:              volumeBackups,
 		},
 	}
 

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -468,8 +468,8 @@ func (ctrl *VMSnapshotController) createContent(vmSnapshot *snapshotv1.VirtualMa
 		},
 		Spec: snapshotv1.VirtualMachineSnapshotContentSpec{
 			VirtualMachineSnapshotName: &vmSnapshot.Name,
-			Source:                     source.Spec(),
-			VolumeBackups:              volumeBackups,
+			Source:        source.Spec(),
+			VolumeBackups: volumeBackups,
 		},
 	}
 
@@ -637,7 +637,8 @@ func (ctrl *VMSnapshotController) updateVolumeSnapshotStatuses(vm *kubevirtv1.Vi
 
 	vmCopy := vm.DeepCopy()
 	var statuses []kubevirtv1.VolumeSnapshotStatus
-	for _, volume := range vmCopy.Spec.Template.Spec.Volumes {
+	for _, volume_ := range vmCopy.Spec.Template.Spec.Volumes {
+		volume := volume_
 		log.Log.V(3).Infof("Update volume snapshot status for volume [%s]", volume.Name)
 		status := ctrl.getVolumeSnapshotStatus(vmCopy, &volume)
 		statuses = append(statuses, status)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -492,8 +492,9 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 	if err != nil {
 		return ready, err
 	}
-	for _, template := range vm.Spec.DataVolumeTemplates {
+	for _, template_ := range vm.Spec.DataVolumeTemplates {
 		var curDataVolume *cdiv1.DataVolume
+		template := template_
 		exists := false
 		for _, curDataVolume = range dataVolumes {
 			if curDataVolume.Name == template.Name {
@@ -543,7 +544,8 @@ func (c *VMController) handleVolumeRequests(vm *virtv1.VirtualMachine, vmi *virt
 		}
 	}
 
-	for _, request := range vm.Status.VolumeRequests {
+	for _, request_ := range vm.Status.VolumeRequests {
+		request := request_
 		vmCopy.Spec.Template.Spec = *controller.ApplyVolumeRequestOnVMISpec(&vmCopy.Spec.Template.Spec, &request)
 
 		if vmi != nil && vmi.DeletionTimestamp == nil {

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -492,9 +492,8 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 	if err != nil {
 		return ready, err
 	}
-	for _, template_ := range vm.Spec.DataVolumeTemplates {
+	for i, template := range vm.Spec.DataVolumeTemplates {
 		var curDataVolume *cdiv1.DataVolume
-		template := template_
 		exists := false
 		for _, curDataVolume = range dataVolumes {
 			if curDataVolume.Name == template.Name {
@@ -505,7 +504,7 @@ func (c *VMController) handleDataVolumes(vm *virtv1.VirtualMachine, dataVolumes 
 		if !exists {
 			// ready = false because encountered DataVolume that is not created yet
 			ready = false
-			newDataVolume := createDataVolumeManifest(&template, vm)
+			newDataVolume := createDataVolumeManifest(&vm.Spec.DataVolumeTemplates[i], vm)
 
 			if err = c.authorizeDataVolume(vm, newDataVolume); err != nil {
 				c.recorder.Eventf(vm, k8score.EventTypeWarning, UnauthorizedDataVolumeCreateReason, "Not authorized to create DataVolume %s: %v", newDataVolume.Name, err)
@@ -544,9 +543,8 @@ func (c *VMController) handleVolumeRequests(vm *virtv1.VirtualMachine, vmi *virt
 		}
 	}
 
-	for _, request_ := range vm.Status.VolumeRequests {
-		request := request_
-		vmCopy.Spec.Template.Spec = *controller.ApplyVolumeRequestOnVMISpec(&vmCopy.Spec.Template.Spec, &request)
+	for i, request := range vm.Status.VolumeRequests {
+		vmCopy.Spec.Template.Spec = *controller.ApplyVolumeRequestOnVMISpec(&vmCopy.Spec.Template.Spec, &vm.Status.VolumeRequests[i])
 
 		if vmi != nil && vmi.DeletionTimestamp == nil {
 			if request.AddVolumeOptions != nil {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1459,8 +1459,7 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 		return err
 	}
 	newStatus := make([]virtv1.VolumeStatus, 0)
-	for _, volume_ := range vmi.Spec.Volumes {
-		volume := volume_
+	for i, volume := range vmi.Spec.Volumes {
 		status := virtv1.VolumeStatus{}
 		if _, ok := oldStatusMap[volume.Name]; ok {
 			// Already have the status, modify if needed
@@ -1480,7 +1479,7 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 				status.HotplugVolume.AttachPodName = ""
 				status.HotplugVolume.AttachPodUID = ""
 				// Pod is gone, or hasn't been created yet, check for the PVC associated with the volume to set phase and message
-				phase, reason, message := c.getVolumePhaseMessageReason(&volume, vmi.Namespace)
+				phase, reason, message := c.getVolumePhaseMessageReason(&vmi.Spec.Volumes[i], vmi.Namespace)
 				status.Phase = phase
 				status.Message = message
 				status.Reason = reason

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1459,7 +1459,8 @@ func (c *VMIController) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, v
 		return err
 	}
 	newStatus := make([]virtv1.VolumeStatus, 0)
-	for _, volume := range vmi.Spec.Volumes {
+	for _, volume_ := range vmi.Spec.Volumes {
+		volume := volume_
 		status := virtv1.VolumeStatus{}
 		if _, ok := oldStatusMap[volume.Name]; ok {
 			// Already have the status, modify if needed

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -546,8 +546,8 @@ func (l *AccessCredentialManager) watchSecrets(vmi *v1.VirtualMachineInstance) {
 		}
 
 		// Step 1. Populate Secrets and filepath Map
-		for _, accessCred_ := range vmi.Spec.AccessCredentials {
-			accessCred := accessCred_
+		for _, accessCred := range vmi.Spec.AccessCredentials {
+			accessCred := accessCred
 			secretName := getSecret(&accessCred)
 			if secretName == "" {
 				continue

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -85,8 +85,8 @@ type AccessCredentialManager struct {
 
 func NewManager(connection cli.Connection, domainModifyLock *sync.Mutex) *AccessCredentialManager {
 	return &AccessCredentialManager{
-		virConn: connection,
-		stopCh:  make(chan struct{}),
+		virConn:                    connection,
+		stopCh:                     make(chan struct{}),
 		resyncCheckIntervalSeconds: 15,
 		domainModifyLock:           domainModifyLock,
 	}

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go
@@ -85,8 +85,8 @@ type AccessCredentialManager struct {
 
 func NewManager(connection cli.Connection, domainModifyLock *sync.Mutex) *AccessCredentialManager {
 	return &AccessCredentialManager{
-		virConn:                    connection,
-		stopCh:                     make(chan struct{}),
+		virConn: connection,
+		stopCh:  make(chan struct{}),
 		resyncCheckIntervalSeconds: 15,
 		domainModifyLock:           domainModifyLock,
 	}
@@ -546,7 +546,8 @@ func (l *AccessCredentialManager) watchSecrets(vmi *v1.VirtualMachineInstance) {
 		}
 
 		// Step 1. Populate Secrets and filepath Map
-		for _, accessCred := range vmi.Spec.AccessCredentials {
+		for _, accessCred_ := range vmi.Spec.AccessCredentials {
+			accessCred := accessCred_
 			secretName := getSecret(&accessCred)
 			if secretName == "" {
 				continue

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -255,8 +255,7 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 	}
 
 	var list []*stats.DomainStats
-	for _, domStat_ := range domStats {
-		domStat := domStat_
+	for i, domStat := range domStats {
 		var err error
 
 		memStats, err := domStat.Domain.MemoryStats(uint32(libvirt.DOMAIN_MEMORY_STAT_NR), 0)
@@ -265,7 +264,7 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 		}
 
 		stat := &stats.DomainStats{}
-		err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(statsconv.DomainIdentifier(domStat.Domain), &domStat, memStats, stat)
+		err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(statsconv.DomainIdentifier(domStat.Domain), &domStats[i], memStats, stat)
 		if err != nil {
 			return list, err
 		}

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -212,8 +212,8 @@ func (l *LibvirtConnection) ListAllDomains(flags libvirt.ConnectListAllDomainsFl
 		return nil, err
 	}
 	doms := make([]VirDomain, len(virDoms))
-	for i, d := range virDoms {
-		doms[i] = &d
+	for i := range virDoms {
+		doms[i] = &virDoms[i]
 	}
 	return doms, nil
 }
@@ -255,7 +255,8 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 	}
 
 	var list []*stats.DomainStats
-	for _, domStat := range domStats {
+	for _, domStat_ := range domStats {
+		domStat := domStat_
 		var err error
 
 		memStats, err := domStat.Domain.MemoryStats(uint32(libvirt.DOMAIN_MEMORY_STAT_NR), 0)

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1174,7 +1174,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	}
 
 	prefixMap := newDeviceNamer(vmi.Status.VolumeStatus, vmi.Spec.Domain.Devices.Disks)
-	for _, disk := range vmi.Spec.Domain.Devices.Disks {
+	for _, disk_ := range vmi.Spec.Domain.Devices.Disks {
+		disk := disk_
 		newDisk := api.Disk{}
 
 		err := Convert_v1_Disk_To_api_Disk(c, &disk, &newDisk, prefixMap, numBlkQueues)
@@ -1278,7 +1279,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	isUSBDevicePresent := false
 	if vmi.Spec.Domain.Devices.Inputs != nil {
 		inputDevices := make([]api.Input, 0)
-		for _, input := range vmi.Spec.Domain.Devices.Inputs {
+		for _, input_ := range vmi.Spec.Domain.Devices.Inputs {
+			input := input_
 			inputDevice := api.Input{}
 			err := Convert_v1_Input_To_api_InputDevice(&input, &inputDevice, c)
 			if err != nil {
@@ -1487,7 +1489,8 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		sriovPciAddresses[key] = append([]string{}, value...)
 	}
 
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+	for _, iface_ := range vmi.Spec.Domain.Devices.Interfaces {
+		iface := iface_
 		net, isExist := networks[iface.Name]
 		if !isExist {
 			return fmt.Errorf("failed to find network %s", iface.Name)

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1174,11 +1174,10 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	}
 
 	prefixMap := newDeviceNamer(vmi.Status.VolumeStatus, vmi.Spec.Domain.Devices.Disks)
-	for _, disk_ := range vmi.Spec.Domain.Devices.Disks {
-		disk := disk_
+	for i, disk := range vmi.Spec.Domain.Devices.Disks {
 		newDisk := api.Disk{}
 
-		err := Convert_v1_Disk_To_api_Disk(c, &disk, &newDisk, prefixMap, numBlkQueues)
+		err := Convert_v1_Disk_To_api_Disk(c, &vmi.Spec.Domain.Devices.Disks[i], &newDisk, prefixMap, numBlkQueues)
 		if err != nil {
 			return err
 		}
@@ -1279,10 +1278,9 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 	isUSBDevicePresent := false
 	if vmi.Spec.Domain.Devices.Inputs != nil {
 		inputDevices := make([]api.Input, 0)
-		for _, input_ := range vmi.Spec.Domain.Devices.Inputs {
-			input := input_
+		for i := range vmi.Spec.Domain.Devices.Inputs {
 			inputDevice := api.Input{}
-			err := Convert_v1_Input_To_api_InputDevice(&input, &inputDevice, c)
+			err := Convert_v1_Input_To_api_InputDevice(&vmi.Spec.Domain.Devices.Inputs[i], &inputDevice, c)
 			if err != nil {
 				return err
 			}
@@ -1489,8 +1487,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		sriovPciAddresses[key] = append([]string{}, value...)
 	}
 
-	for _, iface_ := range vmi.Spec.Domain.Devices.Interfaces {
-		iface := iface_
+	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		net, isExist := networks[iface.Name]
 		if !isExist {
 			return fmt.Errorf("failed to find network %s", iface.Name)
@@ -1509,7 +1506,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 			log.Log.Infof("SR-IOV PCI device allocated: %s", pciAddr)
 			domain.Spec.Devices.HostDevices = append(domain.Spec.Devices.HostDevices, *hostDev)
 		} else {
-			ifaceType := getInterfaceType(&iface)
+			ifaceType := getInterfaceType(&vmi.Spec.Domain.Devices.Interfaces[i])
 			domainIface := api.Interface{
 				Model: &api.Model{
 					Type: translateModel(c, ifaceType),

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -113,7 +113,8 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 		return err
 	}
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+	for _, iface_ := range vmi.Spec.Domain.Devices.Interfaces {
+		iface := iface_
 		networkInterfaceFactory, err := getNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err
@@ -129,7 +130,8 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 
 func SetupNetworkInterfacesPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
-	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+	for _, iface_ := range vmi.Spec.Domain.Devices.Interfaces {
+		iface := iface_
 		vif, err := getNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -113,14 +113,13 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 		return err
 	}
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
-	for _, iface_ := range vmi.Spec.Domain.Devices.Interfaces {
-		iface := iface_
+	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		networkInterfaceFactory, err := getNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err
 		}
 		podInterfaceName = getPodInterfaceName(networks, cniNetworks, iface.Name)
-		err = NetworkInterface.PlugPhase1(networkInterfaceFactory, vmi, &iface, networks[iface.Name], podInterfaceName, pid)
+		err = NetworkInterface.PlugPhase1(networkInterfaceFactory, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], networks[iface.Name], podInterfaceName, pid)
 		if err != nil {
 			return err
 		}
@@ -130,14 +129,13 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 
 func SetupNetworkInterfacesPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
-	for _, iface_ := range vmi.Spec.Domain.Devices.Interfaces {
-		iface := iface_
+	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		vif, err := getNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err
 		}
 		podInterfaceName = getPodInterfaceName(networks, cniNetworks, iface.Name)
-		err = NetworkInterface.PlugPhase2(vif, vmi, &iface, networks[iface.Name], domain, podInterfaceName)
+		err = NetworkInterface.PlugPhase2(vif, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], networks[iface.Name], domain, podInterfaceName)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1122,7 +1122,7 @@ func (s *SlirpPodInterface) decorateConfig() error {
 	for i, iface := range ifaces {
 		if iface.Alias.Name == s.iface.Name {
 			s.domain.Spec.Devices.Interfaces = append(ifaces[:i], ifaces[i+1:]...)
-			foundIface = &iface
+			foundIface = &ifaces[i]
 			break
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1119,10 +1119,11 @@ func (s *SlirpPodInterface) decorateConfig() error {
 	// remove slirp interface from domain spec devices interfaces
 	var foundIface *api.Interface
 	ifaces := s.domain.Spec.Devices.Interfaces
-	for i, iface := range ifaces {
+	for i, iface_ := range ifaces {
+		iface := iface_
 		if iface.Alias.Name == s.iface.Name {
 			s.domain.Spec.Devices.Interfaces = append(ifaces[:i], ifaces[i+1:]...)
-			foundIface = &ifaces[i]
+			foundIface = &iface
 			break
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1117,22 +1117,21 @@ func (s *SlirpPodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
 
 func (s *SlirpPodInterface) decorateConfig() error {
 	// remove slirp interface from domain spec devices interfaces
-	var foundIface *api.Interface
+	var foundIfaceModelType string
 	ifaces := s.domain.Spec.Devices.Interfaces
-	for i, iface_ := range ifaces {
-		iface := iface_
+	for i, iface := range ifaces {
 		if iface.Alias.Name == s.iface.Name {
 			s.domain.Spec.Devices.Interfaces = append(ifaces[:i], ifaces[i+1:]...)
-			foundIface = &iface
+			foundIfaceModelType = iface.Model.Type
 			break
 		}
 	}
 
-	if foundIface == nil {
+	if foundIfaceModelType == "" {
 		return fmt.Errorf("failed to find interface %s in vmi spec", s.iface.Name)
 	}
 
-	qemuArg := fmt.Sprintf("%s,netdev=%s,id=%s", foundIface.Model.Type, s.iface.Name, s.iface.Name)
+	qemuArg := fmt.Sprintf("%s,netdev=%s,id=%s", foundIfaceModelType, s.iface.Name, s.iface.Name)
 	if s.iface.MacAddress != "" {
 		// We assume address was already validated in API layer so just pass it to libvirt as-is.
 		qemuArg += fmt.Sprintf(",mac=%s", s.iface.MacAddress)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix cases in which the address of loop variable is passed to a function or stored. Using the address of a loop variable is dangerous as it allocates a single memory location and hence the address will be the same for all iterations !

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
"NONE"
```
