### PR TITLE
Check error before logging

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -271,7 +271,9 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 	defer func() {
 		for i := range domStats {
 			err := domStats[i].Domain.Free()
-			log.Log.Reason(err).Warning("Error freeing a domain.")
+			if err != nil {
+				log.Log.Reason(err).Warning("Error freeing a domain.")
+			}
 		}
 	}()
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1891,7 +1891,9 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 	defer func() {
 		for i := range doms {
 			err := doms[i].Free()
-			log.Log.Reason(err).Warning("Error freeing a domain")
+			if err != nil {
+				log.Log.Reason(err).Warning("Error freeing a domain")
+			}
 		}
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Check error before logging. My previous PR #5158 was merged before I noticed that it writes to log even if there is no error.

**Release note**:
```release-note
None
```
