### PR TITLE
network: simpler factory

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -71,13 +71,6 @@ func getNetworksAndCniNetworks(vmi *v1.VirtualMachineInstance) (map[string]*v1.N
 	return networks, cniNetworks
 }
 
-func networkIsImplementable(network *v1.Network) error {
-	if network.Pod == nil && network.Multus == nil {
-		return fmt.Errorf("Network not implemented")
-	}
-	return nil
-}
-
 func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string]int, ifaceName string) string {
 	if networks[ifaceName].Multus != nil && !networks[ifaceName].Multus.Default {
 		// multus pod interfaces named netX
@@ -93,10 +86,6 @@ func SetupPodNetworkPhase1(vmi *v1.VirtualMachineInstance, pid int, cacheFactory
 		network, ok := networks[iface.Name]
 		if !ok {
 			return fmt.Errorf("failed to find a network %s", iface.Name)
-		}
-		err := networkIsImplementable(network)
-		if err != nil {
-			return err
 		}
 		podnic := podNICFactory(cacheFactory)
 		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)
@@ -114,10 +103,6 @@ func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain, c
 		network, ok := networks[iface.Name]
 		if !ok {
 			return fmt.Errorf("failed to find a network %s", iface.Name)
-		}
-		err := networkIsImplementable(network)
-		if err != nil {
-			return err
 		}
 		podnic := podNICFactory(cacheFactory)
 		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -71,6 +71,13 @@ func getNetworksAndCniNetworks(vmi *v1.VirtualMachineInstance) (map[string]*v1.N
 	return networks, cniNetworks
 }
 
+func networkIsImplementable(network *v1.Network) error {
+	if network.Pod == nil && network.Multus == nil {
+		return fmt.Errorf("Network not implemented")
+	}
+	return nil
+}
+
 func getPodInterfaceName(networks map[string]*v1.Network, cniNetworks map[string]int, ifaceName string) string {
 	if networks[ifaceName].Multus != nil && !networks[ifaceName].Multus.Default {
 		// multus pod interfaces named netX
@@ -86,6 +93,10 @@ func SetupPodNetworkPhase1(vmi *v1.VirtualMachineInstance, pid int, cacheFactory
 		network, ok := networks[iface.Name]
 		if !ok {
 			return fmt.Errorf("failed to find a network %s", iface.Name)
+		}
+		err := networkIsImplementable(network)
+		if err != nil {
+			return err
 		}
 		podnic, err := podNICFactory(network, cacheFactory)
 		if err != nil {
@@ -107,6 +118,10 @@ func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain, c
 		if !ok {
 			return fmt.Errorf("failed to find a network %s", iface.Name)
 		}
+		err := networkIsImplementable(network)
+		if err != nil {
+			return err
+		}
 		podnic, err := podNICFactory(network, cacheFactory)
 		if err != nil {
 			return err
@@ -121,8 +136,5 @@ func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain, c
 }
 
 func newpodNIC(network *v1.Network, cacheFactory cache.InterfaceCacheFactory) (podNIC, error) {
-	if network.Pod != nil || network.Multus != nil {
-		return &podNICImpl{cacheFactory: cacheFactory}, nil
-	}
-	return nil, fmt.Errorf("Network not implemented")
+	return &podNICImpl{cacheFactory: cacheFactory}, nil
 }

--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -98,10 +98,7 @@ func SetupPodNetworkPhase1(vmi *v1.VirtualMachineInstance, pid int, cacheFactory
 		if err != nil {
 			return err
 		}
-		podnic, err := podNICFactory(network, cacheFactory)
-		if err != nil {
-			return err
-		}
+		podnic := podNICFactory(cacheFactory)
 		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)
 		err = podNIC.PlugPhase1(podnic, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], network, podInterfaceName, pid)
 		if err != nil {
@@ -122,10 +119,7 @@ func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain, c
 		if err != nil {
 			return err
 		}
-		podnic, err := podNICFactory(network, cacheFactory)
-		if err != nil {
-			return err
-		}
+		podnic := podNICFactory(cacheFactory)
 		podInterfaceName := getPodInterfaceName(networks, cniNetworks, iface.Name)
 		err = podNIC.PlugPhase2(podnic, vmi, &vmi.Spec.Domain.Devices.Interfaces[i], network, domain, podInterfaceName)
 		if err != nil {
@@ -135,6 +129,6 @@ func SetupPodNetworkPhase2(vmi *v1.VirtualMachineInstance, domain *api.Domain, c
 	return nil
 }
 
-func newpodNIC(network *v1.Network, cacheFactory cache.InterfaceCacheFactory) (podNIC, error) {
-	return &podNICImpl{cacheFactory: cacheFactory}, nil
+func newpodNIC(cacheFactory cache.InterfaceCacheFactory) podNIC {
+	return &podNICImpl{cacheFactory: cacheFactory}
 }

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -51,8 +51,8 @@ var _ = Describe("Network", func() {
 
 	Context("interface configuration", func() {
 		It("should configure bridged pod networking by default", func() {
-			podNICFactory = func(network *v1.Network, cacheFactory cache.InterfaceCacheFactory) (podNIC, error) {
-				return mockpodNIC, nil
+			podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
+				return mockpodNIC
 			}
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 			iface := v1.DefaultBridgeNetworkInterface()
@@ -68,8 +68,8 @@ var _ = Describe("Network", func() {
 			Expect(err).To(BeNil())
 		})
 		It("should configure networking with multus", func() {
-			podNICFactory = func(network *v1.Network, cacheFactory cache.InterfaceCacheFactory) (podNIC, error) {
-				return mockpodNIC, nil
+			podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
+				return mockpodNIC
 			}
 			const multusInterfaceName = "net1"
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
@@ -87,8 +87,8 @@ var _ = Describe("Network", func() {
 			Expect(err).To(BeNil())
 		})
 		It("should configure networking with multus and a default multus network", func() {
-			podNICFactory = func(network *v1.Network, cacheFactory cache.InterfaceCacheFactory) (podNIC, error) {
-				return mockpodNIC, nil
+			podNICFactory = func(cacheFactory cache.InterfaceCacheFactory) podNIC {
+				return mockpodNIC
 			}
 
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")


### PR DESCRIPTION
The network package has a `podNICFactory = newpodNIC` that it mocked by the tests. I wish we could avoid these cumbersome mocking and have cleaner simpler tests. This PR is small step towards that, as it makes the factory function simpler and more focused to doing the one thing it should (creating a new `podNIC` object).

There should be no functional change in this PR.

```release-note
NONE
```
