### PR TITLE
Remove GPU tests from sig-compute

### DIFF
--- a/tests/vmi_gpu_test.go
+++ b/tests/vmi_gpu_test.go
@@ -52,7 +52,7 @@ func checkGPUDevice(vmi *v1.VirtualMachineInstance, gpuName string) {
 	Expect(err).ToNot(HaveOccurred(), "GPU device %q was not found in the VMI %s within the given timeout", gpuName, vmi.Name)
 }
 
-var _ = Describe("[Serial][owner:@sig-compute]GPU", func() {
+var _ = Describe("[Serial]GPU", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
this GPU test was added to sig-compute tag by mistake, removing it out of this filter
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
