### PR TITLE
Fix flaky secret update on "[test_id:4099] should be rotated when a new CA is created"

### DIFF
--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -123,12 +123,16 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 			}, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
 
 			By("destroying the certificate")
-			secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			secret.Data = map[string][]byte{
-				"random": []byte("nonsense"),
-			}
-			_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				secret, err := virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Get(context.Background(), components.KubeVirtCASecretName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				secret.Data = map[string][]byte{
+					"random": []byte("nonsense"),
+				}
+
+				_, err = virtClient.CoreV1().Secrets(flags.KubeVirtInstallNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+				return err
+			})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("checking that the CA secret gets restored with a new ca bundle")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Prevent conflicts when updating the existing secret as part of destroying the existing certificate.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirt/issues/4198
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5332/pull-kubevirt-e2e-k8s-1.18/1376449874530144256

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
