### PR TITLE
[release-0.34] Virt-handler should only be informed of VMIs scheduled on virt-handler nodes

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -35,8 +35,6 @@ go_library(
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -314,7 +314,10 @@ func (app *virtHandlerApp) Run() {
 	// Bootstrapping. From here on the startup order matters
 	stop := make(chan struct{})
 	defer close(stop)
+
 	factory.Start(stop)
+	go gracefulShutdownInformer.Run(stop)
+	go domainSharedInformer.Run(stop)
 
 	se, exists, err := selinux.NewSELinux()
 	if err == nil && exists {

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -70,6 +70,13 @@ type KubeInformerFactory interface {
 	// Watches for vmi objects
 	VMI() cache.SharedIndexInformer
 
+	// Watches for vmi objects assigned to a specific host
+	VMISourceHost(hostName string) cache.SharedIndexInformer
+
+	// Watches for vmi objects assigned to a specific host
+	// as a migration target
+	VMITargetHost(hostName string) cache.SharedIndexInformer
+
 	// Watches for VirtualMachineInstanceReplicaSet objects
 	VMIReplicaSet() cache.SharedIndexInformer
 
@@ -291,6 +298,40 @@ func (f *kubeInformerFactory) Namespace() cache.SharedIndexInformer {
 func (f *kubeInformerFactory) VMI() cache.SharedIndexInformer {
 	return f.getInformer("vmiInformer", func() cache.SharedIndexInformer {
 		lw := cache.NewListWatchFromClient(f.restClient, "virtualmachineinstances", k8sv1.NamespaceAll, fields.Everything())
+		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineInstance{}, f.defaultResync, cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+			"node": func(obj interface{}) (strings []string, e error) {
+				return []string{obj.(*kubev1.VirtualMachineInstance).Status.NodeName}, nil
+			},
+		})
+	})
+}
+
+func (f *kubeInformerFactory) VMISourceHost(hostName string) cache.SharedIndexInformer {
+	labelSelector, err := labels.Parse(fmt.Sprintf(kubev1.NodeNameLabel+" in (%s)", hostName))
+	if err != nil {
+		panic(err)
+	}
+
+	return f.getInformer("vmiInformer-sources", func() cache.SharedIndexInformer {
+		lw := NewListWatchFromClient(f.restClient, "virtualmachineinstances", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
+		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineInstance{}, f.defaultResync, cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+			"node": func(obj interface{}) (strings []string, e error) {
+				return []string{obj.(*kubev1.VirtualMachineInstance).Status.NodeName}, nil
+			},
+		})
+	})
+}
+
+func (f *kubeInformerFactory) VMITargetHost(hostName string) cache.SharedIndexInformer {
+	labelSelector, err := labels.Parse(fmt.Sprintf(kubev1.MigrationTargetNodeNameLabel+" in (%s)", hostName))
+	if err != nil {
+		panic(err)
+	}
+
+	return f.getInformer("vmiInformer-targets", func() cache.SharedIndexInformer {
+		lw := NewListWatchFromClient(f.restClient, "virtualmachineinstances", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
 		return cache.NewSharedIndexInformer(lw, &kubev1.VirtualMachineInstance{}, f.defaultResync, cache.Indexers{
 			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
 			"node": func(obj interface{}) (strings []string, e error) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -874,7 +874,6 @@ func (c *VirtualMachineController) Run(threadiness int, stopCh chan struct{}) {
 	log.Log.Info("Starting virt-handler controller.")
 
 	// Wait for the domain cache to be synced
-	go c.domainInformer.Run(stopCh)
 	cache.WaitForCacheSync(stopCh, c.domainInformer.HasSynced)
 
 	go c.kvmController.Run(stopCh)
@@ -891,9 +890,6 @@ func (c *VirtualMachineController) Run(threadiness int, stopCh chan struct{}) {
 		)
 	}
 
-	go c.vmiSourceInformer.Run(stopCh)
-	go c.vmiTargetInformer.Run(stopCh)
-	go c.gracefulShutdownInformer.Run(stopCh)
 	cache.WaitForCacheSync(stopCh, c.domainInformer.HasSynced, c.vmiSourceInformer.HasSynced, c.vmiTargetInformer.HasSynced, c.gracefulShutdownInformer.HasSynced)
 
 	go c.heartBeat(c.heartBeatInterval, stopCh)


### PR DESCRIPTION
backports #5060

```release-note
NONE
```
