### PR TITLE
Modify memory metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,8 +9,8 @@ Sometimes the Help text on `/metrics` endpoint just isn't enough to explain what
 Kubevirt's version information
 
 Labels:
-* `goversion` - GO version used to compile this version of KubeVirt 
-* `kubeversion` - Git commit refspec that created this version of KubeVirt 
+* `goversion` - GO version used to compile this version of KubeVirt
+* `kubeversion` - Git commit refspec that created this version of KubeVirt
 
 ## Node Metric
 
@@ -20,7 +20,7 @@ Labels:
 The total amount of VMIs per node and phase.
 
 Labels:
-* `phase` - Phase of the VMI. It can be one of [Virtual Machine Instance Phases](https://github.com/kubevirt/kubevirt/blob/master/staging/src/kubevirt.io/client-go/api/v1/types.go#L415) 
+* `phase` - Phase of the VMI. It can be one of [Virtual Machine Instance Phases](https://github.com/kubevirt/kubevirt/blob/master/staging/src/kubevirt.io/client-go/api/v1/types.go#L415)
 * `node` - Node where the VMI is running on.
 
 ## VMI Metrics
@@ -34,7 +34,7 @@ All VMI metrics listed below contain, but are not limited to, these three labels
 #### kubevirt_vmi_memory_resident_bytes
 #### HELP kubevirt_vmi_memory_resident_bytes resident set size of the process running the domain.
 
-Total resident memory of the process running the VMI. 
+Total resident memory of the process running the VMI.
 
 #### kubevirt_vmi_memory_available_bytes
 #### HELP kubevirt_vmi_memory_available_bytes amount of usable memory as seen by the domain.
@@ -52,7 +52,7 @@ The total amount of unused memory as seen by the domain.
 The amount of traffic that is being read and written in swap memory.
 
 Extra labels:
-* `type` - Whether the data is being transmitted or received. `in` when transmitting and `out` when receiving. 
+* `type` - Whether the data is being transmitted or received. `in` when transmitting and `out` when receiving.
 
 #### kubevirt_vmi_network_errors_total
 #### HELP kubevirt_vmi_network_errors_total network errors.
@@ -115,7 +115,7 @@ The total amount of time spent in each vcpu state
 
 Extra labels:
 * `id` - Identifier to a single Virtual CPU.
-* `state` - Identify the Virtual CPU state. It can be one of libvirt vcpu's states: `OFFLINE`, `RUNNING` or `BLOCKED` 
+* `state` - Identify the Virtual CPU state. It can be one of libvirt vcpu's states: `OFFLINE`, `RUNNING` or `BLOCKED`
 
 
 
@@ -125,7 +125,7 @@ Improving Kubevirt's Observability is a important topic and we are currently wor
 
 A design proposal and its implementation history can be seen [here](https://docs.google.com/document/d/1bEwrnZZkVsCtz0PSyzlxOdhupL6GTurkUYcz7TXFM1g/edit)
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_vcpu_wait_seconds
 #### HELP kubevirt_vmi_vcpu_wait_seconds vcpu time spent by waiting on I/O.
 ## leading_virt_controller
@@ -133,11 +133,11 @@ A design proposal and its implementation history can be seen [here](https://docs
 ## ready_virt_controller
 #### HELP ready_virt_controller Indication for a virt-controller that is ready to take the lead.
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_outdated_count
 #### HELP kubevirt_vmi_outdated_count Indication for the number of VirtualMachineInstance workloads that are not running within the most up-to-date version of the virt-launcher environment.
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_network_receive_bytes_total
 #### HELP kubevirt_vmi_network_receive_bytes_total Network traffic receive in bytes
 ## kubevirt_vmi_network_receive_errors_total
@@ -154,3 +154,19 @@ A design proposal and its implementation history can be seen [here](https://docs
 #### HELP kubevirt_vmi_network_transmit_packets_dropped_total The number of tx packets dropped on vNIC interfaces.
 ## kubevirt_vmi_network_transmit_packets_total
 #### HELP kubevirt_vmi_network_transmit_packets_total Network traffic transmit packets
+
+ # Other Metrics 
+## kubevirt_vmi_memory_actual_balloon_bytes
+#### HELP kubevirt_vmi_memory_actual_balloon_bytes current balloon bytes.
+## kubevirt_vmi_memory_pgmajfault
+#### HELP kubevirt_vmi_memory_pgmajfault The number of page faults when disk IO was required.
+## kubevirt_vmi_memory_pgminfault
+#### HELP kubevirt_vmi_memory_pgminfault The number of other page faults, when disk IO was not required.
+## kubevirt_vmi_memory_swap_in_traffic_bytes_total
+#### HELP kubevirt_vmi_memory_swap_in_traffic_bytes_total Swap in memory traffic in bytes
+## kubevirt_vmi_memory_swap_out_traffic_bytes_total
+#### HELP kubevirt_vmi_memory_swap_out_traffic_bytes_total Swap out memory traffic in bytes
+## kubevirt_vmi_memory_usable_bytes
+#### HELP kubevirt_vmi_memory_usable_bytes The amount of memory which can be reclaimed by balloon without causing host swapping in bytes.
+## kubevirt_vmi_memory_used_total_bytes
+#### HELP kubevirt_vmi_memory_used_total_bytes The amount of memory in bytes used by the domain.

--- a/pkg/monitoring/vms/prometheus/fakeCollector.go
+++ b/pkg/monitoring/vms/prometheus/fakeCollector.go
@@ -27,11 +27,12 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 
 	in := &libstatst[0]
 	inMem := []libvirt.DomainMemoryStat{}
+	inDomInfo := &libvirt.DomainInfo{}
 	out := stats.DomainStats{}
 	ident := statsconv.DomainIdentifier(&fakeIdentifier{})
 	devAliasMap := make(map[string]string)
 
-	if err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out); err != nil {
+	if err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, inDomInfo, devAliasMap, &out); err != nil {
 		panic(err)
 	}
 
@@ -40,6 +41,10 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 	out.Memory.AvailableSet = true
 	out.Memory.RSSSet = true
 	out.Memory.SwapInSet = true
+	out.Memory.SwapOutSet = true
+	out.Memory.UsableSet = true
+	out.Memory.MinorFaultSet = true
+	out.Memory.MajorFaultSet = true
 
 	vmi := k6tv1.VirtualMachineInstance{
 		Status: k6tv1.VirtualMachineInstanceStatus{

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -105,19 +105,67 @@ func (metrics *vmiMetrics) updateMemory(mem *stats.DomainStatsMemory) {
 		)
 	}
 
-	if mem.SwapInSet || mem.SwapOutSet {
-		desc := metrics.newPrometheusDesc(
-			"kubevirt_vmi_memory_swap_traffic_bytes_total",
-			"swap memory traffic.",
-			[]string{"type"},
+	if mem.SwapInSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_swap_in_traffic_bytes_total",
+			"Swap in memory traffic in bytes",
+			prometheus.GaugeValue,
+			float64(mem.SwapIn)*1024,
 		)
+	}
 
-		if mem.SwapInSet {
-			metrics.pushPrometheusMetric(desc, prometheus.GaugeValue, float64(mem.SwapIn)*1024, []string{"in"})
-		}
-		if mem.SwapOutSet {
-			metrics.pushPrometheusMetric(desc, prometheus.GaugeValue, float64(mem.SwapOut)*1024, []string{"out"})
-		}
+	if mem.SwapOutSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_swap_out_traffic_bytes_total",
+			"Swap out memory traffic in bytes",
+			prometheus.GaugeValue,
+			float64(mem.SwapOut)*1024,
+		)
+	}
+
+	if mem.MajorFaultSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_pgmajfault",
+			"The number of page faults when disk IO was required.",
+			prometheus.CounterValue,
+			float64(mem.MajorFault),
+		)
+	}
+
+	if mem.MinorFaultSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_pgminfault",
+			"The number of other page faults, when disk IO was not required.",
+			prometheus.CounterValue,
+			float64(mem.MinorFault),
+		)
+	}
+
+	if mem.ActualBalloonSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_actual_balloon_bytes",
+			"current balloon bytes.",
+			prometheus.GaugeValue,
+			float64(mem.ActualBalloon)*1024,
+		)
+	}
+
+	if mem.UsableSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_usable_bytes",
+			"The amount of memory which can be reclaimed by balloon without causing host swapping in bytes.",
+			prometheus.GaugeValue,
+			float64(mem.Usable)*1024,
+		)
+	}
+
+	if mem.TotalSet {
+		metrics.pushCommonMetric(
+			"kubevirt_vmi_memory_used_total_bytes",
+			"The amount of memory in bytes used by the domain.",
+			prometheus.GaugeValue,
+			float64(mem.Total)*1024,
+		)
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -291,8 +291,13 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 			return list, err
 		}
 
