### PR TITLE
virt-chroot envinfo flag, reporting user and capabilities

### DIFF
--- a/cmd/virt-chroot/BUILD.bazel
+++ b/cmd/virt-chroot/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "envinfo.go",
         "main.go",
         "selinux.go",
         "tap-device-maker.go",
@@ -12,6 +13,7 @@ go_library(
     deps = [
         "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/syndtr/gocapability/capability:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
     ],

--- a/cmd/virt-chroot/envinfo.go
+++ b/cmd/virt-chroot/envinfo.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"os/user"
 
 	"github.com/spf13/cobra"
 	"github.com/syndtr/gocapability/capability"
@@ -39,7 +40,13 @@ func executeEnvInfo() error {
 		return nil
 	}
 
-	return reportCapabilities(0)
+	if err := reportUser(); err != nil {
+		return err
+	}
+	if err := reportCapabilities(0); err != nil {
+		return err
+	}
+	return nil
 }
 
 func reportCapabilities(pid int32) error {
@@ -53,6 +60,16 @@ func reportCapabilities(pid int32) error {
 	}
 
 	fmt.Printf("Capabilities:\n%s\n\n", caps)
+
+	return nil
+}
+
+func reportUser() error {
+	selfUser, err := user.Current()
+	if err != nil {
+		return fmt.Errorf("unable to report user information: %v", err)
+	}
+	fmt.Printf("\nUser: %s (%s/%s)\n", selfUser.Username, selfUser.Uid, selfUser.Gid)
 
 	return nil
 }

--- a/cmd/virt-chroot/envinfo.go
+++ b/cmd/virt-chroot/envinfo.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/syndtr/gocapability/capability"
+)
+
+var (
+	envinfo bool
+)
+
+func addEnvInfoPersistentFlag(command *cobra.Command) {
+	command.PersistentFlags().BoolVar(&envinfo, "envinfo", false, "Report environment information")
+}
+
+func executeEnvInfo() error {
+	if !envinfo {
+		return nil
+	}
+
+	return reportCapabilities(0)
+}
+
+func reportCapabilities(pid int32) error {
+	caps, err := capability.NewPid2(0)
+	if err != nil {
+		return fmt.Errorf("unable to report capabilities: %v", err)
+	}
+
+	if err := caps.Load(); err != nil {
+		return fmt.Errorf("unable to report capabilities: %v", err)
+	}
+
+	fmt.Printf("Capabilities:\n%s\n\n", caps)
+
+	return nil
+}

--- a/cmd/virt-chroot/main.go
+++ b/cmd/virt-chroot/main.go
@@ -100,8 +100,12 @@ func main() {
 					return fmt.Errorf("failed to switch to user: %v", err)
 				}
 			}
-			return nil
 
