### PR TITLE
virt-launcher, Fix flaky VMI report (random missing Guest Agent data)

### DIFF
--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -213,6 +213,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -238,6 +240,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			err := AddGhostRecord("test1-namespace", "test1", "somefile1", "1234-1")
 			Expect(err).ToNot(HaveOccurred())
@@ -266,6 +270,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -284,12 +290,16 @@ var _ = Describe("Domain informer", func() {
 
 			domain := api.NewMinimalDomain("test")
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{domain}, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(domain.Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 			// now prove if we make a change, like adding a label, that the resync
 			// will pick that change up automatically
 			newDomain := domain.DeepCopy()
 			newDomain.ObjectMeta.Labels = make(map[string]string)
 			newDomain.ObjectMeta.Labels["some-label"] = "some-value"
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{newDomain}, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{Name: "fedora"})
+			domainManager.EXPECT().InterfacesStatus(newDomain.Spec.Devices.Interfaces).Return([]api.InterfaceStatus{api.InterfaceStatus{Name: "ethx"}})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -314,6 +324,8 @@ var _ = Describe("Domain informer", func() {
 
 			Expect(ok).To(BeTrue())
 			Expect(val).To(Equal("some-value"))
+			Expect(eventDomain.Status.OSInfo.Name).To(Equal("fedora"))
+			Expect(eventDomain.Status.Interfaces[0].Name).To(Equal("ethx"))
 		})
 
 		It("should detect expired legacy watchdog file.", func() {
@@ -436,6 +448,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			// This file doesn't have a unix sock server behind it
 			// verify list still completes regardless

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -130,6 +130,28 @@ func (s *AsyncAgentStore) GetSysInfo() api.DomainSysInfo {
 	}
 }
 
+// GetInterfaceStatus returns the interfaces Guest Agent reported
+func (s *AsyncAgentStore) GetInterfaceStatus() []api.InterfaceStatus {
+	data, ok := s.store.Load(GET_INTERFACES)
+	interfacesStatus := []api.InterfaceStatus{}
+	if ok {
+		interfacesStatus = data.([]api.InterfaceStatus)
+	}
+
+	return interfacesStatus
+}
+
+// GetGuestOSInfo returns the Guest OS version and architecture
+func (s *AsyncAgentStore) GetGuestOSInfo() api.GuestOSInfo {
+	data, ok := s.store.Load(GET_OSINFO)
+	osinfo := api.GuestOSInfo{}
+	if ok {
+		osinfo = data.(api.GuestOSInfo)
+	}
+
+	return osinfo
+}
+
 // GetGA returns guest agent record with its version if present
 func (s *AsyncAgentStore) GetGA() string {
 	data, ok := s.store.Load(GET_AGENT)

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -289,7 +289,10 @@ func (l *Launcher) GetDomain(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.D
 	}
 
 	if len(list) > 0 {
-		if domain, err := json.Marshal(list[0]); err != nil {
+		domainObj := list[0]
+		domainObj.Status.OSInfo = l.domainManager.GetGuestOSInfo()
+		domainObj.Status.Interfaces = l.domainManager.InterfacesStatus(domainObj.Spec.Devices.Interfaces)
+		if domain, err := json.Marshal(domainObj); err != nil {
 			log.Log.Reason(err).Errorf("Failed to marshal domain")
 			response.Response.Success = false
 			response.Response.Message = getErrorMessage(err)

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -123,6 +123,8 @@ var _ = Describe("Virt remote commands", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 			domain, exists, err := client.GetDomain()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -199,3 +199,23 @@ func (_m *MockDomainManager) FinalizeVirtualMachineMigration(_param0 *v1.Virtual
 func (_mr *_MockDomainManagerRecorder) FinalizeVirtualMachineMigration(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FinalizeVirtualMachineMigration", arg0)
 }
+
+func (_m *MockDomainManager) InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus {
+	ret := _m.ctrl.Call(_m, "InterfacesStatus", domainInterfaces)
+	ret0, _ := ret[0].([]api.InterfaceStatus)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) InterfacesStatus(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InterfacesStatus", arg0)
+}
+
+func (_m *MockDomainManager) GetGuestOSInfo() api.GuestOSInfo {
+	ret := _m.ctrl.Call(_m, "GetGuestOSInfo")
+	ret0, _ := ret[0].(api.GuestOSInfo)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) GetGuestOSInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGuestOSInfo")
+}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -100,6 +100,8 @@ type DomainManager interface {
 	GetUsers() ([]v1.VirtualMachineInstanceGuestOSUser, error)
 	GetFilesystems() ([]v1.VirtualMachineInstanceFileSystem, error)
 	FinalizeVirtualMachineMigration(*v1.VirtualMachineInstance) error
+	InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus
+	GetGuestOSInfo() api.GuestOSInfo
 }
 
 type LibvirtDomainManager struct {
@@ -1363,6 +1365,17 @@ func (l *LibvirtDomainManager) GetGuestInfo() (v1.VirtualMachineInstanceGuestAge
 	}
 
 	return guestInfo, nil
+}
+
+// InterfacesStatus returns the interfaces Guest Agent reported
+func (l *LibvirtDomainManager) InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus {
+	interfaces := l.agentData.GetInterfaceStatus()
+	return agentpoller.MergeAgentStatusesWithDomainData(domainInterfaces, interfaces)
+}
+
+// GetGuestOSInfo returns the Guest OS version and architecture
+func (l *LibvirtDomainManager) GetGuestOSInfo() api.GuestOSInfo {
+	return l.agentData.GetGuestOSInfo()
 }
 
 // GetUsers return the full list of users on the guest machine


### PR DESCRIPTION
 `virt-handler` refreshes the VMI domain information,
 each 300 seconds by `handleResync` function.
    
 The information it got doesn't include
 Guest Agent information such as Guest OS Info,
 and interfaces status.
   
 This will cause flakiness in the VMI status,
 each time that the report is fetched,
 until the next update of Guest Agent will be sent
 by the `virt-launcher` to the `virt-handler`,
as this report does include the Guest Agent data.
   
 This PR fix it by decorating the resync
 domain info, with the Guest Agent information,
 as the `virt-launcher` itself does before sending
 the domain info to the `virt-handler`.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1907707

```release-note
None
```
