### PR TITLE
add event for virt-handler missing

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -476,6 +476,12 @@ spec:
           - update
           - patch
         - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - list
+        - apiGroups:
           - ""
           resources:
           - persistentvolumeclaims

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -378,6 +378,12 @@ rules:
   - update
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - list
+- apiGroups:
   - ""
   resources:
   - persistentvolumeclaims

--- a/pkg/util/lookup/BUILD.bazel
+++ b/pkg/util/lookup/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -11,5 +11,23 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "lookup_suite_test.go",
+        "lookup_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/util/lookup/lookup.go
+++ b/pkg/util/lookup/lookup.go
@@ -31,3 +31,22 @@ func VirtualMachinesOnNode(cli kubecli.KubevirtClient, nodeName string) ([]*virt
 	}
 	return vmis, nil
 }
+
+func ActiveVirtualMachinesOnNode(cli kubecli.KubevirtClient, nodeName string) ([]*virtv1.VirtualMachineInstance, error) {
+	vmis, err := VirtualMachinesOnNode(cli, nodeName)
+	if err != nil {
+		return nil, err
+	}
+
+	activeVMIs := []*virtv1.VirtualMachineInstance{}
+
+	for _, vmi := range vmis {
+		if !vmi.IsRunning() && !vmi.IsScheduled() {
+			continue
+		}
+
+		activeVMIs = append(activeVMIs, vmi)
+	}
+
+	return activeVMIs, nil
+}

--- a/pkg/util/lookup/lookup_suite_test.go
+++ b/pkg/util/lookup/lookup_suite_test.go
@@ -1,0 +1,13 @@
+package lookup
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestOpenapi(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lookup Suite")
+}

