### PR TITLE
[virt-operator] load new certificates earlier and prepare for the 0.37.0 release

### DIFF
--- a/hack/ci/entrypoint.sh
+++ b/hack/ci/entrypoint.sh
@@ -93,7 +93,7 @@ function run_tests() {
     # required to be set for test binary
     export ARTIFACTS=${ARTIFACT_DIR}
 
-    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${BIN_DIR}/oc -kubectl-path=${BIN_DIR}/kubectl -gocli-path=$(pwd)/cluster-up/cli.sh -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slowSpecThreshold=60 ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=index.docker.io/kubevirt -deploy-testing-infra=false
+    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${BIN_DIR}/oc -kubectl-path=${BIN_DIR}/kubectl -gocli-path=$(pwd)/cluster-up/cli.sh -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slowSpecThreshold=60 ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
 }
 
 export PATH="$BIN_DIR:$PATH"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -26,7 +26,7 @@ KUBEVIRT_E2E_PARALLEL_NODES=${KUBEVIRT_E2E_PARALLEL_NODES:-3}
 source hack/common.sh
 source hack/config.sh
 
-_default_previous_release_registry="index.docker.io/kubevirt"
+_default_previous_release_registry="quay.io/kubevirt"
 
 previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_release_registry}
 

--- a/pkg/certificates/bootstrap/BUILD.bazel
+++ b/pkg/certificates/bootstrap/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "//pkg/certificates/triple/cert:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
     ],
 )
@@ -28,6 +30,8 @@ go_test(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/certificates/bootstrap/cert-manager.go
+++ b/pkg/certificates/bootstrap/cert-manager.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/certificate"
 
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
@@ -219,4 +221,67 @@ func (f *FileCertificateManager) loadCertificates() (serverCrt *tls.Certificate,
 	}
 	crt.Leaf = leaf[0]
 	return &crt, nil
+}
+
+type SecretCertificateManager struct {
+	store     cache.Store
+	secretKey string
+	tlsCrt    string
+	tlsKey    string
+	crtLock   *sync.Mutex
+	revision  string
+	crt       *tls.Certificate
+}
+
+func (s *SecretCertificateManager) Start() {
+}
+
+func (s *SecretCertificateManager) Stop() {
+}
+
+func (s *SecretCertificateManager) Current() *tls.Certificate {
+	s.crtLock.Lock()
+	defer s.crtLock.Unlock()
+	rawSecret, exists, err := s.store.GetByKey(s.secretKey)
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("Secret %s can't be retrieved from the cache", s.secretKey)
+		return s.crt
+	} else if !exists {
+		return s.crt
+	}
+	secret := rawSecret.(*v1.Secret)
+	if secret.ObjectMeta.ResourceVersion == s.revision {
+		return s.crt
+	}
+	crt, err := tls.X509KeyPair(secret.Data[s.tlsCrt], secret.Data[s.tlsKey])
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("failed to load certificate from secret %s", s.secretKey)
+		return s.crt
+	}
+	leaf, err := cert.ParseCertsPEM(secret.Data[s.tlsCrt])
+	if err != nil {
+		log.DefaultLogger().Reason(err).Errorf("failed to load leaf certificate from secret %s", s.secretKey)
+		return s.crt
+	}
+	crt.Leaf = leaf[0]
+	s.revision = secret.ResourceVersion
+	s.crt = &crt
+	return s.crt
+}
+
+func (s *SecretCertificateManager) ServerHealthy() bool {
+	panic("implement me")
+}
+
+// NewSecretCertificateManager takes a secret store and the name and the  namespace of a secret. If there is a newer
+// version of the secret in the cache, the next Current() call will immediately wield it. It takes resource versions
+// into account to be efficient.
+func NewSecretCertificateManager(name string, namespace string, store cache.Store) *SecretCertificateManager {
+	return &SecretCertificateManager{
+		store:     store,
+		secretKey: fmt.Sprintf("%s/%s", namespace, name),
+		tlsCrt:    CertBytesValue,
+		tlsKey:    KeyBytesValue,
+		crtLock:   &sync.Mutex{},
+	}
 }

