### PR TITLE
Always set driver cache.

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -323,6 +323,16 @@ func SetOptimalIOMode(disk *api.Disk) error {
 	return nil
 }
 
+func SetDriverCacheAndIO(domain *api.Domain) error {
+	for i := range domain.Spec.Devices.Disks {
+		err := SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
+		if err != nil {
+			return err
+		}
+		SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
+	}
+}
+
 func (n *deviceNamer) getExistingVolumeValue(key string) (string, bool) {
 	if _, ok := n.existingNameMap[key]; ok {
 		return n.existingNameMap[key], true

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -921,6 +921,15 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		return fmt.Errorf("conversion failed: %v", err)
 	}
 
+	// set drivers cache mode
+	for i := range domain.Spec.Devices.Disks {
+		err := converter.SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
+		if err != nil {
+			return err
+		}
+		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
+	}
+
 	dom, err := l.preStartHook(vmi, domain)
 	if err != nil {
 		return fmt.Errorf("pre-start pod-setup failed: %v", err)
@@ -1079,15 +1088,6 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 	// create ServiceAccount disk if exists
 	if err := config.CreateServiceAccountDisk(vmi); err != nil {
 		return domain, fmt.Errorf("creating service account disk failed: %v", err)
-	}
-
-	// set drivers cache mode
-	for i := range domain.Spec.Devices.Disks {
-		err := converter.SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
-		if err != nil {
-			return domain, err
-		}
-		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
 	}
 
 	if err := l.credManager.HandleQemuAgentAccessCredentials(vmi); err != nil {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1304,6 +1304,15 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 		return nil, err
 	}
 
+	// set drivers cache mode
+	for i := range domain.Spec.Devices.Disks {
+		err := converter.SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
+		if err != nil {
+			return nil, err
+		}
+		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
+	}
+
 	// Set defaults which are not coming from the cluster
 	api.NewDefaulter(c.Architecture).SetObjectDefaults_Domain(domain)
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -921,13 +921,9 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		return fmt.Errorf("conversion failed: %v", err)
 	}
 
-	// set drivers cache mode
-	for i := range domain.Spec.Devices.Disks {
-		err := converter.SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
-		if err != nil {
-			return err
-		}
-		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
+	// set drivers cache and IO mode
+	if err := converter.SetDriverCacheAndIO(domain); err != nil {
+		return err
 	}
 
 	dom, err := l.preStartHook(vmi, domain)
@@ -1304,13 +1300,9 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 		return nil, err
 	}
 
-	// set drivers cache mode
-	for i := range domain.Spec.Devices.Disks {
-		err := converter.SetDriverCacheMode(&domain.Spec.Devices.Disks[i])
-		if err != nil {
-			return nil, err
-		}
-		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i])
+	// set drivers cache and IO mode
+	if err := converter.SetDriverCacheAndIO(domain); err != nil {
+		return nil, err
 	}
 
 	// Set defaults which are not coming from the cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Currently _SetDriverCacheMode_ is only called once during _preStartHook_. If the VM fails to start on the first try the driver cache mode will be lost when SyncVMI calls _Convert_v1_VirtualMachine_To_api_Domain_. This PR moves the _SetDriverCacheMode_ call into _Convert_v1_VirtualMachine_To_api_Domain_.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
