### PR TITLE
[WIP] Fedora test tool image for ci

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -182,6 +182,7 @@ container_bundle(
         "$(container_prefix)/$(image_prefix)virtio-container-disk:$(container_tag)": "//containerimages:virtio-container-disk-image",
         # Customized container-disk images
         "$(container_prefix)/$(image_prefix)fedora-sriov-lane-container-disk:$(container_tag)": "//containerimages:fedora-sriov-lane-container-disk-image",
+        "$(container_prefix)/$(image_prefix)fedora-with-test-tooling-container-disk:$(container_tag)": "//containerimages:fedora-with-test-tooling",
         # testing images
         "$(container_prefix)/$(image_prefix)disks-images-provider:$(container_tag)": "//images/disks-images-provider:disks-images-provider-image",
         "$(container_prefix)/$(image_prefix)cdi-http-import-server:$(container_tag)": "//images/cdi-http-import-server:cdi-http-import-server-image",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -327,7 +327,7 @@ container_pull(
 # like stress and qemu guest agent pre-configured
 container_pull(
     name = "fedora_with_test_tooling",
-    digest = "sha256:618a624a703682482c473c105ecd6cce212993d2af856771437dbbf80f20b19d",
+    digest = "sha256:555955be79c502809002fb3af31b0d702b85c38ee306c1dd6d2d6b7bc20e633a",
     registry = "quay.io",
     repository = "dvossel/fedora-with-test-tooling",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -323,6 +323,15 @@ container_pull(
     #tag = "32",
 )
 
+# Pull fedora container-disk preconfigured with ci tooling
+# like stress and qemu guest agent pre-configured
+container_pull(
+    name = "fedora_with_test_tooling",
+    digest = "sha256:618a624a703682482c473c105ecd6cce212993d2af856771437dbbf80f20b19d",
+    registry = "quay.io",
+    repository = "dvossel/fedora-with-test-tooling",
+)
+
 # Pull base image libvirt
 container_pull(
     name = "libvirt",

--- a/containerimages/BUILD.bazel
+++ b/containerimages/BUILD.bazel
@@ -134,3 +134,15 @@ container_image(
     mode = "444",
     visibility = ["//visibility:public"],
 )
+
+container_image(
+    name = "fedora-with-test-tooling",
+    architecture = select({
+        "//conditions:default": "amd64",
+    }),
+    base = select({
+        "//conditions:default": "@fedora_with_test_tooling//image",
+    }),
+    mode = "444",
+    visibility = ["//visibility:public"],
+)

--- a/images/cdi-http-import-server/entrypoint.sh
+++ b/images/cdi-http-import-server/entrypoint.sh
@@ -32,6 +32,7 @@ case "$IMAGE_NAME" in
 cirros) CONVERT_PATH=$CIRROS_IMAGE_PATH ;;
 alpine) CONVERT_PATH=$ALPINE_IMAGE_PATH ;;
 fedora-cloud) CONVERT_PATH=$FEDORA_IMAGE_PATH ;;
+fedora-with-test-tooling) CONVERT_PATH=$FEDORA_IMAGE_PATH ;;
 *)
     echo "failed to find image $IMAGE_NAME"
     ;;

