### PR TITLE
Split storage metrics as read and write

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -171,7 +171,7 @@ A design proposal and its implementation history can be seen [here](https://docs
 ## kubevirt_vmi_memory_used_total_bytes
 #### HELP kubevirt_vmi_memory_used_total_bytes The amount of memory in bytes used by the domain.
 
- # Other Metrics 
+ # Other Metrics
 ## kubevirt_vmi_cpu_affinity
 #### HELP kubevirt_vmi_cpu_affinity vcpu affinity details
 
@@ -180,3 +180,19 @@ A design proposal and its implementation history can be seen [here](https://docs
 #### HELP kubevirt_virt_controller_leading Indication for an operating virt-controller.
 ## kubevirt_virt_controller_ready_total
 #### HELP kubevirt_virt_controller_ready Indication for a virt-controller that is ready to take the lead.
+## kubevirt_vmi_storage_flush_requests_total
+#### HELP kubevirt_vmi_storage_flush_requests_total storage flush requests.
+## kubevirt_vmi_storage_flush_times_ms_total
+#### HELP kubevirt_vmi_storage_flush_times_ms_total total time (ms) spent on cache flushing.
+## kubevirt_vmi_storage_iops_read_total
+#### HELP kubevirt_vmi_storage_iops_read_total I/O read operations
+## kubevirt_vmi_storage_iops_write_total
+#### HELP kubevirt_vmi_storage_iops_write_total I/O write operations
+## kubevirt_vmi_storage_read_times_ms_total
+#### HELP kubevirt_vmi_storage_read_times_ms_total Storage read operation time
+## kubevirt_vmi_storage_read_traffic_bytes_total
+#### HELP kubevirt_vmi_storage_read_traffic_bytes_total Storage read traffic in bytes
+## kubevirt_vmi_storage_write_times_ms_total
+#### HELP kubevirt_vmi_storage_write_times_ms_total Storage write operation time
+## kubevirt_vmi_storage_write_traffic_bytes_total
+#### HELP kubevirt_vmi_storage_write_traffic_bytes_total Storage write traffic in bytes

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -180,6 +180,8 @@ A design proposal and its implementation history can be seen [here](https://docs
 #### HELP kubevirt_virt_controller_leading Indication for an operating virt-controller.
 ## kubevirt_virt_controller_ready_total
 #### HELP kubevirt_virt_controller_ready Indication for a virt-controller that is ready to take the lead.
+
+ # Other Metrics
 ## kubevirt_vmi_storage_flush_requests_total
 #### HELP kubevirt_vmi_storage_flush_requests_total storage flush requests.
 ## kubevirt_vmi_storage_flush_times_ms_total

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -225,54 +225,99 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 			continue
 		}
 
-		diskName := block.Name
+		blkLabels := []string{"drive"}
+		blkLabelValues := []string{block.Name}
+
 		if block.AliasSet {
-			diskName = block.Alias
+			blkLabelValues[0] = block.Alias
 		}
 
-		if block.RdReqsSet || block.WrReqsSet {
-			desc := metrics.newPrometheusDesc(
-				"kubevirt_vmi_storage_iops_total",
-				"I/O operation performed.",
-				[]string{"drive", "type"},
+		if block.RdReqsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_iops_read_total",
+				"I/O read operations",
+				prometheus.CounterValue,
+				float64(block.RdReqs),
+				blkLabels,
+				blkLabelValues,
 			)
-
-			if block.RdReqsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdReqs), []string{diskName, "read"})
-			}
-			if block.WrReqsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrReqs), []string{diskName, "write"})
-			}
 		}
 
-		if block.RdBytesSet || block.WrBytesSet {
-			desc := metrics.newPrometheusDesc(
-				"kubevirt_vmi_storage_traffic_bytes_total",
-				"storage traffic.",
-				[]string{"drive", "type"},
+		if block.WrReqsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_iops_write_total",
+				"I/O write operations",
+				prometheus.CounterValue,
+				float64(block.WrReqs),
+				blkLabels,
+				blkLabelValues,
 			)
-
-			if block.RdBytesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdBytes), []string{diskName, "read"})
-			}
-			if block.WrBytesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrBytes), []string{diskName, "write"})
-			}
 		}
 
