### PR TITLE
network: assorted minor cleanups and code removals

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -46,8 +46,6 @@ type PodCacheInterface struct {
 	PodIPs []string      `json:"podIPs,omitempty"`
 }
 
-type plugFunction func(vif NetworkInterface, vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error
-
 // Network configuration is split into two parts, or phases, each executed in a
 // different context.
 // Phase1 is run by virt-handler and heavylifts most configuration steps. It

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -41,8 +41,6 @@ var qemuArgCacheFile = "/proc/%s/root/var/run/kubevirt-private/qemu-arg-%s.json"
 var vifCacheFile = "/proc/%s/root/var/run/kubevirt-private/vif-cache-%s.json"
 var NetworkInterfaceFactory = getNetworkClass
 
-var podInterfaceName = podInterface
-
 type PodCacheInterface struct {
 	Iface  *v1.Interface `json:"iface,omitempty"`
 	PodIP  string        `json:"podIP,omitempty"`
@@ -118,7 +116,7 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 		if err != nil {
 			return err
 		}
-		podInterfaceName = getPodInterfaceName(networks, cniNetworks, iface.Name)
+		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)
 		err = NetworkInterface.PlugPhase1(networkInterfaceFactory, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], networks[iface.Name], podInterfaceName, pid)
 		if err != nil {
 			return err
@@ -134,7 +132,7 @@ func SetupNetworkInterfacesPhase2(vmi *v1.VirtualMachineInstance, domain *api.Do
 		if err != nil {
 			return err
 		}
-		podInterfaceName = getPodInterfaceName(networks, cniNetworks, iface.Name)
+		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)
 		err = NetworkInterface.PlugPhase2(vif, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], networks[iface.Name], domain, podInterfaceName)
 		if err != nil {
 			return err

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
-const podInterface = "eth0"
+const primaryPodInterfaceName = "eth0"
 
 var interfaceCacheFile = "/proc/%s/root/var/run/kubevirt-private/interface-cache-%s.json"
 var qemuArgCacheFile = "/proc/%s/root/var/run/kubevirt-private/qemu-arg-%s.json"
@@ -100,7 +100,7 @@ func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string
 		// multus pod interfaces named netX
 		return fmt.Sprintf("net%d", cniNetworks[ifaceName])
 	} else {
-		return podInterface
+		return primaryPodInterfaceName
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -85,11 +85,7 @@ func getNetworkInterfaceFactory(networks map[string]*v1.Network, ifaceName strin
 	if !ok {
 		return nil, fmt.Errorf("failed to find a network %s", ifaceName)
 	}
-	vif, err := NetworkInterfaceFactory(network)
-	if err != nil {
-		return nil, err
-	}
-	return vif, nil
+	return NetworkInterfaceFactory(network)
 }
 
 func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string]int, ifaceName string) string {

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -37,7 +37,6 @@ import (
 const primaryPodInterfaceName = "eth0"
 
 var interfaceCacheFile = "/proc/%s/root/var/run/kubevirt-private/interface-cache-%s.json"
-var qemuArgCacheFile = "/proc/%s/root/var/run/kubevirt-private/qemu-arg-%s.json"
 var vifCacheFile = "/proc/%s/root/var/run/kubevirt-private/vif-cache-%s.json"
 var NetworkInterfaceFactory = getNetworkClass
 

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Network", func() {
 			iface := v1.DefaultBridgeNetworkInterface()
 			defaultNet := v1.DefaultPodNetwork()
 
-			mockNetworkInterface.EXPECT().PlugPhase1(vm, iface, defaultNet, podInterface, pid)
+			mockNetworkInterface.EXPECT().PlugPhase1(vm, iface, defaultNet, primaryPodInterfaceName, pid)
 			err := SetupNetworkInterfacesPhase1(vm, pid)
 			Expect(err).To(BeNil())
 		})

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -473,7 +473,7 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, lau
 		return err
 	}
 
-	tapDeviceName := generateTapDeviceName(podInterfaceName)
+	tapDeviceName := generateTapDeviceName(b.podInterfaceName)
 	err := createAndBindTapToBridge(tapDeviceName, b.bridgeInterfaceName, queueNumber, launcherPID, int(b.vif.Mtu))
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
@@ -764,7 +764,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 		return err
 	}
 
-	tapDeviceName := generateTapDeviceName(podInterfaceName)
+	tapDeviceName := generateTapDeviceName(p.podInterfaceName)
 	err = createAndBindTapToBridge(tapDeviceName, p.bridgeInterfaceName, queueNumber, launcherPID, int(p.vif.Mtu))
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)


### PR DESCRIPTION
This PR tries to tidy up few issues found in the network package. Each of the commits is practically independent of the others. I don't have a very good reason for putting them all in one PR, except for saving some CI time and maybe reviewer attention.

*  global `podInterfaceName` variable dropped
* `podInterface` constant renamed
* two unused definitions dropped
* `getNetworkInterfaceFactory` function slightly simplified.

```release-note
NONE
```
