### PR TITLE
Expose CPU affinity metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -155,7 +155,7 @@ A design proposal and its implementation history can be seen [here](https://docs
 ## kubevirt_vmi_network_transmit_packets_total
 #### HELP kubevirt_vmi_network_transmit_packets_total Network traffic transmit packets
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_memory_actual_balloon_bytes
 #### HELP kubevirt_vmi_memory_actual_balloon_bytes current balloon bytes.
 ## kubevirt_vmi_memory_pgmajfault
@@ -170,3 +170,7 @@ A design proposal and its implementation history can be seen [here](https://docs
 #### HELP kubevirt_vmi_memory_usable_bytes The amount of memory which can be reclaimed by balloon without causing host swapping in bytes.
 ## kubevirt_vmi_memory_used_total_bytes
 #### HELP kubevirt_vmi_memory_used_total_bytes The amount of memory in bytes used by the domain.
+
+ # Other Metrics 
+## kubevirt_vmi_cpu_affinity
+#### HELP kubevirt_vmi_cpu_affinity vcpu affinity details

--- a/pkg/monitoring/vms/prometheus/fakeCollector.go
+++ b/pkg/monitoring/vms/prometheus/fakeCollector.go
@@ -45,6 +45,7 @@ func (fc fakeCollector) Collect(ch chan<- prometheus.Metric) {
 	out.Memory.UsableSet = true
 	out.Memory.MinorFaultSet = true
 	out.Memory.MajorFaultSet = true
+	out.CPUMapSet = true
 
 	vmi := k6tv1.VirtualMachineInstance{
 		Status: k6tv1.VirtualMachineInstanceStatus{

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -302,6 +302,14 @@ func (l *LibvirtConnection) GetDomainStats(statsTypes libvirt.DomainStatsTypes, 
 			return list, err
 		}
 
+		cpuMap, err := domStat.Domain.GetVcpuPinInfo(libvirt.DOMAIN_AFFECT_CURRENT)
+		if err != nil {
+			return list, err
+		}
+
+		stat.CPUMap = cpuMap
+		stat.CPUMapSet = true
+
 		list = append(list, stat)
 	}
 

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -58,6 +58,9 @@ type DomainStats struct {
 	Net   []DomainStatsNet
 	Block []DomainStatsBlock
 	// omitted from libvirt-go: Perf
+	// extra stats
+	CPUMapSet bool
+	CPUMap    [][]bool
 }
 
 type DomainStatsCPU struct {

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -240,7 +240,9 @@ var Testdataexpected = `{
        "WaitSet": true,
        "Wait": 1500
      }
-   ]
+   ],
+   "CPUMapSet": false,
+   "CPUMap": null
  }`
 
 func LoadStats() ([]libvirt.DomainStats, error) {


### PR DESCRIPTION
This patch introduces the kubevirt_vmi_cpu_affinity metric which
displays the cpu pinning map via boolean labels in the form of
vcpu_X_cpu_Y.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added a metric for monitoring CPU affinity
```
