### PR TITLE
rephrase "No VolumeSnapshotClass" reason

### DIFF
--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -656,23 +656,26 @@ func (ctrl *VMSnapshotController) getVolumeSnapshotStatus(vm *kubevirtv1.Virtual
 			Reason:  fmt.Sprintf("Volume is nil [%s]", volume.Name),
 		}
 	}
-	sc, err := ctrl.getVolumeStorageClassForVolume(vm.Namespace, volume)
+	sc, err := ctrl.getVolumeStorageClass(vm.Namespace, volume)
 	if err != nil {
 		return kubevirtv1.VolumeSnapshotStatus{Name: volume.Name, Enabled: false, Reason: err.Error()}
 	}
-	if sc == "" {
+	snap, err := ctrl.getVolumeSnapshotClass(sc)
+	if err != nil {
+		return kubevirtv1.VolumeSnapshotStatus{Name: volume.Name, Enabled: false, Reason: err.Error()}
+	}
+	if snap == "" {
 		return kubevirtv1.VolumeSnapshotStatus{
 			Name:    volume.Name,
 			Enabled: false,
-			Reason:  fmt.Sprintf("No Volume Snapshot Storage Class found for volume [%s]", volume.Name),
+			Reason:  fmt.Sprintf("No VolumeSnapshotClass: Volume snapshots are not configured for this StorageClass [%s] [%s]", sc, volume.Name),
 		}
 	}
 
 	return kubevirtv1.VolumeSnapshotStatus{Name: volume.Name, Enabled: true}
 }
 
-func (ctrl *VMSnapshotController) getVolumeStorageClassForVolume(namespace string, volume *kubevirtv1.Volume) (string, error) {
-
+func (ctrl *VMSnapshotController) getVolumeStorageClass(namespace string, volume *kubevirtv1.Volume) (string, error) {
 	// TODO Add Ephemeral (add "|| volume.VolumeSource.Ephemeral != nil" to the `if` below)
 	if volume.VolumeSource.PersistentVolumeClaim != nil {
 		pvcKey := cacheKeyFunc(namespace, volume.VolumeSource.PersistentVolumeClaim.ClaimName)
@@ -687,7 +690,7 @@ func (ctrl *VMSnapshotController) getVolumeStorageClassForVolume(namespace strin
 		}
 		pvc := obj.(*corev1.PersistentVolumeClaim)
 		if pvc.Spec.StorageClassName != nil {
-			return ctrl.getVolumeSnapshotClass(*pvc.Spec.StorageClassName)
+			return *pvc.Spec.StorageClassName, nil
 		}
 		return "", nil
 	}
@@ -696,11 +699,9 @@ func (ctrl *VMSnapshotController) getVolumeStorageClassForVolume(namespace strin
 		if err != nil {
 			return "", err
 		}
-
-		return ctrl.getVolumeSnapshotClass(storageClassName)
+		return storageClassName, nil
 	}
-
-	return "", fmt.Errorf("Volume type does not suport snapshots")
+	return "", fmt.Errorf("Volume type has no StorageClass defined")
 }
 
 func (ctrl *VMSnapshotController) getStorageClassNameForDV(namespace string, dvName string) (string, error) {

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -1179,27 +1179,27 @@ var _ = Describe("Snapshot controlleer", func() {
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Name).To(Equal("disk1"))
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[0].Reason).
-							To(Equal("No Volume Snapshot Storage Class found for volume [disk1]"))
+							To(Equal("No VolumeSnapshotClass: Volume snapshots are not configured for this StorageClass [local] [disk1]"))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[1].Name).To(Equal("disk2"))
 						Expect(vm.Status.VolumeSnapshotStatuses[1].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[1].Reason).
-							To(Equal("Volume type does not suport snapshots"))
+							To(Equal("Volume type has no StorageClass defined"))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[2].Name).To(Equal("disk3"))
 						Expect(vm.Status.VolumeSnapshotStatuses[2].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[2].Reason).
-							To(Equal("No Volume Snapshot Storage Class found for volume [disk3]"))
+							To(Equal("No VolumeSnapshotClass: Volume snapshots are not configured for this StorageClass [local] [disk3]"))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[3].Name).To(Equal("disk4"))
 						Expect(vm.Status.VolumeSnapshotStatuses[3].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[3].Reason).
-							To(Equal("Volume type does not suport snapshots"))
+							To(Equal("Volume type has no StorageClass defined"))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[4].Name).To(Equal("disk5"))
 						Expect(vm.Status.VolumeSnapshotStatuses[4].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[4].Reason).
-							To(Equal("No Volume Snapshot Storage Class found for volume [disk5]"))
+							To(Equal("No VolumeSnapshotClass: Volume snapshots are not configured for this StorageClass [local] [disk5]"))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[5].Name).To(Equal("disk6"))
 						Expect(vm.Status.VolumeSnapshotStatuses[5].Enabled).To(BeFalse())
@@ -1209,12 +1209,12 @@ var _ = Describe("Snapshot controlleer", func() {
 						Expect(vm.Status.VolumeSnapshotStatuses[6].Name).To(Equal("disk7"))
 						Expect(vm.Status.VolumeSnapshotStatuses[6].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[6].Reason).
-							To(Equal("No Volume Snapshot Storage Class found for volume [disk7]"))
+							To(Equal("No VolumeSnapshotClass: Volume snapshots are not configured for this StorageClass [] [disk7]"))
 
 						Expect(vm.Status.VolumeSnapshotStatuses[7].Name).To(Equal("disk8"))
 						Expect(vm.Status.VolumeSnapshotStatuses[7].Enabled).To(BeFalse())
 						Expect(vm.Status.VolumeSnapshotStatuses[7].Reason).
-							To(Equal("No Volume Snapshot Storage Class found for volume [disk8]"))
+							To(Equal("No VolumeSnapshotClass: Volume snapshots are not configured for this StorageClass [] [disk8]"))
 
 						updateCalled = true
 					})


### PR DESCRIPTION
Signed-off-by: Arnon Gilboa <agilboa@redhat.com>

**What this PR does / why we need it**:
Simply rephrase the reason to:
`No VolumeSnapshotClass: Volume snapshots are not configured for this Storage Class [storage_class_name] [volume_name]`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
```release-note
NONE
```
