### PR TITLE
Move complete bazel cache handling for e2e tests to CI

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -33,7 +33,6 @@ export TIMESTAMP=${TIMESTAMP:-1}
 export WORKSPACE="${WORKSPACE:-$PWD}"
 readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
-readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
 
 if [[ $TARGET =~ windows.* ]]; then
   echo "picking the default provider for windows tests"
@@ -160,9 +159,6 @@ make cluster-down
 
 # Create .bazelrc to use remote cache
 cat >ci.bazelrc <<EOF
-startup --host_jvm_args=-Dbazel.DigestFunction=sha256
-build --remote_local_fallback
-build --remote_http_cache=${BAZEL_CACHE}
 build --jobs=4
 EOF
 


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/kubevirt/project-infra/pull/894 we can now control for e2e test executions the cache from CI completely.
We have to remove the cache settings from this file to not override the CI settings.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Needs to be merged together with https://github.com/kubevirt/project-infra/pull/835.
The PR is a draft to not yet trigger CI.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
