### PR TITLE
Add migration metrics from libvirt for prometheus for analyzing live migration progression

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -51,6 +51,21 @@ The total amount of unused memory as seen by the domain.
 
 The amount of traffic that is being read and written in swap memory.
 
+#### kubevirt_migrate_vmi_data_remaining_bytes
+#### HELP kubevirt_migrate_vmi_data_remaining_bytes The remaining VM data to be migrated.
+
+The remaining Guest OS data to be migrated to the new VM.
+
+#### kubevirt_migrate_vmi_data_processed_bytes
+#### HELP kubevirt_migrate_vmi_data_processed_bytes The total VM data processed and migrated.
+
+The total Guest OS data processed and migrated to the new VM.
+
+#### kubevirt_migrate_vmi_dirty_memory_rate_bytes
+#### HELP kubevirt_migrate_vmi_dirty_memory_rate_bytes The rate at which the memory is getting dirty in the VM being Migrated.
+
+The rate of memory being dirtied in the Guest OS.
+
 Extra labels:
 * `type` - Whether the data is being transmitted or received. `in` when transmitting and `out` when receiving.
 

--- a/pkg/monitoring/vms/prometheus/fakeCollector.go
+++ b/pkg/monitoring/vms/prometheus/fakeCollector.go
@@ -28,11 +28,12 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 	in := &libstatst[0]
 	inMem := []libvirt.DomainMemoryStat{}
 	inDomInfo := &libvirt.DomainInfo{}
+	jobInfo := stats.DomainJobInfo{}
 	out := stats.DomainStats{}
 	ident := statsconv.DomainIdentifier(&fakeIdentifier{})
 	devAliasMap := make(map[string]string)
 
-	if err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, inDomInfo, devAliasMap, &out); err != nil {
+	if err = statsconv.Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, inDomInfo, devAliasMap, &jobInfo, &out); err != nil {
 		panic(err)
 	}
 

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -89,6 +89,36 @@ func tryToPushMetric(desc *prometheus.Desc, mv prometheus.Metric, err error, ch 
 	ch <- mv
 }
 
+func (metrics *vmiMetrics) updateMigrateInfo(jobInfo *stats.DomainJobInfo) {
+	if jobInfo.DataRemainingSet {
+		metrics.pushCommonMetric(
+			"kubevirt_migrate_vmi_data_remaining_bytes",
+			"The remaining VM data to be migrated.",
+			prometheus.GaugeValue,
+			float64(jobInfo.DataRemaining)*1024,
+		)
+	}
+
+	if jobInfo.DataProcessedSet {
+		metrics.pushCommonMetric(
+			"kubevirt_migrate_vmi_data_processed_bytes",
+			"The total VM data processed and migrated.",
+			prometheus.GaugeValue,
+			float64(jobInfo.DataProcessed)*1024,
+		)
+	}
+
+	if jobInfo.MemDirtyRateSet {
+		metrics.pushCommonMetric(
+			"kubevirt_migrate_vmi_dirty_memory_rate_bytes",
+			"The rate at which the memory is getting dirty in the VM being Migrated.",
+			prometheus.GaugeValue,
+			float64(jobInfo.MemDirtyRate)*1024,
+		)
+	}
+
+}
+
 func (metrics *vmiMetrics) updateMemory(mem *stats.DomainStatsMemory) {
 	if mem.RSSSet {
 		metrics.pushCommonMetric(
@@ -704,6 +734,7 @@ func (metrics *vmiMetrics) updateMetrics(vmStats *stats.DomainStats) {
 	if vmStats.CPUMapSet {
 		metrics.updateCPUAffinity(vmStats.CPUMap)
 	}
+	metrics.updateMigrateInfo(vmStats.MigrateDomainJobInfo)
 }
 
 func (metrics *vmiMetrics) newPrometheusDesc(name string, help string, customLabels []string) *prometheus.Desc {

--- a/pkg/monitoring/vms/prometheus/prometheus_test.go
+++ b/pkg/monitoring/vms/prometheus/prometheus_test.go
@@ -312,6 +312,84 @@ var _ = Describe("Prometheus", func() {
 			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(float64(1024)))
 		})
 
+		It("should handle Data_Processed metrics for VMs", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				MigrateDomainJobInfo: &stats.DomainJobInfo{
+					DataProcessedSet: true,
+					DataProcessed:    1,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			dto := &io_prometheus_client.Metric{}
+			result.Write(dto)
+
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_migrate_vmi_data_processed_bytes"))
+			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(float64(1024)))
+		})
+
+		It("should handle Data_Remaining metrics for VMs", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				MigrateDomainJobInfo: &stats.DomainJobInfo{
+					DataRemainingSet: true,
+					DataRemaining:    1,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			dto := &io_prometheus_client.Metric{}
+			result.Write(dto)
+
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_migrate_vmi_data_remaining_bytes"))
+			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(float64(1024)))
+		})
+
+		It("should handle MemDirtyRate metrics for VMs", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				MigrateDomainJobInfo: &stats.DomainJobInfo{
+					MemDirtyRateSet: true,
+					MemDirtyRate:    1,
+				},
+			}
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			dto := &io_prometheus_client.Metric{}
+			result.Write(dto)
+
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_migrate_vmi_dirty_memory_rate_bytes"))
+			Expect(dto.Gauge.GetValue()).To(BeEquivalentTo(float64(1024)))
+		})
+
 		It("should handle vcpu metrics", func() {
 			ch := make(chan prometheus.Metric, 1)
 			defer close(ch)

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
+        "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",
         "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -177,15 +177,15 @@ func (_mr *_MockConnectionRecorder) GetAllDomainStats(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAllDomainStats", arg0, arg1)
 }
 
