### PR TITLE
Give the expecter more time on a e2e test to retrieve info

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2373,7 +2373,7 @@ var _ = Describe("Configurations", func() {
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "[ $(sudo dmidecode -s chassis-asset-tag | tr -s ' ') = Test-123 ] && echo 'pass'\n"},
 				&expect.BExp{R: console.RetValue("pass")},
-			}, 1)).To(Succeed())
+			}, 10)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Chassis test gives an Expect only one second to succeed. This is not
always enough. Give it a reasonable value of 10 seconds.

Fixes issues like

```
tests/vmi_configuration_test.go:2352
Expected success, but got an error:
    <expect.TimeoutError>: 1000000000
    expect: timer expired after 1 seconds
tests/vmi_configuration_test.go:2376
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Here an example job: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5082/pull-kubevirt-e2e-k8s-1.19/1372426865519628289

**Release note**:

```release-note
NONE
```
