### PR TITLE
Fix possible memory leak of libvirt.Domains

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -267,6 +267,13 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 	if err != nil {
 		return nil, err
 	}
+	// Free memory allocated for domains
+	defer func() {
+		for i := range domStats {
+			err := domStats[i].Domain.Free()
+			log.Log.Reason(err).Warning("Error freeing a domain.")
+		}
+	}()
 
 	var list []*stats.DomainStats
 	for i, domStat := range domStats {
@@ -284,7 +291,6 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 		}
 
 		list = append(list, stat)
-		domStat.Domain.Free()
 	}
 
 	return list, nil

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1887,6 +1887,13 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Free memory allocated for domains
+	defer func() {
+		for i := range doms {
+			err := doms[i].Free()
+			log.Log.Reason(err).Warning("Error freeing a domain")
+		}
+	}()
 
 	var list []*api.Domain
 	for _, dom := range doms {
@@ -1914,7 +1921,6 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 		}
 		domain.SetState(util.ConvState(status), util.ConvReason(status, reason))
 		list = append(list, domain)
-		dom.Free()
 	}
 
 	return list, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix possible memory leak of `libvirt.Domains`. In these cases, the domains were not freed using `defer`.

**Release note**:
```release-note
None
```
