### PR TITLE
virt-launcher: [masquerade] Stop filtering dhcp reuqests by vm MAC

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -104,7 +104,7 @@ type NetworkHandler interface {
 	GenerateRandomMac() (net.HardwareAddr, error)
 	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
-	StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
+	StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error
 	HasNatIptables(proto iptables.Protocol) bool
 	IsIpv6Enabled(interfaceName string) (bool, error)
 	IsIpv4Primary() (bool, error)
@@ -339,7 +339,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 	return currentMac, nil
 }
 
-func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
+func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
 	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
 	nameservers, searchDomains, err := converter.GetResolvConfDetailsFromPod()
 	if err != nil {
@@ -351,6 +351,7 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInter
 	go func() {
 		if err = DHCPServer(
 			nic.MAC,
+			filterByMAC,
 			nic.IP.IP,
 			nic.IP.Mask,
 			bridgeInterfaceName,

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -49,6 +49,7 @@ var searchDomainValidationRegex = regexp.MustCompile(`^(?:[_a-z0-9](?:[_a-z0-9-]
 
 func SingleClientDHCPServer(
 	clientMAC net.HardwareAddr,
+	filterByMAC bool,
 	clientIP net.IP,
 	clientMask net.IPMask,
 	serverIface string,
@@ -75,6 +76,7 @@ func SingleClientDHCPServer(
 	handler := &DHCPHandler{
 		clientIP:      clientIP,
 		clientMAC:     clientMAC,
+		filterByMAC:   filterByMAC,
 		serverIP:      serverIP.To4(),
 		leaseDuration: infiniteLease,
 		options:       options,
@@ -177,15 +179,18 @@ type DHCPHandler struct {
 	serverIP      net.IP
 	clientIP      net.IP
 	clientMAC     net.HardwareAddr
+	filterByMAC   bool
 	leaseDuration time.Duration
 	options       dhcp.Options
 }
 
 func (h *DHCPHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options dhcp.Options) (d dhcp.Packet) {
 	log.Log.V(4).Info("Serving a new request")
-	if mac := p.CHAddr(); !bytes.Equal(mac, h.clientMAC) {
-		log.Log.V(4).Info("The request is not from our client")
-		return nil // Is not our client
+	if h.filterByMAC {
+		if mac := p.CHAddr(); !bytes.Equal(mac, h.clientMAC) {
+			log.Log.V(4).Info("The request is not from our client")
+			return nil // Is not our client
+		}
 	}
 
 	switch msgType {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -193,14 +193,14 @@ func (_mr *_MockNetworkHandlerRecorder) LinkSetMaster(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetMaster", arg0, arg1)
 }
 
-func (_m *MockNetworkHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
-	ret := _m.ctrl.Call(_m, "StartDHCP", nic, serverAddr, bridgeInterfaceName, dhcpOptions)
+func (_m *MockNetworkHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
+	ret := _m.ctrl.Call(_m, "StartDHCP", nic, serverAddr, bridgeInterfaceName, dhcpOptions, filterByMAC)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2, arg3)
+func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockNetworkHandler) HasNatIptables(proto iptables.Protocol) bool {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -448,7 +448,7 @@ func (b *BridgePodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
 			return fmt.Errorf("failed to parse address while starting DHCP server: %s", addr)
 		}
 		log.Log.Object(b.vmi).Infof("bridge pod interface: %+v %+v", b.vif, b)
-		return Handler.StartDHCP(b.vif, fakeServerAddr.IP, b.bridgeInterfaceName, b.iface.DHCPOptions)
+		return Handler.StartDHCP(b.vif, fakeServerAddr.IP, b.bridgeInterfaceName, b.iface.DHCPOptions, true)
 	}
 	return nil
 }
@@ -728,7 +728,7 @@ func configureVifV6Addresses(p *MasqueradePodInterface, err error) error {
 }
 
 func (p *MasqueradePodInterface) startDHCP(vmi *v1.VirtualMachineInstance) error {
-	return Handler.StartDHCP(p.vif, p.vif.Gateway, p.bridgeInterfaceName, p.iface.DHCPOptions)
+	return Handler.StartDHCP(p.vif, p.vif.Gateway, p.bridgeInterfaceName, p.iface.DHCPOptions, false)
 }
 
 func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -746,14 +746,6 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 		return err
 	}
 
-	if p.iface.MacAddress == "" {
-		p.vif.MAC, err = Handler.GenerateRandomMac()
-		if err != nil {
-			log.Log.Reason(err).Errorf("failed to generate random mac address")
-			return err
-		}
-	}
-
 	err = Handler.LinkSetUp(bridgeNic)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to bring link up for interface: %s", bridgeNic.Name)
@@ -805,7 +797,9 @@ func (p *MasqueradePodInterface) preparePodNetworkInterfaces(queueNumber uint32,
 	}
 
 	p.virtIface.MTU = &api.MTU{Size: strconv.Itoa(p.podNicLink.Attrs().MTU)}
-	p.virtIface.MAC = &api.MAC{MAC: p.vif.MAC.String()}
+	if p.vif.MAC != nil {
+		p.virtIface.MAC = &api.MAC{MAC: p.vif.MAC.String()}
+	}
 	p.virtIface.Target = &api.InterfaceTarget{
 		Device:  tapDeviceName,
 		Managed: "no",
@@ -819,7 +813,7 @@ func (p *MasqueradePodInterface) decorateConfig() error {
 	for i, iface := range ifaces {
 		if iface.Alias.Name == p.iface.Name {
 			ifaces[i].MTU = p.virtIface.MTU
-			ifaces[i].MAC = &api.MAC{MAC: p.vif.MAC.String()}
+			ifaces[i].MAC = p.virtIface.MAC
 			ifaces[i].Target = p.virtIface.Target
 			break
 		}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().ParseAddr(fmt.Sprintf(bridgeFakeIP, 0)).Return(bridgeAddr, nil)
 		mockNetwork.EXPECT().LinkSetMaster(dummy, bridgeTest).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
-		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName, nil)
+		mockNetwork.EXPECT().StartDHCP(testNic, bridgeAddr, api.DefaultBridgeName, nil, true)
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid, mtu).Return(nil)
 		mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
 		mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
@@ -216,7 +216,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, masqueradeBridgeTest).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeGwAddr).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeIpv6GwAddr).Return(nil)
-		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil)
+		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, masqueradeGwAddr, api.DefaultBridgeName, nil, false)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMCIDR).Return(masqueradeGwStr, masqueradeVmStr, nil)
 		mockNetwork.EXPECT().GetHostAndGwAddressesFromCIDR(api.DefaultVMIpv6CIDR).Return(masqueradeIpv6GwStr, masqueradeIpv6VmStr, nil)
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid, mtu).Return(nil)
@@ -376,7 +376,7 @@ var _ = Describe("Pod Network", func() {
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIBridgeInterface("testnamespace", "testVmName")
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
-				mockNetwork.EXPECT().StartDHCP(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed to open file"))
+				mockNetwork.EXPECT().StartDHCP(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed to open file"))
 				SetupPodNetworkPhase2(vm, domain)
 			}
 			Expect(testDhcpPanic).To(Panic())
@@ -613,7 +613,7 @@ var _ = Describe("Pod Network", func() {
 
 			masq.vif.Gateway = masqueradeGwAddr.IP.To4()
 			masq.vif.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
-			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil).Return(nil)
+			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(nil)
 
 			err = masq.startDHCP(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -632,7 +632,7 @@ var _ = Describe("Pod Network", func() {
 			masq.vif.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
 
 			err = fmt.Errorf("failed to start DHCP server")
-			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil).Return(err)
+			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(err)
 
 			err = masq.startDHCP(vmi)
 			Expect(err).To(HaveOccurred())
@@ -649,7 +649,7 @@ var _ = Describe("Pod Network", func() {
 			bridge, ok := driver.(*BridgePodInterface)
 			Expect(ok).To(BeTrue())
 
-			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil).Return(nil)
+			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(nil)
 
 			err = bridge.startDHCP(vmi)
 			Expect(err).ToNot(HaveOccurred())
@@ -665,7 +665,7 @@ var _ = Describe("Pod Network", func() {
 			Expect(ok).To(BeTrue())
 
 			err = fmt.Errorf("failed to start DHCP server")
-			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil).Return(err)
+			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
 
 			err = bridge.startDHCP(vmi)
 			Expect(err).To(HaveOccurred())
@@ -682,7 +682,7 @@ var _ = Describe("Pod Network", func() {
 
 			bridge.vif.IPAMDisabled = true
 			err = fmt.Errorf("failed to start DHCP server")
-			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil).Return(err)
+			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
 
 			err = bridge.startDHCP(vmi)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -895,6 +895,17 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 					return nil
 				}, 120*time.Second).Should(Succeed())
+
+				By("Restarting the vmi")
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "sudo reboot\n"},
+					&expect.BExp{R: "reboot: Restarting system"},
+				}, 10)).To(Succeed(), "failed to restart the vmi")
+				tests.WaitUntilVMIReady(vmi, loginMethod)
+				if ipFamily == k8sv1.IPv6Protocol {
+					Expect(configureIpv6(vmi)).To(Succeed(), "failed to configure ipv6 on vmi after restart")
+				}
+				Expect(ping(podIP)).To(Succeed())
 			},
 				table.Entry("IPv4", k8sv1.IPv4Protocol),
 				table.Entry("IPv6", k8sv1.IPv6Protocol),

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -787,7 +787,6 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 
 		When("performing migration", func() {
 			var vmi *v1.VirtualMachineInstance
-			var virtHandlerIPs []k8sv1.PodIP
 
 			ping := func(ipAddr string) error {
 				return libnet.PingFromVMConsole(vmi, ipAddr, "-c 1", "-w 2")
@@ -889,12 +888,11 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 
 				Eventually(func() error {
-					for _, podIP := range virtHandlerIPs {
-						err := ping(podIP.IP)
-						if err != nil {
-							return err
-						}
+					err := ping(podIP)
+					if err != nil {
+						return err
 					}
+
 					return nil
 				}, 120*time.Second).Should(Succeed())
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The PR stops the filtering of dhcp requests by vm MAC on masquerade binding.
The dhcp server filters out any packets that are not coming via the k6t-eth* interface anyway.
On masquerade binding, only the VM is connected to this interface, so there is no reason to add another filtering.
    
Removing this redundant filtering is enough to fix bug - https://bugzilla.redhat.com/1907988
After migration, unless the VM MAC address was specified in the spec, the virt-launcher doesn't know what MAC address the VM has.
Therefore, the target virt-launcher passed the wrong MAC to the dhcp server, which caused filtering out of valid dhcp requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
 Fixes bug - https://bugzilla.redhat.com/1907988

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
