### PR TITLE
Move SeaBios debug log to be seen as part of the virt-launcher log

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
-        "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
+        "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/precond:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -50,8 +50,6 @@ import (
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/ignition"
 	"kubevirt.io/kubevirt/pkg/util"
-
-	virtlauncherutil "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
 )
 
 type HostDeviceType string
@@ -67,7 +65,8 @@ const (
 	resolvConf                       = "/etc/resolv.conf"
 )
 const (
-	multiQueueMaxQueues = uint32(256)
+	multiQueueMaxQueues  = uint32(256)
+	QEMUSeaBiosDebugPipe = "/QEMUSeaBiosDebugPipe"
 )
 
 type deviceNamer struct {
@@ -1504,7 +1503,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 		domain.Spec.QEMUCmd.QEMUArg = append(domain.Spec.QEMUCmd.QEMUArg,
 			api.Arg{Value: "-chardev"},
-			api.Arg{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", virtlauncherutil.QEMUSeaBiosDebugPipe)},
+			api.Arg{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", QEMUSeaBiosDebugPipe)},
 			api.Arg{Value: "-device"},
 			api.Arg{Value: "isa-debugcon,iobase=0x402,chardev=firmwarelog"})
 	}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -50,6 +50,8 @@ import (
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	"kubevirt.io/kubevirt/pkg/ignition"
 	"kubevirt.io/kubevirt/pkg/util"
+
+	virtlauncherutil "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
 )
 
 type HostDeviceType string
@@ -1502,7 +1504,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 
 		domain.Spec.QEMUCmd.QEMUArg = append(domain.Spec.QEMUCmd.QEMUArg,
 			api.Arg{Value: "-chardev"},
-			api.Arg{Value: "file,id=firmwarelog,path=/tmp/qemu-firmware.log"},
+			api.Arg{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", virtlauncherutil.QEMUSeaBiosDebugPipe)},
 			api.Arg{Value: "-device"},
 			api.Arg{Value: "isa-debugcon,iobase=0x402,chardev=firmwarelog"})
 	}

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util/hardware:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"os/user"
@@ -19,6 +18,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	libvirt "libvirt.org/libvirt-go"
 
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
+
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/hooks"
@@ -27,7 +28,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )
 
-const QEMUSeaBiosDebugPipe = "/QEMUSeaBiosDebugPipe"
+const QEMUSeaBiosDebugPipe = converter.QEMUSeaBiosDebugPipe
 
 var LifeCycleTranslationMap = map[libvirt.DomainState]api.LifeCycle{
 	libvirt.DOMAIN_NOSTATE:     api.NoState,
@@ -254,119 +255,119 @@ func StartLibvirt(stopChan chan struct{}) {
 	}()
 }
 
-func StartVirtlog(stopChan chan struct{}, domainName string) {
-	go func() {
-		for {
-			var args []string
-			args = append(args, "-f")
-			args = append(args, "/etc/libvirt/virtlogd.conf")
-			// #nosec No risk for attacket injection. Args  are predefined strings
-			cmd := exec.Command("/usr/sbin/virtlogd", args...)
+func startVirtlogdLogging(stopChan chan struct{}, domainName string) {
+	for {
+		cmd := exec.Command("/usr/sbin/virtlogd", "-f", "/etc/libvirt/virtlogd.conf")
 
-			exitChan := make(chan struct{})
+		exitChan := make(chan struct{})
 
-			err := cmd.Start()
+		err := cmd.Start()
+		if err != nil {
+			log.Log.Reason(err).Error("failed to start virtlogd")
+			panic(err)
+		}
+
+		go func() {
+			logfile := fmt.Sprintf("/var/log/libvirt/qemu/%s.log", domainName)
+
+			// It can take a few seconds to the log file to be created
+			for {
+				_, err = os.Stat(logfile)
+				if !os.IsNotExist(err) {
+					break
+				}
+				time.Sleep(time.Second)
+			}
+			// #nosec No risk for path injection. logfile has a static basedir
+			file, err := os.Open(logfile)
 			if err != nil {
-				log.Log.Reason(err).Error("failed to start virtlogd")
-				panic(err)
+				errMsg := fmt.Sprintf("failed to open logfile in path: \"%s\"", logfile)
+				log.Log.Reason(err).Error(errMsg)
+				return
+			}
+			defer util.CloseIOAndCheckErr(file, nil)
+
+			scanner := bufio.NewScanner(file)
+			scanner.Buffer(make([]byte, 1024), 512*1024)
+			for scanner.Scan() {
+				log.LogQemuLogLine(log.Log, scanner.Text())
 			}
 
-			go func() {
-				logfile := fmt.Sprintf("/var/log/libvirt/qemu/%s.log", domainName)
+			if err := scanner.Err(); err != nil {
+				log.Log.Reason(err).Error("failed to read virtlogd logs")
+			}
+		}()
 
-				// It can take a few seconds to the log file to be created
-				for {
-					_, err = os.Stat(logfile)
-					if !os.IsNotExist(err) {
-						break
-					}
-					time.Sleep(time.Second)
-				}
-				// #nosec No risk for path injection. logfile has a static basedir
-				file, err := os.Open(logfile)
-				if err != nil {
-					log.Log.Reason(err).Error("failed to catch virtlogd logs")
-					return
-				}
-				defer util.CloseIOAndCheckErr(file, nil)
+		go func() {
+			defer close(exitChan)
+			_ = cmd.Wait()
+		}()
 
-				scanner := bufio.NewScanner(file)
-				scanner.Buffer(make([]byte, 1024), 512*1024)
-				for scanner.Scan() {
-					log.LogQemuLogLine(log.Log, scanner.Text())
-				}
+		select {
+		case <-stopChan:
+			_ = cmd.Process.Kill()
+			return
+		case <-exitChan:
+			log.Log.Errorf("virtlogd exited, restarting")
+		}
 
-				if err := scanner.Err(); err != nil {
-					log.Log.Reason(err).Error("failed to read virtlogd logs")
-				}
-			}()
+		// this sleep is to avoid consumming all resources in the
+		// event of a virtlogd crash loop.
+		time.Sleep(time.Second)
+	}
+}
 
-			go func() {
-				defer close(exitChan)
-				cmd.Wait()
-			}()
+func startQEMUSeaBiosLogging(stopChan chan struct{}) {
+	const QEMUSeaBiosDebugPipeMode uint32 = 0666
+	const logLinePrefix = "[SeaBios]:"
+
+	err := syscall.Mkfifo(QEMUSeaBiosDebugPipe, QEMUSeaBiosDebugPipeMode)
+	if err != nil {
+		log.Log.Reason(err).Error(fmt.Sprintf("%s failed creating a pipe for sea bios debug logs", logLinePrefix))
+		return
+	}
+
+	// Chmod is needed since umask is 0018. Therefore Mkfifo does not actually create a pipe with proper permissions.
+	err = syscall.Chmod(QEMUSeaBiosDebugPipe, QEMUSeaBiosDebugPipeMode)
+	if err != nil {
+		log.Log.Reason(err).Error(fmt.Sprintf("%s failed executing chmod on pipe for sea bios debug logs.", logLinePrefix))
+		return
+	}
+
+	QEMUPipe, err := os.OpenFile(QEMUSeaBiosDebugPipe, os.O_RDONLY, 0666)
+
+	if err != nil {
+		log.Log.Reason(err).Error(fmt.Sprintf("%s failed to open %s", logLinePrefix, QEMUSeaBiosDebugPipe))
+		return
+	}
+	defer QEMUPipe.Close()
+
+	scanner := bufio.NewScanner(QEMUPipe)
+	for {
+		for scanner.Scan() {
+			logLine := fmt.Sprintf("%s %s", logLinePrefix, scanner.Text())
+
+			log.LogQemuLogLine(log.Log, logLine)
 
 			select {
 			case <-stopChan:
-				cmd.Process.Kill()
 				return
-			case <-exitChan:
-				log.Log.Errorf("virtlogd exited, restarting")
+			default:
 			}
-
-			// this sleep is to avoid consumming all resources in the
-			// event of a virtlogd crash loop.
-			time.Sleep(time.Second)
 		}
-	}()
-	go func() {
-		const QEMUSeaBiosDebugPipeMode uint32 = 0666
-		const logLinePrefix = "[SeaBios]:"
 
-		err := syscall.Mkfifo(QEMUSeaBiosDebugPipe, QEMUSeaBiosDebugPipeMode)
-		if err != nil {
-			log.Log.Reason(err).Error(fmt.Sprintf("%s failed creating a pipe for sea bios debug logs: %s", logLinePrefix, err.Error()))
+		if err := scanner.Err(); err != nil {
+			log.Log.Reason(err).Error(fmt.Sprintf("%s reader failed with an error", logLinePrefix))
 			return
 		}
 
-		// Chmod is needed since umask is 0018. Therefore Mkfifo does not actually create a pipe with proper permissions.
-		err = syscall.Chmod(QEMUSeaBiosDebugPipe, QEMUSeaBiosDebugPipeMode)
-		if err != nil {
-			log.Log.Reason(err).Error(fmt.Sprintf("%s failed executing chmod on pipe for sea bios debug logs: %s", logLinePrefix, err.Error()))
-			return
-		}
+		log.Log.Errorf(fmt.Sprintf("%s exited, restarting", logLinePrefix))
+	}
+}
 
-		QEMUPipe, err := os.OpenFile(QEMUSeaBiosDebugPipe, os.O_RDONLY, 0666)
-		defer QEMUPipe.Close()
-
-		if err != nil {
-			log.Log.Reason(err).Error(fmt.Sprintf("%s failed to open %s with an error: %s", logLinePrefix, QEMUSeaBiosDebugPipe, err.Error()))
-		}
-
-		var line []byte
-		reader := bufio.NewReader(QEMUPipe)
-
-		for {
-			for line, _, err = reader.ReadLine(); err == nil; line, _, err = reader.ReadLine() {
-				logLine := fmt.Sprintf("%s %s", logLinePrefix, string(line))
-
-				log.LogQemuLogLine(log.Log, logLine)
-
-				select {
-				case <-stopChan:
-					return
-				default:
-				}
-			}
-
-			if err != io.EOF {
-				log.Log.Reason(err).Error(fmt.Sprintf("%s reader failed with an error: %s", logLinePrefix, err.Error()))
-				return
-			}
-
-			log.Log.Errorf(fmt.Sprintf("%s exited, restarting", logLinePrefix))
-		}
-	}()
+func StartVirtlog(stopChan chan struct{}, domainName string) {
+	go startVirtlogdLogging(stopChan, domainName)
+	go startQEMUSeaBiosLogging(stopChan)
 }
 
 // returns the namespace and name that is encoded in the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As @vladikr suggested in a [previous PR](https://github.com/kubevirt/kubevirt/pull/4917#discussion_r576464454), SeaBios debug logs should be part of virt-launcher log.

Also, as [explained here](https://www.seabios.org/Debugging#Timing_debug_messages) use a pipe instead of a file for logging to prevent the creation of a log file that keeps getting larger.

**Special notes for your reviewer**:
For some reason "syscall.Mkfifo" doesn't make a pipe with the permissions passed as a parameter. I've found a [solution here](https://wenzr.wordpress.com/2018/03/27/go-file-permissions-on-unix/) which is basically to make another call to "syscall.Chmod" to fix pipe's permissions.

Am I missing something here? Anyways I would be happy to hear about a more elegant solution.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
QEMU SeaBios debug logs are being seen as part of virt-launcher log.
```
