### PR TITLE
Fix some vmi cleanup issues in vm_networking.go

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -151,16 +151,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 	BeforeEach(func() {
 		tests.BeforeTestCleanup()
 
-		if !tests.HasLiveMigration() {
-			Skip("LiveMigration feature gate is not enabled in kubevirt-config")
-		}
-
-		nodes := tests.GetAllSchedulableNodes(virtClient)
-		Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-
-		if len(nodes.Items) < 2 {
-			Skip("Migration tests require at least 2 nodes")
-		}
+		tests.SkipIfMigrationIsNotPossible()
 
 		// Taints defined by k8s are special and can't be applied manually.
 		// Temporarily configure KubeVirt to use something else for the duration of these tests.

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1156,16 +1156,7 @@ var _ = SIGDescribe("[Serial]Macvtap", func() {
 		var clientVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
-			nodes := tests.GetAllSchedulableNodes(virtClient)
-			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-
-			if len(nodes.Items) < 2 {
-				Skip("Migration tests require at least 2 nodes")
-			}
-
-			if !tests.HasLiveMigration() {
-				Skip("Migration tests require the 'LiveMigration' feature gate")
-			}
+			tests.SkipIfMigrationIsNotPossible()
 		})
 
 		BeforeEach(func() {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -811,9 +811,7 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 
 			BeforeEach(func() {
-				if !tests.HasLiveMigration() {
-					Skip("LiveMigration feature gate is not enabled in kubevirt-config")
-				}
+				tests.SkipIfMigrationIsNotPossible()
 			})
 
 			AfterEach(func() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3850,6 +3850,22 @@ func SkipIfOpenShift4(message string) {
 	}
 }
 
+func SkipIfMigrationIsNotPossible() {
+	if !HasLiveMigration() {
+		Skip("LiveMigration feature gate is not enabled in kubevirt-config")
+	}
+
+	virtClient, err := kubecli.GetKubevirtClient()
+	PanicOnError(err)
+
+	nodes := GetAllSchedulableNodes(virtClient)
+	Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
+
+	if len(nodes.Items) < 2 {
+		Skip("Migration tests require at least 2 nodes")
+	}
+}
+
 // StartVmOnNode starts a VMI on the specified node
 func StartVmOnNode(vmi *v1.VirtualMachineInstance, nodeName string) *v1.VirtualMachineInstance {
 	virtClient, err := kubecli.GetKubevirtClient()


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that some tests in vmi_networking.go clean up the VMIs they
create. The tests affected by this were partly assuming a complete
cleanup and partly assuming that they share common VMIs.
As a result they were anyway already creating their own VMIs, but were
not cleaning up VMIs from the previous test runs.

An example is this run: https://prow.apps.ovirt.org/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5248/pull-kubevirt-e2e-k8s-1.19/1372226042629984256.

The [overview.log](https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5248/pull-kubevirt-e2e-k8s-1.19/1372226042629984256/artifacts/k8s-reporter/1_overview.log) shows the accumulated VMIs clearly:

```
kubevirt-test-default1   pod/virt-launcher-testvmi-5hrxg-wr4cz         0/2     Terminating   0          6m      10.244.140.80    node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-6prdr-wdtsl         2/2     Running       0          15m     10.244.140.116   node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-8qlr7-8r9g6         2/2     Running       0          19m     10.244.140.121   node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-fjbz9-hcwwf         2/2     Running       0          17m     10.244.140.126   node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-hm98m-kmd69         2/2     Running       0          13m     10.244.140.79    node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-m67st-fl2c2         2/2     Running       0          19m     10.244.140.76    node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-nqn77-fbpc7         2/2     Running       0          16m     10.244.140.119   node02   <none>           <none>
kubevirt-test-default1   pod/virt-launcher-testvmi-t4m6n-5hlm6         0/2     Terminating   0          6m      10.244.140.77    node02   <none>           <none>
```

There may be more cleanup issues, but this resolves the most basic left-over issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
