### PR TITLE
Add Ready into wider output of crds

### DIFF
--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -192,7 +192,8 @@ func NewVirtualMachineCrd() (*extv1.CustomResourceDefinition, error) {
 	err := addFieldsToAllVersions(crd, []extv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", JSONPath: ".metadata.creationTimestamp"},
 		{Name: "Volume", Description: "Primary Volume", Type: "string", JSONPath: ".spec.volumes[0].name"},
-		{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1}}, &extv1.CustomResourceSubresources{
+		{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1},
+		{Name: "Ready", Type: "boolean", JSONPath: ".status.ready", Priority: 1}}, &extv1.CustomResourceSubresources{
 		Status: &extv1.CustomResourceSubresourceStatus{}})
 	if err != nil {
 		return nil, err

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -131,7 +131,7 @@ var _ = Describe("[owner:@sig-compute]oc/kubectl integration", func() {
 			// Verify one of the wide column output field
 			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 		},
-			table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED"}, 1, "true"),
+			table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED", "READY"}, 1, "true"),
 			table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 
@@ -155,7 +155,7 @@ var _ = Describe("[owner:@sig-compute]oc/kubectl integration", func() {
 			// Verify one of the wide column output field
 			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 		},
-			table.Entry("[test_id:4423]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED"}, 1, "true"),
+			table.Entry("[test_id:4423]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED", "READY"}, 1, "true"),
 			table.Entry("[test_id:4422]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

From 
```
# ./cluster-up/kubectl.sh get vm -o wide
NAME        AGE   VOLUME   CREATED   
vm-cirros   6s

```
to 
```
# ./cluster-up/kubectl.sh get vm -o wide
NAME        AGE   VOLUME   CREATED   READY
vm-cirros   6s                        true           true

```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
