### PR TITLE
Patches generic match

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9242,6 +9242,12 @@
    },
    "v1.CustomizeComponentsPatch": {
     "type": "object",
+    "required": [
+     "resourceName",
+     "resourceType",
+     "patch",
+     "type"
+    ],
     "properties": {
      "patch": {
       "type": "string"

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -226,6 +226,11 @@ spec:
                         type: string
                       type:
                         type: string
+                    required:
+                    - patch
+                    - resourceName
+                    - resourceType
+                    - type
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic

--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -181,7 +181,7 @@ func (c *Customizer) GetPatchesForResource(resourceType, name string) []v1.Custo
 	patches := make([]v1.CustomizeComponentsPatch, 0)
 
 	for _, p := range allPatches {
-		if strings.EqualFold(p.ResourceType, resourceType) && strings.EqualFold(p.ResourceName, name) {
+		if (p.ResourceType == "" || strings.EqualFold(p.ResourceType, resourceType)) && (p.ResourceName == "" || strings.EqualFold(p.ResourceName, name)) {
 			patches = append(patches, p)
 		}
 	}

--- a/pkg/virt-operator/resource/apply/patches.go
+++ b/pkg/virt-operator/resource/apply/patches.go
@@ -181,12 +181,20 @@ func (c *Customizer) GetPatchesForResource(resourceType, name string) []v1.Custo
 	patches := make([]v1.CustomizeComponentsPatch, 0)
 
 	for _, p := range allPatches {
-		if (p.ResourceType == "" || strings.EqualFold(p.ResourceType, resourceType)) && (p.ResourceName == "" || strings.EqualFold(p.ResourceName, name)) {
+		if valueMatchesKey(p.ResourceType, resourceType) && valueMatchesKey(p.ResourceName, name) {
 			patches = append(patches, p)
 		}
 	}
 
 	return patches
+}
+
+func valueMatchesKey(value, key string) bool {
+	if value == "*" {
+		return true
+	}
+
+	return strings.EqualFold(key, value)
 }
 
 func getHash(customizations v1.CustomizeComponents) (string, error) {

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -21,6 +21,7 @@ package apply
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/client-go/log"
@@ -58,7 +59,7 @@ var _ = Describe("Patches", func() {
 					Type:         v1.StrategicMergePatchType,
 				},
 				{
-					ResourceName: "",
+					ResourceName: "*",
 					ResourceType: "Deployment",
 					Patch:        `{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"image-pull"}]}}}}`,
 					Type:         v1.StrategicMergePatchType,
@@ -153,4 +154,16 @@ var _ = Describe("Patches", func() {
 			Expect(h1).To(Equal(h2))
 		})
 	})
+
+	table.DescribeTable("valueMatchesKey", func(value, key string, expected bool) {
+
+		matches := valueMatchesKey(value, key)
+		Expect(matches).To(Equal(expected))
+
+	},
+		table.Entry("should match wildcard", "*", "Deployment", true),
+		table.Entry("should match with different cases", "deployment", "Deployment", true),
+		table.Entry("should not match", "Service", "Deployment", false),
+	)
+
 })

--- a/pkg/virt-operator/resource/apply/patches_test.go
+++ b/pkg/virt-operator/resource/apply/patches_test.go
@@ -57,6 +57,12 @@ var _ = Describe("Patches", func() {
 					Patch:        `{"metadata":{"labels":{"new-key":"added-this-label"}}}`,
 					Type:         v1.StrategicMergePatchType,
 				},
+				{
+					ResourceName: "",
+					ResourceType: "Deployment",
+					Patch:        `{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"image-pull"}]}}}}`,
+					Type:         v1.StrategicMergePatchType,
+				},
 			},
 		})
 
@@ -75,6 +81,7 @@ var _ = Describe("Patches", func() {
 			err := config.GenericApplyPatches(deployments)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(deployment.ObjectMeta.Labels["new-key"]).To(Equal("added-this-label"))
+			Expect(deployment.Spec.Template.Spec.ImagePullSecrets[0].Name).To(Equal("image-pull"))
 
 			err = config.GenericApplyPatches([]string{"string"})
 			Expect(err).To(HaveOccurred())

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -422,6 +422,11 @@ var CRDsValidation map[string]string = map[string]string{
                     type: string
                   type:
                     type: string
+                required:
+                - patch
+                - resourceName
+                - resourceType
+                - type
                 type: object
               type: array
               x-kubernetes-list-type: atomic

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -14556,6 +14556,7 @@ func schema_kubevirtio_client_go_api_v1_CustomizeComponentsPatch(ref common.Refe
 						},
 					},
 				},
+				Required: []string{"resourceName", "resourceType", "patch", "type"},
 			},
 		},
 	}

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1352,10 +1352,10 @@ type CustomizeComponents struct {
 
 // +k8s:openapi-gen=true
 type CustomizeComponentsPatch struct {
-	ResourceName string    `json:"resourceName,omitempty"`
-	ResourceType string    `json:"resourceType,omitempty"`
-	Patch        string    `json:"patch,omitempty"`
-	Type         PatchType `json:"type,omitempty"`
+	ResourceName string    `json:"resourceName"`
+	ResourceType string    `json:"resourceType"`
+	Patch        string    `json:"patch"`
+	Type         PatchType `json:"type"`
 }
 
 type PatchType string

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14411,6 +14411,7 @@ func schema_kubevirtio_client_go_api_v1_CustomizeComponentsPatch(ref common.Refe
 						},
 					},
 				},
+				Required: []string{"resourceName", "resourceType", "patch", "type"},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We should allow users to use a wildcard selector for applying patches on resourceName and resourceType. This is a continuation of an older PR https://github.com/kubevirt/kubevirt/pull/4575

It also changes all fields of a Patch object to be required if a patch is specified. 

A follow up PR to add a validationwebhook for create and update of the KubeVirt CR that does not allow for empty strings is needed. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change customizeComponents.patches such that '*' resourceName or resourceType matches all, all fields of a patch (type, patch, resourceName, resourceType) are now required. 
```
