### PR TITLE
tests, outside-connectivity: change hard-coded addresses to cmd flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ functest-image-push: functest-image-build
 	hack/func-tests-image.sh push
 
 conformance:
-	hack/dockerized "hack/conformance.sh"
+	hack/dockerized "export SKIP_OUTSIDE_CONN_TESTS=${SKIP_OUTSIDE_CONN_TESTS} && hack/conformance.sh"
 
 clean:
 	hack/dockerized "./hack/build-go.sh clean ${WHAT} && rm _out/* -rf"

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -62,6 +62,12 @@ Skipped: 579
 make conformance
 ```
 
+To run without outside connectivity tests add the argument:
+
+```bash
+make conformance SKIP_OUTSIDE_CONN_TESTS=true
+```
+
 ## Generate manifests
 
 Conformance tests plugin manifest template under

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -12,6 +12,9 @@ image_pull_policy=${IMAGE_PULL_POLICY:-IfNotPresent}
 verbosity=${VERBOSITY:-2}
 package_name=${PACKAGE_NAME:-kubevirt-dev}
 kubevirtci_git_hash="2105241320-c8ff457"
+conn_check_ipv4_address=${CONN_CHECK_IPV4_ADDRESS:-""}
+conn_check_ipv6_address=${CONN_CHECK_IPV6_ADDRESS:-""}
+conn_check_dns=${CONN_CHECK_DNS:-""}
 
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"

--- a/hack/conformance.sh
+++ b/hack/conformance.sh
@@ -11,8 +11,14 @@ mkdir -p ${ARTIFACTS}
 echo 'Obtaining KUBECONFIG of the development cluster'
 export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
 
+sonobuoy_args="--wait --plugin _out/manifests/release/conformance.yaml"
+
+if [[ ! -z "$SKIP_OUTSIDE_CONN_TESTS" ]]; then
+    sonobuoy_args="${sonobuoy_args} --plugin-env kubevirt-conformance.E2E_SKIP=\[outside_connectivity\]"
+fi
+
 echo 'Executing conformance tests and wait for them to finish'
-sonobuoy run --wait --plugin _out/manifests/release/conformance.yaml
+sonobuoy run ${sonobuoy_args}
 
 trap "{ echo 'Cleaning up after the test execution'; sonobuoy delete --wait; }" EXIT SIGINT SIGTERM SIGQUIT
 

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -40,11 +40,12 @@ rm -rf $ARTIFACTS
 mkdir -p $ARTIFACTS
 
 function functest() {
-    extra_args="${extra_args} -apply-default-e2e-configuration"
+    extra_args="${extra_args} -apply-default-e2e-configuration -conn-check-ipv4-address=${conn_check_ipv4_address} -conn-check-ipv6-address=${conn_check_ipv6_address} -conn-check-dns=${conn_check_dns}"
     if [[ ${KUBEVIRT_PROVIDER} =~ .*(k8s-1\.16)|(k8s-1\.17)|k8s-sriov.* ]]; then
         echo "Will skip test asserting the cluster is in dual-stack mode."
         extra_args="${extra_args} -skip-dual-stack-test"
     fi
+
     _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${functest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,12 +41,41 @@ Integration tests require a running Kubevirt cluster.  Once you have a running
 Kubevirt cluster, you can use the `-master` and the `-kubeconfig` flags to
 point the tests to the cluster.
 
+## Running networking tests for outside connectivity
+
+When running the tests with no internet connection,
+some networking tests ,that test outside connectivity, might fail,
+and you might want to skip them.
+For that some additional flags are needed to be passed.
+In addition, if you'd like to test outside connectivity
+using different addresses than the default
+(`8.8.8.8`, `2001:db8:1::1` and `google.com`), you can achive that with the 
+designated flags as well.
+
+For each method detailed below, there is note about the needed flags
+to the outside connectivity tests and how to pass them.
+
 ## Run them on an arbitrary KubeVirt installation
 
 ```
 cd tests # from the git repo root folder
 go test -kubeconfig=path/to/my/config -config=default-config.json
 ```
+
+>**outside connectivity tests:** The tests will run by default.
+>To skip the outside connectivity tests add
+>`-ginkgo.skip='\[outside_connectivity\]'` To your go command.
+>To change the IPV4, IPV6 or DNS used for outside connectivity tests,
+>add `conn-check-ipv4-address`,
+>`conn-check-ipv6-address` or `conn-check-dns` to your go command,
+>with the desired value.
+>For example:
+>```
+>go test -kubeconfig=$KUBECONFIG -config=default-config.json \
+>-conn-check-ipv4-address=8.8.4.4 -conn-check-ipv6-address=2620:119:35::35 \
+>-conn-check-dns=amazon.com \
+>```
+
 
 ## Run them on one of the core KubeVirt providers
 
@@ -57,6 +86,18 @@ taken from hack/config.sh:
 # from the git repo root folder
 make functest
 ```
