### PR TITLE
Add feature-gate for SRIOV Live Migration feature

### DIFF
--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -482,4 +482,22 @@ var _ = Describe("ConfigMap", func() {
 		emulation = clusterConfig.IsUseEmulation()
 		Expect(emulation).To(BeFalse())
 	})
+
+	table.DescribeTable("when feature-gate", func(openFeatureGates string, isLiveMigrationEnabled, isSRIOVLiveMigrationEnabled bool) {
+		clusterConfig, _, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{
+			Data: map[string]string{virtconfig.FeatureGatesKey: openFeatureGates},
+		})
+
+		Expect(clusterConfig.LiveMigrationEnabled()).To(Equal(isLiveMigrationEnabled))
+		Expect(clusterConfig.SRIOVLiveMigrationEnabled()).To(Equal(isSRIOVLiveMigrationEnabled))
+	},
+		table.Entry("LiveMigration and SRIOVLiveMigration are closed, both should be closed",
+			"", false, false),
+		table.Entry("LiveMigration and SRIOVLiveMigration are open, both should be open",
+			virtconfig.LiveMigrationGate+","+virtconfig.SRIOVLiveMigrationGate, true, true),
+		table.Entry("SRIOVLiveMigration is open, LiveMigration should be open",
+			virtconfig.SRIOVLiveMigrationGate, true, true),
+		table.Entry("LiveMigration is open, SRIOVLiveMigration should be close",
+			virtconfig.LiveMigrationGate, true, false),
+	)
 })

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -24,19 +24,21 @@ package virtconfig
 */
 
 const (
-	CPUManager            = "CPUManager"
-	IgnitionGate          = "ExperimentalIgnitionSupport"
-	LiveMigrationGate     = "LiveMigration"
-	CPUNodeDiscoveryGate  = "CPUNodeDiscovery"
-	HypervStrictCheckGate = "HypervStrictCheck"
-	SidecarGate           = "Sidecar"
-	GPUGate               = "GPU"
-	HostDevicesGate       = "HostDevices"
-	SnapshotGate          = "Snapshot"
-	HotplugVolumesGate    = "HotplugVolumes"
-	HostDiskGate          = "HostDisk"
-	VirtIOFSGate          = "ExperimentalVirtiofsSupport"
-	MacvtapGate           = "Macvtap"
+	CPUManager        = "CPUManager"
+	IgnitionGate      = "ExperimentalIgnitionSupport"
+	LiveMigrationGate = "LiveMigration"
+	// SRIOVLiveMigrationGate enable's Live Migration for VM's with SRIOV interfaces.
+	SRIOVLiveMigrationGate = "SRIOVLiveMigration"
+	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"
+	HypervStrictCheckGate  = "HypervStrictCheck"
+	SidecarGate            = "Sidecar"
+	GPUGate                = "GPU"
+	HostDevicesGate        = "HostDevices"
+	SnapshotGate           = "Snapshot"
+	HotplugVolumesGate     = "HotplugVolumes"
+	HostDiskGate           = "HostDisk"
+	VirtIOFSGate           = "ExperimentalVirtiofsSupport"
+	MacvtapGate            = "Macvtap"
 )
 
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -57,7 +59,12 @@ func (config *ClusterConfig) IgnitionEnabled() bool {
 }
 
 func (config *ClusterConfig) LiveMigrationEnabled() bool {
-	return config.isFeatureGateEnabled(LiveMigrationGate)
+	return config.isFeatureGateEnabled(LiveMigrationGate) ||
+		config.isFeatureGateEnabled(SRIOVLiveMigrationGate)
+}
+
+func (config *ClusterConfig) SRIOVLiveMigrationEnabled() bool {
+	return config.isFeatureGateEnabled(SRIOVLiveMigrationGate)
 }
 
 func (config *ClusterConfig) HypervStrictCheckEnabled() bool {

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1327,20 +1327,22 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, 
 }
 
 func getRequiredCapabilities(vmi *v1.VirtualMachineInstance) []k8sv1.Capability {
-	res := []k8sv1.Capability{}
+	capabilities := []k8sv1.Capability{}
+
 	if (len(vmi.Spec.Domain.Devices.Interfaces) > 0) ||
 		(vmi.Spec.Domain.Devices.AutoattachPodInterface == nil) ||
 		(*vmi.Spec.Domain.Devices.AutoattachPodInterface == true) {
-		res = append(res, CAP_NET_ADMIN)
+		capabilities = append(capabilities, CAP_NET_ADMIN)
 	}
 	// add a CAP_SYS_NICE capability to allow setting cpu affinity
-	res = append(res, CAP_SYS_NICE)
+	capabilities = append(capabilities, CAP_SYS_NICE)
 
 	// add CAP_SYS_ADMIN capability to allow virtiofs
 	if util.IsVMIVirtiofsEnabled(vmi) {
-		res = append(res, CAP_SYS_ADMIN)
+		capabilities = append(capabilities, CAP_SYS_ADMIN)
 	}
-	return res
+
+	return capabilities
 }
 
 func getRequiredResources(vmi *v1.VirtualMachineInstance, useEmulation bool) k8sv1.ResourceList {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1947,11 +1947,7 @@ var _ = Describe("Template", func() {
 					Skip("ppc64le is currently running is privileged mode, so skipping test")
 				}
 				sriovInterface := v1.InterfaceSRIOV{}
-				domain := v1.DomainSpec{
-					Devices: v1.Devices{
-						DisableHotplug: true,
-					},
-				}
+				domain := v1.DomainSpec{}
 				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1968,11 +1964,7 @@ var _ = Describe("Template", func() {
 			})
 			It("should not mount pci related host directories", func() {
 				sriovInterface := v1.InterfaceSRIOV{}
-				domain := v1.DomainSpec{
-					Devices: v1.Devices{
-						DisableHotplug: true,
-					},
-				}
+				domain := v1.DomainSpec{}
 				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1999,9 +1991,6 @@ var _ = Describe("Template", func() {
 			It("should add 1G of memory overhead", func() {
 				sriovInterface := v1.InterfaceSRIOV{}
 				domain := v1.DomainSpec{
-					Devices: v1.Devices{
-						DisableHotplug: true,
-					},
 					Resources: v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
 							kubev1.ResourceMemory: resource.MustParse("1G"),
@@ -2025,9 +2014,6 @@ var _ = Describe("Template", func() {
 			})
 			It("should still add memory overhead for 1 core if cpu topology wasn't provided", func() {
 				domain := v1.DomainSpec{
-					Devices: v1.Devices{
-						DisableHotplug: true,
-					},
 					Resources: v1.ResourceRequirements{
 						Requests: kubev1.ResourceList{
 							kubev1.ResourceMemory: resource.MustParse("512Mi"),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
 
@@ -1946,34 +1947,14 @@ var _ = Describe("Template", func() {
 				if runtime.GOARCH == "ppc64le" {
 					Skip("ppc64le is currently running is privileged mode, so skipping test")
 				}
-				sriovInterface := v1.InterfaceSRIOV{}
-				domain := v1.DomainSpec{}
-				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testvmi", Namespace: "default", UID: "1234",
-					},
-					Spec: v1.VirtualMachineInstanceSpec{Domain: domain},
-				}
-
-				pod, err := svc.RenderLaunchManifest(&vmi)
+				pod, err := svc.RenderLaunchManifest(newVMIWithSriovInterface("testvmi", "1234"))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
 				Expect(*pod.Spec.Containers[0].SecurityContext.Privileged).To(BeFalse())
 			})
 			It("should not mount pci related host directories", func() {
-				sriovInterface := v1.InterfaceSRIOV{}
-				domain := v1.DomainSpec{}
-				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testvmi", Namespace: "default", UID: "1234",
-					},
-					Spec: v1.VirtualMachineInstanceSpec{Domain: domain},
-				}
-
-				pod, err := svc.RenderLaunchManifest(&vmi)
+				pod, err := svc.RenderLaunchManifest(newVMIWithSriovInterface("testvmi", "1234"))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(pod.Spec.Containers)).To(Equal(1))
@@ -1989,70 +1970,44 @@ var _ = Describe("Template", func() {
 				}
 			})
 			It("should add 1G of memory overhead", func() {
-				sriovInterface := v1.InterfaceSRIOV{}
-				domain := v1.DomainSpec{
-					Resources: v1.ResourceRequirements{
-						Requests: kubev1.ResourceList{
-							kubev1.ResourceMemory: resource.MustParse("1G"),
-						},
+				vmi := newVMIWithSriovInterface("testvmi", "1234")
+				vmi.Spec.Domain.Resources = v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceMemory: resource.MustParse("1G"),
 					},
-				}
-				domain.Devices.Interfaces = []v1.Interface{{Name: "testnet", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &sriovInterface}}}
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testvmi", Namespace: "default", UID: "1234",
-					},
-					Spec: v1.VirtualMachineInstanceSpec{Domain: domain},
 				}
 
-				pod, err := svc.RenderLaunchManifest(&vmi)
+				pod, err := svc.RenderLaunchManifest(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
-				expectedMemory.Add(*getMemoryOverhead(&vmi))
-				expectedMemory.Add(*domain.Resources.Requests.Memory())
+				expectedMemory.Add(*getMemoryOverhead(vmi))
+				expectedMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
 			})
 			It("should still add memory overhead for 1 core if cpu topology wasn't provided", func() {
-				domain := v1.DomainSpec{
-					Resources: v1.ResourceRequirements{
-						Requests: kubev1.ResourceList{
-							kubev1.ResourceMemory: resource.MustParse("512Mi"),
-							kubev1.ResourceCPU:    resource.MustParse("150m"),
-						},
+				requirements := v1.ResourceRequirements{
+					Requests: kubev1.ResourceList{
+						kubev1.ResourceMemory: resource.MustParse("512Mi"),
+						kubev1.ResourceCPU:    resource.MustParse("150m"),
 					},
 				}
-				domain1 := v1.DomainSpec{
-					CPU: &v1.CPU{
-						Model: "Conroe",
-						Cores: 1,
-					},
-					Resources: v1.ResourceRequirements{
-						Requests: kubev1.ResourceList{
-							kubev1.ResourceMemory: resource.MustParse("512Mi"),
-							kubev1.ResourceCPU:    resource.MustParse("150m"),
-						},
-					},
-				}
-				vmi := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testvmi", Namespace: "default", UID: "1234",
-					},
-					Spec: v1.VirtualMachineInstanceSpec{Domain: domain},
-				}
-				vmi1 := v1.VirtualMachineInstance{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "testvmi1", Namespace: "default", UID: "1134",
-					},
-					Spec: v1.VirtualMachineInstanceSpec{Domain: domain1},
+				vmi := newVMIWithSriovInterface("testvmi1", "1234")
+				vmi.Spec.Domain.Resources = requirements
+
+				vmi1 := newVMIWithSriovInterface("testvmi2", "1134")
+				vmi1.Spec.Domain.Resources = requirements
+				vmi1.Spec.Domain.CPU = &v1.CPU{
+					Model: "Conroe",
+					Cores: 1,
 				}
 
-				pod, err := svc.RenderLaunchManifest(&vmi)
+				pod, err := svc.RenderLaunchManifest(vmi)
 				Expect(err).ToNot(HaveOccurred())
-				pod1, err := svc.RenderLaunchManifest(&vmi1)
+				pod1, err := svc.RenderLaunchManifest(vmi1)
 				Expect(err).ToNot(HaveOccurred())
 				expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
-				expectedMemory.Add(*getMemoryOverhead(&vmi))
-				expectedMemory.Add(*domain.Resources.Requests.Memory())
+				expectedMemory.Add(*getMemoryOverhead(vmi1))
+				expectedMemory.Add(*vmi.Spec.Domain.Resources.Requests.Memory())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
 				Expect(pod1.Spec.Containers[0].Resources.Requests.Memory().Value()).To(Equal(expectedMemory.Value()))
 			})
@@ -2675,6 +2630,25 @@ var _ = Describe("requestResource", func() {
 		}
 	})
 })
+
+func newVMIWithSriovInterface(name, uid string) *v1.VirtualMachineInstance {
+	sriovInterface := v1.Interface{
+		Name: "sriov-nic",
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{
+			SRIOV: &v1.InterfaceSRIOV{},
+		},
+	}
+	vmi := &v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       types.UID(uid),
+		},
+	}
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{sriovInterface}
+
+	return vmi
+}
 
 func True() *bool {
 	b := true

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1895,16 +1895,36 @@ func (d *VirtualMachineController) isPreMigrationTarget(vmi *v1.VirtualMachineIn
 }
 
 func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
-	networks := map[string]*v1.Network{}
-	for _, network := range vmi.Spec.Networks {
-		networks[network.Name] = network.DeepCopy()
+	err := validatePodNetworkInterfaceUsesMasqueradeBinding(vmi)
+	if err != nil {
+		return err
 	}
+
+	return nil
+}
+
+func validatePodNetworkInterfaceUsesMasqueradeBinding(vmi *v1.VirtualMachineInstance) error {
+	interfacesByName := map[string]v1.Interface{}
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Masquerade == nil && networks[iface.Name].Pod != nil {
-			return fmt.Errorf("cannot migrate VMI which does not use masquerade to connect to the pod network")
+		interfacesByName[iface.Name] = iface
+	}
+
+	vmiPodNetworkName := lookupVMIPodNetworkName(vmi.Spec.Networks)
+	if vmiPodNetworkName != "" && interfacesByName[vmiPodNetworkName].Masquerade == nil {
+		return fmt.Errorf("cannot migrate VMI which does not use masquerade to connect to the pod network")
+	}
+
+	return nil
+}
+
+func lookupVMIPodNetworkName(networks []v1.Network) string {
+	for _, network := range networks {
+		if network.Pod != nil {
+			return network.Name
 		}
 	}
-	return nil
+
+	return ""
 }
 
 func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachineInstance) (blockMigrate bool, err error) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1934,8 +1934,8 @@ func lookupVMIPodNetworkName(networks []v1.Network) string {
 
 func (d *VirtualMachineController) validateSRIOVInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.SRIOV != nil && !d.clusterConfig.SRIOVLiveMigrationEnabled() {
-			return fmt.Errorf("SRIOVLiveMigration feature-gate is closed, can't migrate VMI with SRIOV interfaces")
+		if iface.SRIOV != nil {
+			return fmt.Errorf("Live migration of guest with SR-IOV interfaces is not supported")
 		}
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1900,6 +1900,11 @@ func (d *VirtualMachineController) checkNetworkInterfacesForMigration(vmi *v1.Vi
 		return err
 	}
 
+	err = d.validateSRIOVInterfacesForMigration(vmi)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -1925,6 +1930,16 @@ func lookupVMIPodNetworkName(networks []v1.Network) string {
 	}
 
 	return ""
+}
+
+func (d *VirtualMachineController) validateSRIOVInterfacesForMigration(vmi *v1.VirtualMachineInstance) error {
+	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
+		if iface.SRIOV != nil && !d.clusterConfig.SRIOVLiveMigrationEnabled() {
+			return fmt.Errorf("SRIOVLiveMigration feature-gate is closed, can't migrate VMI with SRIOV interfaces")
+		}
+	}
+
+	return nil
 }
 
 func (d *VirtualMachineController) checkVolumesForMigration(vmi *v1.VirtualMachineInstance) (blockMigrate bool, err error) {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1905,6 +1905,56 @@ var _ = Describe("VirtualMachineInstance", func() {
 				err := controller.checkNetworkInterfacesForMigration(vmi)
 				Expect(err).To(HaveOccurred())
 			})
+			It("should block migration for VMI with SRIOV interface when feature-gate SRIOVLiveMigration is off", func() {
+				vmi := v1.NewMinimalVMI("testvmi")
+				sriovInterfaceName := "sriovnet1"
+				vmi.Spec.Networks = []v1.Network{
+					{
+						Name: sriovInterfaceName,
+						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{
+							NetworkName: "sriov-network1",
+						}},
+					},
+				}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					{
+						Name: sriovInterfaceName,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							SRIOV: &v1.InterfaceSRIOV{},
+						},
+					},
+				}
+
+				Expect(controller.checkNetworkInterfacesForMigration(vmi)).ShouldNot(Succeed())
+			})
+
+			It("should not block migration for VMI with SRIOV interface when feature-gate SRIOVLiveMigration is on", func() {
+				vmi := v1.NewMinimalVMI("testvmi")
+				sriovInterfaceName := "sriovnet1"
+				kubevirtConfigMapFeatureGate := map[string]string{virtconfig.FeatureGatesKey: virtconfig.SRIOVLiveMigrationGate}
+				vmi.Spec.Networks = []v1.Network{
+					{
+						Name: sriovInterfaceName,
+						NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{
+							NetworkName: "sriov-network1",
+						}},
+					},
+				}
+				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					{
+						Name: sriovInterfaceName,
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							SRIOV: &v1.InterfaceSRIOV{},
+						},
+					},
+				}
+				config, _, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
+					Data: kubevirtConfigMapFeatureGate,
+				})
+				controller.clusterConfig = config
+
+				Expect(controller.checkNetworkInterfacesForMigration(vmi)).Should(Succeed())
+			})
 
 			It("should not block migration for masquerade binding assigned to the pod network", func() {
 				vmi := v1.NewMinimalVMI("testvmi")

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1928,7 +1928,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Expect(controller.checkNetworkInterfacesForMigration(vmi)).ShouldNot(Succeed())
 			})
 
