### PR TITLE
Support extracting metadata for transients domains

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -408,6 +408,7 @@ type VirDomain interface {
 	GetJobStats(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error)
 	GetJobInfo() (*libvirt.DomainJobInfo, error)
 	SetTime(secs int64, nsecs uint, flags libvirt.DomainSetTimeFlags) error
+	IsPersistent() (bool, error)
 	AbortJob() error
 	Free() error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Virt-launcher will fail to send a correct domain when the domain is transient. This will corrupt the cache of `virt-handler` and cause bad decisions in the sync loop. This PR ensures we retrieve the correct domain even in a transient state.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1883875
https://bugzilla.redhat.com/show_bug.cgi?id=1886453

**Special notes for your reviewer**:
The root cause for seeing this is the fact that the domain stays transient after migration. Investigating...
**Release note**:
```release-note
Fixing handling of transient domain
```

/cc @vladikr