--- a/pkg/util/lookup/lookup_test.go
+++ b/pkg/util/lookup/lookup_test.go
@@ -1,0 +1,88 @@
+package lookup
+
+import (
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	virtv1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+)
+
+var createVirtualMachineInstance = func(name, nodeName string, phase virtv1.VirtualMachineInstancePhase) *virtv1.VirtualMachineInstance {
+	return &virtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				virtv1.NodeNameLabel: nodeName,
+			},
+		},
+		Status: virtv1.VirtualMachineInstanceStatus{
+			Phase: phase,
+		},
+	}
+}
+
+var _ = Describe("Lookup", func() {
+
+	var virtClient *kubecli.MockKubevirtClient
+	var vmiInterface *kubecli.MockVirtualMachineInstanceInterface
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+		vmiInterface = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
+
+		virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(vmiInterface).AnyTimes()
+	})
+
+	It("should return vmis", func() {
+		vmi1 := createVirtualMachineInstance("vmi1", "node01", virtv1.Running)
+		vmi2 := createVirtualMachineInstance("vmi2", "node01", virtv1.Failed)
+		vmis := []virtv1.VirtualMachineInstance{*vmi1, *vmi2}
+
+		vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{
+			Items: vmis,
+		}, nil)
+
+		returnedVMIs, err := VirtualMachinesOnNode(virtClient, "node01")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(returnedVMIs)).To(Equal(2))
+	})
+
+	It("should return vmis", func() {
+		vmi1 := createVirtualMachineInstance("vmi1", "node01", virtv1.Running)
+		vmi2 := createVirtualMachineInstance("vmi2", "node01", virtv1.Failed)
+		vmis := []virtv1.VirtualMachineInstance{*vmi1, *vmi2}
+
+		vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{
+			Items: vmis,
+		}, nil)
+
+		returnedVMIs, err := ActiveVirtualMachinesOnNode(virtClient, "node01")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(returnedVMIs)).To(Equal(1))
+		Expect(returnedVMIs[0].Status.Phase).To(Equal(v1.Running))
+	})
+
+	table.DescribeTable("should filter out nonactive vmis", func(phase virtv1.VirtualMachineInstancePhase) {
+		vmi := createVirtualMachineInstance("vmi2", "node01", phase)
+
+		vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{
+			Items: []virtv1.VirtualMachineInstance{*vmi},
+		}, nil)
+
+		vmis, err := ActiveVirtualMachinesOnNode(virtClient, "node01")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vmis).To(BeEmpty())
+	},
+		table.Entry("unprocessed state", virtv1.VmPhaseUnset),
+		table.Entry("pending state", virtv1.Pending),
+		table.Entry("scheduling state", virtv1.Scheduling),
+		table.Entry("failed state", virtv1.Failed),
+		table.Entry("failed state", virtv1.Succeeded),
+	)
+})

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -100,6 +100,7 @@ go_test(
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -194,9 +194,9 @@ func nodeIsSchedulable(node *v1.Node) bool {
 }
 
 func (c *NodeController) checkNodeForOrphanedAndErroredVMIs(nodeName string, node *v1.Node, logger *log.FilteredLogger) error {
-	vmis, err := lookup.VirtualMachinesOnNode(c.clientset, nodeName)
+	vmis, err := lookup.ActiveVirtualMachinesOnNode(c.clientset, nodeName)
 	if err != nil {
-		logger.Reason(err).Error("Failed fetch vmis for node")
+		logger.Reason(err).Error("Failed fetching vmis for node")
 		return err
 	}
 
@@ -409,15 +409,14 @@ func filterStuckVirtualMachinesWithoutPods(vmis []*virtv1.VirtualMachineInstance
 
 	filtered := []*virtv1.VirtualMachineInstance{}
 	for _, vmi := range vmis {
-		if vmi.IsScheduled() || vmi.IsRunning() {
-			if podsForVMI, exists := podsPerNamespace[vmi.Namespace]; exists {
-				if _, exists := podsForVMI[string(vmi.UID)]; exists {
-					continue
-				}
+		if podsForVMI, exists := podsPerNamespace[vmi.Namespace]; exists {
+			if _, exists := podsForVMI[string(vmi.UID)]; exists {
+				continue
 			}
-			filtered = append(filtered, vmi)
 		}
+		filtered = append(filtered, vmi)
 	}
+
 	return filtered
 }
 

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/pborman/uuid"
+	appv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,6 +72,7 @@ var _ = Describe("Node controller with", func() {
 		virtClient.EXPECT().VirtualMachineInstance(v1.NamespaceDefault).Return(vmiInterface).AnyTimes()
 		kubeClient = fake.NewSimpleClientset()
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
+		virtClient.EXPECT().AppsV1().Return(kubeClient.AppsV1()).AnyTimes()
 
 		// Make sure that all unexpected calls to kubeClient will fail
 		kubeClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
@@ -166,15 +168,12 @@ var _ = Describe("Node controller with", func() {
 			vmi := NewRunningVirtualMachine("vmi1", node)
 			vmi.Status.Phase = phase
 
-			addNode(node)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				return true, &k8sv1.PodList{}, nil
 			})
-
-			vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{Items: []virtv1.VirtualMachineInstance{*vmi}}, nil)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any())
 
-			controller.Execute()
+			controller.checkVirtLauncherPodsAndUpdateVMIStatus(node.Name, []*virtv1.VirtualMachineInstance{vmi}, log.DefaultLogger())
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 		},
 			table.Entry("running state", virtv1.Running),
@@ -186,17 +185,11 @@ var _ = Describe("Node controller with", func() {
 			vmi1 := NewRunningVirtualMachine("vmi1", node)
 			vmi2 := NewRunningVirtualMachine("vmi2", node)
 
-			addNode(node)
-			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-				return true, &k8sv1.PodList{}, nil
-			})
-
-			vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{Items: []virtv1.VirtualMachineInstance{*vmi, *vmi1, *vmi2}}, nil)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any()).Times(1)
 			vmiInterface.EXPECT().Patch(vmi1.Name, types.JSONPatchType, gomock.Any()).Return(nil, fmt.Errorf("some error")).Times(1)
 			vmiInterface.EXPECT().Patch(vmi2.Name, types.JSONPatchType, gomock.Any()).Times(1)
 
-			controller.Execute()
+			controller.updateVMIWithFailedStatus([]*virtv1.VirtualMachineInstance{vmi, vmi1, vmi2}, log.DefaultLogger())
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
@@ -207,6 +200,11 @@ var _ = Describe("Node controller with", func() {
 
 			vmiFeeder.Add(vmi)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				a, _ := action.(testing.ListAction)
+				if strings.Contains(a.GetListRestrictions().Labels.String(), "virt-handler") {
+					return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewVirtHandlerPod(node.Name)}}, nil
+				}
+
 				return true, &k8sv1.PodList{}, nil
 			})
 
@@ -220,15 +218,13 @@ var _ = Describe("Node controller with", func() {
 			node := NewUnhealthyNode("testnode")
 			vmi := NewRunningVirtualMachine("vmi1", node)
 
-			vmiFeeder.Add(vmi)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewUnhealthyStuckTerminatingPodForVirtualMachine("whatever", vmi)}}, nil
 			})
 
