### PR TITLE
Consider scsi controllers in virtio version decisions

### DIFF
--- a/pkg/testutils/domain.go
+++ b/pkg/testutils/domain.go
@@ -37,14 +37,18 @@ func ExpectVirtioTransitionalOnly(dom *api.DomainSpec) {
 	}
 	ExpectWithOffset(1, hit).To(BeTrue())
 
-	hit = false
+	hitCount := 0
 	for _, controller := range dom.Devices.Controllers {
 		if controller.Type == "virtio-serial" {
 			ExpectWithOffset(1, controller.Model).To(Equal("virtio-transitional"))
-			hit = true
+			hitCount++
+		}
+		if controller.Type == "scsi" {
+			ExpectWithOffset(1, controller.Model).To(Equal("virtio-transitional"))
+			hitCount++
 		}
 	}
-	ExpectWithOffset(1, hit).To(BeTrue())
+	ExpectWithOffset(1, hitCount).To(BeNumerically("==", 2))
 
 	ExpectWithOffset(1, dom.Devices.Rng.Model).To(Equal("virtio-transitional"))
 	ExpectWithOffset(1, dom.Devices.Ballooning.Model).To(Equal("virtio"))

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1320,7 +1320,7 @@ func Convert_v1_VirtualMachine_To_api_Domain(vmi *v1.VirtualMachineInstance, dom
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, api.Controller{
 			Type:  "scsi",
 			Index: "0",
-			Model: "virtio-scsi",
+			Model: translateModel(c, "virtio"),
 		})
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1067,6 +1067,7 @@ var _ = Describe("Converter", func() {
 		It("should use virtio-transitional models if requested", func() {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+			vmi.Spec.Domain.Devices.DisableHotplug = false
 			c.UseVirtioTransitional = true
 			dom := vmiToDomain(vmi, c)
 			testutils.ExpectVirtioTransitionalOnly(&dom.Spec)
@@ -1313,7 +1314,7 @@ var _ = Describe("Converter", func() {
 			Expect(dom.Spec.Devices.Controllers).To(ContainElement(api.Controller{
 				Type:  "scsi",
 				Index: "0",
-				Model: "virtio-scsi",
+				Model: "virtio-non-transitional",
 			}))
 		})
 
@@ -1325,7 +1326,7 @@ var _ = Describe("Converter", func() {
 			Expect(dom.Spec.Devices.Controllers).ToNot(ContainElement(api.Controller{
 				Type:  "scsi",
 				Index: "0",
-				Model: "virtio-scsi",
+				Model: "virtio-non-transitional",
 			}))
 		})
 
@@ -2769,7 +2770,7 @@ var _ = Describe("Converter", func() {
 			for _, controller := range domain.Spec.Devices.Controllers {
 				if controller.Type == "scsi" {
 					foundScsiController = true
-					Expect(controller.Model).To(Equal("virtio-scsi"))
+					Expect(controller.Model).To(Equal("virtio-non-transitional"))
 
 				}
 			}

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Controller devices", func() {
 				if controller.Type == "scsi" {
 					found = true
 					Expect(controller.Index).To(Equal("0"))
-					Expect(controller.Model).To(Equal("virtio-scsi"))
+					Expect(controller.Model).To(Equal("virtio-non-transitional"))
 				}
 			}
 			Expect(found).To(Equal(enabled))


### PR DESCRIPTION
**What this PR does / why we need it**:

virtio scsi controllers support transitional and non transitional virtio
versions. Not considering them in #4730  was an oversight.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virtio-scsi now respects the useTransitionalVirtio flag instead of assigning a virtio version depending on the machine layout
```
