### PR TITLE
tests, Enable watching for vmi errors in case ignoreWarnings is true

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2837,24 +2837,22 @@ func waitForVMIPhase(ctx context.Context, phases []v1.VirtualMachineInstancePhas
 	virtClient, err := kubecli.GetKubevirtClient()
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-	// In case we don't want errors, start an event watcher and  check in parallel if we receive some warnings
-	if ignoreWarnings != true {
-
-		// Fetch the VirtualMachineInstance, to make sure we have a resourceVersion as a starting point for the watch
-		// FIXME: This may start watching too late and we may miss some warnings
-		if vmi.ResourceVersion == "" {
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
-			ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		}
-
-		objectEventWatcher := NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(seconds+2) * time.Second)
-		objectEventWatcher.FailOnWarnings()
-
-		go func() {
-			defer GinkgoRecover()
-			objectEventWatcher.WaitFor(ctx, NormalEvent, v1.Started)
-		}()
+	// Fetch the VirtualMachineInstance, to make sure we have a resourceVersion as a starting point for the watch
+	// FIXME: This may start watching too late and we may miss some warnings
+	if vmi.ResourceVersion == "" {
+		vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	}
+
+	objectEventWatcher := NewObjectEventWatcher(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(seconds+2) * time.Second)
+	if ignoreWarnings != true {
+		objectEventWatcher.FailOnWarnings()
+	}
+
+	go func() {
+		defer GinkgoRecover()
+		objectEventWatcher.WaitFor(ctx, NormalEvent, v1.Started)
+	}()
 
 	timeoutMsg := fmt.Sprintf("Timed out waiting for VMI %s to enter %s phase(s)", vmi.Name, phases)
 	// FIXME the event order is wrong. First the document should be updated


### PR DESCRIPTION
E2e tests use waitForVMI in order to check the vmi is starting.

`waitForVMIPhase` waits that `vmi.Status.Phase` will reach one of the desired phases, according its called arguments.
For example it can be one of the list `v1.Scheduling, v1.Scheduled, v1.Running` in one of its calls.
In case `waitForFail` is false, or if `v1.Failed` is included in the phases list it will assert / return upon `Fail` as well.

While waiting for the phase, it can create a watcher which will listen to VMI events and has two variants:
1. Log VMI warnings events, assert on VMI error events.
2. Assert both on VMI warning events and error events.

In case `ignoreWarnings` is true, it didn't create a watcher at all,
so VMI error events as well were not asserted / logged by the test's watcher.
The VMI might reach any phase, and the info of the error event won't appear in the logs
or as the failure reason, and won't stop the test.
It will appear only on the artifacts events file.

Fix it by always creating the watcher, and setting watcher's
`FailOnWarnings` to be enabled, only in case `ignoreWarnings` is false.
This way VMI error events would always be asserted (as long as the watcher runs).

Benefits:
* Tests will fail faster upon a VMI event error, instead using the whole timeouts and test logic.
* The test will assert and fail upon the first VMI error event, without continuing and failing on obscure trailing errors,
focusing the debugging effort on this error, instead of the surroundings and trailing errors.
* The error event will be shown in the failures report, directly as the reason of the failure, saving precious
time findings it in the scattered artifacts.

In case needed, we can create a method to disable errors as well.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
