### PR TITLE
explicitly skip cd-rom drives during migration

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -420,6 +420,10 @@ func getDiskTargetsForMigration(dom cli.VirDomain, vmi *v1.VirtualMachineInstanc
 	}
 	// the name of the volume should match the alias
 	for _, disk := range disks {
+		// explicitly skip cd-rom drives
+		if disk.Device == "cdrom" {
+			continue
+		}
 		if disk.ReadOnly != nil && !migrationVols.isGeneratedVolume(disk.Alias.GetName()) {
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should explicitly skip cdrom drives during migration. Adding a functional tests as well to cover this scenario.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Should address: https://bugzilla.redhat.com/show_bug.cgi?id=1927378

**Release note**:
```release-note
NONE
```
