### PR TITLE
WFFC support for hotplugging volumes

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -93,7 +93,7 @@ const EXT_LOG_VERBOSITY_THRESHOLD = 5
 
 type TemplateService interface {
 	RenderLaunchManifest(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
-	RenderHotplugAttachmentPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock bool) (*k8sv1.Pod, error)
+	RenderHotplugAttachmentPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock, tempPod bool) (*k8sv1.Pod, error)
 	RenderLaunchManifestNoVm(*v1.VirtualMachineInstance) (*k8sv1.Pod, error)
 }
 
@@ -1214,8 +1214,23 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 	return &pod, nil
 }
 
-func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock bool) (*k8sv1.Pod, error) {
+func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, pvcName string, isBlock, tempPod bool) (*k8sv1.Pod, error) {
 	zero := int64(0)
+	var command []string
+	if tempPod {
+		command = []string{"/bin/bash",
+			"-c",
+			"exit", "0"}
+	} else {
+		command = []string{"/bin/sh", "-c", "tail -f /dev/null"}
+	}
+
+	annotationsList := make(map[string]string)
+	if tempPod {
+		// mark pod as temp - only used for provisioning
+		annotationsList[v1.EphemeralProvisioningObject] = "true"
+	}
+
 	pod := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "hp-volume-",
@@ -1229,13 +1244,14 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, 
 			Labels: map[string]string{
 				v1.AppLabel: "hotplug-disk",
 			},
+			Annotations: annotationsList,
 		},
 		Spec: k8sv1.PodSpec{
 			Containers: []k8sv1.Container{
 				{
 					Name:    "hotplug-disk",
 					Image:   t.launcherImage,
-					Command: []string{"/bin/sh", "-c", "tail -f /dev/null"},
+					Command: command,
 					Resources: k8sv1.ResourceRequirements{ //Took the request and limits from containerDisk init container.
 						Limits: map[k8sv1.ResourceName]resource.Quantity{
 							k8sv1.ResourceCPU:    resource.MustParse("100m"),

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1333,7 +1333,7 @@ func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, ho
 }
 
 func (c *VMIController) createAttachmentPod(vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod, volume *virtv1.Volume) syncError {
-	attachmentPodTemplate, err := c.createAttachmentPodTemplate(vmi, virtLauncherPod, volume)
+	attachmentPodTemplate, _ := c.createAttachmentPodTemplate(vmi, virtLauncherPod, volume)
 	if attachmentPodTemplate == nil { // nil means the PVC is not populated yet.
 		return nil
 	}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -470,7 +470,6 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		if vmiPodExists {
 			c.updateVolumeStatus(vmiCopy, pod)
 		}
-		logger := log.Log.Object(vmi)
 		if !reflect.DeepEqual(vmiCopy.Status.VolumeStatus, vmi.Status.VolumeStatus) {
 			// VolumeStatus changed which means either removed or added volumes.
 			newVolumeStatus, err := json.Marshal(vmiCopy.Status.VolumeStatus)
@@ -482,10 +481,8 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 				return err
 			}
 			if string(oldVolumeStatus) == "null" {
-				logger.V(1).Info("Adding")
 				patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/status/volumeStatus", "value": %s }`, string(newVolumeStatus)))
 			} else {
-				logger.V(1).Info("replacing")
 				patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/volumeStatus", "value": %s }`, string(oldVolumeStatus)))
 				patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/volumeStatus", "value": %s }`, string(newVolumeStatus)))
 			}
@@ -678,19 +675,12 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 		}
 		c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulCreatePodReason, "Created virtual machine pod %s", pod.Name)
 		return nil
-	} else {
-		if isTempPod(pod) && !isWaitForFirstConsumer {
-			// DV is no longer in WaitForFirstConsumer phase, means that tempPod has done its job and should be deleted
-			vmiKey := controller.VirtualMachineKey(vmi)
-			c.podExpectations.ExpectDeletions(vmiKey, []string{controller.PodKey(pod)})
-			err := c.clientset.CoreV1().Pods(vmi.Namespace).Delete(context.Background(), pod.Name, v1.DeleteOptions{})
-			if err != nil && !k8serrors.IsNotFound(err) {
-				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedDeletePodReason, "Failed to delete temporary pod %s", pod.Name)
-				c.podExpectations.DeletionObserved(vmiKey, controller.PodKey(pod))
-				return &syncErrorImpl{fmt.Errorf("Failed to delete temporary pod: %v", err), FailedDeletePodReason}
-			}
-			c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulDeletePodReason, "Deleted temporary pod %s", pod.Name)
-			return nil
+	}
+
+	if !isWaitForFirstConsumer {
+		err := c.cleanupWaitForFirstConsumerTemporaryPods(vmi, pod)
+		if err != nil {
+			return &syncErrorImpl{fmt.Errorf("failed to clean up temporary pods: %v", err), FailedHotplugSyncReason}
 		}
 	}
 	hotplugVolumes := c.getHotplugVolumes(vmi, pod)
@@ -698,9 +688,10 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 	if err != nil {
 		return &syncErrorImpl{fmt.Errorf("failed to get attachment pods: %v", err), FailedHotplugSyncReason}
 	}
-	if pod.DeletionTimestamp == nil && !isWaitForFirstConsumer && c.needsHandleHotplug(hotplugVolumes, hotplugAttachmentPods) {
+
+	if pod.DeletionTimestamp == nil && c.needsHandleHotplug(hotplugVolumes, hotplugAttachmentPods) {
 		var hotplugSyncErr syncError = nil
-		hotplugSyncErr = c.handleHotplugVolumes(hotplugVolumes, hotplugAttachmentPods, vmi, pod)
+		hotplugSyncErr = c.handleHotplugVolumes(hotplugVolumes, hotplugAttachmentPods, vmi, pod, dataVolumes)
 		if hotplugSyncErr != nil {
 			if hotplugSyncErr.Reason() == MissingAttachmentPodReason {
 				// We are missing an essential hotplug pod. Delete all pods associated with the VMI.
@@ -720,46 +711,20 @@ func (c *VMIController) handleSyncDataVolumes(vmi *virtv1.VirtualMachineInstance
 
 	for _, volume := range vmi.Spec.Volumes {
 		// Check both DVs and PVCs
-		if volume.VolumeSource.DataVolume != nil {
-			for _, dataVolume := range dataVolumes {
-				if dataVolume.Name == volume.VolumeSource.DataVolume.Name {
-					if dataVolume.Status.Phase == cdiv1.WaitForFirstConsumer {
-						wffc = true
-					} else if dataVolume.Status.Phase != cdiv1.Succeeded {
-						log.Log.V(3).Object(vmi).Infof("DataVolume %s not ready. Phase=%s", dataVolume.Name, dataVolume.Status.Phase)
-						ready = false
-						// This isn't needed anymore because datavolumes are eventually consistent.
-						if dataVolume.Status.Phase == cdiv1.Failed {
-							c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedDataVolumeImportReason, "DataVolume %s failed", dataVolume.Name)
-							return ready, wffc, &syncErrorImpl{fmt.Errorf("DataVolume %s for volume %s failed", dataVolume.Name, volume.Name), FailedDataVolumeImportReason}
-						}
-					}
-					break
+		if volume.VolumeSource.DataVolume != nil || volume.VolumeSource.PersistentVolumeClaim != nil {
+			volumeReady, volumeWffc, err := c.volumeReadyToUse(vmi.Namespace, volume, dataVolumes)
+			if err != nil {
+				// Keep existing behavior of missing PVC = ready. This in turn triggers template render, which sets conditions and events, and fails appropriately
+				if _, ok := err.(services.PvcNotFoundError); ok {
+					continue
+				} else {
+					c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedPvcNotFoundReason, "Error determining if volume is ready: %v", err)
+					return false, false, &syncErrorImpl{fmt.Errorf("Error determining if volume is ready %v", err), FailedDataVolumeImportReason}
 				}
 			}
-		}
-		if volume.VolumeSource.PersistentVolumeClaim != nil {
-			// err is always nil
-			pvcInterface, pvcExists, _ := c.pvcInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", vmi.Namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName))
-			if pvcExists {
-				pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)
-				populated, err := cdiv1.IsPopulated(pvc, dataVolumeByNameFunc(c.dataVolumeInformer, dataVolumes))
-				if err != nil {
-					return false, false, &syncErrorImpl{fmt.Errorf("Error determining if PVC %s is ready %v", pvc.Name, err), FailedDataVolumeImportReason}
-				}
-				if !populated {
-					waitsForFirstConsumer, err := cdiv1.IsWaitForFirstConsumerBeforePopulating(pvc, dataVolumeByNameFunc(c.dataVolumeInformer, dataVolumes))
-					if err != nil {
-						return false, false, &syncErrorImpl{fmt.Errorf("Error determining if PVC %s is ready %v", pvc.Name, err), FailedDataVolumeImportReason}
-					}
-					if waitsForFirstConsumer {
-						wffc = true
-					} else {
-						log.Log.V(3).Object(vmi).Infof("PVC %s not ready.", pvc.Name)
-						ready = false
-					}
-				}
-			}
+			wffc = wffc || volumeWffc
+			// Ready only becomes false if WFFC is also false.
+			ready = ready && (volumeReady || volumeWffc)
 		}
 	}
 
@@ -1223,6 +1188,56 @@ func (c *VMIController) getHotplugVolumes(vmi *virtv1.VirtualMachineInstance, vi
 	return hotplugVolumes
 }
 
+func (c *VMIController) cleanupWaitForFirstConsumerTemporaryPods(vmi *virtv1.VirtualMachineInstance, virtlauncherPod *k8sv1.Pod) error {
+	// Get all pods from the namespace
+	pods, err := c.listPodsFromNamespace(virtlauncherPod.Namespace)
+	if err != nil {
+		return err
+	}
+	triggerPods := make([]*k8sv1.Pod, 0)
+	for _, pod := range pods {
+		ownerRef := controller.GetControllerOf(pod)
+		if ownerRef == nil || ownerRef.UID != virtlauncherPod.UID || !isTempPod(pod) {
+			// Skip non trigger pods
+			continue
+		}
+		triggerPods = append(triggerPods, pod)
+	}
+	if isTempPod(virtlauncherPod) {
+		triggerPods = append(triggerPods, virtlauncherPod)
+	}
+
+	return c.deleteRunningOrFinishedWFFCPods(vmi, triggerPods...)
+}
+
+func (c *VMIController) deleteRunningOrFinishedWFFCPods(vmi *virtv1.VirtualMachineInstance, pods ...*k8sv1.Pod) error {
+	for _, pod := range pods {
+		err := c.deleteRunningOrFinishedPod(vmi, pod)
+		if err != nil {
+			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedDeletePodReason, "Failed to delete WaitForFirstConsumer temporary pod %s", pod.Name)
+			return err
+		}
+		c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulDeletePodReason, "Deleted WaitForFirstConsumer temporary pod %s", pod.Name)
+	}
+	return nil
+}
+
+func (c *VMIController) deleteRunningOrFinishedPod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
+	zero := int64(0)
+	if pod.Status.Phase == k8sv1.PodRunning || pod.Status.Phase == k8sv1.PodSucceeded {
+		vmiKey := controller.VirtualMachineKey(vmi)
+		c.podExpectations.ExpectDeletions(vmiKey, []string{controller.PodKey(pod)})
+		err := c.clientset.CoreV1().Pods(pod.GetNamespace()).Delete(context.TODO(), pod.Name, v1.DeleteOptions{
+			GracePeriodSeconds: &zero,
+		})
+		if err != nil {
+			c.podExpectations.DeletionObserved(vmiKey, controller.PodKey(pod))
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *VMIController) virtlauncherAttachmentPods(virtlauncherPod *k8sv1.Pod) ([]*k8sv1.Pod, error) {
 	var attachmentPods []*k8sv1.Pod
 
@@ -1265,7 +1280,7 @@ func (c *VMIController) needsHandleHotplug(hotplugVolumes []*virtv1.Volume, curr
 	return false
 }
 
-func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod, vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) syncError {
+func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod, vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod, dataVolumes []*cdiv1.DataVolume) syncError {
 	logger := log.Log.Object(vmi)
 
 	// Examine pods, and determine which volumes were added, and which were deleted.
@@ -1284,38 +1299,106 @@ func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, ho
 	if len(newVolumes) == 0 {
 		return nil
 	}
+	if len(newVolumes) > 0 {
+		// New volumes detected, create hotplug pods.
+		for _, volume := range newVolumes {
+			logger.V(1).Infof("Processing new hotplugged volume: %s", volume.Name)
+			var attachmentPodTemplate *k8sv1.Pod
+			var err error
+			ready, wffc, err := c.volumeReadyToUse(vmi.Namespace, *volume, dataVolumes)
+			if err != nil {
+				return &syncErrorImpl{fmt.Errorf("Error determining volume status %v", err), PVCNotReadyReason}
+			}
+			if wffc {
+				// Volume in WaitForFirstConsumer, it has not been populated by CDI yet. create a dummy pod
+				logger.V(3).Infof("Volume %s/%s is in WaitForFistConsumer, triggering population", vmi.Namespace, volume.Name)
+				syncError := c.triggerHotplugPopulation(volume, vmi, virtLauncherPod)
+				if syncError != nil {
+					return syncError
+				}
+				continue
+			}
+			if !ready {
+				// Volume not ready, skip until it is.
+				logger.V(3).Infof("Skipping hotplugged volume: %s, not ready", volume.Name)
+				continue
+			}
+			// Check if the VMI VolumeStatus contains this volume, if that is the case then something deleted the attachment pod
+			// and we need to stop the VMI as that is a critical error.
+			if c.volumeStatusContainsVolumeAndPod(vmi.Status.VolumeStatus, volume) {
+				logger.V(1).Infof("Detected attachment pod is missing for VMI %s/%s, the VMI will be deleted", vmi.Namespace, vmi.Name)
+				return &syncErrorImpl{fmt.Errorf("Missing pod for hotplugged volume %s", volume.Name), MissingAttachmentPodReason}
+			}
+			attachmentPodTemplate, err = c.createAttachmentPodTemplate(volume, virtLauncherPod, vmi)
+			if attachmentPodTemplate == nil { // nil means the PVC is not populated yet.
+				continue
+			}
+			vmiKey := controller.VirtualMachineKey(vmi)
+			c.podExpectations.ExpectCreations(vmiKey, 1)
 
-	// New volumes detected, create hotplug pods.
-	for _, volume := range newVolumes {
-		logger.V(1).Infof("Processing new hotplugged volume: %s", volume.Name)
-		var attachmentPodTemplate *k8sv1.Pod
-		var err error
-		// Check if the VMI VolumeStatus contains this volume, if that is the case then something deleted the attachment pod
-		// and we need to stop the VMI as that is a critical error.
-		if c.volumeStatusContainsVolumeAndPod(vmi.Status.VolumeStatus, volume) {
-			logger.V(1).Infof("Detected attachment pod is missing for VMI %s/%s, the VMI will be deleted", vmi.Namespace, vmi.Name)
-			return &syncErrorImpl{fmt.Errorf("Missing pod for hotplugged volume %s", volume.Name), MissingAttachmentPodReason}
+			pod, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.TODO(), attachmentPodTemplate, v1.CreateOptions{})
+			if err != nil {
+				c.podExpectations.CreationObserved(vmiKey)
+				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreatePodReason, "Error creating hotplug pod for volume %s: %v", volume.Name, err)
+				return &syncErrorImpl{fmt.Errorf("Error creating attachment pod %v", err), FailedCreatePodReason}
+			}
+			c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulCreatePodReason, "Created attachment pod %s for volume %s", pod.Name, volume.Name)
 		}
-		attachmentPodTemplate, err = c.createAttachmentPodTemplate(volume, virtLauncherPod, vmi)
-		if err != nil {
-			return &syncErrorImpl{fmt.Errorf("Error creating attachment pod template %v", err), FailedCreatePodReason}
-		}
-		if attachmentPodTemplate == nil { // nil means the PVC is not populated yet.
-			continue
-		}
-		vmiKey := controller.VirtualMachineKey(vmi)
-		c.podExpectations.ExpectCreations(vmiKey, 1)
-
-		pod, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.Background(), attachmentPodTemplate, v1.CreateOptions{})
-		if err != nil {
-			c.podExpectations.CreationObserved(vmiKey)
-			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreatePodReason, "Error creating hotplug pod for volume %s: %v", volume.Name, err)
-			return &syncErrorImpl{fmt.Errorf("Error creating attachment pod %v", err), FailedCreatePodReason}
-		}
-		c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulCreatePodReason, "Created attachment pod %s for volume %s", pod.Name, volume.Name)
 	}
 
 	return nil
+}
+
+func (c *VMIController) triggerHotplugPopulation(volume *virtv1.Volume, vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) syncError {
+	populateHotplugPodTemplate, err := c.createAttachmentPopulateTriggerPodTemplate(volume, virtLauncherPod, vmi)
+	if err != nil {
+		return &syncErrorImpl{fmt.Errorf("Error creating trigger pod template %v", err), FailedCreatePodReason}
+	}
+	if populateHotplugPodTemplate != nil { // nil means the PVC is not populated yet.
+		vmiKey := controller.VirtualMachineKey(vmi)
+		c.podExpectations.ExpectCreations(vmiKey, 1)
+
+		_, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.TODO(), populateHotplugPodTemplate, v1.CreateOptions{})
+		if err != nil {
+			c.podExpectations.CreationObserved(vmiKey)
+			c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreatePodReason, "Error creating hotplug population trigger pod for volume %s: %v", volume.Name, err)
+			return &syncErrorImpl{fmt.Errorf("Error creating hotplug population trigger pod %v", err), FailedCreatePodReason}
+		}
+	}
+	return nil
+}
+
+func (c *VMIController) volumeReadyToUse(namespace string, volume virtv1.Volume, dataVolumes []*cdiv1.DataVolume) (bool, bool, error) {
+	name := ""
+	if volume.DataVolume != nil {
+		name = volume.DataVolume.Name
+	} else if volume.PersistentVolumeClaim != nil {
+		name = volume.PersistentVolumeClaim.ClaimName
+	}
+	wffc := false
+	ready := false
+	var err error
+	// err is always nil
+	pvcInterface, pvcExists, _ := c.pvcInformer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+	if pvcExists {
+		pvc := pvcInterface.(*k8sv1.PersistentVolumeClaim)
+		ready, err = cdiv1.IsPopulated(pvc, dataVolumeByNameFunc(c.dataVolumeInformer, dataVolumes))
+		if err != nil {
+			return false, false, err
+		}
+		if !ready {
+			waitsForFirstConsumer, err := cdiv1.IsWaitForFirstConsumerBeforePopulating(pvc, dataVolumeByNameFunc(c.dataVolumeInformer, dataVolumes))
+			if err != nil {
+				return false, false, err
+			}
+			if waitsForFirstConsumer {
+				wffc = true
+			}
+		}
+	} else {
+		return false, false, services.PvcNotFoundError(fmt.Errorf("didn't find PVC %v", name))
+	}
+	return ready, wffc, nil
 }
 
 func (c *VMIController) volumeStatusContainsVolumeAndPod(volumeStatus []virtv1.VolumeStatus, volume *virtv1.Volume) bool {
@@ -1424,10 +1507,33 @@ func (c *VMIController) createAttachmentPodTemplate(volume *virtv1.Volume, virtl
 		return nil, err
 	}
 	if populated {
-		pod, err := c.templateService.RenderHotplugAttachmentPodTemplate(volume, virtlauncherPod, vmi, pvc.Name, isBlock)
+		pod, err := c.templateService.RenderHotplugAttachmentPodTemplate(volume, virtlauncherPod, vmi, pvc.Name, isBlock, false)
 		return pod, err
 	}
 	return nil, nil
+}
+
+func (c *VMIController) createAttachmentPopulateTriggerPodTemplate(volume *virtv1.Volume, virtlauncherPod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance) (*k8sv1.Pod, error) {
+	var claimName string
+	if volume.DataVolume != nil {
+		// TODO, look up the correct PVC name based on the datavolume, right now they match, but that will not always be true.
+		claimName = volume.DataVolume.Name
+	} else if volume.PersistentVolumeClaim != nil {
+		claimName = volume.PersistentVolumeClaim.ClaimName
+	}
+	if claimName == "" {
+		return nil, errors.New("Unable to hotplug, claim not PVC or Datavolume")
+	}
+
+	pvc, exists, isBlock, err := kubevirttypes.IsPVCBlockFromClient(c.clientset, virtlauncherPod.Namespace, claimName)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("Unable to trigger hotplug population, claim %s not found", claimName)
+	}
+	pod, err := c.templateService.RenderHotplugAttachmentPodTemplate(volume, virtlauncherPod, vmi, pvc.Name, isBlock, true)
+	return pod, err
 }
 
 func (c *VMIController) deleteAllAttachmentPods(vmi *virtv1.VirtualMachineInstance) error {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1489,7 +1489,7 @@ func (c *VMIController) createAttachmentPodTemplate(vmi *virtv1.VirtualMachineIn
 		return nil, errors.New("Unable to hotplug, claim not PVC or Datavolume")
 	}
 
-	pvc, exists, isBlock, err := kubevirttypes.IsPVCBlockFromClient(c.clientset, virtlauncherPod.Namespace, claimName)
+	pvc, exists, isBlock, err := kubevirttypes.IsPVCBlockFromStore(c.pvcInformer.GetStore(), virtlauncherPod.Namespace, claimName)
 	if err != nil {
 		return nil, err
 	}
@@ -1526,7 +1526,7 @@ func (c *VMIController) createAttachmentPopulateTriggerPodTemplate(volume *virtv
 		return nil, errors.New("Unable to hotplug, claim not PVC or Datavolume")
 	}
 
-	pvc, exists, isBlock, err := kubevirttypes.IsPVCBlockFromClient(c.clientset, virtlauncherPod.Namespace, claimName)
+	pvc, exists, isBlock, err := kubevirttypes.IsPVCBlockFromStore(c.pvcInformer.GetStore(), virtlauncherPod.Namespace, claimName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1484,16 +1484,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, volume)
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Unable to find datavolume default/test-dv"))
+			Expect(err.Error()).To(ContainSubstring("Unable to hotplug, claim test-dv not found"))
 		})
 
 		It("CreateAttachmentPodTemplate should set status to pending if DV owning PVC is not ready", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimPending)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-				return true, pvc, nil
