### PR TITLE
Normalize DNS search domains to lower-case

### DIFF
--- a/pkg/util/net/dns/resolveconf.go
+++ b/pkg/util/net/dns/resolveconf.go
@@ -56,7 +56,8 @@ func ParseSearchDomains(content string) ([]string, error) {
 		if strings.HasPrefix(line, domainSearchPrefix) {
 			doms := strings.Fields(strings.TrimPrefix(line, domainSearchPrefix))
 			for _, dom := range doms {
-				searchDomains = append(searchDomains, dom)
+				// domain names are case insensitive but kubernetes allows only lower-case
+				searchDomains = append(searchDomains, strings.ToLower(dom))
 			}
 		}
 	}

--- a/pkg/util/net/dns/resolveconf_test.go
+++ b/pkg/util/net/dns/resolveconf_test.go
@@ -69,5 +69,12 @@ var _ = Describe("Resolveconf", func() {
 			Expect(searchDomains).To(Equal([]string{"local"}))
 			Expect(err).To(BeNil())
 		})
+
+		It("should normalize search domains to lower-case", func() {
+			resolvConf := "search LoCaL\nnameserver 8.8.8.8\n"
+			searchDomains, err := ParseSearchDomains(resolvConf)
+			Expect(searchDomains).To(Equal([]string{"local"}))
+			Expect(err).To(BeNil())
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Kubernetes tolerates only lower-case search domains even though they are case insensitive in general. When parsing resolv.conf on a host machine it may include entries with upper-case letters and those will not pass the validation. To ensure compatibility the search domains are now explicitly normalized to lower-case.

Fixes #4541

**Special notes for your reviewer**:

Follow-up of the https://github.com/kubevirt/kubevirt/pull/3449 . As agreed with Maya I will take over the PR and add some tests. As noted in the comment https://github.com/kubevirt/kubevirt/pull/3449#issuecomment-757916635 there are two ways of fixing the issue: 1) updating the regexp to allow upper-case letters; 2) explicitly normalizing search domain entries to lower-case. I tested the approaches and they both seem to work well. However since kubernetes sticks to lower-case-only I think it might be safer to follow the same pattern in kubevirt. Though for now I dont have really strong arguments which way might be better. Any feedback is welcome.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
