### PR TITLE
sig-network, Add networking tests to the sig network family

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -40,6 +40,9 @@ if [[ $TARGET =~ windows.* ]]; then
 elif [[ $TARGET =~ cnao ]]; then
   export KUBEVIRT_WITH_CNAO=true
   export KUBEVIRT_PROVIDER=${TARGET/-cnao/}
+elif [[ $TARGET =~ sig-network ]]; then
+  export KUBEVIRT_WITH_CNAO=true
+  export KUBEVIRT_PROVIDER=${TARGET/-sig-network/}
 else
   export KUBEVIRT_PROVIDER=${TARGET}
 fi
@@ -284,6 +287,8 @@ EOF
   export KUBEVIRT_E2E_FOCUS=Windows
 elif [[ $TARGET =~ (cnao|multus) ]]; then
   export KUBEVIRT_E2E_FOCUS="Multus|Networking|VMIlifecycle|Expose|Macvtap"
+elif [[ $TARGET =~ sig-network ]]; then
+  export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
 elif [[ $TARGET =~ sriov.* ]]; then
   export KUBEVIRT_E2E_FOCUS=SRIOV
 elif [[ $TARGET =~ gpu.* ]]; then

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -48,7 +48,7 @@ func newLabeledVMI(label string, virtClient kubecli.KubevirtClient, createVMI bo
 	return
 }
 
-var _ = Describe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", func() {
+var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:component]Expose", func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error

--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -25,7 +25,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
+var _ = SIGDescribe("[Serial][rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:component]Networkpolicy", func() {
 	var (
 		virtClient                                          kubecli.KubevirtClient
 		serverVMI, clientVMI, clientVMIAlternativeNamespace *v1.VirtualMachineInstance

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -72,7 +72,7 @@ const (
 
 const ptpSubnet = "10.1.1.0/24"
 
-var _ = Describe("[Serial]Multus", func() {
+var _ = SIGDescribe("[Serial]Multus", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -1022,7 +1022,7 @@ var _ = Describe("[Serial]SRIOV", func() {
 	})
 })
 
-var _ = Describe("[Serial]Macvtap", func() {
+var _ = SIGDescribe("[Serial]Macvtap", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var macvtapLowerDevice string

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -54,7 +54,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", func() {
+var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:component]Networking", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -39,7 +39,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial]Slirp Networking", func() {
+var _ = SIGDescribe("[Serial]Slirp Networking", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient


### PR DESCRIPTION
In order to have a method to run sig-network tests in an isolated environment,
mark the relevant tests with `sig-network`.

The dedicated job that has `sig-network` on its TARGET,
would run only the tests that are marked with `[sig-network]`.

CNAO is deployed on `sig-network` jobs.

See https://github.com/kubevirt/project-infra/pull/1007

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