-			})
+			pvcInformer.GetIndexer().Add(pvc)
 			dv := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dv",
@@ -1533,9 +1531,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimBound)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-				return true, pvc, nil
-			})
+			pvcInformer.GetIndexer().Add(pvc)
 			dv := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dv",
@@ -1568,9 +1564,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvc := NewHotplugPVC("test-dv", vmi.Namespace, k8sv1.ClaimBound)
-			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-				return true, pvc, nil
-			})
+			pvcInformer.GetIndexer().Add(pvc)
 			dv := &cdiv1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-dv",

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -77,6 +77,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 	var dataVolumeInformer cache.SharedIndexInformer
 	var dataVolumeFeeder *testutils.DataVolumeFeeder
 	var qemuGid int64 = 107
+	controllerOf := true
 
 	shouldExpectMatchingPodCreation := func(uid types.UID, matchers ...gomegaTypes.GomegaMatcher) {
 		// Expect pod creation
@@ -272,13 +273,13 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: dvVolumeSource,
 			})
 
-			dvPVC := NewPvc(vmi.Namespace, "test1")
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
+
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
 			pvcInformer.GetIndexer().Add(dvPVC)
-
-			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
@@ -298,6 +299,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 				Equal("/bin/bash -c echo bound PVCs"))
 			shouldExpectMatchingPodCreation(vmi.UID, IsPodWithoutVmPayload)
