### PR TITLE
Make mutating webhooks required

### DIFF
--- a/pkg/virt-operator/creation/components/BUILD.bazel
+++ b/pkg/virt-operator/creation/components/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-operator/creation/components/webhooks.go
+++ b/pkg/virt-operator/creation/components/webhooks.go
@@ -119,6 +119,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *v1beta1.Mu
 	vmPath := VMMutatePath
 	vmiPath := VMIMutatePath
 	migrationPath := MigrationMutatePath
+	failurePolicy := v1beta1.Fail
 
 	return &v1beta1.MutatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
@@ -137,8 +138,9 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *v1beta1.Mu
 		},
 		Webhooks: []v1beta1.MutatingWebhook{
 			{
-				Name:        "virtualmachines-mutator.kubevirt.io",
-				SideEffects: &sideEffectNone,
+				Name:          "virtualmachines-mutator.kubevirt.io",
+				SideEffects:   &sideEffectNone,
+				FailurePolicy: &failurePolicy,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -159,8 +161,9 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *v1beta1.Mu
 				},
 			},
 			{
-				Name:        "virtualmachineinstances-mutator.kubevirt.io",
-				SideEffects: &sideEffectNone,
+				Name:          "virtualmachineinstances-mutator.kubevirt.io",
+				SideEffects:   &sideEffectNone,
+				FailurePolicy: &failurePolicy,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -181,8 +184,9 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *v1beta1.Mu
 				},
 			},
 			{
-				Name:        "migrations-mutator.kubevirt.io",
-				SideEffects: &sideEffectNone,
+				Name:          "migrations-mutator.kubevirt.io",
+				SideEffects:   &sideEffectNone,
+				FailurePolicy: &failurePolicy,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,


### PR DESCRIPTION

**What this PR does / why we need it**:

By accident mutating webhooks were defaulting to ignoring the webhook in
case of errors. This led to not properly defaulted VMIs which can cause
issues pretty much everywhere.

This got discovered by CI, where a failing webhook led to incomplete VMI and which could therefore never be scheduled.
In https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4795/pull-kubevirt-e2e-k8s-1.17/1349614846416523264 the service account disk did not get the disk defaulted:

```json
                        "disks": [
                            {
                                "name": "disk0",
                                "disk": {
                                    "bus": "virtio"
                                }
                            },
                            {
                                "name": "default-disk",
                                "serial": "D23YZ9W6WA5DJ487"
                            }
```

which led to this xml snipped without the `device` being set:


```xml
		<disk device="" type="file">
			<source file="/var/run/kubevirt-private/service-account-disk/service-account.iso"></source>
			<target></target>
			<driver cache="none" io="native" name="qemu" type="raw"></driver>
			<alias name="ua-default-disk"></alias>
		</disk>
```

which led to this strange error:


```
 "message": "server error. command SyncVMI failed: \"LibvirtError(Code=67, Domain=20, Message='unsupported configuration: unknown disk device ''')\""
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This should fix some flakes which I have seen lately, however I expect that instead of green tests we will see failing webhook calls instead, which need to be investigated next.

**Release note**:

```release-note
Make the mutating webhooks for VMIs and VMs  required to avoid letting entities into the cluster which are not properly defaulted
```