+
+>**outside connectivity tests:** The tests will run by default. To skip
+>the tests export `KUBEVIRT_E2E_SKIP='\[outside_connectivity\]'` 
+>environment variable before running the tests.
+>To change the IPV4, IPV6 or DNS used for outside connectivity tests,
+>you can export `CONN_CHECK_IPV4_ADDRESS`, `CONN_CHECK_IPV6_ADDRESS` and  
+> `CONN_CHECK_DNS` with the desired values. For example:
+>```
+>export CONN_CHECK_IPV4_ADDRESS=8.8.4.4
+>export CONN_CHECK_IPV6_ADDRESS=2620:119:35::35
+>export CONN_CHECK_DNS=amazon.com
+>```
 
 ## Run them anywhere inside of container
 

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -43,6 +43,9 @@ var PreviousReleaseRegistry = ""
 var ConfigFile = ""
 var SkipShasumCheck bool
 var SkipDualStackTests bool
+var IPV4ConnectivityCheckAddress = ""
+var IPV6ConnectivityCheckAddress = ""
+var ConnectivityCheckDNS = ""
 var ArtifactsDir string
 var ApplyDefaulte2eConfiguration bool
 
@@ -71,6 +74,9 @@ func init() {
 	flag.StringVar(&ArtifactsDir, "artifacts", os.Getenv("ARTIFACTS"), "Directory for storing reporter artifacts like junit files or logs")
 	flag.BoolVar(&SkipShasumCheck, "skip-shasums-check", false, "Skip tests with sha sums.")
 	flag.BoolVar(&SkipDualStackTests, "skip-dual-stack-test", false, "Skip test that actively checks for the presence of IPv6 address in the cluster pods.")
+	flag.StringVar(&IPV4ConnectivityCheckAddress, "conn-check-ipv4-address", "", "Address that is used for testing IPV4 connectivity to the outside world")
+	flag.StringVar(&IPV6ConnectivityCheckAddress, "conn-check-ipv6-address", "", "Address that is used for testing IPV6 connectivity to the outside world")
+	flag.StringVar(&ConnectivityCheckDNS, "conn-check-dns", "", "dns that is used for testing connectivity to the outside world")
 	flag.BoolVar(&ApplyDefaulte2eConfiguration, "apply-default-e2e-configuration", false, "Apply the default e2e test configuration (feature gates, selinux contexts, ...)")
 }
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -737,10 +737,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				ipAddr := gatewayIPFromCIDR(networkCIDR)
 				Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
 
-				By("Checking ping (IPv4) to google")
-				Expect(libnet.PingFromVMConsole(serverVMI, "8.8.8.8", "-c 5", "-w 15")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(clientVMI, "google.com", "-c 5", "-w 15")).To(Succeed())
-
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv4Protocol)).To(Succeed())
 			},
 				table.Entry("with a specific port number [IPv4]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
@@ -748,6 +744,17 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				table.Entry("without a specific port number [IPv4]", []v1.Port{}, 8080, ""),
 				table.Entry("with custom CIDR [IPv4]", []v1.Port{}, 8080, "10.10.10.0/24"),
 			)
+
+			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
+				vmi := masqueradeVMI([]v1.Port{}, "")
+				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
+
+				By("Checking ping (IPv4)")
+				Expect(libnet.PingFromVMConsole(vmi, "8.8.8.8", "-c 5", "-w 15")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, "google.com", "-c 5", "-w 15")).To(Succeed())
+			})
 
 			table.DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {
 				libnet.SkipWhenNotDualStackCluster(virtClient)
@@ -778,14 +785,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				By("starting a http server")
 				tests.StartPythonHttpServer(serverVMI, tcpPort)
 
-				assert.XFail("https://github.com/kubevirt/kubevirt/issues/5113", func() {
-					By("Checking ping (IPv6) from vmi to cluster nodes gateway")
-					// Cluster nodes subnet (docker network gateway)
-					// Docker network subnet cidr definition:
-					// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-					Expect(libnet.PingFromVMConsole(serverVMI, "2001:db8:1::1")).To(Succeed())
-				})
-
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv6Protocol)).To(Succeed())
 			},
 				table.Entry("with a specific port number [IPv6]", []v1.Port{{Name: "http", Port: 8080}}, 8080, ""),
@@ -793,7 +792,22 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				table.Entry("without a specific port number [IPv6]", []v1.Port{}, 8080, ""),
 				table.Entry("with custom CIDR [IPv6]", []v1.Port{}, 8080, "fd10:10:10::/120"),
 			)
