### PR TITLE
Reconcile crd

### DIFF
--- a/pkg/virt-operator/resource/apply/generations.go
+++ b/pkg/virt-operator/resource/apply/generations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/api/policy/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -18,6 +19,9 @@ import (
 func getGroupResource(required runtime.Object) (group string, resource string, err error) {
 
 	switch required.(type) {
+	case *extv1.CustomResourceDefinition:
+		group = "apiextensions.k8s.io/v1"
+		resource = "customresourcedefinitions"
 	case *admissionregistrationv1.MutatingWebhookConfiguration:
 		group = "admissionregistration.k8s.io"
 		resource = "mutatingwebhookconfigurations"


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR reconciles CRD resources on change if their annotations or labels do not match the desired, as well as if they are updated and there generation is incremented outside of our reconciliation loop. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile CustomResourceDefinition resources 
```
