### PR TITLE
[release-0.34] Migrate to persistent target domains instead of transient ones

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -26,10 +26,12 @@ package virtwrap
 */
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -302,7 +304,7 @@ func (l *LibvirtDomainManager) setMigrationResultHelper(vmi *v1.VirtualMachineIn
 }
 
 func prepareMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, allowPostyCopy bool) libvirt.DomainMigrateFlags {
-	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER
+	migrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
 	if isBlockMigration {
 		migrateFlags |= libvirt.MIGRATE_NON_SHARED_INC
@@ -403,6 +405,63 @@ func getDiskTargetsForMigration(dom cli.VirDomain, vmi *v1.VirtualMachineInstanc
 	return copyDisks
 }
 
+func domXMLWithoutKubevirtMetadata(dom cli.VirDomain, vmi *v1.VirtualMachineInstance) (string, error) {
+	xmlstr, err := dom.GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE)
+	if err != nil {
+		log.Log.Object(vmi).Reason(err).Error("Live migration failed. Failed to get XML.")
+		return "", err
+	}
+	decoder := xml.NewDecoder(bytes.NewReader([]byte(xmlstr)))
+	var buf bytes.Buffer
+	encoder := xml.NewEncoder(&buf)
+
+	depth := 0
+	inMeta := false
+	inMetaKV := false
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Log.Object(vmi).Errorf("error getting token: %v\n", err)
+			break
+		}
+
+		switch v := token.(type) {
+		case xml.StartElement:
+			if depth == 1 && v.Name.Local == "metadata" {
+				inMeta = true
+			} else if inMeta && depth == 2 && v.Name.Local == "kubevirt" {
+				inMetaKV = true
+			}
+			depth++
+		case xml.EndElement:
+			depth--
+			if inMetaKV && depth == 2 && v.Name.Local == "kubevirt" {
+				inMetaKV = false
+				continue // Skip </kubevirt>
+			}
+			if inMeta && depth == 1 && v.Name.Local == "metadata" {
+				inMeta = false
+			}
+		}
+		if inMetaKV {
+			continue // We're inside metadata/kubevirt, continuing to skip elements
+		}
+
+		if err := encoder.EncodeToken(xml.CopyToken(token)); err != nil {
+			log.Log.Object(vmi).Reason(err)
+		}
+	}
+
+	if err := encoder.Flush(); err != nil {
+		log.Log.Object(vmi).Reason(err)
+	}
+
+	return string(buf.Bytes()), nil
+}
+
 func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) {
 
 	go func(l *LibvirtDomainManager, vmi *v1.VirtualMachineInstance) {
@@ -464,10 +523,18 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 			return
 		}
 
+		xmlstr, err := domXMLWithoutKubevirtMetadata(dom, vmi)
+		if err != nil {
+			log.Log.Object(vmi).Reason(err).Error("Live migration failed. Could not compute target XML.")
+			return
+		}
+
 		params := &libvirt.DomainMigrateParameters{
-			Bandwidth: bandwidth, // MiB/s
-			URI:       migrURI,
-			URISet:    true,
+			Bandwidth:  bandwidth, // MiB/s
+			URI:        migrURI,
+			URISet:     true,
+			DestXML:    xmlstr,
+			DestXMLSet: true,
 		}
 		copyDisks := getDiskTargetsForMigration(dom, vmi)
 		if len(copyDisks) != 0 {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -808,7 +808,7 @@ var _ = Describe("Manager", func() {
 			migrationMode := migrationType == "postCopy"
 
 			flags := prepareMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, migrationMode)
-			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER
+			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
 			if isBlockMigration {
 				expectedMigrateFlags |= libvirt.MIGRATE_NON_SHARED_INC
@@ -1010,6 +1010,56 @@ var _ = Describe("getEnvAddressListByPrefix with vgpu prefix", func() {
 		Expect(addrs[1]).To(Equal("aa618089-8b16-4d01-a136-25a0f3c73124"))
 	})
 
+})
+
+var _ = Describe("domXMLWithoutKubevirtMetadata", func() {
+	var ctrl *gomock.Controller
+	var mockDomain *cli.MockVirDomain
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockDomain = cli.NewMockVirDomain(ctrl)
+	})
+	It("should remove only the kubevirt metadata", func() {
+		domXML := `<domain type="kvm" id="1">
+  <name>kubevirt</name>
+  <metadata>
+    <kubevirt xmlns="http://kubevirt.io">
+      <metadata>
+         <kubevirt>nested</kubevirt>
+      </metadata>
+      <uid>d38cac9c-435b-42d5-960e-06e8d41146e8</uid>
+      <graceperiod>
+        <deletionGracePeriodSeconds>0</deletionGracePeriodSeconds>
+      </graceperiod>
+    </kubevirt>
+    <othermetadata>
+      <kubevirt>
+         <keepme>42</keepme>
+      </kubevirt>
+    </othermetadata>
+  </metadata>
+  <kubevirt>this should stay</kubevirt>
+</domain>`
+		// domXMLWithoutKubevirtMetadata() removes the kubevirt block but not its ident, which is its own token, hence the blank line below
+		expectedXML := `<domain type="kvm" id="1">
+  <name>kubevirt</name>
+  <metadata>
+    
+    <othermetadata>
+      <kubevirt>
+         <keepme>42</keepme>
+      </kubevirt>
+    </othermetadata>
+  </metadata>
+  <kubevirt>this should stay</kubevirt>
+</domain>`
+		mockDomain.EXPECT().Free()
+		vmi := newVMI("testns", "kubevirt")
+		mockDomain.EXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(string(domXML), nil)
+		newXML, err := domXMLWithoutKubevirtMetadata(mockDomain, vmi)
+		Expect(err).To(BeNil())
+		Expect(newXML).To(Equal(expectedXML))
+	})
 })
 
 func newVMI(namespace, name string) *v1.VirtualMachineInstance {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3045,6 +3045,36 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	return stdout, err
 }
 
+func LibvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
+	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, NamespaceTestDefault)
+	if err != nil {
+		return false, err
+	}
+
+	found := false
+	containerIdx := 0
+	for idx, container := range vmiPod.Spec.Containers {
+		if container.Name == "compute" {
+			containerIdx = idx
+			found = true
+		}
+	}
+	if !found {
+		return false, fmt.Errorf("could not find compute container for pod")
+	}
+
+	stdout, stderr, err := ExecuteCommandOnPodV2(
+		virtClient,
+		vmiPod,
+		vmiPod.Spec.Containers[containerIdx].Name,
+		[]string{"virsh", "--quiet", "list", "--persistent", "--name"},
+	)
+	if err != nil {
+		return false, fmt.Errorf("could not dump libvirt domxml (remotely on pod): %v: %s", err, stderr)
+	}
+	return strings.Contains(stdout, vmi.Namespace+"_"+vmi.Name), nil
+}
+
 func BeforeAll(fn func()) {
 	first := true
 	BeforeEach(func() {


### PR DESCRIPTION
This is a manual cherry-pick of #5010

```release-note
Migrated VMs stay persistent and can therefore survive S3, among other things.
```