### PR TITLE
Lower virt-handler probe intervals to prevent api server calls

### DIFF
--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -457,7 +457,7 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 	container.VolumeMounts = []corev1.VolumeMount{}
 
 	container.LivenessProbe = &corev1.Probe{
-		FailureThreshold: 8,
+		FailureThreshold: 3,
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Scheme: corev1.URISchemeHTTPS,
@@ -470,6 +470,7 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 		},
 		InitialDelaySeconds: 15,
 		TimeoutSeconds:      10,
+		PeriodSeconds:       45,
 	}
 	container.ReadinessProbe = &corev1.Probe{
 		Handler: corev1.Handler{
@@ -484,6 +485,7 @@ func NewHandlerDaemonSet(namespace string, repository string, imagePrefix string
 		},
 		InitialDelaySeconds: 15,
 		TimeoutSeconds:      10,
+		PeriodSeconds:       20,
 	}
 
 	pod.Volumes = []corev1.Volume{}


### PR DESCRIPTION
Reduces our liveness and readiness probe intervals. By default the probe is called every 10 seconds. With this change we only call liveness every 45 seconds and readiness every 20. Since the probes result in virt-handler verifying connectivity to the api server, we should reduce the probe interval. 

related to #5058 

```release-note
NONE
```