+		domInfo, err := domStat.Domain.GetInfo()
+		if err != nil {
+			return list, err
+		}
+
 		stat := &stats.DomainStats{}
-		err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(statsconv.DomainIdentifier(domStat.Domain), &domStats[i], memStats, devAliasMap, stat)
+		err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(statsconv.DomainIdentifier(domStat.Domain), &domStats[i], memStats, domInfo, devAliasMap, stat)
 		if err != nil {
 			return list, err
 		}

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -149,4 +149,12 @@ type DomainStatsMemory struct {
 	SwapIn           uint64
 	SwapOutSet       bool
 	SwapOut          uint64
+	MajorFaultSet    bool
+	MajorFault       uint64
+	MinorFaultSet    bool
+	MinorFault       uint64
+	UsableSet        bool
+	Usable           uint64
+	TotalSet         bool
+	Total            uint64
 }

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -32,7 +32,7 @@ type DomainIdentifier interface {
 	GetUUIDString() (string, error)
 }
 
-func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in *libvirt.DomainStats, inMem []libvirt.DomainMemoryStat, devAliasMap map[string]string, out *stats.DomainStats) error {
+func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in *libvirt.DomainStats, inMem []libvirt.DomainMemoryStat, inDomInfo *libvirt.DomainInfo, devAliasMap map[string]string, out *stats.DomainStats) error {
 	name, err := ident.GetName()
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in
 	out.UUID = uuid
 
 	out.Cpu = Convert_libvirt_DomainStatsCpu_To_stats_DomainStatsCpu(in.Cpu)
-	out.Memory = Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem)
+	out.Memory = Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem, inDomInfo)
 	out.Vcpu = Convert_libvirt_DomainStatsVcpu_To_stats_DomainStatsVcpu(in.Vcpu)
 	out.Net = Convert_libvirt_DomainStatsNet_To_stats_DomainStatsNet(in.Net, devAliasMap)
 	out.Block = Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in.Block)
