### PR TITLE
virt-controller: increase the number of VMI controller threads

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -74,7 +74,8 @@ const (
 
 	ephemeralDiskDir = virtShareDir + "-ephemeral-disks"
 
-	defaultControllerThreads = 3
+	defaultControllerThreads    = 3
+	defaultVMIControllerThreads = 10
 
 	defaultLauncherSubGid                 = 107
 	defaultSnapshotControllerResyncPeriod = 5 * time.Minute
@@ -561,7 +562,7 @@ func (vca *VirtControllerApp) AddFlags() {
 	flag.IntVar(&vca.nodeControllerThreads, "node-controller-threads", defaultControllerThreads,
 		"Number of goroutines to run for node controller")
 
-	flag.IntVar(&vca.vmiControllerThreads, "vmi-controller-threads", defaultControllerThreads,
+	flag.IntVar(&vca.vmiControllerThreads, "vmi-controller-threads", defaultVMIControllerThreads,
 		"Number of goroutines to run for vmi controller")
 
 	flag.IntVar(&vca.rsControllerThreads, "rs-controller-threads", defaultControllerThreads,


### PR DESCRIPTION
**What this PR does / why we need it**:
When running with only 3 VMI controller threads, virt-controller fails to keep up with large numbers of VMIs.
This PR increases that number that number to a value big enough to keep up with the VM starting rate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1903679

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Faster VMI phase transitions thanks to an increased number of VMI watch threads in virt-controller
```
