### PR TITLE
sig-network, Skip sig-network from all non sig-network jobs

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -316,6 +316,14 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
   fi
 fi
 
+if [[ "$KUBEVIRT_E2E_FOCUS" != "\\[sig-network\\]" ]]; then
+  if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+    export KUBEVIRT_E2E_SKIP="${KUBEVIRT_E2E_SKIP}|\\[sig-network\\]"
+  else
+    export KUBEVIRT_E2E_SKIP="\\[sig-network\\]"
+  fi
+fi
+
 # If KUBEVIRT_QUARANTINE is not set, do not run quarantined tests. When it is
 # set the whole suite (quarantined and stable) will be run.
 if [ -z "$KUBEVIRT_QUARANTINE" ]; then


### PR DESCRIPTION
In order to skip sig-network tests from all non sig-network jobs,
this commit checks whether the job should run sig-network,
and if its doesn't it skip sig-network.

We would present a job for each VM based provider that need to test
sig-network.

Note that this rule comes after the condition about
`KUBEVIRT_E2E_FOCUS`, `KUBEVIRT_E2E_SKIP`,
so it will add it even if both were set before.
In case desired, i can move it into the condition as well,
so it will respect the condition.

Alternative to this commit can be that we would set
skip sig-network in the commands of each job that should skip it.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
