### PR TITLE
[SonarCloud]: Create constant to avoid string duplication

### DIFF
--- a/pkg/controller/expectations.go
+++ b/pkg/controller/expectations.go
@@ -175,12 +175,18 @@ func (exp *ControlleeExpectations) isExpired() bool {
 	return clock.RealClock{}.Since(exp.timestamp) > ExpectationsTimeout
 }
 
+func panicWithKeyFuncMsg(err error) {
+	const keyFuncChangedFormat = "KeyFunc was changed, %v"
+
+	panic(fmt.Errorf(keyFuncChangedFormat, err))
+}
+
 // SetExpectations registers new expectations for the given controller. Forgets existing expectations.
 func (r *ControllerExpectations) SetExpectations(controllerKey string, add, del int) {
 	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
 	glog.V(4).Infof("Setting expectations %#v", exp)
 	if err := r.Add(exp); err != nil {
-		panic(fmt.Errorf("KeyFunc was changed, %v", err))
+		panicWithKeyFuncMsg(err)
 	}
 }
 
@@ -326,7 +332,7 @@ func (u *UIDTrackingControllerExpectations) ExpectDeletions(rcKey string, delete
 	}
 	glog.V(4).Infof("Controller %v waiting on deletions for: %+v", rcKey, deletedKeys)
 	if err := u.uidStore.Add(&UIDSet{expectedUIDs, rcKey}); err != nil {
-		panic(fmt.Errorf("KeyFunc was changed, %v", err))
+		panicWithKeyFuncMsg(err)
 	}
 	u.ControllerExpectationsInterface.ExpectDeletions(rcKey, expectedUIDs.Len())
 }
@@ -342,7 +348,7 @@ func (u *UIDTrackingControllerExpectations) AddExpectedDeletion(rcKey string, de
 	expectedUIDs.Insert(deletedKey)
 	glog.V(4).Infof("Controller %v waiting on deletions for: %+v", rcKey, expectedUIDs)
 	if err := u.uidStore.Add(&UIDSet{expectedUIDs, rcKey}); err != nil {
-		panic(fmt.Errorf("KeyFunc was changed, %v", err))
+		panicWithKeyFuncMsg(err)
 	}
 	u.ControllerExpectationsInterface.ExpectDeletions(rcKey, expectedUIDs.Len())
 }


### PR DESCRIPTION
Signed-off-by: Itamar Holder <iholder@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The string "KeyFunc was changed, %v"
was duplicated 3 times in expectations.go, now a constant is defined to
avoid duplication.

Discovered by SonarCloud:
tinyurl.com/4sgtd4br

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