-func (_m *MockConnection) GetDomainStats(statsTypes libvirt_go.DomainStatsTypes, flags libvirt_go.ConnectGetAllDomainStatsFlags) ([]*stats.DomainStats, error) {
-	ret := _m.ctrl.Call(_m, "GetDomainStats", statsTypes, flags)
+func (_m *MockConnection) GetDomainStats(statsTypes libvirt_go.DomainStatsTypes, l *stats.DomainJobInfo, flags libvirt_go.ConnectGetAllDomainStatsFlags) ([]*stats.DomainStats, error) {
+	ret := _m.ctrl.Call(_m, "GetDomainStats", statsTypes, l, flags)
 	ret0, _ := ret[0].([]*stats.DomainStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockConnectionRecorder) GetDomainStats(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDomainStats", arg0, arg1)
+func (_mr *_MockConnectionRecorder) GetDomainStats(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDomainStats", arg0, arg1, arg2)
 }
 
 // Mock of Stream interface

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -124,6 +124,7 @@ type LibvirtDomainManager struct {
 	ovmfPath                 string
 	networkCacheStoreFactory cache.InterfaceCacheFactory
 	ephemeralDiskCreator     ephemeraldisk.EphemeralDiskCreatorInterface
+	migrateInfoStats         *stats.DomainJobInfo
 }
 
 type hostDeviceTypePrefix struct {
@@ -167,6 +168,7 @@ func NewLibvirtDomainManager(connection cli.Connection, virtShareDir string, not
 		ovmfPath:                 ovmfPath,
 		networkCacheStoreFactory: cache.NewInterfaceCacheFactory(),
 		ephemeralDiskCreator:     ephemeralDiskCreator,
+		migrateInfoStats:         &stats.DomainJobInfo{},
 	}
 	manager.credManager = accesscredentials.NewManager(connection, &manager.domainModifyLock)
 
@@ -1290,7 +1292,7 @@ func (l *LibvirtDomainManager) GetDomainStats() ([]*stats.DomainStats, error) {
 	statsTypes := libvirt.DOMAIN_STATS_BALLOON | libvirt.DOMAIN_STATS_CPU_TOTAL | libvirt.DOMAIN_STATS_VCPU | libvirt.DOMAIN_STATS_INTERFACE | libvirt.DOMAIN_STATS_BLOCK
 	flags := libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING
 
-	return l.virConn.GetDomainStats(statsTypes, flags)
+	return l.virConn.GetDomainStats(statsTypes, l.migrateInfoStats, flags)
 }
 
 func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstance, dom cli.VirDomain) ([]cloudinit.DeviceData, error) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -916,6 +916,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
+			//mockDomain.EXPECT().GetJobStats(gomock.Eq(libvirt.DomainGetJobStatsFlags(0))).AnyTimes().Return(fake_jobinfo, nil)
 			mockDomain.EXPECT().AbortJob()
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(xml), nil)
 			mockDomain.EXPECT().
@@ -963,6 +964,7 @@ var _ = Describe("Manager", func() {
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 			mockDomain.EXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(fake_jobinfo, nil)
+			// mockDomain.EXPECT().GetJobStats(gomock.Eq(libvirt.DomainGetJobStatsFlags(0))).AnyTimes().Return(fake_jobinfo, nil)
 			mockDomain.EXPECT().AbortJob()
 			mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).AnyTimes().Return(string(xml), nil)
 			mockDomain.EXPECT().
@@ -1580,8 +1582,10 @@ var _ = Describe("Manager", func() {
 
 	Context("on successful GetAllDomainStats", func() {
 		It("should return content", func() {
+			fake_jobinfo := stats.DomainJobInfo{}
 			mockConn.EXPECT().GetDomainStats(
 				gomock.Eq(libvirt.DOMAIN_STATS_BALLOON|libvirt.DOMAIN_STATS_CPU_TOTAL|libvirt.DOMAIN_STATS_VCPU|libvirt.DOMAIN_STATS_INTERFACE|libvirt.DOMAIN_STATS_BLOCK),
+				&fake_jobinfo,
 				gomock.Eq(libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING),
 			).Return([]*stats.DomainStats{
 				{},

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -53,6 +53,8 @@ type DomainStats struct {
 	Cpu *DomainStatsCPU
 	// new, see below
 	Memory *DomainStatsMemory
+	// new, see below
+	MigrateDomainJobInfo *DomainJobInfo
 	// omitted from libvirt-go: Balloon
 	Vcpu  []DomainStatsVcpu
 	Net   []DomainStatsNet
@@ -161,4 +163,15 @@ type DomainStatsMemory struct {
 	Usable           uint64
 	TotalSet         bool
 	Total            uint64
+}
+
+// mimic existing structs, but data is taken from
+// DomainJobInfo
+type DomainJobInfo struct {
+	DataProcessedSet bool
+	DataProcessed    uint64
+	DataRemainingSet bool
+	DataRemaining    uint64
+	MemDirtyRateSet  bool
+	MemDirtyRate     uint64
 }

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -32,7 +32,7 @@ type DomainIdentifier interface {
 	GetUUIDString() (string, error)
 }
 
-func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in *libvirt.DomainStats, inMem []libvirt.DomainMemoryStat, inDomInfo *libvirt.DomainInfo, devAliasMap map[string]string, out *stats.DomainStats) error {
+func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in *libvirt.DomainStats, inMem []libvirt.DomainMemoryStat, inDomInfo *libvirt.DomainInfo, devAliasMap map[string]string, inDomainJobInfo *stats.DomainJobInfo, out *stats.DomainStats) error {
 	name, err := ident.GetName()
 	if err != nil {
 		return err
@@ -50,6 +50,7 @@ func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in
 	out.Vcpu = Convert_libvirt_DomainStatsVcpu_To_stats_DomainStatsVcpu(in.Vcpu)
 	out.Net = Convert_libvirt_DomainStatsNet_To_stats_DomainStatsNet(in.Net, devAliasMap)
 	out.Block = Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in.Block, devAliasMap)
+	out.MigrateDomainJobInfo = inDomainJobInfo
 
 	return nil
 }
@@ -203,4 +204,19 @@ func Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in []libvirt.Dom
 		ret = append(ret, blkStat)
 	}
 	return ret
+}
+
+func Convert_libvirt_DomainJobInfo_To_stats_DomainJobInfo(info *libvirt.DomainJobInfo) *stats.DomainJobInfo {
+	if info == nil {
+		return &stats.DomainJobInfo{}
+	}
+
+	return &stats.DomainJobInfo{
+		DataProcessedSet: info.DataProcessedSet,
+		DataProcessed:    info.DataProcessed,
+		DataRemainingSet: info.DataRemainingSet,
+		DataRemaining:    info.DataRemaining,
+		MemDirtyRateSet:  info.MemDirtyRateSet,
+		MemDirtyRate:     info.MemDirtyRate,
+	}
 }

--- a/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter_test.go
@@ -52,12 +52,13 @@ var _ = Describe("StatsConverter", func() {
 			in := &libvirt.DomainStats{}
 			inMem := []libvirt.DomainMemoryStat{}
 			devAliasMap := make(map[string]string)
+			inJobInfo := &stats.DomainJobInfo{}
 			out := stats.DomainStats{}
 			mockDomainIdent.EXPECT().GetName().Return("testName", nil)
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, inJobInfo, &out)
 
 			Expect(err).To(BeNil())
 			Expect(out.Name).To(Equal("testName"))
@@ -68,17 +69,19 @@ var _ = Describe("StatsConverter", func() {
 			in := &testStats[0]
 			inMem := []libvirt.DomainMemoryStat{}
 			devAliasMap := make(map[string]string)
+			inJobInfo := &stats.DomainJobInfo{}
 			out := stats.DomainStats{}
 			mockDomainIdent.EXPECT().GetName().Return("testName", nil)
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, inJobInfo, &out)
 
 			Expect(err).To(BeNil())
 			// very very basic sanity check
 			Expect(out.Cpu).To(Not(BeNil()))
 			Expect(out.Memory).To(Not(BeNil()))
+			Expect(out.MigrateDomainJobInfo).To(Not(BeNil()))
 			Expect(len(out.Vcpu)).To(Equal(len(testStats[0].Vcpu)))
 			Expect(len(out.Net)).To(Equal(len(testStats[0].Net)))
 			Expect(len(out.Block)).To(Equal(len(testStats[0].Block)))
@@ -88,12 +91,13 @@ var _ = Describe("StatsConverter", func() {
 			in := &testStats[0]
 			inMem := []libvirt.DomainMemoryStat{}
 			devAliasMap := make(map[string]string)
+			inJobInfo := stats.DomainJobInfo{}
 			out := stats.DomainStats{}
 			mockDomainIdent.EXPECT().GetName().Return("testName", nil)
 			mockDomainIdent.EXPECT().GetUUIDString().Return("testUUID", nil)
 			ident := DomainIdentifier(mockDomainIdent)
 
-			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &out)
+			err := Convert_libvirt_DomainStats_to_stats_DomainStats(ident, in, inMem, nil, devAliasMap, &inJobInfo, &out)
 
 			Expect(err).To(BeNil())
 

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -181,6 +181,14 @@ var Testdataexpected = `{
      "Total": 0,
      "TotalSet": false
    }, 
+   "MigrateDomainJobInfo": {
+     "DataProcessed": 0,
+     "DataProcessedSet": false,
+     "DataRemaining": 0,
+     "DataRemainingSet": false,
+     "MemDirtyRate": 0,
+     "MemDirtyRateSet": false
+   },
    "Name": "testName", 
    "Net": [
      {


### PR DESCRIPTION
Add migration metrics from libvirt for prometheus for analyzing live migration progression.

Signed-off-by: Shweta Padubidri <spadubid@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
