### PR TITLE
network, macvtap bind mech: add a MAC parameter to the bind mech

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1248,15 +1248,9 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-
 	if b.virtIface.MAC == nil {
 		// Get interface MAC address
-		mac, err := Handler.GetMacDetails(b.podInterfaceName)
-		if err != nil {
-			log.Log.Reason(err).Errorf("failed to get MAC for %s", b.podInterfaceName)
-			return err
-		}
-		b.virtIface.MAC = &api.MAC{MAC: mac.String()}
+		b.virtIface.MAC = &api.MAC{MAC: b.podNicLink.Attrs().HardwareAddr.String()}
 	}
 
 	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1247,13 +1247,7 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-	if b.mac != nil {
-		b.virtIface.MAC = &api.MAC{MAC: b.mac.String()}
-	} else {
-		// Get interface MAC address
-		b.virtIface.MAC = &api.MAC{MAC: b.podNicLink.Attrs().HardwareAddr.String()}
-	}
-
+	b.virtIface.MAC = &api.MAC{MAC: b.podIfaceMAC()}
 	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}
 	b.virtIface.Target = &api.InterfaceTarget{
 		Device:  b.podInterfaceName,
@@ -1261,6 +1255,14 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 	}
 
 	return nil
+}
+
+func (b *MacvtapBindMechanism) podIfaceMAC() string {
+	if b.mac != nil {
+		return b.mac.String()
+	} else {
+		return b.podNicLink.Attrs().HardwareAddr.String()
+	}
 }
 
 func (b *MacvtapBindMechanism) preparePodNetworkInterfaces(_ uint32, _ int) error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -368,7 +368,6 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		return &MacvtapBindMechanism{
 			vmi:              vmi,
 			iface:            iface,
-			virtIface:        &api.Interface{},
 			domain:           domain,
 			podInterfaceName: podInterfaceName,
 			mac:              mac,
@@ -1247,11 +1246,13 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-	b.virtIface.MAC = &api.MAC{MAC: b.podIfaceMAC()}
-	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}
-	b.virtIface.Target = &api.InterfaceTarget{
-		Device:  b.podInterfaceName,
-		Managed: "no",
+	b.virtIface = &api.Interface{
+		MAC: &api.MAC{MAC: b.podIfaceMAC()},
+		MTU: &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)},
+		Target: &api.InterfaceTarget{
+			Device:  b.podInterfaceName,
+			Managed: "no",
+		},
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -364,16 +364,14 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		if err != nil {
 			return nil, err
 		}
-		virtIface := &api.Interface{}
-		if mac != nil {
-			virtIface.MAC = &api.MAC{MAC: mac.String()}
-		}
+
 		return &MacvtapBindMechanism{
 			vmi:              vmi,
 			iface:            iface,
-			virtIface:        virtIface,
+			virtIface:        &api.Interface{},
 			domain:           domain,
 			podInterfaceName: podInterfaceName,
+			mac:              mac,
 			storeFactory:     storeFactory,
 		}, nil
 	}
@@ -1238,6 +1236,7 @@ type MacvtapBindMechanism struct {
 	domain           *api.Domain
 	podInterfaceName string
 	podNicLink       netlink.Link
+	mac              *net.HardwareAddr
 	storeFactory     cache.InterfaceCacheFactory
 }
 
@@ -1248,7 +1247,9 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-	if b.virtIface.MAC == nil {
+	if b.mac != nil {
+		b.virtIface.MAC = &api.MAC{MAC: b.mac.String()}
+	} else {
 		// Get interface MAC address
 		b.virtIface.MAC = &api.MAC{MAC: b.podNicLink.Attrs().HardwareAddr.String()}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This allows us to stop using `virtIface` on the pod networking
setup occurring in virt-handler on follow up PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
