### PR TITLE
Remove global var Handler from virt-launcher/virtwrap/network

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -120,8 +120,6 @@ type NetworkHandler interface {
 
 type NetworkUtilsHandler struct{}
 
-var Handler NetworkHandler
-
 func (h *NetworkUtilsHandler) LinkByName(name string) (netlink.Link, error) {
 	return netlink.LinkByName(name)
 }
@@ -486,12 +484,6 @@ func (h *NetworkUtilsHandler) DisableTXOffloadChecksum(ifaceName string) error {
 // Allow mocking for tests
 var DHCPServer = dhcp.SingleClientDHCPServer
 var DHCPv6Server = dhcpv6.SingleClientDHCPv6Server
-
-func initHandler() {
-	if Handler == nil {
-		Handler = &NetworkUtilsHandler{}
-	}
-}
 
 // filter out irrelevant routes
 func filterPodNetworkRoutes(routes []netlink.Route, nic *VIF) (filteredRoutes []netlink.Route) {

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -144,5 +144,5 @@ func isSecondaryMultusNetwork(net v1.Network) bool {
 }
 
 func newpodNIC(cacheFactory cache.InterfaceCacheFactory) podNIC {
-	return &podNICImpl{cacheFactory: cacheFactory, handler: Handler}
+	return &podNICImpl{cacheFactory: cacheFactory, handler: &NetworkUtilsHandler{}}
 }

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -144,5 +144,5 @@ func isSecondaryMultusNetwork(net v1.Network) bool {
 }
 
 func newpodNIC(cacheFactory cache.InterfaceCacheFactory) podNIC {
-	return &podNICImpl{cacheFactory: cacheFactory}
+	return &podNICImpl{cacheFactory: cacheFactory, handler: Handler}
 }

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -62,12 +62,13 @@ func SetupPodNetworkPhase1(vmi *v1.VirtualMachineInstance, pid int, cacheFactory
 	primaryNet := lookupPrimaryNetwork(vmi.Spec.Networks)
 	secondaryNets := filterSecondaryMultusNetworks(vmi.Spec.Networks)
 	podInterfaceNames := mapPodInterfaceNameByNetwork(primaryNet, secondaryNets)
+	handler := &NetworkUtilsHandler{}
 	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		network, ok := networks[iface.Name]
 		if !ok {
 			return fmt.Errorf("failed to find a network %s", iface.Name)
 		}
-		podnic := podNICFactory(cacheFactory)
+		podnic := podNICFactory(handler, cacheFactory)
 		podInterfaceName := podInterfaceNames[network.Name]
 		err := podNIC.PlugPhase1(podnic, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], &network, podInterfaceName, pid)
 		if err != nil {
@@ -82,12 +83,13 @@ func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain, c
 	primaryNet := lookupPrimaryNetwork(vmi.Spec.Networks)
 	secondaryNets := filterSecondaryMultusNetworks(vmi.Spec.Networks)
 	podInterfaceNames := mapPodInterfaceNameByNetwork(primaryNet, secondaryNets)
+	handler := &NetworkUtilsHandler{}
 	for i, iface := range vmi.Spec.Domain.Devices.Interfaces {
 		network, ok := networks[iface.Name]
 		if !ok {
 			return fmt.Errorf("failed to find a network %s", iface.Name)
 		}
-		podnic := podNICFactory(cacheFactory)
+		podnic := podNICFactory(handler, cacheFactory)
 		podInterfaceName := podInterfaceNames[network.Name]
 		err := podNIC.PlugPhase2(podnic, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], &network, domain, podInterfaceName)
 		if err != nil {
@@ -143,6 +145,6 @@ func isSecondaryMultusNetwork(net v1.Network) bool {
 	return net.Multus != nil && !net.Multus.Default
 }
 
-func newpodNIC(cacheFactory cache.InterfaceCacheFactory) podNIC {
-	return &podNICImpl{cacheFactory: cacheFactory, handler: &NetworkUtilsHandler{}}
+func newpodNIC(handler NetworkHandler, cacheFactory cache.InterfaceCacheFactory) podNIC {
+	return &podNICImpl{cacheFactory: cacheFactory, handler: handler}
 }

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Network", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockpodNIC = NewMockpodNIC(ctrl)
 		cacheFactory = fake.NewFakeInMemoryNetworkCacheFactory()
+		podNICFactory = func(handler NetworkHandler, cacheFactory cache.InterfaceCacheFactory) podNIC {
+			return mockpodNIC
+		}
 	})
 	AfterEach(func() {
 		podNICFactory = newpodNIC
@@ -51,9 +54,6 @@ var _ = Describe("Network", func() {
 
 	Context("interface configuration", func() {
 		It("should configure bridged pod networking by default", func() {
-			podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
-				return mockpodNIC
-			}
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 			iface := v1.DefaultBridgeNetworkInterface()
 			defaultNet := v1.DefaultPodNetwork()
@@ -68,9 +68,6 @@ var _ = Describe("Network", func() {
 			Expect(err).To(BeNil())
 		})
 		It("should configure networking with multus", func() {
-			podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
-				return mockpodNIC
-			}
 			const multusInterfaceName = "net1"
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 			iface := v1.DefaultBridgeNetworkInterface()
@@ -87,10 +84,6 @@ var _ = Describe("Network", func() {
 			Expect(err).To(BeNil())
 		})
 		It("should configure networking with multus and a default multus network", func() {
-			podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
-				return mockpodNIC
-			}
-
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 
 			// We plug three multus interfaces in, with the default being second, to ensure the netN

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -171,7 +171,6 @@ func (l *podNICImpl) sortIPsBasedOnPrimaryIP(ipv4, ipv6 string) ([]string, error
 }
 
 func (l *podNICImpl) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, podInterfaceName string, pid int) error {
-	initHandler()
 
 	// There is nothing to plug for SR-IOV devices
 	if iface.SRIOV != nil {
@@ -242,7 +241,6 @@ func ensureDHCP(bindMechanism BindMechanism, podInterfaceName string) error {
 
 func (l *podNICImpl) PlugPhase2(vmi *v1.VirtualMachineInstance, iface *v1.Interface, network *v1.Network, domain *api.Domain, podInterfaceName string) error {
 	precond.MustNotBeNil(domain)
-	initHandler()
 
 	// There is nothing to plug for SR-IOV devices
 	if iface.SRIOV != nil {

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -93,7 +93,6 @@ var _ = Describe("Pod Network", func() {
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockNetwork = NewMockNetworkHandler(ctrl)
-		Handler = mockNetwork
 		podnic = podNICImpl{cacheFactory: cacheFactory, handler: mockNetwork}
 		podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
 			return &podNICImpl{cacheFactory: cacheFactory, handler: mockNetwork}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The virt-launcher network code contains a pair of global elements to
open the door for mocking, a `Handler` variable and a `podNICFactory`,
using global variables is in general bad practice. This change replace
those with structs constructed at the caller making code easier to
follow and to test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is part of the CleanCode initiative.
Depends on https://github.com/kubevirt/kubevirt/pull/5512

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
