### PR TITLE
Support dual stack service on "virtctl expose"

### DIFF
--- a/pkg/virtctl/expose/expose.go
+++ b/pkg/virtctl/expose/expose.go
@@ -75,7 +75,7 @@ virtualmachineinstance (vmi), virtualmachine (vm), virtualmachineinstancereplica
 	cmd.Flags().StringVar(&strTargetPort, "target-port", "", "Name or number for the port on the VM that the service should direct traffic to. Optional.")
 	cmd.Flags().StringVar(&strServiceType, "type", "ClusterIP", "Type for this service: ClusterIP, NodePort, or LoadBalancer.")
 	cmd.Flags().StringVar(&portName, "port-name", "", "Name of the port. Optional.")
-	cmd.Flags().StringVar(&strIPFamily, "ip-family", "IPv4", "IP family over which the service will be exposed. Valid values are 'IPv4' or 'IPv6'.")
+	cmd.Flags().StringVar(&strIPFamily, "ip-family", "IPv4", "IP family over which the service will be exposed. Valid values are 'IPv4', 'IPv6', 'IPv4,IPv6' or 'IPv6,IPv4'")
 	cmd.SetUsageTemplate(templates.UsageTemplate())
 
 	return cmd
@@ -104,7 +104,6 @@ func (o *Command) RunE(args []string) error {
 	var protocol v1.Protocol
 	var targetPort intstr.IntOrString
 	var serviceType v1.ServiceType
-	var ipFamily v1.IPFamily
 
 	// convert from integer to the IntOrString type
 	targetPort = intstr.Parse(strTargetPort)
@@ -133,7 +132,7 @@ func (o *Command) RunE(args []string) error {
 		return fmt.Errorf("unknown service type: %s", strServiceType)
 	}
 
-	ipFamily, err := convertIPFamily(strIPFamily)
+	ipFamilies, err := convertIPFamily(strIPFamily)
 	if err != nil {
 		return err
 	}
@@ -215,7 +214,7 @@ func (o *Command) RunE(args []string) error {
 			ClusterIP:      clusterIP,
 			Type:           serviceType,
 			LoadBalancerIP: loadBalancerIP,
-			IPFamilies:     []v1.IPFamily{ipFamily},
+			IPFamilies:     ipFamilies,
 		},
 	}
 
