### PR TITLE
Move kubevirt/builder image to quay.io

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -92,7 +92,7 @@ RUN set -x && \
     rm -rf /test-infra && \
     rm -rf /go && mkdir /go
 
-RUN pip3 install --upgrade j2cli operator-courier==1.3.0
+RUN pip3 install --upgrade j2cli operator-courier==2.1.11
 
 ENV SONOBUOY_VERSION=0.19.0
 RUN set -x && \

--- a/hack/builder/build.sh
+++ b/hack/builder/build.sh
@@ -23,6 +23,6 @@ docker create -ti --name dummy-qemu-user-static multiarch/qemu-user-static
 docker cp dummy-qemu-user-static:/usr/bin/qemu-ppc64le-static "${SCRIPT_DIR}/qemu-ppc64le-static"
 
 for ARCH in ${ARCHITECTURES}; do
-    docker build -t "kubevirt/builder:${VERSION}-${ARCH}" --build-arg ARCH="${ARCH}" -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
-    TMP_IMAGES="${TMP_IMAGES} kubevirt/builder:${VERSION}-${ARCH}"
+    docker build -t "quay.io/kubevirt/builder:${VERSION}-${ARCH}" --build-arg ARCH="${ARCH}" -f "${SCRIPT_DIR}/Dockerfile" "${SCRIPT_DIR}"
+    TMP_IMAGES="${TMP_IMAGES} quay.io/kubevirt/builder:${VERSION}-${ARCH}"
 done

--- a/hack/builder/publish.sh
+++ b/hack/builder/publish.sh
@@ -17,10 +17,10 @@ cleanup() {
 cleanup
 
 for ARCH in ${ARCHITECTURES}; do
-    docker push kubevirt/builder:${VERSION}-${ARCH}
-    TMP_IMAGES="${TMP_IMAGES} kubevirt/builder:${VERSION}-${ARCH}"
+    docker push quay.io/kubevirt/builder:${VERSION}-${ARCH}
+    TMP_IMAGES="${TMP_IMAGES} quay.io/kubevirt/builder:${VERSION}-${ARCH}"
 done
 
 export DOCKER_CLI_EXPERIMENTAL=enabled
-docker manifest create --amend kubevirt/builder:${VERSION} ${TMP_IMAGES}
-docker manifest push kubevirt/builder:${VERSION}
+docker manifest create --amend quay.io/kubevirt/builder:${VERSION} ${TMP_IMAGES}
+docker manifest push quay.io/kubevirt/builder:${VERSION}

--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,3 @@
-VERSION=30-9.0.3
+VERSION=31-1.0.0
 # TODO: reenable ppc64le when new builds are available
 ARCHITECTURES="amd64"

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:97dabb62132ce8a0fee5224b50f2f4356e6b44ea9fd6177d0dbe28d3d905cbfd"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder@sha256:dbb1e6205eab79c4fd93fb671fc83acf1125450ee7970f5297a8e8a056eda304"
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Migrates the kubevirt/builder image from Docker Hub to quay.io

This PR also updates the image with `operator-courier 2.1.11` which is needed for some follow up work (WIP) done in https://github.com/kubevirt/kubevirt/pull/5017

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
