### PR TITLE
add new checks for hyperv evmcs

### DIFF
--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/util/openapi:go_default_library",
         "//pkg/virt-api/rest:go_default_library",
+        "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
         "//staging/src/github.com/golang/glog:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",

--- a/pkg/virt-api/webhooks/hyperv.go
+++ b/pkg/virt-api/webhooks/hyperv.go
@@ -25,11 +25,13 @@ package webhooks
 
 import (
 	"fmt"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
 var _true bool = true
@@ -127,6 +129,11 @@ func getHypervFeatureDependencies(field *k8sfield.Path, spec *v1.VirtualMachineI
 		Requires: &vpindex,
 	}
 
+	vapic := HypervFeature{
+		State: &hyperv.VAPIC,
+		Field: hypervField.Child("vapic"),
+	}
+
 	syNICTimer := &v1.FeatureState{}
 	if hyperv.SyNICTimer != nil {
 		syNICTimer.Enabled = hyperv.SyNICTimer.Enabled
@@ -134,6 +141,11 @@ func getHypervFeatureDependencies(field *k8sfield.Path, spec *v1.VirtualMachineI
 
 	features := []HypervFeature{
 		// keep in REVERSE order: leaves first.
+		{
+			State:    &hyperv.EVMCS,
+			Field:    hypervField.Child("evmcs"),
+			Requires: &vapic,
+		},
 		{
 			State:    &hyperv.IPI,
 			Field:    hypervField.Child("ipi"),
@@ -166,6 +178,20 @@ func ValidateVirtualMachineInstanceHypervFeatureDependencies(field *k8sfield.Pat
 		}
 	}
 
+	if spec.Domain.Features != nil && spec.Domain.Features.Hyperv != nil && spec.Domain.Features.Hyperv.EVMCS != nil {
+		if spec.Domain.CPU == nil || spec.Domain.CPU.Features == nil || len(spec.Domain.CPU.Features) == 0 {
+			causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueRequired, Message: "vmx cpu feature is required when evmcs is set", Field: "spec.domain.cpu.features"})
+		} else if spec.Domain.CPU != nil || spec.Domain.CPU.Features != nil {
+			for i, f := range spec.Domain.CPU.Features {
+				if f.Name == nodelabellerutil.VmxFeature {
+					if f.Policy != nodelabellerutil.RequirePolicy {
+						causes = append(causes, metav1.StatusCause{Type: metav1.CauseTypeFieldValueInvalid, Message: "vmx cpu feature has to be set to " + nodelabellerutil.RequirePolicy + " policy", Field: "spec.domain.cpu.features[" + strconv.Itoa(i) + "].policy"})
+					}
+				}
+			}
+		}
+	}
+
 	return causes
 }
 
@@ -180,5 +206,42 @@ func SetVirtualMachineInstanceHypervFeatureDependencies(vmi *v1.VirtualMachineIn
 		}
 	}
 
+	//Check if vmi has EVMCS feature enabled. If yes, we have to add vmx cpu feature
+	if vmi.Spec.Domain.Features != nil && vmi.Spec.Domain.Features.Hyperv != nil && vmi.Spec.Domain.Features.Hyperv.EVMCS != nil {
+		setEVMCSDependency(vmi)
+	}
+
 	return nil
