### PR TITLE
Fix flaky test: Waiting for vmi

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1551,6 +1551,9 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 						Expect(err).ToNot(HaveOccurred())
 						return pdbs.Items
 					}, 3*time.Second, 500*time.Millisecond).Should(HaveLen(1))
+					By("waiting for VMI")
+					tests.WaitForSuccessfulVMIStartWithTimeout(vmi, 60)
+
 					By("deleting the VMI")
 					Expect(virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 					By("checking that the PDB disappeared")


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubelet has problems deleting the launcher Pod in a situation where Pod is in initialization(init containers specifically) and we mark it for deletion.
`Feb 08 06:15:24 node01 kubelet[3378]: E0208 06:15:24.222370 3378 pod_workers.go:191] Error syncing pod 207ffddd-b100-4160-9e2f-2b3fd5597ed6 ("virt-launcher-testvmi-q8wqk-q4pr5_kubevirt-test-default1(207ffddd-b100-4160-9e2f-2b3fd5597ed6)"), skipping: failed to "StartContainer" for "container-disk-binary" with CreateContainerConfigError: "cannot find volume \"virt-bin-share-dir\" to mount into container \"container-disk-binary\""`
Waiting for VMI ensures that the launcher Pod will be initialized before we delete VM. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4997

**Special notes for your reviewer**:


**Release note**:

```release-note
None
```
