### PR TITLE
Allow experimenting with live migration compression modes

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1064,6 +1064,16 @@ func ValidateVirtualMachineInstanceMetadata(field *k8sfield.Path, metadata *meta
 		})
 	}
 
+	// Validate live migration compression feature gate if set when the corresponding annotation is found
+	if annotations[v1.LiveMigrationCompressionMethod] != "" && !config.LiveMigrationCompressionEnabled() {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("LiveMigrationCompression feature gate is not enabled in kubevirt-config, invalid entry %s",
+				field.Child("annotations").Child(v1.LiveMigrationCompressionMethod).String()),
+			Field: field.Child("annotations").String(),
+		})
+	}
+
 	return causes
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -425,6 +425,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				map[string]string{hooks.HookSidecarListAnnotationName: "[{'image': 'fake-image'}]"},
 				fmt.Sprintf("invalid entry metadata.annotations.%s", hooks.HookSidecarListAnnotationName),
 			),
+			table.Entry("without live migration compression feature gate enabled",
+				map[string]string{v1.LiveMigrationCompressionMethod: "mt"},
+				fmt.Sprintf("invalid entry metadata.annotations.%s", v1.LiveMigrationCompressionMethod),
+			),
 		)
 
 		table.DescribeTable("should accept annotations which require feature gate enabled", func(annotations map[string]string, featureGate string) {
@@ -443,6 +447,10 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			table.Entry("with sidecar feature gate enabled",
 				map[string]string{hooks.HookSidecarListAnnotationName: "[{'image': 'fake-image'}]"},
 				virtconfig.SidecarGate,
+			),
+			table.Entry("with live migration compression feature gate enabled",
+				map[string]string{v1.LiveMigrationCompressionMethod: "mt"},
+				virtconfig.LiveMigrationCompressionGate,
 			),
 		)
 	})

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -24,19 +24,20 @@ package virtconfig
 */
 
 const (
-	CPUManager            = "CPUManager"
-	IgnitionGate          = "ExperimentalIgnitionSupport"
-	LiveMigrationGate     = "LiveMigration"
-	CPUNodeDiscoveryGate  = "CPUNodeDiscovery"
-	HypervStrictCheckGate = "HypervStrictCheck"
-	SidecarGate           = "Sidecar"
-	GPUGate               = "GPU"
-	HostDevicesGate       = "HostDevices"
-	SnapshotGate          = "Snapshot"
-	HotplugVolumesGate    = "HotplugVolumes"
-	HostDiskGate          = "HostDisk"
-	VirtIOFSGate          = "ExperimentalVirtiofsSupport"
-	MacvtapGate           = "Macvtap"
+	CPUManager                   = "CPUManager"
+	IgnitionGate                 = "ExperimentalIgnitionSupport"
+	LiveMigrationGate            = "LiveMigration"
+	LiveMigrationCompressionGate = "LiveMigrationCompression"
+	CPUNodeDiscoveryGate         = "CPUNodeDiscovery"
+	HypervStrictCheckGate        = "HypervStrictCheck"
+	SidecarGate                  = "Sidecar"
+	GPUGate                      = "GPU"
+	HostDevicesGate              = "HostDevices"
+	SnapshotGate                 = "Snapshot"
+	HotplugVolumesGate           = "HotplugVolumes"
+	HostDiskGate                 = "HostDisk"
+	VirtIOFSGate                 = "ExperimentalVirtiofsSupport"
+	MacvtapGate                  = "Macvtap"
 )
 
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -58,6 +59,10 @@ func (config *ClusterConfig) IgnitionEnabled() bool {
 
 func (config *ClusterConfig) LiveMigrationEnabled() bool {
 	return config.isFeatureGateEnabled(LiveMigrationGate)
+}
+
+func (config *ClusterConfig) LiveMigrationCompressionEnabled() bool {
+	return config.isFeatureGateEnabled(LiveMigrationCompressionGate)
 }
 
 func (config *ClusterConfig) HypervStrictCheckEnabled() bool {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -622,6 +622,12 @@ const (
 	IgnitionAnnotation           string = "kubevirt.io/ignitiondata"
 	PlacePCIDevicesOnRootComplex string = "kubevirt.io/placePCIDevicesOnRootComplex"
 
+	LiveMigrationCompressionMethod            string = "kubevirt.io/LiveMigrationCompressionMethod"
+	LiveMigrationThreadedCompressionLevel     string = "kubevirt.io/LiveMigrationThreadedCompressionLevel"
+	LiveMigrationThreadedCompressionThreads   string = "kubevirt.io/LiveMigrationThreadedCompressionThreads"
+	LiveMigrationThreadedDeCompressionThreads string = "kubevirt.io/LiveMigrationThreadedDeCompressionThreads"
+	LiveMigrationXBZRLECompressionCache       string = "kubevirt.io/LiveMigrationXBZRLECompressionCache"
+
 	VirtualMachineLabel        = AppLabel + "/vm"
 	MemfdMemoryBackend  string = "kubevirt.io/memfd"
 )

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -50,6 +50,7 @@ import (
 
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -546,6 +547,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		Context("with live migration compression", func() {
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
+				tests.EnableFeatureGate(virtconfig.LiveMigrationCompressionGate)
 			})
 
 			It("should complete a migration in multithreaded mode", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows enabling and tuning compression parameters for live migration.
Using compression with live migration is one of the methods to reduce the network traffic during live migration. 
However, it comes at an expense of other resources such as memory and CPU on the host.

Compression isn't a useful method in the general case as it depends on the application workload and the availability of resources on the node. Often, it will not be beneficial.

This PR will allow experimenting with live migration compression.
It exposes a set of tunables that can be set as annotations on the VMI object.
In the simple case, to enable compression, it's enough to set the `LiveMigrationCompressionMethod`

`kubevirt.io/LiveMigrationCompressionMethod` - accepts values `mt` for multi-threaded compression or `xbzrle`
`kubevirt.io/LiveMigrationThreadedCompressionLevel` - accepts values between 0 and 9. 0 is no compression, 1 is maximum speed and 9 is maximum compression.          
`kubevirt.io/LiveMigrationThreadedCompressionThreads` - the number of compression threads for multithread compression          
`kubevirt.io/LiveMigrationThreadedDeCompressionThreads` - the number of de-compression threads for multithread compression
`kubevirt.io/LiveMigrationXBZRLECompressionCache` - the size of page cache for xbzrle compression

```release-note
allow enabling and tuning live migration compression modes
```