+			if err := executeEnvInfo(); err != nil {
+				return err
+			}
+
+			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			_, _ = fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
@@ -112,6 +116,8 @@ func main() {
 	rootCmd.PersistentFlags().Uint32Var(&megabyte, "memory", 0, "memory in megabyte for the process")
 	rootCmd.PersistentFlags().StringVar(&mntNamespace, "mount", "", "mount namespace to use")
 	rootCmd.PersistentFlags().StringVar(&targetUser, "user", "", "switch to this targetUser to e.g. drop privileges")
+
+	addEnvInfoPersistentFlag(rootCmd)
 
 	execCmd := &cobra.Command{
 		Use:   "exec",

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/subgraph/libmacouflage v0.0.1
+	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/vishvananda/netlink v1.1.1-0.20200914145417-7484f55b2263
 	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad
 	golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f

--- a/go.sum
+++ b/go.sum
@@ -803,6 +803,7 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subgraph/libmacouflage v0.0.1 h1:DTzVhFxtANTflvNPhMLGP9c8NxSZzdK2JHIwDEdzX/g=
 github.com/subgraph/libmacouflage v0.0.1/go.mod h1:wTajnv9uXMczTL0k32UMV2oXzTsNDs0A5tfZT60J5oc=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -442,6 +442,7 @@ func buildTapDeviceMaker(tapName string, queueNumber uint32, virtLauncherPID int
 		"--gid", tapOwner,
 		"--queue-number", fmt.Sprintf("%d", queueNumber),
 		"--mtu", fmt.Sprintf("%d", mtu),
+		"--envinfo",
 	}
 	// #nosec No risk for attacket injection. createTapDeviceArgs includes predefined strings
 	cmd := exec.Command("virt-chroot", createTapDeviceArgs...)

--- a/vendor/github.com/syndtr/gocapability/LICENSE
+++ b/vendor/github.com/syndtr/gocapability/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2013 Suryandaru Triandana <syndtr@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/syndtr/gocapability/capability/BUILD.bazel
+++ b/vendor/github.com/syndtr/gocapability/capability/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "capability.go",
+        "capability_linux.go",
+        "capability_noop.go",
+        "enum.go",
+        "enum_gen.go",
+        "syscall_linux.go",
+    ],
+    importmap = "kubevirt.io/kubevirt/vendor/github.com/syndtr/gocapability/capability",
+    importpath = "github.com/syndtr/gocapability/capability",
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/syndtr/gocapability/capability/capability.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Package capability provides utilities for manipulating POSIX capabilities.
+package capability
+
+type Capabilities interface {
+	// Get check whether a capability present in the given
+	// capabilities set. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE, BOUNDING or AMBIENT.
+	Get(which CapType, what Cap) bool
+
+	// Empty check whether all capability bits of the given capabilities
+	// set are zero. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE, BOUNDING or AMBIENT.
+	Empty(which CapType) bool
+
+	// Full check whether all capability bits of the given capabilities
+	// set are one. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE, BOUNDING or AMBIENT.
+	Full(which CapType) bool
+
+	// Set sets capabilities of the given capabilities sets. The
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE, BOUNDING or AMBIENT.
+	Set(which CapType, caps ...Cap)
+
+	// Unset unsets capabilities of the given capabilities sets. The
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE, BOUNDING or AMBIENT.
+	Unset(which CapType, caps ...Cap)
+
+	// Fill sets all bits of the given capabilities kind to one. The
+	// 'kind' value should be one or combination (OR'ed) of CAPS,
+	// BOUNDS or AMBS.
+	Fill(kind CapType)
+
+	// Clear sets all bits of the given capabilities kind to zero. The
+	// 'kind' value should be one or combination (OR'ed) of CAPS,
+	// BOUNDS or AMBS.
+	Clear(kind CapType)
+
+	// String return current capabilities state of the given capabilities
+	// set as string. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE BOUNDING or AMBIENT
+	StringCap(which CapType) string
+
+	// String return current capabilities state as string.
+	String() string
+
+	// Load load actual capabilities value. This will overwrite all
+	// outstanding changes.
+	Load() error
+
+	// Apply apply the capabilities settings, so all changes will take
+	// effect.
+	Apply(kind CapType) error
+}
+
+// NewPid initializes a new Capabilities object for given pid when
+// it is nonzero, or for the current process if pid is 0.
+//
+// Deprecated: Replace with NewPid2.  For example, replace:
+//
+//    c, err := NewPid(0)
+//    if err != nil {
+//      return err
+//    }
+//
+// with:
+//
+//    c, err := NewPid2(0)
+//    if err != nil {
+//      return err
+//    }
+//    err = c.Load()
+//    if err != nil {
+//      return err
+//    }
+func NewPid(pid int) (Capabilities, error) {
+	c, err := newPid(pid)
+	if err != nil {
+		return c, err
+	}
+	err = c.Load()
+	return c, err
+}
+
+// NewPid2 initializes a new Capabilities object for given pid when
+// it is nonzero, or for the current process if pid is 0.  This
+// does not load the process's current capabilities; to do that you
+// must call Load explicitly.
+func NewPid2(pid int) (Capabilities, error) {
+	return newPid(pid)
+}
+
+// NewFile initializes a new Capabilities object for given file path.
+//
+// Deprecated: Replace with NewFile2.  For example, replace:
+//
+//    c, err := NewFile(path)
+//    if err != nil {
+//      return err
+//    }
+//
+// with:
+//
+//    c, err := NewFile2(path)
+//    if err != nil {
+//      return err
+//    }
+//    err = c.Load()
+//    if err != nil {
+//      return err
+//    }
+func NewFile(path string) (Capabilities, error) {
+	c, err := newFile(path)
+	if err != nil {
+		return c, err
+	}
+	err = c.Load()
+	return c, err
+}
+
+// NewFile2 creates a new initialized Capabilities object for given
+// file path.  This does not load the process's current capabilities;
+// to do that you must call Load explicitly.
+func NewFile2(path string) (Capabilities, error) {
+	return newFile(path)
+}

--- a/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -1,0 +1,642 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+var errUnknownVers = errors.New("unknown capability version")
+
+const (
+	linuxCapVer1 = 0x19980330
+	linuxCapVer2 = 0x20071026
+	linuxCapVer3 = 0x20080522
+)
+
+var (
+	capVers    uint32
+	capLastCap Cap
+)
+
+func init() {
+	var hdr capHeader
+	capget(&hdr, nil)
+	capVers = hdr.version
+
+	if initLastCap() == nil {
+		CAP_LAST_CAP = capLastCap
+		if capLastCap > 31 {
+			capUpperMask = (uint32(1) << (uint(capLastCap) - 31)) - 1
+		} else {
+			capUpperMask = 0
+		}
+	}
+}
+
+func initLastCap() error {
+	if capLastCap != 0 {
+		return nil
+	}
+
+	f, err := os.Open("/proc/sys/kernel/cap_last_cap")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var b []byte = make([]byte, 11)
+	_, err = f.Read(b)
+	if err != nil {
+		return err
+	}
+
+	fmt.Sscanf(string(b), "%d", &capLastCap)
+
+	return nil
+}
+
+func mkStringCap(c Capabilities, which CapType) (ret string) {
+	for i, first := Cap(0), true; i <= CAP_LAST_CAP; i++ {
+		if !c.Get(which, i) {
+			continue
+		}
+		if first {
+			first = false
+		} else {
+			ret += ", "
+		}
+		ret += i.String()
+	}
+	return
+}
+
+func mkString(c Capabilities, max CapType) (ret string) {
+	ret = "{"
+	for i := CapType(1); i <= max; i <<= 1 {
+		ret += " " + i.String() + "=\""
+		if c.Empty(i) {
+			ret += "empty"
+		} else if c.Full(i) {
+			ret += "full"
+		} else {
+			ret += c.StringCap(i)
+		}
+		ret += "\""
+	}
+	ret += " }"
+	return
+}
+
+func newPid(pid int) (c Capabilities, err error) {
+	switch capVers {
+	case linuxCapVer1:
+		p := new(capsV1)
+		p.hdr.version = capVers
+		p.hdr.pid = int32(pid)
+		c = p
+	case linuxCapVer2, linuxCapVer3:
+		p := new(capsV3)
+		p.hdr.version = capVers
+		p.hdr.pid = int32(pid)
+		c = p
+	default:
+		err = errUnknownVers
+		return
+	}
+	return
+}
+
+type capsV1 struct {
+	hdr  capHeader
+	data capData
+}
+
+func (c *capsV1) Get(which CapType, what Cap) bool {
+	if what > 32 {
+		return false
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data.effective != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data.permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data.inheritable != 0
+	}
+
+	return false
+}
+
+func (c *capsV1) getData(which CapType) (ret uint32) {
+	switch which {
+	case EFFECTIVE:
+		ret = c.data.effective
+	case PERMITTED:
+		ret = c.data.permitted
+	case INHERITABLE:
+		ret = c.data.inheritable
+	}
+	return
+}
+
+func (c *capsV1) Empty(which CapType) bool {
+	return c.getData(which) == 0
+}
+
+func (c *capsV1) Full(which CapType) bool {
+	return (c.getData(which) & 0x7fffffff) == 0x7fffffff
+}
+
+func (c *capsV1) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		if what > 32 {
+			continue
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data.permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data.inheritable |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsV1) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		if what > 32 {
+			continue
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data.permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data.inheritable &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsV1) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective = 0x7fffffff
+		c.data.permitted = 0x7fffffff
+		c.data.inheritable = 0
+	}
+}
+
+func (c *capsV1) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective = 0
+		c.data.permitted = 0
+		c.data.inheritable = 0
+	}
+}
+
+func (c *capsV1) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsV1) String() (ret string) {
+	return mkString(c, BOUNDING)
+}
+
+func (c *capsV1) Load() (err error) {
+	return capget(&c.hdr, &c.data)
+}
+
+func (c *capsV1) Apply(kind CapType) error {
+	if kind&CAPS == CAPS {
+		return capset(&c.hdr, &c.data)
+	}
+	return nil
+}
+
+type capsV3 struct {
+	hdr     capHeader
+	data    [2]capData
+	bounds  [2]uint32
+	ambient [2]uint32
+}
+
+func (c *capsV3) Get(which CapType, what Cap) bool {
+	var i uint
+	if what > 31 {
+		i = uint(what) >> 5
+		what %= 32
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data[i].effective != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data[i].permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data[i].inheritable != 0
+	case BOUNDING:
+		return (1<<uint(what))&c.bounds[i] != 0
+	case AMBIENT:
+		return (1<<uint(what))&c.ambient[i] != 0
+	}
+
+	return false
+}
+
+func (c *capsV3) getData(which CapType, dest []uint32) {
+	switch which {
+	case EFFECTIVE:
+		dest[0] = c.data[0].effective
+		dest[1] = c.data[1].effective
+	case PERMITTED:
+		dest[0] = c.data[0].permitted
+		dest[1] = c.data[1].permitted
+	case INHERITABLE:
+		dest[0] = c.data[0].inheritable
+		dest[1] = c.data[1].inheritable
+	case BOUNDING:
+		dest[0] = c.bounds[0]
+		dest[1] = c.bounds[1]
+	case AMBIENT:
+		dest[0] = c.ambient[0]
+		dest[1] = c.ambient[1]
+	}
+}
+
+func (c *capsV3) Empty(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	return data[0] == 0 && data[1] == 0
+}
+
+func (c *capsV3) Full(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	if (data[0] & 0xffffffff) != 0xffffffff {
+		return false
+	}
+	return (data[1] & capUpperMask) == capUpperMask
+}
+
+func (c *capsV3) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data[i].effective |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data[i].permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data[i].inheritable |= 1 << uint(what)
+		}
+		if which&BOUNDING != 0 {
+			c.bounds[i] |= 1 << uint(what)
+		}
+		if which&AMBIENT != 0 {
+			c.ambient[i] |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsV3) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data[i].effective &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data[i].permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data[i].inheritable &= ^(1 << uint(what))
+		}
+		if which&BOUNDING != 0 {
+			c.bounds[i] &= ^(1 << uint(what))
+		}
+		if which&AMBIENT != 0 {
+			c.ambient[i] &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsV3) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data[0].effective = 0xffffffff
+		c.data[0].permitted = 0xffffffff
+		c.data[0].inheritable = 0
+		c.data[1].effective = 0xffffffff
+		c.data[1].permitted = 0xffffffff
+		c.data[1].inheritable = 0
+	}
+
+	if kind&BOUNDS == BOUNDS {
+		c.bounds[0] = 0xffffffff
+		c.bounds[1] = 0xffffffff
+	}
+	if kind&AMBS == AMBS {
+		c.ambient[0] = 0xffffffff
+		c.ambient[1] = 0xffffffff
+	}
+}
+
+func (c *capsV3) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data[0].effective = 0
+		c.data[0].permitted = 0
+		c.data[0].inheritable = 0
+		c.data[1].effective = 0
+		c.data[1].permitted = 0
+		c.data[1].inheritable = 0
+	}
+
+	if kind&BOUNDS == BOUNDS {
+		c.bounds[0] = 0
+		c.bounds[1] = 0
+	}
+	if kind&AMBS == AMBS {
+		c.ambient[0] = 0
+		c.ambient[1] = 0
+	}
+}
+
+func (c *capsV3) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsV3) String() (ret string) {
+	return mkString(c, BOUNDING)
+}
+
+func (c *capsV3) Load() (err error) {
+	err = capget(&c.hdr, &c.data[0])
+	if err != nil {
+		return
+	}
+
+	var status_path string
+
+	if c.hdr.pid == 0 {
+		status_path = fmt.Sprintf("/proc/self/status")
+	} else {
+		status_path = fmt.Sprintf("/proc/%d/status", c.hdr.pid)
+	}
+
+	f, err := os.Open(status_path)
+	if err != nil {
+		return
+	}
+	b := bufio.NewReader(f)
+	for {
+		line, e := b.ReadString('\n')
+		if e != nil {
+			if e != io.EOF {
+				err = e
+			}
+			break
+		}
+		if strings.HasPrefix(line, "CapB") {
+			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
+			continue
+		}
+		if strings.HasPrefix(line, "CapA") {
+			fmt.Sscanf(line[4:], "mb:  %08x%08x", &c.ambient[1], &c.ambient[0])
+			continue
+		}
+	}
+	f.Close()
+
+	return
+}
+
+func (c *capsV3) Apply(kind CapType) (err error) {
+	if kind&BOUNDS == BOUNDS {
+		var data [2]capData
+		err = capget(&c.hdr, &data[0])
+		if err != nil {
+			return
+		}
+		if (1<<uint(CAP_SETPCAP))&data[0].effective != 0 {
+			for i := Cap(0); i <= CAP_LAST_CAP; i++ {
+				if c.Get(BOUNDING, i) {
+					continue
+				}
+				err = prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0)
+				if err != nil {
+					// Ignore EINVAL since the capability may not be supported in this system.
+					if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+						err = nil
+						continue
+					}
+					return
+				}
+			}
+		}
+	}
+
+	if kind&CAPS == CAPS {
+		err = capset(&c.hdr, &c.data[0])
+		if err != nil {
+			return
+		}
+	}
+
+	if kind&AMBS == AMBS {
+		for i := Cap(0); i <= CAP_LAST_CAP; i++ {
+			action := pr_CAP_AMBIENT_LOWER
+			if c.Get(AMBIENT, i) {
+				action = pr_CAP_AMBIENT_RAISE
+			}
+			err := prctl(pr_CAP_AMBIENT, action, uintptr(i), 0, 0)
+			// Ignore EINVAL as not supported on kernels before 4.3
+			if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+				err = nil
+				continue
+			}
+		}
+	}
+
+	return
+}
+
+func newFile(path string) (c Capabilities, err error) {
+	c = &capsFile{path: path}
+	return
+}
+
+type capsFile struct {
+	path string
+	data vfscapData
+}
+
+func (c *capsFile) Get(which CapType, what Cap) bool {
+	var i uint
+	if what > 31 {
+		if c.data.version == 1 {
+			return false
+		}
+		i = uint(what) >> 5
+		what %= 32
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data.effective[i] != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data.data[i].permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data.data[i].inheritable != 0
+	}
+
+	return false
+}
+
+func (c *capsFile) getData(which CapType, dest []uint32) {
+	switch which {
+	case EFFECTIVE:
+		dest[0] = c.data.effective[0]
+		dest[1] = c.data.effective[1]
+	case PERMITTED:
+		dest[0] = c.data.data[0].permitted
+		dest[1] = c.data.data[1].permitted
+	case INHERITABLE:
+		dest[0] = c.data.data[0].inheritable
+		dest[1] = c.data.data[1].inheritable
+	}
+}
+
+func (c *capsFile) Empty(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	return data[0] == 0 && data[1] == 0
+}
+
+func (c *capsFile) Full(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	if c.data.version == 0 {
+		return (data[0] & 0x7fffffff) == 0x7fffffff
+	}
+	if (data[0] & 0xffffffff) != 0xffffffff {
+		return false
+	}
+	return (data[1] & capUpperMask) == capUpperMask
+}
+
+func (c *capsFile) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			if c.data.version == 1 {
+				continue
+			}
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective[i] |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data.data[i].permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data.data[i].inheritable |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsFile) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			if c.data.version == 1 {
+				continue
+			}
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective[i] &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data.data[i].permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data.data[i].inheritable &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsFile) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective[0] = 0xffffffff
+		c.data.data[0].permitted = 0xffffffff
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
+			c.data.effective[1] = 0xffffffff
+			c.data.data[1].permitted = 0xffffffff
+			c.data.data[1].inheritable = 0
+		}
+	}
+}
+
+func (c *capsFile) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective[0] = 0
+		c.data.data[0].permitted = 0
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
+			c.data.effective[1] = 0
+			c.data.data[1].permitted = 0
+			c.data.data[1].inheritable = 0
+		}
+	}
+}
+
+func (c *capsFile) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsFile) String() (ret string) {
+	return mkString(c, INHERITABLE)
+}
+
+func (c *capsFile) Load() (err error) {
+	return getVfsCap(c.path, &c.data)
+}
+
+func (c *capsFile) Apply(kind CapType) (err error) {
+	if kind&CAPS == CAPS {
+		return setVfsCap(c.path, &c.data)
+	}
+	return
+}

