### PR TITLE
[release-0.26] virt-launcher: Don't update domain on sync retries

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="kubevirt/builder@sha256:756e317913e2e5c4f342ff4cd5319bc504286bc52ca7aead3337d79182d11b46"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder@sha256:756e317913e2e5c4f342ff4cd5319bc504286bc52ca7aead3337d79182d11b46"
 
 SYNC_OUT=${SYNC_OUT:-true}
 

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -16,7 +16,7 @@
 # Copyright 2020 Red Hat, Inc.
 #
 
-readonly PROM_IMAGE="docker.io/prom/prometheus:v2.15.2"
+readonly PROM_IMAGE="quay.io/prometheus/prometheus:v2.15.2"
 
 function cleanup() {
     local cleanup_files=("${@:?}")

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -200,7 +200,6 @@ var _ = Describe("Manager", func() {
 
 				mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetState().Return(state, 1, nil)
-				mockConn.EXPECT().DomainDefineXML(string(xml)).Return(mockDomain, nil)
 				mockDomain.EXPECT().Create().Return(nil)
 				mockDomain.EXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(2).Return(string(xml), nil)
 				manager, _ := NewLibvirtDomainManager(mockConn, "fake", nil, 0, nil, "/usr/share/OVMF")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Domain spec is presistent between SyncVMI calls, therefore there is no
need to update it.

The existing update does not include network specific parameters which are
required for a proper domain spec (e.g. the tap device). Therefore, this flow
has not worked for some time now and is currently broken.

This change removes the domain spec update on secondary tries.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Cherry-pick from https://github.com/kubevirt/kubevirt/pull/5400
Depends on https://github.com/kubevirt/kubevirt/pull/5432

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
