### PR TITLE
Increase verbosity at selinux context run

### DIFF
--- a/pkg/virt-handler/selinux/executor.go
+++ b/pkg/virt-handler/selinux/executor.go
@@ -22,6 +22,7 @@ package selinux
 //go:generate mockgen -source $GOFILE -package=$GOPACKAGE -destination=generated_mock_$GOFILE
 
 import (
+	"fmt"
 	"os/exec"
 	"runtime"
 	"syscall"
@@ -67,5 +68,9 @@ func (se SELinuxExecutor) CloseOnExec(fd int) {
 }
 
 func (se SELinuxExecutor) Run(cmd *exec.Cmd) error {
-	return cmd.Run()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed running command %s, err: %v, output: %s", cmd.String(), err, output)
+	}
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Some commands return just the resutl code on the error that makes
difficult to debug problem, this change also add the command, stdout and
stderr to the error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Some examples:
Here it just return `The failure to create the tap device only returned `exit status 1` with no additional info.
Journal logs: [https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-prev-prev/1374300084186910721/artifacts/k8s-reporter/3/nodes/1_journal_node02.log
]- Pod log: https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-prev-prev/1374300084186910721/artifacts/k8s-reporter/3/pods/1_kubevirt-test-default3_virt-launcher-testvmi-7tspg-7nwrh-compute.log
virt-handler log: https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-prev-prev/1374300084186910721/artifacts/k8s-reporter/3/pods/1_kubevirt_virt-handler-xmxmq-virt-handler.log

Forced an error to see the output, this is the result

```
"component":"virt-handler","level":"info","msg":"re-enqueuing VirtualMachineInstance default/vmi-masquerade","pos":"vm.go:1122","reason":"failed to configure vmi network: Critical network error: error creating tap device named tap0; failed to execute command in launcher namespace 150226: failed running command /usr/bin/virt-chroot create-tap --tp-name tap0 --uid 0 --gid 0 --queue-number 0 --mtu 1480, err: exit status 1, output: Error: unknown flag: --tp-name\nUsage:\n  virt-chroot create-tap [flags]\n\nFlags:\n      --gid uint              the group of the owner of the tap device\n  -h, --help                  help for create-tap\n      --mtu uint32            the link MTU of the tap device (default 1500)\n      --queue-number uint32   the number of queues to use on multi-queued devices\n      --tap-name string       the name of the tap device (default \"tap0\")\n      --uid uint              the owner of the tap device\n\nGlobal Flags:\n      --cpu uint32      cpu time in seconds for the process\n      --memory uint32   memory in megabyte for the process\n      --mount string    mount namespace to use\n      --user string     switch to this targetUser to e.g. drop privileges\n\nunknown flag: --tp-name\n","timestamp":"2021-03-25T07:22:43.716067Z"}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
