### PR TITLE
Add missing iptables link in virt-handler

### DIFF
--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -325,6 +325,7 @@ rpmtree(
     ],
     symlinks = {
         "/var/run": "../run",
+        "/usr/sbin/iptables": "/usr/sbin/iptables-legacy",
     },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

If nftables is not yet enabled, we fall back to iptables. For this the
iptables binary must be accessible for virt-handler.

Our rpm installation process does intentionally not execute post-install steps (since they require "privileges"). The post-install step would have created this link.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This issue exists for quite some time. This hints that we are not testing iptables, only `nftables`, and also that most people seem to use `nftables`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix fallback to iptables if nftables is not used on the host
```
