### PR TITLE
Require net_bind_service capability

### DIFF
--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -237,7 +237,7 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 				}
 			}
 			caps := *container.SecurityContext.Capabilities
-			Expect(len(caps.Add)).To(Equal(1))
+			Expect(len(caps.Add)).To(Equal(2), fmt.Sprintf("Capabilities in compute %s", caps.Add))
 
 			By("Checking virt-launcher Pod's compute container has precisely the documented extra capabilities")
 			for _, cap := range caps.Add {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -225,8 +225,9 @@ const (
 )
 
 const (
-	capNetRaw  k8sv1.Capability = "NET_RAW"
-	capSysNice k8sv1.Capability = "SYS_NICE"
+	capNetRaw         k8sv1.Capability = "NET_RAW"
+	capSysNice        k8sv1.Capability = "SYS_NICE"
+	capNetBindService k8sv1.Capability = "NET_BIND_SERVICE"
 )
 
 const MigrationWaitTime = 240
@@ -5115,6 +5116,7 @@ func DetectLatestUpstreamOfficialTag() (string, error) {
 func IsLauncherCapabilityValid(capability k8sv1.Capability) bool {
 	switch capability {
 	case
+		capNetBindService,
 		capSysNice:
 		return true
 	}


### PR DESCRIPTION
CRIs have different sets of default capabilities.
There is also always an option that CRI can be configured by an administrator
of Kubernetes cluster or operator deployed in cluster.

Therefore let's explicitly request net_bind_service where it is required.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
