### PR TITLE
Call networking phase2 setup at dom recreate

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1339,6 +1339,10 @@ func (l *LibvirtDomainManager) SyncVMI(vmi *v1.VirtualMachineInstance, useEmulat
 	// To make sure, that we set the right qemu wrapper arguments,
 	// we update the domain XML whenever a VirtualMachineInstance was already defined but not running
 	if !newDomain && cli.IsDown(domState) {
+		err = network.SetupPodNetworkPhase2(vmi, domain)
+		if err != nil {
+			return nil, fmt.Errorf("preparing the pod network failed: %v", err)
+		}
 		dom, err = l.setDomainSpecWithHooks(vmi, &domain.Spec)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When libvirt fails starting a  domain the domain is created but state
is down then kubevirt will call SyncVMI again and the sidecard hooks
being called, but not the network configuration phase2 setup that
decorate the domxml config with stuff like the tap device and friends.
This change just add the call to phase2 at the proper place.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This has being tested manually with https://github.com/kubevirt/kubevirt/pull/4995 since it's very difficult to create a e2e test for it, I may try to just add at a unit test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
