### PR TITLE
create test NFS PVs on a schedulable nodes

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1010,7 +1010,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				// create a new PV and PVC (PVs can't be reused)
 				By("create a new NFS PV and PVC")
 				os := string(cd.ContainerDiskFedora)
-				tests.CreateNFSPvAndPvc(pvName, tests.NamespaceTestDefault, "5Gi", nfsIP, os)
+				tests.CreateNFSPvAndPvc(pvName, tests.NamespaceTestDefault, "5Gi", nfsIP, os, "")
 			})
 
 			AfterEach(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
With parallel tests in place, some of the NFS tests were failing because the required PV was created on a non-schedulable node.
This PR just sets node affinity of the PV to a `schedulableNode`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4829

**Special notes for your reviewer**:
We should be able now to take some of the NFS tests out of QUARANTINE


**Release note**:
```release-note
NONE
```
