### PR TITLE
device controller: remove all device plugins when permittedHostDevices is deleted

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -283,11 +283,12 @@ func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.C
 			return fmt.Errorf("failed to parse SMBIOS config: %v", err)
 		}
 	}
+
 	// updates host devices in the config.
-	// Clear the list first, if whole categories get removed, we want the devices gone
-	newPermittedHostDevices := &v1.PermittedHostDevices{}
+	var newPermittedHostDevices *v1.PermittedHostDevices
 	rawConfig = strings.TrimSpace(configMap.Data[PermittedHostDevicesKey])
 	if rawConfig != "" {
+		newPermittedHostDevices = &v1.PermittedHostDevices{}
 		err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(rawConfig), 1024).Decode(newPermittedHostDevices)
 		if err != nil {
 			return fmt.Errorf("failed to parse host devices config: %v", err)

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -117,14 +117,14 @@ func (c *DeviceController) startDevicePlugin(controlledDev ControlledDevice) {
 func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]ControlledDevice, map[string]ControlledDevice) {
 	devicePluginsToRun := make(map[string]ControlledDevice)
 	devicePluginsToStop := make(map[string]ControlledDevice)
-	if hostDevs := c.virtConfig.GetPermittedHostDevices(); hostDevs != nil {
-		// generate a map of currently started device plugins
-		for resourceName, hostDevDP := range c.devicePlugins {
-			_, isPermanent := permanentDevicePluginPaths[resourceName]
-			if !isPermanent {
-				devicePluginsToStop[resourceName] = hostDevDP
-			}
+	// generate a map of currently started device plugins
+	for resourceName, hostDevDP := range c.devicePlugins {
+		_, isPermanent := permanentDevicePluginPaths[resourceName]
+		if !isPermanent {
+			devicePluginsToStop[resourceName] = hostDevDP
 		}
+	}
+	if hostDevs := c.virtConfig.GetPermittedHostDevices(); hostDevs != nil {
 		supportedPCIDeviceMap := make(map[string]string)
 		if len(hostDevs.PciHostDevices) != 0 {
 			for _, pciDev := range hostDevs.PciHostDevices {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses an edge-case where `permittedHostDevices` is added to the configMap/CR with PCI/Mdev entries, and then removed entirely.
In that case, we wouldn't typically do anything, and the device plugins would keep running.
This PR ensures they're all removed in that scenario.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1944379

**Special notes for your reviewer**:
Misc fixes:
- Ensure `config.PermittedHostDevices` always `nil` when empty
- In tests, ensure the configmap data is valid
- In tests, ensure no stop channel conflict
- In tests, avoid panic by mocking GetDevicePCIID()

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removal of entire `permittedHostDevices` section will now remove all user-defined host device plugins.
```
