### PR TITLE
Add description to VirtualMachinePreset

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -11501,6 +11501,7 @@
     }
    },
    "v1.VirtualMachineInstancePreset": {
+    "description": "VirtualMachineInstancePreset defines a VMI spec.domain to be applied to all VMIs that match the provided label selector More info: https://kubevirt.io/user-guide/virtual_machines/presets/#overrides",
     "type": "object",
     "properties": {
      "apiVersion": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5163,6 +5163,7 @@ var CRDsValidation map[string]string = map[string]string{
   type: object
 `,
 	"virtualmachineinstancepreset": `openAPIV3Schema:
+  description: 'VirtualMachineInstancePreset defines a VMI spec.domain to be applied to all VMIs that match the provided label selector More info: https://kubevirt.io/user-guide/virtual_machines/presets/#overrides'
   properties:
     apiVersion:
       description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -18761,7 +18761,8 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstancePreset(ref common.
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "VirtualMachineInstancePreset defines a VMI spec.domain to be applied to all VMIs that match the provided label selector More info: https://kubevirt.io/user-guide/virtual_machines/presets/#overrides",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -935,6 +935,8 @@ const (
 	MigrationFailed VirtualMachineInstanceMigrationPhase = "Failed"
 )
 
+// VirtualMachineInstancePreset defines a VMI spec.domain to be applied to all VMIs that match the provided label selector
+// More info: https://kubevirt.io/user-guide/virtual_machines/presets/#overrides
 //
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -235,7 +235,7 @@ func (VirtualMachineInstanceMigrationStatus) SwaggerDoc() map[string]string {
 
 func (VirtualMachineInstancePreset) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":     "+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object\n+k8s:openapi-gen=true",
+		"":     "VirtualMachineInstancePreset defines a VMI spec.domain to be applied to all VMIs that match the provided label selector\nMore info: https://kubevirt.io/user-guide/virtual_machines/presets/#overrides\n\n+k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object\n+k8s:openapi-gen=true",
 		"spec": "VirtualMachineInstance Spec contains the VirtualMachineInstance specification.",
 	}
 }

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -18616,7 +18616,8 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstancePreset(ref common.
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "VirtualMachineInstancePreset defines a VMI spec.domain to be applied to all VMIs that match the provided label selector More info: https://kubevirt.io/user-guide/virtual_machines/presets/#overrides",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
**What this PR does / why we need it**:
We have no description for kubevirt VMIPreset right now. This PR adds a brief description that will also show in documentation.

**Special notes for your reviewer**:
Feel free to suggest a better description.

**Release note**:
```release-note
None
```
