### PR TITLE
Don't hardcode ci specific setups for docker in tests

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -766,12 +766,6 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 				tcpPort := 8080
 				tests.StartPythonHttpServer(serverVMI, tcpPort)
 
-				By("Checking ping (IPv6) from vmi to cluster nodes gateway")
-				// Cluster nodes subnet (docker network gateway)
-				// Docker network subnet cidr definition:
-				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-				Expect(libnet.PingFromVMConsole(serverVMI, "2001:db8:1::1")).To(Succeed())
-
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
 			}, table.Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080}}),
 				table.Entry("without a specific port number [IPv6]", []v1.Port{}),


### PR DESCRIPTION
**What this PR does / why we need it**:

docker in CI is configured in a specific way with a specific CIDR. Two
tests are failing because they assume this address to be used by docker.

Removing this check for three reasons:

 1) It would require a specific ipv6 docker setup with a specific CIDR
 2) Without it no special docker configuration is necessary
3) the tests seems to want to implicitly check if the docker setup is right. That should not be it's task. It can not even assume that it runs in such an environment.
 
The tests clearly fail locally if docker is not exactly configured like in CI.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
