### PR TITLE
crds: fix patch formatting

### DIFF
--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -48,11 +48,7 @@ func patchCRD(client clientset.Interface, crd *extv1.CustomResourceDefinition, o
 		return err
 	}
 
-	if ops == nil {
-		ops = make([]string, 1)
-	}
 	ops = append(ops, fmt.Sprintf(replaceSpecPatchTemplate, string(newSpec)))
-
 	_, err = client.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to patch crd %+v: %v", crd, err)
@@ -150,7 +146,7 @@ func (r *Reconciler) rolloutNonCompatibleCRDChange(crd *extv1.CustomResourceDefi
 			return nil
 		}
 		// enable the status subresources now, in case that they were disabled before
-		if err := patchCRD(client, crd, nil); err != nil {
+		if err := patchCRD(client, crd, []string{}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When passing `ops` as `nil` to `patchCRD()` the function
was creating a malformed patch due to initializing `ops` as a 1
element slice causing the next append to make it a 2 elements
slice and ending up in the patch being produced as:

`[, { "op": "replace", "path": "/spec", "value": "something" }]`

This is a simple reproducer of the bug:

```
package main

import "fmt"

const replaceSpecPatchTemplate = `{ "op": "replace", "path": "/spec", "value": %s }`

func main() {
    var ops []string

    if ops == nil {
        ops = make([]string, 1)
    }
    ops = append(ops, fmt.Sprintf(replaceSpecPatchTemplate, "ciao"))
    val := generatePatchBytes(ops)
    fmt.Println(string(val))

}

func generatePatchBytes(ops []string) []byte {
    opsStr := "["
    for idx, entry := range ops {
        sep := ", "
        if len(ops)-1 == idx {
            sep = "]"
        }
        opsStr = fmt.Sprintf("%s%s%s", opsStr, entry, sep)
    }
    return []byte(opsStr)
}
```

This was happening with upgrades from v0.36 to 0v.40 because a v0.36
CRD does not have the status subresource enabled causing the
virt-operator to call `rolloutNonCompatibleCRDChange()` which in turn
calls `patchCRD()` with `ops` as `nil`.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fixes patching of CRDs when rolling out non-compatible CRD changes, this happens when upgrading from v0.36 to v0.40.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5462

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes upgrades from KubeVirt v0.36
```
