### PR TITLE
Migrate to persistent target domains instead of transient ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ go-build:
 
 gosec:
 	hack/dockerized "GOSEC=${GOSEC} ./hack/gosec.sh"
-	
+
 coverage:
 	hack/dockerized "./hack/coverage.sh ${WHAT}"
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -542,6 +542,37 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 
 			})
+			It("should migrate to a persistent (non-transient) libvirt domain.", func() {
+				vmi := tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskCirros))
+				tests.AddUserData(vmi, "cloud-init", "#!/bin/bash\necho 'hello'\n")
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(libnet.WithIPv6(console.LoginToCirros)(vmi)).To(Succeed())
+
+				// execute a migration, wait for finalized state
+				By(fmt.Sprintf("Starting the Migration"))
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, migrationWaitTime)
+
+				// check VMI, confirm migration state
+				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+
+				// ensure the libvirt domain is persistent
+				persistent, err := tests.LibvirtDomainIsPersistent(virtClient, vmi)
+				Expect(err).ToNot(HaveOccurred(), "Should list libvirt domains successfully")
+				Expect(persistent).To(BeTrue(), "The VMI was not found in the list of libvirt persistent domains")
+
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+
+			})
 		})
 		Context("with auto converge enabled", func() {
 			BeforeEach(func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3158,6 +3158,36 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	return stdout, err
 }
 
+func LibvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
+	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, NamespaceTestDefault)
+	if err != nil {
+		return false, err
+	}
+
+	found := false
+	containerIdx := 0
+	for idx, container := range vmiPod.Spec.Containers {
+		if container.Name == "compute" {
+			containerIdx = idx
+			found = true
+		}
+	}
+	if !found {
+		return false, fmt.Errorf("could not find compute container for pod")
+	}
+
+	stdout, stderr, err := ExecuteCommandOnPodV2(
+		virtClient,
+		vmiPod,
+		vmiPod.Spec.Containers[containerIdx].Name,
+		[]string{"virsh", "--quiet", "list", "--persistent", "--name"},
+	)
+	if err != nil {
+		return false, fmt.Errorf("could not dump libvirt domxml (remotely on pod): %v: %s", err, stderr)
+	}
+	return strings.Contains(stdout, vmi.Namespace+"_"+vmi.Name), nil
+}
+
 func BeforeAll(fn func()) {
 	first := true
 	BeforeEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the libvirt migration target domains persistent, as opposed to transient.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Migrated VMs stay persistent and can therefore survive S3, among other things.
```
