### PR TITLE
sig-network, Fix flaky test which pings 8.8.8.8

### DIFF
--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -32,10 +32,10 @@ import (
 
 // PingFromVMConsole performs a ping through the provided VMI console.
 // Optional arguments for the ping command may be provided, overwirting the default ones.
-// (default ping options: "-c 1, -w 5")
-// Note: The maximum overall command timeout is 10 seconds.
+// (default ping options: "-c 5, -w 10")
+// Note: The maximum overall command timeout is 20 seconds.
 func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...string) error {
-	const maxCommandTimeout = 10 * time.Second
+	const maxCommandTimeout = 20 * time.Second
 
 	pingString := "ping"
 	if net.IsIPv6String(ipAddr) {

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -719,8 +719,8 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				Expect(libnet.PingFromVMConsole(serverVMI, ipAddr)).To(Succeed())
 
 				By("Checking ping (IPv4) to google")
-				Expect(libnet.PingFromVMConsole(serverVMI, "8.8.8.8")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(clientVMI, "google.com")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(serverVMI, "8.8.8.8", "-c 5", "-w 15")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(clientVMI, "google.com", "-c 5", "-w 15")).To(Succeed())
 
 				Expect(verifyClientServerConnectivity(clientVMI, serverVMI, tcpPort, k8sv1.IPv4Protocol)).To(Succeed())
 			},


### PR DESCRIPTION
Test 1780, which pings 8.8.8.8 is flaky.
It does manage to ping 8.8.8.8 but it takes time,
since it tries to ping more than one packet,
and the first successful ping started already
too late.

Extend the timeout given for ping,
in order to solve this flakiness.

This PR will at least improve monitoring, since the ping will now won't
be abruptly interrupt by the RunCommand,
as the ping timeout updated to be smaller than RunCommand timeout.

https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5427/pull-kubevirt-e2e-k8s-1.19-sig-network/1381524922219630592

See it managed to ping one packet at least, but then abruptly stopped by the RunCommand timeout.
```
{"component":"tests","kind":"VirtualMachineInstance","level":"info","msg":"[{1 \r\n$  [$  $ ]} {3 ping 8.8.8.8 -c 5 -w 10\r\nPING 8.8.8.8 (8.8.8.8): 56 data bytes\r\n64 bytes from 8.8.8.8: seq=0 ttl=103 time=59.389 ms\r\n []}]","name":"testvmi-qx98s","namespace":"kubevirt-test-default1","pos":"console.go:69","timestamp":"2021-04-12T10:02:23.234730Z","uid":"748a582c-2a6c-46b7-8e25-ad60d7eacb1c"}
```

2nd time:
https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5369/pull-kubevirt-e2e-k8s-1.19-sig-network/1381699823064846336

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```
