### PR TITLE
Fix vmi created with pod masq on calico cannot be accessed

### DIFF
--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -26,6 +26,7 @@ import (
 const (
 	sysctlBase        = "/proc/sys"
 	NetIPv6Forwarding = "net/ipv6/conf/all/forwarding"
+	NetIPv4Forwarding = "net/ipv4/ip_forward"
 	Ipv4ArpIgnoreAll  = "net/ipv4/conf/all/arp_ignore"
 )
 

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -109,6 +109,7 @@ type NetworkHandler interface {
 	IsIpv6Enabled(interfaceName string) (bool, error)
 	IsIpv4Primary() (bool, error)
 	ConfigureIpv6Forwarding() error
+	ConfigureIpv4Forwarding() error
 	ConfigureIpv4ArpIgnore() error
 	IptablesNewChain(proto iptables.Protocol, table, chain string) error
 	IptablesAppendRule(proto iptables.Protocol, table, chain string, rulespec ...string) error
@@ -194,6 +195,11 @@ func (h *NetworkUtilsHandler) ConfigureIpv4ArpIgnore() error {
 
 func (h *NetworkUtilsHandler) ConfigureIpv6Forwarding() error {
 	err := sysctl.New().SetSysctl(sysctl.NetIPv6Forwarding, 1)
+	return err
+}
+
+func (h *NetworkUtilsHandler) ConfigureIpv4Forwarding() error {
+	err := sysctl.New().SetSysctl(sysctl.NetIPv4Forwarding, 1)
 	return err
 }
 

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -265,6 +265,16 @@ func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv6Forwarding() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv6Forwarding")
 }
 
+func (_m *MockNetworkHandler) ConfigureIpv4Forwarding() error {
+	ret := _m.ctrl.Call(_m, "ConfigureIpv4Forwarding")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv4Forwarding() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv4Forwarding")
+}
+
 func (_m *MockNetworkHandler) ConfigureIpv4ArpIgnore() error {
 	ret := _m.ctrl.Call(_m, "ConfigureIpv4ArpIgnore")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -819,6 +819,12 @@ func (b *MasqueradeBindMechanism) preparePodNetworkInterfaces(queueNumber uint32
 	}
 
 	if Handler.HasNatIptables(iptables.ProtocolIPv4) || Handler.NftablesLoad("ipv4-nat") == nil {
+		err = Handler.ConfigureIpv4Forwarding()
+		if err != nil {
+			log.Log.Reason(err).Errorf("failed to configure ipv4 forwarding")
+			return err
+		}
+
 		err = b.createNatRules(iptables.ProtocolIPv4)
 		if err != nil {
 			log.Log.Reason(err).Errorf("failed to create ipv4 nat rules for vm error: %v", err)

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -232,6 +232,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid, mtu).Return(nil)
 		mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
 		// Global nat rules using iptables
+		mockNetwork.EXPECT().ConfigureIpv4Forwarding().Return(nil)
 		mockNetwork.EXPECT().ConfigureIpv6Forwarding().Return(nil)
 		mockNetwork.EXPECT().GetNFTIPString(iptables.ProtocolIPv4).Return("ip").AnyTimes()
 		mockNetwork.EXPECT().GetNFTIPString(iptables.ProtocolIPv6).Return("ip6").AnyTimes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Set up necessary `net.ipv4.ip_forward=1` to use masq in kubevirt pod
drop depends on upstream CNI.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2942 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
