### PR TITLE
Quarantine flakiest tests

### DIFF
--- a/automation/run-quarantined-tests.sh
+++ b/automation/run-quarantined-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+main(){
+    result=$(FUNC_TEST_ARGS='-dryRun -focus=QUARANTINE' make functest)
+    quarantined_tests=$(echo "$result" | grep '^Ran.*of.*Specs' | awk '{print $2}')
+    if [ "${quarantined_tests}" != "0" ]; then
+        automation/test.sh
+    fi
+}
+
+main "$@"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -298,6 +298,11 @@ if [[ "$KUBEVIRT_STORAGE" == "rook-ceph" ]]; then
   export KUBEVIRT_E2E_FOCUS=rook-ceph
 fi
 
+# Only run quarantined tests if KUBEVIRT_QUARANTINE is set
+if [ -z "$KUBEVIRT_QUARANTINE" ]; then
+    KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|QUARANTINE"
+fi
+
 # Prepare RHEL PV for Template testing
 if [[ $TARGET =~ os-.* ]]; then
   ginko_params="$ginko_params|Networkpolicy"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -298,9 +298,20 @@ if [[ "$KUBEVIRT_STORAGE" == "rook-ceph" ]]; then
   export KUBEVIRT_E2E_FOCUS=rook-ceph
 fi
 
