### PR TITLE
Add [release-blocker] test marker for critical tests involved with update path. 

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -848,7 +848,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				By("Waiting for VMI to disappear")
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			})
-			It("[test_id:1377]should be successfully migrated multiple times", func() {
+			It("[release-blocker][test_id:1377]should be successfully migrated multiple times", func() {
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi := tests.NewRandomVMIWithPVC(pvName)
 				vmi = runVMIAndExpectLaunch(vmi, 180)
@@ -1987,7 +1987,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		})
 		Context("with multiple VMIs with eviction policies set", func() {
 
-			It("[test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
+			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
 					vmi := cirrosVMIWithEvictionStrategy()

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1021,7 +1021,7 @@ spec:
 		// running a VM/VMI using that previous release
 		// Updating KubeVirt to the target tested code
 		// Ensuring VM/VMI is still operational after the update from previous release.
-		It("[owner:@sig-compute][test_id:3145]from previous release to target tested release", func() {
+		It("[release-blocker][owner:@sig-compute][test_id:3145]from previous release to target tested release", func() {
 			if !tests.HasCDI() {
 				Skip("Skip Update test when CDI is not present")
 			}

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -1545,7 +1545,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(strings.HasPrefix(stdErr, "Error from server (AlreadyExists): error when creating")).To(BeTrue(), "command should error when creating VM second time")
 		})
 
-		table.DescribeTable("[test_id:299]should create VM via command line using all supported API versions", func(version string) {
+		table.DescribeTable("[release-blocker][test_id:299]should create VM via command line using all supported API versions", func(version string) {
 			vmi = tests.NewRandomVMIWithEphemeralDisk(cd.ContainerDiskFor(cd.ContainerDiskAlpine))
 			vm := tests.NewRandomVirtualMachine(vmi, true)
 


### PR DESCRIPTION
This PR marks tests as ```[release-blocker]``` that are required to be enabled and passing before a new release can be cut. 

A [release-blocker] test is defined as a test that validates functionality involved with ensuring a release can handle seamless non-disruptive Kubernetes and KubeVirt updates. This includes validating basic updates from previous kubevirt releases as well as other update related functionality like migrations, pod eviction handling, and kubevirt API versioning support.

The idea here is that we'll never cut a release without all the  ```[release-blocker]``` passing, which will at a very minimum ensure that we have a path for delivering non-disruptive fixes.

As we move forward with addressing flaky tests, when a ```[release-blocker]``` test becomes flaky we need to either...

*  immediately fix the test without ever disabling it
* or, create an issue marked with the ```release-blocker``` label (this is added by commenting ```/release-blocker master``` on the issue) to track disabling and fixing the test. By commenting on an issue with ```/release-blocker [branch name]``` we are ensured that our release tools will not permit a new release to be made until the issue is closed.  



Mailing list discussion can be found here, https://groups.google.com/g/kubevirt-dev/c/2DI_2RkgXzc 

```release-note
New [release-blocker] functional test marker to signify tests that can never be disabled before making a release
```
