### PR TITLE
 QUARANTINE the vmi workload update verification logic

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -189,6 +189,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//staging/src/kubevirt.io/client-go/subresources:go_default_library",
+        "//tests/assert:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/flags:go_default_library",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -56,6 +56,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
 	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/assert"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -1249,8 +1250,11 @@ spec:
 				}, 90*time.Second, 1*time.Second).Should(BeTrue())
 			}
 
-			By("Verifying all migratable vmi workloads are updated via live migration")
-			verifyVMIsUpdated(migratableVMIs, launcherSha)
+			// QUARANTINED Logic - tracked by issue https://github.com/kubevirt/kubevirt/issues/5228
+			assert.XFail("https://github.com/kubevirt/kubevirt/issues/5228", func() {
+				By("Verifying all migratable vmi workloads are updated via live migration")
+				verifyVMIsUpdated(migratableVMIs, launcherSha)
+			})
 
 			By("Deleting migratable VMIs")
 			deleteAllVMIs(migratableVMIs)


### PR DESCRIPTION
Our update functional test that validates updating from the previous release to the latest code is currently flaky due to vmi's failing during migrations

The issue is being tracked here. #5228 

Since it's very risky to disable the entire update test, I've targeted just the portion that is failing. Issue #5228 is being marked as a release blocker in order to guarantee we can't cut a new release until we get a root cause for whatever is going on here. 


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
