### PR TITLE
tests: fix flakyness on timezone test

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1434,13 +1434,14 @@ var _ = Describe("Configurations", func() {
 				loc, err := time.LoadLocation(timezone)
 				Expect(err).ToNot(HaveOccurred())
 				now := time.Now().In(loc)
-				plusone := now.Add(time.Minute)
+				nowplus := now.Add(20 * time.Second)
+				nowminus := now.Add(-20 * time.Second)
 				By("Checking hardware clock time")
-				expected := fmt.Sprintf("(%02d:%02d:|%02d:%02d:)", now.Hour(), now.Minute(), plusone.Hour(), plusone.Minute())
+				expected := fmt.Sprintf("(%02d:%02d:|%02d:%02d:|%02d:%02d:)", nowminus.Hour(), nowminus.Minute(), now.Hour(), now.Minute(), nowplus.Hour(), nowplus.Minute())
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "sudo hwclock --localtime \n"},
 					&expect.BExp{R: expected},
-				}, 20)).To(Succeed())
+				}, 20)).To(Succeed(), "Expected the VM time to be within 20 seconds of "+now.String())
 
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
If the test runs at the top of the minute and the time on the node is slightly behind,
hwclock shows the previous minute and the test fails.
Changing from allowing just 1 minute in the future to 20 second both ways.
Also added verbosity to more easily debug this in the future if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
