### PR TITLE
[release-0.36] device controller: remove all device plugins when permittedHostDevices is deleted

### DIFF
--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -267,11 +267,12 @@ func setConfigFromConfigMap(config *v1.KubeVirtConfiguration, configMap *k8sv1.C
 			return fmt.Errorf("failed to parse SMBIOS config: %v", err)
 		}
 	}
+
 	// updates host devices in the config.
-	// Clear the list first, if whole categories get removed, we want the devices gone
-	newPermittedHostDevices := &v1.PermittedHostDevices{}
+	var newPermittedHostDevices *v1.PermittedHostDevices
 	rawConfig = strings.TrimSpace(configMap.Data[PermittedHostDevicesKey])
 	if rawConfig != "" {
+		newPermittedHostDevices = &v1.PermittedHostDevices{}
 		err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(rawConfig), 1024).Decode(newPermittedHostDevices)
 		if err != nil {
 			return fmt.Errorf("failed to parse host devices config: %v", err)

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -113,14 +113,14 @@ func (c *DeviceController) startDevicePlugin(controlledDev ControlledDevice) {
 func (c *DeviceController) updatePermittedHostDevicePlugins() (map[string]ControlledDevice, map[string]ControlledDevice) {
 	devicePluginsToRun := make(map[string]ControlledDevice)
 	devicePluginsToStop := make(map[string]ControlledDevice)
-	if hostDevs := c.virtConfig.GetPermittedHostDevices(); hostDevs != nil {
-		// generate a map of currently started device plugins
-		for resourceName, hostDevDP := range c.devicePlugins {
-			_, isPermanent := permanentDevicePluginPaths[resourceName]
-			if !isPermanent {
-				devicePluginsToStop[resourceName] = hostDevDP
-			}
+	// generate a map of currently started device plugins
+	for resourceName, hostDevDP := range c.devicePlugins {
+		_, isPermanent := permanentDevicePluginPaths[resourceName]
+		if !isPermanent {
+			devicePluginsToStop[resourceName] = hostDevDP
 		}
+	}
+	if hostDevs := c.virtConfig.GetPermittedHostDevices(); hostDevs != nil {
 		supportedPCIDeviceMap := make(map[string]string)
 		if len(hostDevs.PciHostDevices) != 0 {
 			for _, pciDev := range hostDevs.PciHostDevices {

--- a/pkg/virt-handler/device-manager/device_controller_test.go
+++ b/pkg/virt-handler/device-manager/device_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
@@ -52,18 +53,33 @@ var _ = Describe("Device Controller", func() {
 	var err error
 	var host string
 	var stop chan struct{}
+	var stop1 chan struct{}
+	var stop2 chan struct{}
 	var fakeConfigMap *virtconfig.ClusterConfig
+	var mockPCI *MockDeviceHandler
+	var ctrl *gomock.Controller
 
 	BeforeEach(func() {
-		permittedDevices := `{"pciHostDevices":[{"pciVendorSelector":"DEAD:BEEF","resourceName":"fake-device2","externalResourceProvider":"true"},{"pciVendorSelector":"DEAD:BEEG","resourceName":"fake-device1","externalResourceProvider":"true"}]}`
+		ctrl = gomock.NewController(GinkgoT())
+		mockPCI = NewMockDeviceHandler(ctrl)
+		Handler = mockPCI
+		mockPCI.EXPECT().GetDevicePCIID(gomock.Any(), gomock.Any()).Return("1234:5678", nil).AnyTimes()
+
+		permittedDevices := `{"pciHostDevices":[`
+		permittedDevices += `{"pciVendorSelector":"DEAD:BEE7","resourceName":"example.org/fake-device1","externalResourceProvider":true},`
+		permittedDevices += `{"pciVendorSelector":"DEAD:BEEF","resourceName":"example.org/fake-device2","externalResourceProvider":true}`
+		permittedDevices += `]}`
 		fakeConfigMap, _, _, _ = testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{
 			Data: map[string]string{virtconfig.PermittedHostDevicesKey: permittedDevices},
 		})
+		Expect(fakeConfigMap.GetPermittedHostDevices()).ToNot(BeNil())
 		workDir, err = ioutil.TempDir("", "kubevirt-test")
 		Expect(err).ToNot(HaveOccurred())
 
 		host = "master"
 		stop = make(chan struct{})
+		stop1 = make(chan struct{})
+		stop2 = make(chan struct{})
 	})
 
 	AfterEach(func() {
@@ -107,19 +123,19 @@ var _ = Describe("Device Controller", func() {
 			plugin2 = NewFakePlugin(deviceName2, devicePath2)
 		})
 
-		It("should restart the device plugin immediately without delays", func() {
+		It("should start the device plugin immediately without delays", func() {
 			deviceController := NewDeviceController(host, 10, fakeConfigMap)
 			deviceController.backoff = []time.Duration{10 * time.Millisecond, 10 * time.Second}
 			// New device controllers include the permanent device plugins, we don't want those
 			deviceController.devicePlugins = make(map[string]ControlledDevice)
 			deviceController.devicePlugins[deviceName2] = ControlledDevice{
 				devicePlugin: plugin2,
-				stopChan:     stop,
+				stopChan:     stop2,
 			}
 			go deviceController.Run(stop)
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
-			}, 500*time.Millisecond).Should(BeNumerically(">=", 3))
+			}, 500*time.Millisecond).Should(BeNumerically(">=", 1))
 			Expect(deviceController.Initialized()).To(BeTrue())
 		})
 
@@ -132,7 +148,7 @@ var _ = Describe("Device Controller", func() {
 			deviceController.devicePlugins = make(map[string]ControlledDevice)
 			deviceController.devicePlugins[deviceName2] = ControlledDevice{
 				devicePlugin: plugin2,
-				stopChan:     stop,
+				stopChan:     stop2,
 			}
 			go deviceController.Run(stop)
 			Consistently(func() int {
@@ -147,11 +163,11 @@ var _ = Describe("Device Controller", func() {
 			deviceController.devicePlugins = make(map[string]ControlledDevice)
 			deviceController.devicePlugins[deviceName1] = ControlledDevice{
 				devicePlugin: plugin1,
-				stopChan:     stop,
+				stopChan:     stop1,
 			}
 			deviceController.devicePlugins[deviceName2] = ControlledDevice{
 				devicePlugin: plugin2,
-				stopChan:     stop,
+				stopChan:     stop2,
 			}
 			go deviceController.Run(stop)
 
@@ -165,6 +181,29 @@ var _ = Describe("Device Controller", func() {
 			Eventually(func() int {
 				return int(atomic.LoadInt32(&plugin2.Starts))
 			}).Should(BeNumerically(">=", 1))
+		})
+
+		It("should remove all device plugins if permittedHostDevices is removed from the CR", func() {
+			emptyConfigMap, _, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
+			Expect(emptyConfigMap.GetPermittedHostDevices()).To(BeNil())
+			deviceController := NewDeviceController(host, 10, emptyConfigMap)
+			// New device controllers include the permanent device plugins, we don't want those
+			deviceController.devicePlugins = make(map[string]ControlledDevice)
+			deviceController.devicePlugins[deviceName1] = ControlledDevice{
+				devicePlugin: plugin1,
+				stopChan:     stop1,
+			}
+			deviceController.devicePlugins[deviceName2] = ControlledDevice{
+				devicePlugin: plugin2,
+				stopChan:     stop2,
+			}
+			go deviceController.Run(stop)
+
+			Eventually(func() bool {
+				_, exists1 := deviceController.devicePlugins[deviceName1]
+				_, exists2 := deviceController.devicePlugins[deviceName2]
+				return exists1 || exists2
+			}).Should(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/5350
This is needed to address[ rhbz#1944379](https://bugzilla.redhat.com/show_bug.cgi?id=1944379)

```release-note
Removal of entire `permittedHostDevices` section will now remove all user-defined host device plugins.
```
