### PR TITLE
Increase wait timeout for VMI deletion in tests/vmi_configuration_test.go

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1499,7 +1499,7 @@ var _ = Describe("Configurations", func() {
 					return true
 				}
 				return false
-			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+			}, 120*time.Second, 1*time.Second).Should(BeTrue())
 		})
 
 		BeforeEach(func() {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
None of events, virt-laucher logs or kubelet log suggest any issue other than that
the termination of the virt-launcher pod sometimes takes over 60 seconds,
which is the current timeout. 

After running the test in a loop, I got the following times of the virt-launcher deletion:
1) 29.204046882s
2) 22.108061286s
3) 44.314289431s
4) 1m4.375520696s
5) 1m5.409205096s
6) 1m3.500083379s
...

After increasing the timeout to 120s, the test has passed more than 20 times without failure. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5008
Fixes #5005
Fixes #4998

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
