### PR TITLE
virt-controller SCC: Allow SYS_RESOURCE capability

### DIFF
--- a/pkg/virt-operator/resource/generate/components/scc.go
+++ b/pkg/virt-operator/resource/generate/components/scc.go
@@ -74,7 +74,7 @@ func NewKubeVirtControllerSCC(namespace string) *secv1.SecurityContextConstraint
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyRunAsAny,
 	}
-	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE"}
+	scc.AllowedCapabilities = []corev1.Capability{"NET_ADMIN", "SYS_NICE", "SYS_RESOURCE"}
 	scc.AllowHostDirVolumePlugin = true
 	scc.AllowHostNetwork = true
 	scc.Users = []string{fmt.Sprintf("system:serviceaccount:%s:kubevirt-controller", namespace)}


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Following PR #4874 


On Openshift, we use SCC's (SecurityContextConstrains) to control which 
capabilities are **allowed** for virt-launcher to run with (but not only for that).

This PR add `SYS_RESOURCE` capability to allowed capabilities on virt-controller SCC.
Since virt-controller SCC is applied on virt-launcher pods, 
this will allow virt-launcher pods to run with this capability when needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable virt-launcher pods to run with SYS_RESOURCE capability when needed on Openshift.
```
