### PR TITLE
Serve promethus VMI info from informer cache

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -305,7 +305,7 @@ func (app *virtHandlerApp) Run() {
 		app.VirtShareDir,
 	)
 
-	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight)
+	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight, vmiSourceInformer)
 
 	go app.clientcertmanager.Start()
 	go app.servercertmanager.Start()

--- a/pkg/monitoring/vms/prometheus/BUILD.bazel
+++ b/pkg/monitoring/vms/prometheus/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/monitoring/vms/prometheus",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/lookup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",
@@ -21,6 +20,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )


### PR DESCRIPTION
Signed-off-by: Marcus Sorensen <mls@apple.com>

**What this PR does / why we need it**:

Whenever prometheus metrics are scraped from virt-handler, the virt-handler calls the Kubernetes API to find the VMIs assigned to the node. This can cause considerable API load for large clusters. Instead, we can serve this information from the VMI informer cache.

**Which issue(s) this PR fixes**:
Fixes #5193 

**Special notes for your reviewer**:
It looks like the existing infra_test suite covers validating that active VMI information properly presents in the /metrics scraping. It should sufficiently test this change, therefore no additional tests were added.

**Release note**:
```release-note
Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
```
