### PR TITLE
Fix pinning of vCPU threads

### DIFF
--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )
 

--- a/pkg/util/hardware/BUILD.bazel
+++ b/pkg/util/hardware/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["hw_utils.go"],
     importpath = "kubevirt.io/kubevirt/pkg/util/hardware",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/api/v1:go_default_library"],
+    deps = [
+        "//pkg/util:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -61,6 +62,18 @@ func ParseCPUSetLine(cpusetLine string) (cpusList []int, err error) {
 		}
 	}
 	return
+}
+
+func ParseCPUSetFile(file string) ([]int, error) {
+	line, err := util.ScanLine(file)
+	if err != nil {
+		return nil, err
+	}
+	cpusList, err := ParseCPUSetLine(line)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cpuset file: %v", err)
+	}
+	return cpusList, nil
 }
 
 //GetNumberOfVCPUs returns number of vCPUs

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -20,11 +20,30 @@
 package hardware
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	v1 "kubevirt.io/client-go/api/v1"
 )
+
+type CPUTopologyData struct {
+	cpus              []int
+	getCPUsErr        error
+	siblings          map[int][]int
+	getCPUSiblingsErr error
+	res               []int
+	err               bool
+}
+
+func (t CPUTopologyData) GetCPUs() ([]int, error) {
+	return t.cpus, t.getCPUsErr
+}
+
+func (t CPUTopologyData) GetCPUSiblings(cpu int) ([]int, error) {
+	return t.siblings[cpu], t.getCPUSiblingsErr
+}
 
 var _ = Describe("Hardware utils test", func() {
 
@@ -36,6 +55,71 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(lst)).To(Equal(7))
 			Expect(lst).To(Equal(expectedList))
+		})
+	})
+
+	Context("CPU threads grouping", func() {
+		It("shoud group CPU threads correctly", func() {
+			cpus8 := []int{0, 1, 2, 3, 4, 5, 6, 7}
+			cpus3 := []int{1, 2, 5}
+			siblings00 := map[int][]int{
+				0: {0}, 4: {4},
+				1: {1}, 5: {5},
+				2: {2}, 6: {6},
+				3: {3}, 7: {7},
+			}
+			siblingsMix := map[int][]int{
+				0: {0}, 4: {4},
+				1: {1, 5}, 5: {1, 5},
+				2: {2}, 6: {6},
+				3: {3}, 7: {7},
+			}
+			siblings01 := map[int][]int{
+				0: {0, 1}, 1: {0, 1},
+				2: {2, 3}, 3: {2, 3},
+				4: {4, 5}, 5: {4, 5},
+				6: {6, 7}, 7: {6, 7},
+			}
+			siblings04 := map[int][]int{
+				0: {0, 4}, 4: {0, 4},
+				1: {1, 5}, 5: {1, 5},
+				2: {2, 6}, 6: {2, 6},
+				3: {3, 7}, 7: {3, 7},
+			}
+			siblings0246 := map[int][]int{
+				0: {0, 2, 4, 6}, 2: {0, 2, 4, 6}, 4: {0, 2, 4, 6}, 6: {0, 2, 4, 6},
+				1: {1, 3, 5, 7}, 3: {1, 3, 5, 7}, 5: {1, 3, 5, 7}, 7: {1, 3, 5, 7},
+			}
+			testData := []CPUTopologyData{
+				// No siblings: expect res, nil
+				{cpus: cpus8, siblings: siblings00, res: cpus8},
+				{cpus: cpus3, siblings: siblings00, res: cpus3},
+				// Mixed siblings/non-siblings 1,5: expect res, nil
+				{cpus: cpus8, siblings: siblingsMix, res: []int{0, 1, 5, 2, 3, 4, 6, 7}},
+				{cpus: cpus3, siblings: siblingsMix, res: []int{1, 5, 2}},
+				// Siblings 0,1 ... 6,7: expect res, nil
+				{cpus: cpus8, siblings: siblings01, res: cpus8},
+				{cpus: cpus3, siblings: siblings01, res: cpus3},
+				// Siblings 0,4 ... 3,7: expect res, nil
+				{cpus: cpus8, siblings: siblings04, res: []int{0, 4, 1, 5, 2, 6, 3, 7}},
+				{cpus: cpus3, siblings: siblings04, res: []int{1, 5, 2}},
+				// Siblings 0,2,4,6 ... 1,2,5,7
+				{cpus: cpus8, siblings: siblings0246, res: []int{0, 2, 4, 6, 1, 3, 5, 7}},
+				{cpus: cpus3, siblings: siblings0246, res: []int{1, 5, 2}},
+				// GetCPUs returns an error: expect nil, err
+				{getCPUsErr: errors.New(""), err: true},
+				// GetCPUSiblings returns an error: expect res, nil
+				{cpus: cpus8, getCPUSiblingsErr: errors.New(""), res: cpus8},
+			}
+			for _, t := range testData {
+				res, err := GroupCPUThreads(t)
+				Expect(res).To(Equal(t.res))
+				if t.err {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+				}
+			}
 		})
 	})
 

