### PR TITLE
virt-launcher, agent-poller, Fix replaceTicker logic

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -192,7 +192,7 @@ type PollerWorker struct {
 type agentCommandsExecutor func(commands []AgentCommand)
 
 // Poll is the call to the guestagent
-func (p *PollerWorker) Poll(execAgentCommands agentCommandsExecutor, closeChan chan struct{}) {
+func (p *PollerWorker) Poll(execAgentCommands agentCommandsExecutor, closeChan chan struct{}, initialInterval time.Duration) {
 	log.Log.Infof("Polling command: %v", p.AgentCommands)
 
 	// do the first round to fill the cache immediately
@@ -201,8 +201,8 @@ func (p *PollerWorker) Poll(execAgentCommands agentCommandsExecutor, closeChan c
 	pollMaxInterval := p.CallTick * time.Second
 	pollInterval := pollMaxInterval
 
-	if pollInitialInterval < pollMaxInterval {
-		pollInterval = pollInitialInterval
+	if initialInterval < pollMaxInterval {
+		pollInterval = initialInterval
 	}
 	ticker := time.NewTicker(pollInterval)
 
@@ -297,7 +297,7 @@ func (p *AgentPoller) Start() {
 		log.Log.Infof("Starting agent poller with commands: %v", p.workers[i].AgentCommands)
 		go p.workers[i].Poll(func(commands []AgentCommand) {
 			executeAgentCommands(commands, p.Connection, p.agentStore, p.domainName)
-		}, p.agentDone)
+		}, p.agentDone, pollInitialInterval)
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -223,7 +223,7 @@ func (p *PollerWorker) Poll(execAgentCommands agentCommandsExecutor, closeChan c
 
 func replaceTicker(ticker *time.Ticker, interval time.Duration) *time.Ticker {
 	ticker.Stop()
-	return time.NewTicker(time.Second * interval)
+	return time.NewTicker(interval)
 }
 
 func incrementPollInterval(interval time.Duration, maxInterval time.Duration) time.Duration {

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -106,13 +106,14 @@ var _ = Describe("Qemu agent poller", func() {
 
 		It("executes the agent commands based on the minimum interval at initial run", func() {
 			const interval = 30
-			const expectedExecutions = 2
+			const expectedExecutions = 3
+			const unitTestPollInitialInterval = time.Second
 
-			// Given the initial interval is 10sec, the code under test is expected to execute the commands at time:
-			// 0, 10sec, 10sec + 2*10sec
-			// Therefore, setting a timeout limit of 20sec should cover the first 2 executions.
-			t := 2 * pollInitialInterval
-			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, t, pollInitialInterval)
+			// Given the initial interval is 1sec, the code under test is expected to execute the commands at time:
+			// 0, 1sec, 1sec + 2*1sec
+			// Therefore, setting a timeout limit of 4sec+ should cover the first 3 executions.
+			t := 10 * unitTestPollInitialInterval
+			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, t, unitTestPollInitialInterval)
 
 			Expect(commandExecutions).To(Equal(expectedExecutions))
 		})

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Qemu agent poller", func() {
 			const interval = 1
 			const expectedExecutions = 1
 
-			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, 0)
+			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, 0, pollInitialInterval)
 
 			Expect(commandExecutions).To(Equal(expectedExecutions))
 		})
@@ -99,7 +99,7 @@ var _ = Describe("Qemu agent poller", func() {
 			const interval = 1
 			const expectedExecutions = 3
 
-			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, 0)
+			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, 0, pollInitialInterval)
 
 			Expect(commandExecutions).To(Equal(expectedExecutions))
 		})
@@ -112,7 +112,7 @@ var _ = Describe("Qemu agent poller", func() {
 			// 0, 10sec, 10sec + 2*10sec
 			// Therefore, setting a timeout limit of 20sec should cover the first 2 executions.
 			t := 2 * pollInitialInterval
-			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, t)
+			commandExecutions := runPollAndCountCommandExecution(interval, expectedExecutions, t, pollInitialInterval)
 
 			Expect(commandExecutions).To(Equal(expectedExecutions))
 		})
@@ -124,7 +124,7 @@ var _ = Describe("Qemu agent poller", func() {
 // The operation is limited by the provided or self calculated timeout and the expected executions.
 // The timeout needs to be large enough to allow the expected executions to occur and to accommodate the
 // inaccuracy of the go-routine execution.
-func runPollAndCountCommandExecution(interval, expectedExecutions int, timeout time.Duration) int {
+func runPollAndCountCommandExecution(interval, expectedExecutions int, timeout time.Duration, initialInterval time.Duration) int {
 	const fakeAgentCommandName = "foo"
 	w := PollerWorker{
 		CallTick:      time.Duration(interval),
@@ -136,7 +136,7 @@ func runPollAndCountCommandExecution(interval, expectedExecutions int, timeout t
 	defer close(c)
 	done := make(chan struct{})
 
-	go w.Poll(func(commands []AgentCommand) { done <- struct{}{} }, c)
+	go w.Poll(func(commands []AgentCommand) { done <- struct{}{} }, c, initialInterval)
 
 	if timeout == 0 {
 		// Calculate the time needed for the poll to execute the commands.


### PR DESCRIPTION
Guest agent poller timer has exponential backoff logic.
Since interval is already a time.Duration, it means it is already multiplied
by time.Second (see `pollInitialInterval` declaration).

Multiplying it again, will result in multiplying it by
1,000,000,000, and the pollers whose ticker is updated
won't be run for a long time, since the new
interval is not the expected one, but much bigger.

Fix it by removing the extra unneeded multiply.

Fix unit tests to validate the exponential backoff logic.

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
