### PR TITLE
Increase mem limit on attachmentPod to prevent OOM

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1256,11 +1256,11 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, 
 					Resources: k8sv1.ResourceRequirements{ //Took the request and limits from containerDisk init container.
 						Limits: map[k8sv1.ResourceName]resource.Quantity{
 							k8sv1.ResourceCPU:    resource.MustParse("100m"),
-							k8sv1.ResourceMemory: resource.MustParse("40M"),
+							k8sv1.ResourceMemory: resource.MustParse("80M"),
 						},
 						Requests: map[k8sv1.ResourceName]resource.Quantity{
 							k8sv1.ResourceCPU:    resource.MustParse("10m"),
-							k8sv1.ResourceMemory: resource.MustParse("1M"),
+							k8sv1.ResourceMemory: resource.MustParse("2M"),
 						},
 					},
 					SecurityContext: &k8sv1.SecurityContext{


### PR DESCRIPTION
Sometimes the attachmentPod would fail to start due to OOM. Increase
the limit to something higher to prevent the OOM during startup.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prevent OOM on attachmentpod startup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
