### PR TITLE
[tests] restore KV CR as part of test cleanup procedure

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -667,7 +667,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 
 			AfterEach(func() {
-				tests.RestoreKubeVirtResource()
 
 				// Wait until virt-handler ds will have expected number of pods
 				Eventually(func() bool {


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
Some functional tests modify the KV CR itself as part
of the test (cert. rotation, pod placement, etc). The
aim of this patch is to reduce the duplication of code
that restores these values.

Also this will protect us from cases where the test author
may forget to restore the cluster to it's state as it was before entering the specific test.

```release-note
NONE
```
