### PR TITLE
docs: host devices: resourceName case consistency

### DIFF
--- a/docs/devel/host-devices-and-device-plugins.md
+++ b/docs/devel/host-devices-and-device-plugins.md
@@ -15,7 +15,7 @@ configuration:
     - pciVendorSelector: "10DE:1EB8"
       resourceName: "nvidia.com/TU104GL_Tesla_T4"
     - pciVendorSelector: "8086:6F54"
-      resourceName: "intel.com/QAT"
+      resourceName: "intel.com/qat"
     mediatedDevices:
     - mdevNameSelector: "GRID T4-1Q"
       resourceName: "nvidia.com/GRID_T4-1Q"


### PR DESCRIPTION
As in https://github.com/kubevirt/user-guide/pull/396, device plugin
resourceName should match the case of deviceName requested by VMs.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

```release-note
NONE
```
/cc @vladikr 