### PR TITLE
Add error message on virtctl image-upload to WaitForFirstConsumer Dat…

### DIFF
--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -138,6 +138,25 @@ var _ = Describe("ImageUpload", func() {
 		return spec
 	}
 
+	dvSpecWithWaitForFirstConsumer := func() *cdiv1.DataVolume {
+		dv := &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      targetName,
+				Namespace: "default",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: cdiv1.SchemeGroupVersion.String(),
+				Kind:       "DataVolume",
+			},
+			Status: cdiv1.DataVolumeStatus{Phase: cdiv1.WaitForFirstConsumer},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: cdiv1.DataVolumeSource{Upload: &cdiv1.DataVolumeSourceUpload{}},
+				PVC:    &v1.PersistentVolumeClaimSpec{},
+			},
+		}
+		return dv
+	}
+
 	addPodPhaseAnnotation := func() {
 		defer GinkgoRecover()
 		time.Sleep(10 * time.Millisecond)
@@ -146,6 +165,19 @@ var _ = Describe("ImageUpload", func() {
 		pvc.Annotations[podPhaseAnnotation] = "Running"
 		pvc.Annotations[podReadyAnnotation] = "true"
 		pvc, err = kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Update(pvc)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
+		}
+		Expect(err).To(BeNil())
+	}
+
+	addDvPhase := func() {
+		defer GinkgoRecover()
+		time.Sleep(10 * time.Millisecond)
+		dv, err := cdiClient.CdiV1alpha1().DataVolumes(targetNamespace).Get(targetName, metav1.GetOptions{})
+		Expect(err).To(BeNil())
+		dv.Status.Phase = cdiv1.UploadReady
+		dv, err = cdiClient.CdiV1alpha1().DataVolumes(targetNamespace).Update(dv)
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
 		}
@@ -176,6 +208,7 @@ var _ = Describe("ImageUpload", func() {
 			dvCreateCalled = true
 
 			go createPVC(dv)
+			go addDvPhase()
 
 			return false, nil, nil
 		})
@@ -296,15 +329,16 @@ var _ = Describe("ImageUpload", func() {
 		return nil
 	}
 
-	testInitAsync := func(statusCode int, async bool, kubeobjects ...runtime.Object) {
+	testInitAsyncWithCdiObjects := func(statusCode int, async bool, kubeobjects []runtime.Object, cdiobjects []runtime.Object) {
 		dvCreateCalled = false
 		pvcCreateCalled = false
 		updateCalled = false
 
 		config := createCDIConfig()
+		cdiobjects = append(cdiobjects, config)
 
 		kubeClient = fakek8sclient.NewSimpleClientset(kubeobjects...)
-		cdiClient = fakecdiclient.NewSimpleClientset(config)
+		cdiClient = fakecdiclient.NewSimpleClientset(cdiobjects...)
 
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
@@ -331,6 +365,10 @@ var _ = Describe("ImageUpload", func() {
 		})
 	}
 
+	testInitAsync := func(statusCode int, async bool, kubeobjects ...runtime.Object) {
+		testInitAsyncWithCdiObjects(statusCode, async, kubeobjects, nil)
+	}
+
 	testInit := func(statusCode int, kubeobjects ...runtime.Object) {
 		testInitAsync(statusCode, true, kubeobjects...)
 	}
@@ -341,6 +379,7 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	Context("Successful upload to PVC", func() {
+
 		It("PVC does not exist deprecated args", func() {
 			testInit(http.StatusOK)
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", targetName, "--pvc-size", pvcSize,
@@ -468,6 +507,20 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).NotTo(BeNil())
+		})
+
+		It("DV in phase WaitForFirstConsumer", func() {
+			testInitAsyncWithCdiObjects(
+				http.StatusOK,
+				true,
+				[]runtime.Object{pvcSpecWithUploadAnnotation()},
+				[]runtime.Object{dvSpecWithWaitForFirstConsumer()},
+			)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
+			err := cmd()
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("cannot upload to DataVolume in WaitForFirstConsumer state"))
 		})
 
 		It("uploadProxyURL not configured", func() {


### PR DESCRIPTION
…aVolume

 
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When the DV is in phase WaitForFirstConsumer the PVC cannot be bound until first consumer pod shows up, so the upload is not possible.

Previously the virtclt timed out, and now it shows an error informing user about the DV state and the need to consume the PVC.

The check only works for upload to DataVolume. Implementing this check for upload to PVC would mean re-implementing CDI logic that updates DataVolume state. It is assumed that users wanting to utilize all CDI functionality use DataVolumes, and users that use PVC have a good reason not to use DV.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=1913320

**Special notes for your reviewer**:

This PR is partially addressing problems mentioned here #4601

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Error messsge on virtctl image-upload to WaitForFirstConsumer DV
```