@@ -237,6 +236,9 @@ func (o *Command) RunE(args []string) error {
 		// For k8s < 1.20 we have to "migrate" the "ipFamilies" field to
 		// "ipFamily" we do this using an unstructured approach
 	} else {
+		if len(ipFamilies) > 1 {
+			return fmt.Errorf("k8s < 1.20 doesn't support multiple ip families")
+		}
 		// convert the Service to unstructured.Unstructured
 		unstructuredService, err := runtime.DefaultUnstructuredConverter.ToUnstructured(service)
 		if err != nil {
@@ -244,7 +246,7 @@ func (o *Command) RunE(args []string) error {
 		}
 
 		// Add ipFamily field with proper content
-		err = unstructured.SetNestedField(unstructuredService, string(ipFamily), "spec", "ipFamily")
+		err = unstructured.SetNestedField(unstructuredService, string(ipFamilies[0]), "spec", "ipFamily")
 		if err != nil {
 			return err
 		}
@@ -259,14 +261,18 @@ func (o *Command) RunE(args []string) error {
 	return nil
 }
 
-func convertIPFamily(strIPFamily string) (v1.IPFamily, error) {
+func convertIPFamily(strIPFamily string) ([]v1.IPFamily, error) {
 	switch strings.ToLower(strIPFamily) {
 	case "ipv4":
-		return v1.IPv4Protocol, nil
+		return []v1.IPFamily{v1.IPv4Protocol}, nil
 	case "ipv6":
-		return v1.IPv6Protocol, nil
+		return []v1.IPFamily{v1.IPv6Protocol}, nil
+	case "ipv4,ipv6":
+		return []v1.IPFamily{v1.IPv4Protocol, v1.IPv6Protocol}, nil
+	case "ipv6,ipv4":
+		return []v1.IPFamily{v1.IPv6Protocol, v1.IPv4Protocol}, nil
 	default:
-		return "", fmt.Errorf("unknown IPFamily: %s", strIPFamily)
+		return nil, fmt.Errorf("unknown IPFamily/s: %s", strIPFamily)
 	}
 }
 

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -282,6 +282,26 @@ var _ = Describe("Expose", func() {
 					Expect(obtainedService.Spec.IPFamilies).To(ConsistOf(k8sv1.IPv6Protocol))
 				})
 
+				It("should succeed with IPv4, IPv6", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family", "ipv4,ipv6")
+					Expect(cmd()).To(Succeed(), "should succeed on an valid IP family - ipv4,ipv6 is valid")
+					Expect(obtainedService).ToNot(BeNil())
+					Expect(obtainedService.Spec.IPFamilies).Should(HaveLen(2))
+					Expect(obtainedService.Spec.IPFamilies[0]).To(Equal(k8sv1.IPv4Protocol))
+					Expect(obtainedService.Spec.IPFamilies[1]).To(Equal(k8sv1.IPv6Protocol))
+				})
+
+				It("should succeed with IPv6, IPv4", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family", "ipv6,ipv4")
+					Expect(cmd()).To(Succeed(), "should succeed on an valid IP family - ipv6,ipv4 is valid")
+					Expect(obtainedService).ToNot(BeNil())
+					Expect(obtainedService.Spec.IPFamilies).Should(HaveLen(2))
+					Expect(obtainedService.Spec.IPFamilies[0]).To(Equal(k8sv1.IPv6Protocol))
+					Expect(obtainedService.Spec.IPFamilies[1]).To(Equal(k8sv1.IPv4Protocol))
+				})
+
 				It("should fail with an invalid IPFamily", func() {
 					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 						"--port", "9999", "--target-port", "http", "--ip-family", "ipv14")
@@ -328,6 +348,18 @@ var _ = Describe("Expose", func() {
 					Expect(found).To(BeTrue())
 					Expect(ipFamily).To(Equal(string(k8sv1.IPv6Protocol)))
 
+				})
+
+				It("should fail with IPv4,IPv6", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family", "ipv4,ipv6")
+					Expect(cmd()).ToNot(Succeed(), "should fail on an invalid IP family - ipv4,ipv6 is invalid")
+				})
+
+				It("should fail with IPv6,IPv4", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family", "ipv6,ipv4")
+					Expect(cmd()).ToNot(Succeed(), "should fail on an invalid IP family - ipv6,ipv4 is invalid")
 				})
 			})
 		})

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -309,6 +309,39 @@ var _ = Describe("Expose", func() {
 
 				})
 			})
