### PR TITLE
[release-0.34] migration admitter: prevent creation of duplicate migrations by adding a special migration label to be used as a label selector

### DIFF
--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -574,7 +574,7 @@ func (app *virtAPIApp) registerValidatingWebhooks() {
 		validating_webhook.ServeVMIPreset(w, r)
 	})
 	http.HandleFunc(components.MigrationCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig)
+		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig, app.virtCli)
 	})
 	http.HandleFunc(components.MigrationUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationUpdate(w, r)

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -51,6 +51,13 @@ func (mutator *MigrationCreateMutator) Mutate(ar *v1beta1.AdmissionReview) *v1be
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
+	// Add our selector label
+	if migration.Labels == nil {
+		migration.Labels = map[string]string{v1.MigrationSelectorLabel: migration.Spec.VMIName}
+	} else {
+		migration.Labels[v1.MigrationSelectorLabel] = migration.Spec.VMIName
+	}
+
 	// Add a finalizer
 	migration.Finalizers = append(migration.Finalizers, v1.VirtualMachineInstanceMigrationFinalizer)
 	var patch []patchOperation

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -86,4 +86,10 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		_, migrationMeta := getMigrationSpecMetaFromResponse()
 		Expect(migrationMeta.Finalizers).To(ContainElement(v1.VirtualMachineInstanceMigrationFinalizer))
 	})
+
+	It("should add the selector label", func() {
+		_, migrationMeta := getMigrationSpecMetaFromResponse()
+		Expect(migrationMeta.Labels).ToNot(BeNil())
+		Expect(migrationMeta.Labels[v1.MigrationSelectorLabel]).To(Equal(migration.Spec.VMIName))
+	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-update-admitter.go
@@ -32,6 +32,34 @@ import (
 type MigrationUpdateAdmitter struct {
 }
 
+func ensureSelectorLabelSafe(newMigration *v1.VirtualMachineInstanceMigration, oldMigration *v1.VirtualMachineInstanceMigration) []metav1.StatusCause {
+	if newMigration.Status.Phase != v1.MigrationSucceeded && newMigration.Status.Phase != v1.MigrationFailed && oldMigration.Labels != nil {
+		oldLabel, oldExists := oldMigration.Labels[v1.MigrationSelectorLabel]
+		if newMigration.Labels == nil {
+			if oldExists {
+				return []metav1.StatusCause{
+					{
+						Type:    metav1.CauseTypeFieldValueNotSupported,
+						Message: "selector label can't be removed from an in-flight migration",
+					},
+				}
+			}
+		} else {
+			newLabel, newExists := newMigration.Labels[v1.MigrationSelectorLabel]
+			if oldExists && (!newExists || newLabel != oldLabel) {
+				return []metav1.StatusCause{
+					{
+						Type:    metav1.CauseTypeFieldValueNotSupported,
+						Message: "selector label can't be modified on an in-flight migration",
+					},
+				}
+			}
+		}
+	}
+
+	return []metav1.StatusCause{}
+}
+
 func (admitter *MigrationUpdateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	// Get new migration from admission response
 	newMigration, oldMigration, err := getAdmissionReviewMigration(ar)
@@ -54,28 +82,9 @@ func (admitter *MigrationUpdateAdmitter) Admit(ar *v1beta1.AdmissionReview) *v1b
 	}
 
 	// Reject Migration update if selector label changed on an in-flight migration
-	if newMigration.Status.Phase != v1.MigrationSucceeded && newMigration.Status.Phase != v1.MigrationFailed && oldMigration.Labels != nil {
-		oldLabel, oldExists := oldMigration.Labels[v1.MigrationSelectorLabel]
-		if newMigration.Labels == nil {
-			if oldExists {
-				return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
-					{
-						Type:    metav1.CauseTypeFieldValueNotSupported,
-						Message: "selector label can't be removed from an in-flight migration",
-					},
-				})
-			}
-		} else {
-			newLabel, newExists := newMigration.Labels[v1.MigrationSelectorLabel]
-			if oldExists && (!newExists || newLabel != oldLabel) {
-				return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
-					{
-						Type:    metav1.CauseTypeFieldValueNotSupported,
-						Message: "selector label can't be modified on an in-flight migration",
-					},
-				})
-			}
-		}
+	causes := ensureSelectorLabelSafe(newMigration, oldMigration)
+	if len(causes) > 0 {
+		return webhookutils.ToAdmissionResponse(causes)
 	}
 
 	reviewResponse := v1beta1.AdmissionResponse{}

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -48,8 +48,8 @@ func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.VMIPresetAdmitter{})
 }
 
-func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{ClusterConfig: clusterConfig})
+func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, &admitters.MigrationCreateAdmitter{ClusterConfig: clusterConfig, VirtClient: virtCli})
 }
 
 func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -168,6 +168,12 @@ func (c *MigrationController) execute(key string) error {
 	if !controller.ObservedLatestApiVersionAnnotation(migration) {
 		migration := migration.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(migration)
+		// Ensure the migration contains our selector label
+		if migration.Labels == nil {
+			migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
+		} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
+			migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
+		}
 		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(migration)
 		return err
 	}

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -146,6 +146,14 @@ func (c *MigrationController) Execute() bool {
 	return true
 }
 
