### PR TITLE
[SonarCloud]: Create constant to avoid string duplication

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -74,6 +74,9 @@ const (
 	defaultTlsKeyFilePath      = "/etc/virt-api/certificates/tls.key"
 	defaultHandlerCertFilePath = "/etc/virt-handler/clientcertificates/tls.crt"
 	defaultHandlerKeyFilePath  = "/etc/virt-handler/clientcertificates/tls.key"
+
+	httpStatusNotFoundMessage   = "Not Found"
+	httpStatusBadRequestMessage = "Bad Request"
 )
 
 type VirtApi interface {
@@ -201,8 +204,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"Restart").
 			Doc("Restart a VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", "")
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, "")
 		restartRouteBuilder.ParameterNamed("body").Required(false)
 		subws.Route(restartRouteBuilder)
 
@@ -212,8 +215,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"Migrate").
 			Doc("Migrate a running VirtualMachine to another node.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("start")).
 			To(subresourceApp.StartVMRequestHandler).
@@ -221,8 +224,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"Start").
 			Doc("Start a VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("stop")).
 			To(subresourceApp.StopVMRequestHandler).
@@ -230,8 +233,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"Stop").
 			Doc("Stop a VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("pause")).
 			To(subresourceApp.PauseVMIRequestHandler).
@@ -239,8 +242,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"Pause").
 			Doc("Pause a VirtualMachineInstance object.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("unpause")).
 			To(subresourceApp.UnpauseVMIRequestHandler). // handles VMIs as well
@@ -248,8 +251,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"Unpause").
 			Doc("Unpause a VirtualMachineInstance object.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR) + rest.SubResourcePath("console")).
 			To(subresourceApp.ConsoleRequestHandler).
@@ -299,8 +302,8 @@ func (app *virtAPIApp) composeSubresources() {
 			Doc("Rename a stopped VirtualMachine object.").
 			Returns(http.StatusOK, "OK", "").
 			Returns(http.StatusAccepted, "Accepted", "").
-			Returns(http.StatusNotFound, "Not Found", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, "").
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.GET(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("userlist")).
 			To(subresourceApp.UserList).
@@ -326,7 +329,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"vmi-addvolume").
 			Doc("Add a volume and disk to a running Virtual Machine Instance").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("removevolume")).
 			To(subresourceApp.VMIRemoveVolumeRequestHandler).
@@ -334,7 +337,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"vmi-removevolume").
 			Doc("Removes a volume and disk from a running Virtual Machine Instance").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("addvolume")).
 			To(subresourceApp.VMAddVolumeRequestHandler).
@@ -342,7 +345,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"vm-addvolume").
 			Doc("Add a volume and disk to a running Virtual Machine.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("removevolume")).
 			To(subresourceApp.VMRemoveVolumeRequestHandler).
@@ -350,7 +353,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"vm-removevolume").
 			Doc("Removes a volume and disk from a running Virtual Machine.").
 			Returns(http.StatusOK, "OK", "").
-			Returns(http.StatusBadRequest, "Bad Request", ""))
+			Returns(http.StatusBadRequest, httpStatusBadRequestMessage, ""))
 
 		// Return empty api resource list.
 		// K8s expects to be able to retrieve a resource list for each aggregated
@@ -429,7 +432,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"getAPISubResources").
 			Doc("Get a KubeVirt API resources").
 			Returns(http.StatusOK, "OK", metav1.APIResourceList{}).
-			Returns(http.StatusNotFound, "Not Found", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, ""))
 
 		restful.Add(subws)
 
@@ -456,7 +459,7 @@ func (app *virtAPIApp) composeSubresources() {
 		Operation("getRootPaths").
 		Doc("Get KubeVirt API root paths").
 		Returns(http.StatusOK, "OK", metav1.RootPaths{}).
-		Returns(http.StatusNotFound, "Not Found", ""))
+		Returns(http.StatusNotFound, httpStatusNotFoundMessage, ""))
 	ws.Route(ws.GET("/healthz").To(healthz.KubeConnectionHealthzFuncFactory(app.clusterConfig)).Doc("Health endpoint"))
 
 	for _, version := range v1.SubresourceGroupVersions {
@@ -469,7 +472,7 @@ func (app *virtAPIApp) composeSubresources() {
 			Operation(version.Version+"GetSubAPIGroup").
 			Doc("Get a KubeVirt API Group").
 			Returns(http.StatusOK, "OK", metav1.APIGroup{}).
-			Returns(http.StatusNotFound, "Not Found", ""))
+			Returns(http.StatusNotFound, httpStatusNotFoundMessage, ""))
 	}
 
 	// K8s needs the ability to query the list of API groups this endpoint supports
@@ -484,7 +487,7 @@ func (app *virtAPIApp) composeSubresources() {
 		Operation("getAPIGroupList").
 		Doc("Get a KubeVirt API GroupList").
 		Returns(http.StatusOK, "OK", metav1.APIGroupList{}).
-		Returns(http.StatusNotFound, "Not Found", ""))
+		Returns(http.StatusNotFound, httpStatusNotFoundMessage, ""))
 
 	once := sync.Once{}
 	var openapispec *spec.Swagger


### PR DESCRIPTION




Signed-off-by: Itamar Holder <iholder@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The strings "Not Found" and "Bad Request" were
duplicated 11 times in api.go, now constants are defined to
avoid duplication.

Discovered by SonarCloud:
tinyurl.com/46q62jcl


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
