### PR TITLE
Fix flaky block storage device tests

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -208,9 +208,9 @@ const (
 	SecretLabel = "kubevirt.io/secret"
 )
 
-const (
+var (
 	// BlockDiskForTest contains name of the block PV and PVC
-	BlockDiskForTest = "block-disk-for-tests"
+	BlockDiskForTest string
 )
 
 const (
@@ -709,6 +709,8 @@ func BeforeTestSuitSetup(_ []byte) {
 	HostPathAlpine = filepath.Join(HostPathBase, fmt.Sprintf("%s%v", "alpine", worker))
 	HostPathCustom = filepath.Join(HostPathBase, fmt.Sprintf("%s%v", "custom", worker))
 	HostPathFedora = filepath.Join(HostPathBase, "fedora-cloud")
+
+	BlockDiskForTest = fmt.Sprintf("block-disk-for-tests%v", worker)
 
 	// Wait for schedulable nodes
 	virtClient, err := kubecli.GetKubevirtClient()


### PR DESCRIPTION
Our test suite runs tests in parallel by default. We have a set of functions that provide a block device PVC with a cirros image to some tests, but there's a naming collision that results in multiple test workers all colliding on creating/deleting pvcs with the same name.

The result is if two tests running in parallel attempt to use a dynamically created block PVC using these standard util functions, they'll stomp on each other.

To fix this, since cirros is already a read only image, i just made each parallel test work use a unique name for the corresponding PVC/PV. 


**Release note**:
```release-note
NONE
```
