### PR TITLE
Bazel test args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ bazel-push-images:
 push: bazel-push-images
 
 bazel-test:
-	hack/dockerized "hack/bazel-fmt.sh && hack/bazel-test.sh"
+	hack/dockerized "hack/bazel-fmt.sh && CI=${CI} hack/bazel-test.sh"
 
 generate:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -3,6 +3,12 @@ set -e
 source hack/common.sh
 source hack/config.sh
 
+if [ "${CI}" == "true" ]; then
+    cat >>ci.bazelrc <<EOF
+test --cache_test_results=no --runs_per_test=4
+EOF
+fi
+
 bazel test \
     --config=${ARCHITECTURE} \
     --test_output=errors -- //staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... //tests/framework/...

--- a/pkg/hooks/manager_test.go
+++ b/pkg/hooks/manager_test.go
@@ -22,6 +22,7 @@ package hooks_test
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -81,10 +82,14 @@ func hookListenAndServe(socketPath string, hookName string, hookPointName string
 
 var _ = Describe("HooksManager", func() {
 	Context("With existing sockets", func() {
-		socketDir := hooks.HookSocketsSharedDirectory
+		var socketDir string
 
 		BeforeEach(func() {
-			os.MkdirAll(socketDir, os.ModePerm)
+			var err error
+			socketDir, err = ioutil.TempDir("", "hooks-manager-test")
+			Expect(err).ToNot(HaveOccurred())
+			err = os.MkdirAll(socketDir, os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Should find sidecar", func() {
@@ -96,7 +101,7 @@ var _ = Describe("HooksManager", func() {
 			defer socket.Close()
 			defer os.Remove(socketPath)
 
-			manager := hooks.GetManager()
+			manager := hooks.NewManager(socketDir)
 			err = manager.Collect(1, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -117,7 +122,7 @@ var _ = Describe("HooksManager", func() {
 				defer os.Remove(socketPath)
 			}
 
-			manager := hooks.GetManager()
+			manager := hooks.NewManager(socketDir)
 			err := manager.Collect(uint(len(hookNames)), 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -139,7 +144,7 @@ var _ = Describe("HooksManager", func() {
 				defer os.Remove(socketPath)
 			}
 
-			manager := hooks.GetManager()
+			manager := hooks.NewManager(socketDir)
 			err := manager.Collect(uint(len(hookNameMap)), 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -112,20 +112,6 @@ var _ = Describe("HotplugVolume mount target records", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("setMountTargetRecord should not write record to file, if record already exists, and no changes", func() {
-		recordFile := filepath.Join(tempDir, string(vmi.UID))
-		info, err := os.Stat(recordFile)
-		Expect(err).ToNot(HaveOccurred())
-		expectedModTime := info.ModTime()
-		m.mountRecords[vmi.UID] = record
-		err = m.setMountTargetRecord(vmi, record)
-		Expect(err).ToNot(HaveOccurred())
-		resInfo, err := os.Stat(recordFile)
-		Expect(err).ToNot(HaveOccurred())
-		resModTime := resInfo.ModTime()
-		Expect(expectedModTime).To(Equal(resModTime))
-	})
-
 	It("getMountTargetRecord should get record from file if not in cache", func() {
 		res, err := m.getMountTargetRecord(vmi)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/github.com/google/uuid:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/pkg/virt-launcher/monitor_test.go
+++ b/pkg/virt-launcher/monitor_test.go
@@ -31,6 +31,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/google/uuid"
+
 	"kubevirt.io/client-go/log"
 )
 
@@ -46,7 +48,7 @@ var _ = Describe("VirtLauncher", func() {
 	var cmdLock sync.Mutex
 	var gracefulShutdownChannel chan struct{}
 
-	uuid := "123-123-123-123"
+	uuid := uuid.New().String()
 
 	log.Log.SetIOWriter(GinkgoWriter)
 

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -476,13 +476,17 @@ type VirDomain interface {
 }
 
 func NewConnection(uri string, user string, pass string, checkInterval time.Duration) (Connection, error) {
+	return NewConnectionWithTimeout(uri, user, pass, checkInterval, ConnectionInterval, ConnectionTimeout)
+}
+
+func NewConnectionWithTimeout(uri string, user string, pass string, checkInterval, connectionInterval, connectionTimeout time.Duration) (Connection, error) {
 	logger := log.Log
 	logger.V(1).Infof("Connecting to libvirt daemon: %s", uri)
 
 	var err error
 	var virConn *libvirt.Connect
 
-	err = utilwait.PollImmediate(ConnectionInterval, ConnectionTimeout, func() (done bool, err error) {
+	err = utilwait.PollImmediate(connectionInterval, connectionTimeout, func() (done bool, err error) {
 		virConn, err = newConnection(uri, user, pass)
 		if err != nil {
 			logger.V(1).Infof("Connecting to libvirt daemon failed: %v", err)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt_test.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt_test.go
@@ -30,7 +30,7 @@ import (
 var _ = Describe("Libvirt Suite", func() {
 	Context("Upon attempt to connect to Libvirt", func() {
 		It("should time out while waiting for libvirt", func() {
-			_, err := NewConnection("http://", "", "", 1*time.Microsecond)
+			_, err := NewConnectionWithTimeout("http://", "", "", 1*time.Microsecond, 100*time.Millisecond, 500*time.Millisecond)
 			msg := fmt.Sprintf("%v", err)
 			Expect(err).To(HaveOccurred())
 			Expect(msg).To(Equal("cannot connect to libvirt daemon: timed out waiting for the condition"))

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -97,6 +97,10 @@ func WatchdogFileExists(baseDir string, vmi *v1.VirtualMachineInstance) (bool, e
 }
 
 func WatchdogFileIsExpired(timeoutSeconds int, baseDir string, vmi *v1.VirtualMachineInstance) (bool, error) {
+	return watchdogFileIsExpired(timeoutSeconds, baseDir, vmi, time.Now())
+}
+
+func watchdogFileIsExpired(timeoutSeconds int, baseDir string, vmi *v1.VirtualMachineInstance, timeNow time.Time) (bool, error) {
 	namespace := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetNamespace())
 	domain := precond.MustNotBeEmpty(vmi.GetObjectMeta().GetName())
 
@@ -116,7 +120,7 @@ func WatchdogFileIsExpired(timeoutSeconds int, baseDir string, vmi *v1.VirtualMa
 		return false, err
 	}
 
-	now := time.Now().UTC().Unix()
+	now := timeNow.UTC().Unix()
 
 	return isExpired(now, timeoutSeconds, stat), nil
 }
@@ -132,6 +136,10 @@ func isExpired(now int64, timeoutSeconds int, stat os.FileInfo) bool {
 }
 
 func GetExpiredDomains(timeoutSeconds int, virtShareDir string) ([]*api.Domain, error) {
+	return getExpiredDomains(timeoutSeconds, virtShareDir, time.Now())
+}
+
+func getExpiredDomains(timeoutSeconds int, virtShareDir string, timeNow time.Time) ([]*api.Domain, error) {
 
 	var domains []*api.Domain
 
@@ -146,7 +154,7 @@ func GetExpiredDomains(timeoutSeconds int, virtShareDir string) ([]*api.Domain, 
 	if err != nil {
 		return nil, err
 	}
-	now := time.Now().UTC().Unix()
+	now := timeNow.UTC().Unix()
 	for _, file := range files {
 		if isExpired(now, timeoutSeconds, file) == true {
 			key := file.Name()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR adjusts bazel options for unit-testing in CI
```bash
"--cache_test_results=no --runs_per_test=4"
``` 

Additionally it introduces small refactorings to enable parallel tests execution with `--runs_per_test=n` and reduce the overall tests execution time.

Fixes #5217, #5279

**Special notes for your reviewer**:

This is needed for https://github.com/kubevirt/kubevirt/issues/5217. The commits are atomic and can be reviewed one by one.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
