### PR TITLE
Specify consumes and body for add/removevolume in api docs

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -6312,6 +6312,16 @@
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
      "operationId": "v1vmi-addvolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.AddVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -6493,6 +6503,16 @@
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
      "operationId": "v1vmi-removevolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.RemoveVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -6662,6 +6682,16 @@
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
      "operationId": "v1vm-addvolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.AddVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -6750,6 +6780,16 @@
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
      "operationId": "v1vm-removevolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.RemoveVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -7062,6 +7102,16 @@
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine Instance",
      "operationId": "v1alpha3vmi-addvolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.AddVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -7243,6 +7293,16 @@
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine Instance",
      "operationId": "v1alpha3vmi-removevolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.RemoveVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -7412,6 +7472,16 @@
     "put": {
      "description": "Add a volume and disk to a running Virtual Machine.",
      "operationId": "v1alpha3vm-addvolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.AddVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",
@@ -7500,6 +7570,16 @@
     "put": {
      "description": "Removes a volume and disk from a running Virtual Machine.",
      "operationId": "v1alpha3vm-removevolume",
+     "parameters": [
+      {
+       "name": "body",
+       "in": "body",
+       "required": true,
+       "schema": {
+        "$ref": "#/definitions/v1.RemoveVolumeOptions"
+       }
+      }
+     ],
      "responses": {
       "200": {
        "description": "OK",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -325,6 +325,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("addvolume")).
 			To(subresourceApp.VMIAddVolumeRequestHandler).
+			Reads(v1.AddVolumeOptions{}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Operation(version.Version+"vmi-addvolume").
 			Doc("Add a volume and disk to a running Virtual Machine Instance").
@@ -333,6 +334,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmiGVR)+rest.SubResourcePath("removevolume")).
 			To(subresourceApp.VMIRemoveVolumeRequestHandler).
+			Reads(v1.RemoveVolumeOptions{}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Operation(version.Version+"vmi-removevolume").
 			Doc("Removes a volume and disk from a running Virtual Machine Instance").
@@ -341,6 +343,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("addvolume")).
 			To(subresourceApp.VMAddVolumeRequestHandler).
+			Reads(v1.AddVolumeOptions{}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Operation(version.Version+"vm-addvolume").
 			Doc("Add a volume and disk to a running Virtual Machine.").
@@ -349,6 +352,7 @@ func (app *virtAPIApp) composeSubresources() {
 
 		subws.Route(subws.PUT(rest.ResourcePath(subresourcesvmGVR)+rest.SubResourcePath("removevolume")).
 			To(subresourceApp.VMRemoveVolumeRequestHandler).
+			Reads(v1.RemoveVolumeOptions{}).
 			Param(rest.NamespaceParam(subws)).Param(rest.NameParam(subws)).
 			Operation(version.Version+"vm-removevolume").
 			Doc("Removes a volume and disk from a running Virtual Machine.").


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The generated API docs didn't specify the body needed for addvolume and removevolume. This PR specifies the types needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4725

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
