### PR TITLE
sriov, Fix race condition between LoginToFedora and cloud init

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -323,10 +323,10 @@ container_pull(
 # instead of index.docker.io
 container_pull(
     name = "fedora_sriov_lane",
-    digest = "sha256:2d332d28863d0e415d58e335e836bd4f8a8c714e7a9d1f8f87418ef3db7c0afb",
+    digest = "sha256:bb21f1c4bd7974ef315285ea15d9e09f8a78a808f7d491ce8527d7f5d14c2d0a",
     registry = "quay.io",
-    repository = "kubevirtci/fedora-sriov-testing",
-    #tag = "32",
+    repository = "oshoval/fedora-sriov-lane-container-disk-test",
+    tag = "devel",
 )
 
 # Pull nfs-server image

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -34,30 +34,48 @@ const (
 // NewFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options.
 func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	return newFedora(cd.ContainerDiskFedora, opts...)
+	userData := `#!/bin/bash
+	echo "fedora" | passwd fedora --stdin
+	echo `
+
+	return newFedora(cd.ContainerDiskFedora, userData, opts...)
 }
 
 // NewSriovFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options, the
 // image used include Guest Agent and some moduled needed by SRIOV.
 func NewSriovFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
-	return newFedora(cd.ContainerDiskFedoraSRIOVLane, opts...)
+	userData := `#!/bin/bash
+	setenforce 0
+	echo "fedora" | passwd fedora --stdin`
+
+	userData = addStartGuestAgentUserDataSuffix(userData)
+	return newFedora(cd.ContainerDiskFedoraSRIOVLane, userData, opts...)
+}
+
+// Start Guest agent must be that last operation of UserData.
+// This will allows to wait for Agent connected event and to know
+// that applying UserData is finished, and that a login can proceed.
+func addStartGuestAgentUserDataSuffix(userData string) string {
+	userData += `
+	cp /home/fedora/qemu-guest-agent.service /lib/systemd/system/
+	systemctl daemon-reload
+	systemctl start qemu-guest-agent
+	systemctl enable qemu-guest-agent`
+
+	return userData
 }
 
 // NewFedora instantiates a new Fedora based VMI configuration with specified
 // containerDisk, building its extra properties based on the specified With*
 // options.
-func newFedora(containerDisk cd.ContainerDisk, opts ...Option) *kvirtv1.VirtualMachineInstance {
-	configurePassword := `#!/bin/bash
-	echo "fedora" |passwd fedora --stdin
-	echo `
-
+func newFedora(containerDisk cd.ContainerDisk, userData string, opts ...Option) *kvirtv1.VirtualMachineInstance {
 	fedoraOptions := []Option{
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory("512M"),
 		WithRng(),
 		WithContainerImage(cd.ContainerDiskFor(containerDisk)),
-		WithCloudInitNoCloudUserData(configurePassword, false),
+		WithCloudInitNoCloudUserData(userData, false),
 	}
 	opts = append(fedoraOptions, opts...)
 	return New(RandName(DefaultVmiName), opts...)

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -47,6 +47,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 func NewSriovFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 	userData := `#!/bin/bash
 	setenforce 0
+	rm -f /var/lib/cloud/instance/boot-finished
 	echo "fedora" | passwd fedora --stdin`
 
 	userData = addStartGuestAgentUserDataSuffix(userData)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4363,7 +4363,6 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 }
 
 func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	By("Waiting for guest agent connection")
 	WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceAgentConnected, 12*60)
 }
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2915,9 +2915,10 @@ func WaitUntilVMIReadyWithContext(ctx context.Context, vmi *v1.VirtualMachineIns
 	vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-	// Lets make sure that the OS is up by waiting until we can login
-
-	ExpectWithOffset(1, loginTo(vmi)).To(Succeed())
+	if loginTo != nil {
+		// Lets make sure that the OS is up by waiting until we can login
+		ExpectWithOffset(1, loginTo(vmi)).To(Succeed())
+	}
 	return vmi
 }
 func NewInt32(x int32) *int32 {

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -660,8 +660,11 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			tests.WaitUntilVMIReady(vmi, libnet.WithIPv6(console.LoginToFedora))
+			tests.WaitUntilVMIReady(vmi, nil)
 			tests.WaitAgentConnected(virtClient, vmi)
+			By("Login and configurating VM via console")
+			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+
 			return vmi
 		}
 

--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -45,6 +45,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
@@ -655,6 +656,23 @@ var _ = Describe("[Serial]SRIOV", func() {
 			return vmi
 		}
 
+		checkCloudInitDone := func(vmi *v1.VirtualMachineInstance) error {
+			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+				err := console.RunCommand(vmi, "cat /var/lib/cloud/instance/boot-finished", 2*time.Second)
+				if err != nil {
+					return false, nil
+				}
+
+				return true, nil
+			})
+
+			if err != nil {
+				log.DefaultLogger().Object(vmi).Infof("checkCloudInitDone failed: %v", err)
+				return err
+			}
+			return nil
+		}
+
 		waitVmi := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 			// Need to wait for cloud init to finish and start the agent inside the vmi.
 			vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
@@ -664,6 +682,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			tests.WaitAgentConnected(virtClient, vmi)
 			By("Login and configurating VM via console")
 			Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+			Expect(checkCloudInitDone(vmi)).To(Succeed())
 
 			return vmi
 		}


### PR DESCRIPTION
VM password is set as part of the Cloud-init `UserData`.
End 2 end tests use `LoginToFedora`, which sometimes tries to login before
Cloud-init finished setting the password.
This leads to a race and breaks the sync that the console
expecter expects (the login prompt is not idempotent when it happens).
    
In order to fix the race and keep the code as simple as possible,
this PR does the following:
1. Use a VM without Guest Agent enabled module.
2. Enable the Guest Agent as the last step of Cloud-init.
3. Wait for Guest Agent Connected event - means that the Cloud-init `UserData` is done,
and since the Guest Agent enable was the last thing, it means the password is also set,
because setting the password was part of the Cloud-init `UserData`.
4. Login to Fedora and configure VM upon needs.
5. Wait for Cloud-init done indication.

Image built by
https://github.com/kubevirt/kubevirtci/pull/550

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```