### PR TITLE
Require all capabilities for virtioFS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,8 +40,8 @@ require (
 	github.com/opencontainers/selinux v1.6.0
 	github.com/openshift/api v0.0.0
 	github.com/openshift/client-go v0.0.0
-	github.com/operator-framework/go-appr v0.0.0-20180917210448-f2aef88446f2 // indirect
 	github.com/openshift/library-go v0.0.0-20200821154433-215f00df72cc
+	github.com/operator-framework/go-appr v0.0.0-20180917210448-f2aef88446f2 // indirect
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190725173916-b56e63a643cc
 	github.com/operator-framework/operator-marketplace v0.0.0-20190617165322-1cbd32624349
 	github.com/pborman/uuid v1.2.0
@@ -56,6 +56,7 @@ require (
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/grpc v1.30.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.3.0

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -61,11 +61,13 @@ const virtiofsDebugLogs = "virtiofsdDebugLogs"
 
 const MultusNetworksAnnotation = "k8s.v1.cni.cncf.io/networks"
 
-const CAP_NET_ADMIN = "NET_ADMIN"
-const CAP_NET_RAW = "NET_RAW"
-const CAP_SYS_ADMIN = "SYS_ADMIN"
-const CAP_SYS_NICE = "SYS_NICE"
-const CAP_SYS_RESOURCE = "SYS_RESOURCE"
+const (
+	CAP_NET_ADMIN    = "NET_ADMIN"
+	CAP_NET_RAW      = "NET_RAW"
+	CAP_SYS_ADMIN    = "SYS_ADMIN"
+	CAP_SYS_NICE     = "SYS_NICE"
+	CAP_SYS_RESOURCE = "SYS_RESOURCE"
+)
 
 // LibvirtStartupDelay is added to custom liveness and readiness probes initial delay value.
 // Libvirt needs roughly 10 seconds to start.
@@ -1370,6 +1372,19 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volume *v1.Volume, 
 	return pod, nil
 }
 
+func getVirtiofsCapabilities() []k8sv1.Capability {
+	return []k8sv1.Capability{
+		"CHOWN",
+		"DAC_OVERRIDE",
+		"FOWNER",
+		"FSETID",
+		"SETGID",
+		"SETUID",
+		"MKNOD",
+		"SETFCAP",
+	}
+}
+
 func getRequiredCapabilities(vmi *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig) []k8sv1.Capability {
 	capabilities := []k8sv1.Capability{}
 
@@ -1384,6 +1399,7 @@ func getRequiredCapabilities(vmi *v1.VirtualMachineInstance, config *virtconfig.
 	// add CAP_SYS_ADMIN capability to allow virtiofs
 	if util.IsVMIVirtiofsEnabled(vmi) {
 		capabilities = append(capabilities, CAP_SYS_ADMIN)
+		capabilities = append(capabilities, getVirtiofsCapabilities()...)
 	}
 
 	// add SYS_RESOURCE capability to enable Live Migration for VM with SRIOV interfaces


### PR DESCRIPTION
**What this PR does / why we need it**:
CRIs have different sets of default capabilities.
There is also always an option that CRI is configured
by administrator or operator deployed Kubernetes.

This PR ensures virtiofs will work on all configurations.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
