### PR TITLE
sriov, Fix race condition between LoginToFedora and cloud init

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -323,10 +323,9 @@ container_pull(
 # instead of index.docker.io
 container_pull(
     name = "fedora_sriov_lane",
-    digest = "sha256:2d332d28863d0e415d58e335e836bd4f8a8c714e7a9d1f8f87418ef3db7c0afb",
+    digest = "sha256:6f66ee747d62c354c0d36e640f8c97d6be0b6ad88a9e8c0180496ac55cba31bf",
     registry = "quay.io",
     repository = "kubevirtci/fedora-sriov-testing",
-    #tag = "32",
 )
 
 # Pull nfs-server image

--- a/tests/libvmi/factory.go
+++ b/tests/libvmi/factory.go
@@ -29,11 +29,16 @@ import (
 const (
 	DefaultTestGracePeriod int64 = 0
 	DefaultVmiName               = "testvmi"
+
+	userDataSetPassword = `#!/bin/bash
+	echo "fedora" | passwd fedora --stdin
+	echo `
 )
 
 // NewFedora instantiates a new Fedora based VMI configuration,
 // building its extra properties based on the specified With* options.
 func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	opts = append([]Option{WithCloudInitNoCloudUserData(userDataSetPassword, false)}, opts...)
 	return newFedora(cd.ContainerDiskFedora, opts...)
 }
 
@@ -41,6 +46,7 @@ func NewFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 // building its extra properties based on the specified With* options.
 // This image has tooling for the guest agent, stress, and more
 func NewTestToolingFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
+	opts = append([]Option{WithCloudInitNoCloudUserData(userDataSetPassword, false)}, opts...)
 	return newFedora(cd.ContainerDiskFedoraTestTooling, opts...)
 }
 
@@ -55,16 +61,11 @@ func NewSriovFedora(opts ...Option) *kvirtv1.VirtualMachineInstance {
 // containerDisk, building its extra properties based on the specified With*
 // options.
 func newFedora(containerDisk cd.ContainerDisk, opts ...Option) *kvirtv1.VirtualMachineInstance {
-	configurePassword := `#!/bin/bash
-	echo "fedora" |passwd fedora --stdin
-	echo `
-
 	fedoraOptions := []Option{
 		WithTerminationGracePeriod(DefaultTestGracePeriod),
 		WithResourceMemory("512M"),
 		WithRng(),
 		WithContainerImage(cd.ContainerDiskFor(containerDisk)),
-		WithCloudInitNoCloudUserData(configurePassword, false),
 	}
 	opts = append(fedoraOptions, opts...)
 	return New(RandName(DefaultVmiName), opts...)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4409,7 +4409,6 @@ func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion str
 }
 
 func WaitAgentConnected(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) {
-	By("Waiting for guest agent connection")
 	WaitForVMICondition(virtClient, vmi, v1.VirtualMachineInstanceAgentConnected, 12*60)
 }
 


### PR DESCRIPTION
There is a potential race between e2e tests `LoginToFedora`,
and Cloud-init which reconfigure the password.

The flow is as follows:
1. e2e spins VM and wait for it to be 'Running'
2. e2e tries to Login to the VM via the console.
3. e2e waits for Agent connected event.

As part of the VM spinning this flow occurs:
A. The VM has Cloud-init UserData, which cause the Cloud-init to reconfig the VM
according the default distro configuration which reset the fedora user to not have a password.
And then runs the UserData commands which adds a password.

In case A started but didn't finish before 2 (login attempt), there will be a race that will cause the login
to fail.
This race can cause the login to eventually fail, in case the retires are exhausted, or in case the console
expecter is going out of sync with the acutal console output (the login prompt is not idempotent when it happens).

In order to fix the race and keep the code as simple as possible,
this PR does the following:

* Use a VM without Cloud-init module which reconfigure the fedora user
to its default values.
* Remove the setting of the password via UserData, as it doesn't needed anymore,
since the password now isn't reset by the Cloud-init default config.

Image built by
kubevirt/kubevirtci#556

```release-note
None
```
