### PR TITLE
docs: Generate manifests after push images

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,7 +15,7 @@ export DOCKER_TAG=mybuild
 Then build the manifests and images:
 
 ```bash
-make && make push
+make && make push && make manifests
 ```
 
 Finally, push the manifests to your cluster:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Just a small update for the `getting-started` guide. After doing `make && make push` I was still having old images deployed in my test cluster. I think it worth to mention in the docs that the manifests should be rebuilt.

Bazel push images creates digest files in

    bazel-bin/push-<image-name>.digest

The SHA sums are taken from those files and if the manifests are not regenerated after pushing they will contain the old sums.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
