### PR TITLE
Add alert for high memory utilization

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -199,7 +199,7 @@ tests:
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 memory utilization is 20 MB close to the limit"
+              description: "Container compute in pod virt-launcher-testvm-123 free memory is less than 20 MB and it is close to memory limit"
               summary: "VM is at risk of being terminated by the runtime."
             exp_labels:
               severity: "warning"

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -185,3 +185,36 @@ tests:
       - eval_time: 5m
         alertname: LowKVMNodesCount
         exp_alerts: []
+
+  # Memory utilization more than 90%
+  - interval: 1m
+    input_series:
+      - series: 'container_spec_memory_limit_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "100 100 100 100 100 100"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "91 91 91 91 91 91"
+
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubevirtVmHighMemoryUsage
+        exp_alerts:
+          - exp_annotations:
+              description: "Container compute in pod virt-launcher-testvm-123 memory utilization is more than 90%"
+              summary: "VM is at risk of being terminated by the runtime."
+            exp_labels:
+              severity: "warning"
+              pod: "virt-launcher-testvm-123"
+              container: "compute"
+
+  # Memory utilization less than 90%
+  - interval: 1m
+    input_series:
+      - series: 'container_spec_memory_limit_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "100 100 100 100 100 100"
+      - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "89 89 89 89 89 89"
+
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubevirtVmHighMemoryUsage
+        exp_alerts: []

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -186,35 +186,35 @@ tests:
         alertname: LowKVMNodesCount
         exp_alerts: []
 
-  # Memory utilization more than 90%
+  # Memory utilization less than 20MB close to limit
   - interval: 1m
     input_series:
-      - series: 'container_spec_memory_limit_bytes{pod="virt-launcher-testvm-123", container="compute"}'
-        values: "100 100 100 100 100 100"
+      - series: 'kube_pod_container_resource_limits_memory_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
-        values: "91 91 91 91 91 91"
+        values: "47185920 48234496 48234496 49283072"
 
     alert_rule_test:
-      - eval_time: 2m
+      - eval_time: 1m
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts:
           - exp_annotations:
-              description: "Container compute in pod virt-launcher-testvm-123 memory utilization is more than 90%"
+              description: "Container compute in pod virt-launcher-testvm-123 memory utilization is 20 MB close to the limit"
               summary: "VM is at risk of being terminated by the runtime."
             exp_labels:
               severity: "warning"
               pod: "virt-launcher-testvm-123"
               container: "compute"
 
-  # Memory utilization less than 90%
-  - interval: 1m
+  # Memory utilization more than 20MB close to limit
+  - interval: 30s
     input_series:
-      - series: 'container_spec_memory_limit_bytes{pod="virt-launcher-testvm-123", container="compute"}'
-        values: "100 100 100 100 100 100"
+      - series: 'kube_pod_container_resource_limits_memory_bytes{pod="virt-launcher-testvm-123", container="compute"}'
+        values: "67108864 67108864 67108864 67108864"
       - series: 'container_memory_working_set_bytes{pod="virt-launcher-testvm-123", container="compute"}'
-        values: "89 89 89 89 89 89"
+        values: "19922944 18874368 18874368 17825792"
 
     alert_rule_test:
-      - eval_time: 2m
+      - eval_time: 1m
         alertname: KubevirtVmHighMemoryUsage
         exp_alerts: []

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -768,10 +768,10 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "KubevirtVmHighMemoryUsage",
-						Expr:  intstr.FromString("(sum(container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'}) by (pod, container) / sum(container_spec_memory_limit_bytes{pod=~'virt-launcher-.*', container='compute'} > 0) by (pod, container) * 100) > 90"),
-						For:   "2m",
+						Expr:  intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_limits_memory_bytes{pod=~'virt-launcher-.*', container='compute'} - on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'}) < 20971520"),
+						For:   "1m",
 						Annotations: map[string]string{
-							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory utilization is more than 90%",
+							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory utilization is 20 MB close to the limit",
 							"summary":     "VM is at risk of being terminated by the runtime.",
 						},
 						Labels: map[string]string{

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -767,8 +767,12 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
+						Record: "kubevirt_vm_container_free_memory_bytes",
+						Expr:   intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_limits_memory_bytes{pod=~'virt-launcher-.*', container='compute'} - on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'})"),
+					},
+					{
 						Alert: "KubevirtVmHighMemoryUsage",
-						Expr:  intstr.FromString("sum by(pod, container) ( kube_pod_container_resource_limits_memory_bytes{pod=~'virt-launcher-.*', container='compute'} - on(pod,container) container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'}) < 20971520"),
+						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes < 20971520"),
 						For:   "1m",
 						Annotations: map[string]string{
 							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory utilization is 20 MB close to the limit",

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -766,6 +766,18 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 							"summary": "More than 80% of the rest calls failed in virt-handler for the last 5 minutes",
 						},
 					},
+					{
+						Alert: "KubevirtVmHighMemoryUsage",
+						Expr:  intstr.FromString("(sum(container_memory_working_set_bytes{pod=~'virt-launcher-.*', container='compute'}) by (pod, container) / sum(container_spec_memory_limit_bytes{pod=~'virt-launcher-.*', container='compute'} > 0) by (pod, container) * 100) > 90"),
+						For:   "2m",
+						Annotations: map[string]string{
+							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory utilization is more than 90%",
+							"summary":     "VM is at risk of being terminated by the runtime.",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -775,7 +775,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Expr:  intstr.FromString("kubevirt_vm_container_free_memory_bytes < 20971520"),
 						For:   "1m",
 						Annotations: map[string]string{
-							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} memory utilization is 20 MB close to the limit",
+							"description": "Container {{ $labels.container }} in pod {{ $labels.pod }} free memory is less than 20 MB and it is close to memory limit",
 							"summary":     "VM is at risk of being terminated by the runtime.",
 						},
 						Labels: map[string]string{


### PR DESCRIPTION
Signed-off-by: Andrey Odarenko <andreyo@il.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR introduces new Prometheus alert that will fire when container that runs a VM is close to it's memory limit and close to a risky state of getting killed by runtime. Alert is firing when memory utilization is 20MB close to the memory limit.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