-# Only run quarantined tests if KUBEVIRT_QUARANTINE is set
-if [ -z "$KUBEVIRT_QUARANTINE" ]; then
-    KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|QUARANTINE"
+# If KUBEVIRT_QUARANTINE is set, only run quarantined tests; if not,
+# do not run quarantined tests.
+if [ -n "$KUBEVIRT_QUARANTINE" ]; then
+    if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+        KUBEVIRT_E2E_FOCUS="${KUBEVIRT_E2E_FOCUS}|QUARANTINE"
+    else
+        KUBEVIRT_E2E_FOCUS="QUARANTINE"
+    fi
+else
+    if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+        KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|QUARANTINE"
+    else
+        KUBEVIRT_E2E_SKIP="QUARANTINE"
+    fi
 fi
 
 # Prepare RHEL PV for Template testing

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -129,7 +129,7 @@ var _ = Describe("[Serial]ImageUpload", func() {
 	}
 
 	Context("Upload an image and start a VMI with PVC on rook-ceph", func() {
-		DescribeTable("[QUARANTINE][test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
+		DescribeTable("[QUARANTINE][owner:@sig-storage][test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := tests.GetCephStorageClass()
 			if !exists {
 				Skip("Skip OCS tests when Ceph is not present")

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -129,8 +129,7 @@ var _ = Describe("[Serial]ImageUpload", func() {
 	}
 
 	Context("Upload an image and start a VMI with PVC on rook-ceph", func() {
-		Skip("Skip due to flakiness")
-		DescribeTable("[test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
+		DescribeTable("[QUARANTINE][test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := tests.GetCephStorageClass()
 			if !exists {
 				Skip("Skip OCS tests when Ceph is not present")

--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -129,6 +129,7 @@ var _ = Describe("[Serial]ImageUpload", func() {
 	}
 
 	Context("Upload an image and start a VMI with PVC on rook-ceph", func() {
+		Skip("Skip due to flakiness")
 		DescribeTable("[test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := tests.GetCephStorageClass()
 			if !exists {

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1000,7 +1000,7 @@ spec:
 		// Updating KubeVirt to the target tested code
 		// Ensuring VM/VMI is still operational after the update from previous release.
 		It("[test_id:3145]from previous release to target tested release", func() {
-
+			Skip("Skip due to flakiness")
 			if !tests.HasCDI() {
 				Skip("Skip Update test when CDI is not present")
 			}
@@ -1405,7 +1405,7 @@ spec:
 		})
 
 		It("[test_id:3150]should be able to update kubevirt install with custom image tag", func() {
-
+			Skip("Skip due to flakiness")
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -999,8 +999,7 @@ spec:
 		// running a VM/VMI using that previous release
 		// Updating KubeVirt to the target tested code
 		// Ensuring VM/VMI is still operational after the update from previous release.
-		It("[test_id:3145]from previous release to target tested release", func() {
-			Skip("Skip due to flakiness")
+		It("[QUARANTINE][test_id:3145]from previous release to target tested release", func() {
 			if !tests.HasCDI() {
 				Skip("Skip Update test when CDI is not present")
 			}
@@ -1404,8 +1403,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[test_id:3150]should be able to update kubevirt install with custom image tag", func() {
-			Skip("Skip due to flakiness")
+		It("[QUARANTINE][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1021,7 +1021,7 @@ spec:
 		// running a VM/VMI using that previous release
 		// Updating KubeVirt to the target tested code
 		// Ensuring VM/VMI is still operational after the update from previous release.
-		It("[QUARANTINE][test_id:3145]from previous release to target tested release", func() {
+		It("[owner:@sig-compute][test_id:3145]from previous release to target tested release", func() {
 			if !tests.HasCDI() {
 				Skip("Skip Update test when CDI is not present")
 			}
@@ -1425,7 +1425,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[QUARANTINE][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
+		It("[QUARANTINE][owner:@sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -641,7 +641,29 @@ var _ = Describe("[Serial]Operator", func() {
 					if vmi.Status.MigrationState == nil {
 						return fmt.Errorf("waiting for vmi %s/%s to migrate as part of update", vmi.Namespace, vmi.Name)
 					} else if !vmi.Status.MigrationState.Completed {
-						return fmt.Errorf("waiting for migration %s to complete for vmi %s/%s", string(vmi.Status.MigrationState.MigrationUID), vmi.Namespace, vmi.Name)
+
+						var startTime time.Time
+						var endTime time.Time
+						now := time.Now()
+
+						if vmi.Status.MigrationState.StartTimestamp != nil {
+							startTime = vmi.Status.MigrationState.StartTimestamp.Time
+						}
+						if vmi.Status.MigrationState.EndTimestamp != nil {
+							endTime = vmi.Status.MigrationState.EndTimestamp.Time
+						}
+
+						return fmt.Errorf("waiting for migration %s to complete for vmi %s/%s. Source Node [%s], Target Node [%s], Start Time [%s], End Time [%s], Now [%s], Failed: %t",
+							string(vmi.Status.MigrationState.MigrationUID),
+							vmi.Namespace,
+							vmi.Name,
+							vmi.Status.MigrationState.SourceNode,
+							vmi.Status.MigrationState.TargetNode,
+							startTime.String(),
+							endTime.String(),
+							now.String(),
+							vmi.Status.MigrationState.Failed,
+						)
 					}
 
 					_, hasOutdatedLabel := vmi.Labels[v1.OutdatedLauncherImageLabel]
@@ -650,7 +672,7 @@ var _ = Describe("[Serial]Operator", func() {
 					}
 				}
 				return nil
-			}, 320, 1).Should(BeNil(), "All VMIs should update via live migration")
+			}, 500, 1).Should(BeNil(), "All VMIs should update via live migration")
 
 			// this is put in an eventually loop because it's possible for the VMI to complete
 			// migrating and for the migration object to briefly lag behind in reporting

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -349,6 +349,7 @@ var _ = Describe("Storage", func() {
 			})
 		})
 		Context("Run a VMI with VirtIO-FS and a datavolume", func() {
+			Skip("Skip due to flakiness")
 			var dataVolume *cdiv1.DataVolume
 			BeforeEach(func() {
 				if !tests.HasCDI() {
@@ -879,6 +880,7 @@ var _ = Describe("Storage", func() {
 
 			// Not a candidate for NFS because local volumes are used in test
 			It("[test_id:1015] should be successfully started", func() {
+				Skip("Skip due to flakiness")
 				tests.SkipPVCTestIfRunnigOnKindInfra()
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi = tests.NewRandomVMIWithPVC(tests.BlockDiskForTest)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -349,7 +349,6 @@ var _ = Describe("Storage", func() {
 			})
 		})
 		Context("Run a VMI with VirtIO-FS and a datavolume", func() {
-			Skip("Skip due to flakiness")
 			var dataVolume *cdiv1.DataVolume
 			BeforeEach(func() {
 				if !tests.HasCDI() {
@@ -358,7 +357,7 @@ var _ = Describe("Storage", func() {
 				dataVolume = tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 			})
 
-			It("should be successfully started and virtiofs could be accessed", func() {
+			It("[QUARANTINE]should be successfully started and virtiofs could be accessed", func() {
 				tests.SkipPVCTestIfRunnigOnKindInfra()
 
 				vmi := tests.NewRandomVMIWithFSFromDataVolume(dataVolume.Name)
@@ -879,8 +878,7 @@ var _ = Describe("Storage", func() {
 			})
 
 			// Not a candidate for NFS because local volumes are used in test
-			It("[test_id:1015] should be successfully started", func() {
-				Skip("Skip due to flakiness")
+			It("[QUARANTINE][test_id:1015] should be successfully started", func() {
 				tests.SkipPVCTestIfRunnigOnKindInfra()
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi = tests.NewRandomVMIWithPVC(tests.BlockDiskForTest)

--- a/tests/storage_test.go
+++ b/tests/storage_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Storage", func() {
 				dataVolume = tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
 			})
 
-			It("[QUARANTINE]should be successfully started and virtiofs could be accessed", func() {
+			It("[QUARANTINE][owner:@sig-compute]should be successfully started and virtiofs could be accessed", func() {
 				tests.SkipPVCTestIfRunnigOnKindInfra()
 
 				vmi := tests.NewRandomVMIWithFSFromDataVolume(dataVolume.Name)
@@ -878,7 +878,7 @@ var _ = Describe("Storage", func() {
 			})
 
 			// Not a candidate for NFS because local volumes are used in test
-			It("[QUARANTINE][test_id:1015] should be successfully started", func() {
+			It("[QUARANTINE][owner:@sig-storage][test_id:1015] should be successfully started", func() {
 				tests.SkipPVCTestIfRunnigOnKindInfra()
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi = tests.NewRandomVMIWithPVC(tests.BlockDiskForTest)

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -245,7 +245,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
-			table.Entry("[QUARANTINE][test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
+			table.Entry("[QUARANTINE][owner:@sig-network][test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
 			table.Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", "InboundVMIWithPodNetworkSet"),
 			table.Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", "InboundVMIWithCustomMacAddress"),
 			table.Entry("[test_id:1542]the internet", "Internet"),

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -245,7 +245,8 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
-			table.Entry("[test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
+			// Skip("Skip due to flakiness")
+			//table.Entry("[test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
 			table.Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", "InboundVMIWithPodNetworkSet"),
 			table.Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", "InboundVMIWithCustomMacAddress"),
 			table.Entry("[test_id:1542]the internet", "Internet"),

--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -245,8 +245,7 @@ var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][le
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
-			// Skip("Skip due to flakiness")
-			//table.Entry("[test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
+			table.Entry("[QUARANTINE][test_id:1539]the Inbound VirtualMachineInstance", "InboundVMI"),
 			table.Entry("[test_id:1540]the Inbound VirtualMachineInstance with pod network connectivity explicitly set", "InboundVMIWithPodNetworkSet"),
 			table.Entry("[test_id:1541]the Inbound VirtualMachineInstance with custom MAC address", "InboundVMIWithCustomMacAddress"),
 			table.Entry("[test_id:1542]the internet", "Internet"),


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: apply the `[QUARANTINE]` label to the flakiest tests at the moment, these tests won't be executed on the required lanes and will be run on separated non-required lanes added in this PR https://github.com/kubevirt/project-infra/pull/1003 

The quarantined tests have been selecting taking into account the most flaky tests as reported by testgrid here:
https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.17&width=20&show-stale-tests=
https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.17-rook-ceph&width=20&show-stale-tests=
https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.18&width=20&show-stale-tests=
https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.19&width=20&show-stale-tests= 
https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.17-sriov&width=20&show-stale-tests=

The main goal is to start unblocking the current bottleneck we have in the CI queue by implementing one of the proposed solutions for addressing flakiness. We don't have any policy in place for removing the quarantined tests from the test suite or bringing them back to the required lanes, we should agree in any case that they are fixed before that happens.

At the moment the quarantine lanes are not reporting status to the PRs to not cause unnecessary noise before this PR is merged. Once it lands we will enable status report.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
