### PR TITLE
Prepend kubevirt_ to recording rules and metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -174,3 +174,9 @@ A design proposal and its implementation history can be seen [here](https://docs
  # Other Metrics 
 ## kubevirt_vmi_cpu_affinity
 #### HELP kubevirt_vmi_cpu_affinity vcpu affinity details
+
+ # Other Metrics 
+## kubevirt_virt_controller_leading_total
+#### HELP kubevirt_virt_controller_leading Indication for an operating virt-controller.
+## kubevirt_virt_controller_ready_total
+#### HELP kubevirt_virt_controller_ready Indication for a virt-controller that is ready to take the lead.

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -61,9 +61,9 @@ tests:
   # Some virt controllers are not ready
   - interval: 1m
     input_series:
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
         values: "1 1 1 1 1 1"
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-2"}'
+      - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-2"}'
         values: "0 0 0 0 0 0"
       - series: 'up{namespace="ci", pod="virt-controller-1"}'
         values: "1 1 1 1 1 1"
@@ -80,7 +80,7 @@ tests:
   # All virt controllers are not ready
   - interval: 1m
     input_series:
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
         values: "0 0 0 0 0 0"
 
     alert_rule_test:
@@ -92,7 +92,7 @@ tests:
 
   - interval: 1m
     input_series:
-      - series: 'ready_virt_controller{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kubevirt_virt_controller_ready{namespace="ci", pod="virt-controller-1"}'
         values: "0 0 0 0 0 0"
 
     alert_rule_test:

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -92,14 +92,14 @@ var (
 
 	leaderGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "leading_virt_controller",
+			Name: "kubevirt_virt_controller_leading",
 			Help: "Indication for an operating virt-controller.",
 		},
 	)
 
 	readyGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "ready_virt_controller",
+			Name: "kubevirt_virt_controller_ready",
 			Help: "Indication for a virt-controller that is ready to take the lead.",
 		},
 	)

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -99,14 +99,14 @@ var (
 
 	leaderGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "leading_virt_operator",
+			Name: "kubevirt_virt_operator_leading",
 			Help: "Indication for an operating virt-operator.",
 		},
 	)
 
 	readyGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "ready_virt_operator",
