### PR TITLE
[clone] network, macvtap bind mech: add a MAC parameter to the bind mech

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -362,7 +362,6 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		return &MacvtapBindMechanism{
 			vmi:              vmi,
 			iface:            iface,
-			virtIface:        &api.Interface{},
 			domain:           domain,
 			podInterfaceName: podInterfaceName,
 			mac:              mac,
@@ -1241,11 +1240,13 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-	b.virtIface.MAC = &api.MAC{MAC: b.getIfaceMACAddr()}
-	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}
-	b.virtIface.Target = &api.InterfaceTarget{
-		Device:  b.podInterfaceName,
-		Managed: "no",
+	b.virtIface = &api.Interface{
+		MAC: &api.MAC{MAC: b.getIfaceMACAddr()},
+		MTU: &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)},
+		Target: &api.InterfaceTarget{
+			Device:  b.podInterfaceName,
+			Managed: "no",
+		},
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1241,13 +1241,7 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-	if b.mac != nil {
-		b.virtIface.MAC = &api.MAC{MAC: b.mac.String()}
-	} else {
-		// Get interface MAC address
-		b.virtIface.MAC = &api.MAC{MAC: b.podNicLink.Attrs().HardwareAddr.String()}
-	}
-
+	b.virtIface.MAC = &api.MAC{MAC: b.getIfaceMACAddr()}
 	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}
 	b.virtIface.Target = &api.InterfaceTarget{
 		Device:  b.podInterfaceName,
@@ -1255,6 +1249,14 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 	}
 
 	return nil
+}
+
+func (b *MacvtapBindMechanism) getIfaceMACAddr() string {
+	if b.mac != nil {
+		return b.mac.String()
+	} else {
+		return b.podNicLink.Attrs().HardwareAddr.String()
+	}
 }
 
 func (b *MacvtapBindMechanism) preparePodNetworkInterfaces(queueNumber uint32, launcherPID int) error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1242,15 +1242,9 @@ func (b *MacvtapBindMechanism) discoverPodNetworkInterface() error {
 		return err
 	}
 	b.podNicLink = link
-
 	if b.virtIface.MAC == nil {
 		// Get interface MAC address
-		mac, err := Handler.GetMacDetails(b.podInterfaceName)
-		if err != nil {
-			log.Log.Reason(err).Errorf("failed to get MAC for %s", b.podInterfaceName)
-			return err
-		}
-		b.virtIface.MAC = &api.MAC{MAC: mac.String()}
+		b.virtIface.MAC = &api.MAC{MAC: b.podNicLink.Attrs().HardwareAddr.String()}
 	}
 
 	b.virtIface.MTU = &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -592,6 +592,14 @@ var _ = Describe("Pod Network", func() {
 			})
 		})
 		Context("Macvtap plug", func() {
+			BeforeEach(func() {
+				primaryPodInterface.HardwareAddr = fakeMac
+			})
+
+			AfterEach(func() {
+				primaryPodInterface.HardwareAddr = nil
+			})
+
 			It("Should pass a non-privileged macvtap interface to qemu", func() {
 				ifaceName := "macvtap0"
 				domain := NewDomainWithMacvtapInterface(ifaceName)
@@ -600,7 +608,6 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 
 				driver, err := getPhase2Binding(vmi, &vmi.Spec.Domain.Devices.Interfaces[0], &vmi.Spec.Networks[0], domain, ifaceName, cacheFactory)
-				mockNetwork.EXPECT().GetMacDetails(ifaceName).Return(fakeMac, nil)
 				mockNetwork.EXPECT().LinkByName(ifaceName).Return(primaryPodInterface, nil)
 				Expect(err).ToNot(HaveOccurred(), "should have identified the correct binding mechanism")
 				TestRunPlug(driver)


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows us to stop using virtIface on the pod networking
setup occurring in virt-handler on follow up PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This is #5057 clone with a rebase.
(I could not push to @maiqueb repo/branch)

**Release note**:
```release-note
NONE
```
