### PR TITLE
[virt-operator] Remove a webhook check which checks workload placement

### DIFF
--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -885,58 +885,6 @@ spec:
 		waitForKv(kv)
 	})
 
-	Describe("Validation Webhooks", func() {
-		var kv *v1.KubeVirt
-		var workloads *v1.ComponentConfig
-
-		workloadPlacementUpdate := &v1.ComponentConfig{
-			NodePlacement: &v1.NodePlacement{
-				NodeSelector: map[string]string{
-					"nodeName": "node1",
-				},
-			},
-		}
-
-		BeforeEach(func() {
-			kv = tests.GetCurrentKv(virtClient)
-			workloads = kv.Spec.Workloads
-		})
-
-		AfterEach(func() {
-			kv = tests.GetCurrentKv(virtClient)
-			kv.Spec.Workloads = workloads
-
-			_, err := virtClient.KubeVirt(kv.Namespace).Update(kv)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should deny KV update when VMI is running", func() {
-			By("starting a VM")
-			vmi := tests.NewRandomVMI()
-			vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
-			Expect(err).To(BeNil())
-			tests.WaitForSuccessfulVMIStart(vmi)
-
-			By("updating workload placement")
-			placementBytes, err := json.Marshal(workloadPlacementUpdate)
-			Expect(err).ToNot(HaveOccurred())
-
-			ops := fmt.Sprintf(`[{ "op": "add", "path": "/spec/workloads", "value": %s }]`, string(placementBytes))
-			_, err = virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(ops))
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should allow KV update when there are no VMIs running", func() {
-			placementBytes, err := json.Marshal(workloadPlacementUpdate)
-			Expect(err).ToNot(HaveOccurred())
-
-			ops := fmt.Sprintf(`[{ "op": "add", "path": "/spec/workloads", "value": %s }]`, string(placementBytes))
-			kv, err := virtClient.KubeVirt(kv.Namespace).Patch(kv.Name, types.JSONPatchType, []byte(ops))
-			Expect(err).To(BeNil())
-			Expect(kv.Spec.Workloads).To(Equal(workloadPlacementUpdate))
-		})
-	})
-
 	Describe("[rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should start a VM", func() {
 		It("[test_id:3144]using virt-launcher with a shasum", func() {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Allow modifying the node layout with kubevirt installed via taints and
labels without having to shut down all VMIs.

Previously, changing node layout was possible, but it was not possible
to adjust the KubeVirt installation without shutting down all VMIs
first.

The admin-supporting aspect of this feature, to detect if VMIs are left
unmonitored on some nodes where virt-handler is not running, is now
covered via proper alerting.

Further it fixes flakyness in the following test, if CI nodes were under pressure:

```
[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]VMIlifecycle [rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Creating a VirtualMachineInstance [Serial]when virt-handler is not responsive [test_id:1634]the node controller should mark the node as unschedulable when the virt-handler heartbeat has timedout
```

The symptom was this:


```
tests/vmi_lifecycle_test.go:704
Timed out after 180.000s.
Expected
    <string>: 
to equal
    <string>: NodeUnresponsive
tests/vmi_lifecycle_test.go:740
```

The reason was this: First virt-handler got evicted, then a VMI got started. Sometimes the VMI did not reach the running state until virt-handler was evacuated. In that scenario virt-controller still owned the object, which caused the node controller to not kick in, since it only moves VMIs to failed state on unresponsive nodes, which are owned by virt-handler.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4720 and fixes #4958

**Special notes for your reviewer**:

Flakefinder entry: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2021-03-14-168h.html#row37

**Release note**:
```release-note
Remove  workload placement validation webhook which blocks placement updates when VMIs are running
```