--- a/pkg/util/os_helper.go
+++ b/pkg/util/os_helper.go
@@ -20,6 +20,7 @@
 package util
 
 import (
+	"bufio"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,6 +40,21 @@ func CloseIOAndCheckErr(c io.Closer, err *error) {
 			*err = ferr
 		}
 	}
+}
+
+// ScanLine tries to read the first line from a file. The text is returned without the end-of-line symbols.
+func ScanLine(filepath string) (line string, err error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return
+	}
+	defer CloseIOAndCheckErr(file, nil)
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		line = scanner.Text()
+	}
+	err = scanner.Err()
+	return
 }
 
 // The following helper functions wrap nosec annotations with os file functions that potentially assign files or directories

--- a/pkg/virt-launcher/virtwrap/util/cpu_utils.go
+++ b/pkg/virt-launcher/virtwrap/util/cpu_utils.go
@@ -20,32 +20,10 @@
 package util
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-
-	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 )
 
 func GetPodCPUSet() ([]int, error) {
-	var cpuset string
-	file, err := os.Open(cgroup.CPUSetPath())
-	if err != nil {
-		return nil, err
-	}
-	defer util.CloseIOAndCheckErr(file, nil)
-	scanner := bufio.NewScanner(file)
-	if scanner.Scan() {
-		cpuset = scanner.Text()
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	cpusList, err := hardware.ParseCPUSetLine(cpuset)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse cpuset file: %v", err)
-	}
-	return cpusList, nil
+	return hardware.ParseCPUSetFile(cgroup.CPUSetPath())
 }

--- a/pkg/virt-launcher/virtwrap/util/cpu_utils.go
+++ b/pkg/virt-launcher/virtwrap/util/cpu_utils.go
@@ -25,5 +25,6 @@ import (
 )
 
 func GetPodCPUSet() ([]int, error) {
-	return hardware.ParseCPUSetFile(cgroup.CPUSetPath())
+	topo := hardware.NewPodCPUTopo(cgroup.CPUSetPath())
+	return hardware.GroupCPUThreads(topo)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently the host CPU topology is not considered when pinning vCPU threads. I.e. the host CPUs are assigned in the same order as in `/sys/fs/cgroup/cpuset/cpuset.cpus`. On the systems with hyperthreading that may lead to non-optimal CPU usage. For better performance the hyperthreads should fall on the same virtual core.

This PR groups the available host CPUs in a way that threads from the same core are assigned properly to the guest. That is achieved by sorting the original CPU list using the topology info provided via `sysfs`.

Fixes #4687

**Special notes for your reviewer**:

In general there are several ways of getting the needed topology info. As an alterantive to the approach in the PR, `lscpu` or `/proc/cpuinfo` can be used (mentioned in the linked issue). Though using the existing info from `/sys/fs/cgroup/cpuset/cpuset.cpus` plus reading thread siblings list from `sysfs` seems to work just fine. For now I skipped the tests. If the approach in general is okay and there are no concerns I will add those to the PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
