### PR TITLE
Bump bazeldnf to v0.0.15

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -142,11 +142,10 @@ http_file(
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "d0833cfb1d60d1e9ca4b3e9619553f22867b15dd827e33010f9b6d093eb7d5f7",
-    strip_prefix = "bazeldnf-0.0.14",
+    sha256 = "60acf03051025e6d013ac24daebefa21e4543225112b89140118f7e10e212378",
+    strip_prefix = "bazeldnf-0.0.15",
     urls = [
-        "https://github.com/rmohr/bazeldnf/archive/v0.0.14.tar.gz",
-        "https://storage.googleapis.com/builddeps/d0833cfb1d60d1e9ca4b3e9619553f22867b15dd827e33010f9b6d093eb7d5f7",
+        "https://github.com/rmohr/bazeldnf/archive/v0.0.15.tar.gz",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug which was sometimes reading symlink names only partially
from a reader. Unblocks #4882.

Without this update sometimes headers are read only partially, leading to results like this:


```
Error: failed to write header ./usr/lib/.build-id/67/2958a88dfe80c7c25608df9a39899332792a5f: archive/tar: cannot encode header: invalid PAX record: "linkpath = o./../../../usr/lib64/gconv/RK1048.s\x00"
```

The last character, an `o` was not read in this case. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
