### PR TITLE
containers: Fix duplicate group name for gid=0

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -98,7 +98,7 @@ group_entry(
 group_entry(
     name = "root-group",
     gid = 0,
-    groupname = "qemu",
+    groupname = "root",
 )
 
 group_file(

--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -68,7 +68,7 @@ group_entry(
 group_entry(
     name = "root-group",
     gid = 0,
-    groupname = "qemu",
+    groupname = "root",
 )
 
 group_file(

--- a/images/BUILD.bazel
+++ b/images/BUILD.bazel
@@ -54,7 +54,7 @@ group_entry(
 group_entry(
     name = "root-group",
     gid = 0,
-    groupname = "nginx",
+    groupname = "root",
 )
 
 group_file(


### PR DESCRIPTION
The definitions of group entries for gid=0 used the same
names as previously defined groups, which gives misleading
`ls -l` output in the container

```console
$ stat /usr/bin/alias | grep Gid
Access: (0755/-rwxr-xr-x)  Uid: (    0/    root)   Gid: (    0/    qemu)
$ ls -l /usr/bin/alias
-rwxr-xr-x. 1 root qemu 33 Jan  1  1970 /usr/bin/alias
$ id
uid=107(qemu) gid=107(qemu) groups=107(qemu)
```

This seems like a copy+paste accident.
Rename the groups to 'root'

**Release note**:
```release-note
NONE
```
