### PR TITLE
Clean error message for not migratable VMI

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1938,7 +1938,7 @@ func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachi
 				return blockMigrate, err
 			}
 			if !shared {
-				return true, fmt.Errorf("cannot migrate VMI with non-shared PVCs")
+				return true, fmt.Errorf("cannot migrate VMI: PVC %v is not shared, live migration requires that all PVCs must be shared (using ReadWriteMany access mode)", volName)
 			}
 		} else if volSrc.HostDisk != nil {
 			shared := volSrc.HostDisk.Shared != nil && *volSrc.HostDisk.Shared

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1672,7 +1672,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(testBlockPvc)
 			blockMigrate, err := controller.checkVolumesForMigration(vmi)
 			Expect(blockMigrate).To(BeTrue())
-			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with non-shared PVCs")))
+			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI: PVC testblock is not shared, live migration requires that all PVCs must be shared (using ReadWriteMany access mode)")))
 		})
 		It("should fail migration for non-shared data volume PVCs", func() {
 
@@ -1703,7 +1703,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).Create(testBlockPvc)
 			blockMigrate, err := controller.checkVolumesForMigration(vmi)
 			Expect(blockMigrate).To(BeTrue())
-			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI with non-shared PVCs")))
+			Expect(err).To(Equal(fmt.Errorf("cannot migrate VMI: PVC testblock is not shared, live migration requires that all PVCs must be shared (using ReadWriteMany access mode)")))
 		})
 		It("should be allowed to migrate a mix of shared and non-shared disks", func() {
 


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add more detailed error message, so now it mentions the actual problem (RWX access mode).
Was: "cannot migrate VMI with non-shared PVCs"
now is: "cannot migrate VMI: Live migration requires that all PVCs must be shared (using RWX access mode)"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1894428

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