+			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				Fail("here")
+				return true, dvPVC, nil
+			})
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
@@ -313,13 +318,17 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: dvVolumeSource,
 			})
 
-			dvPVC := NewPvc(vmi.Namespace, "test1")
+			pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
+				Name: "test1",
+			})
+
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
+
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
 			// be in available but in the Pending state.
 			pvcInformer.GetIndexer().Add(dvPVC)
-
-			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -334,6 +343,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 						Status: k8sv1.ConditionTrue,
 					}))
 			}).Return(vmi, nil)
+			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				return true, dvPVC, nil
+			})
 			controller.Execute()
 		})
 
@@ -346,12 +358,15 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				Name:         "test1",
 				VolumeSource: dvVolumeSource,
 			})
+			pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
+				Name: "test1",
+			})
 
-			dvPVC := NewPvc(vmi.Namespace, "test1")
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
 			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
 			// be in available
 			pvcInformer.GetIndexer().Add(dvPVC)
-			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
@@ -359,6 +374,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			dataVolumeFeeder.Add(dataVolume)
 			shouldExpectPodDeletion(pod)
 
+			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				return true, dvPVC, nil
+			})
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 		})
@@ -376,7 +394,14 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					VolumeSource: dvVolumeSource,
 				})
 
+				pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
+					Name: "test1",
+				})
+
 				dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.WaitForFirstConsumer)
