### PR TITLE
Stabilize unschedulable node tests a bit

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -653,7 +653,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Eventually(func() []k8sv1.Node {
 					nodes = tests.GetAllSchedulableNodes(virtClient)
 					return nodes.Items
-				}, 60*time.Second, 1*time.Second).ShouldNot(BeEmpty(), "There should be schedulable nodes")
+				}, 2*time.Minute, 1*time.Second).ShouldNot(BeEmpty(), "There should be schedulable nodes")
 
 				node := nodes.Items[0]
 				nodeName = node.GetName()


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4387/pull-kubevirt-e2e-k8s-cnao-1.19/1365490827337404416 we have a flake where test_id 1635 failed to find a node that is schedulable in 60 seconds.
The test that ran before it seems like it has an opportunity to "bleed" an unschedulable node by getting the node before the patch is applied.

Make this less likely to happen by first checking that the node was updated.

While here, bump the time we wait for a schedulable node - 1 minute timeout for something that takes a minute is quite a narrow fit.

and then the A
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This fixes the latest flake in #4833, but I have seen it flake elsewhere in the same test during testing :-/

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
