### PR TITLE
[Bugfix]: Fix crypto P-224 curve bug by updating Go version to 1.14.14

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,7 +74,8 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/structtag:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/tests:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unreachable:go_tool_library",
-        "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
+        # FIXME: Nogo fails analysis although configured to be disabled on nogo_config.json.
+        # "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,21 +9,21 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "08369b54a7cbe9348eea474e36c9bbb19d47101e8860cec75cbf1ccd4f749281",
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.0/rules_go-v0.24.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.0/rules_go-v0.24.0.tar.gz",
-        "https://storage.googleapis.com/builddeps/08369b54a7cbe9348eea474e36c9bbb19d47101e8860cec75cbf1ccd4f749281",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://storage.googleapis.com/builddeps/69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "d4113967ab451dd4d2d767c3ca5f927fec4b30f3b2c6f8135a2033b9c05a5687",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.0/bazel-gazelle-v0.22.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.0/bazel-gazelle-v0.22.0.tar.gz",
-        "https://storage.googleapis.com/builddeps/d4113967ab451dd4d2d767c3ca5f927fec4b30f3b2c6f8135a2033b9c05a5687",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://storage.googleapis.com/builddeps/62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
     ],
 )
 
@@ -160,7 +160,7 @@ load("@bazeldnf//:deps.bzl", "bazeldnf_dependencies", "rpm")
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.13.14",
+    go_version = "1.14.14",
     nogo = "@//:nogo_vet",
 )
 

--- a/docs/update-go-version.md
+++ b/docs/update-go-version.md
@@ -4,7 +4,7 @@ A quick guide to update Kubevirt's Go version.
 To update the Go version we need to update the builder image so that it uses the new version,
 push it to the registry and finally let Kubevirt use the new builder image.
 
-In addition, Bazel has to be updated if the current version does not support the target Go version.
+In addition, [go rules for bazel](https://github.com/bazelbuild/rules_go) have to be updated if the current version does not support the target Go version.
 
 ## Updating Go Version
 ### Updating builder image
@@ -40,7 +40,7 @@ In addition, Bazel has to be updated if the current version does not support the
     )
     ```
 
-## Update Bazel Version
+## Update go rules for bazel
 * In [WORKSPACE](../WORKSPACE) find current Bazel release's SHA ID which can be found under `io_bazel_rules_go`.
   * Should look similar to:
     ```shell

