### PR TITLE
removing trello reference as its no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ of options:
 * Chat with us on Slack via [#virtualization @ kubernetes.slack.com](https://kubernetes.slack.com/?redir=%2Farchives%2FC8ED7RKFE)
 * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
 * Stay informed about designs and upcoming events by watching our [community content](https://github.com/kubevirt/community/)
-* Take a glance at [future planning](https://trello.com/b/50CuosoD/kubevirt)
 
 ## Related resources
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:  The referenced trello board is not being used anymore, so removing it.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes # None

Special notes for your reviewer: None

Release note:
```release-note
NONE
```