+				dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+				dvPVC.Status.Phase = k8sv1.ClaimBound
+				pvcInformer.GetIndexer().Add(dvPVC)
 
 				addVirtualMachine(vmi)
 				podFeeder.Add(pod)
@@ -386,6 +411,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
 					Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(expectedPhase))
 				}).Return(vmi, nil)
+				kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+					return true, dvPVC, nil
+				})
 
 				controller.Execute()
 			},
@@ -409,39 +437,18 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			})
 
 			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Pending)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
+			dvPVC.Status.Phase = k8sv1.ClaimPending
+			pvcInformer.GetIndexer().Add(dvPVC)
 
 			addVirtualMachine(vmi)
 			dataVolumeFeeder.Add(dataVolume)
 
 			controller.Execute()
 		})
-
-		It("VMI should fail if DataVolume fails to import", func() {
-			// TODO: Remove this test, Datavolumes are now eventually consistent, and cannot enter into failed state.
-			vmi := NewPendingVirtualMachine("testvmi")
-
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name:         "test1",
-				VolumeSource: dvVolumeSource,
-			})
-
-			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Failed)
-
-			addVirtualMachine(vmi)
-			dataVolumeFeeder.Add(dataVolume)
-
-			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-				Expect(arg.(*v1.VirtualMachineInstance).Status.Phase).To(Equal(v1.Failed))
-			}).Return(vmi, nil)
-
-			controller.Execute()
-			testutils.ExpectEvent(recorder, FailedDataVolumeImportReason)
-		})
-
 	})
 
 	Context("On valid VirtualMachineInstance given with PVC source, ownedRef of DataVolume", func() {
-		controllerOf := true
 
 		pvcVolumeSource := v1.VolumeSource{
 			PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
@@ -520,6 +527,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
+			pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
+				Name: "test1",
+			})
+
 			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
 			dvPVC.Status.Phase = k8sv1.ClaimPending
 			// we are mocking a DataVolume in WFFC phase. we expect the PVC to
@@ -554,19 +565,25 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				VolumeSource: pvcVolumeSource,
 			})
 
