### PR TITLE
Refactor EmptyDisk to reduce cognitive complexity

### DIFF
--- a/pkg/emptydisk/emptydisk.go
+++ b/pkg/emptydisk/emptydisk.go
@@ -13,30 +13,34 @@ import (
 var EmptyDiskBaseDir = "/var/run/libvirt/empty-disks/"
 
 func CreateTemporaryDisks(vmi *v1.VirtualMachineInstance) error {
-
 	for _, volume := range vmi.Spec.Volumes {
-
 		if volume.EmptyDisk != nil {
-			// qemu-img takes the size in bytes or in Kibibytes/Mebibytes/...; lets take bytes
-			size := strconv.FormatInt(volume.EmptyDisk.Capacity.ToDec().ScaledValue(0), 10)
-			file := FilePathForVolumeName(volume.Name)
-			if err := os.MkdirAll(EmptyDiskBaseDir, 0777); err != nil {
-				return err
-			}
-			if _, err := os.Stat(file); os.IsNotExist(err) {
-				// #nosec No risk for attacket injection. Parameters are predefined strings
-				if err := exec.Command("qemu-img", "create", "-f", "qcow2", file, size).Run(); err != nil {
-					return err
-				}
-			} else if err != nil {
-				return err
-			}
-			if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(file); err != nil {
+			if err := createEmptyDiskForVolume(volume); err != nil {
 				return err
 			}
 		}
 	}
+	return nil
+}
 
+func createEmptyDiskForVolume(volume v1.Volume) error {
+	if err := os.MkdirAll(EmptyDiskBaseDir, 0777); err != nil {
+		return err
+	}
+	file := FilePathForVolumeName(volume.Name)
+	if exists, err := ephemeraldiskutils.FileExists(file); !exists {
+		// qemu-img takes the size in bytes or in Kibibytes/Mebibytes/...; lets take bytes
+		size := strconv.FormatInt(volume.EmptyDisk.Capacity.ToDec().ScaledValue(0), 10)
+		// #nosec No risk for attacker injection. Parameters are predefined strings
+		if err := exec.Command("qemu-img", "create", "-f", "qcow2", file, size).Run(); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	if err := ephemeraldiskutils.DefaultOwnershipManager.SetFileOwnership(file); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
PR extracts new func `createEmptyDiskForVolume` from `CreateTemporaryDisks` to reduce
congnitive complexity.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
