### PR TITLE
Fix attachment pod permissions

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1223,12 +1223,12 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, 
 							k8sv1.ResourceMemory: resource.MustParse("1M"),
 						},
 					},
-				},
-			},
-			SecurityContext: &k8sv1.PodSecurityContext{
-				SELinuxOptions: &k8sv1.SELinuxOptions{
-					Level: "s0",
-					Type:  t.clusterConfig.GetSELinuxLauncherType(),
+					SecurityContext: &k8sv1.SecurityContext{
+						SELinuxOptions: &k8sv1.SELinuxOptions{
+							Level: "s0",
+							Type:  t.clusterConfig.GetSELinuxLauncherType(),
+						},
+					},
 				},
 			},
 			Affinity: &k8sv1.Affinity{

--- a/pkg/virt-operator/creation/components/scc.go
+++ b/pkg/virt-operator/creation/components/scc.go
@@ -76,6 +76,7 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	}
 	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE"}
 	scc.AllowHostDirVolumePlugin = true
+	scc.AllowHostNetwork = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}
 
 	return scc


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixed Open Shift SCC permissions to allow attachment pods to use host network.
Fixed selinux to be on container level instead of pod level.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
