### PR TITLE
Bazel can open quite some files, increase ulimits for files inside the build container

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -126,7 +126,7 @@ fi
 
 # Ensure that a bazel server is running
 if [ -z "$($KUBEVIRT_CRI ps --format '{{.Names}}' | grep ${BUILDER}-bazel-server)" ]; then
-    $KUBEVIRT_CRI run --network host -d ${volumes} --security-opt "label=disable" --name ${BUILDER}-bazel-server -w "/root/go/src/kubevirt.io/kubevirt" --rm ${KUBEVIRT_BUILDER_IMAGE} hack/bazel-server.sh
+    $KUBEVIRT_CRI run --ulimit nofile=10000:10000 --network host -d ${volumes} --security-opt "label=disable" --name ${BUILDER}-bazel-server -w "/root/go/src/kubevirt.io/kubevirt" --rm ${KUBEVIRT_BUILDER_IMAGE} hack/bazel-server.sh
 fi
 
 # Update cert trust, if custom is provided


### PR DESCRIPTION
Ensure that file ulimits are high enough for bazel inside the
containerized build environment, independent on what the host default
for containers are.

The symptom is bazel failing with a stack trace containing this:

```
Caused by: io.netty.channel.ChannelException: Failed to open a socket.
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
