### PR TITLE
Fix pathes for oc and kubectl binaries on openshift ci

### DIFF
--- a/hack/ci/entrypoint.sh
+++ b/hack/ci/entrypoint.sh
@@ -90,12 +90,22 @@ function wait_on_kubevirt_ready() {
     oc wait -n kubevirt kv kubevirt --for condition=Available --timeout 15m
 }
 
+function get_path_or_empty_string_for_cmd() {
+    cmd="$1"
+    set +e
+    which "$cmd"
+    set -e
+}
+
 function run_tests() {
     mkdir -p "$ARTIFACT_DIR"
     # required to be set for test binary
     export ARTIFACTS=${ARTIFACT_DIR}
 
-    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${BIN_DIR}/oc -kubectl-path=${BIN_DIR}/kubectl -gocli-path=$(pwd)/cluster-up/cli.sh -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slowSpecThreshold=60 ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
+    OC_PATH=$(get_path_or_empty_string_for_cmd oc)
+    KUBECTL_PATH=$(get_path_or_empty_string_for_cmd kubectl)
+
+    tests.test -v=5 -kubeconfig=${KUBECONFIG} -container-tag=${DOCKER_TAG} -container-tag-alt= -container-prefix=${DOCKER_PREFIX} -image-prefix-alt=-kv -oc-path=${OC_PATH} -kubectl-path=${KUBECTL_PATH} -gocli-path=$(pwd)/cluster-up/cli.sh -test.timeout 420m -ginkgo.noColor -ginkgo.succinct -ginkgo.slowSpecThreshold=60 ${KUBEVIRT_TESTS_FOCUS} -junit-output=${ARTIFACT_DIR}/junit.functest.xml -installed-namespace=kubevirt -previous-release-tag= -previous-release-registry=quay.io/kubevirt -deploy-testing-infra=false
 }
 
 export PATH="$BIN_DIR:$PATH"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Fixes the script that executes the tests on openshift-ci with KubeVirt versions. Seen here: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-kubevirt-kubevirt-master-4.8-e2e/1366222299895697408#1:build-log.txt%3A203

The binary pathes for the oc and kubectl binaries were wrong, possibly
due to overseen changes regarding downloading vs. injection. Fixed path
calculation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @maya-r thanks for the heads up :) 
/cc @rmohr as this script belongs to openshift ci I just created a draft, trying not to cause ci load.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
