### PR TITLE
Policy and criteria for backporting to stable release branches

### DIFF
--- a/docs/release-branch-backporting.md
+++ b/docs/release-branch-backporting.md
@@ -1,0 +1,28 @@
+# Release Branch Backporting Policy
+
+Bug fixes are eligible to be backported from the master branch to any previous
+release branch. The following criteria must be met before a backport can be
+considered. It is the reviewer's and approver's responsibility to uphold this
+policy.
+
+- **Bug Fix Only:** The backport must be a bug fix and the bug fix must be
+first merged into the master branch. The only exception is when a bug only
+exists in a stable branch and does not exist in the master branch.
+
+- **Release Note** The PR description's release-note section must indicate in
+a brief one line statement what the backport addresses. This note gets
+automatically put into our release notes when a new release is cut from the
+stable branch.
+
+- **Detailed Description** The backport pull request's description must either
+contain a detailed explanation for what the bug fix addresses or contain a
+link to such a explanation present in another PR/Issue.
+
+- **CI Lanes Must Pass** The release branch being backported to must still be
+able to execute the unit and functional test lanes in order to validate the bug
+fix on that branch. This only impacts very old branches that are no longer
+compatible with our CI system.
+
+
+
+

--- a/docs/release-branch-backporting.md
+++ b/docs/release-branch-backporting.md
@@ -5,7 +5,7 @@ release branch. The following criteria must be met before a backport can be
 considered. It is the reviewer's and approver's responsibility to uphold this
 policy.
 
-- **Bug Fix Only:** The backport must be a bug fix and the bug fix must be
+- **Bug Fix Only:** The backport must be a [bug fix](https://github.com/kubevirt/kubevirt/blob/master/docs/release-branch-backporting.md#bug-fix-definition) and the bug fix must be
 first merged into the master branch. The only exception is when a bug only
 exists in a stable branch and does not exist in the master branch.
 
@@ -23,6 +23,24 @@ able to execute the unit and functional test lanes in order to validate the bug
 fix on that branch. This only impacts very old branches that are no longer
 compatible with our CI system.
 
+# Bug Fix Definition
 
+For the purposes of determining what is eligible for a backport we define a bug
+fix as any set of patches that loosely fall into one of the following
+categories.
 
+- Addresses a logical defect in KubeVirt
+- Fixes or improves the stability of our test suite
+- Any infrastructure change related testing or releasing
+
+There is purposefully some ambiguity here. These are meant to be read as
+guidelines to help reviewers make judgment calls. The intent here is to keep
+our release branches as stable as possible and only backport PRs that meet that
+goal.
+
+It's possible the eligibility of a backport will not be clear cut, and require
+some debate. Take for instance a PR that introduces new functionality to address
+a defect. Would this be considered a bug fix? Maybe, maybe not. The reviewers
+will have to weigh whether backporting will improve overall stability or
+introduce unacceptable risk.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -267,15 +267,12 @@ The release itself is only a git signed tag as it's used for minor releases as w
 
 # Merging to Release Branches
 
-> **Note:** Before a bug is fixed in a stable release branch, the same bug must
-> be fixed in the `master` branch. The only exception is when a bug exists in a
-> stable branch only.
-
 For every release a branch will be created following the pattern `release-x.y`.
 For now, community members can propose pull requests to be included into a
 stable branch.
 Those pull requests should be limited to bug fixes and must not be
-enhancements.
+enhancements. More info related to the policy around backporting can be found
+in this document, [docs/release-branch-backporting.md](https://github.com/kubevirt/kubevirt/blob/master/docs/release-branch-backporting.md)
 
 Cherry picking can be used to pick a merge commit from the master branch
 to a stable branch. An example:


### PR DESCRIPTION
This PR adds a document outlining our policy and expectations when it comes to backporting bug fixes to stable release branches. It's important that we as maintainers of the project uphold the policy outlined here so we clearly communicate what fixes are going into our release branches.


```release-note
Added our policy around release branch backporting in docs/release-branch-backporting.md
```
