### PR TITLE
Fix file and directory permission setting to comply gosec rule G301 a…

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -143,7 +143,7 @@ if ! $KUBEVIRT_CRI exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "$@"; 
     fi
     set -x
     # Copy the junit where prow can pick it up
-    if [ "$@" = "./hack/gosec.sh" ] && [ "$CI" = "true" ]; then
+    if [ -f ${OUT_DIR}/artifacts/junit-gosec.xml ] && [ "$CI" = "true" ]; then
         echo "Moving file in prow"
         mv ${OUT_DIR}/artifacts/junit-gosec.xml ${ARTIFACTS}
     fi

--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
 )
 
@@ -412,7 +413,7 @@ func SetIsoCreationFunction(isoFunc IsoCreationFunc) {
 }
 
 func SetLocalDirectory(dir string) error {
-	err := os.MkdirAll(dir, 0755)
+	err := util.MkdirAllWithNosec(dir)
 	if err != nil {
 		return fmt.Errorf("unable to initialize cloudInit local cache directory (%s). %v", dir, err)
 	}
@@ -504,7 +505,7 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		return fmt.Errorf("Invalid cloud-init data source: '%v'", data.DataSource)
 	}
 
-	err = os.MkdirAll(dataPath, 0755)
+	err = util.MkdirAllWithNosec(dataPath)
 	if err != nil {
 		log.Log.V(2).Reason(err).Errorf("unable to create cloud-init base path %s", domainBasePath)
 		return err
@@ -525,20 +526,20 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		return err
 	}
 
-	err = ioutil.WriteFile(userFile, userData, 0644)
+	err = ioutil.WriteFile(userFile, userData, 0600)
 	if err != nil {
 		return err
 	}
 	defer os.Remove(userFile)
 
