### PR TITLE
reconcile crd to desired state

### DIFF
--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,42 +48,47 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1beta1.CustomResourceDefinition)
 		return nil
 	}
 
-	if !objectMatchesVersion(&cachedCrd.ObjectMeta, version, imageRegistry, id, r.kv.GetGeneration()) {
-		// Patch if old version
-		var ops []string
+	modified := resourcemerge.BoolPtr(false)
+	existing := cachedCrd.DeepCopy()
 
-		// Add Labels and Annotations Patches
-		labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&crd.ObjectMeta)
-		if err != nil {
-			return err
-		}
-		ops = append(ops, labelAnnotationPatch...)
-
-		// subresource support needs to be introduced carefully after the control plane roll-over
-		// to avoid creating zombie entities which don't get processed du to ignored status updates
-		if cachedCrd.Spec.Subresources == nil || cachedCrd.Spec.Subresources.Status == nil {
-			if crd.Spec.Subresources != nil && crd.Spec.Subresources.Status != nil {
-				crd.Spec.Subresources.Status = nil
-			}
-		}
-
-		// Add Spec Patch
-		newSpec, err := json.Marshal(crd.Spec)
-		if err != nil {
-			return err
-		}
-		ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/spec", "value": %s }`, string(newSpec)))
-
-		_, err = ext.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
-		if err != nil {
-			return fmt.Errorf("unable to patch crd %+v: %v", crd, err)
-		}
-
-		log.Log.V(2).Infof("crd %v updated", crd.GetName())
+	resourcemerge.EnsureCustomResourceDefinitionV1Beta1(modified, existing, *crd)
+	// there was no change to metadata and the spec fields are equal
+	if !*modified {
+		log.Log.V(4).Infof("crd %v is up-to-date", crd.GetName())
 		return nil
 	}
 
-	log.Log.V(4).Infof("crd %v is up-to-date", crd.GetName())
+	// Patch if old version
+	ops := []string{}
+
+	// Add Labels and Annotations Patches
+	labelAnnotationPatch, err := createLabelsAndAnnotationsPatch(&crd.ObjectMeta)
+	if err != nil {
+		return err
+	}
+	ops = append(ops, labelAnnotationPatch...)
+
+	// subresource support needs to be introduced carefully after the control plane roll-over
+	// to avoid creating zombie entities which don't get processed du to ignored status updates
+	if cachedCrd.Spec.Subresources == nil || cachedCrd.Spec.Subresources.Status == nil {
+		if crd.Spec.Subresources != nil && crd.Spec.Subresources.Status != nil {
+			crd.Spec.Subresources.Status = nil
+		}
+	}
+
+	// Add Spec Patch
+	newSpec, err := json.Marshal(crd.Spec)
+	if err != nil {
+		return err
+	}
+	ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/spec", "value": %s }`, string(newSpec)))
+
+	_, err = ext.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to patch crd %+v: %v", crd, err)
+	}
+
+	log.Log.V(2).Infof("crd %v updated", crd.GetName())
 	return nil
 }
 

--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -69,7 +69,7 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1beta1.CustomResourceDefinition)
 	ops = append(ops, labelAnnotationPatch...)
 
 	// subresource support needs to be introduced carefully after the control plane roll-over
-	// to avoid creating zombie entities which don't get processed du to ignored status updates
+	// to avoid creating zombie entities which don't get processed due to ignored status updates
 	if cachedCrd.Spec.Subresources == nil || cachedCrd.Spec.Subresources.Status == nil {
 		if crd.Spec.Subresources != nil && crd.Spec.Subresources.Status != nil {
 			crd.Spec.Subresources.Status = nil

--- a/pkg/virt-operator/resource/apply/crds_test.go
+++ b/pkg/virt-operator/resource/apply/crds_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -197,5 +199,77 @@ var _ = Describe("Apply CRDs", func() {
 		}
 
 		Expect(r.rolloutNonCompatibleCRDChanges()).To(Succeed())
+	})
+
+	It("should not patch CRD on sync when they are equal", func() {
+		cachedCRD, err := components.NewKubeVirtCrd()
+		Expect(err).ToNot(HaveOccurred())
+
+		version, imageRegistry, id := getTargetVersionRegistryID(kv)
+		injectOperatorMetadata(kv, &cachedCRD.ObjectMeta, version, imageRegistry, id, true)
+
+		targetStrategy := loadTargetStrategy(cachedCRD)
+		stores.CrdCache.Add(cachedCRD)
+
+		extClient.Fake.PrependReactor("patch", "customresourcedefinitions", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+			// if patch is called we want to fail
+			Expect(true).To(BeFalse())
+
+			return true, nil, nil
+		})
+
+		r := &Reconciler{
+			kv:             kv,
+			targetStrategy: targetStrategy,
+			stores:         stores,
+			clientset:      clientset,
+			expectations:   expectations,
+		}
+
+		Expect(r.createOrUpdateCrd(cachedCRD)).To(BeNil())
+	})
+
+	It("should patch CRD on sync when it is not equal to the required CRD", func() {
+		updatedFieldName := "NewNameForCRDs"
+
+		cachedCRD, err := components.NewKubeVirtCrd()
+		Expect(err).ToNot(HaveOccurred())
+
+		version, imageRegistry, id := getTargetVersionRegistryID(kv)
+		injectOperatorMetadata(kv, &cachedCRD.ObjectMeta, version, imageRegistry, id, true)
+
+		targetStrategy := loadTargetStrategy(cachedCRD)
+		stores.CrdCache.Add(cachedCRD)
+
+		extClient.Fake.PrependReactor("patch", "customresourcedefinitions", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+			a := action.(testing.PatchActionImpl)
+			patch, err := jsonpatch.DecodePatch(a.Patch)
+			Expect(err).ToNot(HaveOccurred())
+
+			obj, err := json.Marshal(cachedCRD)
+			Expect(err).To(BeNil())
+
+			obj, err = patch.Apply(obj)
+			Expect(err).To(BeNil())
+
+			crd := &extv1beta1.CustomResourceDefinition{}
+			Expect(json.Unmarshal(obj, crd)).To(Succeed())
+			Expect(crd.Spec.Names.Plural).To(Equal(updatedFieldName))
+
+			return true, crd, nil
+		})
+
+		r := &Reconciler{
+			kv:             kv,
+			targetStrategy: targetStrategy,
+			stores:         stores,
+			clientset:      clientset,
+			expectations:   expectations,
+		}
+
+		requiredCRD := cachedCRD.DeepCopy()
+		requiredCRD.Spec.Names.Plural = updatedFieldName
+
+		Expect(r.createOrUpdateCrd(requiredCRD)).To(BeNil())
 	})
 })


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

**What this PR does / why we need it**:

This PR adds reconciliation of the CRD resources. If the spec or metadata of the cached CRD is different from the desired CRD we create a patch and update it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile CRD resources
```
