### PR TITLE
Publish the CA bundle everywhere before rolling out new certificates from a new CA

### DIFF
--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -274,12 +274,6 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ra
 		return err
 	}
 
-	// create/update Certificate secrets
-	err = r.createOrUpdateCertificateSecrets(queue, caCert, certDuration)
-	if err != nil {
-		return err
-	}
-
 	// create/update ValidatingWebhookConfiguration
 	err = r.createOrUpdateValidatingWebhookConfigurations(caBundle)
 	if err != nil {
@@ -294,6 +288,12 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ra
 
 	// create/update APIServices
 	err = r.createOrUpdateAPIServices(caBundle)
+	if err != nil {
+		return err
+	}
+
+	// create/update Certificate secrets
+	err = r.createOrUpdateCertificateSecrets(queue, caCert, certDuration)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-operator/resource/apply/reconcile.go
+++ b/pkg/virt-operator/resource/apply/reconcile.go
@@ -541,42 +541,7 @@ func (r *Reconciler) Sync(queue workqueue.RateLimitingInterface) (bool, error) {
 		return false, err
 	}
 
-	caDuration := getCADuration(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
-	caOverlapTime := getCAOverlapTime(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
-	certDuration := getCertDuration(r.kv.Spec.CertificateRotationStrategy.SelfSigned)
-
-	// create/update CA Certificate secret
-	caCert, err := r.createOrUpdateCACertificateSecret(queue, caDuration)
-	if err != nil {
-		return false, err
-	}
-
-	// create/update CA config map
-	caBundle, err := r.createOrUpdateKubeVirtCAConfigMap(queue, caCert, caOverlapTime)
-	if err != nil {
-		return false, err
-	}
-
-	// create/update Certificate secrets
-	err = r.createOrUpdateCertificateSecrets(queue, caCert, certDuration)
-	if err != nil {
-		return false, err
-	}
-
-	// create/update ValidatingWebhookConfiguration
-	err = r.createOrUpdateValidatingWebhookConfigurations(caBundle)
-	if err != nil {
-		return false, err
-	}
-
-	// create/update MutatingWebhookConfiguration
-	err = r.createOrUpdateMutatingWebhookConfigurations(caBundle)
-	if err != nil {
-		return false, err
-	}
-
-	// create/update APIServices
-	err = r.createOrUpdateAPIServices(caBundle)
+	err = r.createOrUpdateComponentsWithCertificates(queue)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

First CA bundles need to be published before new certificates by the new CA are published.

By first updating CA bundles, clients have a higher chance to know about
a certificate signed by the new CA when they first hit a certificate
signed by it.

Since file-based secrets are updated periodically and not immediately,
chances of running into a situation of a still unknown CA are low, but
it happens from time to time.

The rollout order is now like this:

 1) create a fresh CA
 2) publish the updated CA bundle on the kubevirt configmap
 3) publish the updated CA bundle on webhooks and apiservices
 4) rollout new certificate secrets for all components
 
Before this change, webhooks and apiservers were updated with the new CA bundle after new certificates were distributed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
