### PR TITLE
Allow console connection to paused VM

### DIFF
--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -173,10 +173,6 @@ func (app *SubresourceAPIApp) VNCRequestHandler(request *restful.Request, respon
 			log.Log.Object(vmi).Reason(err).Error("Can't establish VNC connection.")
 			return errors.NewBadRequest(err.Error())
 		}
-		condManager := controller.NewVirtualMachineInstanceConditionManager()
-		if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
-			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("VMI is paused"))
-		}
 		return nil
 	}
 	getConsoleURL := func(vmi *v1.VirtualMachineInstance, conn kubecli.VirtHandlerConn) (string, error) {
@@ -201,10 +197,6 @@ func (app *SubresourceAPIApp) ConsoleRequestHandler(request *restful.Request, re
 		}
 		if vmi.Status.Phase == v1.Failed {
 			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("VMI is in failed status"))
-		}
-		condManager := controller.NewVirtualMachineInstanceConditionManager()
-		if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
-			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name, fmt.Errorf("VMI is paused"))
 		}
 		return nil
 	}

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -307,18 +307,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			close(done)
 		}, 5)
 
-		It("should fail to connect to VNC if the VMI is paused", func(done Done) {
-
-			request.PathParameters()["name"] = "testvmi"
-			request.PathParameters()["namespace"] = "default"
-
-			expectVMI(true, true)
-
-			app.VNCRequestHandler(request, response)
-			ExpectStatusErrorWithCode(recorder, http.StatusConflict)
-			close(done)
-		}, 5)
-
 		It("should fail with no serial console at console connections", func(done Done) {
 
 			request.PathParameters()["name"] = "testvmi"
@@ -348,18 +336,6 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 			request.PathParameters()["namespace"] = "default"
 
 			expectVMI(false, false)
-
-			app.ConsoleRequestHandler(request, response)
-			ExpectStatusErrorWithCode(recorder, http.StatusConflict)
-			close(done)
-		}, 5)
-
-		It("should fail to connect to the serial console if the VMI is paused", func(done Done) {
-
-			request.PathParameters()["name"] = "testvmi"
-			request.PathParameters()["namespace"] = "default"
-
-			expectVMI(true, true)
 
 			app.ConsoleRequestHandler(request, response)
 			ExpectStatusErrorWithCode(recorder, http.StatusConflict)

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -126,6 +126,7 @@ func (c *Console) Run(args []string) error {
 		return fmt.Errorf("Make raw terminal failed: %s", err)
 	}
 	fmt.Fprint(os.Stderr, "Successfully connected to ", vmi, " console. The escape sequence is ^]\n")
+	templates.WarnPaused(virtCli, vmi, namespace)
 
 	in := os.Stdin
 	out := os.Stdout

--- a/pkg/virtctl/console/console.go
+++ b/pkg/virtctl/console/console.go
@@ -126,7 +126,7 @@ func (c *Console) Run(args []string) error {
 		return fmt.Errorf("Make raw terminal failed: %s", err)
 	}
 	fmt.Fprint(os.Stderr, "Successfully connected to ", vmi, " console. The escape sequence is ^]\n")
-	templates.WarnPaused(virtCli, vmi, namespace)
+	templates.PrintWarningForPausedVMI(virtCli, vmi, namespace)
 
 	in := os.Stdin
 	out := os.Stdout

--- a/pkg/virtctl/templates/BUILD.bazel
+++ b/pkg/virtctl/templates/BUILD.bazel
@@ -5,5 +5,11 @@ go_library(
     srcs = ["templates.go"],
     importpath = "kubevirt.io/kubevirt/pkg/virtctl/templates",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/spf13/cobra:go_default_library"],
+    deps = [
+        "//pkg/controller:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -3,8 +3,14 @@ package templates
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
 )
 
 // UsageTemplate returns the usage template for all subcommands
@@ -56,5 +62,14 @@ func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
 			return errors.New("argument validation failed")
 		}
 		return nil
+	}
+}
+
+// WarnPaused prints warning message if VMI is paused
+func WarnPaused(virtCli kubecli.KubevirtClient, name string, namespace string) {
+	vmi, _ := virtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+	condManager := controller.NewVirtualMachineInstanceConditionManager()
+	if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
+		fmt.Fprintf(os.Stderr, "\rWarning: %s is paused. Console will be active after unpause.\n", name)
 	}
 }

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -67,7 +67,10 @@ func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
 
 // WarnPaused prints warning message if VMI is paused
 func WarnPaused(virtCli kubecli.KubevirtClient, name string, namespace string) {
-	vmi, _ := virtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+	vmi, err := virtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+	if err != nil {
+		return
+	}
 	condManager := controller.NewVirtualMachineInstanceConditionManager()
 	if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
 		fmt.Fprintf(os.Stderr, "\rWarning: %s is paused. Console will be active after unpause.\n", name)

--- a/pkg/virtctl/templates/templates.go
+++ b/pkg/virtctl/templates/templates.go
@@ -65,14 +65,14 @@ func ExactArgs(nameOfCommand string, n int) cobra.PositionalArgs {
 	}
 }
 
