### PR TITLE
virt-launcher: Don't set VM MTU via the dhcp server

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -64,7 +64,6 @@ type VIF struct {
 	Gateway      net.IP
 	GatewayIpv6  net.IP
 	Routes       *[]netlink.Route
-	Mtu          uint16
 	IPAMDisabled bool
 }
 
@@ -76,14 +75,13 @@ func (e *CriticalNetworkError) Error() string { return e.Msg }
 
 func (vif VIF) String() string {
 	return fmt.Sprintf(
-		"VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: %t}",
+		"VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, IPAMDisabled: %t}",
 		vif.Name,
 		vif.IP.IP,
 		vif.IP.Mask,
 		vif.IPv6,
 		vif.MAC,
 		vif.Gateway,
-		vif.Mtu,
 		vif.IPAMDisabled,
 	)
 }
@@ -359,7 +357,6 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInter
 			nameservers,
 			nic.Routes,
 			searchDomains,
-			nic.Mtu,
 			dhcpOptions,
 		); err != nil {
 			log.Log.Errorf("failed to run DHCP: %v", err)

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -116,22 +116,21 @@ var _ = Describe("VIF", func() {
 	const ipv6Cidr = "fd10:0:2::2/120"
 	const mac = "de:ad:00:00:be:ef"
 	const ipv4Gateway = "10.0.0.1"
-	const mtu = 1450
 	const vifName = "test-vif"
 
 	Context("String", func() {
 		It("returns correct string representation", func() {
-			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway, mtu)))
+			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac)
+			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, Gateway: %s, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway)))
 		})
 		It("returns correct string representation with ipv6", func() {
-			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu)))
+			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac)
+			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway)))
 		})
 	})
 })
 
