### PR TITLE
Simplify greps in determination of new tests

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -30,16 +30,16 @@ EOF
 function new_tests {
     local target_commit
     target_commit="$1"
-    # 1. fetch the changed file names from within the tests/ directory
-    # 2. grep all files ending with '_test.go'
-    # 3. remove `tests/` and `.go` to only have the test name
+    # 1. fetch the names of all added, copied, modified or renamed files
+    #    from within the tests/ directory
+    # 2. print only the last column of the line (in case of rename this is the new name)
+    # 3. grep all files ending with '.go' but not with '_suite.go'
     # 4. replace newline with `|`
     # 5. remove last `|`
-    git diff --name-status "${target_commit}".. -- tests/ \
-        | grep -v -E '^D.*' \
-        | grep -v '_suite' \
-        | grep -oE '(\w|\/)+_test\.go$' \
-        | sed -E 's/[AM]\s+tests\/(.*_test)\.go/\1/' \
+    git diff --diff-filter=ACMR --name-status "${target_commit}".. -- tests/ \
+        | awk '{print $NF}' \
+        | grep '\.go' \
+        | grep -v '_suite\.go' \
         | tr '\n' '|' \
         | sed -E 's/\|$//'
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Instead of several greps which will be error prone when renamed files
are in the changeset we just use the --diff-filter and awk print the
last column which always results in the new file name.

Also as test files do not necessarily have to have the _test suffix we
just grep for .go (while still excluding suite files).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @jean-edouard 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
