### PR TITLE
[fix] allow permittedHostDevices to support both upper and lowercase letters in the device ID

### DIFF
--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -103,7 +103,7 @@ func (h *DeviceUtilsHandler) GetDevicePCIID(basepath string, pciAddress string) 
 		if strings.HasPrefix(line, "PCI_ID") {
 			equal := strings.Index(line, "=")
 			value := strings.TrimSpace(line[equal+1:])
-			return value, nil
+			return strings.ToLower(value), nil
 		}
 	}
 	return "", fmt.Errorf("no pci_id is found")

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -126,7 +126,7 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]Contro
 			for _, pciDev := range hostDevs.PciHostDevices {
 				// do not add a device plugin for this resource if it's being provided via an external device plugin
 				if !pciDev.ExternalResourceProvider {
-					supportedPCIDeviceMap[pciDev.PCIVendorSelector] = pciDev.ResourceName
+					supportedPCIDeviceMap[strings.ToLower(pciDev.PCIVendorSelector)] = pciDev.ResourceName
 				}
 			}
 			pciHostDevices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -124,6 +124,10 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]Contro
 		supportedPCIDeviceMap := make(map[string]string)
 		if len(hostDevs.PciHostDevices) != 0 {
 			for _, pciDev := range hostDevs.PciHostDevices {
+				log.Log.V(4).Infof("Permitted PCI device in the cluster, ID: %s, resourceName: %s, externalProvider: %t",
+					strings.ToLower(pciDev.PCIVendorSelector),
+					pciDev.ResourceName,
+					pciDev.ExternalResourceProvider)
 				// do not add a device plugin for this resource if it's being provided via an external device plugin
 				if !pciDev.ExternalResourceProvider {
 					supportedPCIDeviceMap[strings.ToLower(pciDev.PCIVendorSelector)] = pciDev.ResourceName
@@ -132,6 +136,7 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]Contro
 			pciHostDevices := discoverPermittedHostPCIDevices(supportedPCIDeviceMap)
 			for pciID, pciDevices := range pciHostDevices {
 				pciResourceName := supportedPCIDeviceMap[pciID]
+				log.Log.V(4).Infof("Discovered PCI device on the node, ID: %s, resourceName: %s", pciID, pciResourceName)
 				// add a device plugin only for new devices
 				if _, isRunning := c.devicePlugins[pciResourceName]; !isRunning {
 					devicePluginsToRun[pciResourceName] = ControlledDevice{
@@ -146,6 +151,9 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]Contro
 		if len(hostDevs.MediatedDevices) != 0 {
 			supportedMdevsMap := make(map[string]string)
 			for _, supportedMdev := range hostDevs.MediatedDevices {
+				log.Log.V(4).Infof("Permitted mediated device in the cluster, ID: %s, resourceName: %s",
+					supportedMdev.MDEVNameSelector,
+					supportedMdev.ResourceName)
 				// do not add a device plugin for this resource if it's being provided via an external device plugin
 				if !supportedMdev.ExternalResourceProvider {
 					selector := removeSelectorSpaces(supportedMdev.MDEVNameSelector)
@@ -156,6 +164,7 @@ func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]Contro
 			hostMdevs := discoverPermittedHostMediatedDevices(supportedMdevsMap)
 			for mdevTypeName, mdevUUIDs := range hostMdevs {
 				mdevResourceName := supportedMdevsMap[mdevTypeName]
+				log.Log.V(4).Infof("Discovered mediated device on the node, type: %s, resourceName: %s", mdevTypeName, mdevResourceName)
 				// add a device plugin only for new devices
 				if _, isRunning := c.devicePlugins[mdevResourceName]; !isRunning {
 					devicePluginsToRun[mdevResourceName] = ControlledDevice{

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	fakeName       = "example.org/deadbeef"
-	fakeID         = "DEAD:BEEF"
+	fakeID         = "dead:beef"
 	fakeDriver     = "vfio-pci"
 	fakeAddress    = "0000:00:00.0"
 	fakeIommuGroup = "0"


### PR DESCRIPTION
**What this PR does / why we need it**:
permittedHostDevices should support both upper and lowercase letters in the device ID

Fixes # #4925 

```release-note
permittedHostDevices will support both upper and lowercase letters in the device ID
```