-		if block.RdTimesSet || block.WrTimesSet {
-			desc := metrics.newPrometheusDesc(
-				"kubevirt_vmi_storage_times_ms_total",
-				"storage operation time.",
-				[]string{"drive", "type"},
+		if block.RdBytesSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_read_traffic_bytes_total",
+				"Storage read traffic in bytes",
+				prometheus.CounterValue,
+				float64(block.RdBytes),
+				blkLabels,
+				blkLabelValues,
 			)
+		}
 
-			if block.RdTimesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdTimes), []string{diskName, "read"})
-			}
-			if block.WrTimesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrTimes), []string{diskName, "write"})
-			}
+		if block.WrBytesSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_write_traffic_bytes_total",
+				"Storage write traffic in bytes",
+				prometheus.CounterValue,
+				float64(block.WrBytes),
+				blkLabels,
+				blkLabelValues,
+			)
+		}
+
+		if block.RdTimesSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_read_times_ms_total",
+				"Storage read operation time",
+				prometheus.CounterValue,
+				float64(block.RdTimes)/1000000,
+				blkLabels,
+				blkLabelValues,
+			)
+		}
+
+		if block.WrTimesSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_write_times_ms_total",
+				"Storage write operation time",
+				prometheus.CounterValue,
+				float64(block.WrTimes)/1000000,
+				blkLabels,
+				blkLabelValues,
+			)
+		}
+
+		if block.FlReqsSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_flush_requests_total",
+				"storage flush requests.",
+				prometheus.CounterValue,
+				float64(block.FlReqs),
+				blkLabels,
+				blkLabelValues,
+			)
+		}
+
+		if block.FlTimesSet {
+			metrics.pushCustomMetric(
+				"kubevirt_vmi_storage_flush_times_ms_total",
+				"total time (ms) spent on cache flushing.",
+				prometheus.CounterValue,
+				float64(block.FlTimes)/1000000,
+				blkLabels,
+				blkLabelValues,
+			)
 		}
 	}
 }

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -225,6 +225,11 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 			continue
 		}
 
+		diskName := block.Name
+		if block.AliasSet {
+			diskName = block.Alias
+		}
+
 		if block.RdReqsSet || block.WrReqsSet {
 			desc := metrics.newPrometheusDesc(
 				"kubevirt_vmi_storage_iops_total",
@@ -233,10 +238,10 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 			)
 
 			if block.RdReqsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdReqs), []string{block.Name, "read"})
+				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdReqs), []string{diskName, "read"})
 			}
 			if block.WrReqsSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrReqs), []string{block.Name, "write"})
+				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrReqs), []string{diskName, "write"})
 			}
 		}
 
@@ -248,10 +253,10 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 			)
 
 			if block.RdBytesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdBytes), []string{block.Name, "read"})
+				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdBytes), []string{diskName, "read"})
 			}
 			if block.WrBytesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrBytes), []string{block.Name, "write"})
+				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrBytes), []string{diskName, "write"})
 			}
 		}
 
@@ -263,10 +268,10 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 			)
 
 			if block.RdTimesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdTimes), []string{block.Name, "read"})
+				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.RdTimes), []string{diskName, "read"})
 			}
 			if block.WrTimesSet {
-				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrTimes), []string{block.Name, "write"})
+				metrics.pushPrometheusMetric(desc, prometheus.CounterValue, float64(block.WrTimes), []string{diskName, "write"})
 			}
 		}
 	}

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -228,7 +228,7 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 		blkLabels := []string{"drive"}
 		blkLabelValues := []string{block.Name}
 
