### PR TITLE
migration admitter: prevent creation of duplicate migrations

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -620,7 +620,7 @@ func (app *virtAPIApp) registerValidatingWebhooks() {
 		validating_webhook.ServeVMIPreset(w, r)
 	})
 	http.HandleFunc(components.MigrationCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig)
+		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.MigrationUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationUpdate(w, r)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -51,6 +51,13 @@ func (mutator *MigrationCreateMutator) Mutate(ar *v1beta1.AdmissionReview) *v1be
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
+	// Add our selector label
+	if migration.Labels == nil {
+		migration.Labels = map[string]string{v1.MigrationSelectorLabel: migration.Spec.VMIName}
+	} else {
+		migration.Labels[v1.MigrationSelectorLabel] = migration.Spec.VMIName
+	}
+
 	// Add a finalizer
 	migration.Finalizers = append(migration.Finalizers, v1.VirtualMachineInstanceMigrationFinalizer)
 	var patch []patchOperation

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -86,4 +86,10 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		_, migrationMeta := getMigrationSpecMetaFromResponse()
 		Expect(migrationMeta.Finalizers).To(ContainElement(v1.VirtualMachineInstanceMigrationFinalizer))
 	})
+
+	It("should add the selector label", func() {
+		_, migrationMeta := getMigrationSpecMetaFromResponse()
+		Expect(migrationMeta.Labels).ToNot(BeNil())
+		Expect(migrationMeta.Labels[v1.MigrationSelectorLabel]).To(Equal(migration.Spec.VMIName))
+	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
@@ -32,6 +32,34 @@ import (
 type MigrationUpdateAdmitter struct {
 }
 
+func ensureSelectorLabelSafe(newMigration *v1.VirtualMachineInstanceMigration, oldMigration *v1.VirtualMachineInstanceMigration) []metav1.StatusCause {
+	if newMigration.Status.Phase != v1.MigrationSucceeded && newMigration.Status.Phase != v1.MigrationFailed && oldMigration.Labels != nil {
+		oldLabel, oldExists := oldMigration.Labels[v1.MigrationSelectorLabel]
+		if newMigration.Labels == nil {
+			if oldExists {
+				return []metav1.StatusCause{
+					{
+						Type:    metav1.CauseTypeFieldValueNotSupported,
+						Message: "selector label can't be removed from an in-flight migration",
+					},
+				}
+			}
+		} else {
+			newLabel, newExists := newMigration.Labels[v1.MigrationSelectorLabel]
+			if oldExists && (!newExists || newLabel != oldLabel) {
+				return []metav1.StatusCause{
+					{
+						Type:    metav1.CauseTypeFieldValueNotSupported,
+						Message: "selector label can't be modified on an in-flight migration",
+					},
+				}
+			}
+		}
+	}
+
+	return []metav1.StatusCause{}
+}
+
 func (admitter *MigrationUpdateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	// Get new migration from admission response
 	newMigration, oldMigration, err := getAdmissionReviewMigration(ar)
@@ -54,28 +82,9 @@ func (admitter *MigrationUpdateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1b
 	}
 
 	// Reject Migration update if selector label changed on an in-flight migration
-	if newMigration.Status.Phase != v1.MigrationSucceeded && newMigration.Status.Phase != v1.MigrationFailed && oldMigration.Labels != nil {
-		oldLabel, oldExists := oldMigration.Labels[v1.MigrationSelectorLabel]
-		if newMigration.Labels == nil {
-			if oldExists {
-				return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
-					{
-						Type:    metav1.CauseTypeFieldValueNotSupported,
-						Message: "selector label can't be removed from an in-flight migration",
-					},
-				})
-			}
-		} else {
-			newLabel, newExists := newMigration.Labels[v1.MigrationSelectorLabel]
-			if oldExists && (!newExists || newLabel != oldLabel) {
-				return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
-					{
-						Type:    metav1.CauseTypeFieldValueNotSupported,
-						Message: "selector label can't be modified on an in-flight migration",
-					},
-				})
-			}
-		}
+	causes := ensureSelectorLabelSafe(newMigration, oldMigration)
+	if len(causes) > 0 {
+		return webhookutils.ToAdmissionResponse(causes)
 	}
 
 	reviewResponse := v1beta1.AdmissionResponse{}

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -48,8 +48,8 @@ func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.VMIPresetAdmitter{})
 }
 
-func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{ClusterConfig: clusterConfig})
+func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{ClusterConfig: clusterConfig, VirtClient: virtCli})
 }
 
 func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -149,6 +149,14 @@ func (c *MigrationController) Execute() bool {
 	return true
 }
 
+func ensureSelectorLabelPresent(migration *virtv1.VirtualMachineInstanceMigration) {
+	if migration.Labels == nil {
+		migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
+	} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
+		migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
+	}
+}
+
 func (c *MigrationController) execute(key string) error {
 	var vmi *virtv1.VirtualMachineInstance
 	var targetPods []*k8sv1.Pod
@@ -172,11 +180,7 @@ func (c *MigrationController) execute(key string) error {
 		migration := migration.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(migration)
 		// Ensure the migration contains our selector label
-		if migration.Labels == nil {
-			migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
-		} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
-			migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
-		}
+		ensureSelectorLabelPresent(migration)
 		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(migration)
 		return err
 	}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -171,6 +171,12 @@ func (c *MigrationController) execute(key string) error {
 	if !controller.ObservedLatestApiVersionAnnotation(migration) {
 		migration := migration.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(migration)
+		// Ensure the migration contains our selector label
+		if migration.Labels == nil {
+			migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
+		} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
+			migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
+		}
 		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(migration)
 		return err
 	}

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -642,6 +642,8 @@ const (
 
 	VirtualMachineLabel        = AppLabel + "/vm"
 	MemfdMemoryBackend  string = "kubevirt.io/memfd"
+
+	MigrationSelectorLabel = "kubevirt.io/vmi-name"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {


### PR DESCRIPTION
by adding a special migration label to be used as a label selector

**What this PR does / why we need it**:
This PR ensure no 2 migrations will ever run simultaneously for a given VMI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1937920

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Creating more than 1 migration at the same time for a given VMI will now fail
```