-func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *VIF {
+func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string) *VIF {
 	addr, _ := netlink.ParseAddr(ipv4cidr)
 	mac, _ := net.ParseMAC(macStr)
 	gw := net.ParseIP(ipv4gateway)
@@ -140,7 +139,6 @@ func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu
 		IP:      *addr,
 		MAC:     mac,
 		Gateway: gw,
-		Mtu:     mtu,
 	}
 	if ipv6cidr != "" {
 		ipv6Addr, _ := netlink.ParseAddr(ipv6cidr)

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -21,7 +21,6 @@ package dhcp
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"os"
@@ -57,7 +56,6 @@ func SingleClientDHCPServer(
 	dnsIPs [][]byte,
 	routes *[]netlink.Route,
 	searchDomains []string,
-	mtu uint16,
 	customDHCPOptions *v1.DHCPOptions) error {
 
 	log.Log.Info("Starting SingleClientDHCPServer")
@@ -67,7 +65,7 @@ func SingleClientDHCPServer(
 		return fmt.Errorf("reading the pods hostname failed: %v", err)
 	}
 
-	options, err := prepareDHCPOptions(clientMask, routerIP, dnsIPs, routes, searchDomains, mtu, hostname, customDHCPOptions)
+	options, err := prepareDHCPOptions(clientMask, routerIP, dnsIPs, routes, searchDomains, hostname, customDHCPOptions)
 	if err != nil {
 		return err
 	}
@@ -98,18 +96,13 @@ func prepareDHCPOptions(
 	dnsIPs [][]byte,
 	routes *[]netlink.Route,
 	searchDomains []string,
-	mtu uint16,
 	hostname string,
 	customDHCPOptions *v1.DHCPOptions) (dhcp.Options, error) {
-
-	mtuArray := make([]byte, 2)
-	binary.BigEndian.PutUint16(mtuArray, mtu)
 
 	dhcpOptions := dhcp.Options{
 		dhcp.OptionSubnetMask:       []byte(clientMask),
 		dhcp.OptionRouter:           []byte(routerIP),
 		dhcp.OptionDomainNameServer: bytes.Join(dnsIPs, nil),
-		dhcp.OptionInterfaceMTU:     mtuArray,
 	}
 
 	netRoutes := formClasslessRoutes(routes)

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
@@ -210,7 +210,7 @@ var _ = Describe("DHCP", func() {
 				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
 			}
 			ip := net.ParseIP("192.168.2.1")
-			options, err := prepareDHCPOptions(ip.DefaultMask(), ip, nil, nil, searchDomains, 1500, "myhost", nil)
+			options, err := prepareDHCPOptions(ip.DefaultMask(), ip, nil, nil, searchDomains, "myhost", nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options[dhcp4.OptionDomainName]).To(Equal([]byte("14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com")))
 		})
@@ -234,7 +234,7 @@ var _ = Describe("DHCP", func() {
 				PrivateOptions: []v1.DHCPPrivateOptions{v1.DHCPPrivateOptions{Option: 240, Value: "private.options.kubevirt.io"}},
 			}
 
-			options, err := prepareDHCPOptions(ip.DefaultMask(), ip, nil, nil, searchDomains, 1500, "myhost", dhcpOptions)
+			options, err := prepareDHCPOptions(ip.DefaultMask(), ip, nil, nil, searchDomains, "myhost", dhcpOptions)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options[dhcp4.OptionBootFileName]).To(Equal([]byte("config")))

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Pod Network", func() {
 	var fakeAddr netlink.Addr
 	var updateFakeMac net.HardwareAddr
 	var bridgeTest *netlink.Bridge
-	var masqueradeBridgeTest *netlink.Bridge
 	var bridgeAddr *netlink.Addr
 	var testNic *VIF
 	var tmpDir string
@@ -109,19 +108,11 @@ var _ = Describe("Pod Network", func() {
 			},
 		}
 
-		masqueradeBridgeTest = &netlink.Bridge{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: api.DefaultBridgeName,
-				MTU:  mtu,
-			},
-		}
-
 		bridgeAddr, _ = netlink.ParseAddr(fmt.Sprintf(bridgeFakeIP, 0))
 		tapDeviceName = "tap0"
 		testNic = &VIF{Name: podInterface,
 			IP:      fakeAddr,
 			MAC:     fakeMac,
-			Mtu:     uint16(mtu),
 			Gateway: gw,
 		}
 
@@ -143,7 +134,6 @@ var _ = Describe("Pod Network", func() {
 			IP:          *masqueradeVmAddr,
 			IPv6:        *masqueradeIpv6VmAddr,
 			MAC:         fakeMac,
-			Mtu:         uint16(mtu),
 			Gateway:     masqueradeGwAddr.IP.To4(),
 			GatewayIpv6: masqueradeIpv6GwAddr.IP.To16()}
 	})
@@ -211,11 +201,11 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkByName(masqueradeDummyName).Return(masqueradeDummy, nil)
 		mockNetwork.EXPECT().LinkSetUp(masqueradeDummy).Return(nil)
 		mockNetwork.EXPECT().GenerateRandomMac().Return(fakeMac, nil)
-		mockNetwork.EXPECT().LinkAdd(masqueradeBridgeTest).Return(nil)
-		mockNetwork.EXPECT().LinkSetUp(masqueradeBridgeTest).Return(nil)
-		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, masqueradeBridgeTest).Return(nil)
-		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeGwAddr).Return(nil)
-		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeIpv6GwAddr).Return(nil)
+		mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
+		mockNetwork.EXPECT().LinkSetUp(bridgeTest).Return(nil)
+		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, bridgeTest).Return(nil)
+		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeGwAddr).Return(nil)
+		mockNetwork.EXPECT().AddrAdd(bridgeTest, masqueradeIpv6GwAddr).Return(nil)
 		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return(masqueradeGwStr, masqueradeVmStr, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return(masqueradeIpv6GwStr, masqueradeIpv6VmStr, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The vm MTU is passed to libvirt and libvirt is passing it to qemu.
Setting it also by the dhcp server is confusing and redundant.

This commit includes also removal of explicit MTU setting on the bridge.
The bridge will inherit its MTU from its slaves (tap/k6t-<podNicName>-nic),

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
