### PR TITLE
Prevent virtctl file double-close on successful upload

### DIFF
--- a/pkg/virtctl/imageupload/imageupload.go
+++ b/pkg/virtctl/imageupload/imageupload.go
@@ -383,7 +383,7 @@ func uploadData(uploadProxyURL, token string, file *os.File, insecure bool) erro
 	reader := bar.NewProxyReader(file)
 
 	client := httpClientCreatorFunc(insecure)
-	req, _ := http.NewRequest("POST", url, reader)
+	req, _ := http.NewRequest("POST", url, ioutil.NopCloser(reader))
 
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("Content-Type", "application/octet-stream")


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

On successful upload, file is closed by http transferWriter via BodyCloser, so we prevent double-close.

**What this PR does / why we need it**:
Solve virtctl "Error when closing file ... file already closed" that shows after successful image upload

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Release note**:
```release-note
Solve virtctl "Error when closing file ... file already closed" that shows after successful image upload
```
