### PR TITLE
Multus func tests remove leftovers

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -106,6 +106,9 @@ var _ = Describe("[Serial]Multus", func() {
 	}
 
 	tests.BeforeAll(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		tests.PanicOnError(err)
+
 		tests.BeforeTestCleanup()
 
 		nodes = tests.GetAllSchedulableNodes(virtClient)
@@ -137,9 +140,6 @@ var _ = Describe("[Serial]Multus", func() {
 	})
 
 	BeforeEach(func() {
-		virtClient, err = kubecli.GetKubevirtClient()
-		tests.PanicOnError(err)
-
 		// Multus tests need to ensure that old VMIs are gone
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestDefault).Resource("virtualmachineinstances").Do().Error()).To(Succeed())
 		Expect(virtClient.RestClient().Delete().Namespace(tests.NamespaceTestAlternative).Resource("virtualmachineinstances").Do().Error()).To(Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The multus tests check that no VMI exists in the cluster before starting the tests.

In the case where a replica set is left when starting the test, the corresponding VMIs will be deleted, which causes the replica
set to re-instantiate them.
The very same `BeforeEach` block checks for all the VMIs to be gone for 6 minutes, which would fail.

By executing the `BeforeAll` block before the `BeforeEach`, we delete the entire namespace - replica sets included. As a direct
result of this, when we attempt to delete the VMIs from the namespace, we will find none, which enables the test setup to
succeed.

**Special notes for your reviewer**:
This issue is not seen on upstream KubeVirt since the multus tests are only executed on the CNAO lane, where the replica set tests are not executed.

To reproduce this issue, run the Functional tests w/

 `FUNC_TEST_ARGS="--seed=13" KUBEVIRT_E2E_FOCUS="Multus|VirtualMachineInstanceReplicaSet" make functest`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
