### PR TITLE
virtctl, expose: set PreferDualStack option on services

### DIFF
--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -204,6 +204,7 @@ func (o *Command) RunE(cmd *cobra.Command, args []string) error {
 		ports = []v1.ServicePort{{Name: portName, Protocol: protocol, Port: port, TargetPort: targetPort}}
 	}
 
+	preferDualStack := v1.IPFamilyPolicyPreferDualStack
 	// actually create the service
 	service := &v1.Service{
 		ObjectMeta: k8smetav1.ObjectMeta{
@@ -217,6 +218,7 @@ func (o *Command) RunE(cmd *cobra.Command, args []string) error {
 			Type:           serviceType,
 			LoadBalancerIP: loadBalancerIP,
 			IPFamilies:     []v1.IPFamily{ipFamily},
+			IPFamilyPolicy: &preferDualStack,
 		},
 	}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
IPFamilyPolicy represents the dual-stack-ness requested or
required by this Service, and is gated by the "IPv6DualStack"
feature gate.

It defaults to SingleStack, which prevents a service to be reached
over IPv6 on a dual-stack cluster. PreferDualStack, on the other
hand, allows for two IP families on dual-stack configured clusters,
or a single IP family on single-stack clusters.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
