### PR TITLE
Add networking metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -136,3 +136,21 @@ A design proposal and its implementation history can be seen [here](https://docs
  # Other Metrics 
 ## kubevirt_vmi_outdated_count
 #### HELP kubevirt_vmi_outdated_count Indication for the number of VirtualMachineInstance workloads that are not running within the most up-to-date version of the virt-launcher environment.
+
+ # Other Metrics 
+## kubevirt_vmi_network_receive_bytes_total
+#### HELP kubevirt_vmi_network_receive_bytes_total Network traffic receive in bytes
+## kubevirt_vmi_network_receive_errors_total
+#### HELP kubevirt_vmi_network_receive_errors_total Network receive error packets
+## kubevirt_vmi_network_receive_packets_dropped_total
+#### HELP kubevirt_vmi_network_receive_packets_dropped_total The number of rx packets dropped on vNIC interfaces.
+## kubevirt_vmi_network_receive_packets_total
+#### HELP kubevirt_vmi_network_receive_packets_total Network traffic receive packets
+## kubevirt_vmi_network_transmit_bytes_total
+#### HELP kubevirt_vmi_network_transmit_bytes_total Network traffic transmit in bytes
+## kubevirt_vmi_network_transmit_errors_total
+#### HELP kubevirt_vmi_network_transmit_errors_total Network transmit error packets
+## kubevirt_vmi_network_transmit_packets_dropped_total
+#### HELP kubevirt_vmi_network_transmit_packets_dropped_total The number of tx packets dropped on vNIC interfaces.
+## kubevirt_vmi_network_transmit_packets_total
+#### HELP kubevirt_vmi_network_transmit_packets_total Network traffic transmit packets

--- a/pkg/monitoring/vms/prometheus/fakeCollector.go
+++ b/pkg/monitoring/vms/prometheus/fakeCollector.go
@@ -29,8 +29,9 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 	inMem := []libvirt.DomainMemoryStat{}
 	out := stats.DomainStats{}
 	ident := statsconv.DomainIdentifier(&fakeIdentifier{})
+	devAliasMap := make(map[string]string)
 
-	if err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, &out); err != nil {
+	if err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out); err != nil {
 		panic(err)
 	}
 

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -209,6 +209,14 @@ func (metrics *vmiMetrics) updateNetwork(netStats []stats.DomainStatsNet) {
 			continue
 		}
 
+		ifaceLabel := net.Name
+		if net.AliasSet {
+			ifaceLabel = net.Alias
+		}
+
+		netLabels := []string{"interface"}
+		netLabelValues := []string{ifaceLabel}
+
 		if net.RxBytesSet || net.TxBytesSet {
 			desc := metrics.newPrometheusDesc(
 				"kubevirt_vmi_network_traffic_bytes_total",
@@ -218,40 +226,93 @@ func (metrics *vmiMetrics) updateNetwork(netStats []stats.DomainStatsNet) {
 
 			if net.RxBytesSet {
 				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(net.RxBytes), []string{net.Name, "rx"})
+				metrics.pushCustomMetric(
+					"kubevirt_vmi_network_receive_bytes_total",
+					"Network traffic receive in bytes",
+					prometheus.CounterValue,
+					float64(net.RxBytes),
+					netLabels,
+					netLabelValues,
+				)
 			}
+
 			if net.TxBytesSet {
 				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(net.TxBytes), []string{net.Name, "tx"})
+				metrics.pushCustomMetric(
+					"kubevirt_vmi_network_transmit_bytes_total",
+					"Network traffic transmit in bytes",
+					prometheus.CounterValue,
+					float64(net.TxBytes),
+					netLabels,
+					netLabelValues,
+				)
 			}
 		}
 
-		if net.RxPktsSet || net.TxPktsSet {
-			desc := metrics.newPrometheusDesc(
-				"kubevirt_vmi_network_traffic_packets_total",
-				"network traffic packets.",
-				[]string{"interface", "type"},
+		if net.RxPktsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_network_receive_packets_total",
+				"Network traffic receive packets",
+				prometheus.CounterValue,
+				float64(net.RxPkts),
+				netLabels,
+				netLabelValues,
 			)
-
-			if net.RxPktsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(net.RxPkts), []string{net.Name, "rx"})
-			}
-			if net.TxPktsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(net.TxPkts), []string{net.Name, "tx"})
-			}
 		}
 
-		if net.RxErrsSet || net.TxErrsSet {
-			desc := metrics.newPrometheusDesc(
-				"kubevirt_vmi_network_errors_total",
-				"network errors.",
-				[]string{"interface", "type"},
+		if net.TxPktsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_network_transmit_packets_total",
+				"Network traffic transmit packets",
+				prometheus.CounterValue,
+				float64(net.TxPkts),
+				netLabels,
+				netLabelValues,
 			)
+		}
 
