### PR TITLE
Convert vcpu times to seconds

### DIFF
--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -178,7 +178,7 @@ func (metrics *vmiMetrics) updateVcpu(vcpuStats []stats.DomainStatsVcpu) {
 				"kubevirt_vmi_vcpu_seconds",
 				"Vcpu elapsed time.",
 				prometheus.CounterValue,
-				float64(vcpu.Time/1000000000),
+				float64(vcpu.Time/1000000),
 				[]string{"id", "state"},
 				[]string{stringVcpuIdx, humanReadableState(vcpu.State)},
 			)


### PR DESCRIPTION
vcpu times is reported in microseconds by libvirt.  In order to convert
it to seconds, we need to divide it by 1e6.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