+			Context("With parametrized IPFamilyPolicy", func() {
+				It("should succeed with singlestack", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family-policy", "singlestack")
+					Expect(cmd()).To(Succeed(), "should succeed on a valid IP family policy - singlestack is valid")
+					Expect(obtainedService).ToNot(BeNil())
+					Expect(*obtainedService.Spec.IPFamilyPolicy).To(Equal(k8sv1.IPFamilyPolicySingleStack))
+
+				})
+
+				It("should succeed with PreferDualStack", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family-policy", "PreferDualStack")
+					Expect(cmd()).To(Succeed(), "should succeed on a valid IP family policy - PreferDualStack is valid")
+					Expect(obtainedService).ToNot(BeNil())
+					Expect(*obtainedService.Spec.IPFamilyPolicy).To(Equal(k8sv1.IPFamilyPolicyPreferDualStack))
+				})
+
+				It("should succeed with RequiredualStack", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family-policy", "RequiredualStack")
+					Expect(cmd()).To(Succeed(), "should succeed on a valid IP family policy - RequiredualStack is valid")
+					Expect(obtainedService).ToNot(BeNil())
+					Expect(*obtainedService.Spec.IPFamilyPolicy).To(Equal(k8sv1.IPFamilyPolicyRequireDualStack))
+				})
+
+				It("should fail with an invalid IPFamilyPolicy", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family-policy", "non-valid-policy")
+					Expect(cmd()).To(HaveOccurred(), "should fail on an invalid IP family policy")
+
+				})
+			})
 		})
 		Context("with k8s <= 1.19", func() {
 			var obtainedUnstructured *unstructured.Unstructured
@@ -360,6 +393,13 @@ var _ = Describe("Expose", func() {
 					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
 						"--port", "9999", "--target-port", "http", "--ip-family", "ipv6,ipv4")
 					Expect(cmd()).ToNot(Succeed(), "should fail on an invalid IP family - ipv6,ipv4 is invalid")
+				})
+			})
+			Context("With IPFamilyPolicy", func() {
+				It("should fail with non-empty IPFamilyPolicy", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", vmName, "--name", "my-service",
+						"--port", "9999", "--target-port", "http", "--ip-family-policy", "PreferDualStack")
+					Expect(cmd()).ToNot(Succeed(), "should fail on non empty IP family policy")
 				})
 			})
 		})

--- a/tests/assert/xfail.go
+++ b/tests/assert/xfail.go
@@ -30,14 +30,17 @@ import (
 // XFail skips the test once it fails and leaves a XFAIL label on the message.
 // It is useful to mark tests as XFail when one wants them to run even though they fail,
 // monitoring and collecting information.
-func XFail(reason string, f func()) {
-	defer RegisterFailHandler(Fail)
-	RegisterFailHandler(func(m string, offset ...int) {
-		depth := 0
-		if len(offset) > 0 {
-			depth = offset[0]
-		}
-		Skip(fmt.Sprintf("[XFAIL] %s, failure: %s", reason, m), depth+1)
-	})
+// 'condition' can be used to specify whether the test should be marked as XFail
+func XFail(reason string, f func(), condition ...bool) {
+	if len(condition) == 0 || condition[0] {
+		defer RegisterFailHandler(Fail)
+		RegisterFailHandler(func(m string, offset ...int) {
+			depth := 0
+			if len(offset) > 0 {
+				depth = offset[0]
+			}
+			Skip(fmt.Sprintf("[XFAIL] %s, failure: %s", reason, m), depth+1)
+		})
+	}
 	f()
 }

--- a/tests/network/expose.go
+++ b/tests/network/expose.go
@@ -132,12 +132,12 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 		return vmiExposeArgs
 	}
 
-	createAndWaitForJobToSucceed := func(helloWorldJobCreator func(host, port, namespace string) *batchv1.Job, namespace, ip, port, viaMessage string, timeout time.Duration) error {
+	createAndWaitForJobToSucceed := func(helloWorldJobCreator func(host, port, namespace string) *batchv1.Job, namespace, ip, port, viaMessage string) error {
 		By(fmt.Sprintf("Starting a job which tries to reach the VMI via the %s", viaMessage))
 		job := helloWorldJobCreator(ip, port, namespace)
 
 		By("Waiting for the job to report a successful connection attempt")
-		return tests.WaitForJobToSucceed(job, timeout*time.Second)
+		return tests.WaitForJobToSucceed(job, time.Duration(120)*time.Second)
 	}
 
 	Context("Expose service on a VM", func() {
@@ -183,7 +183,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				serviceIPs := svc.Spec.ClusterIPs
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, ip, servicePort, fmt.Sprintf("%dst ClusterIP", ipOrderNum+1), 420)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, ip, servicePort, fmt.Sprintf("%dst ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 			},
@@ -342,7 +342,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					if ipFamily != ipv6 {
 						By("Connecting to IPv4 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily), 420)).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
 						}, ipFamily == dualIPv6Primary)
 					}
 					if doesSupportIpv6(ipFamily) {
@@ -356,7 +356,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 
 						By("Connecting to IPv6 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily), 420)).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(runHelloWorldJob, tcpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), fmt.Sprintf("NodePort using %s node ip", ipFamily))).To(Succeed())
 						}, ipFamily == dualIPv4Primary)
 					}
 				}
@@ -414,7 +414,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				By("Iterating over the ClusterIPs")
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ip, servicePort, fmt.Sprintf("%dst ClusterIP", ipOrderNum+1), 420)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ip, servicePort, fmt.Sprintf("%dst ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 			},
@@ -462,7 +462,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				serviceIPs := svc.Spec.ClusterIPs
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1), 120)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 
@@ -488,13 +488,13 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 					if ipFamily != ipv6 {
 						By("Connecting to IPv4 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address", 420)).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, nodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv4 address")).To(Succeed())
 						}, ipFamily == dualIPv6Primary)
 					}
 					if doesSupportIpv6(ipFamily) {
 						By("Connecting to IPv6 node IP")
 						assert.XFail(xfailError, func() {
-							Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address", 420)).To(Succeed())
+							Expect(createAndWaitForJobToSucceed(runHelloWorldJobUDP, udpVM.Namespace, ipv6NodeIP, strconv.Itoa(int(nodePort)), "NodePort ipv6 address")).To(Succeed())
 						}, ipFamily == dualIPv4Primary)
 					}
 				}