-			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", "test1", &controllerOf)
+			pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
+				Name: "test1",
+			})
+
+			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
+			dvPVC := NewPvcWithOwner(vmi.Namespace, "test1", dataVolume.Name, &controllerOf)
 			dvPVC.Status.Phase = k8sv1.ClaimBound
 			// we are mocking a DataVolume in Succeeded phase. we expect the PVC to
 			// be in available
 			pvcInformer.GetIndexer().Add(dvPVC)
-
-			dataVolume := NewDv(vmi.Namespace, "test1", cdiv1.Succeeded)
 
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
 			addActivePods(vmi, pod.UID, "")
 			dataVolumeFeeder.Add(dataVolume)
 			shouldExpectPodDeletion(pod)
+			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				return true, dvPVC, nil
+			})
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
@@ -1712,6 +1729,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				}
 				dataVolumeInformer.GetIndexer().Add(dv)
+				pvcInformer.GetIndexer().Add(pvc)
 			}
 		}
 
@@ -1786,12 +1804,23 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmi.Status.VolumeStatus = orgStatus
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			pvcFunc(pvcIndexes...)
+			datavolumes := []*cdiv1.DataVolume{}
+			for _, volume := range hotplugVolumes {
+				datavolumes = append(datavolumes, &cdiv1.DataVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: volume.Name,
+					},
+					Status: cdiv1.DataVolumeStatus{
+						Phase: cdiv1.Succeeded,
+					},
+				})
+			}
 			addVirtualMachine(vmi)
 			podFeeder.Add(virtlauncherPod)
 			if createPodReaction != nil {
 				createPodReaction(virtlauncherPod, pvcIndexes...)
 			}
