### PR TITLE
Fix issues impacting KubeVirt update test

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -189,7 +189,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
-        "//tests/assert:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -56,7 +56,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -1198,11 +1197,8 @@ spec:
 				}, 90*time.Second, 1*time.Second).Should(BeTrue())
 			}
 
-			// QUARANTINED Logic - tracked by issue https://github.com/kubevirt/kubevirt/issues/5228
-			assert.XFail("https://github.com/kubevirt/kubevirt/issues/5228", func() {
-				By("Verifying all migratable vmi workloads are updated via live migration")
-				verifyVMIsUpdated(migratableVMIs, launcherSha)
-			})
+			By("Verifying all migratable vmi workloads are updated via live migration")
+			verifyVMIsUpdated(migratableVMIs, launcherSha)
 
 			By("Deleting migratable VMIs")
 			deleteAllVMIs(migratableVMIs)

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1104,7 +1104,7 @@ spec:
 			waitForUpdateCondition(kv)
 
 			By("Waiting for KV to stabilize")
-			waitForKv(kv)
+			waitForKvWithTimeout(kv, 420)
 
 			By("Verifying infrastructure Is Updated")
 			allPodsAreReady(kv)


### PR DESCRIPTION
This PR is to address the VMI failures during migration as identified by #5228 

There were 2 primary issues occurring here.

1. the VMI cache on virt-handler was being corrupted. This is due to a recent change with the ordering of how our informers start. Previously we'd start the domain infomer, inject some values into the vmi informer cache, then start the vmi informer. Now we start both informers in parallel, which meant when we injected values into the cache, we were working wiht a live informer rather than a pre-initialized cache.

ultimately, this caused some odd behavior. One of the odd behaviors is that the domain notify socket wouldn't get created for an active VMI until very late, around the time a migration starts, which didn't give the launcher enough time to reconnect to report the migration success. 

2. The virt-launcher notify client was not resilient enough to server disconnects. Virt launcher needs to try really hard to send domain notify events, because if something like a "migration succeeded" event is missed, it doesn't happen again. 

To handle this, when an event send fails, we force disconnect/reconnect and retry a few times before giving up. It appears that simply doing this force retry once typically clears up any issue where the client connection is stale and hasn't been reconnected yet. I put the logic in a waituntil loop though so several attempts are made with a backoff.  

The combination of these two fixes should make our update test much more reliable. these are real issues people will encounter. Item [1] is particularly concerning, so I've marked this as a release blocker. This issue was introduced in the past few weeks and is not in an official kubevirt release... so it's clearly a regression. 

fixes: #5228 

```release-note
NONE
```
