### PR TITLE
Fix when case when node-labeller doesn't have access to kvm

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/migration-proxy:go_default_library",
         "//pkg/virt-handler/node-labeller:go_default_library",
+        "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-handler/rest:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -352,10 +352,7 @@ func (app *virtHandlerApp) Run() {
 
 	go vmController.Run(10, stop)
 
-	nodeLabellerController, err := nodelabeller.NewNodeLabeller(&devicemanager.DeviceController{}, app.clusterConfig, app.virtCli, app.HostOverride, app.namespace)
-	if err != nil {
-		panic(err)
-	}
+	nodeLabellerController := nodelabeller.NewNodeLabeller(&devicemanager.DeviceController{}, app.clusterConfig, app.virtCli, app.HostOverride, app.namespace)
 
 	go nodeLabellerController.Run(10, stop)
 

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -72,6 +72,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
 	nodelabeller "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller"
+	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/rest"
 	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
 	virt_api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -352,9 +353,17 @@ func (app *virtHandlerApp) Run() {
 
 	go vmController.Run(10, stop)
 
-	nodeLabellerController := nodelabeller.NewNodeLabeller(&devicemanager.DeviceController{}, app.clusterConfig, app.virtCli, app.HostOverride, app.namespace)
+	deviceController := &devicemanager.DeviceController{}
+	if deviceController.NodeHasDevice(nodelabellerutil.KVMPath) {
+		nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig, app.virtCli, app.HostOverride, app.namespace)
+		if err != nil {
+			panic(err)
+		}
 
-	go nodeLabellerController.Run(10, stop)
+		go nodeLabellerController.Run(10, stop)
+	} else {
+		logger.V(1).Level(log.INFO).Log("node-labeller is disabled, cannot work without KVM device.")
+	}
 
 	doneCh := make(chan string)
 	defer close(doneCh)

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-handler/device-manager:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -38,7 +37,6 @@ go_test(
     deps = [
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
-        "//pkg/virt-handler/device-manager:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -86,7 +86,6 @@ func (n *NodeLabeller) loadHostCapabilities() error {
 	}
 
 	n.hostCapabilities.items = usableModels
-	n.hostCapabilitiesLoaded = true
 
 	return nil
 }
@@ -111,7 +110,6 @@ func (n *NodeLabeller) loadHostSupportedFeatures() error {
 	}
 
 	n.supportedFeatures = usableFeatures
-	n.supportedFeaturesLoaded = true
 	return nil
 }
 
@@ -137,7 +135,6 @@ func (n *NodeLabeller) loadCPUInfo() error {
 	}
 
 	n.cpuInfo.models = models
-	n.cpuInfoIsLoaded = true
 	return nil
 }
 

--- a/pkg/virt-handler/node-labeller/cpu_plugin.go
+++ b/pkg/virt-handler/node-labeller/cpu_plugin.go
@@ -86,6 +86,7 @@ func (n *NodeLabeller) loadHostCapabilities() error {
 	}
 
 	n.hostCapabilities.items = usableModels
+	n.hostCapabilitiesLoaded = true
 
 	return nil
 }
@@ -110,6 +111,7 @@ func (n *NodeLabeller) loadHostSupportedFeatures() error {
 	}
 
 	n.supportedFeatures = usableFeatures
+	n.supportedFeaturesLoaded = true
 	return nil
 }
 
@@ -135,7 +137,7 @@ func (n *NodeLabeller) loadCPUInfo() error {
 	}
 
 	n.cpuInfo.models = models
-
+	n.cpuInfoIsLoaded = true
 	return nil
 }
 

