### PR TITLE
Fix bug enabling libvirt debug logs if debugLogs label key exists

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -956,10 +956,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_VIRT_LAUNCHER_LOG_VERBOSITY, Value: verbosityStr})
 	}
 
-	if _, ok := vmi.Labels[debugLogs]; ok || virtLauncherLogVerbosity > EXT_LOG_VERBOSITY_THRESHOLD {
+	if labelValue, ok := vmi.Labels[debugLogs]; (ok && strings.EqualFold(labelValue, "true")) || virtLauncherLogVerbosity > EXT_LOG_VERBOSITY_THRESHOLD {
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_LIBVIRT_DEBUG_LOGS, Value: "1"})
 	}
-	if _, ok := vmi.Labels[virtiofsDebugLogs]; ok || virtLauncherLogVerbosity > EXT_LOG_VERBOSITY_THRESHOLD {
+	if labelValue, ok := vmi.Labels[virtiofsDebugLogs]; (ok && strings.EqualFold(labelValue, "true")) || virtLauncherLogVerbosity > EXT_LOG_VERBOSITY_THRESHOLD {
 		compute.Env = append(compute.Env, k8sv1.EnvVar{Name: ENV_VAR_VIRTIOFSD_DEBUG_LOGS, Value: "1"})
 	}
 

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -413,14 +413,14 @@ func SetupLibvirt() (err error) {
 		return err
 	}
 
-	if _, ok := os.LookupEnv("LIBVIRT_DEBUG_LOGS"); ok {
+	if envVarValue, ok := os.LookupEnv("LIBVIRT_DEBUG_LOGS"); ok && (envVarValue == "1") {
 		// see https://libvirt.org/kbase/debuglogs.html for details
 		_, err = libvirtConf.WriteString("log_filters=\"3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*\"\n")
 		if err != nil {
 			return err
 		}
 	}
-	if _, ok := os.LookupEnv("VIRTIOFSD_DEBUG_LOGS"); ok {
+	if envVarValue, ok := os.LookupEnv("VIRTIOFSD_DEBUG_LOGS"); ok && (envVarValue == "1") {
 		_, err = qemuConf.WriteString("virtiofsd_debug = 1\n")
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: iholder <iholder@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Libvirt debug logs are being enabled if a label with "debugLogs"
key exists, without any dependency on the label's value.

For example, label definition "debugLogs: false" will
enable debug logs since "debugLogs" key exists.

After fix debug logs are to be enabled only if the label's
value is "true" (case in-sensitive).

Also, a unit-test was added to verify that the bug was fixed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fixed: Enabling libvirt debug logs only if debugLogs label value is "true", disabling otherwise.
```
