### PR TITLE
Run service clients as non privileged pods

### DIFF
--- a/tests/job.go
+++ b/tests/job.go
@@ -92,7 +92,7 @@ const (
 //                   Make sure to leave enough time for the reporter to collect the logs.
 // timeout: The overall time at which the job is terminated, regardless of it finishing or not.
 func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, timeout int64) *batchv1.Job {
-	pod := RenderPrivilegedPod(name, cmd, args)
+	pod := RenderPod(name, cmd, args)
 	job := batchv1.Job{
 		ObjectMeta: pod.ObjectMeta,
 		Spec: batchv1.JobSpec{

--- a/tests/job.go
+++ b/tests/job.go
@@ -92,7 +92,7 @@ const (
 //                   Make sure to leave enough time for the reporter to collect the logs.
 // timeout: The overall time at which the job is terminated, regardless of it finishing or not.
 func NewJob(name string, cmd, args []string, retry, ttlAfterFinished int32, timeout int64) *batchv1.Job {
-	pod := RenderPod(name, cmd, args)
+	pod := RenderPrivilegedPod(name, cmd, args)
 	job := batchv1.Job{
 		ObjectMeta: pod.ObjectMeta,
 		Spec: batchv1.JobSpec{

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1271,7 +1271,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					podName := fmt.Sprintf("migration-killer-pod-%d", idx)
 
 					// kill the handler right as we detect the qemu target process come online
-					pod := tests.RenderPod(podName, []string{"/bin/bash", "-c"}, []string{fmt.Sprintf("while true; do ps aux | grep \"%s\" && pkill -9 virt-handler && exit 0; done", emulator)})
+					pod := tests.RenderPrivilegedPod(podName, []string{"/bin/bash", "-c"}, []string{fmt.Sprintf("while true; do ps aux | grep \"%s\" && pkill -9 virt-handler && exit 0; done", emulator)})
 
 					pod.Spec.NodeName = entry.Name
 					createdPod, err := virtClient.CoreV1().Pods(tests.NamespaceTestDefault).Create(context.Background(), pod, metav1.CreateOptions{})

--- a/tests/pod_servers.go
+++ b/tests/pod_servers.go
@@ -15,12 +15,12 @@ import (
 
 func NewHTTPServerPod(port int) *corev1.Pod {
 	serverCommand := fmt.Sprintf("nc -klp %d --sh-exec 'echo -e \"HTTP/1.1 200 OK\\nContent-Length: 12\\n\\nHello World!\"'", port)
-	return RenderPod("http-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
+	return RenderPrivilegedPod("http-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
 }
 
 func NewTCPServerPod(port int) *corev1.Pod {
 	serverCommand := fmt.Sprintf("nc -klp %d --sh-exec 'echo \"Hello World!\"'", port)
-	return RenderPod("tcp-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
+	return RenderPrivilegedPod("tcp-hello-world-server", []string{"/bin/bash"}, []string{"-c", serverCommand})
 }
 
 func CreatePodAndWaitUntil(pod *corev1.Pod, phaseToWait corev1.PodPhase) *corev1.Pod {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -2953,7 +2953,7 @@ func NewBool(x bool) *bool {
 	return &x
 }
 
-func RenderPod(name string, cmd []string, args []string) *k8sv1.Pod {
+func RenderPrivilegedPod(name string, cmd []string, args []string) *k8sv1.Pod {
 	pod := k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
@@ -3707,7 +3707,7 @@ func CreateHostDiskImage(diskPath string) *k8sv1.Pod {
 }
 
 func RenderHostPathPod(podName string, dir string, hostPathType k8sv1.HostPathType, mountPropagation k8sv1.MountPropagationMode, cmd []string, args []string) *k8sv1.Pod {
-	pod := RenderPod(podName, cmd, args)
+	pod := RenderPrivilegedPod(podName, cmd, args)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, k8sv1.VolumeMount{
 		Name:             "hostpath-mount",
 		MountPropagation: &mountPropagation,

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1634,7 +1634,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 })
 
 func renderPkillAllPod(processName string) *k8sv1.Pod {
-	return tests.RenderPod("vmi-killer", []string{"pkill"}, []string{"-9", processName})
+	return tests.RenderPrivilegedPod("vmi-killer", []string{"pkill"}, []string{"-9", processName})
 }
 
 func getVirtLauncherLogs(virtCli kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `Job`s being used to encapsulate HTTP / TCP / UDP clients that validate the functionality of Kubevirt's exposed `Service`s
should not be run as privileged pods, or share the host's PID namespace - both of these security options require a particular SCC on Openshift, something which is not being provisioned.

The simplest way out is to provide an option to have both privileged / unprivileged pods and let the developers choose which to use according to their requirements. 

In this case, the `Job`s do not require to be run as privileged, hence, we can just the `RenderPod` function, which creates wraps the `Job` in an unprivileged pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
