### PR TITLE
Fix limits/requests to accept int again

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10673,10 +10673,7 @@
     "properties": {
      "limits": {
       "description": "Limits describes the maximum amount of compute resources allowed. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
-      }
+      "type": "object"
      },
      "overcommitGuestOverhead": {
       "description": "Don't ask the scheduler to take the guest-management overhead into account. Instead put the overhead only into the container's memory limit. This can lead to crashes if all memory is in use on a node. Defaults to false.",
@@ -10684,10 +10681,7 @@
      },
      "requests": {
       "description": "Requests is a description of the initial vmi resources. Valid resource keys are \"memory\" and \"cpu\".",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
-      }
+      "type": "object"
      }
     }
    },

--- a/pkg/util/openapi/openapi.go
+++ b/pkg/util/openapi/openapi.go
@@ -142,6 +142,21 @@ func LoadOpenAPISpec(webServices []*restful.WebService) *spec.Swagger {
 			break
 		}
 	}
+	resourceRequirements, exists := openapispec.Definitions["v1.ResourceRequirements"]
+	if exists {
+		limits, exists := resourceRequirements.Properties["limits"]
+		if exists {
+			limits.AdditionalProperties = nil
+			resourceRequirements.Properties["limits"] = limits
+		}
+		requests, exists := resourceRequirements.Properties["requests"]
+		if exists {
+			requests.AdditionalProperties = nil
+			resourceRequirements.Properties["requests"] = requests
+		}
+
+	}
+
 	objectMeta, exists := openapispec.Definitions[objectmeta]
 	if exists {
 		prop := objectMeta.Properties["creationTimestamp"]

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1900,7 +1900,10 @@ func SecretToLibvirtSecret(vmi *v1.VirtualMachineInstance, secretName string) st
 }
 
 func QuantityToByte(quantity resource.Quantity) (api.Memory, error) {
-	memorySize, _ := quantity.AsInt64()
+	memorySize, int := quantity.AsInt64()
+	if !int {
+		memorySize = quantity.Value() - 1
+	}
 	if memorySize < 0 {
 		return api.Memory{Unit: "b"}, fmt.Errorf("Memory size '%s' must be greater than or equal to 0", quantity.String())
 	}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -1070,6 +1071,12 @@ var _ = Describe("Converter", func() {
 			c.UseVirtioTransitional = true
 			dom := vmiToDomain(vmi, c)
 			testutils.ExpectVirtioTransitionalOnly(&dom.Spec)
+		})
+
+		It("should handle float memory", func() {
+			vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceMemory] = resource.MustParse("2222222200m")
+			xml := vmiToDomainXML(vmi, c)
+			Expect(strings.Contains(xml, `<memory unit="b">2222222</memory>`)).To(BeTrue(), xml)
 		})
 
 		table.DescribeTable("should be converted to a libvirt Domain with vmi defaults set", func(arch string, domain string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
[My PR](https://github.com/kubevirt/kubevirt/pull/3357 ) introduced a bug that causes `int` to be an invalid type for `cpu`/`memory` `requests`/`limits`.

Root cause is a bad openapi definition of Quantity type. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4809

**Special notes for your reviewer**:
[This](https://github.com/kubernetes/kube-openapi/pull/221) seems like a solution for the root cause(unable to update the dependencies at this momemnt). This PR is hotfix to unblock users.

**Release note**:
```release-note
Fixed limits/requests to accept int again
```
