### PR TITLE
Support extracting metadata for transients domains

### DIFF
--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Notify", func() {
 				mockDomain.EXPECT().Free()
 				mockDomain.EXPECT().GetName().Return("test", nil).AnyTimes()
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+				mockDomain.EXPECT().IsPersistent().Return(true, nil)
 				mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 
 				eventCallback(mockCon, util.NewDomainFromName("test", "1234"), libvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: event}}, client, deleteNotificationSent, nil, nil, nil)
@@ -168,6 +169,7 @@ var _ = Describe("Notify", func() {
 				mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, -1, nil)
 				mockDomain.EXPECT().GetName().Return("test", nil).AnyTimes()
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+				mockDomain.EXPECT().IsPersistent().Return(true, nil)
 				mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 
 				interfaceStatus := []api.InterfaceStatus{
@@ -204,6 +206,7 @@ var _ = Describe("Notify", func() {
 				mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, -1, nil)
 				mockDomain.EXPECT().GetName().Return("test", nil).AnyTimes()
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+				mockDomain.EXPECT().IsPersistent().Return(true, nil)
 				mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 
 				guestOsName := "TestGuestOS"
@@ -304,6 +307,7 @@ var _ = Describe("Notify", func() {
 			mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(libvirt.DOMAIN_PAUSED_IOERROR), nil)
 			mockDomain.EXPECT().Free()
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+			mockDomain.EXPECT().IsPersistent().Return(true, nil)
 			mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 			mockDomain.EXPECT().GetDiskErrors(uint32(0)).Return(faultDisk, nil)
 

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -471,6 +471,17 @@ func (_mr *_MockVirDomainRecorder) SetTime(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTime", arg0, arg1, arg2)
 }
 
+func (_m *MockVirDomain) IsPersistent() (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsPersistent")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirDomainRecorder) IsPersistent() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsPersistent")
+}
+
 func (_m *MockVirDomain) AbortJob() error {
 	ret := _m.ctrl.Call(_m, "AbortJob")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -409,6 +409,7 @@ type VirDomain interface {
 	GetJobInfo() (*libvirt.DomainJobInfo, error)
 	GetDiskErrors(flags uint32) ([]libvirt.DomainDiskError, error)
 	SetTime(secs int64, nsecs uint, flags libvirt.DomainSetTimeFlags) error
+	IsPersistent() (bool, error)
 	AbortJob() error
 	Free() error
 }

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Manager", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockConn = cli.NewMockConnection(ctrl)
 		mockDomain = cli.NewMockVirDomain(ctrl)
+		mockDomain.EXPECT().IsPersistent().AnyTimes().Return(true, nil)
 	})
 
 	expectIsolationDetectionForVMI := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -30,9 +30,13 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/go-kit/kit/log:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Virt-launcher will fail to send a correct domain when the domain is transient. This will corrupt the cache of `virt-handler` and cause bad decisions in the sync loop. This PR ensures we retrieve the correct domain even in a transient state.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1883875
https://bugzilla.redhat.com/show_bug.cgi?id=1886453

**Special notes for your reviewer**:
The root cause for seeing this is the fact that the domain stays transient after migration. Investigating...
**Release note**:
```release-note
Fixing handling of transient domain
```

/cc @vladikr
