### PR TITLE
[WIP] migration: create MigrationState on VMI before creating the target pod

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -474,10 +474,23 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 	}
 
 	if !canMigrate {
-		return fmt.Errorf("vmi is inelgible for migration because another migration job is running")
+		return fmt.Errorf("vmi is ineligible for migration because another migration job is running")
 	}
 
 	switch migration.Status.Phase {
+	case virtv1.MigrationPhaseUnset:
+		vmiCopy := vmi.DeepCopy()
+		vmiCopy.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+			MigrationUID: migration.UID,
+			SourceNode:   vmi.Status.NodeName,
+		}
+		if !reflect.DeepEqual(vmi.Status, vmiCopy.Status) ||
+			!reflect.DeepEqual(vmi.Labels, vmiCopy.Labels) {
+			_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Update(vmiCopy)
+			if err != nil {
+				return err
+			}
+		}
 	case virtv1.MigrationPending:
 		if podExists {
 			// nothing to do if the target pod already exists
@@ -496,7 +509,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			// Don't start new migrations if we wait for migration object updates because of new target pods
 			runningMigrations, err := c.findRunningMigrations()
 			if err != nil {
-				return fmt.Errorf("failed to determin the number of running migrations: %v", err)
+				return fmt.Errorf("failed to determine the number of running migrations: %v", err)
 			}
 
 			// XXX: Make this configurable, think about limit per node, bandwidth per migration, and so on.
@@ -531,12 +544,12 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 		// setting the target and source nodes. This kicks off the preparation stage.
 		if podExists && !podIsDown(pod) {
 			vmiCopy := vmi.DeepCopy()
-			vmiCopy.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
-				MigrationUID: migration.UID,
-				TargetNode:   pod.Spec.NodeName,
-				SourceNode:   vmi.Status.NodeName,
-				TargetPod:    pod.Name,
+			if vmiCopy.Status.MigrationState == nil {
+				c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedHandOverPodReason, fmt.Sprintf("Migration scheduled but not initiated."))
+				return fmt.Errorf("MigrationState is unexpectedly empty")
 			}
+			vmiCopy.Status.MigrationState.TargetNode = pod.Spec.NodeName
+			vmiCopy.Status.MigrationState.TargetPod = pod.Name
 
 			// By setting this label, virt-handler on the target node will receive
 			// the vmi and prepare the local environment for the migration
@@ -546,7 +559,7 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 				!reflect.DeepEqual(vmi.Labels, vmiCopy.Labels) {
 				_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Update(vmiCopy)
 				if err != nil {
-					c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedHandOverPodReason, fmt.Sprintf("Failed to set MigrationStat in VMI status. :%v", err))
+					c.recorder.Eventf(migration, k8sv1.EventTypeWarning, FailedHandOverPodReason, fmt.Sprintf("Failed to update MigrationState in VMI status. :%v", err))
 					return err
 				}
 				c.recorder.Eventf(migration, k8sv1.EventTypeNormal, SuccessfulHandOverPodReason, "Migration target pod is ready for preparation by virt-handler.")

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -592,7 +592,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				By("Starting the VirtualMachineInstance")
 				vmi = runVMIAndExpectLaunch(vmi, 240)
 
-				// Need to wait for cloud init to finnish and start the agent inside the vmi.
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
@@ -794,6 +794,31 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				// check VMI, confirm migration state
 				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
+
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+			})
+			It("should reject a second migration on the same VMI if the first one is not finished", func() {
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				migration1 := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migration2 := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				tests.RunMigrationAndExpectPending(virtClient, migration1, 10)
+				tests.RunDuplicateMigrationAndExpectFailure(virtClient, migration2, 5)
 
 				// delete VMI
 				By("Deleting the VMI")


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this, many migrations can be created for the same VMI as long as no target pod is Running

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
When creating multiple migrations at once for a given VMI, only the first one will be accepted
```