-			syncError := controller.handleHotplugVolumes(hotplugVolumes, hotplugAttachmentPods, vmi, virtlauncherPod)
+			syncError := controller.handleHotplugVolumes(hotplugVolumes, hotplugAttachmentPods, vmi, virtlauncherPod, datavolumes)
 			if expectedErr != nil {
 				Expect(syncError).To(BeEquivalentTo(expectedErr))
 			} else {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1430,7 +1430,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					ConfigMap: &v1.ConfigMapVolumeSource{},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(invalidVolume, virtlauncherPod, vmi)
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, invalidVolume)
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unable to hotplug, claim not PVC or Datavolume"))
@@ -1452,7 +1452,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(nopvcVolume, virtlauncherPod, vmi)
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, nopvcVolume)
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unable to hotplug, claim noclaim not found"))
@@ -1481,7 +1481,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(volume, virtlauncherPod, vmi)
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, volume)
 			Expect(pod).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Unable to find datavolume default/test-dv"))
@@ -1517,7 +1517,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(volume, virtlauncherPod, vmi)
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, volume)
 			Expect(pod).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -1559,7 +1559,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(volume, virtlauncherPod, vmi)
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, volume)
 			Expect(pod).To(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -1594,7 +1594,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					},
 				},
 			}
-			pod, err := controller.createAttachmentPodTemplate(volume, virtlauncherPod, vmi)
+			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, volume)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.GenerateName).To(Equal("hp-volume-"))
 			Expect(pod.Spec.Volumes[0].Name).To(Equal(volume.Name))

