### PR TITLE
Reconcile Role and ClusterRole resources

### DIFF
--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -445,7 +445,7 @@ func (r *Reconciler) createOrUpdateRbac() error {
 
 	// create/update Roles
 	for _, role := range r.targetStrategy.Roles() {
-		err := r.createOrUpdateRole(role, version, imageRegistry, id, r.kv.Namespace)
+		err := r.createOrUpdateRole(role, version, imageRegistry, id)
 		if err != nil {
 			return err
 		}
@@ -453,7 +453,7 @@ func (r *Reconciler) createOrUpdateRbac() error {
 
 	// create/update RoleBindings
 	for _, rb := range r.targetStrategy.RoleBindings() {
-		err := r.createOrUpdateRoleBinding(rb, version, imageRegistry, id, r.kv.Namespace)
+		err := r.createOrUpdateRoleBinding(rb, version, imageRegistry, id)
 		if err != nil {
 			return err
 		}

--- a/pkg/virt-operator/resource/apply/rbac.go
+++ b/pkg/virt-operator/resource/apply/rbac.go
@@ -45,7 +45,7 @@ func (r *Reconciler) createOrUpdate(role interface{},
 	roleType RoleType,
 	avoidIfServiceAccount bool) (err error) {
 
-	roleTypeName := getName(roleType)
+	roleTypeName := getRoleTypeName(roleType)
 	createRole := r.getRoleCreateFunction(role, roleType)
 	updateRole := r.getRoleUpdateFunction(role, roleType)
 
@@ -172,7 +172,7 @@ func (r *Reconciler) getRoleUpdateFunction(obj interface{}, roleType RoleType) (
 	return
 }
 
-func getName(roleType RoleType) (name string) {
+func getRoleTypeName(roleType RoleType) (name string) {
 	switch roleType {
 	case TypeRole:
 		name = "role"

--- a/pkg/virt-operator/resource/apply/rbacbackup.go
+++ b/pkg/virt-operator/resource/apply/rbacbackup.go
@@ -87,7 +87,7 @@ func (r *Reconciler) backupRBACs() error {
 }
 
 func (r *Reconciler) backupRBAC(obj interface{}, name, UID, imageTag, imageRegistry, id string, roleType RoleType) error {
-	meta := getRoleMetaObject(obj, roleType)
+	meta := getMetaObject(obj, roleType)
 	*meta = metav1.ObjectMeta{
 		GenerateName: name,
 	}
@@ -95,7 +95,7 @@ func (r *Reconciler) backupRBAC(obj interface{}, name, UID, imageTag, imageRegis
 	meta.Annotations[v1.EphemeralBackupObject] = UID
 
 	// Create backup
-	createRole := r.getRoleCreateFunction(obj, roleType)
+	createRole := r.getCreateFunction(obj, roleType)
 	err := createRole()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Reconcile Role and ClusterRole resources:
* Add a semantic deep equal on role and clusterrole `rules` object.
* Validate the metadata of the objects is equal with resourcemerge.EnsureObjectMeta() function.

Also refactor duplicate code in rbac.go and rbacbackup.go.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
