### PR TITLE
automation, Use cluster-sync instead its partial targets

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -200,13 +200,7 @@ set -e
 echo "Nodes are ready:"
 kubectl get nodes
 
-make cluster-build
-
-# I do not have good indication that OKD API server ready to serve requests, so I will just
-# repeat cluster-deploy until it succeeds
-until make cluster-deploy; do
-    sleep 1
-done
+make cluster-sync
 
 hack/dockerized bazel shutdown
 


### PR DESCRIPTION
Use make cluster-sync as this is the official target.
Remove the until, in case the cluster-sync is failed,
we shouldn't mask it with an infinite retry,
nor try forever in case there is a non transient failure,
consuming the resources of the CI.

The reasons it was used are outdated, as we don't have
a OKD provider anymore under kubevirtci.    

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
