### PR TITLE
tests: make client in hello world job UDP wait for response

### DIFF
--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -739,7 +739,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 func generateBatchJobSpec(host string, port string, clientBuilder func(host string, port string, checkConnectivityCmdPrefixes ...string) *batchv1.Job) *batchv1.Job {
 	if net.IsIPv6String(host) {
 		// TODO - remove this if condition code once https://github.com/kubevirt/kubevirt/issues/4428 is fixed
-		return clientBuilder(host, port, fmt.Sprintf("ping -c1 %s;", host))
+		return clientBuilder(host, port, fmt.Sprintf("ping -w 20 %s;", host))
 	}
 	return clientBuilder(host, port)
 }

--- a/tests/expose_test.go
+++ b/tests/expose_test.go
@@ -727,7 +727,7 @@ var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 				job = runHelloWorldJob(serviceIP, servicePort, vm.Namespace)
 
 				By("Waiting for the job to report a failed connection attempt.")
-				Expect(tests.WaitForJobToFail(job, 120*time.Second)).To(Succeed())
+				Expect(tests.WaitForJobToFail(job, 240*time.Second)).To(Succeed())
 			},
 				table.Entry("[test_id:343] over default IPv4 IP family", k8sv1.IPv4Protocol),
 				table.Entry("over IPv6 IP family", k8sv1.IPv6Protocol),


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: 
The tests that check exposing NodePort UDP services are failing eventually, as described here https://github.com/kubevirt/kubevirt/issues/4689#issuecomment-756650076 with the current approach the local UDP listener created to catch the server response can be up after the response has arrived, making the client wait forever and the test to timeout.

The fix consists of removing the local listener and making netcat wait for the time defined as timeout, failing if the response doesn't arrive on time as expected.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4689

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
