### PR TITLE
Use CDI v1.26.1 from Quay

### DIFF
--- a/manifests/testing/cdi-v1.26.1.yaml.in
+++ b/manifests/testing/cdi-v1.26.1.yaml.in
@@ -2085,22 +2085,22 @@ spec:
         - name: OPERATOR_VERSION
           value: v1.26.1
         - name: CONTROLLER_IMAGE
-          value: kubevirt/cdi-controller:v1.26.1
+          value: quay.io/kubevirt/cdi-controller:v1.26.1
         - name: IMPORTER_IMAGE
-          value: kubevirt/cdi-importer:v1.26.1
+          value: quay.io/kubevirt/cdi-importer:v1.26.1
         - name: CLONER_IMAGE
-          value: kubevirt/cdi-cloner:v1.26.1
+          value: quay.io/kubevirt/cdi-cloner:v1.26.1
         - name: APISERVER_IMAGE
-          value: kubevirt/cdi-apiserver:v1.26.1
+          value: quay.io/kubevirt/cdi-apiserver:v1.26.1
         - name: UPLOAD_SERVER_IMAGE
-          value: kubevirt/cdi-uploadserver:v1.26.1
+          value: quay.io/kubevirt/cdi-uploadserver:v1.26.1
         - name: UPLOAD_PROXY_IMAGE
-          value: kubevirt/cdi-uploadproxy:v1.26.1
+          value: quay.io/kubevirt/cdi-uploadproxy:v1.26.1
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
-        image: kubevirt/cdi-operator:v1.26.1
+        image: quay.io/kubevirt/cdi-operator:v1.26.1
         imagePullPolicy: IfNotPresent
         name: cdi-operator
         ports:


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: We are having a lot of errors because of ImagePullBackOff of kubevirt/cdi-operator from Docker Hub, for instance https://prow.k8s.io/view/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.17/1364830915716452352 These changes update the image references to the existing CDI version used in kubevirt to Quay.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5071

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
