### PR TITLE
[tests] Ginkgo test flags to have default values for utility container pull URL

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -51,10 +51,10 @@ var PathToTestingInfrastrucureManifests = ""
 
 func init() {
 	kubecli.Init()
-	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "", "Set the image tag or digest to use")
+	flag.StringVar(&KubeVirtUtilityVersionTag, "utility-container-tag", "latest", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtVersionTag, "container-tag", "latest", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtVersionTagAlt, "container-tag-alt", "", "An alternate tag that can be used to test operator deployments")
-	flag.StringVar(&KubeVirtUtilityRepoPrefix, "utility-container-prefix", "", "Set the repository prefix for all images")
+	flag.StringVar(&KubeVirtUtilityRepoPrefix, "utility-container-prefix", "kubevirt", "Set the repository prefix for all images")
 	flag.StringVar(&KubeVirtRepoPrefix, "container-prefix", "kubevirt", "Set the repository prefix for all images")
 	flag.StringVar(&ImagePrefixAlt, "image-prefix-alt", "", "Optional prefix for virt-* image names for additional imagePrefix operator test")
 	flag.StringVar(&ContainerizedDataImporterNamespace, "cdi-namespace", "cdi", "Set the repository prefix for CDI components")


### PR DESCRIPTION
The naming `Utility container` refers to pre-built container-disk OS images
that are used in the functional tests, as well as the testing infrastructure containers such as
`vmi-killer` or `cdi-http-import-server` etc.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
When constructing the container image URL for container-disk
based VMs the URL depends on utility-container-tag
and utility-container-prefix flags. When these flags don't
have default values, the URL may be broken in case the user
didn't set these flags. Therefore, set the default prefix and tag
to the same as contaner-tag and container-prefix

**Release note**:

```release-note
NONE
```