--- a/tests/datavolume_test.go
+++ b/tests/datavolume_test.go
@@ -142,7 +142,7 @@ var _ = Describe("[Serial]DataVolume Integration", func() {
 				if tests.HasBindingModeWaitForFirstConsumer() {
 					tests.WaitForDataVolumePhaseWFFC(dataVolume.Namespace, dataVolume.Name, 30)
 				}
-				// with WFFC the run actually starts the import and then runs VM, so the timeout has t oinclude both
+				// with WFFC the run actually starts the import and then runs VM, so the timeout has to include both
 				// import and start
 				vmi = runVMIAndExpectLaunch(vmi, dataVolume, 500)
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -388,7 +388,7 @@ var _ = SIGDescribe("Hotplug", func() {
 				Skip("Skip no local wffc storage class available")
 			}
 
-			template := tests.NewRandomFedoraVMIWitGuestAgent()
+			template := tests.NewRandomFedoraVMI()
 			vm = createVirtualMachine(true, template)
 			Eventually(func() bool {
 				vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
@@ -489,7 +489,7 @@ var _ = SIGDescribe("Hotplug", func() {
 					Skip("Skip OCS tests when Ceph is not present")
 				}
 
-				template := tests.NewRandomFedoraVMIWitGuestAgent()
+				template := tests.NewRandomFedoraVMI()
 				node := findCPUManagerWorkerNode()
 				if node != "" {
 					template.Spec.NodeSelector = make(map[string]string)
@@ -875,7 +875,7 @@ var _ = SIGDescribe("Hotplug", func() {
 					Skip("Skip OCS tests when Ceph is not present")
 				}
 
-				vmi = tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi = tests.NewRandomFedoraVMI()
 				vmi = tests.RunVMIAndExpectLaunch(vmi, 240)
 			})
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -377,6 +377,87 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 	})
 
+	Context("WFFC storage", func() {
+		var (
+			vm *kubevirtv1.VirtualMachine
+		)
+
+		BeforeEach(func() {
+			hasWffc := tests.HasBindingModeWaitForFirstConsumer()
+			if !hasWffc {
+				Skip("Skip no local wffc storage class available")
+			}
+
+			template := tests.NewRandomFedoraVMIWitGuestAgent()
+			vm = createVirtualMachine(true, template)
+			Eventually(func() bool {
+				vm, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Get(vm.Name, &metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return vm.Status.Ready
+			}, 300*time.Second, 1*time.Second).Should(BeTrue())
+		})
+
+		It("Should be able to add and use WFFC local storage", func() {
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 240)
+			testVolumes := make([]string, 0)
+			dvNames := make([]string, 0)
+			for i := 0; i < 3; i++ {
+				volumeName := fmt.Sprintf("volume%d", i)
+				By("Creating DataVolume")
+				dv := tests.NewRandomBlankDataVolume(tests.NamespaceTestDefault, tests.Config.StorageClassLocal, "64Mi", corev1.ReadWriteOnce, corev1.PersistentVolumeFilesystem)
+				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(context.TODO(), dv, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
+				testVolumes = append(testVolumes, volumeName)
+				dvNames = append(dvNames, dv.Name)
+			}
+			defer func(dvNames []string, namespace string) {
+				for _, dvName := range dvNames {
+					By("Deleting the DataVolume")
+					ExpectWithOffset(1, virtClient.CdiClient().CdiV1alpha1().DataVolumes(namespace).Delete(context.TODO(), dvName, metav1.DeleteOptions{})).To(Succeed())
+				}
+			}(dvNames, vmi.Namespace)
+
+			for i := 0; i < 3; i++ {
+				By("Adding volume " + strconv.Itoa(i) + " to running VM, dv name:" + dvNames[i])
+				addDVVolumeVMI(vm.Name, vm.Namespace, testVolumes[i], dvNames[i], "scsi")
+			}
+
+			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(vm.Name, &metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			verifyVolumeAndDiskVMIAdded(vmi, testVolumes...)
+			By("Verify the volume status of the hotplugged volume is ready")
+			verifyVolumeStatus(vmi, kubevirtv1.VolumeReady, testVolumes...)
+			By("Obtaining the serial console")
+			Expect(console.LoginToFedora(vmi)).To(Succeed())
+			targets := getTargetsFromVolumeStatus(vmi, testVolumes...)
+			for i := range testVolumes {
+				Eventually(func() error {
+					return console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: fmt.Sprintf("sudo ls %s\n", targets[i])},
+						&expect.BExp{R: targets[i]},
+						&expect.BSnd{S: "echo $?\n"},
+						&expect.BExp{R: console.RetValue("0")},
+					}, 10)
+				}, 40*time.Second, 2*time.Second).Should(Succeed())
+			}
+			for _, target := range targets {
+				verifyCreateData(vmi, target)
+			}
+			for i, volumeName := range testVolumes {
+				By("removing volume " + volumeName + " from VM")
+				removeVolumeVMI(vm.Name, vm.Namespace, volumeName)
+				Eventually(func() error {
+					return console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: fmt.Sprintf("sudo ls %s\n", targets[i])},
+						&expect.BExp{R: fmt.Sprintf("ls: cannot access '%s'", targets[i])},
+					}, 5)
+				}, 90*time.Second, 2*time.Second).Should(Succeed())
+			}
+		})
+	})
+
 	Context("rook-ceph", func() {
 		Context("Online VM", func() {
 			var (

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2239,6 +2239,17 @@ func AddEphemeralCdrom(vmi *v1.VirtualMachineInstance, name string, bus string, 
 	return vmi
 }
 
+func NewRandomFedoraVMI() *v1.VirtualMachineInstance {
+	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
+	Expect(err).NotTo(HaveOccurred())
+
+	return libvmi.NewFedora(
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		libvmi.WithCloudInitNoCloudNetworkData(networkData, false),
+	)
+}
+
 func NewRandomFedoraVMIWitGuestAgent() *v1.VirtualMachineInstance {
 	networkData, err := libnet.CreateDefaultCloudInitNetworkData()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Hotplug is now supported on WFFC datavolumes. This means the following happens when you hotplug a WFFC datavolume:
1. virt-controller detects the datavolume being hotplugged is WFFC, and not ready.
2. virt-controller creates a 'trigger' pod with the same affinity of a regular attachment pod.
3. This triggers the WFFC DV to become bound on the node the VM is running on.
4. This triggers CDI to populate the datavolume
5. Once CDI is done populating the datavolume, virt-controller now attaches the volume to the VM in same manner as before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Hotplug support for WFFC datavolumes.
```
