### PR TITLE
Bind mech receiver name consistency

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1172,51 +1172,51 @@ type SlirpBindMechanism struct {
 	domain    *api.Domain
 }
 
-func (s *SlirpBindMechanism) discoverPodNetworkInterface() error {
+func (b *SlirpBindMechanism) discoverPodNetworkInterface() error {
 	return nil
 }
 
-func (s *SlirpBindMechanism) preparePodNetworkInterfaces(_ uint32, _ int) error {
+func (b *SlirpBindMechanism) preparePodNetworkInterfaces(_ uint32, _ int) error {
 	return nil
 }
 
-func (s *SlirpBindMechanism) startDHCP() error {
+func (b *SlirpBindMechanism) startDHCP() error {
 	return nil
 }
 
-func (s *SlirpBindMechanism) decorateConfig() error {
+func (b *SlirpBindMechanism) decorateConfig() error {
 	// remove slirp interface from domain spec devices interfaces
 	var foundIfaceModelType string
-	ifaces := s.domain.Spec.Devices.Interfaces
+	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
-		if iface.Alias.GetName() == s.iface.Name {
-			s.domain.Spec.Devices.Interfaces = append(ifaces[:i], ifaces[i+1:]...)
+		if iface.Alias.GetName() == b.iface.Name {
+			b.domain.Spec.Devices.Interfaces = append(ifaces[:i], ifaces[i+1:]...)
 			foundIfaceModelType = iface.Model.Type
 			break
 		}
 	}
 
 	if foundIfaceModelType == "" {
-		return fmt.Errorf("failed to find interface %s in vmi spec", s.iface.Name)
+		return fmt.Errorf("failed to find interface %s in vmi spec", b.iface.Name)
 	}
 
-	qemuArg := fmt.Sprintf("%s,netdev=%s,id=%s", foundIfaceModelType, s.iface.Name, s.iface.Name)
-	if s.iface.MacAddress != "" {
+	qemuArg := fmt.Sprintf("%s,netdev=%s,id=%s", foundIfaceModelType, b.iface.Name, b.iface.Name)
+	if b.iface.MacAddress != "" {
 		// We assume address was already validated in API layer so just pass it to libvirt as-is.
-		qemuArg += fmt.Sprintf(",mac=%s", s.iface.MacAddress)
+		qemuArg += fmt.Sprintf(",mac=%s", b.iface.MacAddress)
 	}
 	// Add interface configuration to qemuArgs
-	s.domain.Spec.QEMUCmd.QEMUArg = append(s.domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: "-device"})
-	s.domain.Spec.QEMUCmd.QEMUArg = append(s.domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: qemuArg})
+	b.domain.Spec.QEMUCmd.QEMUArg = append(b.domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: "-device"})
+	b.domain.Spec.QEMUCmd.QEMUArg = append(b.domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: qemuArg})
 
 	return nil
 }
 
-func (s *SlirpBindMechanism) loadCachedInterface(_, _ string) (bool, error) {
+func (b *SlirpBindMechanism) loadCachedInterface(_, _ string) (bool, error) {
 	return true, nil
 }
 
-func (s *SlirpBindMechanism) loadCachedVIF(_, _ string) (bool, error) {
+func (b *SlirpBindMechanism) loadCachedVIF(_, _ string) (bool, error) {
 	return true, nil
 }
 
@@ -1224,7 +1224,7 @@ func (b *SlirpBindMechanism) setCachedVIF(_, _ string) error {
 	return nil
 }
 
-func (s *SlirpBindMechanism) setCachedInterface(_, _ string) error {
+func (b *SlirpBindMechanism) setCachedInterface(_, _ string) error {
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
PR [0] renamed all the bind mechanisms implementation receivers to
have the same name; however, for whatever reason, slirp was left
out.
    
This commit follows up on that, and also renames slirp receivers
accordingly.

[0] - https://github.com/kubevirt/kubevirt/pull/4856

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
