### PR TITLE
A very simple fix to avoid builder push collisions

### DIFF
--- a/hack/builder/version.sh
+++ b/hack/builder/version.sh
@@ -1,3 +1,3 @@
-VERSION=32-1.0.0
+VERSION=$(date +"%y%m%d%H%M")-$(git rev-parse --short HEAD)
 # TODO: reenable ppc64le when new builds are available
 ARCHITECTURES="amd64"

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder@sha256:7a8c5a02a9aa4f9a1457a89daddc3769e136b99e414fbe35f0d85d802b79fc66"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2103171450-7edc9308c"
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It is easy to override tags with the current builder bump flow. Since
quay.io does not keep images based on digest, if they have no tag,
applying a simple workaround to avoid that people accidentaly override
each others builder images.

It actually just happened right now. I restored the builder image from my local machine, but we need to prevent that.
This is really just a very simple workaround. On the long run I expect the builder image to be replaced with the kubevirtci/bootstrap image with bazel being installed as the only requirement.

The downside of risking to get different images from the same tag is tried to be minimized by creating the tags in a pretty unique way.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
