### PR TITLE
[release-0.36] Add error message on virtctl image-upload to WaitForFirstConsumer DataVolume

### DIFF
--- a/docs/localstorage-disks.md
+++ b/docs/localstorage-disks.md
@@ -1,0 +1,127 @@
+# Local Storage Placement for VM Disks
+
+This document describes a special handling of `DataVolumes` in the `WaitForFirstConsumer` state. 
+`WaitForFirstConsumer` state is available from [CDI v1.21.0](https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.21.0), and the logic to handle this is available from [Kubevirt v0.36.0](https://github.com/kubevirt/kubevirt/releases/tag/v0.36.0)
+
+## Use-case
+
+When the `Virtual Machine` has a `DataVolume` disk (or disks) then bind Local Storage `PVC` to a `PV` on the same `node` where the `VMI` is going to be scheduled.
+
+## The problem
+
+Virtual Machines are able to have a DataVolume disks that are based on Local Storage PVs. Local Storage PVs are bound to a specific node.
+Since DataVolumes involve preparing storage with an image before being consumed by the VMI, 
+it's possible to result in an Unschedulable VMI in the event that a VMI can not be scheduled to the node the local storage PV was previously pinned to. 
+
+When the VM with a DataVolumeTemplate is defined a DataVolume is created from the template and the `CDI` creates a worker Pod to import/upload/clone data to the PVC (specified in a template).
+To run a VMI kubevirt creates a virtlauncher pod with all the VMI requirements. Kubernetes uses the virtlauncher pod requirements to schedule it on a specific node.
+Worker Pod might have different constraints than a kubevirt VM. When the VM is scheduled on a different node than the PVC it becomes unusable. 
+This is especially problematic when using a VM with DataVolumeTemplate with many disks managed by CDI. 
+
+## The solution
+
+The solution is to leverage Kubernetes pod scheduler to bind the PVC to a PV on a correct node.
+By using a StorageClass with `volumeBindingMode` set to `WaitForFirstConsumer` the binding and provisioning of PV is delayed until a Pod using the PersistentVolumeClaim is created. 
+Kubevirt can schedule a special ephemeral pod that becomes a first consumer of the PersistentVolumeClaim.
+Its only purpose is to be scheduled to a node capable of running VM and by using PVCs to trigger kubernetes to provision and bind PV's on the same node.
+After PVC are bound the `CDI` can do its work and Kubevirt can start the actual VM. 
+  
+## Implementation
+
+### Flow
+
+1. A StorageClass with volumeBindingMode=WaitForFirstConsumer is created
+2. User creates the VM with DataVolumeTemplate containing 
+3. `Kubevirt` creates DataVolume
+4. The `CDI` sees that new DV has unbound PVC with storage class with volumeBindingMode=WaitForFirstConsumer, sets the phase of DV to `WaitForFirstConsumer` and waits for PVC to be bound by some external action. 
+5. `Kubevirt` sees the DV in phase `WaitForFirstConsumer`, so it creates an ephemeral pod (basically a virtlauncher pod
+without a VM payload and with `kubevirt.io/ephemeral-provisioning` annotation) only used to force PV provisioning 
+6. Kubernetes schedules the ephemeral pod, (the node selected meets all the VM requirements), pod requires 
+ the same PVC as the VM so kubenertes has to provision and bind the PV to PVC on a correct node before the pod can be started
+7. `CDI` sees that PVC is Bound, changes DV status to "ImportScheduled" (or clone/upload), and tries to start worker pods
+8. `Kubevirt` sees DV status is `ImportScheduled`, it can terminate the ephemeral provisioning pod
+8. `CDI` does the Import, marks DV as `Succeeded`
+9. `Kubevirt` creates the virtlauncher pod to start a VM 
+
+This flow differs from standard scenario (import/upload/clone on storage with Immediate binding) by steps 4, 5, 6 and 8. 
+
+Note: 
+`WaitForFirstConsumer` state for DataVolumes is available in CDI from v1.21.0 and toggled by a `HonorWaitForFirstConsumer` feature gate. 
+When the `HonorWaitForFirstConsumer` feature gate is enabled, the `CDI` is not starting any worker pods when the PVCs StorageClass binding mode is `WaitForFirstConsumer`. In such case the `CDI` puts the DataVolume in a new state `WaitForFirstConsumer`.
+More in CDI docs [here](https://github.com/kubevirt/containerized-data-importer/blob/master/doc/waitforfirstconsumer-storage-handling.md).
+
+## Interaction with virtctl
+
+This change solves the problem of node placement for the `VMs`. And everything works automatically when using VM with DV Template, 
+but it makes it harder to use virtctl image-upload to upload images to cloud storage.
+
+Right now it is not supported by the virtctl and the user has to do additional steps to upload an image to the storage with `WaitForFirstConsumer` binding.
+
+1. Start an upload with virtctl 
+```
+virtctl image-upload dv fedora-dv --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2
+
+DataVolume default/fedora-dv created
+Waiting for PVC fedora-dv upload pod to be ready...
+cannot upload to DataVolume in state WaitForFirstConsumer
+```
+
+Current version of virtctl should immediatetly detect the problem and error. The older version will take all the time limit and finish with timeout.
+
+2. To bind the `PVC` create a consumer `POD`. With a `nodeSelector` to select a specific node ot without for a random node.
+
+Find a pvc:
+`k get pvc -l app=containerized-data-importer -o custom-columns=NAME:.metadata.name,OWNER:.metadata.ownerReferences  | grep fedora-dv
+`
+
+Create a pod to bind a pvc to any node using the following snippet with correct pvc name and namespace.
+
+```
+PVC=<PVC_NAME>
+NAMESPACE=<PVC_NAMESPACE>
+
+cat <<EOF | kubectl create -n $NAMESPACE -f -   
+apiVersion: v1
+kind: Pod
+metadata:
+  name: consumer-$PVC
+spec:
+  volumes:
+    - name: pod1-storage
+      persistentVolumeClaim:
+        claimName: $PVC
+  containers:
+  - name: test-pod-container
+    image: busybox
+    command: ['sh', '-c', 'echo "Will bind the pvc!" ']
+    volumeMounts:
+      - mountPath: /disk
+        name: pod1-storage
+  nodeSelector:
+    kubernetes.io/hostname: <NODE_HOSTNAME>
+
+EOF
+```
+
+Check if the pvc is bound and kill the temporary pod.
+```
+kubectl delete pod consumer-$PVC -n $NAMESPACE
+```
+
+3. Repeat the virtctl upload command.
+
+```
+virtctl image-upload dv fedora-dv --uploadproxy-url=https://cdi-uploadproxy.mycluster.com --image-path=/images/fedora30.qcow2
+
+DataVolume default/fedora-dv created
+Waiting for PVC fedora-dv upload pod to be ready...
+Pod now ready
+Uploading data to https://localhost:9443
+
+ 319.13 MiB / 319.13 MiB [================================================================================================================] 100.00% 0s
+
+Uploading data completed successfully, waiting for processing to complete, you can hit ctrl-c without interrupting the progress
+Processing completed successfully
+Uploading /images/fedora30.qcow2 completed successfully
+
+```

--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -257,11 +257,17 @@ func (c *command) run(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Using existing PVC %s/%s\n", namespace, pvc.Name)
 	}
 
-	err = waitUploadServerReady(virtClient, namespace, name, uploadReadyWaitInterval, time.Duration(uploadPodWaitSecs)*time.Second)
-	if err != nil {
-		return err
+	if createPVC {
+		err = waitUploadServerReady(virtClient, namespace, name, uploadReadyWaitInterval, time.Duration(uploadPodWaitSecs)*time.Second)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = waitDvUploadScheduled(virtClient, namespace, name, uploadReadyWaitInterval, time.Duration(uploadPodWaitSecs)*time.Second)
+		if err != nil {
+			return err
+		}
 	}
-
 	if uploadProxyURL == "" {
 		uploadProxyURL, err = getUploadProxyURL(virtClient.CdiClient())
 		if err != nil {
@@ -416,6 +422,40 @@ func getUploadToken(client cdiClientset.Interface, namespace, name string) (stri
 	}
 
 	return response.Status.Token, nil
+}
+
+func waitDvUploadScheduled(client kubecli.KubevirtClient, namespace, name string, interval, timeout time.Duration) error {
+	loggedStatus := false
+	//
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		dv, err := client.CdiClient().CdiV1alpha1().DataVolumes(namespace).Get(name, metav1.GetOptions{})
+
+		if err != nil {
+			// DataVolume controller may not have created the DV yet ? TODO:
+			if k8serrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		if dv.Status.Phase == cdiv1.WaitForFirstConsumer {
+			return false, fmt.Errorf("cannot upload to DataVolume in WaitForFirstConsumer state, make sure the PVC is Bound")
+		}
+		done := dv.Status.Phase == cdiv1.UploadReady
+		if !done && !loggedStatus {
+			fmt.Printf("Waiting for PVC %s upload pod to be ready...\n", name)
+			loggedStatus = true
+		}
+
+		if done && loggedStatus {
+			fmt.Printf("Pod now ready\n")
+		}
+
+		return done, nil
+	})
+
+	return err
 }
 
 func waitUploadServerReady(client kubernetes.Interface, namespace, name string, interval, timeout time.Duration) error {

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -138,6 +138,25 @@ var _ = Describe("ImageUpload", func() {
 		return spec
 	}
 
+	dvSpecWithWaitForFirstConsumer := func() *cdiv1.DataVolume {
+		dv := &cdiv1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      targetName,
+				Namespace: "default",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: cdiv1.SchemeGroupVersion.String(),
+				Kind:       "DataVolume",
+			},
+			Status: cdiv1.DataVolumeStatus{Phase: cdiv1.WaitForFirstConsumer},
+			Spec: cdiv1.DataVolumeSpec{
+				Source: cdiv1.DataVolumeSource{Upload: &cdiv1.DataVolumeSourceUpload{}},
+				PVC:    &v1.PersistentVolumeClaimSpec{},
+			},
+		}
+		return dv
+	}
+
 	addPodPhaseAnnotation := func() {
 		defer GinkgoRecover()
 		time.Sleep(10 * time.Millisecond)
@@ -146,6 +165,19 @@ var _ = Describe("ImageUpload", func() {
 		pvc.Annotations[podPhaseAnnotation] = "Running"
 		pvc.Annotations[podReadyAnnotation] = "true"
 		pvc, err = kubeClient.CoreV1().PersistentVolumeClaims(targetNamespace).Update(pvc)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
+		}
+		Expect(err).To(BeNil())
+	}
+
+	addDvPhase := func() {
+		defer GinkgoRecover()
+		time.Sleep(10 * time.Millisecond)
+		dv, err := cdiClient.CdiV1alpha1().DataVolumes(targetNamespace).Get(targetName, metav1.GetOptions{})
+		Expect(err).To(BeNil())
+		dv.Status.Phase = cdiv1.UploadReady
+		dv, err = cdiClient.CdiV1alpha1().DataVolumes(targetNamespace).Update(dv)
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "Error: %v\n", err)
 		}
@@ -176,6 +208,7 @@ var _ = Describe("ImageUpload", func() {
 			dvCreateCalled = true
 
 			go createPVC(dv)
+			go addDvPhase()
 
 			return false, nil, nil
 		})
@@ -296,15 +329,16 @@ var _ = Describe("ImageUpload", func() {
 		return nil
 	}
 
-	testInitAsync := func(statusCode int, async bool, kubeobjects ...runtime.Object) {
+	testInitAsyncWithCdiObjects := func(statusCode int, async bool, kubeobjects []runtime.Object, cdiobjects []runtime.Object) {
 		dvCreateCalled = false
 		pvcCreateCalled = false
 		updateCalled = false
 
 		config := createCDIConfig()
+		cdiobjects = append(cdiobjects, config)
 
 		kubeClient = fakek8sclient.NewSimpleClientset(kubeobjects...)
-		cdiClient = fakecdiclient.NewSimpleClientset(config)
+		cdiClient = fakecdiclient.NewSimpleClientset(cdiobjects...)
 
 		kubecli.MockKubevirtClientInstance.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		kubecli.MockKubevirtClientInstance.EXPECT().CdiClient().Return(cdiClient).AnyTimes()
@@ -331,6 +365,10 @@ var _ = Describe("ImageUpload", func() {
 		})
 	}
 
+	testInitAsync := func(statusCode int, async bool, kubeobjects ...runtime.Object) {
+		testInitAsyncWithCdiObjects(statusCode, async, kubeobjects, nil)
+	}
+
 	testInit := func(statusCode int, kubeobjects ...runtime.Object) {
 		testInitAsync(statusCode, true, kubeobjects...)
 	}
@@ -341,6 +379,7 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	Context("Successful upload to PVC", func() {
+
 		It("PVC does not exist deprecated args", func() {
 			testInit(http.StatusOK)
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", targetName, "--pvc-size", pvcSize,
@@ -458,6 +497,20 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).NotTo(BeNil())
+		})
+
+		It("DV in phase WaitForFirstConsumer", func() {
+			testInitAsyncWithCdiObjects(
+				http.StatusOK,
+				true,
+				[]runtime.Object{pvcSpecWithUploadAnnotation()},
+				[]runtime.Object{dvSpecWithWaitForFirstConsumer()},
+			)
+			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
+				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
+			err := cmd()
+			Expect(err).NotTo(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("cannot upload to DataVolume in WaitForFirstConsumer state"))
 		})
 
 		It("uploadProxyURL not configured", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

A manual backport of #4779 to release-0.36

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://bugzilla.redhat.com/show_bug.cgi?id=1913320

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Error messsge on virtctl image-upload to WaitForFirstConsumer DV
```
