### PR TITLE
Remove skips not used by any lane 

### DIFF
--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -74,8 +74,6 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			})
 
 			It("[test_id:782]Should be the fs layout the same for a pod and vmi", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				expectedOutput := "value1value2value3"
 
 				By("Running VMI")
@@ -167,8 +165,6 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 			})
 
 			It("[test_id:779]Should be the fs layout the same for a pod and vmi", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				expectedOutput := "adminredhat"
 
 				By("Running VMI")
@@ -241,8 +237,6 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 		serviceAccountPath := config.ServiceAccountSourceDir
 
 		It("[test_id:998]Should be the namespace and token the same for a pod and vmi", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			By("Running VMI")
 			vmi := tests.NewRandomVMIWithServiceAccount("default")
 			tests.RunVMIAndExpectLaunch(vmi, 90)
@@ -511,8 +505,6 @@ var _ = Describe("[Serial][rfe_id:899][crit:medium][vendor:cnv-qe@redhat.com][le
 		expectedOutput := testLabelKey + "=" + "\"" + testLabelVal + "\""
 
 		It("[test_id:790]Should be the namespace and token the same for a pod and vmi", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			By("Running VMI")
 			vmi := tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 			//Add the testing label to the VMI

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1065,8 +1065,6 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			var wffcPod *k8sv1.Pod
 
 			BeforeEach(func() {
-				tests.SkipNFSTestIfRunnigOnKindInfra()
-
 				quantity, err := resource.ParseQuantity("5Gi")
 				Expect(err).ToNot(HaveOccurred())
 				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -53,8 +53,6 @@ var _ = Describe("[Serial][sig-compute]SecurityFeatures", func() {
 		tests.BeforeAll(func() {
 			kv := tests.GetCurrentKv(virtClient)
 			kubevirtConfiguration = &kv.Spec.Configuration
-
-			tests.SkipSELinuxTestIfRunnigOnKindInfra()
 		})
 
 		var container k8sv1.Container

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -82,8 +82,6 @@ var _ = SIGDescribe("Storage", func() {
 		})
 
 		initNFS := func(targetImage string) *k8sv1.Pod {
-			tests.SkipNFSTestIfRunnigOnKindInfra()
-
 			// Prepare a NFS backed PV
 			By("Starting an NFS POD")
 			nfsPod := storageframework.RenderNFSServer("nfsserver", targetImage)
@@ -154,7 +152,6 @@ var _ = SIGDescribe("Storage", func() {
 					}
 				})
 				table.DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily, imageOwnedByQEMU bool) {
-					tests.SkipPVCTestIfRunnigOnKindInfra()
 					if family == k8sv1.IPv6Protocol {
 						libnet.SkipWhenNotDualStackCluster(virtClient)
 					}
@@ -189,8 +186,6 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 			table.DescribeTable("should be successfully started and stopped multiple times", func(newVMI VMICreationFunc) {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi = newVMI(tests.DiskAlpineHostPath)
 
 				num := 3
@@ -308,8 +303,6 @@ var _ = SIGDescribe("Storage", func() {
 			}, 120)
 
 			It("should be successfully started and virtiofs could be accessed", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				pvcName := fmt.Sprintf("disk-%s", pvc)
 				vmi := tests.NewRandomVMIWithPVCFS(pvcName)
 				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512Mi")
@@ -361,8 +354,6 @@ var _ = SIGDescribe("Storage", func() {
 			})
 
 			It("should be successfully started and virtiofs could be accessed", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi := tests.NewRandomVMIWithFSFromDataVolume(dataVolume.Name)
 				_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -454,7 +445,6 @@ var _ = SIGDescribe("Storage", func() {
 
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
 				table.DescribeTable("started", func(newVMI VMICreationFunc, storageEngine string, family k8sv1.IPFamily) {
-					tests.SkipPVCTestIfRunnigOnKindInfra()
 					if family == k8sv1.IPv6Protocol {
 						libnet.SkipWhenNotDualStackCluster(virtClient)
 					}
@@ -481,8 +471,6 @@ var _ = SIGDescribe("Storage", func() {
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3137]should not persist data", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi = tests.NewRandomVMIWithEphemeralPVC(tests.DiskAlpineHostPath)
 
 				By("Starting the VirtualMachineInstance")
@@ -547,8 +535,6 @@ var _ = SIGDescribe("Storage", func() {
 
 			// Not a candidate for testing on NFS because the VMI is restarted and NFS PVC can't be re-used
 			It("[test_id:3138]should start vmi multiple times", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
-
 				vmi = tests.NewRandomVMIWithPVC(tests.DiskAlpineHostPath)
 				tests.AddPVCDisk(vmi, "disk1", "virtio", tests.DiskCustomHostPath)
 
@@ -892,7 +878,6 @@ var _ = SIGDescribe("Storage", func() {
 
 			// Not a candidate for NFS because local volumes are used in test
 			It("[test_id:1015]should be successfully started", func() {
-				tests.SkipPVCTestIfRunnigOnKindInfra()
 				// Start the VirtualMachineInstance with the PVC attached
 				vmi = tests.NewRandomVMIWithPVC(tests.BlockDiskForTest)
 				// Without userdata the hostname isn't set correctly and the login expecter fails...

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4940,24 +4940,6 @@ func IsRunningOnKindInfra() bool {
 	return strings.HasPrefix(provider, "kind")
 }
 
-func SkipPVCTestIfRunnigOnKindInfra() {
-	if IsRunningOnKindInfra() {
-		Skip("Skip PVC tests till PR https://github.com/kubevirt/kubevirt/pull/3171 is merged")
-	}
-}
-
-func SkipNFSTestIfRunnigOnKindInfra() {
-	if IsRunningOnKindInfra() {
-		Skip("Skip NFS tests till issue https://github.com/kubevirt/kubevirt/issues/3322 is fixed")
-	}
-}
-
-func SkipSELinuxTestIfRunnigOnKindInfra() {
-	if IsRunningOnKindInfra() {
-		Skip("Skip SELinux tests till issue https://github.com/kubevirt/kubevirt/issues/3780 is fixed")
-	}
-}
-
 func IsUsingBuiltinNodeDrainKey() bool {
 	return GetNodeDrainKey() == "node.kubernetes.io/unschedulable"
 }

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1755,8 +1755,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[test_id:1681]should set appropriate cache modes", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			vmi := tests.NewRandomVMI()
 
 			By("adding disks to a VMI")
@@ -1805,8 +1803,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("[test_id:5360]should set appropriate IO modes", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			vmi := tests.NewRandomVMI()
 
 			By("adding disks to a VMI")
@@ -1867,8 +1863,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	Context("Block size configuration set", func() {
 
 		It("Should set BlockIO when using custom block sizes", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			By("creating a block volume")
 			tests.CreateBlockVolumePvAndPvc("1Gi")
 
@@ -1901,8 +1895,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("Should set BlockIO when set to match volume block sizes on block devices", func() {
-			tests.SkipPVCTestIfRunnigOnKindInfra()
-
 			By("creating a block volume")
 			tests.CreateBlockVolumePvAndPvc("1Gi")
 


### PR DESCRIPTION
We previously had a lot of trouble with a lane running on "kubernetes in docker" (kind).
The only remaining use for it is the SR-IOV lane, that only runs a subset of tests.
Remove no longer relevant skips - the issues referenced by the skip are already closed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
