### PR TITLE
Get test_id:1589 out of quarantine

### DIFF
--- a/tests/console_test.go
+++ b/tests/console_test.go
@@ -96,7 +96,7 @@ var _ = Describe("[rfe_id:127][posneg:negative][crit:medium][vendor:cnv-qe@redha
 			})
 
 			Context("with a fedora image", func() {
-				It("[QUARANTINE][owner:@sig-compute][test_id:1589]should return that we are running fedora", func() {
+				It("[owner:@sig-compute][test_id:1589]should return that we are running fedora", func() {
 					vmi := tests.NewRandomVMIWithEphemeralDiskHighMemory(cd.ContainerDiskFor(cd.ContainerDiskFedora))
 					RunVMIAndWaitForStart(vmi)
 					ExpectConsoleOutput(


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: All the recent failures of test_id:1589 are related to errors in PRs code or failed memory allocations because of golang bump (already fixed), so let's get it out of quarantine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