--- a/pkg/virt-handler/node-labeller/kvm-caps-info-plugin.go
+++ b/pkg/virt-handler/node-labeller/kvm-caps-info-plugin.go
@@ -54,6 +54,7 @@ import (
 	"unsafe"
 
 	"kubevirt.io/client-go/log"
+	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
 const (
@@ -218,7 +219,7 @@ func exposeCapabilities(fd uintptr, supportedMSRS map[uint32]bool) []string {
 }
 
 func getCapLabels() []string {
-	devkvm, err := os.OpenFile("/dev/kvm", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	devkvm, err := os.OpenFile(util.KVMPath, syscall.O_RDWR|syscall.O_CLOEXEC, 0)
 	if err != nil {
 		log.DefaultLogger().Errorf("something happened during opening kvm file: " + err.Error())
 		return nil

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Node-labeller ", func() {
 
 		prepareFileDomCapabilities()
 
-		nlController, _ = NewNodeLabeller(&device_manager.DeviceController{}, config, virtClient, "testNode", k8sv1.NamespaceDefault)
+		nlController = NewNodeLabeller(&device_manager.DeviceController{}, config, virtClient, "testNode", k8sv1.NamespaceDefault)
 
 		mockQueue = testutils.NewMockWorkQueue(nlController.queue)
 

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -20,8 +20,6 @@
 package nodelabeller
 
 import (
-	"strings"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -37,7 +35,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	util "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 )
 
@@ -61,8 +58,12 @@ var _ = Describe("Node-labeller ", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		kubeClient = fake.NewSimpleClientset()
-
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
+
+		kubeClient.Fake.PrependReactor("get", "nodes", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			return true, newNode("testNode"), nil
+		})
+
 		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		kv := &kubevirtv1.KubeVirt{
@@ -82,7 +83,7 @@ var _ = Describe("Node-labeller ", func() {
 
 		prepareFileDomCapabilities()
 
-		nlController = NewNodeLabeller(&device_manager.DeviceController{}, config, virtClient, "testNode", k8sv1.NamespaceDefault)
+		nlController, _ = NewNodeLabeller(config, virtClient, "testNode", k8sv1.NamespaceDefault)
 
 		mockQueue = testutils.NewMockWorkQueue(nlController.queue)
 
@@ -91,15 +92,10 @@ var _ = Describe("Node-labeller ", func() {
 
 	It("should run node-labelling", func() {
 		addNode(newNode("testNode"))
-		kubeClient.Fake.PrependReactor("*", "nodes", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-			update, _ := action.(testing.PatchAction)
-			Expect(update.GetName()).To(Equal("testNode"), "names should equal")
-			containCorrectLabel := strings.Contains(string(update.GetPatch()), "Penryn")
-			Expect(containCorrectLabel).To(Equal(true), "labels should contain cpu model")
-			return true, nil, nil
-		})
 
-		nlController.execute()
+		res := nlController.execute()
+		Expect(res).To(Equal(true), "labeller should end with true result")
+		Expect(nlController.queue.Len()).To(Equal(0), "labeller should process all nodes from queue")
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-handler/node-labeller/util/util.go
+++ b/pkg/virt-handler/node-labeller/util/util.go
@@ -41,4 +41,8 @@ var DefaultObsoleteCPUModels = map[string]bool{
 	"Conroe":     true,
 	"athlon":     true,
 	"phenom":     true,
+	"qemu64":     true,
+	"qemu32":     true,
+	"kvm64":      true,
+	"kvm32":      true,
 }

--- a/pkg/virt-handler/node-labeller/util/util.go
+++ b/pkg/virt-handler/node-labeller/util/util.go
@@ -27,6 +27,7 @@ const (
 	DeprecatedHyperPrefix                        = "/kvm-info-cap-hyperv-"
 	DefaultMinCPUModel                           = "Penryn"
 	RequirePolicy                                = "require"
+	KVMPath                                      = "/dev/kvm"
 )
 
 var DefaultObsoleteCPUModels = map[string]bool{


### PR DESCRIPTION
**What this PR does / why we need it**:
fix when case when node-labeller doesn't have access to kvm device

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubevirt/kubevirt/issues/5364

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
