### PR TITLE
add validationwebhook for KubeVirt.Spec.CustomizeComponents

### DIFF
--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -221,8 +221,10 @@ spec:
                       patch:
                         type: string
                       resourceName:
+                        minLength: 1
                         type: string
                       resourceType:
+                        minLength: 1
                         type: string
                       type:
                         type: string

--- a/pkg/util/webhooks/validating-webhooks/BUILD.bazel
+++ b/pkg/util/webhooks/validating-webhooks/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/util/webhooks:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -2,9 +2,11 @@ package validating_webhooks
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -25,6 +27,32 @@ func NewPassingAdmissionResponse() *v1beta1.AdmissionResponse {
 
 func (*AlwaysPassAdmitter) Admit(*v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	return NewPassingAdmissionResponse()
+}
+
+func NewAdmissionResponse(causes []v1.StatusCause) *v1beta1.AdmissionResponse {
+	if len(causes) == 0 {
+		return NewPassingAdmissionResponse()
+	}
+
+	globalMessage := ""
+	for _, cause := range causes {
+		if globalMessage == "" {
+			globalMessage = cause.Message
+		} else {
+			globalMessage = fmt.Sprintf("%s, %s", globalMessage, cause.Message)
+		}
+	}
+
+	return &v1beta1.AdmissionResponse{
+		Result: &v1.Status{
+			Message: globalMessage,
+			Reason:  v1.StatusReasonInvalid,
+			Code:    http.StatusUnprocessableEntity,
+			Details: &v1.StatusDetails{
+				Causes: causes,
+			},
+		},
+	}
 }
 
 func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -417,8 +417,10 @@ var CRDsValidation map[string]string = map[string]string{
                   patch:
                     type: string
                   resourceName:
+                    minLength: 1
                     type: string
                   resourceType:
+                    minLength: 1
                     type: string
                   type:
                     type: string

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "kubevirt-update-admitter.go",
-        "kubevirt-update-admitter-test.go",
         "webhook.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator/webhooks",
@@ -12,27 +11,24 @@ go_library(
     deps = [
         "//pkg/util/webhooks:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",
-        "//pkg/virt-api/webhooks:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
-        "//vendor/github.com/golang/mock/gomock:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
+        "kubevirt-update-admitter_test.go",
         "webhook_test.go",
         "webhooks_suite_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/virt-api/webhooks:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -42,5 +38,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1415,7 +1415,9 @@ type CustomizeComponents struct {
 
 // +k8s:openapi-gen=true
 type CustomizeComponentsPatch struct {
-	ResourceName string    `json:"resourceName"`
+	// +kubebuilder:validation:MinLength=1
+	ResourceName string `json:"resourceName"`
+	// +kubebuilder:validation:MinLength=1
 	ResourceType string    `json:"resourceType"`
 	Patch        string    `json:"patch"`
 	Type         PatchType `json:"type"`

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -404,7 +404,9 @@ func (CustomizeComponents) SwaggerDoc() map[string]string {
 
 func (CustomizeComponentsPatch) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"": "+k8s:openapi-gen=true",
+		"":             "+k8s:openapi-gen=true",
+		"resourceName": "+kubebuilder:validation:MinLength=1",
+		"resourceType": "+kubebuilder:validation:MinLength=1",
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds validation to KV resources CustomizeComponents object. It lets the user know before applying that empty strings for the `ResourceName` and `ResourceType` are not valid. It will also alert the user if the `patch` that they have provided is not valid json. 

This is a follow up to PR #4984 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add validation to CustomizeComponents object on the KubeVirt resource 
```