--- a/pkg/certificates/bootstrap/cert-manager_test.go
+++ b/pkg/certificates/bootstrap/cert-manager_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -18,112 +20,149 @@ import (
 
 var _ = Describe("cert-manager", func() {
 
-	var certDir string
-	var certFilePath string
-	var keyFilePath string
+	Context("based on mounted files", func() {
+		var certDir string
+		var certFilePath string
+		var keyFilePath string
 
-	BeforeEach(func() {
-		var err error
-		certDir, err = ioutil.TempDir("", "certs")
-		certFilePath = filepath.Join(certDir, "tls.crt")
-		keyFilePath = filepath.Join(certDir, "tls.key")
-		Expect(err).ToNot(HaveOccurred())
-	})
+		BeforeEach(func() {
+			var err error
+			certDir, err = ioutil.TempDir("", "certs")
+			certFilePath = filepath.Join(certDir, "tls.crt")
+			keyFilePath = filepath.Join(certDir, "tls.key")
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-	It("should return nil if no certificate exists", func() {
-		certManager := NewFileCertificateManager(certFilePath, keyFilePath)
-		go certManager.Start()
-		defer certManager.Stop()
-		Consistently(func() *tls.Certificate {
-			return certManager.Current()
-		}, time.Second).Should(BeNil())
-	})
-
-	It("should load a certificate if it exists", func() {
-		certManager := NewFileCertificateManager(certFilePath, keyFilePath)
-		writeCertsToDir(certDir)
-		go certManager.Start()
-		defer certManager.Stop()
-		Eventually(func() *tls.Certificate {
-			return certManager.Current()
-		}, time.Second).Should(Not(BeNil()))
-	})
-
-	It("should load a certificate even if cert and key file are in different directories", func() {
-		writeCertsToDir(certDir)
-
-		var err error
-		newCertDir, err := ioutil.TempDir("", "certs")
-		Expect(err).ToNot(HaveOccurred())
-		newKeyDir, err := ioutil.TempDir("", "keys")
-		Expect(err).ToNot(HaveOccurred())
-		crt, err := ioutil.ReadFile(certFilePath)
-		Expect(err).ToNot(HaveOccurred())
-		key, err := ioutil.ReadFile(keyFilePath)
-		Expect(err).ToNot(HaveOccurred())
-
-		newCertFilePath := filepath.Join(newCertDir, "tls.crt")
-		newKeyFilePath := filepath.Join(newKeyDir, "tls.key")
-		Expect(ioutil.WriteFile(newCertFilePath, crt, 0777)).To(Succeed())
-		Expect(ioutil.WriteFile(newKeyFilePath, key, 0777)).To(Succeed())
-
-		certManager := NewFileCertificateManager(newCertFilePath, newKeyFilePath)
-		go certManager.Start()
-		defer certManager.Stop()
-		Eventually(func() *tls.Certificate {
-			return certManager.Current()
-		}, time.Second).Should(Not(BeNil()))
-	})
-
-	It("should load a certificate if it appears after the start", func() {
-		certManager := NewFileCertificateManager(certFilePath, keyFilePath)
-		go certManager.Start()
-		defer certManager.Stop()
-		Consistently(func() *tls.Certificate {
-			return certManager.Current()
-		}, time.Second).Should(BeNil())
-		writeCertsToDir(certDir)
-		Eventually(func() *tls.Certificate {
-			return certManager.Current()
-		}, 3*time.Second).Should(Not(BeNil()))
-	})
-
-	It("should keep the latest certificate if it can't load new certs", func() {
-		certManager := NewFileCertificateManager(certFilePath, keyFilePath)
-		writeCertsToDir(certDir)
-		go certManager.Start()
-		defer certManager.Stop()
-		Eventually(func() *tls.Certificate {
-			return certManager.Current()
-		}, time.Second).Should(Not(BeNil()))
-		Expect(ioutil.WriteFile(filepath.Join(certDir, CertBytesValue), []byte{}, 0777)).To(Succeed())
-		Consistently(func() *tls.Certificate {
-			return certManager.Current()
-		}, 2*time.Second).ShouldNot(BeNil())
-	})
-
-	Context("with fallback handling", func() {
-		It("should return a fallback certificate if the is no certificate", func() {
-			certManager := NewFallbackCertificateManager(NewFileCertificateManager(certFilePath, keyFilePath))
+		It("should return nil if no certificate exists", func() {
+			certManager := NewFileCertificateManager(certFilePath, keyFilePath)
 			go certManager.Start()
 			defer certManager.Stop()
-			Expect(certManager.Current().Leaf.Subject.CommonName).To(Equal("fallback.certificate.kubevirt.io"))
+			Consistently(func() *tls.Certificate {
+				return certManager.Current()
+			}, time.Second).Should(BeNil())
 		})
-		It("should return the real certificate if the is one", func() {
-			kubevirtCache := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-			kubevirtCache.Add(&v1.KubeVirt{})
-			certManager := NewFallbackCertificateManager(NewFileCertificateManager(certFilePath, keyFilePath))
+
+		It("should load a certificate if it exists", func() {
+			certManager := NewFileCertificateManager(certFilePath, keyFilePath)
 			writeCertsToDir(certDir)
 			go certManager.Start()
 			defer certManager.Stop()
-			Eventually(func() string {
-				return certManager.Current().Leaf.Subject.CommonName
-			}, time.Second).Should(Equal("loaded.certificate.kubevirt.io"))
+			Eventually(func() *tls.Certificate {
+				return certManager.Current()
+			}, time.Second).Should(Not(BeNil()))
+		})
+
+		It("should load a certificate even if cert and key file are in different directories", func() {
+			writeCertsToDir(certDir)
+
+			var err error
+			newCertDir, err := ioutil.TempDir("", "certs")
+			Expect(err).ToNot(HaveOccurred())
+			newKeyDir, err := ioutil.TempDir("", "keys")
+			Expect(err).ToNot(HaveOccurred())
+			crt, err := ioutil.ReadFile(certFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			key, err := ioutil.ReadFile(keyFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			newCertFilePath := filepath.Join(newCertDir, "tls.crt")
+			newKeyFilePath := filepath.Join(newKeyDir, "tls.key")
+			Expect(ioutil.WriteFile(newCertFilePath, crt, 0777)).To(Succeed())
+			Expect(ioutil.WriteFile(newKeyFilePath, key, 0777)).To(Succeed())
+
+			certManager := NewFileCertificateManager(newCertFilePath, newKeyFilePath)
+			go certManager.Start()
+			defer certManager.Stop()
+			Eventually(func() *tls.Certificate {
+				return certManager.Current()
+			}, time.Second).Should(Not(BeNil()))
+		})
+
+		It("should load a certificate if it appears after the start", func() {
+			certManager := NewFileCertificateManager(certFilePath, keyFilePath)
+			go certManager.Start()
+			defer certManager.Stop()
+			Consistently(func() *tls.Certificate {
+				return certManager.Current()
+			}, time.Second).Should(BeNil())
+			writeCertsToDir(certDir)
+			Eventually(func() *tls.Certificate {
+				return certManager.Current()
+			}, 3*time.Second).Should(Not(BeNil()))
+		})
+
+		It("should keep the latest certificate if it can't load new certs", func() {
+			certManager := NewFileCertificateManager(certFilePath, keyFilePath)
+			writeCertsToDir(certDir)
+			go certManager.Start()
+			defer certManager.Stop()
+			Eventually(func() *tls.Certificate {
+				return certManager.Current()
+			}, time.Second).Should(Not(BeNil()))
+			Expect(ioutil.WriteFile(filepath.Join(certDir, CertBytesValue), []byte{}, 0777)).To(Succeed())
+			Consistently(func() *tls.Certificate {
+				return certManager.Current()
+			}, 2*time.Second).ShouldNot(BeNil())
+		})
+
+		Context("with fallback handling", func() {
+			It("should return a fallback certificate if the is no certificate", func() {
+				certManager := NewFallbackCertificateManager(NewFileCertificateManager(certFilePath, keyFilePath))
+				go certManager.Start()
+				defer certManager.Stop()
+				Expect(certManager.Current().Leaf.Subject.CommonName).To(Equal("fallback.certificate.kubevirt.io"))
+			})
+			It("should return the real certificate if the is one", func() {
+				kubevirtCache := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+				kubevirtCache.Add(&v1.KubeVirt{})
+				certManager := NewFallbackCertificateManager(NewFileCertificateManager(certFilePath, keyFilePath))
+				writeCertsToDir(certDir)
+				go certManager.Start()
+				defer certManager.Stop()
+				Eventually(func() string {
+					return certManager.Current().Leaf.Subject.CommonName
+				}, time.Second).Should(Equal("loaded.certificate.kubevirt.io"))
+			})
+		})
+		AfterEach(func() {
+			os.RemoveAll(certDir)
 		})
 	})
 
-	AfterEach(func() {
-		os.RemoveAll(certDir)
+	Context("based on a secret store", func() {
+		var secretCache cache.Store
+
+		BeforeEach(func() {
+			secretCache = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+		})
+		It("should return nil if there is no certificate", func() {
+			manager := NewSecretCertificateManager("name", "namespace", secretCache)
+			Expect(manager.Current()).To(BeNil())
+		})
+		It("should load the certificate from a secret in the cache", func() {
+			secretCache.Add(writeCertsToSecret("name", "namespace", "1"))
+			manager := NewSecretCertificateManager("name", "namespace", secretCache)
+			Expect(manager.Current()).ToNot(BeNil())
+		})
+		It("should update the certificate if the revision changes", func() {
+			secretCache.Add(writeCertsToSecret("name", "namespace", "1"))
+			manager := NewSecretCertificateManager("name", "namespace", secretCache)
+			crt := manager.Current()
+			Expect(crt).ToNot(BeNil())
+			secretCache.Add(writeCertsToSecret("name", "namespace", "2"))
+			newCrt := manager.Current()
+			Expect(newCrt).ToNot(BeNil())
+			Expect(newCrt).ToNot(Equal(crt))
+		})
+		It("should not update the certificate if the revision does not change", func() {
+			secretCache.Add(writeCertsToSecret("name", "namespace", "1"))
+			manager := NewSecretCertificateManager("name", "namespace", secretCache)
+			crt := manager.Current()
+			Expect(crt).ToNot(BeNil())
+			secretCache.Add(writeCertsToSecret("name", "namespace", "1"))
+			newCrt := manager.Current()
+			Expect(newCrt).To(Equal(crt))
+		})
 	})
 })
 
@@ -143,4 +182,31 @@ func writeCertsToDir(dir string) {
 	key := cert.EncodePrivateKeyPEM(keyPair.Key)
 	Expect(ioutil.WriteFile(filepath.Join(dir, CertBytesValue), crt, 0777)).To(Succeed())
 	Expect(ioutil.WriteFile(filepath.Join(dir, KeyBytesValue), key, 0777)).To(Succeed())
+}
+
+func writeCertsToSecret(name string, namespace string, revision string) *k8sv1.Secret {
+	caKeyPair, _ := triple.NewCA("kubevirt.io", time.Hour*24*7)
+	keyPair, _ := triple.NewServerKeyPair(
+		caKeyPair,
+		"loaded.certificate.kubevirt.io",
+		"important",
+		"this is",
+		"cluster.local",
+		nil,
+		nil,
+		time.Hour*24,
+	)
+	crt := cert.EncodeCertPEM(keyPair.Cert)
+	key := cert.EncodePrivateKeyPEM(keyPair.Key)
+	return &k8sv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: revision,
+		},
+		Data: map[string][]byte{
+			CertBytesValue: crt,
+			KeyBytesValue:  key,
+		},
+	}
 }

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -395,5 +395,11 @@ func (app *VirtOperatorApp) AddFlags() {
 }
 
 func (app *VirtOperatorApp) prepareCertManagers() {
-	app.operatorCertManager = bootstrap.NewFallbackCertificateManager(bootstrap.NewFileCertificateManager("/etc/virt-operator/certificates/tls.crt", "/etc/virt-operator/certificates/tls.key"))
+	app.operatorCertManager = bootstrap.NewFallbackCertificateManager(
+		bootstrap.NewSecretCertificateManager(
+			components.VirtOperatorCertSecretName,
+			app.operatorNamespace,
+			app.informers.Secrets.GetStore(),
+		),
+	)
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,7 +72,7 @@ docker run \
     kubevirt/tests:latest \
         --kubeconfig=data/openshift-master.kubeconfig \
         --container-tag=latest \
-        --container-prefix=docker.io/kubevirt \
+        --container-prefix=quay.io/kubevirt \
         --test.timeout 180m \
         --junit-output=data/results/junit.xml \
         --deploy-testing-infra \

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -66,7 +66,7 @@ func init() {
 	flag.BoolVar(&DeployTestingInfrastructureFlag, "deploy-testing-infra", false, "Deploy testing infrastructure if set")
 	flag.StringVar(&PathToTestingInfrastrucureManifests, "path-to-testing-infra-manifests", "manifests/testing", "Set path to testing infrastructure manifests")
 	flag.StringVar(&PreviousReleaseTag, "previous-release-tag", "", "Set tag of the release to test updating from")
-	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "index.docker.io/kubevirt", "Set registry of the release to test updating from")
+	flag.StringVar(&PreviousReleaseRegistry, "previous-release-registry", "quay.io/kubevirt", "Set registry of the release to test updating from")
 	flag.StringVar(&ConfigFile, "config", "tests/default-config.json", "Path to a JSON formatted file from which the test suite will load its configuration. The path may be absolute or relative; relative paths start at the current working directory.")
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -660,7 +660,7 @@ var _ = Describe("[Serial]Operator", func() {
 				supportedVersions = append(supportedVersions, crd.Spec.Version)
 			}
 
-			for _, version := range supportedVersions {
+			for i, version := range supportedVersions {
 				vmYaml := fmt.Sprintf(`apiVersion: kubevirt.io/%s
 kind: VirtualMachine
 metadata:
@@ -670,7 +670,7 @@ metadata:
 spec:
   dataVolumeTemplates:
   - metadata:
-      name: test-dv
+      name: test-dv%v
     spec:
       pvc:
         accessModes:
@@ -706,7 +706,7 @@ spec:
       terminationGracePeriodSeconds: 0
       volumes:
       - dataVolume:
-          name: test-dv
+          name: test-dv%v
         name: datavolumedisk1
       - containerDisk:
           image: %s/%s-container-disk-demo:%s
@@ -717,7 +717,7 @@ spec:
 
             echo 'printed from cloud-init userdata'
         name: cloudinitdisk
-`, version, version, version, version, previousImageRegistry, cd.ContainerDiskCirros, previousImageTag)
+`, version, version, version, i, version, i, previousImageRegistry, cd.ContainerDiskCirros, previousImageTag)
 
 				yamlFile := filepath.Join(workDir, fmt.Sprintf("vm-%s.yaml", version))
 				err = ioutil.WriteFile(yamlFile, []byte(vmYaml), 0644)


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of waiting for the mounted secret to propagate a certificate,
immediately take the secret from the secret store and load the
certificate as soon as it is available. This would be in general the
preferred method for all our components if we would want to allow
accessing secrets, which we don't. However virt-operator, as the only
component with access to secrets can just do that.

This resolves issues where virt-operator webhooks on KubeVirt resources
would deny mutations until the new certificate is available. The
file-based appraoch can take up to minutes, the watcher based approach
reflects changes almost immediately.

This improvement was not necessarry until #4599 but is necessary now.
Our CI system fails pretty often on that: https://search.ci.kubevirt.io/?search=kubevirt-validate-update&maxAge=48h&context=1&type=bug%2Bjunit&name=&maxMatches=5&maxBytes=20971520&groupBy=job

The experienced failures due to temporary blocked updates look like this:

```
Message: "failed calling webhook \"kubevirt-update-validator.kubevirt.io\": Post https://kubevirt-operator-webhook.kubevirt.svc:443/kubevirt-validate-update?timeout=30s: x509: certificate signed by unknown authority (possibly because of \"crypto/rsa: verification error\" while trying to verify candidate authority certificate \"kubevirt.io\")",
```

Additionally some changes were necessary due to the parallel 0.37.0 release while writing this PR:

 * new kubevirt releses are now hosted on quay only
 * CDI blocks referencing the same PVC from two different datavolumes, fixing the update test:
 
 ```
 {"component":"virt-controller","level":"info","msg":"re-enqueuing VirtualMachine kubevirt-test-default1/vm-v1alpha3","pos":"vm.go:151","reason":"Failed to create DataVolume: admission webhook \"datavolume-validate.cdi.kubevirt.io\" denied the request:  Destination PVC already exists","service":"http","timestamp":"2021-01-20T09:29:17.570983Z"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4649 and fixes #4698

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix an issue where it may not be able to update the KubeVirt CR after creation for up to minutes due to certificate propagation delays
```
