### PR TITLE
alert users if they have an orphaned vmi for more than an hour

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -33,6 +33,31 @@ tests:
           - exp_annotations:
               summary: "All virt-operator servers are down."
 
+    # vmi running on a node without a virt-handler pod
+  - interval: 1m
+    input_series:
+      - series: 'node_namespace_pod:kube_pod_info:{pod="virt-launcher-vmi", node="node01"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kube_pod_container_status_ready{pod="virt-handler-asdf", node="node01"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'node_namespace_pod:kube_pod_info:{pod="virt-handler-asdf", node="node01"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kube_pod_container_status_ready{pod="virt-handler-asdfg", node="node02"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'node_namespace_pod:kube_pod_info:{pod="virt-handler-asdfg", node="node02"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: OrphanedVirtualMachineImages
+        exp_alerts:
+          - exp_annotations:
+              summary: "No virt-handler pod detected on node node01 with running vmis for more than an hour"
+            exp_labels:
+              node: "node01"
+              pod: "virt-handler-asdf"
+              severity: "warning"
+
   # Some virt controllers are not ready
   - interval: 1m
     input_series:

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -843,6 +843,21 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 							"severity": "warning",
 						},
 					},
+					{
+						Record: "kubevirt_num_virt_handlers_by_node_running_virt_launcher",
+						Expr:   intstr.FromString("count by(node)(node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} ) * on (node) group_left(pod) (1*(kube_pod_container_status_ready{pod=~'virt-handler-.*'} + on (pod) group_left(node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-handler-.*'} ))) or on (node) (0 * node_namespace_pod:kube_pod_info:{pod=~'virt-launcher-.*'} )"),
+					},
+					{
+						Alert: "OrphanedVirtualMachineImages",
+						Expr:  intstr.FromString("(kubevirt_num_virt_handlers_by_node_running_virt_launcher) == 0"),
+						For:   "60m",
+						Annotations: map[string]string{
+							"summary": "No virt-handler pod detected on node {{ $labels.node }} with running vmis for more than an hour",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This is an addition alert for human operators to know if they have orphaned `vmis`. This prom query check to see if there are `vmis` running on a node that there is also a `virt-handler` running on that node, if there is not a `virt-handler` running on the node for more than an hour we alert. This allows for me discoverability into a cluster and is in addition to create an kubernetes event in this same case (https://github.com/kubevirt/kubevirt/pull/4952)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://bugzilla.redhat.com/show_bug.cgi?id=1868099

**Special notes for your reviewer**:

**Release note**:
```release-note
Fire Prometheus Alert when a vmi is orphaned for more than an hour 
```
