### PR TITLE
Fix gosec target on prow

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -143,7 +143,7 @@ if ! $KUBEVIRT_CRI exec ${USE_TTY} ${BUILDER}-bazel-server /entrypoint.sh "$@"; 
     fi
     set -x
     # Copy the junit where prow can pick it up
-    if [ "$@" = "./hack/gosec.sh" ] && [ "$CI" = "true" ]; then
+    if [ -f ${OUT_DIR}/artifacts/junit-gosec.xml ] && [ "$CI" = "true" ]; then
         echo "Moving file in prow"
         mv ${OUT_DIR}/artifacts/junit-gosec.xml ${ARTIFACTS}
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Copy junit generated by gosec if junit file exists and we are on prow
Previous solution failed because we added GOSEC variable for running subset of tests

**Special notes for your reviewer**:

```release-note
None
```
/cc @dhiller 