-			vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{Items: []virtv1.VirtualMachineInstance{*vmi}}, nil)
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any())
 
-			controller.Execute()
+			controller.checkVirtLauncherPodsAndUpdateVMIStatus("testnode", []*virtv1.VirtualMachineInstance{vmi}, log.DefaultLogger())
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 		})
 		It("should set a vmi without a pod to failed state, triggered by node update", func() {
@@ -238,6 +234,11 @@ var _ = Describe("Node controller with", func() {
 			nodeInformer.GetStore().Add(node)
 			modifyNode(node.DeepCopy())
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				a, _ := action.(testing.ListAction)
+				if strings.Contains(a.GetListRestrictions().Labels.String(), "virt-handler") {
+					return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewVirtHandlerPod(node.Name)}}, nil
+				}
+
 				return true, &k8sv1.PodList{}, nil
 			})
 
@@ -254,6 +255,11 @@ var _ = Describe("Node controller with", func() {
 			nodeInformer.GetStore().Add(node)
 			deleteNode(node.DeepCopy())
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				a, _ := action.(testing.ListAction)
+				if strings.Contains(a.GetListRestrictions().Labels.String(), "virt-handler") {
+					return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewVirtHandlerPod(node.Name)}}, nil
+				}
+
 				return true, &k8sv1.PodList{}, nil
 			})
 
@@ -270,6 +276,11 @@ var _ = Describe("Node controller with", func() {
 			vmiInformer.GetStore().Add(vmi)
 			vmiFeeder.Modify(vmi)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				a, _ := action.(testing.ListAction)
+				if strings.Contains(a.GetListRestrictions().Labels.String(), "virt-handler") {
+					return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewVirtHandlerPod(node.Name)}}, nil
+				}
+
 				return true, &k8sv1.PodList{}, nil
 			})
 
@@ -286,6 +297,11 @@ var _ = Describe("Node controller with", func() {
 			vmiInformer.GetStore().Add(vmi)
 			vmiFeeder.Modify(vmi)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				a, _ := action.(testing.ListAction)
+				if strings.Contains(a.GetListRestrictions().Labels.String(), "virt-handler") {
+					return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewVirtHandlerPod(node.Name)}}, nil
+				}
+
 				return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewUnhealthyPodForVirtualMachine("whatever", vmi)}}, nil
 			})
 
@@ -300,14 +316,11 @@ var _ = Describe("Node controller with", func() {
 			vmi := NewRunningVirtualMachine("vmi1", node)
 			vmi.Status.Phase = phase
 
-			addNode(node)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				return true, &k8sv1.PodList{}, nil
 			})
 
-			vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{Items: []virtv1.VirtualMachineInstance{*vmi}}, nil)
-
-			controller.Execute()
+			controller.checkVirtLauncherPodsAndUpdateVMIStatus(node.Name, []*virtv1.VirtualMachineInstance{vmi}, log.DefaultLogger())
 		},
 			table.Entry("unprocessed state", virtv1.VmPhaseUnset),
 			table.Entry("pending state", virtv1.Pending),
@@ -315,6 +328,7 @@ var _ = Describe("Node controller with", func() {
 			table.Entry("failed state", virtv1.Failed),
 			table.Entry("failed state", virtv1.Succeeded),
 		)
+
 		table.DescribeTable("should ignore a vmi which still has a healthy pod in", func(phase virtv1.VirtualMachineInstancePhase) {
 			node := NewUnhealthyNode("testnode")
 			vmi := NewRunningVirtualMachine("vmi", node)
@@ -322,20 +336,60 @@ var _ = Describe("Node controller with", func() {
 			vmi1 := NewRunningVirtualMachine("vmi1", node)
 			vmi1.Status.Phase = phase
 
-			addNode(node)
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewHealthyPodForVirtualMachine("whatever", vmi1)}}, nil
 			})
 
-			vmiInterface.EXPECT().List(gomock.Any()).Return(&virtv1.VirtualMachineInstanceList{Items: []virtv1.VirtualMachineInstance{*vmi}}, nil)
 			By("checking that only a vmi with a pod gets removed")
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any())
 
-			controller.Execute()
+			controller.checkVirtLauncherPodsAndUpdateVMIStatus(node.Name, []*virtv1.VirtualMachineInstance{vmi}, log.DefaultLogger())
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 		},
 			table.Entry("running state", virtv1.Running),
 			table.Entry("scheduled state", virtv1.Scheduled),
