### PR TITLE
automation, Validate that TARGET is non empty

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -35,6 +35,11 @@ readonly ARTIFACTS_PATH="${ARTIFACTS-$WORKSPACE/exported-artifacts}"
 readonly TEMPLATES_SERVER="https://templates.ovirt.org/kubevirt/"
 readonly BAZEL_CACHE="${BAZEL_CACHE:-http://bazel-cache.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt}"
 
+if [ -z $TARGET ]; then
+  echo "FATAL: TARGET must be non empty"
+  exit 1
+fi
+
 if [[ $TARGET =~ windows.* ]]; then
   echo "picking the default provider for windows tests"
 elif [[ $TARGET =~ cnao ]]; then


### PR DESCRIPTION
In order to fail fast, in case the job doesnt set
TARGET due to an error, and to not hide
delicate errors that might occour, since otherwise
the default configuration would be selected,
Validate that TARGET is set.

Example 
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1042/rehearsal-pull-kubevirt-e2e-kind-1.17-sriov/1372521867209871360
The job is using a new bootstrap image, which doesn't have apt, so the whole command of the job that exports env vars is not triggered.
The job still runs and uses the default provider, and might even pass after running all tests on a provider it didn't mean to, and tests it didn't mean.
Giving false positive and hiding problems.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
