### PR TITLE
Handle several active VMI pods during disk hotplug

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -568,11 +568,17 @@ func (m *volumeMounter) mountFileSystemHotplugVolume(vmi *v1.VirtualMachineInsta
 	return nil
 }
 
-func (m *volumeMounter) findVirtlauncherUID(vmi *v1.VirtualMachineInstance) types.UID {
-	if len(vmi.Status.ActivePods) == 1 {
-		for k := range vmi.Status.ActivePods {
-			return k
+func (m *volumeMounter) findVirtlauncherUID(vmi *v1.VirtualMachineInstance) (uid types.UID) {
+	cnt := 0
+	for podUID := range vmi.Status.ActivePods {
+		_, err := m.hotplugDiskManager.GetHotplugTargetPodPathOnHost(podUID)
+		if err == nil {
+			uid = podUID
+			cnt++
 		}
+	}
+	if cnt == 1 {
+		return
 	}
 	// Either no pods, or multiple pods, skip.
 	return types.UID("")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Several `virt-launcher` pods may still be running for a single VMI after migration and that will prevent from mounting hotplug disks. Find the proper pod by checking if the expected hotplug directory exists.

**Special notes for your reviewer**:

After successfull migration the source launcher pod is not deleted:
```
virt-launcher-testvm-gs7n4       0/2     Completed   0          47m
```
and it stays in the list of VMI `Active Pods`:
```
Status:
  Active Pods:
    148a69ba-95ae-43dd-b12f-f0eab833a83b:  node02
    c0a7a88a-4dac-44f9-bd5c-e966db1464d7:  node01
```


The fix is based on the approach implemented for `ContainerDisks`:
https://github.com/kubevirt/kubevirt/blob/d2eb0cf7ddc93eb88e0f590b1790558e44c6586b/pkg/container-disk/container-disk.go#L61-L79

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
