### PR TITLE
Fix repeated_test.sh on file rename

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -38,7 +38,7 @@ function new_tests {
     git diff --name-status "${target_commit}".. -- tests/ \
         | grep -v -E '^D.*' \
         | grep -v '_suite' \
-        | grep -E '_test\.go$' \
+        | grep -oE '(\w|\/)+_test\.go$' \
         | sed -E 's/[AM]\s+tests\/(.*_test)\.go/\1/' \
         | tr '\n' '|' \
         | sed -E 's/\|$//'
@@ -93,7 +93,7 @@ echo "Number of per lane runs: $NUM_TESTS"
 
 test_start_pattern='(Specify|It|Entry)\('
 tests_total_estimate=$(find tests/ -name '*_test.go' -print0 | xargs -0 grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
-tests_to_run_estimate=$(echo "${NEW_TESTS}" | tr '|' '\n' | sed 's/.*/tests\/&\.go/g' | xargs grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
+tests_to_run_estimate=$(echo "${NEW_TESTS}" | tr '|' '\n' | xargs grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
 tests_total_for_all_runs_estimate=$(expr $tests_to_run_estimate \* $NUM_TESTS \* ${#TEST_LANES[@]})
 echo -e "Estimates:\ttests_total_estimate: $tests_total_estimate\ttests_total_for_all_runs_estimate: $tests_total_for_all_runs_estimate"
 if [ $tests_total_for_all_runs_estimate -gt $tests_total_estimate ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Due to an error in the new_tests grep expression the names of the
changed tests were wrong in case of test file movement. We now
exactly grep the new file names and skip the sed later on.

Example run: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5170/pull-kubevirt-check-tests-for-flakes/1368948867701149698

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@EdDev FYI , either cherry-pick the change or rebase your PR on this one

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