--- a/vendor/github.com/syndtr/gocapability/capability/capability_noop.go
+++ b/vendor/github.com/syndtr/gocapability/capability/capability_noop.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// +build !linux
+
+package capability
+
+import "errors"
+
+func newPid(pid int) (Capabilities, error) {
+	return nil, errors.New("not supported")
+}
+
+func newFile(path string) (Capabilities, error) {
+	return nil, errors.New("not supported")
+}

--- a/vendor/github.com/syndtr/gocapability/capability/enum.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum.go
@@ -1,0 +1,268 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+type CapType uint
+
+func (c CapType) String() string {
+	switch c {
+	case EFFECTIVE:
+		return "effective"
+	case PERMITTED:
+		return "permitted"
+	case INHERITABLE:
+		return "inheritable"
+	case BOUNDING:
+		return "bounding"
+	case CAPS:
+		return "caps"
+	case AMBIENT:
+		return "ambient"
+	}
+	return "unknown"
+}
+
+const (
+	EFFECTIVE CapType = 1 << iota
+	PERMITTED
+	INHERITABLE
+	BOUNDING
+	AMBIENT
+
+	CAPS   = EFFECTIVE | PERMITTED | INHERITABLE
+	BOUNDS = BOUNDING
+	AMBS   = AMBIENT
+)
+
+//go:generate go run enumgen/gen.go
+type Cap int
+
+// POSIX-draft defined capabilities.
+const (
+	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+	// overrides the restriction of changing file ownership and group
+	// ownership.
+	CAP_CHOWN = Cap(0)
+
+	// Override all DAC access, including ACL execute access if
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
+	CAP_DAC_OVERRIDE = Cap(1)
+
+	// Overrides all DAC restrictions regarding read and search on files
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
+	CAP_DAC_READ_SEARCH = Cap(2)
+
+	// Overrides all restrictions about allowed operations on files, where
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
+	CAP_FOWNER = Cap(3)
+
+	// Overrides the following restrictions that the effective user ID
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
+	CAP_FSETID = Cap(4)
+
+	// Overrides the restriction that the real or effective user ID of a
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
+	CAP_KILL = Cap(5)
+
+	// Allows setgid(2) manipulation
+	// Allows setgroups(2)
+	// Allows forged gids on socket credentials passing.
+	CAP_SETGID = Cap(6)
+
+	// Allows set*uid(2) manipulation (including fsuid).
+	// Allows forged pids on socket credentials passing.
+	CAP_SETUID = Cap(7)
+
+	// Linux-specific capabilities
+
+	// Without VFS support for capabilities:
+	//   Transfer any capability in your permitted set to any pid,
+	//   remove any capability in your permitted set from any pid
+	// With VFS support for capabilities (neither of above, but)
+	//   Add any capability from current's capability bounding set
+	//     to the current process' inheritable set
+	//   Allow taking bits out of capability bounding set
+	//   Allow modification of the securebits for a process
+	CAP_SETPCAP = Cap(8)
+
+	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
+	CAP_LINUX_IMMUTABLE = Cap(9)
+
+	// Allows binding to TCP/UDP sockets below 1024
+	// Allows binding to ATM VCIs below 32
+	CAP_NET_BIND_SERVICE = Cap(10)
+
+	// Allow broadcasting, listen to multicast
+	CAP_NET_BROADCAST = Cap(11)
+
+	// Allow interface configuration
+	// Allow administration of IP firewall, masquerading and accounting
+	// Allow setting debug option on sockets
+	// Allow modification of routing tables
+	// Allow setting arbitrary process / process group ownership on
+	// sockets
+	// Allow binding to any address for transparent proxying (also via NET_RAW)
+	// Allow setting TOS (type of service)
+	// Allow setting promiscuous mode
+	// Allow clearing driver statistics
+	// Allow multicasting
+	// Allow read/write of device-specific registers
+	// Allow activation of ATM control sockets
+	CAP_NET_ADMIN = Cap(12)
+
+	// Allow use of RAW sockets
+	// Allow use of PACKET sockets
+	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
+	CAP_NET_RAW = Cap(13)
+
+	// Allow locking of shared memory segments
+	// Allow mlock and mlockall (which doesn't really have anything to do
+	// with IPC)
+	CAP_IPC_LOCK = Cap(14)
+
+	// Override IPC ownership checks
+	CAP_IPC_OWNER = Cap(15)
+
+	// Insert and remove kernel modules - modify kernel without limit
+	CAP_SYS_MODULE = Cap(16)
+
+	// Allow ioperm/iopl access
+	// Allow sending USB messages to any device via /proc/bus/usb
+	CAP_SYS_RAWIO = Cap(17)
+
+	// Allow use of chroot()
+	CAP_SYS_CHROOT = Cap(18)
+
+	// Allow ptrace() of any process
+	CAP_SYS_PTRACE = Cap(19)
+
+	// Allow configuration of process accounting
+	CAP_SYS_PACCT = Cap(20)
+
+	// Allow configuration of the secure attention key
+	// Allow administration of the random device
+	// Allow examination and configuration of disk quotas
+	// Allow setting the domainname
+	// Allow setting the hostname
+	// Allow calling bdflush()
+	// Allow mount() and umount(), setting up new smb connection
+	// Allow some autofs root ioctls
+	// Allow nfsservctl
+	// Allow VM86_REQUEST_IRQ
+	// Allow to read/write pci config on alpha
+	// Allow irix_prctl on mips (setstacksize)
+	// Allow flushing all cache on m68k (sys_cacheflush)
+	// Allow removing semaphores
+	// Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+	// and shared memory
+	// Allow locking/unlocking of shared memory segment
+	// Allow turning swap on/off
+	// Allow forged pids on socket credentials passing
+	// Allow setting readahead and flushing buffers on block devices
+	// Allow setting geometry in floppy driver
+	// Allow turning DMA on/off in xd driver
+	// Allow administration of md devices (mostly the above, but some
+	// extra ioctls)
+	// Allow tuning the ide driver
+	// Allow access to the nvram device
+	// Allow administration of apm_bios, serial and bttv (TV) device
+	// Allow manufacturer commands in isdn CAPI support driver
+	// Allow reading non-standardized portions of pci configuration space
+	// Allow DDI debug ioctl on sbpcd driver
+	// Allow setting up serial ports
+	// Allow sending raw qic-117 commands
+	// Allow enabling/disabling tagged queuing on SCSI controllers and sending
+	// arbitrary SCSI commands
+	// Allow setting encryption key on loopback filesystem
+	// Allow setting zone reclaim policy
+	CAP_SYS_ADMIN = Cap(21)
+
+	// Allow use of reboot()
+	CAP_SYS_BOOT = Cap(22)
+
+	// Allow raising priority and setting priority on other (different
+	// UID) processes
+	// Allow use of FIFO and round-robin (realtime) scheduling on own
+	// processes and setting the scheduling algorithm used by another
+	// process.
+	// Allow setting cpu affinity on other processes
+	CAP_SYS_NICE = Cap(23)
+
+	// Override resource limits. Set resource limits.
+	// Override quota limits.
+	// Override reserved space on ext2 filesystem
+	// Modify data journaling mode on ext3 filesystem (uses journaling
+	// resources)
+	// NOTE: ext2 honors fsuid when checking for resource overrides, so
+	// you can override using fsuid too
+	// Override size restrictions on IPC message queues
+	// Allow more than 64hz interrupts from the real-time clock
+	// Override max number of consoles on console allocation
+	// Override max number of keymaps
+	CAP_SYS_RESOURCE = Cap(24)
+
+	// Allow manipulation of system clock
+	// Allow irix_stime on mips
+	// Allow setting the real-time clock
+	CAP_SYS_TIME = Cap(25)
+
+	// Allow configuration of tty devices
+	// Allow vhangup() of tty
+	CAP_SYS_TTY_CONFIG = Cap(26)
+
+	// Allow the privileged aspects of mknod()
+	CAP_MKNOD = Cap(27)
+
+	// Allow taking of leases on files
+	CAP_LEASE = Cap(28)
+
+	CAP_AUDIT_WRITE   = Cap(29)
+	CAP_AUDIT_CONTROL = Cap(30)
+	CAP_SETFCAP       = Cap(31)
+
+	// Override MAC access.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
+	CAP_MAC_OVERRIDE = Cap(32)
+
+	// Allow MAC configuration or state changes.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
+	CAP_MAC_ADMIN = Cap(33)
+
+	// Allow configuring the kernel's syslog (printk behaviour)
+	CAP_SYSLOG = Cap(34)
+
+	// Allow triggering something that will wake the system
+	CAP_WAKE_ALARM = Cap(35)
+
+	// Allow preventing system suspends
+	CAP_BLOCK_SUSPEND = Cap(36)
+
+	// Allow reading audit messages from the kernel
+	CAP_AUDIT_READ = Cap(37)
+)
+
+var (
+	// Highest valid capability of the running kernel.
+	CAP_LAST_CAP = Cap(63)
+
+	capUpperMask = ^uint32(0)
+)

