### PR TITLE
Refactor common code: virt-handler/isolation

### DIFF
--- a/pkg/virt-handler/isolation/isolation_test.go
+++ b/pkg/virt-handler/isolation/isolation_test.go
@@ -129,6 +129,13 @@ var _ = Describe("Isolation", func() {
 					return filepath.Join(base, fmt.Sprintf("%s_launcher", testCase))
 				}
 
+				mounted, err := NodeIsolationResult().IsMounted("/")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mounted).To(BeTrue())
+				mounted, err = NodeIsolationResult().IsMounted("???")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mounted).To(BeFalse())
+
 				result, err := NewSocketBasedIsolationDetector(tmpDir).Whitelist([]string{"devices"}).Detect(vm)
 				Expect(err).ToNot(HaveOccurred())
 				mountInfo, err := result.MountInfoRoot()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR introduces some refactoring aimed to reduce code duplication. It includes changes to the following packages:
- `virt-handler/isolation`: wrap the code which parses `/proc/mountinfo` into an iterator-like function. The function handles the IO operations, parses each line and invokes the given lambda passing the parsed record as an argument. The itaration process can be stopped before the EOF by returning `true` from the lambda.

**Special notes for your reviewer**:

The PR addresses the issue from SonarCloud: https://sonarcloud.io/component_measures?id=kubevirt_kubevirt&metric=duplicated_blocks&selected=kubevirt_kubevirt%3Apkg%2Fvirt-handler%2Fisolation%2Fisolation.go&view=list

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
