### PR TITLE
network: remove the unused attr from the startDHCP bind mech method

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/generated_mock_podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_podinterface.go
@@ -5,8 +5,6 @@ package network
 
 import (
 	gomock "github.com/golang/mock/gomock"
-
-	v1 "kubevirt.io/client-go/api/v1"
 )
 
 // Mock of BindMechanism interface
@@ -102,12 +100,12 @@ func (_mr *_MockBindMechanismRecorder) decorateConfig() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "decorateConfig")
 }
 
-func (_m *MockBindMechanism) startDHCP(vmi *v1.VirtualMachineInstance) error {
-	ret := _m.ctrl.Call(_m, "startDHCP", vmi)
+func (_m *MockBindMechanism) startDHCP() error {
+	ret := _m.ctrl.Call(_m, "startDHCP")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockBindMechanismRecorder) startDHCP(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "startDHCP", arg0)
+func (_mr *_MockBindMechanismRecorder) startDHCP() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "startDHCP")
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -65,7 +65,7 @@ type BindMechanism interface {
 	// The following entry points require domain initialized for the
 	// binding and can be used in phase2 only.
 	decorateConfig() error
-	startDHCP(vmi *v1.VirtualMachineInstance) error
+	startDHCP() error
 }
 
 type podNICImpl struct {
@@ -236,7 +236,7 @@ func ensureDHCP(vmi *v1.VirtualMachineInstance, bindMechanism BindMechanism, pod
 	dhcpStartedFile := fmt.Sprintf("/var/run/kubevirt-private/dhcp_started-%s", podInterfaceName)
 	_, err := os.Stat(dhcpStartedFile)
 	if os.IsNotExist(err) {
-		if err := bindMechanism.startDHCP(vmi); err != nil {
+		if err := bindMechanism.startDHCP(); err != nil {
 			return fmt.Errorf("failed to start DHCP server for interface %s", podInterfaceName)
 		}
 		newFile, err := os.Create(dhcpStartedFile)
@@ -450,7 +450,7 @@ func (b *BridgeBindMechanism) getFakeBridgeIP() (string, error) {
 	return "", fmt.Errorf("Failed to generate bridge fake address for interface %s", b.iface.Name)
 }
 
-func (b *BridgeBindMechanism) startDHCP(_ *v1.VirtualMachineInstance) error {
+func (b *BridgeBindMechanism) startDHCP() error {
 	if !b.vif.IPAMDisabled {
 		addr, err := b.getFakeBridgeIP()
 		if err != nil {
@@ -796,7 +796,7 @@ func configureVifV6Addresses(b *MasqueradeBindMechanism, err error) error {
 	return nil
 }
 
-func (b *MasqueradeBindMechanism) startDHCP(_ *v1.VirtualMachineInstance) error {
+func (b *MasqueradeBindMechanism) startDHCP() error {
 	return Handler.StartDHCP(b.vif, b.vif.Gateway, b.bridgeInterfaceName, b.iface.DHCPOptions, false)
 }
 
@@ -1183,7 +1183,7 @@ func (s *SlirpBindMechanism) preparePodNetworkInterfaces(_ uint32, _ int) error 
 	return nil
 }
 
-func (s *SlirpBindMechanism) startDHCP(_ *v1.VirtualMachineInstance) error {
+func (s *SlirpBindMechanism) startDHCP() error {
 	return nil
 }
 
@@ -1312,7 +1312,7 @@ func (b *MacvtapBindMechanism) setCachedVIF(_, _ string) error {
 	return nil
 }
 
-func (b *MacvtapBindMechanism) startDHCP(_ *v1.VirtualMachineInstance) error {
+func (b *MacvtapBindMechanism) startDHCP() error {
 	// macvtap will connect to the host's subnet
 	return nil
 }

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -625,8 +625,7 @@ var _ = Describe("Pod Network", func() {
 			masq.vif.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
 			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(nil)
 
-			err = masq.startDHCP(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(masq.startDHCP()).To(Succeed())
 		})
 		It("should fail when DHCP server failed", func() {
 			domain := NewDomainWithBridgeInterface()
@@ -644,8 +643,7 @@ var _ = Describe("Pod Network", func() {
 			err = fmt.Errorf("failed to start DHCP server")
 			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(err)
 
-			err = masq.startDHCP(vmi)
-			Expect(err).To(HaveOccurred())
+			Expect(masq.startDHCP()).To(HaveOccurred())
 		})
 	})
 	Context("Bridge startDHCP", func() {
@@ -661,8 +659,7 @@ var _ = Describe("Pod Network", func() {
 
 			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(nil)
 
-			err = bridge.startDHCP(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(bridge.startDHCP()).To(Succeed())
 		})
 		It("should fail when DHCP server failed", func() {
 			domain := NewDomainWithBridgeInterface()
@@ -677,8 +674,7 @@ var _ = Describe("Pod Network", func() {
 			err = fmt.Errorf("failed to start DHCP server")
 			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
 
-			err = bridge.startDHCP(vmi)
-			Expect(err).To(HaveOccurred())
+			Expect(bridge.startDHCP()).To(HaveOccurred())
 		})
 		It("should succeed when DHCP server started and isLayer2 = true", func() {
 			domain := NewDomainWithBridgeInterface()
@@ -694,8 +690,7 @@ var _ = Describe("Pod Network", func() {
 			err = fmt.Errorf("failed to start DHCP server")
 			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
 
-			err = bridge.startDHCP(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(bridge.startDHCP()).To(Succeed())
 		})
 	})
 	Context("Slirp startDHCP", func() {
@@ -709,8 +704,7 @@ var _ = Describe("Pod Network", func() {
 			slirp, ok := driver.(*SlirpBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			err = slirp.startDHCP(vmi)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(slirp.startDHCP()).To(Succeed())
 		})
 		// slirp never fails to start DHCP because it doesn't need it at all
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The attribute on the bind mechanism interface is not used on any of the implementations.

As such, let's clean the interface up by removing it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
