### PR TITLE
webhooks: fix AdmissionReview responses

### DIFF
--- a/pkg/util/webhooks/validating-webhooks/validating-webhook.go
+++ b/pkg/util/webhooks/validating-webhooks/validating-webhook.go
@@ -56,7 +56,6 @@ func NewAdmissionResponse(causes []v1.StatusCause) *v1beta1.AdmissionResponse {
 }
 
 func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {
-	response := v1beta1.AdmissionReview{}
 	review, err := webhooks.GetAdmissionReview(req)
 
 	if err != nil {
@@ -64,6 +63,12 @@ func Serve(resp http.ResponseWriter, req *http.Request, admitter Admitter) {
 		return
 	}
 
+	response := v1beta1.AdmissionReview{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "AdmissionReview",
+		},
+	}
 	reviewResponse := admitter.Admit(review)
 	if reviewResponse != nil {
 		response.Response = reviewResponse

--- a/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"kubevirt.io/client-go/log"
@@ -37,7 +38,6 @@ type mutator interface {
 }
 
 func serve(resp http.ResponseWriter, req *http.Request, m mutator) {
-	response := v1beta1.AdmissionReview{}
 	review, err := webhookutils.GetAdmissionReview(req)
 
 	if err != nil {
@@ -45,6 +45,12 @@ func serve(resp http.ResponseWriter, req *http.Request, m mutator) {
 		return
 	}
 
+	response := v1beta1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
+			Kind:       "AdmissionReview",
+		},
+	}
 	reviewResponse := m.Mutate(review)
 	if reviewResponse != nil {
 		response.Response = reviewResponse


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`AdmissionReview` responses from Validating/Mutating webhooks are not well-formed as they do not include `apiVersion` and `Kind`, this commit fixes it.

For reference:
- https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#response
- https://github.com/kubernetes/kubernetes/issues/85681

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