--- a/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
+++ b/vendor/github.com/syndtr/gocapability/capability/enum_gen.go
@@ -1,0 +1,129 @@
+// generated file; DO NOT EDIT - use go generate in directory with source
+
+package capability
+
+func (c Cap) String() string {
+	switch c {
+	case CAP_CHOWN:
+		return "chown"
+	case CAP_DAC_OVERRIDE:
+		return "dac_override"
+	case CAP_DAC_READ_SEARCH:
+		return "dac_read_search"
+	case CAP_FOWNER:
+		return "fowner"
+	case CAP_FSETID:
+		return "fsetid"
+	case CAP_KILL:
+		return "kill"
+	case CAP_SETGID:
+		return "setgid"
+	case CAP_SETUID:
+		return "setuid"
+	case CAP_SETPCAP:
+		return "setpcap"
+	case CAP_LINUX_IMMUTABLE:
+		return "linux_immutable"
+	case CAP_NET_BIND_SERVICE:
+		return "net_bind_service"
+	case CAP_NET_BROADCAST:
+		return "net_broadcast"
+	case CAP_NET_ADMIN:
+		return "net_admin"
+	case CAP_NET_RAW:
+		return "net_raw"
+	case CAP_IPC_LOCK:
+		return "ipc_lock"
+	case CAP_IPC_OWNER:
+		return "ipc_owner"
+	case CAP_SYS_MODULE:
+		return "sys_module"
+	case CAP_SYS_RAWIO:
+		return "sys_rawio"
+	case CAP_SYS_CHROOT:
+		return "sys_chroot"
+	case CAP_SYS_PTRACE:
+		return "sys_ptrace"
+	case CAP_SYS_PACCT:
+		return "sys_pacct"
+	case CAP_SYS_ADMIN:
+		return "sys_admin"
+	case CAP_SYS_BOOT:
+		return "sys_boot"
+	case CAP_SYS_NICE:
+		return "sys_nice"
+	case CAP_SYS_RESOURCE:
+		return "sys_resource"
+	case CAP_SYS_TIME:
+		return "sys_time"
+	case CAP_SYS_TTY_CONFIG:
+		return "sys_tty_config"
+	case CAP_MKNOD:
+		return "mknod"
+	case CAP_LEASE:
+		return "lease"
+	case CAP_AUDIT_WRITE:
+		return "audit_write"
+	case CAP_AUDIT_CONTROL:
+		return "audit_control"
+	case CAP_SETFCAP:
+		return "setfcap"
+	case CAP_MAC_OVERRIDE:
+		return "mac_override"
+	case CAP_MAC_ADMIN:
+		return "mac_admin"
+	case CAP_SYSLOG:
+		return "syslog"
+	case CAP_WAKE_ALARM:
+		return "wake_alarm"
+	case CAP_BLOCK_SUSPEND:
+		return "block_suspend"
+	case CAP_AUDIT_READ:
+		return "audit_read"
+	}
+	return "unknown"
+}
+
+// List returns list of all supported capabilities
+func List() []Cap {
+	return []Cap{
+		CAP_CHOWN,
+		CAP_DAC_OVERRIDE,
+		CAP_DAC_READ_SEARCH,
+		CAP_FOWNER,
+		CAP_FSETID,
+		CAP_KILL,
+		CAP_SETGID,
+		CAP_SETUID,
+		CAP_SETPCAP,
+		CAP_LINUX_IMMUTABLE,
+		CAP_NET_BIND_SERVICE,
+		CAP_NET_BROADCAST,
+		CAP_NET_ADMIN,
+		CAP_NET_RAW,
+		CAP_IPC_LOCK,
+		CAP_IPC_OWNER,
+		CAP_SYS_MODULE,
+		CAP_SYS_RAWIO,
+		CAP_SYS_CHROOT,
+		CAP_SYS_PTRACE,
+		CAP_SYS_PACCT,
+		CAP_SYS_ADMIN,
+		CAP_SYS_BOOT,
+		CAP_SYS_NICE,
+		CAP_SYS_RESOURCE,
+		CAP_SYS_TIME,
+		CAP_SYS_TTY_CONFIG,
+		CAP_MKNOD,
+		CAP_LEASE,
+		CAP_AUDIT_WRITE,
+		CAP_AUDIT_CONTROL,
+		CAP_SETFCAP,
+		CAP_MAC_OVERRIDE,
+		CAP_MAC_ADMIN,
+		CAP_SYSLOG,
+		CAP_WAKE_ALARM,
+		CAP_BLOCK_SUSPEND,
+		CAP_AUDIT_READ,
+	}
+}

