### PR TITLE
Cache healthz version response and clear when informers error

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -138,7 +138,10 @@ type virtHandlerApp struct {
 	clusterConfig     *virtconfig.ClusterConfig
 }
 
-var _ service.Service = &virtHandlerApp{}
+var (
+	_                service.Service = &virtHandlerApp{}
+	apiHealthVersion                 = new(healthz.KubeApiHealthzVersion)
+)
 
 func (app *virtHandlerApp) prepareCertManager() (err error) {
 	app.clientcertmanager = bootstrap.NewFileCertificateManager(app.clientCertFilePath, app.clientKeyFilePath)
@@ -360,7 +363,7 @@ func (app *virtHandlerApp) runPrometheusServer(errCh chan error) {
 	mux := restful.NewContainer()
 	webService := new(restful.WebService)
 	webService.Path("/").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
-	webService.Route(webService.GET("/healthz").To(healthz.KubeConnectionHealthzFuncFactory(app.clusterConfig)).Doc("Health endpoint"))
+	webService.Route(webService.GET("/healthz").To(healthz.KubeConnectionHealthzFuncFactory(app.clusterConfig, apiHealthVersion)).Doc("Health endpoint"))
 	mux.Add(webService)
 	log.Log.V(1).Infof("metrics: max concurrent requests=%d", app.MaxRequestsInFlight)
 	mux.Handle("/metrics", promvm.Handler(app.MaxRequestsInFlight))
@@ -457,6 +460,9 @@ func (app *virtHandlerApp) AddFlags() {
 
 func (app *virtHandlerApp) setupTLS(factory controller.KubeInformerFactory) error {
 	kubevirtCAConfigInformer := factory.KubeVirtCAConfigMap()
+	kubevirtCAConfigInformer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
+		apiHealthVersion.Clear()
+	})
 	caManager := webhooks.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace, app.caConfigMapName)
 
 	app.promTLSConfig = webhooks.SetupPromTLS(app.servercertmanager)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -462,6 +462,7 @@ func (app *virtHandlerApp) setupTLS(factory controller.KubeInformerFactory) erro
 	kubevirtCAConfigInformer := factory.KubeVirtCAConfigMap()
 	kubevirtCAConfigInformer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
 		apiHealthVersion.Clear()
+		cache.DefaultWatchErrorHandler(r, err)
 	})
 	caManager := webhooks.NewCAManager(kubevirtCAConfigInformer.GetStore(), app.namespace, app.caConfigMapName)
 