@@ -577,7 +577,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				serviceIPs := svc.Spec.ClusterIPs
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vmrs.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1), 420)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vmrs.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 			},
@@ -681,8 +681,8 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				serviceIPs := svc.Spec.ClusterIPs
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vm.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1), 420)).To(Succeed())
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJobHttp, vm.Namespace, ip, servicePort, fmt.Sprintf("same %dst ClusterIP, this time over HTTP", ipOrderNum+1), 120)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vm.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJobHttp, vm.Namespace, ip, servicePort, fmt.Sprintf("same %dst ClusterIP, this time over HTTP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 			},
@@ -714,7 +714,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				serviceIPs := svc.Spec.ClusterIPs
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vmObj.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1), 120)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vmObj.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 
@@ -746,7 +746,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				By("Repeating the sequence as prior to restarting the VM: Connect to exposed ClusterIP service.")
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vmObj.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1), 120)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vmObj.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 			},
@@ -795,7 +795,7 @@ var _ = SIGDescribe("[rfe_id:253][crit:medium][vendor:cnv-qe@redhat.com][level:c
 				serviceIPs := svc.Spec.ClusterIPs
 				for ipOrderNum, ip := range serviceIPs {
 					assert.XFail(xfailError, func() {
-						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vm.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1), 120)).To(Succeed())
+						Expect(createAndWaitForJobToSucceed(runHelloWorldJob, vm.Namespace, ip, servicePort, fmt.Sprintf("%d ClusterIP", ipOrderNum+1))).To(Succeed())
 					}, ipOrderNum > 0)
 				}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
k8s 1.20 and beyond added support for dual stack services [1].
This PR allows passing dual stack `ipFamilies` ("ipv4,ipv6" and "ipv6,ipv4") to `virtctl expose` `ip-family` flag.
It also allows specifying `ipFamilyPolicy` ("SingleStack", "PreferDualStack", "RequireDualStack"). (TBD)

[1] https://kubernetes.io/docs/concepts/services-networking/dual-stack/

Note: Secondary IP on dual stack service is not working (at least not on k8s 1.20), therefore, XFail was added when testing it.
Tracking issue: https://github.com/kubevirt/kubevirt/issues/5477

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support dual stack service on "virtctl expose"- 
Introducing `ip-family-policy` flag and support dual stack values on `ip-family` flag.
```
