### PR TITLE
conformance, tests: running migration tests requires > 1 node

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -197,6 +197,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
         "//tests/assert:go_default_library",
+        "//tests/cluster:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",

--- a/tests/cluster/BUILD.bazel
+++ b/tests/cluster/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["skips.go"],
+    importpath = "kubevirt.io/kubevirt/tests/cluster",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/cluster/nodes.go
+++ b/tests/cluster/nodes.go
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package cluster
+
+import (
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v13 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *v1.NodeList {
+	nodes, err := virtClient.CoreV1().Nodes().List(v12.ListOptions{LabelSelector: v13.NodeSchedulable + "=" + "true"})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Should list compute nodes")
+	return nodes
+}
+

--- a/tests/cluster/skips.go
+++ b/tests/cluster/skips.go
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package cluster
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/client-go/kubecli"
+)
+
+func SkipWhenClusterHasASingleNode(virtClient kubecli.KubevirtClient) {
+	clusterNodes := GetAllSchedulableNodes(virtClient)
+	Expect(clusterNodes).NotTo(BeEmpty(), "there must be some schedulable nodes")
+
+	if len(clusterNodes.Items) < 2 {
+		Skip("At least 2 nodes are required for this test.")
+	}
+}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -59,6 +59,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
 	crds "kubevirt.io/kubevirt/pkg/virt-operator/creation/components"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -290,7 +291,7 @@ var _ = Describe("[Serial]Infrastructure", func() {
 				Expect(len(pods.Items)).To(BeNumerically(">", 0), "no kubevirt pods found")
 
 				By("finding all schedulable nodes")
-				schedulableNodesList := tests.GetAllSchedulableNodes(virtClient)
+				schedulableNodesList := cluster.GetAllSchedulableNodes(virtClient)
 				schedulableNodes := map[string]*k8sv1.Node{}
 				for _, node := range schedulableNodesList.Items {
 					schedulableNodes[node.Name] = node.DeepCopy()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -59,6 +59,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 	migrations "kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -154,7 +155,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			Skip("LiveMigration feature gate is not enabled in kubevirt-config")
 		}
 
-		nodes := tests.GetAllSchedulableNodes(virtClient)
+		nodes := cluster.GetAllSchedulableNodes(virtClient)
 		Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 		if len(nodes.Items) < 2 {
@@ -1200,7 +1201,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				// launch killer pod on every node that isn't the vmi's node
 				By("Starting our migration killer pods")
-				nodes := tests.GetAllSchedulableNodes(virtClient)
+				nodes := cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				for idx, entry := range nodes.Items {
 					if entry.Name == vmi.Status.NodeName {
@@ -1888,7 +1889,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				}
 
 				By("selecting a node as the source")
-				sourceNode := tests.GetAllSchedulableNodes(virtClient).Items[0]
+				sourceNode := cluster.GetAllSchedulableNodes(virtClient).Items[0]
 				tests.AddLabelToNode(sourceNode.Name, "tests.kubevirt.io", "target")
 
 				By("starting four VMIs on that node")
@@ -1903,7 +1904,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				}
 
 				By("selecting a node as the target")
-				targetNode := tests.GetAllSchedulableNodes(virtClient).Items[1]
+				targetNode := cluster.GetAllSchedulableNodes(virtClient).Items[1]
 				tests.AddLabelToNode(targetNode.Name, "tests.kubevirt.io", "target")
 
 				By("tainting the source node as non-schedulabele")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	cluster2 "kubevirt.io/kubevirt/tests/cluster"
 	"net"
 	"net/http"
 	"os"
@@ -583,7 +584,7 @@ func BeforeTestCleanup() {
 func CleanNodes() {
 	virtCli, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	nodes := GetAllSchedulableNodes(virtCli).Items
+	nodes := cluster2.GetAllSchedulableNodes(virtCli).Items
 
 	clusterDrainKey := GetNodeDrainKey()
 
@@ -770,7 +771,7 @@ func BeforeTestSuitSetup(_ []byte) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
 	Eventually(func() int {
-		nodes := GetAllSchedulableNodes(virtClient)
+		nodes := cluster2.GetAllSchedulableNodes(virtClient)
 		if len(nodes.Items) > 0 {
 			idx := rand.Intn(len(nodes.Items))
 			schedulableNode = nodes.Items[idx].Name
@@ -3743,12 +3744,6 @@ func GetNodeWithHugepages(virtClient kubecli.KubevirtClient, hugepages k8sv1.Res
 		}
 	}
 	return nil
-}
-
-func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
-	nodes, err := virtClient.CoreV1().Nodes().List(metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true"})
-	Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
-	return nodes
 }
 
 // SkipIfVersionBelow will skip tests if it runs on an environment with k8s version below specified

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -34,6 +34,7 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
@@ -150,7 +151,7 @@ var _ = Describe("[Serial][ref_id:2717]KubeVirt control plane resilience", func(
 		BeforeEach(func() {
 			tests.BeforeTestCleanup()
 
-			nodeList = tests.GetAllSchedulableNodes(virtCli).Items
+			nodeList = cluster.GetAllSchedulableNodes(virtCli).Items
 			for _, node := range nodeList {
 				setNodeUnschedulable(node.Name)
 			}

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/virtctl/vm"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -998,7 +999,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				})
 
 				It("[test_id:4119]should migrate a running VM", func() {
-					nodes := tests.GetAllSchedulableNodes(virtClient)
+					nodes := cluster.GetAllSchedulableNodes(virtClient)
 					if len(nodes.Items) < 2 {
 						Skip("Migration tests require at least 2 nodes")
 					}

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -49,6 +49,7 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
+	clusterlib "kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
@@ -2314,7 +2315,7 @@ var _ = Describe("Configurations", func() {
 
 			BeforeEach(func() {
 
-				nodes := tests.GetAllSchedulableNodes(virtClient)
+				nodes := clusterlib.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some nodes")
 				node = nodes.Items[1].Name
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -50,6 +50,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -491,7 +492,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			It("[test_id:1633]should indicate that a node is ready for vmis", func() {
 
 				By("adding a heartbeat annotation and a schedulable label to the node")
-				nodes := tests.GetAllSchedulableNodes(virtClient)
+				nodes := cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				for _, node := range nodes.Items {
 					Expect(node.Annotations[v1.VirtHandlerHeartbeat]).ToNot(HaveLen(0), "Nodes should have be ready for VMI")
@@ -689,7 +690,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			var nodes *k8sv1.NodeList
 			var err error
 			BeforeEach(func() {
-				nodes = tests.GetAllSchedulableNodes(virtClient)
+				nodes = cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 				// Taint first node with "NoSchedule"
@@ -737,7 +738,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			var err error
 
 			BeforeEach(func() {
-				nodes = tests.GetAllSchedulableNodes(virtClient)
+				nodes = cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 			})
 
@@ -866,7 +867,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			var originalLabels map[string]string
 
 			BeforeEach(func() {
-				nodes := tests.GetAllSchedulableNodes(virtClient)
+				nodes := cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 				node = &nodes.Items[0]
@@ -1068,7 +1069,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with non default namespace", func() {
 			table.DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should log libvirt start and stop lifecycle events of the domain", func(namespace *string) {
 
-				nodes := tests.GetAllSchedulableNodes(virtClient)
+				nodes := cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
 
@@ -1307,7 +1308,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			It("[test_id:1648]Should provide KVM via plugin framework", func() {
-				nodeList := tests.GetAllSchedulableNodes(virtClient)
+				nodeList := cluster.GetAllSchedulableNodes(virtClient)
 
 				if len(nodeList.Items) == 0 {
 					Skip("There are no compute nodes in cluster")
@@ -1454,7 +1455,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		})
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", func() {
-				nodes := tests.GetAllSchedulableNodes(virtClient)
+				nodes := cluster.GetAllSchedulableNodes(virtClient)
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 				node := nodes.Items[0].Name
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/assert"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -137,7 +138,7 @@ var _ = Describe("[Serial]Multus", func() {
 	tests.BeforeAll(func() {
 		tests.BeforeTestCleanup()
 
-		nodes = tests.GetAllSchedulableNodes(virtClient)
+		nodes = cluster.GetAllSchedulableNodes(virtClient)
 		Expect(len(nodes.Items) > 0).To(BeTrue())
 
 		configureNodeNetwork(virtClient)
@@ -1018,7 +1019,7 @@ var _ = Describe("[Serial]Macvtap", func() {
 		var nodeName string
 
 		BeforeEach(func() {
-			nodeList = tests.GetAllSchedulableNodes(virtClient)
+			nodeList = cluster.GetAllSchedulableNodes(virtClient)
 			Expect(nodeList.Items).NotTo(BeEmpty(), "schedulable kubernetes nodes must be present")
 			nodeName = nodeList.Items[0].Name
 			chosenMAC = "de:ad:00:00:be:af"
@@ -1048,7 +1049,7 @@ var _ = Describe("[Serial]Macvtap", func() {
 		var clientVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			nodes := tests.GetAllSchedulableNodes(virtClient)
+			nodes := cluster.GetAllSchedulableNodes(virtClient)
 			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 			if len(nodes.Items) < 2 {
@@ -1317,7 +1318,7 @@ func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
 	}
 
 	// Make sure that all pods in the Daemon Set finished the configuration
-	nodes := tests.GetAllSchedulableNodes(virtClient)
+	nodes := cluster.GetAllSchedulableNodes(virtClient)
 	Eventually(func() int {
 		daemonSet := getNetworkConfigDaemonSet()
 		return int(daemonSet.Status.NumberAvailable)
@@ -1325,7 +1326,7 @@ func configureNodeNetwork(virtClient kubecli.KubevirtClient) {
 }
 
 func checkSriovEnabled(virtClient kubecli.KubevirtClient, sriovResourceName string) bool {
-	nodes := tests.GetAllSchedulableNodes(virtClient)
+	nodes := cluster.GetAllSchedulableNodes(virtClient)
 	Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 	for _, node := range nodes.Items {

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -44,6 +44,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/cluster"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -825,6 +826,8 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				if !tests.HasLiveMigration() {
 					Skip("LiveMigration feature gate is not enabled in kubevirt-config")
 				}
+
+				cluster.SkipWhenClusterHasASingleNode(virtClient)
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR skips the migration networking conformance tests when the tests are run against a cluster with a single node.

Migrating a VM requires more than one node.

This can be reproduced by (the 2 migration tests in the conformance suite fail):

```bash
$ export KUBEVIRT_NUM_NODES=1 # must have a single node
$ make cluster-up && make cluster-sync
$ KUBEVIRT_E2E_FOCUS="Networking" make functest
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