--- a/pkg/healthz/BUILD.bazel
+++ b/pkg/healthz/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -10,5 +10,18 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "healthz_suite_test.go",
+        "healthz_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -71,8 +71,9 @@ func (h *KubeApiHealthzVersion) GetVersion() (v interface{}) {
 func KubeConnectionHealthzFuncFactory(clusterConfig *virtconfig.ClusterConfig, hVersion *KubeApiHealthzVersion) func(_ *restful.Request, response *restful.Response) {
 	return func(_ *restful.Request, response *restful.Response) {
 		res := map[string]interface{}{}
+		var version = hVersion.GetVersion()
 
-		if hVersion.GetVersion() == nil {
+		if version == nil {
 			cli, err := kubecli.GetKubevirtClient()
 			if err != nil {
 				unhealthy(err, clusterConfig, response)
@@ -85,7 +86,6 @@ func KubeConnectionHealthzFuncFactory(clusterConfig *virtconfig.ClusterConfig, h
 				return
 			}
 
-			var version interface{}
 			err = json.Unmarshal(body, &version)
 			if err != nil {
 				unhealthy(err, clusterConfig, response)
@@ -95,7 +95,7 @@ func KubeConnectionHealthzFuncFactory(clusterConfig *virtconfig.ClusterConfig, h
 			hVersion.Update(version)
 		}
 
-		res["apiserver"] = map[string]interface{}{"connectivity": "ok", "version": hVersion.GetVersion()}
+		res["apiserver"] = map[string]interface{}{"connectivity": "ok", "version": version}
 		res["config-resource-version"] = clusterConfig.GetResourceVersion()
 		response.WriteHeaderAndJson(http.StatusOK, res, restful.MIME_JSON)
 		return

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 
 	restful "github.com/emicklei/go-restful"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -32,32 +33,75 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-func KubeConnectionHealthzFuncFactory(clusterConfig *virtconfig.ClusterConfig) func(_ *restful.Request, response *restful.Response) {
+type KubeApiHealthzVersion struct {
+	version interface{}
+	sync.RWMutex
+}
+
+func (h *KubeApiHealthzVersion) Update(body interface{}) {
+	h.Lock()
+	defer h.Unlock()
+	h.version = body
+}
+
+func (h *KubeApiHealthzVersion) Clear() {
+	h.Lock()
+	defer h.Unlock()
+	h.version = nil
+}
+
+func (h *KubeApiHealthzVersion) GetVersion() (v interface{}) {
+	h.RLock()
+	defer h.RUnlock()
+	v = h.version
+	return
+}
+
+/*
+   This check is primarily to determine whether a controller can reach the Kubernetes API.
+   We can reflect this based on other connections we depend on (informers and their error handling),
+   rather than testing the kubernetes API every time the healthcheck endpoint is called. This
+   should avoid a lot of unnecessary calls to the API while informers are healthy.
+
+   Note that It is possible for the contents of a KubeApiHealthzVersion to be out of date if the
+   Kubernetes API version changes without an informer disconnect, or if informer doesn't call
+   KubeApiHealthzVersion.Clear() when it encounters an error.
+*/
+
+func KubeConnectionHealthzFuncFactory(clusterConfig *virtconfig.ClusterConfig, hVersion *KubeApiHealthzVersion) func(_ *restful.Request, response *restful.Response) {
 	return func(_ *restful.Request, response *restful.Response) {
 		res := map[string]interface{}{}
-		cli, err := kubecli.GetKubevirtClient()
-		if err != nil {
-			unhealthy(err, clusterConfig, response)
-			return
+
+		if hVersion.GetVersion() == nil {
+			cli, err := kubecli.GetKubevirtClient()
+			if err != nil {
+				unhealthy(err, clusterConfig, response)
+				return
+			}
+
+			body, err := cli.CoreV1().RESTClient().Get().AbsPath("/version").Do(context.Background()).Raw()
+			if err != nil {
+				unhealthy(err, clusterConfig, response)
+				return
+			}
+
+			var version interface{}
+			err = json.Unmarshal(body, &version)
+			if err != nil {
+				unhealthy(err, clusterConfig, response)
+				return
+			}
+
+			hVersion.Update(version)
 		}
 
-		body, err := cli.CoreV1().RESTClient().Get().AbsPath("/version").Do(context.Background()).Raw()
-		if err != nil {
-			unhealthy(err, clusterConfig, response)
-			return
-		}
-		var version interface{}
-		err = json.Unmarshal(body, &version)
-		if err != nil {
-			unhealthy(err, clusterConfig, response)
-			return
-		}
-		res["apiserver"] = map[string]interface{}{"connectivity": "ok", "version": version}
+		res["apiserver"] = map[string]interface{}{"connectivity": "ok", "version": hVersion.GetVersion()}
 		res["config-resource-version"] = clusterConfig.GetResourceVersion()
 		response.WriteHeaderAndJson(http.StatusOK, res, restful.MIME_JSON)
 		return
 	}
 }
+
 func unhealthy(err error, clusterConfig *virtconfig.ClusterConfig, response *restful.Response) {
 	res := map[string]interface{}{}
 	res["apiserver"] = map[string]interface{}{"connectivity": "failed", "error": fmt.Sprintf("%v", err)}

--- a/pkg/healthz/healthz_suite_test.go
+++ b/pkg/healthz/healthz_suite_test.go
@@ -1,0 +1,13 @@
+package healthz
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestHealthz(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Healthz Suite")
+}

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,0 +1,27 @@
+package healthz
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Healthz", func() {
+	Context("KubeApiHealthzVersion", func() {
+		apiHealthVersion := KubeApiHealthzVersion{}
+		testValue := "this is a test"
+
+		It("Should return nil by default", func() {
+			Expect(apiHealthVersion.GetVersion()).To(BeNil())
+		})
+
+		It("Should store a value", func() {
+			apiHealthVersion.Update(testValue)
+			Expect(apiHealthVersion.GetVersion()).To(Equal(testValue))
+		})
+
+		It("Should be clearable", func() {
+			apiHealthVersion.Clear()
+			Expect(apiHealthVersion.GetVersion()).To(BeNil())
+		})
+	})
+})

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -738,6 +738,7 @@ func (app *virtAPIApp) Run() {
 	// Wire up health check trigger
 	configMapInformer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
 		apiHealthVersion.Clear()
+		cache.DefaultWatchErrorHandler(r, err)
 	})
 
 	stopChan := make(chan struct{}, 1)

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -249,6 +249,7 @@ func Execute() {
 	// Wire up health check triggers
 	configMapInformer.SetWatchErrorHandler(func(r *cache.Reflector, err error) {
 		apiHealthVersion.Clear()
+		cache.DefaultWatchErrorHandler(r, err)
 	})
 
 	cache.WaitForCacheSync(stopChan, configMapInformer.HasSynced, app.crdInformer.HasSynced, app.kubeVirtInformer.HasSynced)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4766,6 +4766,31 @@ func FormatIPForURL(ip string) string {
 	return ip
 }
 
+func getClusterDnsServiceIP(virtClient kubecli.KubevirtClient) (string, error) {
+	dnsServiceName := "kube-dns"
+	dnsNamespace := "kube-system"
+	if IsOpenShift() {
+		dnsServiceName = "dns-default"
+		dnsNamespace = "openshift-dns"
+	}
+	kubeDNSService, err := virtClient.CoreV1().Services(dnsNamespace).Get(context.Background(), dnsServiceName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return kubeDNSService.Spec.ClusterIP, nil
+}
+
+func GetKubernetesApiServiceIp(virtClient kubecli.KubevirtClient) (string, error) {
+	kubernetesServiceName := "kubernetes"
+	kubernetesServiceNamespace := "default"
+
+	kubernetesService, err := virtClient.CoreV1().Services(kubernetesServiceNamespace).Get(context.Background(), kubernetesServiceName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return kubernetesService.Spec.ClusterIP, nil
+}
+
 func IsRunningOnKindInfra() bool {
 	provider := os.Getenv("KUBEVIRT_PROVIDER")
 	return strings.HasPrefix(provider, "kind")

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -230,6 +230,49 @@ var _ = Describe("[Serial][ref_id:2717]KubeVirt control plane resilience", func(
 
 		})
 
+		When("[test_id:2807]Control plane pods temporarily lose connection to Kubernetes API", func() {
+			// virt-handler is the only component that has the tools to add blackhole routes for testing healthz
+			componentName := "virt-handler"
+
+			readyFunc := func() int32 {
+				daemonSet, err := virtCli.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), componentName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				return daemonSet.Status.NumberReady
+			}
+
+			blackHolePodFunc := func(addOrDel string) {
+				pods, err := virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: fmt.Sprintf("kubevirt.io=%s", componentName)})
+				Expect(err).NotTo(HaveOccurred())
+
+				serviceIp, err := tests.GetKubernetesApiServiceIp(virtCli)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, pod := range pods.Items {
+					_, err = tests.ExecuteCommandOnPod(virtCli, &pod, componentName, []string{"ip", "route", addOrDel, "blackhole", serviceIp})
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+
+			It("should begin to fail health checks", func() {
+				By("ensuring we have ready pods")
+				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically(">", 0))
+
+				By("blocking connection to API on pods")
+				blackHolePodFunc("add")
+
+				By("ensuring we no longer have a ready pod")
+				Eventually(readyFunc, 120*time.Second, time.Second).Should(BeNumerically("==", 0))
+			})
+
+			It("should recover health checks", func() {
+				By("removing blockage to API")
+				blackHolePodFunc("del")
+
+				By("ensuring we now have a ready virt-handler daemonset")
+				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically(">", 0))
+			})
+		})
+
 	})
 
 })

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -230,8 +230,8 @@ var _ = Describe("[Serial][ref_id:2717]KubeVirt control plane resilience", func(
 
 		})
 
-		When("[test_id:2807]Control plane pods temporarily lose connection to Kubernetes API", func() {
-			// virt-handler is the only component that has the tools to add blackhole routes for testing healthz
+		When("Control plane pods temporarily lose connection to Kubernetes API", func() {
+			// virt-handler is the only component that has the tools to add blackhole routes for testing healthz. Ideally we would test all component healthz endpoints.
 			componentName := "virt-handler"
 
 			readyFunc := func() int32 {
@@ -253,7 +253,7 @@ var _ = Describe("[Serial][ref_id:2717]KubeVirt control plane resilience", func(
 				}
 			}
 
-			It("should begin to fail health checks", func() {
+			It("should fail health checks when connectivity is lost, and recover when connectivity is regained", func() {
 				By("ensuring we have ready pods")
 				Eventually(readyFunc, 30*time.Second, time.Second).Should(BeNumerically(">", 0))
 
@@ -262,9 +262,7 @@ var _ = Describe("[Serial][ref_id:2717]KubeVirt control plane resilience", func(
 
 				By("ensuring we no longer have a ready pod")
 				Eventually(readyFunc, 120*time.Second, time.Second).Should(BeNumerically("==", 0))
-			})
 
-			It("should recover health checks", func() {
 				By("removing blockage to API")
 				blackHolePodFunc("del")
 


### PR DESCRIPTION
Add functional test for healthz endpoint on virt-handler

Signed-off-by: Marcus Sorensen <mls@apple.com>

**What this PR does / why we need it**:

The change moves the Kubernetes API version check that is performed by the controller /healthz endpoints to a struct that acts as a cache. So long as the controller watches don't encounter errors, the result of /healthz is served from this cache.  If the controller watch fails, the watch error handler function is called, which clears the cache. This is reflected as unhealthy in the /healthz response, and the /healthz cache then checks connectivity to the Kubernetes API until it is re-established.

**Which issue(s) this PR fixes**:
Fixes #5058 

**Special notes for your reviewer**:
I wasn't sure how to come up with a proper test_id for the functional tests, so I took a guess.  This test is not fast, because it requires a certain amount of time for the watch to time out, if there's a more acceptable way to do this I'm happy to rework it. 

Ideally I would have liked to test the /healthz behavior against virt-api, virt-controller, and virt-handler, but the current virt-handler container is the only one with the tools necessary to block connectivity. It at least functionally tests the package.  I also considered trying to block this connectivity from the node level, but I'm not certain that would be as portable/compatible with various node configurations and networking types. Could also add ip utils to the virt-controller and virt-api but I didn't want to assume that it's worthwhile for just this one test.

```release-note
Controller health checks will no longer actively test connectivity to the Kubernetes API. They will rely in health of their watches to determine if they have API connectivity.
```
