### PR TITLE
test_id:713: make failure slightly more legible

### DIFF
--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -20,6 +20,7 @@
 package tests_test
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -115,7 +116,11 @@ var _ = Describe("[rfe_id:609]VMIheadless", func() {
 				memDiff := normalComputeContainer.Resources.Requests.Memory()
 				memDiff.Sub(*computeContainer.Resources.Requests.Memory())
 
-				Expect(memDiff.ScaledValue(resource.Mega) > 15).To(BeTrue(), "memory difference between headless and normal should be roughly 16M")
+				Expect(memDiff.ScaledValue(resource.Mega) > 15).To(BeTrue(),
+					fmt.Sprintf("memory difference between headless (%s) and normal (%s) is %dM, but should be roughly 16M",
+						computeContainer.Resources.Requests.Memory(),
+						normalComputeContainer.Resources.Requests.Memory(),
+						memDiff.ScaledValue(resource.Mega)))
 			})
 
 			It("[test_id:738][posneg:negative]should not connect to VNC", func() {


### PR DESCRIPTION
Let the failure text state the numbers which failed comparison.

```release-note
NONE
```
