### PR TITLE
Add automation kubevirtci pr flag

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -44,6 +44,11 @@ else
   export KUBEVIRT_PROVIDER=${TARGET}
 fi
 
+if [ ! -z "$KUBEVIRTCI_PR" ]; then
+    # Disable CI flag to skip conformance
+    CI="false" hack/pin-kubevirtci-pr.sh $KUBEVIRTCI_PR
+fi
+
 if [ ! -d "cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
   echo "The cluster provider $KUBEVIRT_PROVIDER does not exist"
   exit 1

--- a/hack/pin-kubevirtci-pr.sh
+++ b/hack/pin-kubevirtci-pr.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -xe
+
+remote=$(echo $1 | sed "s/:.*//")
+branch=$(echo $1 | sed "s/.*://")
+version=$(echo $KUBEVIRT_PROVIDER | sed "s/k8s-//")
+
+cleanup() {
+    rm -rf kubevirtci
+}
+
+provision() {
+    (
+        cd kubevirtci/cluster-provision/k8s/$version
+        ../provision.sh
+    )
+}
+
+trap cleanup EXIT
+
+git clone https://github.com/$remote/kubevirtci -b $branch
+rsync kubevirtci/cluster-up cluster-up
+rsync -rt --links ./kubevirtci/cluster-up/* ./cluster-up/
+
+provision
+
+echo "export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:latest" >> cluster-up/hack/common.sh
+echo "export KUBEVIRTCI_PROVISION_CHECK=1" >> cluster-up/hack/common.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Sometimes is needed to test the full kubevirt/kubevirt lanes with a
specific kubevirtci PR, this change add a flag to automatin to specify
the remote:branch of a PR at kubevirtci and then sync/provision it and
mark scripts to use it at cluster-up

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Testing it at https://github.com/kubevirt/kubevirt/pull/5192

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