-		if block.AliasSet {
+		if block.Name != "" || block.Alias != "" {
 			blkLabelValues[0] = block.Alias
 		}
 

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -228,7 +228,7 @@ func (metrics *vmiMetrics) updateBlock(blkStats []stats.DomainStatsBlock) {
 		blkLabels := []string{"drive"}
 		blkLabelValues := []string{block.Name}
 
-		if block.Name != "" || block.Alias != "" {
+		if block.Alias != "" {
 			blkLabelValues[0] = block.Alias
 		}
 

--- a/pkg/monitoring/vms/prometheus/prometheus_test.go
+++ b/pkg/monitoring/vms/prometheus/prometheus_test.go
@@ -471,7 +471,7 @@ var _ = Describe("Prometheus", func() {
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_iops_total"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_iops_read_total"))
 		})
 
 		It("should handle block write iops metrics", func() {
@@ -498,7 +498,7 @@ var _ = Describe("Prometheus", func() {
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_iops_total"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_iops_write_total"))
 		})
 
 		It("should handle block read bytes metrics", func() {
@@ -525,7 +525,7 @@ var _ = Describe("Prometheus", func() {
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_traffic_bytes_total"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_read_traffic_bytes_total"))
 		})
 
 		It("should handle block write bytes metrics", func() {
@@ -552,7 +552,7 @@ var _ = Describe("Prometheus", func() {
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_traffic_bytes_total"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_write_traffic_bytes_total"))
 		})
 
 		It("should handle block read time metrics", func() {
@@ -579,7 +579,7 @@ var _ = Describe("Prometheus", func() {
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_times_ms_total"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_read_times_ms_total"))
 		})
 
 		It("should handle block write time metrics", func() {
@@ -606,7 +606,61 @@ var _ = Describe("Prometheus", func() {
 
 			result := <-ch
 			Expect(result).ToNot(BeNil())
-			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_times_ms_total"))
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_write_times_ms_total"))
+		})
+
+		It("should handle block flush requests metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:   true,
+						Name:      "vda",
+						FlReqsSet: true,
+						FlReqs:    1000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_flush_requests_total"))
+		})
+
+		It("should handle block flush times metrics", func() {
+			ch := make(chan prometheus.Metric, 1)
+			defer close(ch)
+
+			ps := prometheusScraper{ch: ch}
+
+			vmStats := &stats.DomainStats{
+				Cpu:    &stats.DomainStatsCPU{},
+				Memory: &stats.DomainStatsMemory{},
+				Block: []stats.DomainStatsBlock{
+					{
+						NameSet:    true,
+						Name:       "vda",
+						FlTimesSet: true,
+						FlTimes:    1000000,
+					},
+				},
+			}
+
+			vmi := k6tv1.VirtualMachineInstance{}
+			ps.Report("test", &vmi, vmStats)
+
+			result := <-ch
+			Expect(result).ToNot(BeNil())
+			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_storage_flush_times_ms_total"))
 		})
 
 		It("should not expose nameless block metrics", func() {

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -335,6 +335,10 @@ func (l *LibvirtConnection) GetDeviceAliasMap(domain *libvirt.Domain) (map[strin
 		devAliasMap[iface.Target.Device] = iface.Alias.GetName()
 	}
 
+	for _, disk := range domSpec.Devices.Disks {
+		devAliasMap[disk.Target.Device] = disk.Alias.GetName()
+	}
+
 	return devAliasMap, nil
 }
 

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -107,6 +107,8 @@ type DomainStatsNet struct {
 type DomainStatsBlock struct {
 	NameSet         bool
 	Name            string
+	AliasSet        bool
+	Alias           string
 	BackingIndexSet bool
 	BackingIndex    uint
 	PathSet         bool

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -107,7 +107,6 @@ type DomainStatsNet struct {
 type DomainStatsBlock struct {
 	NameSet         bool
 	Name            string
-	AliasSet        bool
 	Alias           string
 	BackingIndexSet bool
 	BackingIndex    uint

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -49,7 +49,7 @@ func Convert_libvirt_DomainStats_to_stats_DomainStats(ident DomainIdentifier, in
 	out.Memory = Convert_libvirt_MemoryStat_to_stats_DomainStatsMemory(inMem, inDomInfo)
 	out.Vcpu = Convert_libvirt_DomainStatsVcpu_To_stats_DomainStatsVcpu(in.Vcpu)
 	out.Net = Convert_libvirt_DomainStatsNet_To_stats_DomainStatsNet(in.Net, devAliasMap)
-	out.Block = Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in.Block)
+	out.Block = Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in.Block, devAliasMap)
 
 	return nil
 }
@@ -160,10 +160,10 @@ func Convert_libvirt_DomainStatsNet_To_stats_DomainStatsNet(in []libvirt.DomainS
 	return ret
 }
 
-func Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in []libvirt.DomainStatsBlock) []stats.DomainStatsBlock {
+func Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in []libvirt.DomainStatsBlock, devAliasMap map[string]string) []stats.DomainStatsBlock {
 	ret := make([]stats.DomainStatsBlock, 0, len(in))
 	for _, inItem := range in {
-		ret = append(ret, stats.DomainStatsBlock{
+		blkStat := stats.DomainStatsBlock{
 			NameSet:         inItem.NameSet,
 			Name:            inItem.Name,
 			BackingIndexSet: inItem.BackingIndexSet,
@@ -194,7 +194,13 @@ func Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in []libvirt.Dom
 			Capacity:        inItem.Capacity,
 			PhysicalSet:     inItem.PhysicalSet,
 			Physical:        inItem.Physical,
-		})
+		}
+
+		if inItem.NameSet {
+			blkStat.Alias, blkStat.AliasSet = devAliasMap[inItem.Name]
+		}
+
+		ret = append(ret, blkStat)
 	}
 	return ret
 }

--- a/pkg/virt-launcher/virtwrap/statsconv/converter.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/converter.go
@@ -197,7 +197,7 @@ func Convert_libvirt_DomainStatsBlock_To_stats_DomainStatsBlock(in []libvirt.Dom
 		}
 
 		if inItem.NameSet {
-			blkStat.Alias, blkStat.AliasSet = devAliasMap[inItem.Name]
+			blkStat.Alias, _ = devAliasMap[inItem.Name]
 		}
 
 		ret = append(ret, blkStat)

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -133,7 +133,6 @@ var Testdataexpected = `{
        "Name": "vda", 
        "NameSet": true, 
        "Alias": "",
-       "AliasSet": false,
        "Path": "/var/lib/libvirt/images/f28-worker-0.qcow2", 
        "PathSet": true, 
        "Physical": 41385254912, 

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -132,6 +132,8 @@ var Testdataexpected = `{
        "FlTimesSet": true, 
        "Name": "vda", 
        "NameSet": true, 
+       "Alias": "",
+       "AliasSet": false,
        "Path": "/var/lib/libvirt/images/f28-worker-0.qcow2", 
        "PathSet": true, 
        "Physical": 41385254912, 

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -791,25 +791,42 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			table.Entry("by using IPv6", k8sv1.IPv6Protocol),
 		)
 
-		table.DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily) {
+		table.DescribeTable("should include the storage metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
 			if family == k8sv1.IPv6Protocol {
 				libnet.SkipWhenNotDualStackCluster(virtClient)
 			}
 
 			ip := getSupportedIP(metricsIPs, family)
 
-			metrics := collectMetrics(ip, "kubevirt_vmi_storage_")
+			metrics := collectMetrics(ip, metricSubstring)
 			By("Checking the collected metrics")
 			keys := getKeysFromMetrics(metrics)
 			for _, key := range keys {
 				if strings.Contains(key, `drive="vdb"`) {
 					value := metrics[key]
-					Expect(value).To(BeNumerically(">", float64(0.0)))
+					fmt.Fprintf(GinkgoWriter, "metric value was %f\n", value)
+					Expect(value).To(BeNumerically(operator, float64(0.0)))
 				}
 			}
 		},
-			table.Entry("[test_id:4142] by using IPv4", k8sv1.IPv4Protocol),
-			table.Entry("by using IPv6", k8sv1.IPv6Protocol),
+			table.Entry("[test_id:4142] by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_", ">="),
+			table.Entry("by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_", ">="),
+			table.Entry("[test_id:4142] storage flush requests metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
+			table.Entry("storage flush requests metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_requests_total", ">="),
+			table.Entry("[test_id:4142] time (ms) spent on cache flushing metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
+			table.Entry("time (ms) spent on cache flushing metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_flush_times_ms_total", ">="),
+			table.Entry("[test_id:4142] I/O read operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
+			table.Entry("I/O read operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_read_total", ">="),
+			table.Entry("[test_id:4142] I/O write operations metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
+			table.Entry("I/O write operations metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_iops_write_total", ">="),
+			table.Entry("[test_id:4142] storage read operation time metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
+			table.Entry("storage read operation time metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_times_ms_total", ">="),
+			table.Entry("[test_id:4142] storage read traffic in bytes metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+			table.Entry("storage read traffic in bytes metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+			table.Entry("[test_id:4142] storage write operation time metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
+			table.Entry("storage write operation time metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_times_ms_total", ">="),
+			table.Entry("[test_id:4142] storage write traffic in bytes metric by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+			table.Entry("storage write traffic in bytes metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 		)
 
 		table.DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -829,6 +829,25 @@ var _ = Describe("[Serial][sig-compute]Infrastructure", func() {
 			table.Entry("storage write traffic in bytes metric by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 		)
 
+		table.DescribeTable("should respect alias for disk names", func(family k8sv1.IPFamily, metricSubstring string) {
+			if family == k8sv1.IPv6Protocol {
+				libnet.SkipWhenNotDualStackCluster(virtClient)
+			}
+
+			ip := getSupportedIP(metricsIPs, family)
+			metrics := collectMetrics(ip, metricSubstring)
+			keys := getKeysFromMetrics(metrics)
+			for _, vmi := range preparedVMIs {
+				for _, vol := range vmi.Spec.Volumes {
+					key := getMetricKeyForVmiDisk(keys, vmi.Name, vol.Name)
+					Expect(key).To(Not(BeEmpty()))
+				}
+			}
+		},
+			table.Entry("[test_id:4142] by using IPv4", k8sv1.IPv4Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total"),
+			table.Entry("[test_id:4142] by using IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_storage_read_traffic_bytes_total"),
+		)
+
 		table.DescribeTable("should include metrics for a running VM", func(family k8sv1.IPFamily, metricSubstring, operator string) {
 			if family == k8sv1.IPv6Protocol {
 				libnet.SkipWhenNotDualStackCluster(virtClient)
@@ -1378,4 +1397,14 @@ func getSupportedIP(ips []string, family k8sv1.IPFamily) string {
 
 func prepareMetricsURL(ip string, port int) string {
 	return fmt.Sprintf("https://%s/metrics", net.JoinHostPort(ip, strconv.Itoa(port)))
+}
+
+func getMetricKeyForVmiDisk(keys []string, vmiName string, diskName string) interface{} {
+	for _, key := range keys {
+		if strings.Contains(key, "name=\""+vmiName+"\"") &&
+			strings.Contains(key, "drive=\""+diskName+"\"") {
+			return key
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
**What does this PR?**

This PR replaces

- `kubevirt_vmi_storage_iops_total` with  `kubevirt_vmi_storage_iops_read_total` and `kubevirt_vmi_storage_iops_write_total`

- `kubevirt_vmi_storage_traffic_bytes_total`  with `kubevirt_vmi_storage_read_traffic_bytes_total` and `kubevirt_vmi_storage_write_traffic_bytes_total`

- `kubevirt_vmi_storage_times_ms_total`  with `kubevirt_vmi_storage_read_times_ms_total` and `kubevirt_vmi_storage_write_times_ms_total`

This PR adds detailed functional tests which check the labels of metrics and verifies that volume names of VMIs exist there.

**Special notes for your reviewer**:

This PR contains the work in #5204 and it resolves review issues on that PR.  

`AliasSet` is removed in this PR after this comment: https://github.com/kubevirt/kubevirt/pull/5204#discussion_r601208122


**Release note**:
```release-note
Some cleanups and small additions to the storage metrics
```
