### PR TITLE
Move runSafeCommand to console.RunSafeCommand

### DIFF
--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -74,8 +74,8 @@ func ExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, time
 // SafeExpectBatch runs the batch from `expected` connecting to a VMI's console and
 // wait `timeout` for the batch to return, it also check that the sended commands arrives to console checking.
 // NOTE: This functions heritage limitations from `ExpectBatchWithValidatedSend` refer to it to check them.
-func SafeExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) error {
-	_, err := SafeExpectBatchWithResponse(vmi, expected, wait)
+func SafeExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, timeout time.Duration) error {
+	_, err := SafeExpectBatchWithResponse(vmi, expected, timeout)
 	return err
 }
 
@@ -83,7 +83,7 @@ func SafeExpectBatch(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, 
 // wait `timeout` for the batch to return with a response.
 // It includes a safety check which validates that the commands arrive to the console.
 // NOTE: This functions inherits limitations from `ExpectBatchWithValidatedSend`, refer to it for more information.
-func SafeExpectBatchWithResponse(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, wait int) ([]expect.BatchRes, error) {
+func SafeExpectBatchWithResponse(vmi *v1.VirtualMachineInstance, expected []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	if err != nil {
 		panic(err)
@@ -94,7 +94,7 @@ func SafeExpectBatchWithResponse(vmi *v1.VirtualMachineInstance, expected []expe
 	}
 	defer expecter.Close()
 
-	resp, err := ExpectBatchWithValidatedSend(expecter, expected, time.Second*time.Duration(wait))
+	resp, err := ExpectBatchWithValidatedSend(expecter, expected, time.Second*timeout)
 	if err != nil {
 		log.DefaultLogger().Object(vmi).Infof("%v", resp)
 	}
@@ -139,7 +139,7 @@ func RunSafeCommandSuccessfully(vmi *v1.VirtualMachineInstance, command string, 
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: "echo $?\n"},
 		&expect.BExp{R: ShellSuccess},
-	}, int(timeout))
+	}, timeout)
 }
 
 // SecureBootExpecter should be called on a VMI that has EFI enabled

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -85,7 +85,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		VerifyUserDataVMI = func(vmi *v1.VirtualMachineInstance, commands []expect.Batcher, timeout time.Duration) {
 			By("Checking that the VirtualMachineInstance serial console output equals to expected one")
-			Expect(console.SafeExpectBatch(vmi, commands, int(timeout.Seconds()))).To(Succeed())
+			Expect(console.SafeExpectBatch(vmi, commands, timeout)).To(Succeed())
 		}
 
 		mountCloudInitFunc := func(devName string) func(*v1.VirtualMachineInstance) {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -314,7 +314,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		})
 
 		Context("with boot order", func() {
-			table.DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should be able to boot from selected disk", func(alpineBootOrder uint, cirrosBootOrder uint, consoleText string, wait int) {
+			table.DescribeTable("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]should be able to boot from selected disk", func(alpineBootOrder uint, cirrosBootOrder uint, consoleText string, timeout time.Duration) {
 				By("defining a VirtualMachineInstance with an Alpine disk")
 				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskAlpine), "#!/bin/sh\n\necho 'hi'\n")
 				By("adding a Cirros Disk")
@@ -335,11 +335,11 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				err = console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "\n"},
 					&expect.BExp{R: consoleText},
-				}, wait)
+				}, timeout)
 				Expect(err).ToNot(HaveOccurred(), "Should match the console in VMI")
 			},
-				table.Entry("[test_id:1627]Alpine as first boot", uint(1), uint(2), "Welcome to Alpine", 90),
-				table.Entry("[test_id:1628]Cirros as first boot", uint(2), uint(1), "cirros", 90),
+				table.Entry("[test_id:1627]Alpine as first boot", uint(1), uint(2), "Welcome to Alpine", 90*time.Second),
+				table.Entry("[test_id:1628]Cirros as first boot", uint(2), uint(1), "cirros", 90*time.Second),
 			)
 		})
 


### PR DESCRIPTION

Signed-off-by: Quique Llorente <ellorent@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The multus tests has a function to pass the command to execute and
execute them at the console ensuring that commands are returning ok,
this change move that functions to "console" package so other tests can
use it.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
