### PR TITLE
Return error if VMI is in Failed state when console access

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -199,6 +199,9 @@ func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, re
 			log.Log.Object(vmi).Reason(err).Error("Can't establish a serial console connection.")
 			return errors.NewBadRequest(err.Error())
 		}
+		if vmi.Status.Phase == v1.Failed {
+			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("VMI is in failed status"))
+		}
 		condManager := controller.NewVirtualMachineInstanceConditionManager()
 		if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
 			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("VMI is paused"))

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -342,6 +342,18 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			close(done)
 		}, 5)
 
+		It("should fail to connect to the serial console if the VMI is Failed", func(done Done) {
+
+			request.PathParameters()["name"] = "testvmi"
+			request.PathParameters()["namespace"] = "default"
+
+			expectVMI(false, false)
+
+			app.ConsoleRequestHandler(request, response)
+			ExpectStatusErrorWithCode(recorder, http.StatusConflict)
+			close(done)
+		}, 5)
+
 		It("should fail to connect to the serial console if the VMI is paused", func(done Done) {
 
 			request.PathParameters()["name"] = "testvmi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5360

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
