### PR TITLE
Extend timeout for a flaky imageupload test

### DIFF
--- a/tests/imageupload_test.go
+++ b/tests/imageupload_test.go
@@ -143,7 +143,7 @@ var _ = Describe("[Serial]ImageUpload", func() {
 				"--image-path", imagePath,
 				"--size", pvcSize,
 				"--uploadproxy-url", fmt.Sprintf("https://127.0.0.1:%d", localUploadProxyPort),
-				"--wait-secs", "30",
+				"--wait-secs", "60",
 				"--storage-class", sc,
 				"--insecure")
 			err := virtctlCmd()


### PR DESCRIPTION
Test 4621 fails waiting for upload pod to be ready. Sometimes the upload pod has a slow start (probably image pulling). Updating timeout should help.

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Updates timeout.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubevirt/kubevirt/issues/4527
https://github.com/kubevirt/kubevirt/issues/4868

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
