### PR TITLE
Fix estimation of number of tests per repeated test run

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -44,6 +44,28 @@ function new_tests {
         | sed -E 's/\|$//'
 }
 
+# taking into account that each file containing changed tests is run several times per default
+# and considering overhead of cluster-up etc., we should just skip the run
+# if the total number of tests for all runs gets higher than the total number of tests
+function should_skip_test_run_due_to_too_many_tests() {
+    local new_tests="$1"
+    local test_start_pattern='(Specify|It|Entry)\('
+    local tests_total_estimate=0
+    while IFS= read -r -d '' test_file_name; do
+        tests_total_estimate=$(( tests_total_estimate + $(grep -hcE "${test_start_pattern}" "$test_file_name") ))
+    done < <(find tests/ -name '*.go' -print0)
+    local tests_to_run_estimate=0
+    for test_file_name in $(echo "${new_tests}" | tr '|' '\n'); do
+        set +e
+        tests_to_run_estimate=$(( tests_to_run_estimate + $(grep -hcE "${test_start_pattern}" "$test_file_name") ))
+        set -e
+    done
+    local tests_total_for_all_runs_estimate
+    tests_total_for_all_runs_estimate=$(( tests_to_run_estimate * NUM_TESTS * ${#TEST_LANES[@]} ))
+    echo -e "Estimates:\ttests_total_estimate: $tests_total_estimate\ttests_total_for_all_runs_estimate: $tests_total_for_all_runs_estimate"
+    [ "$tests_total_for_all_runs_estimate" -gt $tests_total_estimate ]
+}
+
 
 if (( $# > 0 )); then
     if [[ "$1" =~ -h ]]; then
@@ -91,15 +113,7 @@ echo "Test files touched: $(echo ${NEW_TESTS} | tr '|' ',')"
 NUM_TESTS=${NUM_TESTS-3}
 echo "Number of per lane runs: $NUM_TESTS"
 
-test_start_pattern='(Specify|It|Entry)\('
-tests_total_estimate=$(find tests/ -name '*_test.go' -print0 | xargs -0 grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
-tests_to_run_estimate=$(echo "${NEW_TESTS}" | tr '|' '\n' | xargs grep -hcE "${test_start_pattern}" | awk '{total += $1} END {print total}')
-tests_total_for_all_runs_estimate=$(expr $tests_to_run_estimate \* $NUM_TESTS \* ${#TEST_LANES[@]})
-echo -e "Estimates:\ttests_total_estimate: $tests_total_estimate\ttests_total_for_all_runs_estimate: $tests_total_for_all_runs_estimate"
-if [ $tests_total_for_all_runs_estimate -gt $tests_total_estimate ]; then
-    # taking into account that each file containing changed tests is run several times per default
-    # and considering overhead of cluster-up etc., we should just skip the run
-    # if the total number of tests for all runs gets higher than the total number of tests
+if should_skip_test_run_due_to_too_many_tests "${NEW_TESTS}"; then
     echo "Skipping run due to number of tests in total being too high for repeated run."
     exit 0
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Due to grep returning non zero exit code in case of no match we rewrite
the grepping logic to ignore these errors. This also makes it a bit
better to read as the awk sum is replaced by proper arithmetic
expressions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@oshoval at some time in the past there was a convention of using `_test.go` for test files. As this is no more valid I need to adjust the logic to reflect that.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
