### PR TITLE
[release-0.36] support extracting metadata for transients domains

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -224,7 +224,7 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 			domain.SetState(util.ConvState(status), util.ConvReason(status, reason))
 		}
 
-		spec, err := util.GetDomainSpecWithRuntimeInfo(status, d)
+		spec, err := util.GetDomainSpecWithRuntimeInfo(d)
 		if err != nil {
 			// NOTE: Getting domain metadata for a live-migrating VM isn't allowed
 			if !domainerrors.IsNotFound(err) && !domainerrors.IsInvalidOperation(err) {

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Notify", func() {
 				mockDomain.EXPECT().Free()
 				mockDomain.EXPECT().GetName().Return("test", nil).AnyTimes()
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+				mockDomain.EXPECT().IsPersistent().Return(true, nil)
 				mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 
 				eventCallback(mockCon, util.NewDomainFromName("test", "1234"), libvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: event}}, client, deleteNotificationSent, nil, nil)
@@ -168,6 +169,7 @@ var _ = Describe("Notify", func() {
 				mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, -1, nil)
 				mockDomain.EXPECT().GetName().Return("test", nil).AnyTimes()
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+				mockDomain.EXPECT().IsPersistent().Return(true, nil)
 				mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 
 				interfaceStatus := []api.InterfaceStatus{
@@ -204,6 +206,7 @@ var _ = Describe("Notify", func() {
 				mockDomain.EXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, -1, nil)
 				mockDomain.EXPECT().GetName().Return("test", nil).AnyTimes()
 				mockDomain.EXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+				mockDomain.EXPECT().IsPersistent().Return(true, nil)
 				mockDomain.EXPECT().GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG).Return(`<kubevirt></kubevirt>`, nil)
 
 				guestOsName := "TestGuestOS"

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -460,6 +460,17 @@ func (_mr *_MockVirDomainRecorder) SetTime(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTime", arg0, arg1, arg2)
 }
 
+func (_m *MockVirDomain) IsPersistent() (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsPersistent")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockVirDomainRecorder) IsPersistent() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsPersistent")
+}
+
 func (_m *MockVirDomain) AbortJob() error {
 	ret := _m.ctrl.Call(_m, "AbortJob")
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -407,6 +407,7 @@ type VirDomain interface {
 	GetJobStats(flags libvirt.DomainGetJobStatsFlags) (*libvirt.DomainJobInfo, error)
 	GetJobInfo() (*libvirt.DomainJobInfo, error)
 	SetTime(secs int64, nsecs uint, flags libvirt.DomainSetTimeFlags) error
+	IsPersistent() (bool, error)
 	AbortJob() error
 	Free() error
 }

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1636,7 +1636,7 @@ func (l *LibvirtDomainManager) getDomainSpec(dom cli.VirDomain) (*api.DomainSpec
 		return nil, err
 	}
 
-	domainSpec, err := util.GetDomainSpecWithRuntimeInfo(state, dom)
+	domainSpec, err := util.GetDomainSpecWithRuntimeInfo(dom)
 	if err != nil {
 		// Return without runtime info only for cases we know for sure it's not supposed to be there
 		if domainerrors.IsNotFound(err) || domainerrors.IsInvalidOperation(err) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Manager", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockConn = cli.NewMockConnection(ctrl)
 		mockDomain = cli.NewMockVirDomain(ctrl)
+		mockDomain.EXPECT().IsPersistent().AnyTimes().Return(true, nil)
 	})
 
 	expectIsolationDetectionForVMI := func(vmi *v1.VirtualMachineInstance) *api.DomainSpec {

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -30,9 +30,13 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/go-kit/kit/log:go_default_library",
+        "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -117,7 +117,7 @@ func SetDomainSpecStrWithHooks(virConn cli.Connection, vmi *v1.VirtualMachineIns
 }
 
 // GetDomainSpecWithRuntimeInfo return the active domain XML with runtime information embedded
-func GetDomainSpecWithRuntimeInfo(status libvirt.DomainState, dom cli.VirDomain) (*api.DomainSpec, error) {
+func GetDomainSpecWithRuntimeInfo(dom cli.VirDomain) (*api.DomainSpec, error) {
 
 	// get libvirt xml with runtime status
 	activeSpec, err := GetDomainSpecWithFlags(dom, 0)
@@ -126,7 +126,13 @@ func GetDomainSpecWithRuntimeInfo(status libvirt.DomainState, dom cli.VirDomain)
 		return nil, err
 	}
 
-	metadataXML, err := dom.GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", libvirt.DOMAIN_AFFECT_CONFIG)
+	// use different flag with GetMetadata for transient domains
+	domainModificationImpactFlag, err := getDomainModificationImpactFlag(dom)
+	if err != nil {
+		return activeSpec, err
+	}
+
+	metadataXML, err := dom.GetMetadata(libvirt.DOMAIN_METADATA_ELEMENT, "http://kubevirt.io", domainModificationImpactFlag)
 	if err != nil {
 		log.Log.Reason(err).Error("failed to get domain metadata")
 		return activeSpec, err
@@ -427,4 +433,18 @@ func SetupLibvirt() (err error) {
 	}
 
 	return nil
+}
+
+func getDomainModificationImpactFlag(dom cli.VirDomain) (libvirt.DomainModificationImpact, error) {
+	isDomainPersistent, err := dom.IsPersistent()
+	if err != nil {
+		log.Log.Reason(err).Error("failed to query a domain")
+		return libvirt.DOMAIN_AFFECT_CONFIG, err
+	}
+	if !isDomainPersistent {
+		log.Log.V(3).Info("domain is transient")
+		return libvirt.DOMAIN_AFFECT_LIVE, nil
+	}
+	log.Log.V(3).Info("domain is persistent")
+	return libvirt.DOMAIN_AFFECT_CONFIG, nil
 }

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -974,11 +974,11 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 				migrationUID := tests.RunMigrationAndExpectCompletion(virtClient, migration, migrationWaitTime)
 
-				// check VMI, confirm migration state
+				By("Checking VMI, confirm migration state")
 				tests.ConfirmVMIPostMigration(virtClient, vmi, migrationUID)
 				confirmMigrationMode(vmi, mode)
 
-				// Is agent connected after migration
+				By("Is agent connected after migration")
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Checking that the migrated VirtualMachineInstance console has expected output")
@@ -1008,6 +1008,35 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
 				}, v1.MigrationPostCopy),
 			)
