### PR TITLE
[WIP] merge CPUNodeDiscovery and HypervStrictCheck

### DIFF
--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -28,17 +28,16 @@ const (
 	IgnitionGate      = "ExperimentalIgnitionSupport"
 	LiveMigrationGate = "LiveMigration"
 	// SRIOVLiveMigrationGate enable's Live Migration for VM's with SRIOV interfaces.
-	SRIOVLiveMigrationGate = "SRIOVLiveMigration"
-	CPUNodeDiscoveryGate   = "CPUNodeDiscovery"
-	HypervStrictCheckGate  = "HypervStrictCheck"
-	SidecarGate            = "Sidecar"
-	GPUGate                = "GPU"
-	HostDevicesGate        = "HostDevices"
-	SnapshotGate           = "Snapshot"
-	HotplugVolumesGate     = "HotplugVolumes"
-	HostDiskGate           = "HostDisk"
-	VirtIOFSGate           = "ExperimentalVirtiofsSupport"
-	MacvtapGate            = "Macvtap"
+	SRIOVLiveMigrationGate                = "SRIOVLiveMigration"
+	IgnoreCPUFeaturesDuringSchedulingGate = "IgnoreCPUFeaturesDuringScheduling"
+	SidecarGate                           = "Sidecar"
+	GPUGate                               = "GPU"
+	HostDevicesGate                       = "HostDevices"
+	SnapshotGate                          = "Snapshot"
+	HotplugVolumesGate                    = "HotplugVolumes"
+	HostDiskGate                          = "HostDisk"
+	VirtIOFSGate                          = "ExperimentalVirtiofsSupport"
+	MacvtapGate                           = "Macvtap"
 )
 
 func (c *ClusterConfig) isFeatureGateEnabled(featureGate string) bool {
@@ -67,12 +66,8 @@ func (config *ClusterConfig) SRIOVLiveMigrationEnabled() bool {
 	return config.isFeatureGateEnabled(SRIOVLiveMigrationGate)
 }
 
-func (config *ClusterConfig) HypervStrictCheckEnabled() bool {
-	return config.isFeatureGateEnabled(HypervStrictCheckGate)
-}
-
-func (config *ClusterConfig) CPUNodeDiscoveryEnabled() bool {
-	return config.isFeatureGateEnabled(CPUNodeDiscoveryGate)
+func (config *ClusterConfig) IgnoreCPUFeaturesDuringSchedulingGateEnabled() bool {
+	return config.isFeatureGateEnabled(IgnoreCPUFeaturesDuringSchedulingGate)
 }
 
 func (config *ClusterConfig) SidecarEnabled() bool {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1100,7 +1100,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		nodeSelector[k] = v
 
 	}
-	if t.clusterConfig.CPUNodeDiscoveryEnabled() {
+	if !t.clusterConfig.IgnoreCPUFeaturesDuringSchedulingGateEnabled() {
 		if cpuModelLabel, err := CPUModelLabelFromCPUModel(vmi); err == nil {
 			if vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
 				nodeSelector[cpuModelLabel] = "true"
@@ -1109,11 +1109,8 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		for _, cpuFeatureLable := range CPUFeatureLabelsFromCPUFeatures(vmi) {
 			nodeSelector[cpuFeatureLable] = "true"
 		}
-	}
 
-	if t.clusterConfig.HypervStrictCheckEnabled() {
-		hvNodeSelectors := getHypervNodeSelectors(vmi)
-		for k, v := range hvNodeSelectors {
+		for k, v := range getHypervNodeSelectors(vmi) {
 			nodeSelector[k] = v
 		}
 	}
@@ -1257,7 +1254,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		pod.Spec.Affinity = vmi.Spec.Affinity.DeepCopy()
 	}
 
-	if t.clusterConfig.CPUNodeDiscoveryEnabled() {
+	if !t.clusterConfig.IgnoreCPUFeaturesDuringSchedulingGateEnabled() {
 		SetNodeAffinityForForbiddenFeaturePolicy(vmi, &pod)
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -930,8 +930,6 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should add node selector for node discovery feature to template", func() {
-				enableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
-
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -997,9 +995,7 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).To(HaveKeyWithValue("node-role.kubernetes.io/compute", "true"))
 			})
 
-			It("should not add node selector for hyperv nodes if VMI does not request hyperv features", func() {
-				enableFeatureGate(virtconfig.HypervStrictCheckGate)
-
+			It("should not add node selector for hyperv nodes if VMI does not request cpu features", func() {
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testvmi",
@@ -1024,7 +1020,9 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.NodeSelector).To(Not(HaveKey(ContainSubstring(NFD_KVM_INFO_PREFIX))))
 			})
 
-			It("should not add node selector for hyperv nodes if VMI requests hyperv features, but feature gate is disabled", func() {
+			It("should not add node selector for hyperv nodes if VMI requests cpu features, but feature gate is disabled", func() {
+				enableFeatureGate(virtconfig.IgnoreCPUFeaturesDuringSchedulingGate)
+
 				enabled := true
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1058,8 +1056,6 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should add node selector for hyperv nodes if VMI requests hyperv features which depend on host kernel", func() {
-				enableFeatureGate(virtconfig.HypervStrictCheckGate)
-
 				enabled := true
 				vmi := v1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1102,8 +1098,6 @@ var _ = Describe("Template", func() {
 			})
 
 			It("should not add node selector for hyperv nodes if VMI requests hyperv features which do not depend on host kernel", func() {
-				enableFeatureGate(virtconfig.HypervStrictCheckGate)
-
 				var retries uint32 = 4095
 				enabled := true
 				vmi := v1.VirtualMachineInstance{

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
@@ -922,8 +921,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					}
 
 				}
-
-				tests.EnableFeatureGate(virtconfig.CPUNodeDiscoveryGate)
 			})
 
 			It("[test_id:1639]the vmi with cpu.model matching a nfd label on a node should be scheduled", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
As node-labeler is now a part of kubevirt, we can default `CPUNodeDiscovery` and `HypervStrictCheck` to true.
This PR merges the two feature gates as there is no reason anymore to keep them separate and adds a combined gate allowing to disable them called `IgnoreCPUFeaturesDuringScheduling`

I don't know if we can actually do this as it might break people that try to set those flags before, but it would be the behavior we'd like to achieve.
As a follow-up HCO should remove the flag(s) and optionally expose the new one in their API as the behavior might not work with emulation.

**Release note**:
```release-note
- Remove `CPUNodeDiscovery` and `HypervStrictCheck` and default the behavior to true.
- Add `IgnoreCPUFeaturesDuringScheduling` to disable cpu feature node selectors.
```

/cc @omeryahud @fabiand @ksimon1 