@@ -69,8 +69,14 @@ func Convert_libvirt_DomainStatsCpu_To_stats_DomainStatsCpu(in *libvirt.DomainSt
 	}
 }
 
-func Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem []libvirt.DomainMemoryStat) *stats.DomainStatsMemory {
+func Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem []libvirt.DomainMemoryStat, inDomInfo *libvirt.DomainInfo) *stats.DomainStatsMemory {
 	ret := &stats.DomainStatsMemory{}
+
+	if inDomInfo != nil {
+		ret.TotalSet = true
+		ret.Total = inDomInfo.Memory
+	}
+
 	for _, stat := range inMem {
 		tag := libvirt.DomainMemoryStatTags(stat.Tag)
 		switch tag {
@@ -92,6 +98,15 @@ func Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem []libvirt.Domai
 		case libvirt.DOMAIN_MEMORY_STAT_SWAP_OUT:
 			ret.SwapOutSet = true
 			ret.SwapOut = stat.Val
+		case libvirt.DOMAIN_MEMORY_STAT_MAJOR_FAULT:
+			ret.MajorFaultSet = true
+			ret.MajorFault = stat.Val
+		case libvirt.DOMAIN_MEMORY_STAT_MINOR_FAULT:
+			ret.MinorFaultSet = true
+			ret.MinorFault = stat.Val
+		case libvirt.DOMAIN_MEMORY_STAT_USABLE:
+			ret.UsableSet = true
+			ret.Usable = stat.Val
 		}
 	}
 	return ret

--- a/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
@@ -60,7 +60,7 @@ var _ = Describe("StatsConverter", func() {
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &out)
 
 			Expect(err).To(BeNil())
 			Expect(out.Name).To(Equal("testName"))
@@ -76,7 +76,7 @@ var _ = Describe("StatsConverter", func() {
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &out)
 
 			Expect(err).To(BeNil())
 			// very very basic sanity check
@@ -96,7 +96,7 @@ var _ = Describe("StatsConverter", func() {
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, devAliasMap, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &out)
 
 			Expect(err).To(BeNil())
 

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -170,7 +170,15 @@ var Testdataexpected = `{
      "SwapOut": 0,
      "SwapOutSet": false,
      "Unused": 0, 
-     "UnusedSet": false
+     "UnusedSet": false,
+     "MajorFault": 0,
+     "MajorFaultSet": false,
+     "MinorFault": 0,
+     "MinorFaultSet": false,
+     "Usable": 0,
+     "UsableSet": false,
+     "Total": 0,
+     "TotalSet": false
    }, 
    "Name": "testName", 
    "Net": [

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -932,10 +932,10 @@ var _ = Describe("[Serial]Infrastructure", func() {
 				if in && out {
 					break
 				}
-				if strings.Contains(k, `type="in"`) {
+				if strings.Contains(k, `swap_in`) {
 					in = true
 				}
-				if strings.Contains(k, `type="out"`) {
+				if strings.Contains(k, `swap_out`) {
 					out = true
 				}
 			}


### PR DESCRIPTION
- Split swap traffic bytes metric to swap in and swap out
- Expose counter metrics for minor and major page faults
- Expose gauge metric for actual balloon bytes
- Expose gauge metric for usable memory bytes
- Expose gauge metric for total used memory

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Modified memory related metrics by adding several new metrics and splitting the swap traffic bytes metric
```
