### PR TITLE
set the mutatingwebhookconfiguration generation after create to avoid…

### DIFF
--- a/pkg/virt-operator/resource/apply/admissionregistration.go
+++ b/pkg/virt-operator/resource/apply/admissionregistration.go
@@ -179,7 +179,7 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 		}
 
 		SetMutatingWebhookConfigurationGeneration(&r.kv.Status.Generations, webhook)
-
+		log.Log.V(2).Infof("mutatingwebhoookconfiguration %v created", webhook.Name)
 		return nil
 	}
 

--- a/pkg/virt-operator/resource/apply/admissionregistration.go
+++ b/pkg/virt-operator/resource/apply/admissionregistration.go
@@ -172,11 +172,13 @@ func (r *Reconciler) createOrUpdateMutatingWebhookConfiguration(webhook *admissi
 
 	if !exists {
 		r.expectations.MutatingWebhook.RaiseExpectations(r.kvKey, 1, 0)
-		_, err := r.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.Background(), webhook, metav1.CreateOptions{})
+		webhook, err = r.clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.Background(), webhook, metav1.CreateOptions{})
 		if err != nil {
 			r.expectations.MutatingWebhook.LowerExpectations(r.kvKey, 1, 0)
 			return fmt.Errorf("unable to create mutatingwebhook %+v: %v", webhook, err)
 		}
+
+		SetMutatingWebhookConfigurationGeneration(&r.kv.Status.Generations, webhook)
 
 		return nil
 	}


### PR DESCRIPTION
… an unnecessary update

Signed-off-by: Ashley Schuett <aschuett@redhat.com>


**What this PR does / why we need it**:

I introduced this bug in my recent reconciliation PR. We should update the KV status with the generation on create so that we don't patch the object when it is not needed. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
