### PR TITLE
Remove quay login from release shell script

### DIFF
--- a/automation/release.sh
+++ b/automation/release.sh
@@ -37,7 +37,6 @@ function build_release_artifacts() {
     make olm-verify
     make prom-rules-verify
 
-    docker login -u="$QUAY_USER" -p="$QUAY_PASSWORD" quay.io
     QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub" make bazel-push-images
 
     make build-functests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Can't work currently as the `env vars` from the job configuration are pointing to files that need to get passed in. Sp this PR removes the login to quay.io in the release script. Another PR in project-infra adds it to the job configuration. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @davidvossel 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
