### PR TITLE
Add sig-compute owner string to relevant tests

### DIFF
--- a/tests/access_test.go
+++ b/tests/access_test.go
@@ -35,7 +35,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:component]User Access", func() {
+var _ = Describe("[rfe_id:500][crit:high][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]User Access", func() {
 
 	view := tests.ViewServiceAccountName
 	edit := tests.EditServiceAccountName

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -36,7 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component]Config", func() {
+var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]Config", func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -38,7 +38,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component]Console", func() {
+var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]Console", func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/credentials_test.go
+++ b/tests/credentials_test.go
@@ -38,7 +38,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("Guest Access Credentials", func() {
+var _ = Describe("[owner:@sig-compute]Guest Access Credentials", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -66,7 +66,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[Serial]Infrastructure", func() {
+var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		aggregatorClient *aggregatorclient.Clientset
@@ -1072,7 +1072,7 @@ func getKeysFromMetrics(metrics map[string]float64) []string {
 // returning the first unexpected error if any, or a custom error in case
 // there were no errors at all.
 func validatedHTTPResponses(errorsChan chan error, concurrency int) error {
-	var expectedErrorsCount int = 0
+	var expectedErrorsCount = 0
 	var unexpectedError error
 	for ix := 0; ix < concurrency; ix++ {
 		err := <-errorsChan

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -13,7 +13,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("oc/kubectl integration", func() {
+var _ = Describe("[owner:@sig-compute]oc/kubectl integration", func() {
 	var (
 		k8sClient, result string
 		err               error

--- a/tests/kubevirt_configmap_test.go
+++ b/tests/kubevirt_configmap_test.go
@@ -37,7 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-var _ = Describe("[Serial]KubeVirtConfigmapConfiguration", func() {
+var _ = Describe("[Serial][owner:@sig-compute]KubeVirtConfigmapConfiguration", func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -72,7 +72,7 @@ const (
 	stressdefaultVMSize = "100"
 )
 
-var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system] VM Live Migration", func() {
+var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][owner:@sig-compute] VM Live Migration", func() {
 	var virtClient kubecli.KubevirtClient
 	var originalKubeVirtConfig *v1.KubeVirt
 	var err error

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component]Pausing", func() {
+var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]Pausing", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -44,7 +44,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstanceReplicaSet", func() {
+var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]VirtualMachineInstanceReplicaSet", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
@@ -178,7 +178,7 @@ var _ = Describe("[Serial][rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][le
 		newRS, err = virtClient.ReplicaSet(tests.NamespaceTestDefault).Create(newRS)
 		Expect(err).ToNot(HaveOccurred())
 		doScaleWithHPA(newRS.ObjectMeta.Name, int32(startScale), int32(startScale), int32(startScale))
-		doScaleWithHPA(newRS.ObjectMeta.Name, int32(stopScale), (int32(stopScale)), int32(stopScale))
+		doScaleWithHPA(newRS.ObjectMeta.Name, int32(stopScale), int32(stopScale), int32(stopScale))
 		doScaleWithHPA(newRS.ObjectMeta.Name, int32(1), int32(1), int32(1))
 
 	},

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -36,7 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial]SecurityFeatures", func() {
+var _ = Describe("[Serial][owner:@sig-compute]SecurityFeatures", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -638,7 +638,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					},
 				}
 
-				pvc, err = virtClient.CoreV1().PersistentVolumeClaims((pvc.Namespace)).Create(context.Background(), pvc, metav1.CreateOptions{})
+				pvc, err = virtClient.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				pvc = waitPVCReady(pvc)
 

--- a/tests/subresource_api_test.go
+++ b/tests/subresource_api_test.go
@@ -37,7 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests/flags"
 )
 
-var _ = Describe("Subresource Api", func() {
+var _ = Describe("[owner:@sig-compute]Subresource Api", func() {
 
 	var err error
 	var virtCli kubecli.KubevirtClient

--- a/tests/version_test.go
+++ b/tests/version_test.go
@@ -30,7 +30,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("Version", func() {
+var _ = Describe("[owner:@sig-compute]Version", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -43,7 +43,7 @@ const (
 	DefaultPollIntervalInSeconds         = 3
 )
 
-var _ = Describe("[Serial][ref_id:2717]KubeVirt control plane resilience", func() {
+var _ = Describe("[Serial][ref_id:2717][owner:@sig-compute]KubeVirt control plane resilience", func() {
 
 	var err error
 	var virtCli kubecli.KubevirtClient

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -55,7 +55,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnet"
 )
 
-var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachine", func() {
+var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]VirtualMachine", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -141,7 +141,7 @@ func createCommandWithNSAndRedirect(namespace, cmdName string, args ...string) (
 	return cmd, stdOut, stdErr, nil
 }
 
-var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:component]VmWatch", func() {
+var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]VmWatch", func() {
 	var err error
 	var virtCli kubecli.KubevirtClient
 

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -40,7 +40,7 @@ import (
 
 const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
 
-var _ = Describe("CloudInitHookSidecars", func() {
+var _ = Describe("[owner:@sig-compute]CloudInitHookSidecars", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -53,7 +53,7 @@ const (
 	testUserData     = "#cloud-config"
 )
 
-var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component]CloudInit UserData", func() {
+var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]CloudInit UserData", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -59,7 +59,7 @@ import (
 
 type VMICreationFuncWithEFI func() *v1.VirtualMachineInstance
 
-var _ = Describe("Configurations", func() {
+var _ = Describe("[owner:@sig-compute]Configurations", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_controller_test.go
+++ b/tests/vmi_controller_test.go
@@ -14,7 +14,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("Controller devices", func() {
+var _ = Describe("[owner:@sig-compute]Controller devices", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -52,7 +52,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }
 
-var _ = Describe("[Serial]GPU", func() {
+var _ = Describe("[Serial][owner:@sig-compute]GPU", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_headless_test.go
+++ b/tests/vmi_headless_test.go
@@ -36,7 +36,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[rfe_id:609]VMIheadless", func() {
+var _ = Describe("[rfe_id:609][owner:@sig-compute]VMIheadless", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -46,7 +46,7 @@ const (
 	sidecarContainerName = "hook-sidecar-0"
 )
 
-var _ = Describe("HookSidecars", func() {
+var _ = Describe("[owner:@sig-compute]HookSidecars", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -15,7 +15,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("[Serial]HostDevices", func() {
+var _ = Describe("[Serial][owner:@sig-compute]HostDevices", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -33,7 +33,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component]IgnitionData", func() {
+var _ = Describe("[Serial][rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]IgnitionData", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -76,7 +76,7 @@ func addNodeAffinityToVMI(vmi *v1.VirtualMachineInstance, nodeName string) {
 	}
 }
 
-var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]VMIlifecycle", func() {
+var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]VMIlifecycle", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_monitoring_test.go
+++ b/tests/vmi_monitoring_test.go
@@ -33,7 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-var _ = Describe("Health Monitoring", func() {
+var _ = Describe("[owner:@sig-compute]Health Monitoring", func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_multiqueue_test.go
+++ b/tests/vmi_multiqueue_test.go
@@ -40,7 +40,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[Serial]MultiQueue", func() {
+var _ = Describe("[Serial][owner:@sig-compute]MultiQueue", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmidefaults_test.go
+++ b/tests/vmidefaults_test.go
@@ -33,7 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[Serial]VMIDefaults", func() {
+var _ = Describe("[Serial][owner:@sig-compute]VMIDefaults", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmipreset_test.go
+++ b/tests/vmipreset_test.go
@@ -40,7 +40,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]VMIPreset", func() {
+var _ = Describe("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]VMIPreset", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vnc_test.go
+++ b/tests/vnc_test.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests"
 )
 
-var _ = Describe("[Serial][rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component]VNC", func() {
+var _ = Describe("[Serial][rfe_id:127][crit:medium][vendor:cnv-qe@redhat.com][level:component][owner:@sig-compute]VNC", func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/windows_test.go
+++ b/tests/windows_test.go
@@ -114,7 +114,7 @@ var getWindowsVMISpec = func() v1.VirtualMachineInstanceSpec {
 
 }
 
-var _ = Describe("[Serial]Windows VirtualMachineInstance", func() {
+var _ = Describe("[Serial][owner:@sig-compute]Windows VirtualMachineInstance", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add sig-compute owner string to relevant tests so that a separate test lane can filter and run these specific tests.
The tests that seemed to relate the core virt components, like VM, VMI, VNC and more are marked here with `sig-compute` owner tag

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
