### PR TITLE
Added supported values for v1.Disk cache mode in API document

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9491,7 +9491,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
       "type": "string"
      },
      "cdrom": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -2182,7 +2182,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                                 type: integer
                               cache:
-                                description: Cache specifies which kvm disk cache mode should be used.
+                                description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -3244,7 +3244,7 @@ var CRDsValidation map[string]string = map[string]string{
                         description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                         type: integer
                       cache:
-                        description: Cache specifies which kvm disk cache mode should be used.
+                        description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -3987,7 +3987,7 @@ var CRDsValidation map[string]string = map[string]string{
                         description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                         type: integer
                       cache:
-                        description: Cache specifies which kvm disk cache mode should be used.
+                        description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -5389,7 +5389,7 @@ var CRDsValidation map[string]string = map[string]string{
                         description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                         type: integer
                       cache:
-                        description: Cache specifies which kvm disk cache mode should be used.
+                        description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -6566,7 +6566,7 @@ var CRDsValidation map[string]string = map[string]string{
                                 description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                                 type: integer
                               cache:
-                                description: Cache specifies which kvm disk cache mode should be used.
+                                description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8681,7 +8681,7 @@ var CRDsValidation map[string]string = map[string]string{
                                             description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                                             type: integer
                                           cache:
-                                            description: Cache specifies which kvm disk cache mode should be used.
+                                            description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom to the vmi.
@@ -9743,7 +9743,7 @@ var CRDsValidation map[string]string = map[string]string{
                                     description: BootOrder is an integer value > 0, used to determine ordering of boot devices. Lower values take precedence. Each disk or interface that has a boot order must have a unique value. Disks without a boot order are not tried if a disk with a boot order exists.
                                     type: integer
                                   cache:
-                                    description: Cache specifies which kvm disk cache mode should be used.
+                                    description: 'Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.'
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the vmi.

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -15035,7 +15035,7 @@ func schema_kubevirtio_client_go_api_v1_Disk(ref common.ReferenceCallback) commo
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -483,6 +483,7 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
+	// Supported values are: CacheNone, CacheWriteThrough.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -247,7 +247,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: CacheNone, CacheWriteThrough.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 	}

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14886,7 +14886,7 @@ func schema_kubevirtio_client_go_api_v1_Disk(ref common.ReferenceCallback) commo
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION

Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In KubeVirt API document at https://kubevirt.io/api-reference/master/definitions.html#_v1_disk , the default values for the disk cache mode should be specified for good user experience. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1896795

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
