### PR TITLE
Update our README.md to point to kubevirt-dev slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Licensed under Apache License version 2.0](https://img.shields.io/github/license/kubevirt/kubevirt.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Coverage Status](https://img.shields.io/coveralls/kubevirt/kubevirt/master.svg)](https://coveralls.io/github/kubevirt/kubevirt?branch=master)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3203/badge)](https://bestpractices.coreinfrastructure.org/projects/3203)
-[![Visit our Slack channel](https://img.shields.io/badge/slack-@kubernetes/virtualization-40abb8.svg?logo=slack)](https://kubernetes.slack.com/?redir=%2Farchives%2FC8ED7RKFE)
+[![Visit our Slack channel](https://img.shields.io/badge/slack-@kubernetes/kubevirt--dev-40abb8.svg?logo=slack)](https://kubernetes.slack.com/?redir=%2Farchives%2FC0163DT0R8X)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fkubevirt%2Fkubevirt.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fkubevirt%2Fkubevirt?ref=badge_shield)
 
 **KubeVirt** is a virtual machine management add-on for Kubernetes.


### PR DESCRIPTION
The kubevirt-dev slack channel is more targeted for kubevirt related topics that #virtualization. It's also the channel that many of us more closely watch now. Maybe we should consider updating our readme to reflect this. 

```release-note
NONE
```
