### PR TITLE
Consider another type of error to indicate migration abort success.

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -774,6 +774,9 @@ monitorLoop:
 				if strings.Contains(passedErr.Error(), "canceled by client") {
 					abortStatus = v1.MigrationAbortSucceeded
 				}
+				if strings.Contains(passedErr.Error(), "client socket is closed") {
+					abortStatus = v1.MigrationAbortSucceeded
+				}
 				l.setMigrationResult(vmi, true, fmt.Sprintf("Live migration failed %v", passedErr), abortStatus)
 				break monitorLoop
 			}


### PR DESCRIPTION
We stop processing errors at the first one, and while "canceled by
client" might've happened too, we might write to a closed socket before
handling this error.

Should assist with flaky migration tests (that test for abort success).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Inspired by #3363.
Run where we handled this error first: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5092/pull-kubevirt-e2e-k8s-1.18/1374724631486795776

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Stabilization for quarantined live migration tests.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
