### PR TITLE
Remove test_id:3243 from quarantine.

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1723,7 +1723,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				Expect(resVMI.Status.EvacuationNodeName).To(Equal(""), "vmi evacuation state should be clean")
 			})
 
-			It("[QUARANTINE][owner:@sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", func() {
+			It("[owner:@sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated", func() {
 				for x := 0; x < 3; x++ {
 					By("creating the VMI")
 					_, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)


### PR DESCRIPTION
This test showed up as having many failures due to unrelated issues
and being slightly flaky on a release branch. The master branch
already [had a fix](https://github.com/kubevirt/kubevirt/commit/daca413fe95f52741b7d16771a2c7f57c3fa181c), and after observing it for a while, we are sure
that it isn't flaky.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