+
+			It("should have guest agent functional after migration", func() {
+				By("Creating the  VMI")
+				vmi = tests.NewRandomVMIWithPVC(pvName)
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
+				vmi.Spec.Domain.Devices.Rng = &v1.Rng{}
+
+				tests.AddUserData(vmi, "cloud-init", tests.GetGuestAgentUserData())
+				vmi = runVMIAndExpectLaunchIgnoreWarnings(vmi, 180)
+
+				By("Checking guest agent")
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Starting the Migration for iteration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				_ = tests.RunMigrationAndExpectCompletion(virtClient, migration, migrationWaitTime)
+
+				By("Agent stays connected")
+				Consistently(func() error {
+					updatedVmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Get(vmi.Name, &metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					for _, condition := range updatedVmi.Status.Conditions {
+						if condition.Type == v1.VirtualMachineInstanceAgentConnected && condition.Status == k8sv1.ConditionTrue {
+							return nil
+						}
+					}
+					return fmt.Errorf("Guest Agent Disconnected")
+				}, 5*time.Minute, 10*time.Second).Should(Succeed())
+			})
 		})
 
 		Context("migration security", func() {


### PR DESCRIPTION
What this PR does / why we need it:
Virt-launcher will fail to send a correct domain when the domain is transient. This will corrupt the cache of virt-handler and cause bad decisions in the sync loop. This PR ensures we retrieve the correct domain even in a transient state.

Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes #
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1883875
https://bugzilla.redhat.com/show_bug.cgi?id=1886453
**Special notes for your reviewer**:

**Release note**:
```release-note
Fixing handling of transient domain
```
