### PR TITLE
Virt Handler Migration logic refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/pborman/uuid v1.2.0
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/procfs v0.2.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/subgraph/libmacouflage v0.0.1

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -66,7 +66,6 @@ import (
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
-	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
 	"kubevirt.io/kubevirt/pkg/watchdog"
@@ -183,7 +182,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 		mockContainerDiskMounter = container_disk.NewMockMounter(ctrl)
 		mockHotplugVolumeMounter = hotplug_volume.NewMockVolumeMounter(ctrl)
 
-		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig)
 		controller = NewController(recorder,
 			virtClient,
 			host,
@@ -200,7 +198,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			tlsConfig,
 			tlsConfig,
 			mockIsolationDetector,
-			migrationProxy,
 		)
 		controller.hotplugVolumeMounter = mockHotplugVolumeMounter
 		controller.networkCacheStoreFactory = networkingfake.NewFakeInMemoryNetworkCacheFactory()

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1489,6 +1489,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Labels = make(map[string]string)
 			vmi.Status.NodeName = host
 			vmi.Labels[v1.MigrationTargetNodeNameLabel] = "othernode"
+			vmi.Status.Interfaces = make([]v1.VirtualMachineInstanceNetworkInterface, 0)
 			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
 				TargetNode:               "othernode",
 				TargetNodeAddress:        "127.0.0.1:12345",


### PR DESCRIPTION
Migrations are complicated to start with and our code paths in virt-handler compound that complexity by intertwining source and target code paths. 

This PR is an effort to begin detangling the source and target migration code paths by refactoring these logical chunks into standalone functions. It should be easier to follow what logic is invoked in certain scenarios now which will help us during debugging and future development. 

No functional impact is expected to occur as a result of these patches. I have some logical changes/fixes coming in future PRs, however I wanted to keep this PR as straightforward as possible by not including any of those changes. 

```release-note
NONE
```