+}
+
+func setEVMCSDependency(vmi *v1.VirtualMachineInstance) {
+	vmxFeature := v1.CPUFeature{
+		Name:   nodelabellerutil.VmxFeature,
+		Policy: nodelabellerutil.RequirePolicy,
+	}
+
+	cpuFeatures := []v1.CPUFeature{
+		vmxFeature,
+	}
+
+	if vmi.Spec.Domain.CPU == nil {
+		vmi.Spec.Domain.CPU = &v1.CPU{
+			Features: cpuFeatures,
+		}
+	} else if len(vmi.Spec.Domain.CPU.Features) == 0 {
+		vmi.Spec.Domain.CPU.Features = cpuFeatures
+	} else {
+		vmxFound := false
+		for i, f := range vmi.Spec.Domain.CPU.Features {
+			if f.Name == nodelabellerutil.VmxFeature {
+				vmxFound = true
+				if f.Policy != nodelabellerutil.RequirePolicy {
+					vmi.Spec.Domain.CPU.Features[i].Policy = nodelabellerutil.RequirePolicy
+				}
+			}
+		}
+		if !vmxFound {
+			vmi.Spec.Domain.CPU.Features = append(vmi.Spec.Domain.CPU.Features, vmxFeature)
+		}
+	}
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/testutils:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/util/webhooks:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -77,6 +77,7 @@ const LibvirtStartupDelay = 10
 const NFD_CPU_MODEL_PREFIX = "cpu-model.node.kubevirt.io/"
 const NFD_CPU_FEATURE_PREFIX = "cpu-feature.node.kubevirt.io/"
 const NFD_KVM_INFO_PREFIX = "hyperv.node.kubevirt.io/"
+const IntelVendorName = "Intel"
 
 const MULTUS_RESOURCE_NAME_ANNOTATION = "k8s.v1.cni.cncf.io/resourceName"
 const MULTUS_DEFAULT_NETWORK_CNI_ANNOTATION = "v1.multus-cni.io/default-network"
@@ -206,6 +207,11 @@ func getHypervNodeSelectors(vmi *v1.VirtualMachineInstance) map[string]string {
 			nodeSelectors[NFD_KVM_INFO_PREFIX+hv.Label] = "true"
 		}
 	}
+
+	if vmi.Spec.Domain.Features.Hyperv.EVMCS != nil {
+		nodeSelectors[v1.CPUModelVendorLabel+IntelVendorName] = "true"
+	}
+
 	return nodeSelectors
 }
 
@@ -1110,7 +1116,6 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 			nodeSelector[cpuFeatureLable] = "true"
 		}
 	}
-
 	if t.clusterConfig.HypervStrictCheckEnabled() {
 		hvNodeSelectors := getHypervNodeSelectors(vmi)
 		for k, v := range hvNodeSelectors {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -1022,6 +1022,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
+				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(v1.CPUModelVendorLabel))))
 			})
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features, but feature gate is disabled", func() {
@@ -1045,6 +1046,9 @@ var _ = Describe("Template", func() {
 									Reenlightenment: &v1.FeatureState{
 										Enabled: &enabled,
 									},
+									EVMCS: &v1.FeatureState{
+										Enabled: &enabled,
+									},
 								},
 							},
 						},
@@ -1055,6 +1059,7 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
+				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(v1.CPUModelVendorLabel))))
 			})
 
 			It("should add node selector for hyperv nodes if VMI requests hyperv features which depend on host kernel", func() {
@@ -1086,6 +1091,9 @@ var _ = Describe("Template", func() {
 									IPI: &v1.FeatureState{
 										Enabled: &enabled,
 									},
+									EVMCS: &v1.FeatureState{
+										Enabled: &enabled,
+									},
 								},
 							},
 						},
@@ -1099,6 +1107,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"synictimer", "true"))
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"frequencies", "true"))
 				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(NFD_KVM_INFO_PREFIX+"ipi", "true"))
