### PR TITLE
virt-launcher: make nftables as the default

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -26,6 +26,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/onsi/ginkgo/extensions/table"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
@@ -109,6 +112,20 @@ var _ = Describe("Common Methods", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strings.HasPrefix(mac.String(), "02:00:00")).To(BeTrue())
 		})
+	})
+	Context("composeNftablesLoad function", func() {
+		table.DescribeTable("should compose the correct command",
+			func(protocol iptables.Protocol, protocolVersionNum string) {
+				cmd := composeNftablesLoad(protocol)
+				Expect(cmd.Path).To(Equal("nft"))
+				Expect(cmd.Args).To(Equal([]string{
+					"nft",
+					"-f",
+					fmt.Sprintf("/etc/nftables/ipv%s-nat.nft", protocolVersionNum)}))
+			},
+			table.Entry("ipv4", iptables.ProtocolIPv4, "4"),
+			table.Entry("ipv6", iptables.ProtocolIPv6, "6"),
+		)
 	})
 })
 

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -255,24 +255,14 @@ func (_mr *_MockNetworkHandlerRecorder) IsIpv4Primary() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsIpv4Primary")
 }
 
-func (_m *MockNetworkHandler) ConfigureIpv6Forwarding() error {
-	ret := _m.ctrl.Call(_m, "ConfigureIpv6Forwarding")
+func (_m *MockNetworkHandler) ConfigureIpForwarding(proto iptables.Protocol) error {
+	ret := _m.ctrl.Call(_m, "ConfigureIpForwarding", proto)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv6Forwarding() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv6Forwarding")
-}
-
-func (_m *MockNetworkHandler) ConfigureIpv4Forwarding() error {
-	ret := _m.ctrl.Call(_m, "ConfigureIpv4Forwarding")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockNetworkHandlerRecorder) ConfigureIpv4Forwarding() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpv4Forwarding")
+func (_mr *_MockNetworkHandlerRecorder) ConfigureIpForwarding(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConfigureIpForwarding", arg0)
 }
 
 func (_m *MockNetworkHandler) ConfigureIpv4ArpIgnore() error {
@@ -335,8 +325,8 @@ func (_mr *_MockNetworkHandlerRecorder) NftablesAppendRule(arg0, arg1, arg2 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NftablesAppendRule", _s...)
 }
 
-func (_m *MockNetworkHandler) NftablesLoad(fnName string) error {
-	ret := _m.ctrl.Call(_m, "NftablesLoad", fnName)
+func (_m *MockNetworkHandler) NftablesLoad(proto iptables.Protocol) error {
+	ret := _m.ctrl.Call(_m, "NftablesLoad", proto)
 	ret0, _ := ret[0].(error)
 	return ret0
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently the default is iptables, and only if iptables are not working we
try to use nft.

Since iptables is deprecated in fedora 32 we need to change the default to
be nft.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher, masquerade binding - prefer nft over iptables.
```