+			Name: "kubevirt_virt_operator_ready",
 			Help: "Indication for a virt-operator that is ready to take the lead.",
 		},
 	)

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -549,14 +549,14 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 				Name: "kubevirt.rules",
 				Rules: []promv1.Rule{
 					{
-						Record: "num_of_running_virt_api_servers",
+						Record: "kubevirt_virt_api_up_total",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-api-.*'})", ns),
 						),
 					},
 					{
 						Alert: "VirtAPIDown",
-						Expr:  intstr.FromString("num_of_running_virt_api_servers == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_api_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "All virt-api servers are down.",
@@ -568,7 +568,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "LowVirtAPICount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_running_virt_api_servers < 2)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_api_up_total < 2)"),
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-api should be running if more than one worker nodes exist.",
@@ -591,20 +591,20 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
-						Record: "num_of_running_virt_controllers",
+						Record: "kubevirt_virt_controller_up_total",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{pod=~'virt-controller-.*', namespace='%s'})", ns),
 						),
 					},
 					{
-						Record: "num_of_ready_virt_controllers",
+						Record: "kubevirt_virt_controller_ready_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(ready_virt_controller{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_virt_controller_ready{namespace='%s'})", ns),
 						),
 					},
 					{
 						Alert: "LowReadyVirtControllersCount",
-						Expr:  intstr.FromString("num_of_ready_virt_controllers <  num_of_running_virt_controllers"),
+						Expr:  intstr.FromString("kubevirt_virt_controller_ready_total <  kubevirt_virt_controller_up_total"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "Some virt controllers are running but not ready.",
@@ -612,7 +612,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "NoReadyVirtController",
-						Expr:  intstr.FromString("num_of_ready_virt_controllers == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_controller_ready_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No ready virt-controller was detected for the last 5 min.",
@@ -620,7 +620,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "VirtControllerDown",
-						Expr:  intstr.FromString("num_of_running_virt_controllers == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_controller_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No running virt-controller was detected for the last 5 min.",
@@ -628,7 +628,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "LowVirtControllersCount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_ready_virt_controllers < 2)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_controller_ready_total < 2)"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-controller should be ready if more than one worker node.",
@@ -675,14 +675,14 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
-						Record: "num_of_running_virt_operators",
+						Record: "kubevirt_virt_operator_up_total",
 						Expr: intstr.FromString(
 							fmt.Sprintf("sum(up{namespace='%s', pod=~'virt-operator-.*'})", ns),
 						),
 					},
 					{
 						Alert: "VirtOperatorDown",
-						Expr:  intstr.FromString("num_of_running_virt_operators == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_operator_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "All virt-operator servers are down.",
@@ -690,7 +690,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "LowVirtOperatorCount",
-						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (num_of_running_virt_operators < 2)"),
+						Expr:  intstr.FromString("(num_of_allocatable_nodes > 1) and (kubevirt_virt_operator_up_total < 2)"),
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-operator should be running if more than one worker nodes exist.",
@@ -737,20 +737,20 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						},
 					},
 					{
-						Record: "num_of_ready_virt_operators",
+						Record: "kubevirt_virt_operator_ready_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(ready_virt_operator{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_virt_operator_ready{namespace='%s'})", ns),
 						),
 					},
 					{
-						Record: "num_of_leading_virt_operators",
+						Record: "kubevirt_virt_operator_leading_total",
 						Expr: intstr.FromString(
-							fmt.Sprintf("sum(ready_virt_operator{namespace='%s'})", ns),
+							fmt.Sprintf("sum(kubevirt_virt_operator_leading{namespace='%s'})", ns),
 						),
 					},
 					{
 						Alert: "LowReadyVirtOperatorsCount",
-						Expr:  intstr.FromString("num_of_ready_virt_operators <  num_of_running_virt_operators"),
+						Expr:  intstr.FromString("kubevirt_virt_operator_ready_total <  kubevirt_virt_operator_up_total"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "Some virt-operators are running but not ready.",
@@ -758,7 +758,7 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "NoReadyVirtOperator",
-						Expr:  intstr.FromString("num_of_running_virt_operators == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_operator_up_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No ready virt-operator was detected for the last 5 min.",
@@ -766,14 +766,14 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 					},
 					{
 						Alert: "NoLeadingVirtOperator",
-						Expr:  intstr.FromString("num_of_leading_virt_operators == 0"),
+						Expr:  intstr.FromString("kubevirt_virt_operator_leading_total == 0"),
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No leading virt-operator was detected for the last 5 min.",
 						},
 					},
 					{
-						Record: "num_of_running_virt_handlers",
+						Record: "kubevirt_virt_handler_up_total",
 						Expr:   intstr.FromString(fmt.Sprintf("sum(up{pod=~'virt-handler-.*', namespace='%s'})", ns)),
 					},
 					{

--- a/tests/infra_test.go
+++ b/tests/infra_test.go
@@ -630,9 +630,9 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 						continue
 					}
 					switch data {
-					case "leading_virt_controller 1":
+					case "kubevirt_virt_controller_leading 1":
 						foundMetrics["leading"]++
-					case "ready_virt_controller 1":
+					case "kubevirt_virt_controller_ready 1":
 						foundMetrics["ready"]++
 					}
 				}
@@ -669,9 +669,9 @@ var _ = Describe("[Serial][owner:@sig-compute]Infrastructure", func() {
 						continue
 					}
 					switch data {
-					case "leading_virt_operator 1":
+					case "kubevirt_virt_operator_leading 1":
 						foundMetrics["leading"]++
-					case "ready_virt_operator 1":
+					case "kubevirt_virt_operator_ready 1":
 						foundMetrics["ready"]++
 					}
 				}


### PR DESCRIPTION
Some metrics and recording rules are difficult to find, this patch will
add a kubevirt_ prefix to those, making them more visible.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Generally, every component that ships metrics/alerts, names them with a common prefix, this helps the user search for those in the monitoring UI.
This PR renames and adds the kubevirt_ prefix to the following recording rules and metrics:
num_of_running_virt_api_servers -> kubevirt_virt_api_up_total
num_of_running_virt_operators -> kubevirt_virt_operator_up_total
num_of_running_virt_handlers -> kubevirt_virt_handler_up_total
num_of_running_virt_controllers -> kubevirt_virt_controller_up_total
num_of_ready_virt_controllers -> kubevirt_virt_controller_ready_total
num_of_ready_virt_operators -> kubevirt_virt_operator_ready_total
num_of_leading_virt_operators -> kubevirt_virt_operator_leading_total
leading_virt_controller -> kubevirt_virt_controller_leading
ready_virt_controller -> kubevirt_virt_controller_ready

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
it's just a follow up of #4636 since I don't have update rights there.

**Release note**:
```release-note
Added a kubevirt_ prefix to several recording rules and metrics
```