-			It("should not block migration for VMI with SRIOV interface when feature-gate SRIOVLiveMigration is on", func() {
+			It("should block migration for VMI with SRIOV interface when feature-gate SRIOVLiveMigration is on", func() {
 				vmi := v1.NewMinimalVMI("testvmi")
 				sriovInterfaceName := "sriovnet1"
 				kubevirtConfigMapFeatureGate := map[string]string{virtconfig.FeatureGatesKey: virtconfig.SRIOVLiveMigrationGate}
@@ -1953,7 +1953,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				})
 				controller.clusterConfig = config
 
-				Expect(controller.checkNetworkInterfacesForMigration(vmi)).Should(Succeed())
+				Expect(controller.checkNetworkInterfacesForMigration(vmi)).ShouldNot(Succeed())
 			})
 
 			It("should not block migration for masquerade binding assigned to the pod network", func() {

--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -74,7 +74,7 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyRunAsAny,
 	}
-	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE"}
+	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE", "SYS_RESOURCE"}
 	scc.AllowHostDirVolumePlugin = true
 	scc.AllowHostNetwork = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
At the current state, if you try to migrate SRIOV VM it will fail constantly with no error from virt-api (admission or validation webhooks).
Also libvirt doesn't support migration for domain that has SRIOV host-devices attached.
We would get the following error on VMI description if we try:
```
VirtualMachineInstance migration uid bc2b1c0d-b858-44ee-b043-382caad887c8 failed. reason:Live migration failed virError(Code=84, Domain=10, Message='Operation not supported: cannot migrate a domain with <hostdev mode='subsystem' type='pci'>')
```
Even though live migration for SRIOV VMs will always fail it is not blocked on kubevirt which may cause confusion.
Thus it should be blocked and return informative error until it will be supported.
________________________________________________________

SRIOV Live Migration feature is under development,
we plan to hot-unplug SRIOV host-devices just before migration starts and hot-plug them back after the migration is finished ([design doc](https://docs.google.com/document/d/13Xne78gWheboxk_V4b5yQynYEWv5lYSTpZNICGRTeg0/edit?ts=60084ac1#heading=h.5o7sz4vqjq95))

We use VFIO driver to pass-through SRIOV host devices.
When a VFIO host-device is attached to running domain (qemu-kvm process already exists),
libvirtd adjusts the domain process resources limits.
Since virt-launcher is non-privileged, libvirtd runs as root and the domain process runs with different UID/GID,
libvirt fail to adjusts qemu-kvm process max memory limit due to the lake of CAP_SYS_RESOURCE capability [rlimits man page](https://man7.org/linux/man-pages/man3/vlimit.3.html)

________________________________________________________
This PR present new feature gate for SRIOV Live Migration
it will control when virt-launcher will run with CAP_SYS_RESOURCE capability.
This feature gate will block live migration for SRIOV VM's until it will be fully supported.

To provide better user experience It will work in a way that if SRIOVLiveMigration feature-gate is open, LiveMigration feature gate will takes affect as well.
But not the counterpart; if LiveMigration feature-gate is specified  then 
SRIOVLiveMigration will **not** take affect.
Doing so will avoid the user from enabling both `LiveMigration` `SRIOVLiveMigration` feature-gates.

This feature-gate could probably dropped once this is resolved
https://bugzilla.redhat.com/show_bug.cgi?id=1916346
    
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR is needed for handling SRIOV Live Migration on the target side.
Related to https://github.com/kubevirt/kubevirt/pull/4741

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new feature-gate SRIOVLiveMigration,
controls running virt-launcher with CAP_SYS_RESOURCE.
Live migration for SRIOV VM's is blocked until fully supported.
```
