### PR TITLE
remove functional test-id 3150 from quarantine

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1429,7 +1429,7 @@ spec:
 			allPodsAreReady(kv)
 		})
 
-		It("[QUARANTINE][owner:@sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
+		It("[owner:@sig-compute][test_id:3150]should be able to update kubevirt install with custom image tag", func() {
 			if flags.KubeVirtVersionTagAlt == "" {
 				Skip("Skip operator custom image tag test because alt tag is not present")
 			}


### PR DESCRIPTION
The issue resolved in https://github.com/kubevirt/kubevirt/pull/5194 likely resolves the flakiness observed in test-id 3150 as well. Now that the fix is merged, we should be able to consider removing 3150 from quarantine once we've proven the fix reduces flakiness. 

```release-note
NONE
```