--- a/tests/containerdisk/containerdisk.go
+++ b/tests/containerdisk/containerdisk.go
@@ -33,6 +33,7 @@ const (
 	ContainerDiskAlpine               ContainerDisk = "alpine"
 	ContainerDiskFedora               ContainerDisk = "fedora-cloud"
 	ContainerDiskFedoraSRIOVLane      ContainerDisk = "fedora-sriov-lane"
+	ContainerDiskFedoraTestTooling    ContainerDisk = "fedora-with-test-tooling"
 	ContainerDiskMicroLiveCD          ContainerDisk = "microlivecd"
 	ContainerDiskVirtio               ContainerDisk = "virtio-container-disk"
 	ContainerDiskEmpty                ContainerDisk = "empty"
@@ -47,7 +48,7 @@ func ContainerDiskFor(name ContainerDisk) string {
 		return fmt.Sprintf("%s/%s-container-disk-demo:%s", flags.KubeVirtUtilityRepoPrefix, name, flags.KubeVirtUtilityVersionTag)
 	case ContainerDiskVirtio:
 		return fmt.Sprintf("%s/virtio-container-disk:%s", flags.KubeVirtUtilityRepoPrefix, flags.KubeVirtUtilityVersionTag)
-	case ContainerDiskFedoraSRIOVLane:
+	case ContainerDiskFedoraSRIOVLane, ContainerDiskFedoraTestTooling:
 		return fmt.Sprintf("%s/%s-container-disk:%s", flags.KubeVirtUtilityRepoPrefix, name, flags.KubeVirtUtilityVersionTag)
 	}
 	panic(fmt.Sprintf("Unsupported registry disk %s", name))

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Guest Access Credentials", func() {
 	Context("with qemu guest agent", func() {
 		It("should propagate public ssh keys", func() {
 			secretID := "my-pub-key"
-			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Namespace = tests.NamespaceTestDefault
 			vmi.Spec.AccessCredentials = []v1.AccessCredential{
 				{
@@ -160,7 +160,7 @@ var _ = Describe("Guest Access Credentials", func() {
 
 		It("should propagate user password", func() {
 			secretID := "my-user-pass"
-			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Namespace = tests.NamespaceTestDefault
 
 			vmi.Spec.AccessCredentials = []v1.AccessCredential{

--- a/tests/framework/storage/nfs.go
+++ b/tests/framework/storage/nfs.go
@@ -12,6 +12,53 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
+func RenderNFSServerWithPVC(generateName string, pvcName string) *k8sv1.Pod {
+	image := fmt.Sprintf("%s/nfs-server:%s", flags.KubeVirtRepoPrefix, flags.KubeVirtVersionTag)
+	resources := k8sv1.ResourceRequirements{}
+	resources.Requests = make(k8sv1.ResourceList)
+	resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("256M")
+	resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("500m")
+	pod := &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateName,
+			Labels: map[string]string{
+				v1.AppLabel: generateName,
+			},
+		},
+		Spec: k8sv1.PodSpec{
+			RestartPolicy: k8sv1.RestartPolicyNever,
+			Volumes: []k8sv1.Volume{
+				{
+					Name: "nfsdata",
+					VolumeSource: k8sv1.VolumeSource{
+						PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: pvcName,
+						},
+					},
+				},
+			},
+			Containers: []k8sv1.Container{
+				{
+					Name:            generateName,
+					Image:           image,
+					ImagePullPolicy: k8sv1.PullAlways,
+					Resources:       resources,
+					SecurityContext: &k8sv1.SecurityContext{
+						Privileged: pointer.BoolPtr(true),
+					},
+					VolumeMounts: []k8sv1.VolumeMount{
+						{
+							Name:      "nfsdata",
+							MountPath: "/data/nfs",
+						},
+					},
+				},
+			},
+		},
+	}
+	return pod
+}
+
 func RenderNFSServer(generateName string, hostPath string) *k8sv1.Pod {
 	image := fmt.Sprintf("%s/nfs-server:%s", flags.KubeVirtRepoPrefix, flags.KubeVirtVersionTag)
 	resources := k8sv1.ResourceRequirements{}

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -37,6 +37,13 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	return newFedora(cd.ContainerDiskFedora, opts...)
 }
 
+// NewTestToolingFedora instantiates a new Fedora based VMI configuration,
+// building its extra properties based on the specified With* options.
+// This image has tooling for the guest agent, stress, and more
+func NewTestToolingFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	return newFedora(cd.ContainerDiskFedoraTestTooling, opts...)
+}
+
 // NewSriovFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options, the
 // image used include Guest Agent and some moduled needed by SRIOV.

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -890,12 +890,51 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		Context("with a Fedora shared NFS PVC (using nfs ipv4 address), cloud init and service account", func() {
 			var pvName string
 			var vmi *v1.VirtualMachineInstance
+			var dv *cdiv1.DataVolume
+			var wffcPod *k8sv1.Pod
+
 			BeforeEach(func() {
 				tests.SkipNFSTestIfRunnigOnKindInfra()
+
+				quantity, err := resource.ParseQuantity("5Gi")
+				Expect(err).ToNot(HaveOccurred())
+				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
+				dv := tests.NewRandomDataVolumeWithRegistryImport(url, tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+				dv.Spec.PVC.Resources.Requests["storage"] = quantity
+				_, err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
+				Expect(err).ToNot(HaveOccurred())
+
+				wffcPod = tests.RenderPod("wffc-temp-pod", []string{"echo"}, []string{"done"})
+				wffcPod.Spec.Containers[0].VolumeMounts = []k8sv1.VolumeMount{
+
+					{
+						Name:      "tmp-data",
+						MountPath: "/data/tmp-data",
+					},
+				}
+				wffcPod.Spec.Volumes = []k8sv1.Volume{
+					{
+						Name: "tmp-data",
+						VolumeSource: k8sv1.VolumeSource{
+							PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: dv.Name,
+							},
+						},
+					},
+				}
+
+				By("pinning the wffc dv")
+				wffcPod, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(wffcPod)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(ThisPod(wffcPod), 120).Should(BeInPhase(k8sv1.PodSucceeded))
+
+				By("waiting for the dv import to pvc to finish")
+				tests.WaitForSuccessfulDataVolumeImport(dv, 600)
+
 				pvName = "test-nfs" + rand.String(48)
 				// Prepare a NFS backed PV
-				By("Starting an NFS POD")
-				nfsPod := storageframework.RenderNFSServer("nfsserver", tests.HostPathFedora)
+				By("Starting an NFS POD to serve the PVC contents")
+				nfsPod := storageframework.RenderNFSServerWithPVC("nfsserver", dv.Name)
 				nfsPod, err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(nfsPod)
 				Expect(err).ToNot(HaveOccurred())
 				Eventually(ThisPod(nfsPod), 120).Should(BeInPhase(k8sv1.PodRunning))
@@ -913,6 +952,18 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				By("Deleting NFS pod")
 				// PVs can't be reused
 				tests.DeletePvAndPvc(pvName)
+
+				if dv != nil {
+					By("Deleting the DataVolume")
+					Expect(virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Delete(dv.Name, &metav1.DeleteOptions{})).To(Succeed())
+					dv = nil
+				}
+				if wffcPod != nil {
+					By("Deleting the wffc pod")
+					err = virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Delete(wffcPod.Name, &metav1.DeleteOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					wffcPod = nil
+				}
 			})
 
 			table.DescribeTable("should be migrated successfully, using guest agent on VM", func(migrationConfiguration *v1.MigrationConfiguration, mode v1.MigrationMode) {
@@ -933,7 +984,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					mkdir /mnt/servacc
 					mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') /mnt/servacc
 				`, secretDiskSerial)
-				userData := fmt.Sprintf("%s\n%s", tests.DeprecatedGetGuestAgentUserData(), mountSvcAccCommands)
+				userData := fmt.Sprintf("%s\n%s", tests.GetFedoraToolsGuestAgentUserData(), mountSvcAccCommands)
 				tests.AddUserData(vmi, "cloud-init", userData)
 
 				tests.AddServiceAccountDisk(vmi, "default")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -554,17 +554,17 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			})
 
 			It("[test_id:3237]should complete a migration", func() {
-				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
-				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-
 				// Need to wait for cloud init to finnish and start the agent inside the vmi.
 				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
 				runStressTest(vmi)
 
@@ -586,7 +586,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		})
 		Context("with setting guest time", func() {
 			It("[test_id:4114]should set an updated time after a migration", func() {
-				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
 
@@ -933,7 +933,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					mkdir /mnt/servacc
 					mount /dev/$(lsblk --nodeps -no name,serial | grep %s | cut -f1 -d' ') /mnt/servacc
 				`, secretDiskSerial)
-				userData := fmt.Sprintf("%s\n%s", tests.GetGuestAgentUserData(), mountSvcAccCommands)
+				userData := fmt.Sprintf("%s\n%s", tests.DeprecatedGetGuestAgentUserData(), mountSvcAccCommands)
 				tests.AddUserData(vmi, "cloud-init", userData)
 
 				tests.AddServiceAccountDisk(vmi, "default")
@@ -991,7 +991,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			})
 
 			It("[test_id:2303][posneg:negative] should secure migrations with TLS", func() {
-				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 				By("Starting the VirtualMachineInstance")
@@ -1094,7 +1094,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				config.MigrationConfiguration.CompletionTimeoutPerGiB = pointer.Int64Ptr(1)
 				tests.UpdateKubeVirtConfigValueAndWait(config)
 
-				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
 				By("Starting the VirtualMachineInstance")
@@ -1152,7 +1152,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.UpdateKubeVirtConfigValueAndWait(cfg)
 			})
 			PIt("[test_id:2227] should abort a vmi migration without progress", func() {
-				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
 				By("Starting the VirtualMachineInstance")
@@ -1183,7 +1183,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			})
 
 			It(" Should detect a failed migration", func() {
-				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("1Gi")
 
 				By("Starting the VirtualMachineInstance")
@@ -1331,7 +1331,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				type vmiBuilder func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume)
 
 				newVirtualMachineInstanceWithFedoraContainerDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-					return tests.NewRandomFedoraVMIWitGuestAgent(), nil
+					return tests.NewRandomFedoraVMIWithGuestAgent(), nil
 				}
 
 				newVirtualMachineInstanceWithFedoraOCSDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
@@ -1346,7 +1346,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					}
 
 					By("Starting an iSCSI POD")
-					iscsiTargetPod := tests.CreateISCSITargetPOD(cd.ContainerDiskFedora)
+					iscsiTargetPod := tests.CreateISCSITargetPOD(cd.ContainerDiskFedoraTestTooling)
 					iscsiTargetIPAddress := libnet.GetPodIpByFamily(iscsiTargetPod, k8sv1.IPv4Protocol)
 					Expect(iscsiTargetIPAddress).NotTo(BeEmpty())
 
@@ -1363,7 +1363,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulDataVolumeImport(dv, 600)
 					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
-					tests.AddUserData(vmi, "disk1", tests.GetGuestAgentUserData())
+					tests.AddUserData(vmi, "disk1", tests.GetFedoraToolsGuestAgentUserData())
 					return vmi, dv
 				}
 
@@ -1407,7 +1407,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					table.Entry("[test_id:2731] with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
 				)
 				It("[test_id:3241]should be able to cancel a migration right after posting it", func() {
-					vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+					vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
 					By("Starting the VirtualMachineInstance")
@@ -1957,7 +1957,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 })
 
 func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
-	vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+	vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 	strategy := v1.EvictionStrategyLiveMigrate
 	vmi.Spec.EvictionStrategy = &strategy
 	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1345,21 +1345,17 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 						Skip("Skip OCS tests when Ceph is not present")
 					}
 
-					By("Starting an iSCSI POD")
-					iscsiTargetPod := tests.CreateISCSITargetPOD(cd.ContainerDiskFedoraTestTooling)
-					iscsiTargetIPAddress := libnet.GetPodIpByFamily(iscsiTargetPod, k8sv1.IPv4Protocol)
-					Expect(iscsiTargetIPAddress).NotTo(BeEmpty())
+					quantity, err := resource.ParseQuantity("5Gi")
+					Expect(err).ToNot(HaveOccurred())
 
 					volMode := k8sv1.PersistentVolumeBlock
-					// create a new PV and PVC (PVs can't be reused)
-					pvName := "test-iscsi-lun" + rand.String(48)
-					tests.CreateISCSIPvAndPvc(pvName, "5Gi", iscsiTargetIPAddress, k8sv1.ReadWriteMany, volMode)
-					Expect(err).ToNot(HaveOccurred())
-					defer tests.DeletePvAndPvc(pvName)
-
-					dv := tests.NewRandomDataVolumeWithPVCSourceWithStorageClass(tests.NamespaceTestDefault, pvName, tests.NamespaceTestDefault, sc, "5Gi", k8sv1.ReadWriteMany)
+					url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
+					dv := tests.NewRandomDataVolumeWithRegistryImport(url, tests.NamespaceTestDefault, k8sv1.ReadWriteMany)
+					dv.Spec.PVC.StorageClassName = &sc
+					dv.Spec.PVC.Resources.Requests["storage"] = quantity
 					dv.Spec.PVC.VolumeMode = &volMode
-					_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
+
+					_, err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(dv)
 					Expect(err).ToNot(HaveOccurred())
 					tests.WaitForSuccessfulDataVolumeImport(dv, 600)
 					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -232,6 +232,7 @@ func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.Virtual
 	vmi := libvmi.NewTestToolingFedora(
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithCloudInitNoCloudUserData(tests.GetFedoraToolsGuestAgentUserData(), false),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)
 	return vmi, nil

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -229,10 +229,9 @@ func newFedoraWithGuestAgentAndDefaultInterface(iface v1.Interface) (*v1.Virtual
 		return nil, err
 	}
 
-	vmi := libvmi.NewFedora(
+	vmi := libvmi.NewTestToolingFedora(
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudUserData(tests.GetGuestAgentUserData(), false),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)
 	return vmi, nil

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -407,7 +407,7 @@ var _ = SIGDescribe("Hotplug", func() {
 					Skip("Skip OCS tests when Ceph is not present")
 				}
 
-				template := tests.NewRandomFedoraVMIWitGuestAgent()
+				template := tests.NewRandomFedoraVMIWithGuestAgent()
 				node := findCPUManagerWorkerNode()
 				if node != "" {
 					template.Spec.NodeSelector = make(map[string]string)
@@ -793,7 +793,7 @@ var _ = SIGDescribe("Hotplug", func() {
 					Skip("Skip OCS tests when Ceph is not present")
 				}
 
-				vmi = tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi = tests.NewRandomFedoraVMIWithGuestAgent()
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 			})
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -275,7 +275,7 @@ var _ = Describe("Storage", func() {
                                        mount -t virtiofs %s %s
                                        touch %s
                                `, virtiofsMountPath, fs.Name, virtiofsMountPath, virtiofsTestFile)
-				userData := fmt.Sprintf("%s\n%s", tests.GetGuestAgentUserData(), mountVirtiofsCommands)
+				userData := fmt.Sprintf("%s\n%s", tests.DeprecatedGetGuestAgentUserData(), mountVirtiofsCommands)
 				tests.AddUserData(vmi, "cloud-init", userData)
 
 				vmi = tests.RunVMIAndExpectLaunchIgnoreWarnings(vmi, 300)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2304,8 +2304,11 @@ func NewRandomFedoraVMIWithVirtWhatCpuidHelper() *v1.VirtualMachineInstance {
 
 func GetFedoraToolsGuestAgentUserData() string {
 	return `#!/bin/bash
+            echo "fedora" |passwd fedora --stdin
             sudo setenforce Permissive
-	    sudo systemctl start qemu-guest-agent
+	    sudo mv /home/fedora/qemu-guest-agent.service /lib/systemd/system/
+	    sudo systemctl daemon-reload
+            sudo systemctl start qemu-guest-agent
 `
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2223,14 +2223,14 @@ func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus string, 
 	return vmi
 }
 
-func NewRandomFedoraVMIWitGuestAgent() *v1.VirtualMachineInstance {
+func NewRandomFedoraVMIWithGuestAgent() *v1.VirtualMachineInstance {
 	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
 	Expect(err).NotTo(HaveOccurred())
 
-	return libvmi.NewFedora(
+	return libvmi.NewTestToolingFedora(
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithCloudInitNoCloudUserData(GetGuestAgentUserData(), false),
+		libvmi.WithCloudInitNoCloudUserData(GetFedoraToolsGuestAgentUserData(), false),
 		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
 	)
 }
@@ -2302,7 +2302,14 @@ func NewRandomFedoraVMIWithVirtWhatCpuidHelper() *v1.VirtualMachineInstance {
 	return vmi
 }
 
-func GetGuestAgentUserData() string {
+func GetFedoraToolsGuestAgentUserData() string {
+	return `#!/bin/bash
+            sudo setenforce Permissive
+	    sudo systemctl start qemu-guest-agent
+`
+}
+
+func DeprecatedGetGuestAgentUserData() string {
 	guestAgentUrl := GetUrl(GuestAgentHttpUrl)
 	return fmt.Sprintf(`#!/bin/bash
                 echo "fedora" |passwd fedora --stdin

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2306,9 +2306,10 @@ func GetFedoraToolsGuestAgentUserData() string {
 	return `#!/bin/bash
             echo "fedora" |passwd fedora --stdin
             sudo setenforce Permissive
-	    sudo mv /home/fedora/qemu-guest-agent.service /lib/systemd/system/
+	    sudo cp /home/fedora/qemu-guest-agent.service /lib/systemd/system/
 	    sudo systemctl daemon-reload
             sudo systemctl start qemu-guest-agent
+            sudo systemctl enable qemu-guest-agent
 `
 }
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1144,7 +1144,7 @@ var _ = Describe("Configurations", func() {
 
 			prepareAgentVM := func() *v1.VirtualMachineInstance {
 				// TODO: actually review this once the VM image is present
-				agentVMI := tests.NewRandomFedoraVMIWitGuestAgent()
+				agentVMI := tests.NewRandomFedoraVMIWithGuestAgent()
 
 				By("Starting a VirtualMachineInstance")
 				agentVMI, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(agentVMI)
@@ -1215,7 +1215,7 @@ var _ = Describe("Configurations", func() {
 
 				By("Terminating guest agent and waiting for it to disappear.")
 				Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-					&expect.BSnd{S: "systemctl stop guestagent\n"},
+					&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
 					&expect.BExp{R: console.PromptExpression},
 				}, 400)).To(Succeed())
 
@@ -1310,7 +1310,7 @@ var _ = Describe("Configurations", func() {
 
 				By("Terminating guest agent and waiting for it to disappear.")
 				Expect(console.SafeExpectBatch(agentVMI, []expect.Batcher{
-					&expect.BSnd{S: "systemctl stop guestagent\n"},
+					&expect.BSnd{S: "systemctl stop qemu-guest-agent\n"},
 					&expect.BExp{R: console.PromptExpression},
 				}, 400)).To(Succeed())
 
@@ -2587,7 +2587,7 @@ var _ = Describe("Configurations", func() {
 
 		BeforeEach(func() {
 			var bootOrder uint = 1
-			vmi = tests.NewRandomFedoraVMIWitGuestAgent()
+			vmi = tests.NewRandomFedoraVMIWithGuestAgent()
 			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1024M")
 			vmi.Spec.Domain.Devices.Disks[0].BootOrder = &bootOrder
 		})

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -44,7 +44,7 @@ var _ = Describe("[Serial]HostDevices", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(config)
 
 			By("Creating a Fedora VMI with the sound card as a host device")
-			randomVMI := tests.NewRandomFedoraVMIWitGuestAgent()
+			randomVMI := tests.NewRandomFedoraVMIWithGuestAgent()
 			hostDevs := []v1.HostDevice{
 				v1.HostDevice{
 					Name:       "sound",

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -59,7 +59,7 @@ var _ = Describe("[Serial]MultiQueue", func() {
 		})
 
 		It("[test_id:4599]should be able to successfully boot fedora to the login prompt with networking mutiqueues enabled without being blocked by selinux", func() {
-			vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+			vmi := tests.NewRandomFedoraVMIWithGuestAgent()
 			numCpus := 3
 			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
 				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -388,6 +388,7 @@ var _ = Describe("[Serial]Multus", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
+					libvmi.WithCloudInitNoCloudUserData(tests.GetFedoraToolsGuestAgentUserData(), false),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", "10.1.1.2/24"), false))
 				vmiTwo = tests.StartVmOnNode(vmiTwo, nodes.Items[0].Name)
 
@@ -399,6 +400,7 @@ var _ = Describe("[Serial]Multus", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
+					libvmi.WithCloudInitNoCloudUserData(tests.GetFedoraToolsGuestAgentUserData(), false),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, "10.1.1.1/24"), false))
 				vmiOne = tests.StartVmOnNode(vmiOne, nodes.Items[0].Name)
 
@@ -525,9 +527,13 @@ var _ = Describe("[Serial]Multus", func() {
                     setenforce 0
                     ip link add ep1 type veth peer name ep2
                     ip addr add %s dev ep1
-	                ip addr add %s dev ep2
-	                ip addr add %s dev ep1
-	                ip addr add %s dev ep2
+                    ip addr add %s dev ep2
+                    ip addr add %s dev ep1
+                    ip addr add %s dev ep2
+                    sudo cp /home/fedora/qemu-guest-agent.service /lib/systemd/system/
+                    sudo systemctl daemon-reload
+                    sudo systemctl start qemu-guest-agent
+                    sudo systemctl enable qemu-guest-agent
                 `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
 				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userdata)
 
@@ -966,6 +972,7 @@ var _ = Describe("[Serial]Macvtap", func() {
 				*libvmi.InterfaceWithMac(
 					v1.DefaultMacvtapNetworkInterface(macvtapNetworkName), mac)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithCloudInitNoCloudUserData(tests.GetFedoraToolsGuestAgentUserData(), false),
 			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName)))
 	}
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -383,24 +383,22 @@ var _ = Describe("[Serial]Multus", func() {
 			customMacAddress := "50:00:00:00:90:0d"
 			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", func() {
 				By("Creating a VM with Linux bridge CNI network interface and default MAC address.")
-				vmiTwo := libvmi.NewFedora(
+				vmiTwo := libvmi.NewTestToolingFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudUserData(tests.GetGuestAgentUserData(), false),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByDevice("eth1", "10.1.1.2/24"), false))
 				vmiTwo = tests.StartVmOnNode(vmiTwo, nodes.Items[0].Name)
 
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
 				linuxBridgeInterfaceWithCustomMac := linuxBridgeInterface
 				linuxBridgeInterfaceWithCustomMac.MacAddress = customMacAddress
-				vmiOne := libvmi.NewFedora(
+				vmiOne := libvmi.NewTestToolingFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
-					libvmi.WithCloudInitNoCloudUserData(tests.GetGuestAgentUserData(), false),
 					libvmi.WithCloudInitNoCloudNetworkData(cloudInitNetworkDataWithStaticIPsByMac(linuxBridgeInterfaceWithCustomMac.Name, customMacAddress, "10.1.1.1/24"), false))
 				vmiOne = tests.StartVmOnNode(vmiOne, nodes.Items[0].Name)
 
@@ -530,13 +528,8 @@ var _ = Describe("[Serial]Multus", func() {
 	                ip addr add %s dev ep2
 	                ip addr add %s dev ep1
 	                ip addr add %s dev ep2
-                    mkdir -p /usr/local/bin
-                    curl %s > /usr/local/bin/qemu-ga
-                    chmod +x /usr/local/bin/qemu-ga
-		    curl %s > /lib64/libpixman-1.so.0
-                    systemd-run --unit=guestagent /usr/local/bin/qemu-ga
-                `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6, tests.GetUrl(tests.GuestAgentHttpUrl), tests.GetUrl(tests.PixmanUrl))
-				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedora), userdata)
+                `, ep1Cidr, ep2Cidr, ep1CidrV6, ep2CidrV6)
+				agentVMI := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling), userdata)
 
 				agentVMI.Spec.Domain.Devices.Interfaces = interfaces
 				agentVMI.Spec.Networks = networks
@@ -967,14 +960,13 @@ var _ = Describe("[Serial]Macvtap", func() {
 	}
 
 	newFedoraVMIWithExplicitMacAndGuestAgent := func(macvtapNetworkName string, mac string) *v1.VirtualMachineInstance {
-		return libvmi.NewFedora(
+		return libvmi.NewTestToolingFedora(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 			libvmi.WithInterface(
 				*libvmi.InterfaceWithMac(
 					v1.DefaultMacvtapNetworkInterface(macvtapNetworkName), mac)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName)),
-			libvmi.WithCloudInitNoCloudUserData(tests.GetGuestAgentUserData(), false))
+			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName)))
 	}
 
 	createCirrosVMIStaticIPOnNode := func(nodeName string, networkName string, ifaceName string, ipCIDR string, mac *string) *v1.VirtualMachineInstance {


### PR DESCRIPTION
Currently we're caching tools like the qemu agent as binaries in an http server and pulling them into our VM guests during testing. This works, but it has turned into a pain to update. It sounds crazy, but we're in this scenario where somehow the repos we use to build our production containers are actually tied to the guest VMs we run in CI. So if we want to do something simple like update the version of the fedora container disk, that has this ripple effect that goes all the way to the point of requiring us to update the repos we use for our production containers... not great.

With this PR, we're leveraging a pre-configured fedora container disk image that has all the tools (like guest agent) pre installed. That image is created in kubevirt/kubevirtci using the config in this PR, https://github.com/kubevirt/kubevirtci/pull/530


```release-note
NONE
```
