### PR TITLE
move listVmWithLocalData out of diskutils

### DIFF
--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/precond:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -569,8 +569,3 @@ func GenerateLocalData(vmiName string, namespace string, data *CloudInitData) er
 	log.Log.V(2).Infof("generated nocloud iso file %s", iso)
 	return nil
 }
-
-// Lists all vmis cloud-init has local data for
-func listVmWithLocalData() ([]*v1.VirtualMachineInstance, error) {
-	return diskutils.ListVmWithEphemeralDisk(cloudInitLocalDir)
-}

--- a/pkg/cloud-init/cloud-init_test.go
+++ b/pkg/cloud-init/cloud-init_test.go
@@ -35,7 +35,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
-	"kubevirt.io/client-go/precond"
 )
 
 var _ = Describe("CloudInit", func() {
@@ -209,42 +208,6 @@ var _ = Describe("CloudInit", func() {
 					domain := "fake-domain"
 					err := removeLocalData(domain, namespace)
 					Expect(err).ToNot(HaveOccurred())
-				})
-			})
-
-			Context("with multiple data dirs and files", func() {
-				It("should list all VirtualMachineInstance's", func() {
-					domains := []string{
-						"fakens1/fakedomain1",
-						"fakens1/fakedomain2",
-						"fakens2/fakedomain1",
-						"fakens2/fakedomain2",
-						"fakens3/fakedomain1",
-						"fakens4/fakedomain1",
-					}
-					msg := "fake content"
-					bytes := []byte(msg)
-
-					for _, dom := range domains {
-						err := os.MkdirAll(fmt.Sprintf("%s/%s/some-other-dir", tmpDir, dom), 0755)
-						Expect(err).ToNot(HaveOccurred())
-						err = ioutil.WriteFile(fmt.Sprintf("%s/%s/some-file", tmpDir, dom), bytes, 0644)
-						Expect(err).ToNot(HaveOccurred())
-					}
-
-					vmis, err := listVmWithLocalData()
-					for _, vmi := range vmis {
-						namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
-						domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
-
-						Expect(namespace).To(ContainSubstring("fakens"))
-						Expect(domain).To(ContainSubstring("fakedomain"))
-					}
-
-					Expect(len(vmis)).To(Equal(len(domains)))
-					Expect(err).ToNot(HaveOccurred())
-
-					// verify a vmi from each namespace is present
 				})
 			})
 		})

--- a/pkg/ephemeral-disk-utils/BUILD.bazel
+++ b/pkg/ephemeral-disk-utils/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = ["utils.go"],
     importpath = "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils",
     visibility = ["//visibility:public"],
-    deps = ["//staging/src/kubevirt.io/client-go/api/v1:go_default_library"],
 )
 
 go_test(

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -121,7 +121,7 @@ func ListVmWithEphemeralDisk(localPath string) ([]*v1.VirtualMachineInstance, er
 		if namespace == "" || domain == "" {
 			return nil
 		}
-		keys = append(keys, v1.NewVMIReferenceFromNameWithNS(dirs[0], dirs[1]))
+		keys = append(keys, v1.NewVMIReferenceFromNameWithNS(namespace, domain))
 		return nil
 	})
 

--- a/pkg/ephemeral-disk-utils/utils.go
+++ b/pkg/ephemeral-disk-utils/utils.go
@@ -23,11 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path/filepath"
 	"strconv"
-	"strings"
-
-	v1 "kubevirt.io/client-go/api/v1"
 )
 
 // TODO this should be part of structs, instead of a global
@@ -85,47 +81,6 @@ func FileExists(path string) (bool, error) {
 		err = nil
 	}
 	return exists, err
-}
-
-// Lists all vmis ephemeral disk has local data for
-func ListVmWithEphemeralDisk(localPath string) ([]*v1.VirtualMachineInstance, error) {
-	var keys []*v1.VirtualMachineInstance
-
-	exists, err := FileExists(localPath)
-	if err != nil {
-		return nil, err
-	}
-	if exists == false {
-		return nil, nil
-	}
-
-	err = filepath.Walk(localPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() == false {
-			return nil
-		}
-
-		relativePath := strings.TrimPrefix(path, localPath+"/")
-		if relativePath == "" {
-			return nil
-		}
-		dirs := strings.Split(relativePath, "/")
-		if len(dirs) != 2 {
-			return nil
-		}
-
-		namespace := dirs[0]
-		domain := dirs[1]
-		if namespace == "" || domain == "" {
-			return nil
-		}
-		keys = append(keys, v1.NewVMIReferenceFromNameWithNS(namespace, domain))
-		return nil
-	})
-
-	return keys, err
 }
 
 type OwnershipManagerInterface interface {


### PR DESCRIPTION
listVmWithLocalData iterates over objects created in cloudinit package. Since 2018's https://github.com/kubevirt/kubevirt/commit/58b636ad28ed2d63db92f2ecc0f16541e41c29eb#diff-dd99dd4530ed2b9071463f32731f2134d96d0f429ef21bf59b9a4f469e3a15e4L82 , nothing is using it except its own test code.
This PR drops it.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>


```release-note
NONE
```
