### PR TITLE
Increase timeouts in sriov unit tests

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/sriov/hostdev_test.go
@@ -21,6 +21,7 @@ package sriov_test
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -253,7 +254,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c := newCallbackerStub(false, false)
 			c.sendEvent("non-sriov")
 			d := deviceDetacherStub{}
-			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 1)).To(HaveOccurred())
+			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 10*time.Millisecond)).To(HaveOccurred())
 			Expect(len(c.EventChannel())).To(Equal(0))
 		})
 
@@ -264,7 +265,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c := newCallbackerStub(false, true)
 			c.sendEvent(api.UserAliasPrefix + hostDevice.Alias.GetName())
 			d := deviceDetacherStub{}
-			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 1)).To(Succeed())
+			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 10*time.Millisecond)).To(Succeed())
 		})
 
 		It("succeeds detaching 2 sriov devices", func() {
@@ -275,7 +276,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 			c.sendEvent(api.UserAliasPrefix + hostDevice.Alias.GetName())
 			c.sendEvent(api.UserAliasPrefix + hostDevice2.Alias.GetName())
 			d := deviceDetacherStub{}
-			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 1)).To(Succeed())
+			Expect(sriov.SafelyDetachHostDevices(domainSpec, c, d, 10*time.Millisecond)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently some unit-tests fail randomly. The PR addresses the problem. It fixes timeout values in sriov package. The details are provided bellow.

The timeout of 1ns used in sriov unit tests is too strict for the
bellow case:

    for {
        select {
        case ...:
            ...
        case <-time.After(timeout):
            ...
        }
    }

Here the compiler will place the 'time.After(...)' call prior to the
'select' block (that can be observed in objdump). The call is equivalent
to 'NewTimer(...).C' and it will start the timer. Then each 'case'
statement will be probed for readiness (in the "source order") and the
timeout of 1ns has a good chance to expire. If several 'cases' are ready
to proceed, a single one is "chosen via a uniform pseudo-random select"
(according to the golang spec). That causes non-deterministic tests
behaviour.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
