### PR TITLE
Add vm snapshot indications

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12930,6 +12930,13 @@
      "error": {
       "$ref": "#/definitions/v1alpha1.Error"
      },
+     "indications": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "x-kubernetes-list-type": "set"
+     },
      "readyToUse": {
       "type": "boolean"
      },

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -91,8 +91,7 @@ func vmSnapshotError(vmSnapshot *snapshotv1.VirtualMachineSnapshot) *snapshotv1.
 }
 
 func vmSnapshotProgressing(vmSnapshot *snapshotv1.VirtualMachineSnapshot) bool {
-	return vmSnapshotError(vmSnapshot) == nil &&
-		(vmSnapshot.Status == nil || vmSnapshot.Status.ReadyToUse == nil || !*vmSnapshot.Status.ReadyToUse)
+	return vmSnapshotError(vmSnapshot) == nil && !vmSnapshotReady(vmSnapshot)
 }
 
 func getVMSnapshotContentName(vmSnapshot *snapshotv1.VirtualMachineSnapshot) string {
@@ -183,7 +182,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 	var volueSnapshotStatus []snapshotv1.VolumeSnapshotStatus
 	var deletedSnapshots, skippedSnapshots []string
 
-	currentlyReady := content.Status != nil && content.Status.ReadyToUse != nil && *content.Status.ReadyToUse
+	currentlyReady := vmSnapshotContentReady(content)
 	currentlyError := content.Status != nil && content.Status.Error != nil
 
 	for _, volumeBackup := range content.Spec.VolumeBackups {

--- a/pkg/virt-controller/watch/snapshot/snapshot.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot.go
@@ -179,7 +179,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshot(vmSnapshot *snapshotv1.Virtua
 func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.VirtualMachineSnapshotContent) (time.Duration, error) {
 	log.Log.V(3).Infof("Updating VirtualMachineSnapshotContent %s/%s", content.Namespace, content.Name)
 
-	var volueSnapshotStatus []snapshotv1.VolumeSnapshotStatus
+	var volumeSnapshotStatus []snapshotv1.VolumeSnapshotStatus
 	var deletedSnapshots, skippedSnapshots []string
 
 	currentlyReady := vmSnapshotContentReady(content)
@@ -234,7 +234,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 			vss.Error = translateError(volumeSnapshot.Status.Error)
 		}
 
-		volueSnapshotStatus = append(volueSnapshotStatus, vss)
+		volumeSnapshotStatus = append(volumeSnapshotStatus, vss)
 	}
 
 	ready := true
@@ -252,7 +252,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 		ready = false
 		errorMessage = fmt.Sprintf("VolumeSnapshots (%s) skipped because in error state", strings.Join(skippedSnapshots, ","))
 	} else {
-		for _, vss := range volueSnapshotStatus {
+		for _, vss := range volumeSnapshotStatus {
 			if vss.ReadyToUse == nil || !*vss.ReadyToUse {
 				ready = false
 				break
@@ -272,7 +272,7 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 	}
 
 	contentCpy.Status.ReadyToUse = &ready
-	contentCpy.Status.VolumeSnapshotStatus = volueSnapshotStatus
+	contentCpy.Status.VolumeSnapshotStatus = volumeSnapshotStatus
 
 	if !reflect.DeepEqual(content, contentCpy) {
 		if _, err := ctrl.Client.VirtualMachineSnapshotContent(contentCpy.Namespace).Update(context.Background(), contentCpy, metav1.UpdateOptions{}); err != nil {

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -659,6 +659,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
 				updatedSnapshot.Status.CreationTime = timeFunc()
 				updatedSnapshot.Status.ReadyToUse = &t
+				updatedSnapshot.Status.Indications = nil
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "Operation complete"),
 					newReadyCondition(corev1.ConditionTrue, "Operation complete"),

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7844,6 +7844,12 @@ var CRDsValidation map[string]string = map[string]string{
               format: date-time
               type: string
           type: object
+        indications:
+          items:
+            description: Indication is a way to indicate the state of the vm when taking the snapshot
+            type: string
+          type: array
+          x-kubernetes-list-type: set
         readyToUse:
           type: boolean
         sourceUID:

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/deepcopy_generated.go
@@ -487,6 +487,11 @@ func (in *VirtualMachineSnapshotStatus) DeepCopyInto(out *VirtualMachineSnapshot
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Indications != nil {
+		in, out := &in.Indications, &out.Indications
+		*out = make([]Indication, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -20680,6 +20680,24 @@ func schema_client_go_apis_snapshot_v1alpha1_VirtualMachineSnapshotStatus(ref co
 							},
 						},
 					},
+					"indications": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "set",
+							},
+						},
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types.go
@@ -62,6 +62,14 @@ type VirtualMachineSnapshotSpec struct {
 	DeletionPolicy *DeletionPolicy `json:"deletionPolicy,omitempty"`
 }
 
+// Indication is a way to indicate the state of the vm when taking the snapshot
+type Indication string
+
+const (
+	VMSnapshotOnlineSnapshotIndication Indication = "Online"
+	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
+)
+
 // VirtualMachineSnapshotStatus is the status for a VirtualMachineSnapshot resource
 type VirtualMachineSnapshotStatus struct {
 	// +optional
@@ -82,6 +90,10 @@ type VirtualMachineSnapshotStatus struct {
 
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
+
+	// +optional
+	// +listType=set
+	Indications []Indication `json:"indications,omitempty"`
 }
 
 // Error is the last error encountered during the snapshot/restore

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/types_swagger_generated.go
@@ -25,6 +25,7 @@ func (VirtualMachineSnapshotStatus) SwaggerDoc() map[string]string {
 		"readyToUse":                        "+optional",
 		"error":                             "+optional",
 		"conditions":                        "+optional",
+		"indications":                       "+optional\n+listType=set",
 	}
 }
 

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -105,6 +105,8 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 			Expect(snapshot.Status.SourceUID).ToNot(BeNil())
 			Expect(*snapshot.Status.SourceUID).To(Equal(vm.UID))
 
+			Expect(snapshot.Status.Indications).To(BeEmpty())
+
 			contentName := *snapshot.Status.VirtualMachineSnapshotContentName
 			content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
    Currently online vm snapshot is not supported, hence indications
    should not be updated. When online vm snapshot will be supported
    indications will be updated with a msg that the vm was running when
    takeing the vm snapshot, futhermore in the future it will be
    possible to decide if the vm snapshot should be taken using guest
    agent coordination, if not then a msg that the guest agent was not
    participating will be added to the indications.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
