### PR TITLE
Cirros, Bump version to 0.5.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,19 +79,17 @@ http_file(
 
 http_file(
     name = "cirros_image",
-    sha256 = "a8dd75ecffd4cdd96072d60c2237b448e0c8b2bc94d57f10fdbc8c481d9005b8",
+    sha256 = "638cc49a994ab6e441949ddd27c0ad9184892e78ce238f9c265c4f6ac1b0f8d3",
     urls = [
-        "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
-        "https://storage.googleapis.com/builddeps/a8dd75ecffd4cdd96072d60c2237b448e0c8b2bc94d57f10fdbc8c481d9005b8",
+        "https://download.cirros-cloud.net/0.5.0/cirros-0.5.0-x86_64-disk.img",
     ],
 )
 
 http_file(
     name = "cirros_image_ppc64le",
-    sha256 = "175063e409f4019acb760478eb1a94819628a1bec9376d26d3aa333449fe061d",
+    sha256 = "8b335bbd38d38929b12a66f99a87ea1c09916ccf8615da5efa29bf6911be1c96",
     urls = [
-        "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-ppc64le-disk.img",
-        "https://storage.googleapis.com/builddeps/175063e409f4019acb760478eb1a94819628a1bec9376d26d3aa333449fe061d",
+        "https://download.cirros-cloud.net/0.5.0/cirros-0.5.0-ppc64le-disk.img",
     ],
 )
 

--- a/docs/devel/storage.md
+++ b/docs/devel/storage.md
@@ -58,7 +58,7 @@ metadata:
   labels:
     app: containerized-data-importer
   annotations:
-    cdi.kubevirt.io/storage.import.endpoint: "https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img"   # Required.  Format: (http||s3)://www.myUrl.com/path/of/data
+    cdi.kubevirt.io/storage.import.endpoint: "https://download.cirros-cloud.net/0.5.0/cirros-0.5.0-x86_64-disk.img"   # Required.  Format: (http||s3)://www.myUrl.com/path/of/data
     cdi.kubevirt.io/storage.import.secretName: "" # Optional.  The name of the secret containing credentials for the data source
 spec:
   accessModes:

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -76,7 +76,7 @@ func NewCirros(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	cirrosOpts := []Option{
 		WithContainerImage(cd.ContainerDiskFor(cd.ContainerDiskCirros)),
 		WithCloudInitNoCloudUserData("#!/bin/bash\necho 'hello'\n", true),
-		WithResourceMemory("128Mi"),
+		WithResourceMemory("512Mi"),
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 	}
 	cirrosOpts = append(cirrosOpts, opts...)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -568,7 +568,7 @@ var _ = Describe("Configurations", func() {
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("236")},
+					&expect.BExp{R: console.RetValue("226")},
 				}, 10)).To(Succeed())
 
 			})
@@ -588,7 +588,7 @@ var _ = Describe("Configurations", func() {
 
 				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 					&expect.BSnd{S: "free -m | grep Mem: | tr -s ' ' | cut -d' ' -f2\n"},
-					&expect.BExp{R: console.RetValue("236")},
+					&expect.BExp{R: console.RetValue("226")},
 				}, 10)).To(Succeed())
 
 			})


### PR DESCRIPTION
Upgrade Cirros to 0.5.0 in order to be aligned to more recent changes.
Adapt needed tests to this change:
Migration with macVtap needs 512Mi in order to migrate faster,
else some ping packets will be received and some doesn't

Note:
Worth to considering updating all tests to 512Mi
as its the guarantee safe according Cirros community and tests,
and also make things faster and more reliable.

Fixes: https://github.com/kubevirt/kubevirt/issues/5040

```release-note
None
```