--- a/docs/update-go-version.md
+++ b/docs/update-go-version.md
@@ -1,0 +1,60 @@
+# How to update Go version 
+A quick guide to update Kubevirt's Go version.
+
+To update the Go version we need to update the builder image so that it uses the new version,
+push it to the registry and finally let Kubevirt use the new builder image.
+
+In addition, Bazel has to be updated if the current version does not support the target Go version.
+
+## Updating Go Version
+### Updating builder image
+* Update `VERSION` tag in [hack/builder/version.sh](../hack/builder/version.sh).
+  * For example, change from `VERSION=30-9.0.3` to `VERSION=30-9.0.4`
+* Change the `GIMME_GO` version in the [hack/builder/Dockerfile](../hack/builder/Dockerfile) to the desired Go version.
+* Rebuild the builder image by executing `make builder-build`.
+  
+### Publishing builder image
+* Publish new builder image with `make builder-publish`.
+  * Note: Proper access rights are required in order to publish builder image.
+  * When publish is finished, the builder image tag will be presented. For instance, if the output of `make builder-publish` is:
+    ```shell
+    2103210933-9be558add-amd64: digest: sha256:cc83534b5d99da35643f8a2a87830b0dabcb4f130c1db181a835dc8def09174b size: 3271
+    + TMP_IMAGES=' quay.io/kubevirt/builder:2103210933-9be558add-amd64'
+    + export DOCKER_CLI_EXPERIMENTAL=enabled
+    + DOCKER_CLI_EXPERIMENTAL=enabled
+    + docker manifest create --amend quay.io/kubevirt/builder:2103210933-9be558add quay.io/kubevirt/builder:2103210933-9be558add-amd64
+      Created manifest list quay.io/kubevirt/builder:2103210933-9be558add
+    + docker manifest push quay.io/kubevirt/builder:2103210933-9be558add
+      sha256:d828eb647e7ef3115f39ff4cb2d5d41da39b4134056e429be16c3a019b521957
+    + cleanup
+    + rm manifests/ -rf
+    ```
+  * The image tag is `2103210933-9be558add`
+* Change `KUBEVIRT_BUILDER_IMAGE` variable in [hack/dockerized](../hack/dockerized) to the tag from the previous step.
+* In [WORKSPACE](../WORKSPACE) change `go_version` to the desired Go version.
+  * Should look similar to:
+    ```shell
+    go_register_toolchains(
+        go_version = "1.14.14",
+        nogo = "@//:nogo_vet",
+    )
+    ```
+
+## Update Bazel Version
+* In [WORKSPACE](../WORKSPACE) find current Bazel release's SHA ID which can be found under `io_bazel_rules_go`.
+  * Should look similar to:
+    ```shell
+    http_archive(
+      name = "io_bazel_rules_go",
+      sha256 = "52d0a57ea12139d727883c2fef03597970b89f2cc2a05722c42d1d7d41ec065b",
+      urls = [
+        ...
+      ],
+    )
+    ```
+* Visit [Bazel's releases page](https://github.com/bazelbuild/rules_go/releases) and check whether the current Bazel version supports the new Go version.
+  * If it is not supported, replace the `io_bazel_rules_go` definition with the one provided in Bazel's page.
+* Use [project-infra's uploader tool](https://github.com/kubevirt/project-infra/blob/master/plugins/cmd/uploader/README.md) to upload new dependencies to dependency mirror.
+
+
+  

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -45,7 +45,7 @@ RUN wget https://services.gradle.org/distributions/gradle-6.6-bin.zip && \
 ENV PATH=$PATH:/opt/gradle/gradle-6.6/bin \
     JAVA_HOME=/usr/lib/jvm/java-11
 
-ENV GIMME_GO_VERSION=1.13.14
+ENV GIMME_GO_VERSION=1.14.14
 
 RUN mkdir -p /gimme && curl -sL \
     https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | \

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2103171450-7edc9308c"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2103211041-2ff584851"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/pkg/certificates/BUILD.bazel
+++ b/pkg/certificates/BUILD.bazel
@@ -18,8 +18,8 @@ go_test(
         "certificates_suite_test.go",
         "certificates_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/hooks/BUILD.bazel
+++ b/pkg/hooks/BUILD.bazel
@@ -28,8 +28,8 @@ go_test(
         "hooks_test.go",
         "manager_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/hooks/info:go_default_library",
         "//pkg/hooks/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",

--- a/pkg/util/openapi/BUILD.bazel
+++ b/pkg/util/openapi/BUILD.bazel
@@ -27,8 +27,8 @@ go_test(
         "openapi_suite_test.go",
         "openapi_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/virt-api/rest:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -30,8 +30,8 @@ go_test(
         "utils_test.go",
         "webhooks_suite_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -27,8 +27,8 @@ go_test(
         "disruptionbudget_suite_test.go",
         "disruptionbudget_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/BUILD.bazel
@@ -17,8 +17,8 @@ go_test(
         "device_suite_test.go",
         "pciaddress_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/sriov/BUILD.bazel
@@ -26,8 +26,8 @@ go_test(
         "pcipool_test.go",
         "sriov_suite_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -30,8 +30,8 @@ go_test(
         "root_suite_test.go",
         "root_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virtctl/expose/BUILD.bazel
+++ b/pkg/virtctl/expose/BUILD.bazel
@@ -26,8 +26,8 @@ go_test(
         "expose_suite_test.go",
         "expose_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -30,8 +30,8 @@ go_test(
         "imageupload_suite_test.go",
         "imageupload_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests:go_default_library",

--- a/pkg/virtctl/pause/BUILD.bazel
+++ b/pkg/virtctl/pause/BUILD.bazel
@@ -22,8 +22,8 @@ go_test(
         "pause_suite_test.go",
         "pause_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
         "vm_suite_test.go",
         "vm_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -157,9 +157,9 @@ go_test(
         "vnc_test.go",
         "windows_test.go",
     ],
-    embed = [":go_default_library"],
     visibility = ["//visibility:public"],
     deps = [
+        ":go_default_library",
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/cloud-init:go_default_library",

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/BUILD.bazel
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/BUILD.bazel
@@ -59,9 +59,6 @@ go_library(
             "//vendor/github.com/coreos/go-systemd/v22/dbus:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/golang.org/x/sys/unix:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],

--- a/vendor/github.com/prometheus/client_golang/prometheus/BUILD.bazel
+++ b/vendor/github.com/prometheus/client_golang/prometheus/BUILD.bazel
@@ -68,9 +68,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/prometheus/procfs:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/github.com/prometheus/procfs:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/github.com/prometheus/procfs:go_default_library",
         ],

--- a/vendor/github.com/u-root/u-root/pkg/rand/BUILD.bazel
+++ b/vendor/github.com/u-root/u-root/pkg/rand/BUILD.bazel
@@ -34,9 +34,6 @@ go_library(
             "//vendor/github.com/u-root/u-root/pkg/cmdline:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/golang.org/x/sys/unix:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],

--- a/vendor/github.com/vishvananda/netlink/BUILD.bazel
+++ b/vendor/github.com/vishvananda/netlink/BUILD.bazel
@@ -87,9 +87,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/vishvananda/netns:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/github.com/vishvananda/netns:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/github.com/vishvananda/netns:go_default_library",
         ],


### PR DESCRIPTION
Signed-off-by: Itamar Holder <iholder@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Update Go version to 1.14.14.
    
This addresses the following Bugzilla bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1929069
    
As written in bug description, this bug is fixed in Go upstream:
https://github.com/golang/go/commit/d95ca9138026cbe40e0857d76a81a16d03230871

In addition, add a small tutorial that will document the procedure needed to update Go version.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Go version updated to 1.14.14
```
