### PR TITLE
Add vim minimal rpm mirror

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6591,6 +6591,7 @@ rpm(
         "https://sjc.edge.kernel.org/fedora-buffet/fedora/linux/updates/32/Everything/x86_64/Packages/v/vim-minimal-8.2.2146-2.fc32.x86_64.rpm",
         "https://mirror.genesisadaptive.com/fedora/updates/32/Everything/x86_64/Packages/v/vim-minimal-8.2.2146-2.fc32.x86_64.rpm",
         "https://mirror.umd.edu/fedora/linux/updates/32/Everything/x86_64/Packages/v/vim-minimal-8.2.2146-2.fc32.x86_64.rpm",
+        "https://img.cs.montana.edu/linux/fedora/updates/32/Everything/x86_64/Packages/v/vim-minimal-8.2.2146-2.fc32.x86_64.rpm",
         "https://storage.googleapis.com/builddeps/1cf36a5d4a96954167ebd75ca34a21b0b6fd00a7935820528b515ab936ee6393",
     ],
 )


### PR DESCRIPTION
All the other mirros currently unreachable.
Sha256sum of the file was checked and matches.

Error example
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5045/pull-kubevirt-e2e-k8s-1.19/1362310306608451584

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
