### PR TITLE
Fix SRIOV IPv6 pings tests, ping destinations

### DIFF
--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -913,10 +913,10 @@ var _ = Describe("[Serial]SRIOV", func() {
 			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, vmi1CIDR, vmi2CIDR)
 
 			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi1, vmi1IP)
+				return libnet.PingFromVMConsole(vmi1, vmi2IP)
 			}, 15*time.Second, time.Second).Should(Succeed())
 			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi2, vmi2IP)
+				return libnet.PingFromVMConsole(vmi2, vmi1IP)
 			}, 15*time.Second, time.Second).Should(Succeed())
 		})
 

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -902,21 +902,21 @@ var _ = Describe("[Serial]SRIOV", func() {
 		})
 
 		It("[test_id:3957]should connect to another machine with sriov interface over IPv6", func() {
-			cidrA := "fc00::1/64"
-			cidrB := "fc00::2/64"
-			ipA, err := cidrToIP(cidrA)
+			vmi1CIDR := "fc00::1/64"
+			vmi2CIDR := "fc00::2/64"
+			vmi1IP, err := cidrToIP(vmi1CIDR)
 			Expect(err).ToNot(HaveOccurred())
-			ipB, err := cidrToIP(cidrB)
+			vmi2IP, err := cidrToIP(vmi2CIDR)
 			Expect(err).ToNot(HaveOccurred())
 
 			//create two vms on the same sriov network
-			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, cidrA, cidrB)
+			vmi1, vmi2 := createSriovVMs(sriovnet3, sriovnet3, vmi1CIDR, vmi2CIDR)
 
 			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi1, ipA)
+				return libnet.PingFromVMConsole(vmi1, vmi1IP)
 			}, 15*time.Second, time.Second).Should(Succeed())
 			Eventually(func() error {
-				return libnet.PingFromVMConsole(vmi2, ipB)
+				return libnet.PingFromVMConsole(vmi2, vmi2IP)
 			}, 15*time.Second, time.Second).Should(Succeed())
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On SRIOV IPv6 ping tests we spin up two VMI's where each have SRIOV interface
configured with IPv6.
Then we test IPv6 ping connectivity from each VM to the other.

Currently each VM ping itself instead of each other,
I guess it happen due to the last change to the test, with the current IP address variables naming its easy to confuse and ping the wrong address.
This PR suggest new naming for the IP addresses variables and fix the test logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