-	err = ioutil.WriteFile(metaFile, metaData, 0644)
+	err = ioutil.WriteFile(metaFile, metaData, 0600)
 	if err != nil {
 		return err
 	}
 	defer os.Remove(metaFile)
 
 	if len(networkData) > 0 {
-		err = ioutil.WriteFile(networkFile, networkData, 0644)
+		err = ioutil.WriteFile(networkFile, networkData, 0600)
 		if err != nil {
 			return err
 		}

--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -96,7 +96,7 @@ func GetDiskTargetPathFromLauncherView(volumeIndex int) string {
 
 func SetLocalDirectory(dir string) error {
 	mountBaseDir = dir
-	return os.MkdirAll(dir, 0755)
+	return os.MkdirAll(dir, 0750)
 }
 
 func SetKubeletPodsDirectory(dir string) {
@@ -106,7 +106,7 @@ func SetKubeletPodsDirectory(dir string) {
 // used for testing - we don't want to MkdirAll on a production host mount
 func setPodsDirectory(dir string) error {
 	podsBaseDir = dir
-	return os.MkdirAll(dir, 0755)
+	return os.MkdirAll(dir, 0750)
 }
 
 // The unit test suite uses this function

--- a/pkg/emptydisk/BUILD.bazel
+++ b/pkg/emptydisk/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
     ],
 )

--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -8,6 +8,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 var EmptyDiskBaseDir = "/var/run/libvirt/empty-disks/"
@@ -20,7 +21,7 @@ func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
 			// qemu-img takes the size in bytes or in Kibibytes/Mebibytes/...; lets take bytes
 			size := strconv.FormatInt(volume.EmptyDisk.Capacity.ToDec().ScaledValue(0), 10)
 			file := FilePathForVolumeName(volume.Name)
-			if err := os.MkdirAll(EmptyDiskBaseDir, 0777); err != nil {
+			if err := util.MkdirAllWithNosec(EmptyDiskBaseDir); err != nil {
 				return err
 			}
 			if _, err := os.Stat(file); os.IsNotExist(err) {

--- a/pkg/ephemeral-disk/BUILD.bazel
+++ b/pkg/ephemeral-disk/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
     ],
 )

--- a/pkg/ephemeral-disk/ephemeral-disk.go
+++ b/pkg/ephemeral-disk/ephemeral-disk.go
@@ -27,6 +27,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 var mountBaseDir = "/var/run/libvirt/kubevirt-ephemeral-disk"
@@ -46,19 +47,19 @@ func getBackingFilePath(volumeName string) string {
 
 func SetLocalDirectory(dir string) error {
 	mountBaseDir = dir
-	return os.MkdirAll(dir, 0755)
+	return util.MkdirAllWithNosec(dir)
 }
 
 // Used by tests.
 func setBackingDirectory(dir string) error {
 	pvcBaseDir = dir
-	return os.MkdirAll(dir, 0755)
+	return util.MkdirAllWithNosec(dir)
 }
 
 func createVolumeDirectory(volumeName string) error {
 	dir := generateVolumeMountDir(volumeName)
 
-	err := os.MkdirAll(dir, 0755)
+	err := util.MkdirAllWithNosec(dir)
 	if err != nil {
 		return err
 	}
@@ -103,6 +104,7 @@ func CreateBackedImageForVolume(volume v1.Volume, backingFile string) error {
 		return fmt.Errorf("qemu-img failed with output '%s': %v", string(output), err)
 	}
 
+	// #nosec G302: Poor file permissions used with chmod. Safe permission setting for files shared between virt-launcher and qemu.
 	if err = os.Chmod(imagePath, 0640); err != nil {
 		return fmt.Errorf("failed to change permissions on %s", imagePath)
 	}

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -47,7 +47,7 @@ const (
 // Used by tests.
 func setDiskDirectory(dir string) error {
 	pvcBaseDir = dir
-	return os.MkdirAll(dir, 0755)
+	return os.MkdirAll(dir, 0750)
 }
 
 func ReplacePVCByHostDisk(vmi *v1.VirtualMachineInstance, clientset kubecli.KubevirtClient) error {

--- a/pkg/hotplug-disk/hotplug-disk.go
+++ b/pkg/hotplug-disk/hotplug-disk.go
@@ -60,7 +60,7 @@ func GetFileSystemDiskTargetPathFromHostView(virtlauncherPodUID types.UID, volum
 	diskPath := filepath.Join(targetPath, volumeName)
 	exists, _ := diskutils.FileExists(diskPath)
 	if !exists && create {
-		err = os.Mkdir(diskPath, 0755)
+		err = os.Mkdir(diskPath, 0750)
 		if err != nil {
 			return diskPath, err
 		}
@@ -73,7 +73,7 @@ func GetFileSystemDiskTargetPathFromHostView(virtlauncherPodUID types.UID, volum
 // a directory under this, that contains the volume name. block volumes will be in this directory as a block device.
 func SetLocalDirectory(dir string) error {
 	mountBaseDir = dir
-	return os.MkdirAll(dir, 0755)
+	return os.MkdirAll(dir, 0750)
 }
 
 // SetKubeletPodsDirectory sets the base directory of where the kubelet stores its pods.

--- a/pkg/ignition/BUILD.bazel
+++ b/pkg/ignition/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",

--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -22,13 +22,12 @@ package ignition
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 var ignitionLocalDir = "/var/run/libvirt/ignition-dir"
@@ -41,7 +40,7 @@ func GetIgnitionSource(vmi *v1.VirtualMachineInstance) string {
 }
 
 func SetLocalDirectory(dir string) error {
-	err := os.MkdirAll(dir, 0755)
+	err := util.MkdirAllWithNosec(dir)
 	if err != nil {
 		return errors.New(fmt.Sprintf("Unable to initialize Ignition local cache directory (%s). %v", dir, err))
 	}
@@ -66,7 +65,7 @@ func GenerateIgnitionLocalData(vmi *v1.VirtualMachineInstance, namespace string)
 	precond.MustNotBeNil(vmi.Annotations[v1.IgnitionAnnotation])
 
 	domainBasePath := GetDomainBasePath(vmi.Name, namespace)
-	err := os.MkdirAll(domainBasePath, 0755)
+	err := util.MkdirAllWithNosec(domainBasePath)
 	if err != nil {
 		log.Log.V(2).Reason(err).Errorf("unable to create Ignition base path %s", domainBasePath)
 		return err
@@ -74,7 +73,7 @@ func GenerateIgnitionLocalData(vmi *v1.VirtualMachineInstance, namespace string)
 
 	ignitionFile := fmt.Sprintf("%s/%s", domainBasePath, IgnitionFile)
 	ignitionData := []byte(vmi.Annotations[v1.IgnitionAnnotation])
-	err = ioutil.WriteFile(ignitionFile, ignitionData, 0644)
+	err = util.WriteFileWithNosec(ignitionFile, ignitionData)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/net/grpc/BUILD.bazel
+++ b/pkg/util/net/grpc/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util/net/grpc",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/pkg/util/net/grpc/grpc.go
+++ b/pkg/util/net/grpc/grpc.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -65,7 +66,7 @@ func DialSocketWithTimeout(socketPath string, timeout int) (*grpc.ClientConn, er
 func CreateSocket(socketPath string) (net.Listener, error) {
 	os.RemoveAll(socketPath)
 
-	err := os.MkdirAll(filepath.Dir(socketPath), 0755)
+	err := util.MkdirAllWithNosec(filepath.Dir(socketPath))
 	if err != nil {
 		log.Log.Reason(err).Errorf("unable to create directory for unix socket %v", socketPath)
 		return nil, err

--- a/pkg/util/sysctl/BUILD.bazel
+++ b/pkg/util/sysctl/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["sysctl.go"],
     importpath = "kubevirt.io/kubevirt/pkg/util/sysctl",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/util:go_default_library"],
 )

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -21,6 +21,8 @@ import (
 	"path"
 	"strconv"
 	"strings"
+
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -62,5 +64,5 @@ func (*procSysctl) GetSysctl(sysctl string) (int, error) {
 
 // SetSysctl modifies the specified sysctl flag to the new value
 func (*procSysctl) SetSysctl(sysctl string, newVal int) error {
-	return ioutil.WriteFile(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)), 0640)
+	return util.WriteFileWithNosec(path.Join(sysctlBase, sysctl), []byte(strconv.Itoa(newVal)))
 }

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/host-disk:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -102,7 +102,7 @@ func InitializeGhostRecordCache(directoryPath string) error {
 
 	ghostRecordGlobalCache = make(map[string]ghostRecord)
 	ghostRecordDir = directoryPath
-	err := os.MkdirAll(ghostRecordDir, 0755)
+	err := util.MkdirAllWithNosec(ghostRecordDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -161,12 +161,12 @@ func (m *mounter) setMountTargetRecord(vmi *v1.VirtualMachineInstance, record *v
 		return err
 	}
 
-	err = os.MkdirAll(filepath.Dir(recordFile), 0755)
+	err = os.MkdirAll(filepath.Dir(recordFile), 0750)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(recordFile, bytes, 0644)
+	err = ioutil.WriteFile(recordFile, bytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -211,12 +211,12 @@ func (m *volumeMounter) setMountTargetRecord(vmi *v1.VirtualMachineInstance, rec
 		return err
 	}
 
-	err = os.MkdirAll(filepath.Dir(recordFile), 0755)
+	err = os.MkdirAll(filepath.Dir(recordFile), 0750)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(recordFile, bytes, 0644)
+	err = ioutil.WriteFile(recordFile, bytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -31,6 +31,7 @@ import (
 	"sync"
 
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/ip"
 )
 
@@ -348,7 +349,7 @@ func (m *migrationProxy) createTcpListener() error {
 func (m *migrationProxy) createUnixListener() error {
 
 	os.RemoveAll(m.unixSocketPath)
-	err := os.MkdirAll(filepath.Dir(m.unixSocketPath), 0755)
+	err := util.MkdirAllWithNosec(filepath.Dir(m.unixSocketPath))
 	if err != nil {
 		log.Log.Reason(err).Error("unable to create directory for unix socket")
 		return err

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -130,7 +130,7 @@ func defaultCopyPolicyFunc(policyName string, dir string) (err error) {
 	}
 
 	destinationFile := dir + "/" + sourceFile
-	err = ioutil.WriteFile(destinationFile, input, 0644)
+	err = ioutil.WriteFile(destinationFile, input, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create a policy file %v: %v ", destinationFile, err)
 	}

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	"kubevirt.io/kubevirt/pkg/util"
 	netcache "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network/cache"
 
 	"kubevirt.io/kubevirt/pkg/virt-handler/heartbeat"
@@ -294,7 +295,7 @@ func (d *VirtualMachineController) startDomainNotifyPipe(domainPipeStopChan chan
 	socketPath := filepath.Join(res.MountRoot(), d.virtShareDir, "domain-notify-pipe.sock")
 
 	os.RemoveAll(socketPath)
-	err = os.MkdirAll(filepath.Dir(socketPath), 0755)
+	err = util.MkdirAllWithNosec(filepath.Dir(socketPath))
 	if err != nil {
 		log.Log.Reason(err).Error("unable to create directory for unix socket")
 		return err

--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -30,6 +30,7 @@ import (
 
 	"kubevirt.io/client-go/log"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 type OnShutdownCallback func(pid int)
@@ -52,7 +53,7 @@ type ProcessMonitor interface {
 }
 
 func InitializePrivateDirectories(baseDir string) error {
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := util.MkdirAllWithNosec(baseDir); err != nil {
 		return err
 	}
 	if err := diskutils.DefaultOwnershipManager.SetFileOwnership(baseDir); err != nil {
@@ -62,12 +63,13 @@ func InitializePrivateDirectories(baseDir string) error {
 }
 
 func InitializeDisksDirectories(baseDir string) error {
-	err := os.MkdirAll(baseDir, 0755)
+	err := os.MkdirAll(baseDir, 0750)
 	if err != nil {
 		return err
 	}
 
-	err = os.Chmod(baseDir, 0755)
+	// #nosec G302: Poor file permissions used with chmod. Using the safe permission setting for a directory.
+	err = os.Chmod(baseDir, 0750)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -912,7 +912,7 @@ func (l *LibvirtDomainManager) MigrateVMI(vmi *v1.VirtualMachineInstance, option
 }
 
 var updateHostsFile = func(entry string) (err error) {
-	file, err := os.OpenFile("/etc/hosts", os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := kutil.OpenFileWithNosec("/etc/hosts", os.O_WRONLY|os.O_APPEND)
 	if err != nil {
 		return fmt.Errorf("failed opening file: %s", err)
 	}
@@ -1525,7 +1525,7 @@ func checkIfDiskReadyToUseFunc(filename string) (bool, error) {
 		return false, err
 	}
 	if (info.Mode() & os.ModeDevice) != 0 {
-		file, err := os.OpenFile(filename, os.O_RDONLY, 0777)
+		file, err := os.OpenFile(filename, os.O_RDONLY, 0600)
 		if err != nil {
 			log.DefaultLogger().V(1).Infof("Unable to open file: %v", err)
 			return false, nil
@@ -1536,7 +1536,7 @@ func checkIfDiskReadyToUseFunc(filename string) (bool, error) {
 		return true, nil
 	}
 	// Before attempting to attach, ensure we can open the file
-	file, err := os.OpenFile(filename, os.O_RDWR, 0660)
+	file, err := os.OpenFile(filename, os.O_RDWR, 0600)
 	if err != nil {
 		return false, nil
 	}

--- a/pkg/virt-launcher/virtwrap/network/cache/infocache.go
+++ b/pkg/virt-launcher/virtwrap/network/cache/infocache.go
@@ -115,7 +115,7 @@ func newPodInterfaceCacheStore(vmi *v1.VirtualMachineInstance, baseDir, pattern 
 }
 
 func writeToCachedFile(obj interface{}, fileName string) error {
-	if err := os.MkdirAll(filepath.Dir(fileName), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(fileName), 0750); err != nil {
 		return err
 	}
 	buf, err := json.MarshalIndent(&obj, "", "  ")
@@ -123,7 +123,7 @@ func writeToCachedFile(obj interface{}, fileName string) error {
 		return fmt.Errorf("error marshaling cached object: %v", err)
 	}
 
-	err = ioutil.WriteFile(fileName, buf, 0644)
+	err = ioutil.WriteFile(fileName, buf, 0600)
 	if err != nil {
 		return fmt.Errorf("error writing cached object: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -77,7 +77,7 @@ func getVifFilePath(pid, name string) string {
 }
 
 func writeVifFile(buf []byte, pid, name string) error {
-	err := ioutil.WriteFile(getVifFilePath(pid, name), buf, 0644)
+	err := ioutil.WriteFile(getVifFilePath(pid, name), buf, 0600)
 	if err != nil {
 		return fmt.Errorf("error writing vif object: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -334,7 +334,7 @@ func startQEMUSeaBiosLogging(stopChan chan struct{}) {
 		return
 	}
 
-	QEMUPipe, err := os.OpenFile(QEMUSeaBiosDebugPipe, os.O_RDONLY, 0666)
+	QEMUPipe, err := os.OpenFile(QEMUSeaBiosDebugPipe, os.O_RDONLY, 0600)
 
 	if err != nil {
 		log.Log.Reason(err).Error(fmt.Sprintf("%s failed to open %s", logLinePrefix, QEMUSeaBiosDebugPipe))
@@ -433,6 +433,7 @@ func SetupLibvirt() (err error) {
 		if err != nil {
 			return err
 		}
+		// #nosec G302: Poor file permissions used with chmod. Safe to use the common permission setting for the specific system file
 		err = os.Chmod("/dev/kvm", 0660)
 		if err != nil {
 			return err
@@ -441,7 +442,7 @@ func SetupLibvirt() (err error) {
 		return err
 	}
 
-	qemuConf, err := os.OpenFile("/etc/libvirt/qemu.conf", os.O_APPEND|os.O_WRONLY, 0644)
+	qemuConf, err := os.OpenFile("/etc/libvirt/qemu.conf", os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
@@ -461,7 +462,7 @@ func SetupLibvirt() (err error) {
 	}
 
 	// Let libvirt log to stderr
-	libvirtConf, err := os.OpenFile("/etc/libvirt/libvirtd.conf", os.O_APPEND|os.O_WRONLY, 0644)
+	libvirtConf, err := util.OpenFileWithNosec("/etc/libvirt/libvirtd.conf", os.O_APPEND|os.O_WRONLY)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
...and G306, mapping to following gosec testsuite names:

- Expect file permissions to be 0600 or less
- Expect WriteFile permissions to be 0600 or less
- Expect directory permissions to be 0750 or less

Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fix warnings coming from the gosec static analysis. Audit the code to make sure no warning associated to weak permission settings of file and directory operations in `go` programs. Specifically, the warnings addressed in this PR are as below. They are associated to gosec rule G301, G302 and G306:

- Expect file permissions to be 0600 or less
- Expect WriteFile permissions to be 0600 or less
- Expect directory permissions to be 0750 or less

The treatments are two folds:
- When not breaking e2e tests, change file permission specifications from 644 to 600 and directory permission specification from 755 to 750.
- For complaining lines where the permission specifications can not be altered, repeating file operations are redirected into 3 *unsafe* helper functions that wrap ```#nosec``` lines with file operations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The output of `/test pull-kubevirt-gosec` with the latest changes are kept at: https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4756/pull-kubevirt-gosec/1372561001886519296/artifacts/junit-gosec.xml. There is no file/directory/chmod permission related gosec complains.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
"NONE"
```
