### PR TITLE
Allow pre-setting the KUBEVIRT_E2E_FOCUS env var in tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -281,24 +281,30 @@ spec:
     path: /
   storageClassName: windows
 EOF
-  # Run only Windows tests
-  export KUBEVIRT_E2E_FOCUS=Windows
-elif [[ $TARGET =~ (cnao|multus) ]]; then
-  export KUBEVIRT_E2E_FOCUS="Multus|Networking|VMIlifecycle|Expose|Macvtap"
-elif [[ $TARGET =~ sig-network ]]; then
-  export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
-elif [[ $TARGET =~ sriov.* ]]; then
-  export KUBEVIRT_E2E_FOCUS=SRIOV
-elif [[ $TARGET =~ gpu.* ]]; then
-  export KUBEVIRT_E2E_FOCUS=GPU
-elif [[ $TARGET =~ (okd|ocp).* ]]; then
-  export KUBEVIRT_E2E_SKIP="SRIOV|GPU"
-else
-  export KUBEVIRT_E2E_SKIP="Multus|SRIOV|GPU|Macvtap"
 fi
 
-if [[ "$KUBEVIRT_STORAGE" == "rook-ceph" ]]; then
-  export KUBEVIRT_E2E_FOCUS=rook-ceph
+# Set KUBEVIRT_E2E_FOCUS and KUBEVIRT_E2E_SKIP only if both of them are not already set
+if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
+  if [[ $TARGET =~ windows.* ]]; then
+    # Run only Windows tests
+    export KUBEVIRT_E2E_FOCUS=Windows
+  elif [[ $TARGET =~ (cnao|multus) ]]; then
+    export KUBEVIRT_E2E_FOCUS="Multus|Networking|VMIlifecycle|Expose|Macvtap"
+  elif [[ $TARGET =~ sig-network ]]; then
+    export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
+  elif [[ $TARGET =~ sriov.* ]]; then
+    export KUBEVIRT_E2E_FOCUS=SRIOV
+  elif [[ $TARGET =~ gpu.* ]]; then
+    export KUBEVIRT_E2E_FOCUS=GPU
+  elif [[ $TARGET =~ (okd|ocp).* ]]; then
+    export KUBEVIRT_E2E_SKIP="SRIOV|GPU"
+  else
+    export KUBEVIRT_E2E_SKIP="Multus|SRIOV|GPU|Macvtap"
+  fi
+
+  if [[ "$KUBEVIRT_STORAGE" == "rook-ceph" ]]; then
+    export KUBEVIRT_E2E_FOCUS=rook-ceph
+  fi
 fi
 
 # If KUBEVIRT_QUARANTINE is not set, do not run quarantined tests. When it is


### PR DESCRIPTION
In order to ease lane filtering, the `automation/test.sh` scrip will not compute the `KUBEVIRT_E2E_FOCUS` and the `KUBEVIRT_E2E_SKIP` environment variables according to the TARGET variable, one or them (or both) is already set.

That allows setting this variable from the test configuration.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
