### PR TITLE
Pause on IO error

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "config.go",
+        "io_utils.go",
         "job.go",
         "migration.go",
         "pod_servers.go",

--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -2,21 +2,16 @@ package tests_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt/tests"
-	"kubevirt.io/kubevirt/tests/flags"
 )
 
 const (
@@ -28,181 +23,61 @@ const (
 
 var _ = Describe("[Serial] K8s IO events", func() {
 	var (
-		ns         string
-		node       string
+		nodeName   string
 		virtClient kubecli.KubevirtClient
-		vmi        *v1.VirtualMachineInstance
-		sc         = "test-ioerror"
+		pv         *k8sv1.PersistentVolume
+		pvc        *k8sv1.PersistentVolumeClaim
 	)
-	executeCommandInVirtHandlerPod := func(args []string) error {
-		var stdout, stderr string
-		pod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(node).Pod()
-		if err != nil {
-			return err
-		}
-		stdout, stderr, err = tests.ExecuteCommandOnPodV2(virtClient, pod, "virt-handler", args)
-		if err != nil {
-			return fmt.Errorf("Failed excuting command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
-		}
-		return nil
-	}
 
-	createFaultyDisk := func() {
-		var n *corev1.Node
-		var err error
-		listOptions := metav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
-		virtClient, err = kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-		virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)
-		Expect(err).ToNot(HaveOccurred())
-		n, err = virtClient.CoreV1().Nodes().Get(context.Background(), virtHandlerPods.Items[0].Spec.NodeName, metav1.GetOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		node = n.ObjectMeta.Name
-		args := []string{"dmsetup", "create", deviceName, "--table", "0 204791 error"}
-		err = executeCommandInVirtHandlerPod(args)
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	removeFaultyDisk := func() error {
-		args := []string{"dmsetup", "remove", deviceName}
-		return executeCommandInVirtHandlerPod(args)
-	}
-
-	createPVCwithFaultyDisk := func(ns string) {
-		size := resource.MustParse("1Gi")
-		vMode := corev1.PersistentVolumeBlock
-		affinity := corev1.VolumeNodeAffinity{
-			Required: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{
-								Key:      "kubernetes.io/hostname",
-								Operator: corev1.NodeSelectorOpIn,
-								Values:   []string{node},
-							},
-						},
-					},
-				},
-			},
-		}
-		pv := &corev1.PersistentVolume{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ioerrorPV,
-			},
-			Spec: corev1.PersistentVolumeSpec{
-				Capacity:         map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: size},
-				StorageClassName: sc,
-				VolumeMode:       &vMode,
-				NodeAffinity:     &affinity,
-				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				PersistentVolumeSource: corev1.PersistentVolumeSource{
-					Local: &corev1.LocalVolumeSource{
-						Path: "/dev/mapper/" + deviceName,
-					},
-				},
-			},
-		}
-		pvc := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: ioerrorPVC,
-			},
-			Spec: corev1.PersistentVolumeClaimSpec{
-				VolumeMode:       &vMode,
-				StorageClassName: &sc,
-				AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.ResourceRequirements{
-					Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: size},
-				},
-			},
-		}
-		virtCli, err := kubecli.GetKubevirtClient()
-		Expect(err).ToNot(HaveOccurred())
-
-		_, err = virtCli.CoreV1().PersistentVolumes().Create(context.Background(), pv, metav1.CreateOptions{})
-		if !errors.IsAlreadyExists(err) {
-			Expect(err).ToNot(HaveOccurred())
-		}
-
-		_, err = virtCli.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), pvc, metav1.CreateOptions{})
-		if !errors.IsAlreadyExists(err) {
-			Expect(err).ToNot(HaveOccurred())
-		}
-	}
-
-	createVMIwithFaultyPVC := func(ns string) {
-		vmi = tests.NewRandomVMIWithNS(ns)
-		bus := "virtio"
-		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-			Name: diskName,
-			DiskDevice: v1.DiskDevice{
-				Disk: &v1.DiskTarget{
-					Bus: bus,
-				},
-			},
-		})
-		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-			Name: diskName,
-			VolumeSource: v1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: ioerrorPVC,
-				},
-			},
-		})
-
-		vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("512M")
-		_, err := virtClient.VirtualMachineInstance(ns).Create(vmi)
-		Expect(err).To(BeNil(), "Create VMI successfully")
-	}
-
-	removeVMI := func(ns string) {
-		err := virtClient.VirtualMachineInstance(ns).Delete(vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
-		Expect(err).To(BeNil(), "Delete VMI successfully")
-	}
-
-	removePVwithFaultyDisk := func() {
-		err := virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), ioerrorPV, metav1.DeleteOptions{})
-		Expect(err).ToNot(HaveOccurred())
-	}
-
-	isExpectedIOEvent := func(e corev1.Event) bool {
+	isExpectedIOEvent := func(e corev1.Event, vmiName string) bool {
 		if e.Type == "Warning" &&
 			e.Reason == "IOerror" &&
 			e.Message == "VM Paused due to IO error at the volume: "+diskName &&
 			e.InvolvedObject.Kind == "VirtualMachineInstance" &&
-			e.InvolvedObject.Name == vmi.ObjectMeta.Name {
+			e.InvolvedObject.Name == vmiName {
 			return true
 		}
 		return false
 	}
 
 	BeforeEach(func() {
-		ns = tests.NamespaceTestDefault
-		createFaultyDisk()
-		createPVCwithFaultyDisk(ns)
+		var err error
+		virtClient, err = kubecli.GetKubevirtClient()
+		Expect(err).ToNot(HaveOccurred())
+
+		nodeName = tests.NodeNameWithHandler()
+		tests.CreateFaultyDisk(nodeName, deviceName)
+		pv, pvc, err = tests.CreatePVandPVCwithFaultyDisk(nodeName, deviceName, tests.NamespaceTestDefault)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create PV and PVC for faulty disk")
 	})
 	AfterEach(func() {
-		// Try a couple of times to remove the disk in case the device is busy
-		Eventually(func() error {
-			return removeFaultyDisk()
-		}, 30*time.Second, 5*time.Second).ShouldNot(HaveOccurred())
-		removePVwithFaultyDisk()
+		tests.RemoveFaultyDisk(nodeName, deviceName)
+
+		err := virtClient.CoreV1().PersistentVolumes().Delete(context.Background(), pv.Name, metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
 	})
 	It("[test_id:6225]Should catch the IO error event", func() {
-		createVMIwithFaultyPVC(ns)
+		By("Creating VMI with faulty disk")
+		vmi := tests.NewRandomVMIWithPVC(pvc.Name)
+		vmi, err := virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+		Expect(err).To(BeNil(), "Failed to create vmi")
+
 		tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmi, 120)
+
+		By("Expecting  paused event on VMI ")
 		Eventually(func() bool {
-			events, err := virtClient.CoreV1().Events(ns).List(context.Background(), metav1.ListOptions{})
+			events, err := virtClient.CoreV1().Events(tests.NamespaceTestDefault).List(context.Background(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			for _, e := range events.Items {
-				if isExpectedIOEvent(e) {
+				if isExpectedIOEvent(e, vmi.Name) {
 					return true
 				}
 			}
 
 			return false
 		}, 30*time.Second, 5*time.Second).Should(BeTrue())
-		removeVMI(ns)
+		err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Delete(vmi.ObjectMeta.Name, &metav1.DeleteOptions{})
+		Expect(err).To(BeNil(), "Failed to delete VMI")
 		tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 	})
 })

--- a/tests/io_utils.go
+++ b/tests/io_utils.go
@@ -1,0 +1,148 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/client-go/api/v1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests/flags"
+)
+
+func NodeNameWithHandler() string {
+	listOptions := metav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
+	virtClient, err := kubecli.GetKubevirtClient()
+	Expect(err).ToNot(HaveOccurred())
+	virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)
+	Expect(err).ToNot(HaveOccurred())
+	node, err := virtClient.CoreV1().Nodes().Get(context.Background(), virtHandlerPods.Items[0].Spec.NodeName, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	return node.ObjectMeta.Name
+}
+
+func ExecuteCommandInVirtHandlerPod(nodeName string, args []string) error {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return err
+	}
+
+	pod, err := kubecli.NewVirtHandlerClient(virtClient).Namespace(flags.KubeVirtInstallNamespace).ForNode(nodeName).Pod()
+	if err != nil {
+		return err
+	}
+
+	stdout, stderr, err := ExecuteCommandOnPodV2(virtClient, pod, "virt-handler", args)
+	if err != nil {
+		return fmt.Errorf("Failed excuting command=%v, error=%v, stdout=%s, stderr=%s", args, err, stdout, stderr)
+	}
+	return nil
+}
+
+func CreateFaultyDisk(nodeName, deviceName string) {
+	By(fmt.Sprintf("Creating faulty disk %s on %s node", deviceName, nodeName))
+	args := []string{"dmsetup", "create", deviceName, "--table", "0 204791 error"}
+	err := ExecuteCommandInVirtHandlerPod(nodeName, args)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to create faulty disk")
+}
+
+func CreatePVandPVCwithFaultyDisk(nodeName, deviceName, namespace string) (*corev1.PersistentVolume, *corev1.PersistentVolumeClaim, error) {
+	virtClient, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	size := resource.MustParse("1Gi")
+	volumeMode := corev1.PersistentVolumeBlock
+	storageClass := "faulty-disks"
+
+	affinity := corev1.VolumeNodeAffinity{
+		Required: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      "kubernetes.io/hostname",
+							Operator: corev1.NodeSelectorOpIn,
+							Values:   []string{nodeName},
+						},
+					},
+				},
+			},
+		},
+	}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "ioerrorpv",
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity:         map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: size},
+			StorageClassName: storageClass,
+			VolumeMode:       &volumeMode,
+			NodeAffinity:     &affinity,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				Local: &corev1.LocalVolumeSource{
+					Path: "/dev/mapper/" + deviceName,
+				},
+			},
+		},
+	}
+	pv, err = virtClient.CoreV1().PersistentVolumes().Create(context.Background(), pv, metav1.CreateOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "ioerrorpvc",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeMode:       &volumeMode,
+			StorageClassName: &storageClass,
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: map[corev1.ResourceName]resource.Quantity{corev1.ResourceStorage: size},
+			},
+		},
+	}
+
+	pvc, err = virtClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		return pv, nil, err
+	}
+
+	return pv, pvc, err
+}
+
+func RemoveFaultyDisk(nodeName, deviceName string) {
+	By(fmt.Sprintf("Removing faulty disk %s on %s node", deviceName, nodeName))
+	args := []string{"dmsetup", "remove", deviceName}
+	EventuallyWithOffset(1, func() error {
+		return ExecuteCommandInVirtHandlerPod(nodeName, args)
+	}, 30*time.Second, 5*time.Second).ShouldNot(HaveOccurred(), "Failed to remove faulty disk")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reflects pausing of domain on IO error to VMI. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1901335

**Special notes for your reviewer**:
`SyncVMI` will try to unpause the domain.

**Release note**:
```release-note
None
```
