### PR TITLE
remove need for type casting by using runtime.Object

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -739,7 +739,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		registry := fmt.Sprintf("rand-%s", rand.String(10))
 		config := getConfig(registry, version)
 
-		all := make([]interface{}, 0)
+		all := make([]runtime.Object, 0)
 		all = append(all, &k8sv1.ServiceAccount{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "v1",
@@ -859,7 +859,7 @@ var _ = Describe("KubeVirt Operator", func() {
 	addAll := func(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
 		c, _ := apply.NewCustomizer(kv.Spec.CustomizeComponents)
 
-		all := make([]interface{}, 0)
+		all := make([]runtime.Object, 0)
 
 		// rbac
 		all = append(all, rbac.GetAllCluster()...)
@@ -961,11 +961,7 @@ var _ = Describe("KubeVirt Operator", func() {
 		}
 
 		for _, obj := range all {
-			if resource, ok := obj.(runtime.Object); ok {
-				addResource(resource, config, kv)
-			} else {
-				Fail("could not cast to runtime.Object")
-			}
+			addResource(obj, config, kv)
 		}
 	}
 

--- a/pkg/virt-operator/resource/generate/install/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/install/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -44,6 +44,7 @@ import (
 	extv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -368,7 +369,7 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 		strategy.crds = append(strategy.crds, crd)
 	}
 
-	rbaclist := make([]interface{}, 0)
+	rbaclist := make([]runtime.Object, 0)
 	rbaclist = append(rbaclist, rbac.GetAllCluster()...)
 	rbaclist = append(rbaclist, rbac.GetAllApiServer(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllController(config.GetNamespace())...)

--- a/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/pkg/virt-operator/resource/generate/rbac/apiserver.go
+++ b/pkg/virt-operator/resource/generate/rbac/apiserver.go
@@ -22,14 +22,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
 
 const ApiServiceAccountName = "kubevirt-apiserver"
 
-func GetAllApiServer(namespace string) []interface{} {
-	return []interface{}{
+func GetAllApiServer(namespace string) []runtime.Object {
+	return []runtime.Object{
 		newApiServerServiceAccount(namespace),
 		newApiServerClusterRole(),
 		newApiServerClusterRoleBinding(namespace),

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -21,12 +21,13 @@ package rbac
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
 
-func GetAllCluster() []interface{} {
-	return []interface{}{
+func GetAllCluster() []runtime.Object {
+	return []runtime.Object{
 		newDefaultClusterRole(),
 		newDefaultClusterRoleBinding(),
 		newAdminClusterRole(),

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -22,14 +22,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
 
 const ControllerServiceAccountName = "kubevirt-controller"
 
-func GetAllController(namespace string) []interface{} {
-	return []interface{}{
+func GetAllController(namespace string) []runtime.Object {
+	return []runtime.Object{
 		newControllerServiceAccount(namespace),
 		newControllerClusterRole(),
 		newControllerClusterRoleBinding(namespace),

--- a/pkg/virt-operator/resource/generate/rbac/handler.go
+++ b/pkg/virt-operator/resource/generate/rbac/handler.go
@@ -23,14 +23,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
 
 const HandlerServiceAccountName = "kubevirt-handler"
 
-func GetAllHandler(namespace string) []interface{} {
-	return []interface{}{
+func GetAllHandler(namespace string) []runtime.Object {
+	return []runtime.Object{
 		newHandlerServiceAccount(namespace),
 		newHandlerClusterRole(),
 		newHandlerClusterRoleBinding(namespace),

--- a/pkg/virt-operator/resource/generate/rbac/servicemonitor.go
+++ b/pkg/virt-operator/resource/generate/rbac/servicemonitor.go
@@ -22,14 +22,15 @@ package rbac
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
 
 const MONITOR_SERVICEACCOUNT_NAME = "kubevirt-monitoring"
 
-func GetAllServiceMonitor(namespace string, monitorNamespace string, monitorServiceAccount string) []interface{} {
-	return []interface{}{
+func GetAllServiceMonitor(namespace string, monitorNamespace string, monitorServiceAccount string) []runtime.Object {
+	return []runtime.Object{
 		newServiceMonitorRole(namespace),
 		newServiceMonitorRoleBinding(namespace, monitorNamespace, monitorServiceAccount),
 	}


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>


**What this PR does / why we need it**:

This changes some instances of interface{} to instead use runtime.Object to avoid type casting. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
