### PR TITLE
Add default value for the BlockMultiQueue parameter for API docu

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -9448,7 +9448,7 @@
       "type": "boolean"
      },
      "blockMultiQueue": {
-      "description": "Whether or not to enable virtio multi-queue for block devices",
+      "description": "Whether or not to enable virtio multi-queue for block devices. Defaults to false.",
       "type": "boolean"
      },
      "disableHotplug": {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -2197,7 +2197,7 @@ var CRDsValidation map[string]string = map[string]string{
                           description: Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.
                           type: boolean
                         blockMultiQueue:
-                          description: Whether or not to enable virtio multi-queue for block devices
+                          description: Whether or not to enable virtio multi-queue for block devices. Defaults to false.
                           type: boolean
                         disableHotplug:
                           description: DisableHotplug disabled the ability to hotplug disks.
@@ -4002,7 +4002,7 @@ var CRDsValidation map[string]string = map[string]string{
                   description: Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.
                   type: boolean
                 blockMultiQueue:
-                  description: Whether or not to enable virtio multi-queue for block devices
+                  description: Whether or not to enable virtio multi-queue for block devices. Defaults to false.
                   type: boolean
                 disableHotplug:
                   description: DisableHotplug disabled the ability to hotplug disks.
@@ -5404,7 +5404,7 @@ var CRDsValidation map[string]string = map[string]string{
                   description: Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.
                   type: boolean
                 blockMultiQueue:
-                  description: Whether or not to enable virtio multi-queue for block devices
+                  description: Whether or not to enable virtio multi-queue for block devices. Defaults to false.
                   type: boolean
                 disableHotplug:
                   description: DisableHotplug disabled the ability to hotplug disks.
@@ -6581,7 +6581,7 @@ var CRDsValidation map[string]string = map[string]string{
                           description: Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.
                           type: boolean
                         blockMultiQueue:
-                          description: Whether or not to enable virtio multi-queue for block devices
+                          description: Whether or not to enable virtio multi-queue for block devices. Defaults to false.
                           type: boolean
                         disableHotplug:
                           description: DisableHotplug disabled the ability to hotplug disks.
@@ -8696,7 +8696,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       description: Whether to attach the default serial console or not. Serial console access will not be available if set to false. Defaults to true.
                                       type: boolean
                                     blockMultiQueue:
-                                      description: Whether or not to enable virtio multi-queue for block devices
+                                      description: Whether or not to enable virtio multi-queue for block devices. Defaults to false.
                                       type: boolean
                                     disableHotplug:
                                       description: DisableHotplug disabled the ability to hotplug disks.

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -19668,7 +19668,7 @@ func schema_kubevirtio_client_go_api_v1_Devices(ref common.ReferenceCallback) co
 					},
 					"blockMultiQueue": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether or not to enable virtio multi-queue for block devices",
+							Description: "Whether or not to enable virtio multi-queue for block devices. Defaults to false.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/v1/schema.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema.go
@@ -398,7 +398,8 @@ type Devices struct {
 	// Whether to have random number generator from host
 	// +optional
 	Rng *Rng `json:"rng,omitempty"`
-	// Whether or not to enable virtio multi-queue for block devices
+	// Whether or not to enable virtio multi-queue for block devices.
+	// Defaults to false.
 	// +optional
 	BlockMultiQueue *bool `json:"blockMultiQueue,omitempty"`
 	// If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.

--- a/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/schema_swagger_generated.go
@@ -195,7 +195,7 @@ func (Devices) SwaggerDoc() map[string]string {
 		"autoattachSerialConsole":    "Whether to attach the default serial console or not.\nSerial console access will not be available if set to false. Defaults to true.",
 		"autoattachMemBalloon":       "Whether to attach the Memory balloon device with default period.\nPeriod can be adjusted in virt-config.\nDefaults to true.\n+optional",
 		"rng":                        "Whether to have random number generator from host\n+optional",
-		"blockMultiQueue":            "Whether or not to enable virtio multi-queue for block devices\n+optional",
+		"blockMultiQueue":            "Whether or not to enable virtio multi-queue for block devices.\nDefaults to false.\n+optional",
 		"networkInterfaceMultiqueue": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.\n+optional",
 		"gpus":                       "Whether to attach a GPU device to the vmi.\n+optional\n+listType=atomic",
 		"filesystems":                "Filesystems describes filesystem which is connected to the vmi.\n+optional\n+listType=atomic",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -14752,7 +14752,7 @@ func schema_kubevirtio_client_go_api_v1_Devices(ref common.ReferenceCallback) co
 					},
 					"blockMultiQueue": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Whether or not to enable virtio multi-queue for block devices",
+							Description: "Whether or not to enable virtio multi-queue for block devices. Defaults to false.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In KubeVirt API document at https://kubevirt.io/api-reference/master/definitions.html#_v1_devices, the default value for the device blockMultiQueue setting should be mentioned for good user experience.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1896797

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
