### PR TITLE
Allow kubevirt:edit role to get,list kubevirts

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -735,6 +735,13 @@ spec:
         - apiGroups:
           - kubevirt.io
           resources:
+          - kubevirts
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - kubevirt.io
+          resources:
           - virtualmachines
           - virtualmachineinstances
           - virtualmachineinstancepresets

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -637,6 +637,13 @@ rules:
 - apiGroups:
   - kubevirt.io
   resources:
+  - kubevirts
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachines
   - virtualmachineinstances
   - virtualmachineinstancepresets

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -270,6 +270,17 @@ func newEditClusterRole() *rbacv1.ClusterRole {
 					"get", "delete", "create", "update", "patch", "list", "watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"kubevirt.io",
+				},
+				Resources: []string{
+					"kubevirts",
+				},
+				Verbs: []string{
+					"get", "list",
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Kubevirt resource is in category all.
`kubectl get all` fails if the user don't have the permissions to list Kubevirt resource.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4888

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
