### PR TITLE
Fix detection of previous release version in operator func test

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4814,7 +4814,7 @@ func getTagHint() string {
 		return ""
 	}
 
-	return strings.Split(string(bytes), "-rc")[0]
+	return strings.TrimSpace(strings.Split(string(bytes), "-rc")[0])
 
 }
 


### PR DESCRIPTION
Somehow a newline was messing up our semver conversion during the detection of the previous kubevirt version in our operator tests. This caused us to always pick the latest kubevirt version rather than the previous one for a given branch. 


```release-note
NONE
```
