### PR TITLE
Add observedGeneration to virt-operator status to have a race-free way for detecting KubeVirt config rollouts

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10317,6 +10317,10 @@
      "observedDeploymentID": {
       "type": "string"
      },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64"
+     },
      "observedKubeVirtRegistry": {
       "type": "string"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -1062,6 +1062,9 @@ spec:
               type: string
             observedDeploymentID:
               type: string
+            observedGeneration:
+              format: int64
+              type: integer
             observedKubeVirtRegistry:
               type: string
             observedKubeVirtVersion:

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -94,5 +94,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1040,6 +1040,7 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 			logger.Info("All KubeVirt components ready")
 			kv.Status.Phase = v1.KubeVirtPhaseDeployed
 			util.UpdateConditionsAvailable(kv)
+			kv.Status.ObservedGeneration = &kv.ObjectMeta.Generation
 			return nil
 		}
 	}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	"k8s.io/utils/pointer"
 
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
 
@@ -1451,7 +1452,8 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 				Status: v1.KubeVirtStatus{
-					Phase: v1.KubeVirtPhaseDeleted,
+					Phase:              v1.KubeVirtPhaseDeleted,
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			// Add kubevirt deployment and mark everything as ready
@@ -1513,8 +1515,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					ImageTag: "custom.tag",
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 
@@ -1537,7 +1540,6 @@ var _ = Describe("KubeVirt Operator", func() {
 			controller.Execute()
 			kv = getLatestKubeVirt(kv)
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
-
 		}, 15)
 
 		It("delete temporary validation webhook once virt-api is deployed", func(done Done) {
@@ -1551,8 +1553,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					Generation: int64(1),
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			defaultConfig.SetTargetDeploymentConfig(kv)
@@ -1591,8 +1594,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					Generation: int64(1),
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			defaultConfig.SetTargetDeploymentConfig(kv)
@@ -1625,8 +1629,9 @@ var _ = Describe("KubeVirt Operator", func() {
 					Generation: int64(1),
 				},
 				Status: v1.KubeVirtStatus{
-					Phase:           v1.KubeVirtPhaseDeployed,
-					OperatorVersion: version.Get().String(),
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.Int64Ptr(1),
 				},
 			}
 			defaultConfig.SetTargetDeploymentConfig(kv)

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1283,6 +1283,9 @@ var CRDsValidation map[string]string = map[string]string{
           type: string
         observedDeploymentID:
           type: string
+        observedGeneration:
+          format: int64
+          type: integer
         observedKubeVirtRegistry:
           type: string
         observedKubeVirtVersion:

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -1838,6 +1838,11 @@ func (in *KubeVirtStatus) DeepCopyInto(out *KubeVirtStatus) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.ObservedGeneration != nil {
+		in, out := &in.ObservedGeneration, &out.ObservedGeneration
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -16636,6 +16636,12 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtStatus(ref common.ReferenceCallb
 							Format: "int32",
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1454,6 +1454,7 @@ type KubeVirtStatus struct {
 	ObservedDeploymentConfig                string              `json:"observedDeploymentConfig,omitempty" optional:"true"`
 	ObservedDeploymentID                    string              `json:"observedDeploymentID,omitempty" optional:"true"`
 	OutdatedVirtualMachineInstanceWorkloads *int                `json:"outdatedVirtualMachineInstanceWorkloads,omitempty" optional:"true"`
+	ObservedGeneration                      *int64              `json:"observedGeneration,omitempty"`
 }
 
 // KubeVirtPhase is a label for the phase of a KubeVirt deployment at the current time.

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -16487,6 +16487,12 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtStatus(ref common.ReferenceCallb
 							Format: "int32",
 						},
 					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Processes can now check if kubevirt is up to date from the KubeVirt
configuration by comparing `objectMeta.generation` with
`status.observedGeneration`.

This is race-free and avoids having to wait for the KubeVirt PR showing
update conditions. It makes these kinds of checks obsolete.

The operator update tests still stick with the current pattern (extra
waiting for update conditions to appear, before waiting for the operator
to be in sync again), since they have to deal with different operator
versions.

Other tests can now simply wait for the virt-operator to be "available"
and have the same generation on the metadata and the status without
having to consider intermediate steps.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

-->
```release-note
Add observedGeneration to virt-operator to have a race-free way to detect KubeVirt config rollouts
```