+func ensureSelectorLabelPresent(migration *virtv1.VirtualMachineInstanceMigration) {
+	if migration.Labels == nil {
+		migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
+	} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
+		migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
+	}
+}
+
 func (c *MigrationController) execute(key string) error {
 	var vmi *virtv1.VirtualMachineInstance
 	var targetPods []*k8sv1.Pod
@@ -169,11 +177,7 @@ func (c *MigrationController) execute(key string) error {
 		migration := migration.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(migration)
 		// Ensure the migration contains our selector label
-		if migration.Labels == nil {
-			migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
-		} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
-			migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
-		}
+		ensureSelectorLabelPresent(migration)
 		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(migration)
 		return err
 	}

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -547,6 +547,8 @@ const (
 
 	VirtualMachineLabel        = AppLabel + "/vm"
 	MemfdMemoryBackend  string = "kubevirt.io/memfd"
+
+	MigrationSelectorLabel = "kubevirt.io/vmi-name"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -900,7 +900,13 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitAgentConnected(virtClient, vmi)
 
 				By("Checking that the VirtualMachineInstance console has expected output")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
+				expecter, err := tests.LoggedInFedoraExpecter(vmi)
+				Expect(err).ToNot(HaveOccurred(), "Should be able to login to the Fedora VM")
+
+				// Only stressing the VMI for 60 seconds to ensure the first migration eventually succeeds
+				By("Stressing the VMI")
+				runStressTest(expecter)
+				expecter.Close()
 
 				By("Starting a first migration")
 				migration1 := tests.NewRandomMigration(vmi.Name, vmi.Namespace)

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -276,14 +276,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 		Expect(vmi.Status.Phase).To(Equal(v1.Running))
 		return vmi
 	}
-	runMigrationAndExpectCompletion := func(migration *v1.VirtualMachineInstanceMigration, timeout int) string {
-		By("Starting a Migration")
-		var migrationCreated *v1.VirtualMachineInstanceMigration
-		Eventually(func() error {
-			migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
-			return err
-		}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
-		migration = migrationCreated
+	expectMigrationSuccess := func(migration *v1.VirtualMachineInstanceMigration, timeout int) string {
 		By("Waiting until the Migration Completes")
 
 		uid := ""
@@ -303,6 +296,16 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 		}, timeout, 1*time.Second).ShouldNot(HaveOccurred(), fmt.Sprintf("migration should succeed after %d s", timeout))
 		return uid
+	}
+	runMigrationAndExpectCompletion := func(migration *v1.VirtualMachineInstanceMigration, timeout int) string {
+		By("Starting a Migration")
+		var migrationCreated *v1.VirtualMachineInstanceMigration
+		Eventually(func() error {
+			migrationCreated, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
+			return err
+		}, timeout, 1*time.Second).ShouldNot(HaveOccurred())
+		migration = migrationCreated
+		return expectMigrationSuccess(migration, timeout)
 	}
 	runAndCancelMigration := func(migration *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, timeout int) *v1.VirtualMachineInstanceMigration {
 		By("Starting a Migration")
@@ -878,6 +881,49 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 
 				// check VMI, confirm migration state
 				confirmVMIPostMigration(vmi, migrationUID)
+
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
+			})
+			It("should reject additional migrations on the same VMI if the first one is not finished", func() {
+				vmi := tests.NewRandomFedoraVMIWitGuestAgent()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
+
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
+
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
+				tests.WaitAgentConnected(virtClient, vmi)
+
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+				By("Starting a first migration")
+				migration1 := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migration1, err = virtClient.VirtualMachineInstanceMigration(migration1.Namespace).Create(migration1)
+				Expect(err).To(BeNil())
+
+				// Successfully tested with 40, but requests start getting throttled above 10, which is better to avoid to prevent flakyness
+				By("Starting 10 more migrations expecting all to fail to create")
+				var wg sync.WaitGroup
+				for n := 0; n < 10; n++ {
+					wg.Add(1)
+					go func(n int) {
+						defer GinkgoRecover()
+						defer wg.Done()
+						migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+						_, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
+						Expect(err).To(HaveOccurred(), fmt.Sprintf("Extra migration %d should have failed to create", n))
+						Expect(err.Error()).To(ContainSubstring(`admission webhook "migration-create-validator.kubevirt.io" denied the request: in-flight migration detected.`))
+					}(n)
+				}
+				wg.Wait()
+
+				expectMigrationSuccess(migration1, migrationWaitTime)
 
 				// delete VMI
 				By("Deleting the VMI")


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/5242

```release-note
Creating more than 1 migration at the same time for a given VMI will now fail
```
