### PR TITLE
Replace custom reconcile throttler with standard rate limit logic

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/golang.org/x/time/rate:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -8,9 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
 	k8sv1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +56,7 @@ var (
 const periodicReEnqueueIntervalSeconds = 30
 
 // ensures we don't execute more than once every 5 seconds
-const defaultThrottleIntervalSeconds = 5
+const defaultThrottleIntervalSeconds = 5 * time.Second
 
 const defaultBatchDeletionIntervalSeconds = 60
 const defaultBatchDeletionCount = 10
@@ -168,7 +167,7 @@ func (c *WorkloadUpdateController) addMigration(obj interface{}) {
 		}
 	}
 
-	c.queue.Add(key)
+	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
 }
 
 func (c *WorkloadUpdateController) deleteMigration(_ interface{}) {
@@ -177,7 +176,7 @@ func (c *WorkloadUpdateController) deleteMigration(_ interface{}) {
 		return
 	}
 
-	c.queue.Add(key)
+	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
 }
 
 func (c *WorkloadUpdateController) updateMigration(_, _ interface{}) {
@@ -186,7 +185,7 @@ func (c *WorkloadUpdateController) updateMigration(_, _ interface{}) {
 		return
 	}
 
-	c.queue.Add(key)
+	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
 }
 
 func (c *WorkloadUpdateController) addKubeVirt(obj interface{}) {
@@ -211,7 +210,7 @@ func (c *WorkloadUpdateController) enqueueKubeVirt(obj interface{}) {
 	if err != nil {
 		logger.Object(kv).Reason(err).Error("Failed to extract key from KubeVirt.")
 	}
-	c.queue.Add(key)
+	c.queue.AddAfter(key, defaultThrottleIntervalSeconds)
 }
 
 // Run runs the passed in NodeController.


### PR DESCRIPTION
This removes a bunch of complicate logic for rate limiting a work queue. The logic is replaced by the standard queue rate limiting logic. 


```release-note
NONE
```
