### PR TITLE
fix: change hotplug pvc using isBlockPVC

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -512,7 +512,7 @@ func Convert_v1_PersistentVolumeClaim_To_api_Disk(name string, disk *api.Disk, c
 
 // Convert_v1_Hotplug_PersistentVolumeClaim_To_api_Disk converts a Hotplugged PVC to an api disk
 func Convert_v1_Hotplug_PersistentVolumeClaim_To_api_Disk(name string, disk *api.Disk, c *ConverterContext) error {
-	if c.IsBlockDV[name] {
+	if c.IsBlockPVC[name] {
 		return Convert_v1_Hotplug_BlockVolumeSource_To_api_Disk(name, disk, c)
 	}
 	return Convert_v1_Hotplug_FilesystemVolumeSource_To_api_Disk(name, disk, c)


### PR DESCRIPTION
when hotplug a PVC Block to a running VMI, here should be judged as isBlockPVC but not isBlockDV, otherwise here would be regarded as a disk.img

Signed-off-by: actor168@gmail.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
