### PR TITLE
Remove check for removed secret.

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1035,9 +1035,6 @@ var _ = SIGDescribe("Hotplug", func() {
 					&expect.BExp{R: fmt.Sprintf("ls: cannot access '%s'", targets[0])},
 				}, 10)
 			}, 40*time.Second, 2*time.Second).Should(Succeed())
-			By("Verifying the secret is gone")
-			_, err = virtClient.CoreV1().Secrets(vmi.Namespace).Get(context.Background(), name, metav1.GetOptions{})
-			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
This was a leftover that somehow escaped review.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
One of the hotplug tests is verifying a secret doesn't exist, that secret is never created because the code that created the secret never made it into the code base. This PR removes the check.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
