### PR TITLE
Paused VMIs should remain paused after migration

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1341,8 +1341,9 @@ var _ = Describe("Manager", func() {
 			isUnsafeMigration := migrationType == "unsafe"
 			allowAutoConverge := migrationType == "autoConverge"
 			migrationMode := migrationType == "postCopy"
+			isVmiPaused := migrationType == "paused"
 
-			flags := prepareMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, migrationMode)
+			flags := prepareMigrationFlags(isBlockMigration, isUnsafeMigration, allowAutoConverge, migrationMode, isVmiPaused)
 			expectedMigrateFlags := libvirt.MIGRATE_LIVE | libvirt.MIGRATE_PEER2PEER | libvirt.MIGRATE_PERSIST_DEST
 
 			if isBlockMigration {
@@ -1356,6 +1357,9 @@ var _ = Describe("Manager", func() {
 			if migrationType == "postCopy" {
 				expectedMigrateFlags |= libvirt.MIGRATE_POSTCOPY
 			}
+			if migrationType == "paused" {
+				expectedMigrateFlags |= libvirt.MIGRATE_PAUSED
+			}
 			Expect(flags).To(Equal(expectedMigrateFlags))
 		},
 		table.Entry("with block migration", "block"),
@@ -1363,6 +1367,7 @@ var _ = Describe("Manager", func() {
 		table.Entry("unsafe migration", "unsafe"),
 		table.Entry("migration auto converge", "autoConverge"),
 		table.Entry("migration using postcopy", "postCopy"),
+		table.Entry("migration of paused vmi", "paused"),
 	)
 
 	table.DescribeTable("on successful list all domains",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3246,7 +3246,6 @@ func LibvirtDomainIsPaused(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMac
 	return strings.Contains(stdout, "paused"), nil
 }
 
-
 func LibvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
 	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, NamespaceTestDefault)
 	if err != nil {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3216,6 +3216,37 @@ func GetRunningVirtualMachineInstanceDomainXML(virtClient kubecli.KubevirtClient
 	return stdout, err
 }
 
+func LibvirtDomainIsPaused(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
+	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, NamespaceTestDefault)
+	if err != nil {
+		return false, err
+	}
+
+	found := false
+	containerIdx := 0
+	for idx, container := range vmiPod.Spec.Containers {
+		if container.Name == "compute" {
+			containerIdx = idx
+			found = true
+		}
+	}
+	if !found {
+		return false, fmt.Errorf("could not find compute container for pod")
+	}
+
+	stdout, stderr, err := ExecuteCommandOnPodV2(
+		virtClient,
+		vmiPod,
+		vmiPod.Spec.Containers[containerIdx].Name,
+		[]string{"virsh", "--quiet", "domstate", vmi.Namespace + "_" + vmi.Name},
+	)
+	if err != nil {
+		return false, fmt.Errorf("could not get libvirt domstate (remotely on pod): %v: %s", err, stderr)
+	}
+	return strings.Contains(stdout, "paused"), nil
+}
+
+
 func LibvirtDomainIsPersistent(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineInstance) (bool, error) {
 	vmiPod, err := getRunningPodByVirtualMachineInstance(vmi, NamespaceTestDefault)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, VMIs in a paused state are being unpaused after migration.
This PR simply adds a flag to indicate that these VMIs shouldn't be unpaused on destination.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [RHBZ#1939987]( https://bugzilla.redhat.com/show_bug.cgi?id=1939987)
**Release note**:
```release-note
NONE
```