-		})
+
+			It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
+				vmi, err := fedoraMasqueradeVMI([]v1.Port{}, "")
+				Expect(err).ToNot(HaveOccurred())
+				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+
+				assert.XFail("https://github.com/kubevirt/kubevirt/issues/5113", func() {
+					By("Checking ping (IPv6) from vmi to cluster nodes gateway")
+					// Cluster nodes subnet (docker network gateway)
+					// Docker network subnet cidr definition:
+					// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
+					Expect(libnet.PingFromVMConsole(serverVMI, "2001:db8:1::1")).To(Succeed())
+				})
+			})
 
 		When("performing migration", func() {
 			var vmi *v1.VirtualMachineInstance

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -818,10 +817,8 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
 				Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).To(Succeed(), "failed to configure ipv6 on vmi")
 
-				assert.XFail("https://github.com/kubevirt/kubevirt/issues/5113", func() {
-					By("Checking ping (IPv6) from vmi to cluster nodes gateway")
-					Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
-				})
+				By("Checking ping (IPv6) from vmi to cluster nodes gateway")
+				Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
 			})
 		})
 

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -746,14 +746,23 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 			)
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv4]", func() {
+				ipv4Address := "8.8.8.8"
+				if flags.IPV4ConnectivityCheckAddress != "" {
+					ipv4Address = flags.IPV4ConnectivityCheckAddress
+				}
+				dns := "google.com"
+				if flags.ConnectivityCheckDNS != "" {
+					dns = flags.ConnectivityCheckDNS
+				}
+
 				vmi := masqueradeVMI([]v1.Port{}, "")
 				_, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				By("Checking ping (IPv4)")
-				Expect(libnet.PingFromVMConsole(vmi, "8.8.8.8", "-c 5", "-w 15")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmi, "google.com", "-c 5", "-w 15")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
 			})
 
 			table.DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {
@@ -794,20 +803,27 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 			)
 
 			It("[outside_connectivity]should be able to reach the outside world [IPv6]", func() {
+				// Cluster nodes subnet (docker network gateway)
+				// Docker network subnet cidr definition:
+				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
+				ipv6Address := "2001:db8:1::1"
+				if flags.IPV6ConnectivityCheckAddress != "" {
+					ipv6Address = flags.IPV6ConnectivityCheckAddress
+				}
+
 				vmi, err := fedoraMasqueradeVMI([]v1.Port{}, "")
 				Expect(err).ToNot(HaveOccurred())
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).ToNot(HaveOccurred())
 				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToFedora)
+				Expect(configureIpv6(vmi, api.DefaultVMIpv6CIDR)).To(Succeed(), "failed to configure ipv6 on vmi")
 
 				assert.XFail("https://github.com/kubevirt/kubevirt/issues/5113", func() {
 					By("Checking ping (IPv6) from vmi to cluster nodes gateway")
-					// Cluster nodes subnet (docker network gateway)
-					// Docker network subnet cidr definition:
-					// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-					Expect(libnet.PingFromVMConsole(serverVMI, "2001:db8:1::1")).To(Succeed())
+					Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
 				})
 			})
+		})
 
 		When("performing migration", func() {
 			var vmi *v1.VirtualMachineInstance

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -139,12 +139,17 @@ var _ = SIGDescribe("[Serial]Slirp Networking", func() {
 		)
 		log.Log.Infof("%v", output)
 		Expect(err).To(HaveOccurred())
+	},
+		table.Entry("VirtualMachineInstance with slirp interface", &genericVmi),
+		table.Entry("VirtualMachineInstance with slirp interface with custom MAC address", &deadbeafVmi),
+	)
 
-		By("communicate with the outside world")
+	table.DescribeTable("[outside_connectivity]should be able to communicate with the outside world", func(vmiRef **v1.VirtualMachineInstance) {
+		vmi := *vmiRef
 		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: "curl -o /dev/null -s -w \"%{http_code}\\n\" -k https://google.com\n"},
+			&expect.BSnd{S: "curl -o /dev/null -s -w \"%%{http_code}\\n\" -k https://google.com\n"},
 			&expect.BExp{R: "301"},
 		}, 180)).To(Succeed())
 	},

--- a/tests/network/vmi_slirp_interface.go
+++ b/tests/network/vmi_slirp_interface.go
@@ -20,6 +20,7 @@
 package network
 
 import (
+	"fmt"
 	"strings"
 
 	expect "github.com/google/goexpect"
@@ -36,6 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
+	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
@@ -146,10 +148,15 @@ var _ = SIGDescribe("[Serial]Slirp Networking", func() {
 
 	table.DescribeTable("[outside_connectivity]should be able to communicate with the outside world", func(vmiRef **v1.VirtualMachineInstance) {
 		vmi := *vmiRef
+		dns := "google.com"
+		if flags.ConnectivityCheckDNS != "" {
+			dns = flags.ConnectivityCheckDNS
+		}
+
 		Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 			&expect.BSnd{S: "\n"},
 			&expect.BExp{R: console.PromptExpression},
-			&expect.BSnd{S: "curl -o /dev/null -s -w \"%%{http_code}\\n\" -k https://google.com\n"},
+			&expect.BSnd{S: fmt.Sprintf("curl -o /dev/null -s -w \"%%{http_code}\\n\" -k https://%s\n", dns)},
 			&expect.BExp{R: "301"},
 		}, 180)).To(Succeed())
 	},


### PR DESCRIPTION
Signed-off-by: alonsadan <asadan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Internal  and external connectivity tests are two separate networking
capabilities, that should be tested seperatly. This PR extracts the external
conn' tests to a separate ginkgo case. 

In addition, to allow running the network tests also in an environment
with no internet connection, This PR adds the ability to skip, or set 
different addresses  for the outside conn' tests.
This allowes also to remove the XFAIL from the ipv6 outside conn' test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5113 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
