### PR TITLE
network: podinterface: a bit more variable name consistency

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1221,10 +1221,10 @@ func (m *MacvtapBindMechanism) decorateConfig() error {
 	return nil
 }
 
-func (m *MacvtapBindMechanism) loadCachedInterface(uid, name string) (bool, error) {
+func (m *MacvtapBindMechanism) loadCachedInterface(pid, name string) (bool, error) {
 	var ifaceConfig api.Interface
 
-	isExist, err := readFromCachedFile(uid, name, interfaceCacheFile, &ifaceConfig)
+	isExist, err := readFromCachedFile(pid, name, interfaceCacheFile, &ifaceConfig)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Giving multiple names to something that is essentially the same thing (a BindMechanism) adds metal burden on the reader. This PR tries to increase consistency for the names used.

```release-note
NONE
```