+				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(v1.CPUModelVendorLabel+IntelVendorName, "true"))
 			})
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features which do not depend on host kernel", func() {

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -77,6 +77,10 @@ func (n *NodeLabeller) loadHostCapabilities() error {
 
 	usableModels := make([]string, 0)
 	for _, mode := range hostDomCapabilities.CPU.Mode {
+		if mode.Vendor.Name != "" {
+			n.cpuModelVendor = mode.Vendor.Name
+		}
+
 		for _, model := range mode.Model {
 			if model.Usable == isUnusable || model.Usable == "" {
 				continue

--- a/pkg/virt-handler/node-labeller/model.go
+++ b/pkg/virt-handler/node-labeller/model.go
@@ -42,8 +42,9 @@ type CPU struct {
 
 //Mode represents slice of cpu models
 type Mode struct {
-	Vendor Vendor  `xml:"vendor"`
-	Model  []Model `xml:"model"`
+	Vendor  Vendor        `xml:"vendor"`
+	Feature []HostFeature `xml:"feature"`
+	Model   []Model       `xml:"model"`
 }
 
 type SupportedHostFeature struct {

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -51,6 +51,7 @@ type NodeLabeller struct {
 	queue             workqueue.RateLimitingInterface
 	supportedFeatures []string
 	cpuInfo           cpuInfo
+	cpuModelVendor    string
 }
 
 func NewNodeLabeller(clusterConfig *virtconfig.ClusterConfig, clientset kubecli.KubevirtClient, host, namespace string) (*NodeLabeller, error) {
@@ -231,6 +232,9 @@ func (n *NodeLabeller) prepareLabels(cpuModels []string, cpuFeatures cpuFeatures
 	for _, key := range n.hypervFeatures.items {
 		newLabels[kubevirtv1.HypervLabel+key] = "true"
 	}
+
+	newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
+
 	return newLabels
 }
 

--- a/pkg/virt-handler/node-labeller/util/util.go
+++ b/pkg/virt-handler/node-labeller/util/util.go
@@ -28,6 +28,7 @@ const (
 	DefaultMinCPUModel                           = "Penryn"
 	RequirePolicy                                = "require"
 	KVMPath                                      = "/dev/kvm"
+	VmxFeature                                   = "vmx"
 )
 
 var DefaultObsoleteCPUModels = map[string]bool{

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -641,6 +641,8 @@ const (
 	CPUModelLabel = "cpu-model.node.kubevirt.io/"
 	// This label represents supported HyperV features on the node
 	HypervLabel = "hyperv.node.kubevirt.io/"
+	// This label represents vendor of cpu model on the node
+	CPUModelVendorLabel = "cpu-vendor.node.kubevirt.io/"
 
 	VirtualMachineLabel        = AppLabel + "/vm"
 	MemfdMemoryBackend  string = "kubevirt.io/memfd"

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -1004,14 +1004,17 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 	})
 
 	Describe("Node-labeller", func() {
+		var nodesWithKVM []*k8sv1.Node
+
+		BeforeEach(func() {
+			tests.BeforeTestCleanup()
+			nodesWithKVM = tests.GetNodesWithKVM()
+			if len(nodesWithKVM) == 0 {
+				Skip("Skip testing with node-labeller, because there are no nodes with kvm")
+			}
+		})
+
 		Context("basic labelling", func() {
-			var nodesWithKVM []*k8sv1.Node
-
-			BeforeEach(func() {
-				tests.BeforeTestCleanup()
-				nodesWithKVM = tests.GetNodesWithKVM()
-			})
-
 			It("label nodes with cpu model and cpu features", func() {
 				for _, node := range nodesWithKVM {
 					Expect(err).ToNot(HaveOccurred())
@@ -1062,13 +1065,9 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 		})
 
 		Context("advanced labelling", func() {
-			var nodesWithKVM []*k8sv1.Node
 			var originalKubeVirt *v1.KubeVirt
 
 			BeforeEach(func() {
-				tests.BeforeTestCleanup()
-				nodesWithKVM = tests.GetNodesWithKVM()
-
 				originalKubeVirt = tests.GetCurrentKv(virtClient)
 			})
 
@@ -1104,6 +1103,20 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 				}
 
 				Expect(found).To(Equal(false), "Node can't contain label "+v1.CPUModelLabel+obsoleteModel)
+			})
+
+			It("should update node with new cpu model vendor label", func() {
+				nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				for _, node := range nodes.Items {
+					for key := range node.Labels {
+						if strings.HasPrefix(key, v1.CPUModelVendorLabel) {
+							return
+						}
+					}
+				}
+
+				Fail("No node contains label " + v1.CPUModelVendorLabel)
 			})
 
 			It("should update node with new cpu feature label set", func() {
@@ -1154,13 +1167,11 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 		})
 
 		Context("Clean up after old labeller", func() {
-			var nodesWithKVM []*k8sv1.Node
 			nfdLabel := "feature.node.kubernetes.io/some-fancy-feature-which-should-not-be-deleted"
 			var originalKubeVirt *v1.KubeVirt
 
 			BeforeEach(func() {
 				tests.BeforeTestCleanup()
-				nodesWithKVM = tests.GetNodesWithKVM()
 				originalKubeVirt = tests.GetCurrentKv(virtClient)
 
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
HyperV EVMCS requires hyperv Vapic and vmx cpu feature to properly work.
This PR adds new checks for hyperv evmcs. When user sets evmcs, kubevirt now checks if vapic is enabled, if not, it enables it. Then it adds vmx cpu feature and node selector so the vm with evmcs will be scheduled only on intel nodes which supports vmx.
Previously when user set evmcs, kubevirt didn't add vapic and vmx features.

**Release note**:
```
Add checks for hyperv evmcs feature
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
