### PR TITLE
Update KubeVirt to use apiregistration.k8s.io/v1

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -47,7 +47,7 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
     ],

--- a/pkg/controller/virtinformers.go
+++ b/pkg/controller/virtinformers.go
@@ -46,7 +46,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	v1beta12 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
 	kubev1 "kubevirt.io/client-go/api/v1"
@@ -761,8 +761,8 @@ func (f *kubeInformerFactory) OperatorAPIService() cache.SharedIndexInformer {
 			panic(err)
 		}
 
-		lw := NewListWatchFromClient(f.aggregatorClient.ApiregistrationV1beta1().RESTClient(), "apiservices", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
-		return cache.NewSharedIndexInformer(lw, &v1beta12.APIService{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		lw := NewListWatchFromClient(f.aggregatorClient.ApiregistrationV1().RESTClient(), "apiservices", k8sv1.NamespaceAll, fields.Everything(), labelSelector)
+		return cache.NewSharedIndexInformer(lw, &apiregv1.APIService{}, f.defaultResync, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	})
 }
 

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -95,6 +95,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
 )

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -265,7 +265,7 @@ func Execute() {
 	app.prepareCertManagers()
 
 	app.kubeVirtRecorder = app.getNewRecorder(k8sv1.NamespaceAll, "virt-operator")
-	app.kubeVirtController = *NewKubeVirtController(app.clientSet, app.aggregatorClient.ApiregistrationV1beta1().APIServices(), app.kubeVirtInformer, app.kubeVirtRecorder, app.stores, app.informers, app.operatorNamespace)
+	app.kubeVirtController = *NewKubeVirtController(app.clientSet, app.aggregatorClient.ApiregistrationV1().APIServices(), app.kubeVirtInformer, app.kubeVirtRecorder, app.stores, app.informers, app.operatorNamespace)
 
 	image := os.Getenv(util.OperatorImageEnvName)
 	if image == "" {

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 
@@ -56,6 +55,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 	"k8s.io/client-go/tools/record"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	promclientfake "kubevirt.io/client-go/generated/prometheus-operator/clientset/versioned/fake"
@@ -267,7 +267,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		stores.ValidationWebhookCache = informers.ValidationWebhook.GetStore()
 		informers.MutatingWebhook, mutatingWebhookSource = testutils.NewFakeInformerFor(&admissionregistrationv1beta1.MutatingWebhookConfiguration{})
 		stores.MutatingWebhookCache = informers.MutatingWebhook.GetStore()
-		informers.APIService, apiserviceSource = testutils.NewFakeInformerFor(&v1beta1.APIService{})
+		informers.APIService, apiserviceSource = testutils.NewFakeInformerFor(&apiregv1.APIService{})
 		stores.APIServiceCache = informers.APIService.GetStore()
 
 		informers.SCC, sccSource = testutils.NewFakeInformerFor(&secv1.SecurityContextConstraints{})
@@ -496,7 +496,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		mockQueue.Wait()
 	}
 
-	addAPIService := func(wh *v1beta1.APIService) {
+	addAPIService := func(wh *apiregv1.APIService) {
 		mockQueue.ExpectAdds(1)
 		apiserviceSource.Add(wh)
 		mockQueue.Wait()
@@ -589,8 +589,8 @@ var _ = Describe("KubeVirt Operator", func() {
 		case *admissionregistrationv1beta1.MutatingWebhookConfiguration:
 			injectMetadata(&obj.(*admissionregistrationv1beta1.MutatingWebhookConfiguration).ObjectMeta, config)
 			addMutatingWebhook(resource, kv)
-		case *v1beta1.APIService:
-			injectMetadata(&obj.(*v1beta1.APIService).ObjectMeta, config)
+		case *apiregv1.APIService:
+			injectMetadata(&obj.(*apiregv1.APIService).ObjectMeta, config)
 			addAPIService(resource)
 		case *batchv1.Job:
 			injectMetadata(&obj.(*batchv1.Job).ObjectMeta, config)

--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -52,7 +52,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/resource/apply/apiservices.go
+++ b/pkg/virt-operator/resource/apply/apiservices.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	"kubevirt.io/client-go/log"
 )
@@ -19,7 +19,7 @@ func (r *Reconciler) createOrUpdateAPIServices(caBundle []byte) error {
 	version, imageRegistry, id := getTargetVersionRegistryID(r.kv)
 
 	for _, apiService := range r.targetStrategy.APIServices() {
-		var cachedAPIService *v1beta1.APIService
+		var cachedAPIService *apiregv1.APIService
 		var err error
 
 		apiService = apiService.DeepCopy()
@@ -38,7 +38,7 @@ func (r *Reconciler) createOrUpdateAPIServices(caBundle []byte) error {
 				exists = true
 			}
 		} else if exists {
-			cachedAPIService = obj.(*v1beta1.APIService)
+			cachedAPIService = obj.(*apiregv1.APIService)
 		}
 
 		certsMatch := true

--- a/pkg/virt-operator/resource/apply/delete.go
+++ b/pkg/virt-operator/resource/apply/delete.go
@@ -33,7 +33,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -222,7 +222,7 @@ func DeleteAll(kv *v1.KubeVirt,
 	// delete apiservices
 	objects = stores.APIServiceCache.List()
 	for _, obj := range objects {
-		if apiservice, ok := obj.(*v1beta1.APIService); ok && apiservice.DeletionTimestamp == nil {
+		if apiservice, ok := obj.(*apiregv1.APIService); ok && apiservice.DeletionTimestamp == nil {
 			if key, err := controller.KeyFunc(apiservice); err == nil {
 				expectations.APIService.AddExpectedDeletion(kvkey, key)
 				err := aggregatorclient.Delete(context.Background(), apiservice.Name, deleteOptions)

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	secv1 "github.com/openshift/api/security/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -36,9 +37,7 @@ import (
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
-
-	"github.com/blang/semver"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -735,7 +734,7 @@ func (r *Reconciler) deleteObjectsNotInInstallStrategy() error {
 	// remove unused APIServices
 	objects = r.stores.APIServiceCache.List()
 	for _, obj := range objects {
-		if apiService, ok := obj.(*v1beta1.APIService); ok && apiService.DeletionTimestamp == nil {
+		if apiService, ok := obj.(*apiregv1.APIService); ok && apiService.DeletionTimestamp == nil {
 			found := false
 			for _, targetAPIService := range r.targetStrategy.APIServices() {
 				if targetAPIService.Name == apiService.Name {

--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -34,7 +34,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/resource/generate/components/apiservices.go
+++ b/pkg/virt-operator/resource/generate/components/apiservices.go
@@ -2,20 +2,20 @@ package components
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
 )
 
-func NewVirtAPIAPIServices(installNamespace string) []*v1beta1.APIService {
-	apiservices := []*v1beta1.APIService{}
+func NewVirtAPIAPIServices(installNamespace string) []*apiregv1.APIService {
+	apiservices := []*apiregv1.APIService{}
 
 	for _, version := range v1.SubresourceGroupVersions {
 		subresourceAggregatedApiName := version.Version + "." + version.Group
 
-		apiservices = append(apiservices, &v1beta1.APIService{
+		apiservices = append(apiservices, &apiregv1.APIService{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apiregistration.k8s.io/v1beta1",
+				APIVersion: "apiregistration.k8s.io/v1",
 				Kind:       "APIService",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -28,8 +28,8 @@ func NewVirtAPIAPIServices(installNamespace string) []*v1beta1.APIService {
 					"certificates.kubevirt.io/secret": VirtApiCertSecretName,
 				},
 			},
-			Spec: v1beta1.APIServiceSpec{
-				Service: &v1beta1.ServiceReference{
+			Spec: apiregv1.APIServiceSpec{
+				Service: &apiregv1.ServiceReference{
 					Namespace: installNamespace,
 					Name:      VirtApiServiceName,
 				},

--- a/pkg/virt-operator/resource/generate/install/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/install/BUILD.bazel
@@ -31,7 +31,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
 )
 

--- a/pkg/virt-operator/resource/generate/install/generated_mock_strategy.go
+++ b/pkg/virt-operator/resource/generate/install/generated_mock_strategy.go
@@ -9,7 +9,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
-	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	v10 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 // Mock of APIServiceInterface interface
@@ -33,9 +33,9 @@ func (_m *MockAPIServiceInterface) EXPECT() *_MockAPIServiceInterfaceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAPIServiceInterface) Get(ctx context.Context, name string, options v1.GetOptions) (*v1beta1.APIService, error) {
+func (_m *MockAPIServiceInterface) Get(ctx context.Context, name string, options v1.GetOptions) (*v10.APIService, error) {
 	ret := _m.ctrl.Call(_m, "Get", ctx, name, options)
-	ret0, _ := ret[0].(*v1beta1.APIService)
+	ret0, _ := ret[0].(*v10.APIService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -44,9 +44,9 @@ func (_mr *_MockAPIServiceInterfaceRecorder) Get(arg0, arg1, arg2 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
-func (_m *MockAPIServiceInterface) Create(ctx context.Context, apiService *v1beta1.APIService, opts v1.CreateOptions) (*v1beta1.APIService, error) {
+func (_m *MockAPIServiceInterface) Create(ctx context.Context, apiService *v10.APIService, opts v1.CreateOptions) (*v10.APIService, error) {
 	ret := _m.ctrl.Call(_m, "Create", ctx, apiService, opts)
-	ret0, _ := ret[0].(*v1beta1.APIService)
+	ret0, _ := ret[0].(*v10.APIService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,13 +65,13 @@ func (_mr *_MockAPIServiceInterfaceRecorder) Delete(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockAPIServiceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (*v1beta1.APIService, error) {
+func (_m *MockAPIServiceInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (*v10.APIService, error) {
 	_s := []interface{}{ctx, name, pt, data, opts}
 	for _, _x := range subresources {
 		_s = append(_s, _x)
 	}
 	ret := _m.ctrl.Call(_m, "Patch", _s...)
-	ret0, _ := ret[0].(*v1beta1.APIService)
+	ret0, _ := ret[0].(*v10.APIService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -34,7 +34,7 @@ import (
 	"github.com/golang/glog"
 	secv1 "github.com/openshift/api/security/v1"
 	"k8s.io/api/admissionregistration/v1beta1"
-	v1beta12 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -63,10 +63,10 @@ const ManifestsEncodingGzipBase64 = "gzip+base64"
 //go:generate mockgen -source $GOFILE -imports "libvirt=libvirt.org/libvirt-go" -package=$GOPACKAGE -destination=generated_mock_$GOFILE
 
 type APIServiceInterface interface {
-	Get(ctx context.Context, name string, options metav1.GetOptions) (*v1beta12.APIService, error)
-	Create(ctx context.Context, apiService *v1beta12.APIService, opts metav1.CreateOptions) (*v1beta12.APIService, error)
+	Get(ctx context.Context, name string, options metav1.GetOptions) (*apiregv1.APIService, error)
+	Create(ctx context.Context, apiService *apiregv1.APIService, opts metav1.CreateOptions) (*apiregv1.APIService, error)
 	Delete(ctx context.Context, name string, options metav1.DeleteOptions) error
-	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1beta12.APIService, err error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *apiregv1.APIService, err error)
 }
 
 type Strategy struct {
@@ -85,7 +85,7 @@ type Strategy struct {
 	daemonSets                      []*appsv1.DaemonSet
 	validatingWebhookConfigurations []*v1beta1.ValidatingWebhookConfiguration
 	mutatingWebhookConfigurations   []*v1beta1.MutatingWebhookConfiguration
-	apiServices                     []*v1beta12.APIService
+	apiServices                     []*apiregv1.APIService
 	certificateSecrets              []*corev1.Secret
 	sccs                            []*secv1.SecurityContextConstraints
 	serviceMonitors                 []*promv1.ServiceMonitor
@@ -160,7 +160,7 @@ func (ins *Strategy) MutatingWebhookConfigurations() []*admissionregistrationv1b
 	return ins.mutatingWebhookConfigurations
 }
 
-func (ins *Strategy) APIServices() []*v1beta12.APIService {
+func (ins *Strategy) APIServices() []*apiregv1.APIService {
 	return ins.apiServices
 }
 
@@ -574,7 +574,7 @@ func loadInstallStrategyFromBytes(data string) (*Strategy, error) {
 			}
 			strategy.mutatingWebhookConfigurations = append(strategy.mutatingWebhookConfigurations, webhook)
 		case "APIService":
-			apiService := &v1beta12.APIService{}
+			apiService := &apiregv1.APIService{}
 			if err := yaml.Unmarshal([]byte(entry), &apiService); err != nil {
 				return nil, err
 			}

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -172,7 +172,7 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 
 			By("checking that the ca bundle gets propagated to the apiservice")
 			Eventually(func() bool {
-				apiService, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Get(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
+				apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return tests.ContainsCrt(apiService.Spec.CABundle, newCA)
 			}, 10*time.Second, 1*time.Second).Should(BeTrue())

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1866,7 +1866,7 @@ spec:
 		patchData := []byte(fmt.Sprint(`[{ "op": "replace", "path": "/metadata/labels", "value": {} }]`))
 		_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Patch(context.Background(), components.VirtApiCertSecretName, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		_, err = aggregatorClient.ApiregistrationV1beta1().APIServices().Patch(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), types.JSONPatchType, patchData, metav1.PatchOptions{})
+		_, err = aggregatorClient.ApiregistrationV1().APIServices().Patch(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		_, err = virtClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Patch(context.Background(), components.VirtAPIValidatingWebhookName, types.JSONPatchType, patchData, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -1880,7 +1880,7 @@ spec:
 			return secret.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))
 		Eventually(func() map[string]string {
-			apiService, err := aggregatorClient.ApiregistrationV1beta1().APIServices().Get(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
+			apiService, err := aggregatorClient.ApiregistrationV1().APIServices().Get(context.Background(), fmt.Sprintf("%s.subresources.kubevirt.io", v1.ApiLatestVersion), metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			return apiService.Labels
 		}, 20*time.Second, 1*time.Second).Should(HaveKeyWithValue(v1.ManagedByLabel, v1.ManagedByLabelOperatorValue))

--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -19,6 +19,6 @@ go_library(
         "//vendor/github.com/onsi/ginkgo/types:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
 )

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onsi/ginkgo/types"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apiservices "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	v12 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -456,7 +456,7 @@ func (r *KubernetesReporter) logAPIServices(virtCli kubecli.KubevirtClient) {
 		fmt.Fprintf(os.Stderr, "failed to fetch apiServices: %v\n", err)
 		return
 	}
-	apiServices := apiservices.APIServiceList{}
+	apiServices := apiregv1.APIServiceList{}
 	err = json.Unmarshal(result, &apiServices)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to unmarshal raw result to apiServicesList: %v\n", err)


### PR DESCRIPTION
Change apiregistration.k8s.io/v1beta1 to apiregistration.k8s.io/v1
as the former is deprecated and will be removed from Kubernetes 1.22.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Replaces all occurrences of apiregistration.k8s.io/v1beta1 with apiregistration.k8s.io/v1
as the former is deprecated and will be removed from Kubernetes 1.22.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
