### PR TITLE
tests, Increase default memory of VMIs to 128Mi

### DIFF
--- a/examples/vm-alpine-datavolume.yaml
+++ b/examples/vm-alpine-datavolume.yaml
@@ -37,7 +37,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 128Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - dataVolume:

--- a/examples/vm-alpine-multipvc.yaml
+++ b/examples/vm-alpine-multipvc.yaml
@@ -25,7 +25,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 128Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - name: pvcdisk1

--- a/examples/vm-cirros.yaml
+++ b/examples/vm-cirros.yaml
@@ -25,7 +25,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 128Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vm-priorityclass.yaml
+++ b/examples/vm-priorityclass.yaml
@@ -25,7 +25,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 128Mi
       priorityClassName: non-preemtible
       terminationGracePeriodSeconds: 0
       volumes:

--- a/examples/vmi-block-pvc.yaml
+++ b/examples/vmi-block-pvc.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - name: blockpvcdisk

--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-flavor-small.yaml
+++ b/examples/vmi-flavor-small.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-host-disk.yaml
+++ b/examples/vmi-host-disk.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - hostDisk:

--- a/examples/vmi-migratable.yaml
+++ b/examples/vmi-migratable.yaml
@@ -19,7 +19,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   networks:
   - name: default
     pod: {}

--- a/examples/vmi-nocloud.yaml
+++ b/examples/vmi-nocloud.yaml
@@ -22,7 +22,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/examples/vmi-preset-small.yaml
+++ b/examples/vmi-preset-small.yaml
@@ -10,7 +10,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   selector:
     matchLabels:
       kubevirt.io/vmPreset: vmi-preset-small

--- a/examples/vmi-pvc.yaml
+++ b/examples/vmi-pvc.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - name: pvcdisk

--- a/examples/vmi-replicaset-cirros.yaml
+++ b/examples/vmi-replicaset-cirros.yaml
@@ -23,7 +23,7 @@ spec:
           type: ""
         resources:
           requests:
-            memory: 64M
+            memory: 128Mi
       terminationGracePeriodSeconds: 0
       volumes:
       - containerDisk:

--- a/examples/vmi-sata.yaml
+++ b/examples/vmi-sata.yaml
@@ -16,7 +16,7 @@ spec:
       type: ""
     resources:
       requests:
-        memory: 64M
+        memory: 128Mi
   terminationGracePeriodSeconds: 0
   volumes:
   - containerDisk:

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -75,7 +75,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n", true),
-		WithResourceMemory("64M"),
+		WithResourceMemory("128Mi"),
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)

--- a/tests/restore_test.go
+++ b/tests/restore_test.go
@@ -228,16 +228,16 @@ var _ = Describe("[Serial]VirtualMachineRestore Tests", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					origSpec = vm.Spec.DeepCopy()
-					Expect(origSpec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("64M")))
+					Expect(origSpec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("128Mi")))
 
-					vm.Spec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory] = resource.MustParse("128M")
+					vm.Spec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory] = resource.MustParse("256Mi")
 					updatedVM, err = virtClient.VirtualMachine(vm.Namespace).Update(vm)
 					if errors.IsConflict(err) {
 						return false
 					}
 					vm = updatedVM
 					Expect(err).ToNot(HaveOccurred())