--- a/vendor/github.com/syndtr/gocapability/capability/syscall_linux.go
+++ b/vendor/github.com/syndtr/gocapability/capability/syscall_linux.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type capHeader struct {
+	version uint32
+	pid     int32
+}
+
+type capData struct {
+	effective   uint32
+	permitted   uint32
+	inheritable uint32
+}
+
+func capget(hdr *capHeader, data *capData) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_CAPGET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func capset(hdr *capHeader, data *capData) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_CAPSET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+// not yet in syscall
+const (
+	pr_CAP_AMBIENT           = 47
+	pr_CAP_AMBIENT_IS_SET    = uintptr(1)
+	pr_CAP_AMBIENT_RAISE     = uintptr(2)
+	pr_CAP_AMBIENT_LOWER     = uintptr(3)
+	pr_CAP_AMBIENT_CLEAR_ALL = uintptr(4)
+)
+
+func prctl(option int, arg2, arg3, arg4, arg5 uintptr) (err error) {
+	_, _, e1 := syscall.Syscall6(syscall.SYS_PRCTL, uintptr(option), arg2, arg3, arg4, arg5, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+const (
+	vfsXattrName = "security.capability"
+
+	vfsCapVerMask = 0xff000000
+	vfsCapVer1    = 0x01000000
+	vfsCapVer2    = 0x02000000
+
+	vfsCapFlagMask      = ^vfsCapVerMask
+	vfsCapFlageffective = 0x000001
+
+	vfscapDataSizeV1 = 4 * (1 + 2*1)
+	vfscapDataSizeV2 = 4 * (1 + 2*2)
+)
+
+type vfscapData struct {
+	magic uint32
+	data  [2]struct {
+		permitted   uint32
+		inheritable uint32
+	}
+	effective [2]uint32
+	version   int8
+}
+
+var (
+	_vfsXattrName *byte
+)
+
+func init() {
+	_vfsXattrName, _ = syscall.BytePtrFromString(vfsXattrName)
+}
+
+func getVfsCap(path string, dest *vfscapData) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	r0, _, e1 := syscall.Syscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(dest)), vfscapDataSizeV2, 0, 0)
+	if e1 != 0 {
+		if e1 == syscall.ENODATA {
+			dest.version = 2
+			return
+		}
+		err = e1
+	}
+	switch dest.magic & vfsCapVerMask {
+	case vfsCapVer1:
+		dest.version = 1
+		if r0 != vfscapDataSizeV1 {
+			return syscall.EINVAL
+		}
+		dest.data[1].permitted = 0
+		dest.data[1].inheritable = 0
+	case vfsCapVer2:
+		dest.version = 2
+		if r0 != vfscapDataSizeV2 {
+			return syscall.EINVAL
+		}
+	default:
+		return syscall.EINVAL
+	}
+	if dest.magic&vfsCapFlageffective != 0 {
+		dest.effective[0] = dest.data[0].permitted | dest.data[0].inheritable
+		dest.effective[1] = dest.data[1].permitted | dest.data[1].inheritable
+	} else {
+		dest.effective[0] = 0
+		dest.effective[1] = 0
+	}
+	return
+}
+
+func setVfsCap(path string, data *vfscapData) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	var size uintptr
+	if data.version == 1 {
+		data.magic = vfsCapVer1
+		size = vfscapDataSizeV1
+	} else if data.version == 2 {
+		data.magic = vfsCapVer2
+		if data.effective[0] != 0 || data.effective[1] != 0 {
+			data.magic |= vfsCapFlageffective
+		}
+		size = vfscapDataSizeV2
+	} else {
+		return syscall.EINVAL
+	}
+	_, _, e1 := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(data)), size, 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -308,6 +308,8 @@ github.com/spf13/cobra
 github.com/spf13/pflag
 # github.com/subgraph/libmacouflage v0.0.1
 github.com/subgraph/libmacouflage
+# github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+github.com/syndtr/gocapability/capability
 # github.com/u-root/u-root v7.0.0+incompatible
 github.com/u-root/u-root/pkg/cmdline
 github.com/u-root/u-root/pkg/rand


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a global flag to the `virt-chroot` binary that reports verbose environment information.

The information includes at this stage user info and process capabilities.

Use the `--envinfo` flag to enable this additional info.

It is included in the tap device creation operation. Intended to help debug the random failure seen at the tap creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
A following PR will add additional operations for debugging the tap device.
This PR has been proposed as a reasonable addition for future debugging needs.

Depends on ~~#5387~~

**Release note**:
```release-note
NONE
```