+		)
+	})
+
+	Context("check for orphaned vmis", func() {
+
+		var node *k8sv1.Node
+		var vmi *virtv1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			node = NewHealthyNode("testnode")
+			vmi = NewRunningVirtualMachine("vmi", node)
+		})
+
+		table.DescribeTable("testing orpahned event", func(returnVirtHandler bool, ds *appv1.DaemonSet, hasrunningvmi bool, expectEvent bool) {
+
+			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				if returnVirtHandler {
+					return true, &k8sv1.PodList{Items: []k8sv1.Pod{*NewVirtHandlerPod(node.Name)}}, nil
+				}
+
+				return true, &k8sv1.PodList{}, nil
+			})
+
+			kubeClient.Fake.PrependReactor("list", "daemonsets", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				return true, &appv1.DaemonSetList{Items: []appv1.DaemonSet{*ds}}, nil
+			})
+
+			vmis := []*virtv1.VirtualMachineInstance{}
+			if hasrunningvmi {
+				vmis = []*virtv1.VirtualMachineInstance{vmi}
+			}
+
+			err := controller.createEventIfNodeHasOrphanedVMIs(node, vmis)
+			Expect(err).To(BeNil())
+			if expectEvent {
+				testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
+			}
+		},
+			table.Entry("is not created when no vmis", true, &appv1.DaemonSet{}, false, false),
+			table.Entry("is not created when virt-handler is running", true, &appv1.DaemonSet{}, true, false),
+			table.Entry("is not created when daemonSet is not stable", false, UnHealthVirtHandlerDS(), true, false),
+			table.Entry("is created when virt-handler is missing on node with vmis", false, HealthVirtHandlerDS(), true, true),
 		)
 	})
 
@@ -362,6 +416,39 @@ func NewHealthyNode(nodeName string) *k8sv1.Node {
 	}
 }
 
+func HealthVirtHandlerDS() *appv1.DaemonSet {
+	ds := newVirtHanderDS()
+	ds.Status = appv1.DaemonSetStatus{
+		CurrentNumberScheduled: 1,
+		DesiredNumberScheduled: 1,
+		NumberReady:            1,
+	}
+
+	return ds
+}
+
+func UnHealthVirtHandlerDS() *appv1.DaemonSet {
+	ds := newVirtHanderDS()
+	ds.Status = appv1.DaemonSetStatus{
+		CurrentNumberScheduled: 0,
+		DesiredNumberScheduled: 1,
+		NumberReady:            0,
+	}
+
+	return ds
+}
+
+func newVirtHanderDS() *appv1.DaemonSet {
+	return &appv1.DaemonSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "virt-handler",
+			Labels: map[string]string{
+				"kubevirt.io": "virt-handler",
+			},
+		},
+	}
+}
+
 func NewUnhealthyNode(nodeName string) *k8sv1.Node {
 	node := NewHealthyNode(nodeName)
 	node.Annotations[virtv1.VirtHandlerHeartbeat] = nowAsJSONWithOffset(-10 * time.Minute)
@@ -376,6 +463,20 @@ func nowAsJSONWithOffset(offset time.Duration) string {
 	data, err := json.Marshal(now)
 	Expect(err).ToNot(HaveOccurred())
 	return strings.Trim(string(data), `"`)
+}
+
+func NewVirtHandlerPod(nodeName string) *k8sv1.Pod {
+	return &k8sv1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "virt-handler",
+			Labels: map[string]string{
+				"kubevirt.io": "virt-handler",
+			},
+		},
+		Spec: k8sv1.PodSpec{
+			NodeName: nodeName,
+		},
+	}
 }
 
 func NewRunningVirtualMachine(vmiName string, node *k8sv1.Node) *virtv1.VirtualMachineInstance {

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -122,6 +122,17 @@ func newControllerClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{
+					"apps",
+				},
+				Resources: []string{
+					"daemonsets",
+				},
+				Verbs: []string{
+					"list",
+				},
+			},
+			{
+				APIGroups: []string{
 					"",
 				},
 				Resources: []string{


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

**What this PR does / why we need it**:

This will give insight into the state of the cluster and let the operator know that some of their VMIs are in an orphaned state. They can then choose to shut down the VMIs or rerun the `virt-handler` on the node to migrate the VMIs off the node before re-removing the `virt-handler`. If the user in facts does not want the node running the `virt-handler`. 

This only creates an `event` if a node is running a VMI, the `virt-handler` is missing, and the virt-handler `daemonset` is running as expected and not in a transient state. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Create warning NodeUnresponsive event if a node is running a VMI pod but not a virt-handler pod 
```
