### PR TITLE
virt-launcher, migration: Protect the setup using a lock, fix some missing operations and refactor the code

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -506,6 +506,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		if err := hotUnplugHostDevices(l.virConn, dom); err != nil {
 			log.Log.Object(vmi).Reason(err).Error(fmt.Sprintf("Live migration failed."))
 			l.setMigrationResult(vmi, true, fmt.Sprintf("%v", err), "")
+			return
 		}
 
 		params, err := prepareMigrationParams(options, vmi, loopbackAddress, dom)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -511,6 +511,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		params, err := prepareMigrationParams(options, vmi, loopbackAddress, dom)
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Error("Live migration failed.")
+			l.setMigrationResult(vmi, true, fmt.Sprintf("%v", err), "")
 			return
 		}
 		// start live migration tracking

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -531,6 +531,9 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 }
 
 func setupMigration(l *LibvirtDomainManager, vmi *v1.VirtualMachineInstance, dom cli.VirDomain, options *cmdclient.MigrationOptions, loopbackAddress string) (*libvirt.DomainMigrateParameters, error) {
+	l.domainModifyLock.Lock()
+	defer l.domainModifyLock.Unlock()
+
 	if err := hotUnplugHostDevices(l.virConn, dom); err != nil {
 		log.Log.Object(vmi).Reason(err).Error(fmt.Sprintf("Live migration failed."))
 		return nil, err

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -485,38 +485,16 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 
 	go func(l *LibvirtDomainManager, vmi *v1.VirtualMachineInstance) {
 
-		// Start local migration proxy.
-		//
-		// Right now Libvirt won't let us perform a migration using a unix socket, so
-		// we have to create a local host tcp server (on port 22222) that forwards the traffic
-		// to libvirt in order to trick libvirt into doing what we want.
-		// This also creates a tcp server for each additional direct migration connections
-		// that will be proxied to the destination pod
-
 		isBlockMigration := (vmi.Status.MigrationMethod == v1.BlockMigration)
-		migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
 
 		loopbackAddress := ip.GetLoopbackAddress()
-		// Create a tcp server for each direct connection proxy
-		for _, port := range migrationPortsRange {
-			key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-			migrationProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
-			defer migrationProxy.StopListening()
-			err := migrationProxy.StartListening()
-			if err != nil {
-				l.setMigrationResult(vmi, true, fmt.Sprintf("%v", err), "")
-				return
-			}
-		}
 
-		//  proxy incoming migration requests on port 22222 to the vmi's existing libvirt connection
-		libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
-		defer libvirtConnectionProxy.StopListening()
-		err := libvirtConnectionProxy.StartListening()
+		stopMigrationProxyServer, err := startMigrationProxyServer(l.virtShareDir, vmi, loopbackAddress)
 		if err != nil {
 			l.setMigrationResult(vmi, true, fmt.Sprintf("%v", err), "")
 			return
 		}
+		defer stopMigrationProxyServer()
 
 		// For a tunnelled migration, this is always the uri
 		dstURI := fmt.Sprintf("qemu+tcp://%s/system", net.JoinHostPort(loopbackAddress, strconv.Itoa(LibvirtLocalConnectionPort)))
@@ -578,6 +556,55 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		}
 		log.Log.Object(vmi).Infof("Live migration succeeded.")
 	}(l, vmi)
+}
+
+// startMigrationProxyServer starts a local migration proxy.
+// Right now Libvirt won't let us perform a migration using a unix socket, so
+// we have to create a local host tcp server (on port 22222) that forwards the traffic
+// to libvirt in order to trick libvirt into doing what we want.
+// This also creates a tcp server for each additional direct migration connections
+// that will be proxied to the destination pod
+//
+// On success, a teardown function is returned that the caller is expected to call in order to
+// cleanup the proxy-server resources.
+// On failure, an error is returned and the cleanup is performed internally without any need
+// from the caller to act.
+func startMigrationProxyServer(virtShareDir string, vmi *v1.VirtualMachineInstance, loopbackAddress string) (stopServer func(), err error) {
+	var proxyStopListenPool []func()
+	stopServer = func() {
+		for _, f := range proxyStopListenPool {
+			f()
+		}
+	}
+	defer func() {
+		// On error, stop the servers before returning.
+		if err != nil {
+			stopServer()
+			stopServer = nil
+		}
+	}()
+
+	isBlockMigration := vmi.Status.MigrationMethod == v1.BlockMigration
+	migrationPortsRange := migrationproxy.GetMigrationPortsList(isBlockMigration)
+
+	// Create a tcp server for each direct connection proxy
+	for _, port := range migrationPortsRange {
+		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
+		migrationProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(virtShareDir, key))
+		if e := migrationProxy.StartListening(); e != nil {
+			return stopServer, e
+		}
+		proxyStopListenPool = append(proxyStopListenPool, migrationProxy.StopListening)
+	}
+
+	//  proxy incoming migration requests on port 22222 to the vmi's existing libvirt connection
+	libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(virtShareDir, string(vmi.UID)))
+	if e := libvirtConnectionProxy.StartListening(); e != nil {
+		return stopServer, e
+	}
+	proxyStopListenPool = append(proxyStopListenPool, libvirtConnectionProxy.StopListening)
+
+	return stopServer, nil
 }
 
 func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

Operations on the domain which involve its state change are protected
from concurrent access using a domain-modify-lock (mutex).

In the migration setup stage, currently two operations are affecting the
domain state:
- Detaching of SR-IOV devices.
- Preparing migration parameters (which includes the domxml)

These operation need to be protected from change of the domain and
therefore the domain-modify-lock is added.

As part of this journey, a refactoring was needed to avoid double-locking.
In addition, some small fixes have been added:
- Report migration status on all failures.
- Abort the detach operation in case of failure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
In order to follow the changes, it is recommended to review this change one commit at a time.

**Release note**:
```release-note
NONE
```