-			if net.RxErrsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(net.RxErrs), []string{net.Name, "rx"})
-			}
-			if net.TxErrsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(net.TxErrs), []string{net.Name, "tx"})
-			}
+		if net.RxErrsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_network_receive_errors_total",
+				"Network receive error packets",
+				prometheus.CounterValue,
+				float64(net.RxErrs),
+				netLabels,
+				netLabelValues,
+			)
+		}
+
+		if net.TxErrsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_network_transmit_errors_total",
+				"Network transmit error packets",
+				prometheus.CounterValue,
+				float64(net.TxErrs),
+				netLabels,
+				netLabelValues,
+			)
+		}
+
+		if net.RxDropSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_network_receive_packets_dropped_total",
+				"The number of rx packets dropped on vNIC interfaces.",
+				prometheus.CounterValue,
+				float64(net.RxDrop),
+				netLabels,
+				netLabelValues,
+			)
+		}
+
+		if net.TxDropSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_network_transmit_packets_dropped_total",
+				"The number of tx packets dropped on vNIC interfaces.",
+				prometheus.CounterValue,
+				float64(net.TxDrop),
+				netLabels,
+				netLabelValues,
+			)
 		}
 	}
 }

--- a/pkg/virt-launcher/virtwrap/cli/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cli/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -22,6 +22,7 @@ package cli
 //go:generate mockgen -source $GOFILE -imports "libvirt=libvirt.org/libvirt-go" -package=$GOPACKAGE -destination=generated_mock_$GOFILE
 
 import (
+	"encoding/xml"
 	"fmt"
 	"io"
 	"sync"
@@ -31,6 +32,7 @@ import (
 	libvirt "libvirt.org/libvirt-go"
 
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/statsconv"
@@ -277,8 +279,13 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 			return list, err
 		}
 
+		devAliasMap, err := l.GetDeviceAliasMap(domStat.Domain)
+		if err != nil {
+			return list, err
+		}
+
 		stat := &stats.DomainStats{}
-		err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(statsconv.DomainIdentifier(domStat.Domain), &domStats[i], memStats, stat)
+		err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(statsconv.DomainIdentifier(domStat.Domain), &domStats[i], memStats, devAliasMap, stat)
 		if err != nil {
 			return list, err
 		}
@@ -288,6 +295,26 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 	}
 
 	return list, nil
+}
+
+func (l *LibvirtConnection) GetDeviceAliasMap(domain *libvirt.Domain) (map[string]string, error) {
+	devAliasMap := make(map[string]string)
+
+	domSpec := &api.DomainSpec{}
+	domxml, err := domain.GetXMLDesc(0)
+	if err != nil {
+		return devAliasMap, err
+	}
+	err = xml.Unmarshal([]byte(domxml), domSpec)
+	if err != nil {
+		return devAliasMap, err
+	}
+
+	for _, iface := range domSpec.Devices.Interfaces {
+		devAliasMap[iface.Target.Device] = iface.Alias.GetName()
+	}
+
+	return devAliasMap, nil
 }
 
 // Installs a watchdog which will check periodically if the libvirt connection is still alive.

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -81,6 +81,8 @@ type DomainStatsVcpu struct {
 type DomainStatsNet struct {
 	NameSet    bool
 	Name       string
+	AliasSet   bool
+	Alias      string
 	RxBytesSet bool
 	RxBytes    uint64
 	RxPktsSet  bool

--- a/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
@@ -54,12 +54,13 @@ var _ = Describe("StatsConverter", func() {
 		It("should handle empty input", func() {
 			in := &libvirt.DomainStats{}
 			inMem := []libvirt.DomainMemoryStat{}
+			devAliasMap := make(map[string]string)
 			out := stats.DomainStats{}
 			mockDomainIdent.EXPECT().GetName().Return("testName", nil)
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out)
 
 			Expect(err).To(BeNil())
 			Expect(out.Name).To(Equal("testName"))
@@ -69,12 +70,13 @@ var _ = Describe("StatsConverter", func() {
 		It("should handle valid input", func() {
 			in := &testStats[0]
 			inMem := []libvirt.DomainMemoryStat{}
+			devAliasMap := make(map[string]string)
 			out := stats.DomainStats{}
 			mockDomainIdent.EXPECT().GetName().Return("testName", nil)
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out)
 
 			Expect(err).To(BeNil())
 			// very very basic sanity check
@@ -88,12 +90,13 @@ var _ = Describe("StatsConverter", func() {
 		It("should convert valid input", func() {
 			in := &testStats[0]
 			inMem := []libvirt.DomainMemoryStat{}
+			devAliasMap := make(map[string]string)
 			out := stats.DomainStats{}
 			mockDomainIdent.EXPECT().GetName().Return("testName", nil)
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out)
 
 			Expect(err).To(BeNil())
 

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -177,6 +177,8 @@ var Testdataexpected = `{
      {
        "Name": "vnet0", 
        "NameSet": true, 
+       "Alias": "",
+       "AliasSet": false,
        "RxBytes": 29735062, 
        "RxBytesSet": true, 
        "RxDrop": 0, 


### PR DESCRIPTION
- add dropped packets count
- split total errors metric to transmit and receive
- split total packets count metric to transmit and receive
- add metric for transmit and receive bytes while keeping the previous
  metric in order to not break the UI
- modified networking metrics to display the interface alias label
  instead of the guest target device

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
These metrics can be collected by executing `curl -sk http://localhost:8443/metrics` on the virt-handler pod

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Modified networking metrics by adding new metrics, splitting existing ones by rx/tx and using the device alias for the interface name when available
```
