### PR TITLE
[Bug-fix]: Migration pod becomes "Evicted" since no ephemeral-storage is requested

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -44,6 +44,8 @@ var mountBaseDir = filepath.Join(util.VirtShareDir, "/container-disks")
 
 type SocketPathGetter func(vmi *v1.VirtualMachineInstance, volumeIndex int) (string, error)
 
+const ephemeralStorageOverheadSize = "50M"
+
 func GetLegacyVolumeMountDirOnHost(vmi *v1.VirtualMachineInstance) string {
 	return filepath.Join(mountBaseDir, string(vmi.UID))
 }
@@ -194,6 +196,7 @@ func generateContainersHelper(vmi *v1.VirtualMachineInstance, podVolumeName stri
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("40M")
+				resources.Requests[kubev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorageOverheadSize)
 			} else {
 				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("100m")
@@ -201,6 +204,7 @@ func generateContainersHelper(vmi *v1.VirtualMachineInstance, podVolumeName stri
 				resources.Requests = make(kubev1.ResourceList)
 				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1M")
+				resources.Requests[kubev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorageOverheadSize)
 			}
 			var args []string
 			var name string

--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -189,22 +189,18 @@ func generateContainersHelper(vmi *v1.VirtualMachineInstance, podVolumeName stri
 			diskContainerName := fmt.Sprintf("volume%s", volume.Name)
 			diskContainerImage := volume.ContainerDisk.Image
 			resources := kubev1.ResourceRequirements{}
+			resources.Limits = make(kubev1.ResourceList)
+			resources.Requests = make(kubev1.ResourceList)
+			resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
+			resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
+			resources.Requests[kubev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorageOverheadSize)
+
 			if vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed() {
-				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("10m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
-				resources.Requests = make(kubev1.ResourceList)
-				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("40M")
-				resources.Requests[kubev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorageOverheadSize)
 			} else {
-				resources.Limits = make(kubev1.ResourceList)
 				resources.Limits[kubev1.ResourceCPU] = resource.MustParse("100m")
-				resources.Limits[kubev1.ResourceMemory] = resource.MustParse("40M")
-				resources.Requests = make(kubev1.ResourceList)
-				resources.Requests[kubev1.ResourceCPU] = resource.MustParse("10m")
 				resources.Requests[kubev1.ResourceMemory] = resource.MustParse("1M")
-				resources.Requests[kubev1.ResourceEphemeralStorage] = resource.MustParse(ephemeralStorageOverheadSize)
 			}
 			var args []string
 			var name string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes the following bug: https://bugzilla.redhat.com/show_bug.cgi?id=1731819

Migration pods became evicted since no they used ephemeral-storage that they didn't request. Therefore this PR adds an ephemeral-storage of small amount (1MB) to both compute and volume-disk containers.

**Special notes for your reviewer**:
Unfortunately I couldn't reproduce the error. I've consulted @vladikr which said it might be very difficult to reproduce the bug locally.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
