### PR TITLE
cloudinit.GenerateLocalData: minor refactoring

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -535,16 +535,11 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 		return err
 	}
 
-	files := make([]string, 0, 3)
-	files = append(files, metaFile)
-	files = append(files, userFile)
-
 	if len(networkData) > 0 {
 		err = ioutil.WriteFile(networkFile, networkData, 0644)
 		if err != nil {
 			return err
 		}
-		files = append(files, networkFile)
 	}
 
 	switch data.DataSource {

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -530,16 +530,20 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 	if err != nil {
 		return err
 	}
+	defer os.Remove(userFile)
+
 	err = ioutil.WriteFile(metaFile, metaData, 0644)
 	if err != nil {
 		return err
 	}
+	defer os.Remove(metaFile)
 
 	if len(networkData) > 0 {
 		err = ioutil.WriteFile(networkFile, networkData, 0644)
 		if err != nil {
 			return err
 		}
+		defer os.Remove(networkFile)
 	}
 
 	switch data.DataSource {
@@ -551,9 +555,6 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 	if err != nil {
 		return err
 	}
-	diskutils.RemoveFile(metaFile)
-	diskutils.RemoveFile(userFile)
-	diskutils.RemoveFile(networkFile)
 
 	if err := diskutils.DefaultOwnershipManager.SetFileOwnership(isoStaging); err != nil {
 		return err


### PR DESCRIPTION
This change fixes two `cloudinit.GenerateLocalData` issues raised by @ezrasilvera. It drops a needless `files` variable, and it defers removal of files right after they are created.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