-					Expect(vm.Spec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("128M")))
+					Expect(vm.Spec.Template.Spec.Domain.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("256Mi")))
 					return true
 				}, 180*time.Second, time.Second).Should(BeTrue())
 

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Storage", func() {
 			It("[test_id:3134]should create a writeable emptyDisk with the right capacity", func() {
 
 				// Start the VirtualMachineInstance with the empty disk attached
-				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
+				vmi = tests.NewRandomVMIWithEphemeralDiskAndUserdataHighMemory(cd.ContainerDiskFor(cd.ContainerDiskCirros), "echo hi!")
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 					Name: "emptydisk1",
 					DiskDevice: v1.DiskDevice{

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1917,14 +1917,13 @@ func NewRandomVMIWithNS(namespace string) *v1.VirtualMachineInstance {
 			Masquerade: &v1.InterfaceMasquerade{}}}}}
 
 	vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
 
 	return vmi
 }
 
 func NewRandomVMIWithDataVolume(dataVolumeName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
-
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 
 	diskName := "disk0"
 	bus := "virtio"
@@ -2089,7 +2088,6 @@ func NewRandomMigration(vmiName string, namespace string) *v1.VirtualMachineInst
 func NewRandomVMIWithEphemeralDisk(containerImage string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
 	if containerImage == cd.ContainerDiskFor(cd.ContainerDiskFedora) {
 		vmi.Spec.Domain.Devices.Rng = &v1.Rng{} // newer fedora kernels may require hardware RNG to boot
@@ -2231,7 +2229,7 @@ func NewRandomVMIWithFSFromDataVolume(dataVolumeName string) *v1.VirtualMachineI
 
 func NewRandomVMIWithPVCFS(claimName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+
 	containerImage := cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
 	AddEphemeralDisk(vmi, "disk0", "virtio", containerImage)
 	vmi = AddPVCFS(vmi, "disk1", claimName)
@@ -2342,14 +2340,14 @@ func addCloudInitDiskAndVolume(vmi *v1.VirtualMachineInstance, name string, volu
 
 func NewRandomVMIWithPVC(claimName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+
 	vmi = AddPVCDisk(vmi, "disk0", "virtio", claimName)
 	return vmi
 }
 
 func NewRandomVMIWithPVCAndUserData(claimName, userData string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+
 	vmi = AddPVCDisk(vmi, "disk0", "virtio", claimName)
 	AddUserData(vmi, "disk1", userData)
 	return vmi
@@ -2467,7 +2465,6 @@ func deleteBlockPVAndPVC() {
 func NewRandomVMIWithCDRom(claimName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: "disk0",
 		DiskDevice: v1.DiskDevice{
@@ -2492,7 +2489,6 @@ func NewRandomVMIWithCDRom(claimName string) *v1.VirtualMachineInstance {
 func NewRandomVMIWithEphemeralPVC(claimName string) *v1.VirtualMachineInstance {
 	vmi := NewRandomVMI()
 
-	vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 	vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 		Name: "disk0",
 		DiskDevice: v1.DiskDevice{

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -158,8 +158,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				vmi := tests.NewRandomVMI()
 
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
-
 				diskName := "disk0"
 				bus := "virtio"
 				vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
@@ -204,8 +202,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				}).Should(Not(BeNil()), 30)
 
 				vmi := tests.NewRandomVMI()
-
-				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
 
 				diskName := "disk0"
 				bus := "virtio"

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	k8sv1 "k8s.io/api/core/v1"
 	kubev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -553,8 +554,7 @@ var _ = Describe("Configurations", func() {
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {
 			It("[test_id:1669]should show the requested guest memory inside the VMI", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
-				guestMemory := resource.MustParse("128M")
+				guestMemory := resource.MustParse("256Mi")
 				vmi.Spec.Domain.Memory = &v1.Memory{
 					Guest: &guestMemory,
 				}
@@ -567,7 +567,7 @@ var _ = Describe("Configurations", func() {
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("104")},
+					&expect.BExp{R: console.RetValue("236")},
 				}, 10)).To(Succeed())
 
 			})
@@ -576,9 +576,8 @@ var _ = Describe("Configurations", func() {
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging memory limit from memory request and no guest memory", func() {
 			It("[test_id:3115]should show the memory limit inside the VMI", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
-				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
 				vmi.Spec.Domain.Resources.Limits = kubev1.ResourceList{
-					kubev1.ResourceMemory: resource.MustParse("128M"),
+					kubev1.ResourceMemory: resource.MustParse("256Mi"),
 				}
 				vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -588,7 +587,7 @@ var _ = Describe("Configurations", func() {
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("104")},
+					&expect.BExp{R: console.RetValue("236")},
 				}, 10)).To(Succeed())
 
 			})
@@ -598,7 +597,6 @@ var _ = Describe("Configurations", func() {
 			It("[test_id:755]should show the requested memory different than guest memory", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				guestMemory := resource.MustParse("256Mi")
-				vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64Mi")
 				vmi.Spec.Domain.Resources.OvercommitGuestOverhead = true
 				vmi.Spec.Domain.Memory = &v1.Memory{
 					Guest: &guestMemory,
@@ -613,7 +611,7 @@ var _ = Describe("Configurations", func() {
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 200 ] && echo 'pass'\n"},
 					&expect.BExp{R: console.RetValue("pass")},
-					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=118k\n"},
+					&expect.BSnd{S: "swapoff -a && dd if=/dev/zero of=/dev/shm/test bs=1k count=100k\n"},
 					&expect.BExp{R: console.PromptExpression},
 					&expect.BSnd{S: "echo $?\n"},
 					&expect.BExp{R: console.RetValue("0")},
@@ -665,7 +663,7 @@ var _ = Describe("Configurations", func() {
 
 				// Check on the VM, if the Free memory is roughly what we expected
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 95 ] && echo 'pass'\n"},
+					&expect.BSnd{S: "[ $(free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2) -gt 90 ] && echo 'pass'\n"},
 					&expect.BExp{R: console.RetValue("pass")},
 				}, 15)).To(Succeed())
 			})
@@ -1684,11 +1682,6 @@ var _ = Describe("Configurations", func() {
 
 		It("[test_id:3128]should set CPU request when it is not provided", func() {
 			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-				Requests: kubev1.ResourceList{
-					kubev1.ResourceMemory: resource.MustParse("64M"),
-				},
-			}
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
 			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, tests.NamespaceTestDefault)
@@ -1706,11 +1699,6 @@ var _ = Describe("Configurations", func() {
 			tests.UpdateKubeVirtConfigValueAndWait(config)
 
 			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-				Requests: kubev1.ResourceList{
-					kubev1.ResourceMemory: resource.MustParse("64M"),
-				},
-			}
 			runningVMI := tests.RunVMIAndExpectScheduling(vmi, 30)
 
 			readyPod := libvmi.GetPodByVirtualMachineInstance(runningVMI, tests.NamespaceTestDefault)
@@ -1740,7 +1728,6 @@ var _ = Describe("Configurations", func() {
 			tests.SkipPVCTestIfRunnigOnKindInfra()
 
 			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
 
 			By("adding disks to a VMI")
 			tests.AddEphemeralDisk(vmi, "ephemeral-disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
@@ -1791,7 +1778,6 @@ var _ = Describe("Configurations", func() {
 			tests.SkipPVCTestIfRunnigOnKindInfra()
 
 			vmi := tests.NewRandomVMI()
-			vmi.Spec.Domain.Resources.Requests[kubev1.ResourceMemory] = resource.MustParse("64M")
 
 			By("adding disks to a VMI")
 			// disk[0]:  File, sparsed, no user-input, cache=none
@@ -1998,11 +1984,6 @@ var _ = Describe("Configurations", func() {
 					Cores:                 2,
 					DedicatedCPUPlacement: true,
 				}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
 
 				By("Starting a VirtualMachineInstance")
 				cpuVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
@@ -2123,11 +2104,6 @@ var _ = Describe("Configurations", func() {
 					DedicatedCPUPlacement: true,
 					IsolateEmulatorThread: true,
 				}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
 
 				By("Starting a VirtualMachineInstance")
 				cpuVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
@@ -2189,11 +2165,6 @@ var _ = Describe("Configurations", func() {
 					IsolateEmulatorThread: true,
 				}
 
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
 				By("Starting a VirtualMachineInstance")
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
@@ -2204,12 +2175,8 @@ var _ = Describe("Configurations", func() {
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					DedicatedCPUPlacement: true,
 				}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("2"),
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
+				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
+
 				By("Starting a VirtualMachineInstance")
 				cpuVmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).ToNot(HaveOccurred())
@@ -2232,12 +2199,9 @@ var _ = Describe("Configurations", func() {
 					Cores:                 2,
 					DedicatedCPUPlacement: true,
 				}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("3"),
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
+
+				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("3")
+
 				By("Starting a VirtualMachineInstance")
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
@@ -2247,12 +2211,9 @@ var _ = Describe("Configurations", func() {
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					DedicatedCPUPlacement: true,
 				}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("300m"),
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
+
+				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("300m")
+
 				By("Starting a VirtualMachineInstance")
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(cpuVmi)
 				Expect(err).To(HaveOccurred())
@@ -2262,11 +2223,8 @@ var _ = Describe("Configurations", func() {
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					DedicatedCPUPlacement: true,
 				}
+				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
 				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("2"),
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
 					Limits: kubev1.ResourceList{
 						kubev1.ResourceCPU: resource.MustParse("4"),
 					},
@@ -2281,18 +2239,9 @@ var _ = Describe("Configurations", func() {
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					DedicatedCPUPlacement: true,
 				}
-				cpuVmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("2"),
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
-				Vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-					Requests: kubev1.ResourceList{
-						kubev1.ResourceCPU:    resource.MustParse("1"),
-						kubev1.ResourceMemory: resource.MustParse("64M"),
-					},
-				}
+
+				cpuVmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("2")
+				Vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU] = resource.MustParse("1")
 				Vmi.Spec.NodeSelector = map[string]string{v1.CPUManager: "true"}
 
 				By("Starting a VirtualMachineInstance with dedicated cpus")

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -234,11 +234,6 @@ var _ = Describe("[Serial]IOThreads", func() {
 				DedicatedCPUPlacement: true,
 				IsolateEmulatorThread: true,
 			}
-			vmi.Spec.Domain.Resources = v1.ResourceRequirements{
-				Requests: k8sv1.ResourceList{
-					k8sv1.ResourceMemory: resource.MustParse("64M"),
-				},
-			}
 
 			tests.AddEphemeralDisk(vmi, "disk1", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 			tests.AddEphemeralDisk(vmi, "ded2", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -1062,7 +1062,7 @@ sockfd = None`})
 			var t int64 = 0
 			vmi := v1.NewMinimalVMIWithNS(tests.NamespaceTestDefault, libvmi.RandName(libvmi.DefaultVmiName))
 			vmi.Spec.TerminationGracePeriodSeconds = &t
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
 			tests.AddEphemeralDisk(vmi, "disk0", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)

--- a/tests/vmi_slirp_interface_test.go
+++ b/tests/vmi_slirp_interface_test.go
@@ -165,7 +165,7 @@ var _ = Describe("[Serial]Slirp Networking", func() {
 			var t int64 = 0
 			vmi := v1.NewMinimalVMIWithNS(tests.NamespaceTestDefault, libvmi.RandName(libvmi.DefaultVmiName))
 			vmi.Spec.TerminationGracePeriodSeconds = &t
-			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("64M")
+			vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")
 			tests.AddEphemeralDisk(vmi, "disk0", "virtio", cd.ContainerDiskFor(cd.ContainerDiskCirros))
 
 			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)

--- a/tools/vms-generator/utils/utils.go
+++ b/tools/vms-generator/utils/utils.go
@@ -107,7 +107,7 @@ func getBaseVMISpec() *v1.VirtualMachineInstanceSpec {
 		Domain: v1.DomainSpec{
 			Resources: v1.ResourceRequirements{
 				Requests: k8sv1.ResourceList{
-					k8sv1.ResourceMemory: resource.MustParse("64M"),
+					k8sv1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 			},
 		},
@@ -971,7 +971,7 @@ func GetVMIPresetSmall() *v1.VirtualMachineInstancePreset {
 	vmPreset.Spec.Domain = &v1.DomainSpec{
 		Resources: v1.ResourceRequirements{
 			Requests: k8sv1.ResourceList{
-				k8sv1.ResourceMemory: resource.MustParse("64M"),
+				k8sv1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 		},
 	}


### PR DESCRIPTION
A OOM on Cirros ext4 file system was observed on Issue https://github.com/kubevirt/kubevirt/issues/4902
test_id:3134 which cause test to flake (more details at issue).

Changes of this PR:
* As suggested by Cirros community [1],
increase default VMI memory to be 128Mi
instead of 8Mi or 64Mi in the specific
functions that create VMI template and update
the memory request to 64M.
(affect other VMIs types as well, but only increase memory).
* Use the right notation of Mi instead of M.
* Remove duplicate memory settings in order
to make code lighter.
* The flake of test_id:3134 was detected when there was 64MB memory.
increase it to 512Mi, as it's guaranteed safe
according to the Cirros community.
128Mi might be enough, but Cirros boot tests
use 512Mi, so better be on the safe side.

The job has enough memory for this change,
other machines are already using more than 128Mi so basically this change is safe.

A follow PR [2] updates Cirros to 0.5.0 as a good to have step,
according Community and common sense.
Some changes in this PR are done in order to make the code robust
to both Cirros 0.4.0 (current) and 0.5.0.

[1] https://github.com/cirros-dev/cirros/issues/52#issuecomment-595389740
[2] https://github.com/kubevirt/kubevirt/pull/5055

Fixes: https://github.com/kubevirt/kubevirt/issues/4902

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
