### PR TITLE
Add alert for insufficient number of nodes with KVM resources

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -136,3 +136,52 @@ tests:
               summary: "More than 80% of the rest calls failed in virt-handler for the last 5 minutes"
             exp_labels:
               pod: "virt-handler-1"
+
+  # Some nodes without KVM resources
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node1"}'
+        values: "110 110 110 110 110 110"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node2 "}'
+        values: "0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LowKVMNodesCount
+        exp_alerts:
+          - exp_annotations:
+              description: "Low number of nodes with KVM resource available."
+              summary: "At least two nodes with kvm resource required for VM life migration."
+            exp_labels:
+              severity: "warning"
+
+  # All nodes without KVM resources
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node1"}'
+        values: "0 0 0 0 0 0"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node2 "}'
+        values: "0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LowKVMNodesCount
+        exp_alerts:
+          - exp_annotations:
+              description: "Low number of nodes with KVM resource available."
+              summary: "At least two nodes with kvm resource required for VM life migration."
+            exp_labels:
+              severity: "warning"
+
+  # Two nodes with KVM resources
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node1"}'
+        values: "110 110 110 110 110 110"
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node ="node2 "}'
+        values: "110 110 110 110 110 110"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LowKVMNodesCount
+        exp_alerts: []

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -519,7 +519,7 @@ func NewPrometheusRuleSpec(ns string) *promv1.PrometheusRuleSpec {
 					},
 					{
 						Alert: "LowKVMNodesCount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_kvm_available_nodes < 3)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_kvm_available_nodes < 2)"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"description": "Low number of nodes with KVM resource available.",

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -514,6 +514,22 @@ func NewPrometheusRuleSpec(ns string) *promv1.PrometheusRuleSpec {
 						},
 					},
 					{
+						Record: "num_of_kvm_available_nodes",
+						Expr:   intstr.FromString("num_of_allocatable_nodes - count(kube_node_status_allocatable{resource=\"devices_kubevirt_io_kvm\"} == 0)"),
+					},
+					{
+						Alert: "LowKVMNodesCount",
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_kvm_available_nodes < 3)"),
+						For:   "5m",
+						Annotations: map[string]string{
+							"description": "Low number of nodes with KVM resource available.",
+							"summary":     "At list two nodes with kvm resource required for VM life migration.",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+					},
+					{
 						Record: "num_of_running_virt_controllers",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'})", ns),

--- a/pkg/virt-operator/creation/components/crds.go
+++ b/pkg/virt-operator/creation/components/crds.go
@@ -523,7 +523,7 @@ func NewPrometheusRuleSpec(ns string) *promv1.PrometheusRuleSpec {
 						For:   "5m",
 						Annotations: map[string]string{
 							"description": "Low number of nodes with KVM resource available.",
-							"summary":     "At list two nodes with kvm resource required for VM life migration.",
+							"summary":     "At least two nodes with kvm resource required for VM life migration.",
 						},
 						Labels: map[string]string{
 							"severity": "warning",


### PR DESCRIPTION
Signed-off-by: Andrey Odarenko <andreyo@il.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR introduces new Prometheus alert that will fire when insufficient number of nodes with KVM resource available is detected in the cluster. The threshold is 2 (as we need 2 nodes for live migration).

**Which issue(s) this PR fixes**
https://issues.redhat.com/browse/CNV-7779

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```