### PR TITLE
masquerade, migration: hardcode the bridge MAC addr

### DIFF
--- a/pkg/network/BUILD.bazel
+++ b/pkg/network/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["reserved_macs.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/network/reserved_macs.go
+++ b/pkg/network/reserved_macs.go
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package network
+
+const StaticMasqueradeBridgeMAC = "02:00:00:00:00:00"
+
+func IsReserved(mac string) bool {
+	return mac == StaticMasqueradeBridgeMAC
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/network:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/driver:go_default_library",
         "//pkg/network/errors:go_default_library",
@@ -31,6 +32,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/network:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/cache/fake:go_default_library",
         "//pkg/network/driver:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -47,6 +47,8 @@ const (
 	LibvirtBlockMigrationPort  = 49153
 )
 
+const staticMasqueradeBridgeMAC = "02:00:00:00:00:00"
+
 type BindMechanism interface {
 	discoverPodNetworkInterface() error
 	preparePodNetworkInterface() error
@@ -904,11 +906,16 @@ func (b *MasqueradeBindMechanism) createBridge() error {
 		return err
 	}
 
+	mac, err := net.ParseMAC(staticMasqueradeBridgeMAC)
+	if err != nil {
+		return err
+	}
 	// Create a bridge
 	bridge := &netlink.Bridge{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: b.bridgeInterfaceName,
-			MTU:  int(b.dhcpConfig.Mtu),
+			Name:         b.bridgeInterfaceName,
+			MTU:          int(b.dhcpConfig.Mtu),
+			HardwareAddr: mac,
 		},
 	}
 	err = b.handler.LinkAdd(bridge)

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -32,6 +32,7 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/precond"
+	"kubevirt.io/kubevirt/pkg/network"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/network/errors"
@@ -46,8 +47,6 @@ const (
 	LibvirtDirectMigrationPort = 49152
 	LibvirtBlockMigrationPort  = 49153
 )
-
-const staticMasqueradeBridgeMAC = "02:00:00:00:00:00"
 
 type BindMechanism interface {
 	discoverPodNetworkInterface() error
@@ -906,7 +905,7 @@ func (b *MasqueradeBindMechanism) createBridge() error {
 		return err
 	}
 
-	mac, err := net.ParseMAC(staticMasqueradeBridgeMAC)
+	mac, err := net.ParseMAC(network.StaticMasqueradeBridgeMAC)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -129,10 +129,12 @@ var _ = Describe("Pod Network", func() {
 			},
 		}
 
+		masqueradeBridgeMAC, _ := net.ParseMAC(staticMasqueradeBridgeMAC)
 		masqueradeBridgeTest = &netlink.Bridge{
 			LinkAttrs: netlink.LinkAttrs{
-				Name: api.DefaultBridgeName,
-				MTU:  mtu,
+				Name:         api.DefaultBridgeName,
+				MTU:          mtu,
+				HardwareAddr: masqueradeBridgeMAC,
 			},
 		}
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/kubevirt/pkg/network"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/cache/fake"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
@@ -129,7 +130,7 @@ var _ = Describe("Pod Network", func() {
 			},
 		}
 
-		masqueradeBridgeMAC, _ := net.ParseMAC(staticMasqueradeBridgeMAC)
+		masqueradeBridgeMAC, _ := net.ParseMAC(network.StaticMasqueradeBridgeMAC)
 		masqueradeBridgeTest = &netlink.Bridge{
 			LinkAttrs: netlink.LinkAttrs{
 				Name:         api.DefaultBridgeName,

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -895,14 +895,7 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 
-				Eventually(func() error {
-					err := ping(podIP)
-					if err != nil {
-						return err
-					}
-
-					return nil
-				}, 120*time.Second).Should(Succeed())
+				Expect(ping(podIP)).To(Succeed())
 
 				By("Restarting the vmi")
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Since the bridge MAC address no longer changes, the ARP tables do
not need to stabilize, which preserves connectivity from the
outside world to the guest.
    
This is tested in this commit since the `Eventually` block in the
vmi_networking_test for masquerade binding migration can be safely
removed.

Reserve the hardcoded mac address when masquerade binding is used; as such, throw an error whenever a user attempts to
specify that MAC on a masquerade interface.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4999

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
