### PR TITLE
tests: On ExecuteCommandOnPod failure print both err and stderr is exist

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -3136,7 +3136,7 @@ func ExecuteCommandOnPod(virtCli kubecli.KubevirtClient, pod *k8sv1.Pod, contain
 	stdout, stderr, err := ExecuteCommandOnPodV2(virtCli, pod, containerName, command)
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed executing command on pod: %v: stderr %v: stdout: %v", err, stderr, stdout)
 	}
 
 	if len(stderr) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

On ExecuteCommandOnPod failure print both err and stderr is exist.
Sometimes stderr contains more information than the err.

For example, I encountered the following -
"**err**: command terminated with exit code 1, **stderr**: cat: /sys/class/net/net12/mtu: No such file or directory"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
