### PR TITLE
virt-launcher, sriov: Update the domain config state on detach

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -334,6 +334,16 @@ func (_mr *_MockVirDomainRecorder) DetachDevice(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachDevice", arg0)
 }
 
+func (_m *MockVirDomain) DetachDeviceFlags(xml string, flags libvirt_go.DomainDeviceModifyFlags) error {
+	ret := _m.ctrl.Call(_m, "DetachDeviceFlags", xml, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) DetachDeviceFlags(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DetachDeviceFlags", arg0, arg1)
+}
+
 func (_m *MockVirDomain) DestroyFlags(flags libvirt_go.DomainDestroyFlags) error {
 	ret := _m.ctrl.Call(_m, "DestroyFlags", flags)
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -408,6 +408,7 @@ type VirDomain interface {
 	Resume() error
 	AttachDevice(xml string) error
 	DetachDevice(xml string) error
+	DetachDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
 	DestroyFlags(flags libvirt.DomainDestroyFlags) error
 	ShutdownFlags(flags libvirt.DomainShutdownFlags) error
 	UndefineFlags(flags libvirt.DomainUndefineFlagsValues) error

--- a/pkg/virt-launcher/virtwrap/device/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/sriov/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/device:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )
 
@@ -32,5 +33,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/device/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/sriov/hostdev.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"libvirt.org/libvirt-go"
+
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -94,7 +96,7 @@ func createHostDevice(iface v1.Interface, hostPCIAddress string) (*api.HostDevic
 }
 
 type deviceDetacher interface {
-	DetachDevice(xmlData string) error
+	DetachDeviceFlags(xml string, flags libvirt.DomainDeviceModifyFlags) error
 }
 
 type eventRegistrar interface {
@@ -143,7 +145,7 @@ func detachHostDevices(dom deviceDetacher, hostDevices []api.HostDevice) error {
 		if err != nil {
 			return fmt.Errorf("failed to encode (xml) hostdev %v, err: %v", hostDev, err)
 		}
-		err = dom.DetachDevice(string(devXML))
+		err = dom.DetachDeviceFlags(string(devXML), libvirt.DOMAIN_DEVICE_MODIFY_LIVE|libvirt.DOMAIN_DEVICE_MODIFY_CONFIG)
 		if err != nil {
 			return fmt.Errorf("failed to detach hostdev %s, err: %v", devXML, err)
 		}

--- a/pkg/virt-launcher/virtwrap/device/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/sriov/hostdev_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"libvirt.org/libvirt-go"
+
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/sriov"
@@ -313,7 +315,7 @@ type deviceDetacherStub struct {
 	fail bool
 }
 
-func (d deviceDetacherStub) DetachDevice(data string) error {
+func (d deviceDetacherStub) DetachDeviceFlags(data string, flags libvirt.DomainDeviceModifyFlags) error {
 	if d.fail {
 		return fmt.Errorf("detach device error")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

When detaching a SR-IOV host-device, the existing `DetachDevice`
function only updates the domain live state.

In order to update the domain config, the `DetachDeviceFlags` needs to
be used and instructed to update both domain states.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This should be a per-requirement for #5037 .

The issue has pop up after #5010 got in, fixing the domain mode on the target (from transient to persisted).

**Release note**:
```release-note
NONE
```