-// WarnPaused prints warning message if VMI is paused
-func WarnPaused(virtCli kubecli.KubevirtClient, name string, namespace string) {
-	vmi, err := virtCli.VirtualMachineInstance(namespace).Get(name, &k8smetav1.GetOptions{})
+// PrintWarningForPausedVMI prints warning message if VMI is paused
+func PrintWarningForPausedVMI(virtCli kubecli.KubevirtClient, vmiName string, namespace string) {
+	vmi, err := virtCli.VirtualMachineInstance(namespace).Get(vmiName, &k8smetav1.GetOptions{})
 	if err != nil {
 		return
 	}
 	condManager := controller.NewVirtualMachineInstanceConditionManager()
 	if condManager.HasCondition(vmi, v1.VirtualMachineInstancePaused) {
-		fmt.Fprintf(os.Stderr, "\rWarning: %s is paused. Console will be active after unpause.\n", name)
+		fmt.Fprintf(os.Stderr, "\rWarning: %s is paused. Console will be active after unpause.\n", vmiName)
 	}
 }

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -155,7 +155,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 		defer fd.Close()
 
 		glog.V(2).Infof("VNC Client connected in %v", time.Now().Sub(start))
-		templates.WarnPaused(virtCli, vmi, namespace)
+		templates.PrintWarningForPausedVMI(virtCli, vmi, namespace)
 
 		// write to FD <- pipeOutReader
 		go func() {

--- a/pkg/virtctl/vnc/vnc.go
+++ b/pkg/virtctl/vnc/vnc.go
@@ -155,6 +155,7 @@ func (o *VNC) Run(cmd *cobra.Command, args []string) error {
 		defer fd.Close()
 
 		glog.V(2).Infof("VNC Client connected in %v", time.Now().Sub(start))
+		templates.WarnPaused(virtCli, vmi, namespace)
 
 		// write to FD <- pipeOutReader
 		go func() {

--- a/tests/pausing_test.go
+++ b/tests/pausing_test.go
@@ -335,7 +335,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 			})
 
-			It("[test_id:3083]should gracefully handle console connection", func() {
+			It("[test_id:3083]should connect to serial console", func() {
 
 				runVM()
 
@@ -346,11 +346,10 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				By("Trying to console into the VM")
 				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).SerialConsole(vm.ObjectMeta.Name, &kubecli.SerialConsoleOptions{ConnectionTimeout: 30 * time.Second})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("VMI is paused"))
+				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:3084]should gracefully handle vnc connection", func() {
+			It("[test_id:3084]should connect to vnc console", func() {
 
 				runVM()
 
@@ -361,8 +360,7 @@ var _ = Describe("[rfe_id:3064][crit:medium][vendor:cnv-qe@redhat.com][level:com
 
 				By("Trying to vnc into the VM")
 				_, err = virtClient.VirtualMachineInstance(vm.ObjectMeta.Namespace).VNC(vm.ObjectMeta.Name)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("VMI is paused"))
+				Expect(err).ToNot(HaveOccurred())
 
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Until now console connection to paused VM was not permitted. This PR will allow serial and VNC console into paused VM. Console will be active after VM is unpaused. 
This can be useful for debugging. In the future we can start VM with it's guest paused and debug guest OS boot issues.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
