### PR TITLE
Istio, Update nft rules for VMI with masquarade interface with no explicit ports

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -482,9 +482,7 @@ var _ = Describe("Pod Network", func() {
 			})
 		})
 		Context("Masquerade Plug", func() {
-			It("should define a new DhcpConfig bind to a bridge and create a default nat rule using iptables", func() {
-
-				// forward all the traffic
+			It("should define a bridge in pod and forward all traffic to VM using iptables", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().NftablesLoad(proto).Return(fmt.Errorf("no nft"))
 					mockNetwork.EXPECT().HasNatIptables(proto).Return(true).Times(2)
@@ -498,8 +496,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new DhcpConfig bind to a bridge and create a specific nat rule using iptables", func() {
-				// Forward a specific port
+			It("should define a bridge in pod and forward specific ports to VM using iptables", func() {
 				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
 				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
@@ -536,8 +533,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new DhcpConfig bind to a bridge and create a default nat rule using nftables", func() {
-				// forward all the traffic
+			It("should define a bridge in pod and forward all traffic to VM using nftables", func() {
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().NftablesLoad(proto).Return(nil)
 				}
@@ -550,8 +546,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new DhcpConfig bind to a bridge and create a specific nat rule using nftables", func() {
-				// Forward a specific port
+			It("should define a bridge in pod and forward specific ports to VM using nftables", func() {
 				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
 				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
@@ -587,8 +582,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new DhcpConfig bind to a bridge with Istio enabled and create a default nat rule using nftables", func() {
-				// forward all the traffic
+			It("should define a bridge in pod with Istio proxy and forward all traffic to VM using nftables", func() {
 				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
 				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
@@ -630,8 +624,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new DhcpConfig bind to a bridge with Istio enabled and create a specific nat rule using nftables", func() {
-				// Forward a specific port
+			It("should define a bridge in pod with Istio proxy and forward specific ports to VM using nftables", func() {
 				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
 				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -313,8 +313,8 @@ var _ = Describe("Pod Network", func() {
 				mockNetwork.EXPECT().NftablesAppendRule(proto, "nat", chain, "tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(portsUsedByLiveMigration(), ", ")), GetNFTIPString(proto), "saddr", getLoopbackAdrress(proto), "counter", "return").Return(nil)
 			}
 			mockNetwork.EXPECT().NftablesAppendRule(proto, "nat", "KUBEVIRT_PREINBOUND", "counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil)
-			mockNetwork.EXPECT().NftablesAppendRule(proto, "nat", "KUBEVIRT_POSTINBOUND", GetNFTIPString(proto), "saddr", getLoopbackAdrress(proto), "counter", "snat", "to", GetMasqueradeGwIp(proto)).Return(nil)
-			mockNetwork.EXPECT().NftablesAppendRule(proto, "nat", "output", GetNFTIPString(proto), "daddr", getLoopbackAdrress(proto), "counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil)
+			mockNetwork.EXPECT().NftablesAppendRule(proto, "nat", "KUBEVIRT_POSTINBOUND", GetNFTIPString(proto), "saddr", fmt.Sprintf("{ %s }", getLoopbackAdrress(proto)), "counter", "snat", "to", GetMasqueradeGwIp(proto)).Return(nil)
+			mockNetwork.EXPECT().NftablesAppendRule(proto, "nat", "output", GetNFTIPString(proto), "daddr", fmt.Sprintf("{ %s }", getLoopbackAdrress(proto)), "counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil)
 		}
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid, mtu, libvirtUser).Return(nil)
 		mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
@@ -583,6 +583,92 @@ var _ = Describe("Pod Network", func() {
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
 				vm.Spec.Domain.Devices.Interfaces[0].Ports = []v1.Port{{Name: "test", Port: 80, Protocol: "TCP"}}
+
+				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
+				TestPodInterfaceIPBinding(vm, domain)
+			})
+			It("should define a new DhcpConfig bind to a bridge with Istio enabled and create a default nat rule using nftables", func() {
+				// forward all the traffic
+				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
+
+				for _, proto := range ipProtocols() {
+					mockNetwork.EXPECT().NftablesLoad(proto).Return(nil)
+
+					for _, chain := range []string{"output", "KUBEVIRT_POSTINBOUND"} {
+						mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+							chain, "tcp", "dport", fmt.Sprintf("{ %s }", strings.Join(portsUsedByIstio(), ", ")),
+							GetNFTIPString(proto), "saddr", getLoopbackAdrress(proto), "counter", "return").Return(nil)
+					}
+
+					mockNetwork.EXPECT().ReadIPAddressesFromLink(primaryPodInterfaceName).Return(fakeAddr.IP.String(), "", nil)
+					mockNetwork.EXPECT().LinkByName(primaryPodInterfaceName).Return(primaryPodInterface, nil)
+
+					srcAddressesToSnat := []string{getLoopbackAdrress(proto)}
+					dstAddressesToDnat := []string{getLoopbackAdrress(proto)}
+					if proto == iptables.ProtocolIPv4 {
+						srcAddressesToSnat = append(srcAddressesToSnat, getEnvoyLoopbackAddress())
+						dstAddressesToDnat = append(dstAddressesToDnat, fakeAddr.IP.String())
+					}
+					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+						"KUBEVIRT_POSTINBOUND", GetNFTIPString(proto), "saddr", fmt.Sprintf("{ %s }", strings.Join(srcAddressesToSnat, ", ")),
+						"counter", "snat", "to", GetMasqueradeGwIp(proto)).Return(nil)
+					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+						"output", GetNFTIPString(proto), "daddr", fmt.Sprintf("{ %s }", strings.Join(dstAddressesToDnat, ", ")),
+						"counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil)
+					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+						"KUBEVIRT_PREINBOUND",
+						"counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil).Times(0)
+				}
+
+				domain := NewDomainWithBridgeInterface()
+				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
+				vm.Annotations = map[string]string{
+					IstioInjectAnnotation: "true",
+				}
+
+				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
+				TestPodInterfaceIPBinding(vm, domain)
+			})
+			It("should define a new DhcpConfig bind to a bridge with Istio enabled and create a specific nat rule using nftables", func() {
+				// Forward a specific port
+				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
+
+				for _, proto := range [2]iptables.Protocol{iptables.ProtocolIPv4, iptables.ProtocolIPv6} {
+					mockNetwork.EXPECT().NftablesLoad(proto).Return(nil)
+
+					mockNetwork.EXPECT().ReadIPAddressesFromLink(primaryPodInterfaceName).Return(fakeAddr.IP.String(), "", nil)
+					mockNetwork.EXPECT().LinkByName(primaryPodInterfaceName).Return(primaryPodInterface, nil)
+
+					srcAddressesToSnat := []string{getLoopbackAdrress(proto)}
+					dstAddressesToDnat := []string{getLoopbackAdrress(proto)}
+					if proto == iptables.ProtocolIPv4 {
+						srcAddressesToSnat = append(srcAddressesToSnat, getEnvoyLoopbackAddress())
+						dstAddressesToDnat = append(dstAddressesToDnat, fakeAddr.IP.String())
+					}
+					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+						"KUBEVIRT_POSTINBOUND",
+						"tcp", "dport", "80",
+						GetNFTIPString(proto), "saddr", fmt.Sprintf("{ %s }", strings.Join(srcAddressesToSnat, ", ")),
+						"counter", "snat", "to", GetMasqueradeGwIp(proto)).Return(nil)
+					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+						"output",
+						GetNFTIPString(proto), "daddr", fmt.Sprintf("{ %s }", strings.Join(dstAddressesToDnat, ", ")),
+						"tcp", "dport", "80",
+						"counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil)
+					mockNetwork.EXPECT().NftablesAppendRule(proto, "nat",
+						"KUBEVIRT_PREINBOUND",
+						"tcp", "dport", "80",
+						"counter", "dnat", "to", GetMasqueradeVmIp(proto)).Return(nil).Times(0)
+				}
+
+				domain := NewDomainWithBridgeInterface()
+				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
+				vm.Spec.Domain.Devices.Interfaces[0].Ports = []v1.Port{{Name: "test", Port: 80, Protocol: "TCP"}}
+				vm.Annotations = map[string]string{
+					IstioInjectAnnotation: "true",
+				}
 
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/virtctl/expose:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

#### proxy Istio traffic with default masquarade iface

This pull request adds nft rules that correctly route
traffic proxied by Istio envoy if VMI has
Istio sidecar injection enabled with an annotation.

Not updating IPtables because this is a new feature.

This PR deals with VMI with masquerade binding
with interface, that doesn't explicitly specify any ports.

There are two issues addressed:
1) With Istio proxy, we can't dnat traffic at KUBEVIRT_PREINBOUND
2) Istio uses the following ports for its functionality:
    "15000", "15001", "15006", "15008", "15020", "15021", "15090"
    These ports need to be excluded from forwarding to the VM.

E2E tests are extended to also include VMI without explicitly specified
ports for each scenario.
Additionally, a test testing that port restricted for istio is not reachable in the VMI is added. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends on
- #5200
- #5431 
- #5514

**Release note**:
```release-note
Add support for Istio proxy when no explicit ports are specified on masquerade interface 
```
