### PR TITLE
[tests] Taking test_id:5268 out of quarantine

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1431,7 +1431,7 @@ var _ = Describe("[owner:@sig-compute]Configurations", func() {
 
 		Context("with Clock and timezone", func() {
 
-			It("[QUARANTINE][owner:@sig-compute][test_id:5268]guest should see timezone", func() {
+			It("[owner:@sig-compute][test_id:5268]guest should see timezone", func() {
 				vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(cd.ContainerDiskFor(cd.ContainerDiskCirros), "#!/bin/bash\necho 'hello'\n")
 				timezone := "America/New_York"
 				tz := v1.ClockOffsetTimezone(timezone)


### PR DESCRIPTION
Taking test_id:5268 out of quarantine

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
The timezone test was flaky but over the last two weeks it shows stability over all quarantine lanes.

```release-note
NONE
```
