### PR TITLE
Prefetch cdi images for tests

### DIFF
--- a/hack/cluster-build.sh
+++ b/hack/cluster-build.sh
@@ -29,8 +29,7 @@ DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
 source hack/common.sh
 source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
 source hack/config.sh
-
-kubectl() { cluster-up/kubectl.sh "$@"; }
+source hack/prefetch-images.sh
 
 echo "Building ..."
 
@@ -56,34 +55,7 @@ if [[ $image_prefix_alt ]]; then
     done
 fi
 
-if [[ $KUBEVIRT_PROVIDER == "external" ]] || [[ $KUBEVIRT_PROVIDER =~ kind.* ]] || [[ $KUBEVIRT_PROVIDER == "local" ]]; then
-    nodes=() # in case of external provider / kind we have no control over the nodes
-else
-    nodes=()
-    nodes+=($(_kubectl get nodes -o name | sed "s#node/##g"))
-    pull_command="docker"
-fi
-
-for node in ${nodes[@]}; do
-    count=0
-    until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container}\" | xargs \-\-max-args=1 sudo ${pull_command} pull"; do
-        count=$((count + 1))
-        if [ $count -eq 10 ]; then
-            echo "Failed to '${pull_command} pull' in ${node}" >&2
-            exit 1
-        fi
-        sleep 1
-    done
-
-    count=0
-    until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container_alias}\" | xargs \-\-max-args=2 sudo ${pull_command} tag"; do
-        count=$((count + 1))
-        if [ $count -eq 10 ]; then
-            echo "Failed to '${pull_command} tag' in ${node}" >&2
-            exit 1
-        fi
-        sleep 1
-    done
-done
+prefetch-images::pull_on_nodes $container
+prefetch-images::tag_on_nodes $container_alias
 
 echo "Done $0"

--- a/hack/cluster-build.sh
+++ b/hack/cluster-build.sh
@@ -56,22 +56,11 @@ if [[ $image_prefix_alt ]]; then
     done
 fi
 
-# OKD/OCP providers has different node names and does not have docker
-if [[ $KUBEVIRT_PROVIDER =~ ocp.* ]]; then
-    nodes=()
-    nodes+=($(kubectl get nodes --no-headers | awk '{print $1}' | grep master))
-    nodes+=($(kubectl get nodes --no-headers | awk '{print $1}' | grep worker))
-    pull_command="podman"
-elif [[ $KUBEVIRT_PROVIDER =~ okd.* ]]; then
-    nodes=("master-0" "worker-0")
-    pull_command="podman"
-elif [[ $KUBEVIRT_PROVIDER == "external" ]] || [[ $KUBEVIRT_PROVIDER =~ kind.* ]] || [[ $KUBEVIRT_PROVIDER == "local" ]]; then
+if [[ $KUBEVIRT_PROVIDER == "external" ]] || [[ $KUBEVIRT_PROVIDER =~ kind.* ]] || [[ $KUBEVIRT_PROVIDER == "local" ]]; then
     nodes=() # in case of external provider / kind we have no control over the nodes
 else
     nodes=()
-    for i in $(seq 1 ${KUBEVIRT_NUM_NODES}); do
-        nodes+=("node$(printf "%02d" ${i})")
-    done
+    nodes+=($(_kubectl get nodes -o name | sed "s#node/##g"))
     pull_command="docker"
 fi
 

--- a/hack/prefetch-images.sh
+++ b/hack/prefetch-images.sh
@@ -1,0 +1,57 @@
+set -ex pipefail
+
+source hack/common.sh
+source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
+source hack/config.sh
+
+function prefetch-images::find_node_names() {
+    if [[ $KUBEVIRT_PROVIDER == "external" ]] || [[ $KUBEVIRT_PROVIDER =~ kind.* ]] || [[ $KUBEVIRT_PROVIDER == "local" ]]; then
+        echo "" # in case of external provider / kind we have no control over the nodes
+    else
+        local nodes=()
+        nodes+=($(_kubectl get nodes -o name | sed "s#node/##g"))
+        echo "${nodes[@]}"
+    fi
+}
+
+# Given a list of images, find nodes, SSH into each node and execute a command to pull image
+function prefetch-images::pull_on_nodes() {
+    local -r containers_to_pull=$@
+    local -r nodes=$(prefetch-images::find_node_names)
+    # only internal providers are supported (we have control over the nodes), and there we know it's docker
+    local -r pull_command="docker"
+    local -r max_retry=10
+
+    for node in ${nodes[@]}; do
+        count=0
+        until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${containers_to_pull}\" | xargs \-\-max-args=1 sudo ${pull_command} pull"; do
+            count=$((count + 1))
+            if [ $count -eq max_retry ]; then
+                echo "Failed to '${pull_command} pull' in ${node}" >&2
+                exit 1
+            fi
+            sleep 1
+        done
+    done
+}
+
+# Given a list of images and tags, find nodes, SSH into each node and execute a command to tag image
+function prefetch-images::tag_on_nodes() {
+    local -r container_alias=$@
+    local -r nodes=$(prefetch-images::find_node_names)
+    # only internal providers are supported, (we have control over the nodes) and there we know it's docker
+    local -r pull_command="docker"
+    local -r max_retry=10
+
+    for node in ${nodes[@]}; do
+        count=0
+        until ${KUBEVIRT_PATH}cluster-up/ssh.sh ${node} "echo \"${container_alias}\" | xargs \-\-max-args=2 sudo ${pull_command} tag"; do
+            count=$((count + 1))
+            if [ $count -eq max_retry ]; then
+                echo "Failed to '${pull_command} tag' in ${node}" >&2
+                exit 1
+            fi
+            sleep 1
+        done
+    done
+}


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In general everything except CDI is right now either already baked into kubevirtci or pre-fetched. With this PR CDI images are pre-fetched to all kubevirtci nodes during make cluster-sync to avoid weird unpredictable timeouts due to varying pull speeds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Might fix flakiness in tests using CDI upload/import/clone.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
