### PR TITLE
tests, vmi lifecycle: Do not restore to original kubevirt config

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -744,7 +744,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			AfterEach(func() {
-				tests.RestoreKubeVirtResource()
+				tests.UpdateKubeVirtConfigValueAndWait(tests.KubeVirtDefaultConfig)
 
 				// Wait until virt-handler ds will have expected number of pods
 				Eventually(func() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

The e2e tests are setting specific kubevirt config values on suite
setup and restores the original one on suite teardown.

Test are not expected to restore the original config as that may
randomly cause different tests to run with different kubevirt config and
cause flakiness.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```