### PR TITLE
tests, sriov: Do not configure pod network IPv6 on fedora-login

### DIFF
--- a/tests/vmi_multus_test.go
+++ b/tests/vmi_multus_test.go
@@ -665,7 +665,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 			// Kubevirt re-enqueue the request once it happens, so its safe to ignore this warning.
 			// see https://github.com/kubevirt/kubevirt/issues/5027
 			warningsIgnoreList := []string{"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded"}
-			tests.WaitUntilVMIReadyIgnoreSelectedWarnings(vmi, libnet.WithIPv6(console.LoginToFedora), warningsIgnoreList)
+			tests.WaitUntilVMIReadyIgnoreSelectedWarnings(vmi, console.LoginToFedora, warningsIgnoreList)
 			tests.WaitAgentConnected(virtClient, vmi)
 			return vmi
 		}


### PR DESCRIPTION
Sriov tests doesn't need to configure ipv6 for pod network,
as they don't check deafault pod network.
Moreoever in case we do need to config it, the right way
will be to use NetworkData, as it would also solve
potential misconfiguration that using hardocoded eth0
might lead to.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
