### PR TITLE
crds: do not log if crds are up-to-date

### DIFF
--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -114,7 +114,7 @@ func (r *Reconciler) createOrUpdateCrd(crd *extv1.CustomResourceDefinition) erro
 		}
 		log.Log.V(2).Infof("crd %v updated", crd.GetName())
 	} else {
-		log.Log.V(2).Infof("crd %v is up-to-date", crd.GetName())
+		log.Log.V(4).Infof("crd %v is up-to-date", crd.GetName())
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This message gets logged way too many times and it pollutes the logs with no useful info.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
