### PR TITLE
rename several network entities

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -61,7 +61,6 @@ go_test(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",
-        "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1036,7 +1036,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		}
 	}
 
-	err = network.SetupNetworkInterfacesPhase2(vmi, domain)
+	err = network.SetupPodNetworkPhase2(vmi, domain)
 	if err != nil {
 		return domain, fmt.Errorf("preparing the pod network failed: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -50,7 +50,6 @@ import (
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 
@@ -115,7 +114,6 @@ var _ = Describe("Manager", func() {
 		It("should define and start a new VirtualMachineInstance", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 
@@ -136,7 +134,6 @@ var _ = Describe("Manager", func() {
 		It("should define and start a new VirtualMachineInstance with userData", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 
@@ -159,7 +156,6 @@ var _ = Describe("Manager", func() {
 		It("should define and start a new VirtualMachineInstance with userData and networkData", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 			userData := "fake\nuser\ndata\n"
@@ -328,7 +324,6 @@ var _ = Describe("Manager", func() {
 		It("should hotplug a disk if a volume was hotplugged", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
@@ -460,7 +455,6 @@ var _ = Describe("Manager", func() {
 		It("should unplug a disk if a volume was unplugged", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
@@ -572,7 +566,6 @@ var _ = Describe("Manager", func() {
 		It("should not plug/unplug a disk if nothing changed", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
@@ -653,7 +646,6 @@ var _ = Describe("Manager", func() {
 		It("should not hotplug a disk if a volume was hotplugged, but the disk is not ready yet", func() {
 			// Make sure that we always free the domain after use
 			mockDomain.EXPECT().Free()
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Spec.Domain.Devices.Disks = []v1.Disk{
 				{
@@ -1024,7 +1016,6 @@ var _ = Describe("Manager", func() {
 			updateHostsFile = func(entry string) error {
 				return nil
 			}
-			StubOutNetworkForTest()
 			vmi := newVMI(testNamespace, testVmName)
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				MigrationUID: "111222333",
@@ -1589,10 +1580,6 @@ func newVMI(namespace, name string) *v1.VirtualMachineInstance {
 	vmi := v1.NewMinimalVMIWithNS(namespace, name)
 	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 	return vmi
-}
-
-func StubOutNetworkForTest() {
-	network.SetupPodNetworkPhase2 = func(vm *v1.VirtualMachineInstance, domain *api.Domain) error { return nil }
 }
 
 func addCloudInitDisk(vmi *v1.VirtualMachineInstance, userData string, networkData string) {

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -522,7 +522,6 @@ func (h *NetworkUtilsHandler) DisableTXOffloadChecksum(ifaceName string) error {
 }
 
 // Allow mocking for tests
-var SetupPodNetworkPhase2 = SetupNetworkInterfacesPhase2
 var DHCPServer = dhcp.SingleClientDHCPServer
 var DHCPv6Server = dhcpv6.SingleClientDHCPv6Server
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -522,7 +522,6 @@ func (h *NetworkUtilsHandler) DisableTXOffloadChecksum(ifaceName string) error {
 }
 
 // Allow mocking for tests
-var SetupPodNetworkPhase1 = SetupNetworkInterfacesPhase1
 var SetupPodNetworkPhase2 = SetupNetworkInterfacesPhase2
 var DHCPServer = dhcp.SingleClientDHCPServer
 var DHCPv6Server = dhcpv6.SingleClientDHCPv6Server

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_network.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_network.go
@@ -50,11 +50,3 @@ func (_m *MockNetworkInterface) PlugPhase2(vmi *v1.VirtualMachineInstance, iface
 func (_mr *_MockNetworkInterfaceRecorder) PlugPhase2(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PlugPhase2", arg0, arg1, arg2, arg3, arg4)
 }
-
-func (_m *MockNetworkInterface) Unplug() {
-	_m.ctrl.Call(_m, "Unplug")
-}
-
-func (_mr *_MockNetworkInterfaceRecorder) Unplug() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unplug")
-}

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_network.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_network.go
@@ -10,43 +10,43 @@ import (
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
-// Mock of NetworkInterface interface
-type MockNetworkInterface struct {
+// Mock of podNIC interface
+type MockpodNIC struct {
 	ctrl     *gomock.Controller
-	recorder *_MockNetworkInterfaceRecorder
+	recorder *_MockpodNICRecorder
 }
 
-// Recorder for MockNetworkInterface (not exported)
-type _MockNetworkInterfaceRecorder struct {
-	mock *MockNetworkInterface
+// Recorder for MockpodNIC (not exported)
+type _MockpodNICRecorder struct {
+	mock *MockpodNIC
 }
 
-func NewMockNetworkInterface(ctrl *gomock.Controller) *MockNetworkInterface {
-	mock := &MockNetworkInterface{ctrl: ctrl}
-	mock.recorder = &_MockNetworkInterfaceRecorder{mock}
+func NewMockpodNIC(ctrl *gomock.Controller) *MockpodNIC {
+	mock := &MockpodNIC{ctrl: ctrl}
+	mock.recorder = &_MockpodNICRecorder{mock}
 	return mock
 }
 
-func (_m *MockNetworkInterface) EXPECT() *_MockNetworkInterfaceRecorder {
+func (_m *MockpodNIC) EXPECT() *_MockpodNICRecorder {
 	return _m.recorder
 }
 
-func (_m *MockNetworkInterface) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, podInterfaceName string, pid int) error {
+func (_m *MockpodNIC) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, podInterfaceName string, pid int) error {
 	ret := _m.ctrl.Call(_m, "PlugPhase1", vmi, iface, network, podInterfaceName, pid)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkInterfaceRecorder) PlugPhase1(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (_mr *_MockpodNICRecorder) PlugPhase1(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PlugPhase1", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockNetworkInterface) PlugPhase2(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
+func (_m *MockpodNIC) PlugPhase2(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
 	ret := _m.ctrl.Call(_m, "PlugPhase2", vmi, iface, network, domain, podInterfaceName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkInterfaceRecorder) PlugPhase2(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (_mr *_MockpodNICRecorder) PlugPhase2(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PlugPhase2", arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -97,7 +97,7 @@ func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string
 	}
 }
 
-func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error {
+func SetupPodNetworkPhase1(vmi *v1.VirtualMachineInstance, pid int) error {
 	// Create a dir with VMI UID under network-info-dir to store network files
 	err := os.MkdirAll(fmt.Sprintf(util.VMIInterfaceDir, vmi.ObjectMeta.UID), 0755)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -38,7 +38,7 @@ const primaryPodInterfaceName = "eth0"
 
 var interfaceCacheFile = "/proc/%s/root/var/run/kubevirt-private/interface-cache-%s.json"
 var vifCacheFile = "/proc/%s/root/var/run/kubevirt-private/vif-cache-%s.json"
-var NetworkInterfaceFactory = getNetworkClass
+var NetworkInterfaceFactory = getNewNetworkInterface
 
 type PodCacheInterface struct {
 	Iface  *v1.Interface `json:"iface,omitempty"`
@@ -134,8 +134,7 @@ func SetupNetworkInterfacesPhase2(vmi *v1.VirtualMachineInstance, domain *api.Do
 	return nil
 }
 
-// a factory to get suitable network interface
-func getNetworkClass(network *v1.Network) (NetworkInterface, error) {
+func getNewNetworkInterface(network *v1.Network) (NetworkInterface, error) {
 	if network.Pod != nil || network.Multus != nil {
 		return new(PodInterface), nil
 	}

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -118,7 +118,7 @@ func SetupPodNetworkPhase1(vmi *v1.VirtualMachineInstance, pid int) error {
 	return nil
 }
 
-func SetupNetworkInterfacesPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
 	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		vif, err := invokeNetworkInterfaceFactory(networks, iface.Name)

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -80,7 +80,7 @@ func getNetworksAndCniNetworks(vmi *v1.VirtualMachineInstance) (map[string]*v1.N
 	return networks, cniNetworks
 }
 
-func getNetworkInterfaceFactory(networks map[string]*v1.Network, ifaceName string) (NetworkInterface, error) {
+func invokeNetworkInterfaceFactory(networks map[string]*v1.Network, ifaceName string) (NetworkInterface, error) {
 	network, ok := networks[ifaceName]
 	if !ok {
 		return nil, fmt.Errorf("failed to find a network %s", ifaceName)
@@ -105,12 +105,12 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 	}
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
 	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		networkInterfaceFactory, err := getNetworkInterfaceFactory(networks, iface.Name)
+		networkInterface, err := invokeNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err
 		}
 		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)
-		err = NetworkInterface.PlugPhase1(networkInterfaceFactory, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], networks[iface.Name], podInterfaceName, pid)
+		err = NetworkInterface.PlugPhase1(networkInterface, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], networks[iface.Name], podInterfaceName, pid)
 		if err != nil {
 			return err
 		}
@@ -121,7 +121,7 @@ func SetupNetworkInterfacesPhase1(vmi *v1.VirtualMachineInstance, pid int) error
 func SetupNetworkInterfacesPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	networks, cniNetworks := getNetworksAndCniNetworks(vmi)
 	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		vif, err := getNetworkInterfaceFactory(networks, iface.Name)
+		vif, err := invokeNetworkInterfaceFactory(networks, iface.Name)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -64,7 +64,6 @@ type PodCacheInterface struct {
 type NetworkInterface interface {
 	PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, podInterfaceName string, pid int) error
 	PlugPhase2(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error
-	Unplug()
 }
 
 func getNetworksAndCniNetworks(vmi *v1.VirtualMachineInstance) (map[string]*v1.Network, map[string]int) {

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -53,12 +53,12 @@ var _ = Describe("Network", func() {
 			defaultNet := v1.DefaultPodNetwork()
 
 			mockNetworkInterface.EXPECT().PlugPhase1(vm, iface, defaultNet, primaryPodInterfaceName, pid)
-			err := SetupNetworkInterfacesPhase1(vm, pid)
+			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(BeNil())
 		})
 		It("should accept empty network list", func() {
 			vmi := newVMI("testnamespace", "testVmName")
-			err := SetupNetworkInterfacesPhase1(vmi, pid)
+			err := SetupPodNetworkPhase1(vmi, pid)
 			Expect(err).To(BeNil())
 		})
 		It("should configure networking with multus", func() {
@@ -77,7 +77,7 @@ var _ = Describe("Network", func() {
 			vm.Spec.Networks = []v1.Network{*cniNet}
 
 			mockNetworkInterface.EXPECT().PlugPhase1(vm, iface, cniNet, multusInterfaceName, pid)
-			err := SetupNetworkInterfacesPhase1(vm, pid)
+			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(BeNil())
 		})
 		It("should configure networking with multus and a default multus network", func() {
@@ -134,7 +134,7 @@ var _ = Describe("Network", func() {
 			mockNetworkInterface.EXPECT().PlugPhase1(vm, &vm.Spec.Domain.Devices.Interfaces[0], additionalCNINet1, "net1", pid)
 			mockNetworkInterface.EXPECT().PlugPhase1(vm, &vm.Spec.Domain.Devices.Interfaces[1], cniNet, "eth0", pid)
 			mockNetworkInterface.EXPECT().PlugPhase1(vm, &vm.Spec.Domain.Devices.Interfaces[2], additionalCNINet2, "net2", pid)
-			err := SetupNetworkInterfacesPhase1(vm, pid)
+			err := SetupPodNetworkPhase1(vm, pid)
 			Expect(err).To(BeNil())
 		})
 	})

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Network", func() {
 		mockNetworkInterface = NewMockNetworkInterface(ctrl)
 	})
 	AfterEach(func() {
-		NetworkInterfaceFactory = getNetworkClass
+		NetworkInterfaceFactory = getNewNetworkInterface
 	})
 
 	Context("interface configuration", func() {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -72,8 +72,6 @@ type BindMechanism interface {
 
 type PodInterface struct{}
 
-func (l *PodInterface) Unplug() {}
-
 func getVifFilePath(pid, name string) string {
 	return fmt.Sprintf(vifCacheFile, pid, name)
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -70,7 +70,7 @@ type BindMechanism interface {
 	startDHCP(vmi *v1.VirtualMachineInstance) error
 }
 
-type PodInterface struct{}
+type podNICImpl struct{}
 
 func getVifFilePath(pid, name string) string {
 	return fmt.Sprintf(vifCacheFile, pid, name)
@@ -164,7 +164,7 @@ func sortIPsBasedOnPrimaryIP(ipv4, ipv6 string) ([]string, error) {
 	return []string{ipv6, ipv4}, nil
 }
 
-func (l *PodInterface) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, podInterfaceName string, pid int) error {
+func (l *podNICImpl) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, podInterfaceName string, pid int) error {
 	initHandler()
 
 	// There is nothing to plug for SR-IOV devices
@@ -242,7 +242,7 @@ func ensureDHCP(vmi *v1.VirtualMachineInstance, driver BindMechanism, podInterfa
 	return nil
 }
 
-func (l *PodInterface) PlugPhase2(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
+func (l *podNICImpl) PlugPhase2(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
 	precond.MustNotBeNil(domain)
 	initHandler()
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -319,7 +319,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		if mac != nil {
 			vif.MAC = *mac
 		}
-		return &BridgePodInterface{iface: iface,
+		return &BridgeBindMechanism{iface: iface,
 			virtIface:           &api.Interface{},
 			vmi:                 vmi,
 			vif:                 vif,
@@ -336,7 +336,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		if mac != nil {
 			vif.MAC = *mac
 		}
-		return &MasqueradePodInterface{iface: iface,
+		return &MasqueradeBindMechanism{iface: iface,
 			virtIface:           &api.Interface{},
 			vmi:                 vmi,
 			vif:                 vif,
@@ -347,7 +347,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 			bridgeInterfaceName: fmt.Sprintf("k6t-%s", podInterfaceName)}, nil
 	}
 	if iface.Slirp != nil {
-		return &SlirpPodInterface{vmi: vmi, iface: iface, domain: domain}, nil
+		return &SlirpBindMechanism{vmi: vmi, iface: iface, domain: domain}, nil
 	}
 	if iface.Macvtap != nil {
 		mac, err := retrieveMacAddress(iface)
@@ -358,7 +358,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		if mac != nil {
 			virtIface.MAC = &api.MAC{MAC: mac.String()}
 		}
-		return &MacvtapPodInterface{
+		return &MacvtapBindMechanism{
 			vmi:              vmi,
 			iface:            iface,
 			virtIface:        virtIface,
@@ -369,7 +369,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 	return nil, fmt.Errorf("Not implemented")
 }
 
-type BridgePodInterface struct {
+type BridgeBindMechanism struct {
 	vmi                 *v1.VirtualMachineInstance
 	vif                 *VIF
 	iface               *v1.Interface
@@ -380,7 +380,7 @@ type BridgePodInterface struct {
 	bridgeInterfaceName string
 }
 
-func (b *BridgePodInterface) discoverPodNetworkInterface() error {
+func (b *BridgeBindMechanism) discoverPodNetworkInterface() error {
 	link, err := Handler.LinkByName(b.podInterfaceName)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to get a link for interface: %s", b.podInterfaceName)
@@ -427,7 +427,7 @@ func (b *BridgePodInterface) discoverPodNetworkInterface() error {
 	return nil
 }
 
-func (b *BridgePodInterface) getFakeBridgeIP() (string, error) {
+func (b *BridgeBindMechanism) getFakeBridgeIP() (string, error) {
 	ifaces := b.vmi.Spec.Domain.Devices.Interfaces
 	for i, iface := range ifaces {
 		if iface.Name == b.iface.Name {
@@ -437,7 +437,7 @@ func (b *BridgePodInterface) getFakeBridgeIP() (string, error) {
 	return "", fmt.Errorf("Failed to generate bridge fake address for interface %s", b.iface.Name)
 }
 
-func (b *BridgePodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
+func (b *BridgeBindMechanism) startDHCP(vmi *v1.VirtualMachineInstance) error {
 	if !b.vif.IPAMDisabled {
 		addr, err := b.getFakeBridgeIP()
 		if err != nil {
@@ -453,7 +453,7 @@ func (b *BridgePodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
+func (b *BridgeBindMechanism) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
 	// Set interface link to down to change its MAC address
 	if err := Handler.LinkSetDown(b.podNicLink); err != nil {
 		log.Log.Reason(err).Errorf("failed to bring link down for interface: %s", b.podInterfaceName)
@@ -505,7 +505,7 @@ func (b *BridgePodInterface) preparePodNetworkInterfaces(queueNumber uint32, lau
 	return nil
 }
 
-func (b *BridgePodInterface) decorateConfig() error {
+func (b *BridgeBindMechanism) decorateConfig() error {
 	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
 		if iface.Alias.Name == b.iface.Name {
@@ -518,7 +518,7 @@ func (b *BridgePodInterface) decorateConfig() error {
 	return nil
 }
 
-func (b *BridgePodInterface) loadCachedInterface(pid, name string) (bool, error) {
+func (b *BridgeBindMechanism) loadCachedInterface(pid, name string) (bool, error) {
 	var ifaceConfig api.Interface
 
 	isExist, err := readFromCachedFile(pid, name, interfaceCacheFile, &ifaceConfig)
@@ -534,12 +534,12 @@ func (b *BridgePodInterface) loadCachedInterface(pid, name string) (bool, error)
 	return false, nil
 }
 
-func (b *BridgePodInterface) setCachedInterface(pid, name string) error {
+func (b *BridgeBindMechanism) setCachedInterface(pid, name string) error {
 	err := writeToCachedFile(b.virtIface, interfaceCacheFile, pid, name)
 	return err
 }
 
-func (b *BridgePodInterface) loadCachedVIF(pid, name string) (bool, error) {
+func (b *BridgeBindMechanism) loadCachedVIF(pid, name string) (bool, error) {
 	buf, err := ioutil.ReadFile(getVifFilePath(pid, name))
 	if err != nil {
 		return false, err
@@ -552,7 +552,7 @@ func (b *BridgePodInterface) loadCachedVIF(pid, name string) (bool, error) {
 	return true, nil
 }
 
-func (b *BridgePodInterface) setCachedVIF(pid, name string) error {
+func (b *BridgeBindMechanism) setCachedVIF(pid, name string) error {
 	buf, err := json.MarshalIndent(&b.vif, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling vif object: %v", err)
@@ -560,7 +560,7 @@ func (b *BridgePodInterface) setCachedVIF(pid, name string) error {
 	return writeVifFile(buf, pid, name)
 }
 
-func (b *BridgePodInterface) setInterfaceRoutes() error {
+func (b *BridgeBindMechanism) setInterfaceRoutes() error {
 	routes, err := Handler.RouteList(b.podNicLink, netlink.FAMILY_V4)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to get routes for %s", b.podInterfaceName)
@@ -577,7 +577,7 @@ func (b *BridgePodInterface) setInterfaceRoutes() error {
 	return nil
 }
 
-func (b *BridgePodInterface) createBridge() error {
+func (b *BridgeBindMechanism) createBridge() error {
 	// Create a bridge
 	bridge := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
@@ -626,7 +626,7 @@ func (b *BridgePodInterface) createBridge() error {
 	return nil
 }
 
-type MasqueradePodInterface struct {
+type MasqueradeBindMechanism struct {
 	vmi                 *v1.VirtualMachineInstance
 	vif                 *VIF
 	iface               *v1.Interface
@@ -641,7 +641,7 @@ type MasqueradePodInterface struct {
 	gatewayIpv6Addr     *netlink.Addr
 }
 
-func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
+func (p *MasqueradeBindMechanism) discoverPodNetworkInterface() error {
 	link, err := Handler.LinkByName(p.podInterfaceName)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to get a link for interface: %s", p.podInterfaceName)
@@ -675,7 +675,7 @@ func (p *MasqueradePodInterface) discoverPodNetworkInterface() error {
 	return nil
 }
 
-func configureVifV4Addresses(p *MasqueradePodInterface, err error) error {
+func configureVifV4Addresses(p *MasqueradeBindMechanism, err error) error {
 	if p.vmNetworkCIDR == "" {
 		p.vmNetworkCIDR = api.DefaultVMCIDR
 	}
@@ -701,7 +701,7 @@ func configureVifV4Addresses(p *MasqueradePodInterface, err error) error {
 	return nil
 }
 
-func configureVifV6Addresses(p *MasqueradePodInterface, err error) error {
+func configureVifV6Addresses(p *MasqueradeBindMechanism, err error) error {
 	if p.vmIpv6NetworkCIDR == "" {
 		p.vmIpv6NetworkCIDR = api.DefaultVMIpv6CIDR
 	}
@@ -727,11 +727,11 @@ func configureVifV6Addresses(p *MasqueradePodInterface, err error) error {
 	return nil
 }
 
-func (p *MasqueradePodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
+func (p *MasqueradeBindMechanism) startDHCP(vmi *v1.VirtualMachineInstance) error {
 	return Handler.StartDHCP(p.vif, p.vif.Gateway, p.bridgeInterfaceName, p.iface.DHCPOptions, false)
 }
 
-func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
+func (p *MasqueradeBindMechanism) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
 	// Create an master bridge interface
 	bridgeNicName := fmt.Sprintf("%s-nic", p.bridgeInterfaceName)
 	bridgeNic := &netlink.Dummy{
@@ -808,7 +808,7 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 	return nil
 }
 
-func (p *MasqueradePodInterface) decorateConfig() error {
+func (p *MasqueradeBindMechanism) decorateConfig() error {
 	ifaces := p.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
 		if iface.Alias.Name == p.iface.Name {
@@ -821,7 +821,7 @@ func (p *MasqueradePodInterface) decorateConfig() error {
 	return nil
 }
 
-func (p *MasqueradePodInterface) loadCachedInterface(pid, name string) (bool, error) {
+func (p *MasqueradeBindMechanism) loadCachedInterface(pid, name string) (bool, error) {
 	var ifaceConfig api.Interface
 
 	isExist, err := readFromCachedFile(pid, name, interfaceCacheFile, &ifaceConfig)
@@ -837,12 +837,12 @@ func (p *MasqueradePodInterface) loadCachedInterface(pid, name string) (bool, er
 	return false, nil
 }
 
-func (p *MasqueradePodInterface) setCachedInterface(pid, name string) error {
+func (p *MasqueradeBindMechanism) setCachedInterface(pid, name string) error {
 	err := writeToCachedFile(p.virtIface, interfaceCacheFile, pid, name)
 	return err
 }
 
-func (p *MasqueradePodInterface) loadCachedVIF(pid, name string) (bool, error) {
+func (p *MasqueradeBindMechanism) loadCachedVIF(pid, name string) (bool, error) {
 	buf, err := ioutil.ReadFile(getVifFilePath(pid, name))
 	if err != nil {
 		return false, err
@@ -856,7 +856,7 @@ func (p *MasqueradePodInterface) loadCachedVIF(pid, name string) (bool, error) {
 	return true, nil
 }
 
-func (p *MasqueradePodInterface) setCachedVIF(pid, name string) error {
+func (p *MasqueradeBindMechanism) setCachedVIF(pid, name string) error {
 	buf, err := json.MarshalIndent(&p.vif, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error marshaling vif object: %v", err)
@@ -864,7 +864,7 @@ func (p *MasqueradePodInterface) setCachedVIF(pid, name string) error {
 	return writeVifFile(buf, pid, name)
 }
 
-func (p *MasqueradePodInterface) createBridge() error {
+func (p *MasqueradeBindMechanism) createBridge() error {
 	// Get dummy link
 	bridgeNicName := fmt.Sprintf("%s-nic", p.bridgeInterfaceName)
 	bridgeNicLink, err := Handler.LinkByName(bridgeNicName)
@@ -923,14 +923,14 @@ func (p *MasqueradePodInterface) createBridge() error {
 	return nil
 }
 
-func (p *MasqueradePodInterface) createNatRules(protocol iptables.Protocol) error {
+func (p *MasqueradeBindMechanism) createNatRules(protocol iptables.Protocol) error {
 	if Handler.HasNatIptables(protocol) {
 		return p.createNatRulesUsingIptables(protocol)
 	}
 	return p.createNatRulesUsingNftables(protocol)
 }
 
-func (p *MasqueradePodInterface) createNatRulesUsingIptables(protocol iptables.Protocol) error {
+func (p *MasqueradeBindMechanism) createNatRulesUsingIptables(protocol iptables.Protocol) error {
 	err := Handler.IptablesNewChain(protocol, "nat", "KUBEVIRT_PREINBOUND")
 	if err != nil {
 		return err
@@ -1012,7 +1012,7 @@ func (p *MasqueradePodInterface) createNatRulesUsingIptables(protocol iptables.P
 	return nil
 }
 
-func (p *MasqueradePodInterface) getGatewayByProtocol(proto iptables.Protocol) string {
+func (p *MasqueradeBindMechanism) getGatewayByProtocol(proto iptables.Protocol) string {
 	if proto == iptables.ProtocolIPv4 {
 		return p.gatewayAddr.IP.String()
 	} else {
@@ -1020,7 +1020,7 @@ func (p *MasqueradePodInterface) getGatewayByProtocol(proto iptables.Protocol) s
 	}
 }
 
-func (p *MasqueradePodInterface) getVifIpByProtocol(proto iptables.Protocol) string {
+func (p *MasqueradeBindMechanism) getVifIpByProtocol(proto iptables.Protocol) string {
 	if proto == iptables.ProtocolIPv4 {
 		return p.vif.IP.IP.String()
 	} else {
@@ -1036,7 +1036,7 @@ func getLoopbackAdrress(proto iptables.Protocol) string {
 	}
 }
 
-func (p *MasqueradePodInterface) createNatRulesUsingNftables(proto iptables.Protocol) error {
+func (p *MasqueradeBindMechanism) createNatRulesUsingNftables(proto iptables.Protocol) error {
 	err := Handler.NftablesNewChain(proto, "nat", "KUBEVIRT_PREINBOUND")
 	if err != nil {
 		return err
@@ -1107,26 +1107,26 @@ func (p *MasqueradePodInterface) createNatRulesUsingNftables(proto iptables.Prot
 	return nil
 }
 
-type SlirpPodInterface struct {
+type SlirpBindMechanism struct {
 	vmi       *v1.VirtualMachineInstance
 	iface     *v1.Interface
 	virtIface *api.Interface
 	domain    *api.Domain
 }
 
-func (s *SlirpPodInterface) discoverPodNetworkInterface() error {
+func (s *SlirpBindMechanism) discoverPodNetworkInterface() error {
 	return nil
 }
 
-func (s *SlirpPodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
+func (s *SlirpBindMechanism) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
 	return nil
 }
 
-func (s *SlirpPodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
+func (s *SlirpBindMechanism) startDHCP(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-func (s *SlirpPodInterface) decorateConfig() error {
+func (s *SlirpBindMechanism) decorateConfig() error {
 	// remove slirp interface from domain spec devices interfaces
 	var foundIfaceModelType string
 	ifaces := s.domain.Spec.Devices.Interfaces
@@ -1154,23 +1154,23 @@ func (s *SlirpPodInterface) decorateConfig() error {
 	return nil
 }
 
-func (s *SlirpPodInterface) loadCachedInterface(pid, name string) (bool, error) {
+func (s *SlirpBindMechanism) loadCachedInterface(pid, name string) (bool, error) {
 	return true, nil
 }
 
-func (s *SlirpPodInterface) loadCachedVIF(pid, name string) (bool, error) {
+func (s *SlirpBindMechanism) loadCachedVIF(pid, name string) (bool, error) {
 	return true, nil
 }
 
-func (b *SlirpPodInterface) setCachedVIF(pid, name string) error {
+func (b *SlirpBindMechanism) setCachedVIF(pid, name string) error {
 	return nil
 }
 
-func (s *SlirpPodInterface) setCachedInterface(pid, name string) error {
+func (s *SlirpBindMechanism) setCachedInterface(pid, name string) error {
 	return nil
 }
 
-type MacvtapPodInterface struct {
+type MacvtapBindMechanism struct {
 	vmi              *v1.VirtualMachineInstance
 	iface            *v1.Interface
 	virtIface        *api.Interface
@@ -1179,7 +1179,7 @@ type MacvtapPodInterface struct {
 	podNicLink       netlink.Link
 }
 
-func (m *MacvtapPodInterface) discoverPodNetworkInterface() error {
+func (m *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 	link, err := Handler.LinkByName(m.podInterfaceName)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to get a link for interface: %s", m.podInterfaceName)
@@ -1206,11 +1206,11 @@ func (m *MacvtapPodInterface) discoverPodNetworkInterface() error {
 	return nil
 }
 
-func (m *MacvtapPodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
+func (m *MacvtapBindMechanism) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {
 	return nil
 }
 
-func (m *MacvtapPodInterface) decorateConfig() error {
+func (m *MacvtapBindMechanism) decorateConfig() error {
 	ifaces := m.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
 		if iface.Alias.Name == m.iface.Name {
@@ -1223,7 +1223,7 @@ func (m *MacvtapPodInterface) decorateConfig() error {
 	return nil
 }
 
-func (m *MacvtapPodInterface) loadCachedInterface(uid, name string) (bool, error) {
+func (m *MacvtapBindMechanism) loadCachedInterface(uid, name string) (bool, error) {
 	var ifaceConfig api.Interface
 
 	isExist, err := readFromCachedFile(uid, name, interfaceCacheFile, &ifaceConfig)
@@ -1239,20 +1239,20 @@ func (m *MacvtapPodInterface) loadCachedInterface(uid, name string) (bool, error
 	return false, nil
 }
 
-func (m *MacvtapPodInterface) setCachedInterface(pid, name string) error {
+func (m *MacvtapBindMechanism) setCachedInterface(pid, name string) error {
 	err := writeToCachedFile(m.virtIface, interfaceCacheFile, pid, name)
 	return err
 }
 
-func (m *MacvtapPodInterface) loadCachedVIF(pid, name string) (bool, error) {
+func (m *MacvtapBindMechanism) loadCachedVIF(pid, name string) (bool, error) {
 	return true, nil
 }
 
-func (m *MacvtapPodInterface) setCachedVIF(pid, name string) error {
+func (m *MacvtapBindMechanism) setCachedVIF(pid, name string) error {
 	return nil
 }
 
-func (m *MacvtapPodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
+func (m *MacvtapBindMechanism) startDHCP(vmi *v1.VirtualMachineInstance) error {
 	// macvtap will connect to the host's subnet
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -408,11 +408,11 @@ var _ = Describe("Pod Network", func() {
 					},
 				}
 				vmi := newVMI("testnamespace", "testVmName")
-				podiface := PodInterface{}
-				err := podiface.PlugPhase1(vmi, iface, net, "fakeiface", pid)
+				podnic := podNICImpl{}
+				err := podnic.PlugPhase1(vmi, iface, net, "fakeiface", pid)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = podiface.PlugPhase2(vmi, iface, net, domain, "fakeiface")
+				err = podnic.PlugPhase2(vmi, iface, net, domain, "fakeiface")
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Pod Network", func() {
 					vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 					driver, err := getPhase1Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], primaryPodInterfaceName)
 					Expect(err).ToNot(HaveOccurred())
-					bridge, ok := driver.(*BridgePodInterface)
+					bridge, ok := driver.(*BridgeBindMechanism)
 					Expect(ok).To(BeTrue())
 					Expect(bridge.vif.MAC.String()).To(Equal("de:ad:00:00:be:af"))
 				})
@@ -608,7 +608,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			masq, ok := driver.(*MasqueradePodInterface)
+			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			masq.vif.Gateway = masqueradeGwAddr.IP.To4()
@@ -625,7 +625,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			masq, ok := driver.(*MasqueradePodInterface)
+			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			masq.vif.Gateway = masqueradeGwAddr.IP.To4()
@@ -646,7 +646,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			bridge, ok := driver.(*BridgePodInterface)
+			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(nil)
@@ -661,7 +661,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			bridge, ok := driver.(*BridgePodInterface)
+			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			err = fmt.Errorf("failed to start DHCP server")
@@ -677,7 +677,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			bridge, ok := driver.(*BridgePodInterface)
+			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			bridge.vif.IPAMDisabled = true
@@ -696,7 +696,7 @@ var _ = Describe("Pod Network", func() {
 
 			driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			slirp, ok := driver.(*SlirpPodInterface)
+			slirp, ok := driver.(*SlirpBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			err = slirp.startDHCP(vmi)
@@ -711,7 +711,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase1Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			bridge, ok := driver.(*BridgePodInterface)
+			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			succ, err := bridge.loadCachedVIF(fmt.Sprintf("%d", pid), "fakename")
@@ -723,7 +723,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase1Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			bridge, ok := driver.(*BridgePodInterface)
+			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			err = bridge.setCachedVIF(fmt.Sprintf("%d", pid), "fakename")
@@ -741,7 +741,7 @@ var _ = Describe("Pod Network", func() {
 
 			driver, err := getPhase1Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			slirp, ok := driver.(*SlirpPodInterface)
+			slirp, ok := driver.(*SlirpBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			// it doesn't fail regardless, whether called without setCachedVIF...
@@ -765,7 +765,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase1Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			masq, ok := driver.(*MasqueradePodInterface)
+			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			succ, err := masq.loadCachedVIF(fmt.Sprintf("%d", pid), "fakename")
@@ -777,7 +777,7 @@ var _ = Describe("Pod Network", func() {
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
 			driver, err := getPhase1Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], primaryPodInterfaceName)
 			Expect(err).ToNot(HaveOccurred())
-			masq, ok := driver.(*MasqueradePodInterface)
+			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
 			err = masq.setCachedVIF(fmt.Sprintf("%d", pid), "fakename")


### PR DESCRIPTION
This is a follow up of PR #4775. Much like its predecessor, it includes multiple commits, each introducing a name change or code deletion. The most notable changes here are
* Various implementations of BindMechanism are named accordingly, so it is easier to discern their interface
* The aggregate of the two PlugPhase functions is renamed to "PlugPhases" since its current name (NetworkInterface) is too overloaded

I hope these changes make the code more accessible to newcomers like myself.


```release-note
NONE
```
