### PR TITLE
[tests] Fix kubevirt default configuration initialization

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -738,8 +738,9 @@ func AdjustKubeVirtResource() {
 	PanicOnError(err)
 
 	kv := GetCurrentKv(virtClient)
-
 	originalKV = kv.DeepCopy()
+
+	KubeVirtDefaultConfig = originalKV.Spec.Configuration
 
 	if !flags.ApplyDefaulte2eConfiguration {
 		return


### PR DESCRIPTION
Initialize the KubeVirtDefaultConfig to original KV cluster configuration. 

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The issue was that `KubeVirtDefaultConfig` wasn't
initialized in case the tests were run w/o the `--apply-default-configuration`
flag, but on the other hand this variable is being unconditionally used in the 
`BeforeTestCleanup()` function.

**Release note**:
```release-note
NONE
```
