### PR TITLE
[release-0.40] crds: fix patch formatting

### DIFF
--- a/pkg/virt-operator/resource/apply/crds.go
+++ b/pkg/virt-operator/resource/apply/crds.go
@@ -48,11 +48,7 @@ func patchCRD(client clientset.Interface, crd *extv1.CustomResourceDefinition, o
 		return err
 	}
 
-	if ops == nil {
-		ops = make([]string, 1)
-	}
-	ops = append(ops, fmt.Sprintf(`{ "op": "replace", "path": "/spec", "value": %s }`, string(newSpec)))
-
+	ops = append(ops, fmt.Sprintf(replaceSpecPatchTemplate, string(newSpec)))
 	_, err = client.ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), crd.Name, types.JSONPatchType, generatePatchBytes(ops), metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to patch crd %+v: %v", crd, err)
@@ -149,7 +145,7 @@ func (r *Reconciler) rolloutNonCompatibleCRDChange(crd *extv1.CustomResourceDefi
 			return nil
 		}
 		// enable the status subresources now, in case that they were disabled before
-		if err := patchCRD(client, crd, nil); err != nil {
+		if err := patchCRD(client, crd, []string{}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherrypick of #5463.

Fixes patching of CRDs when rolling out non-compatible CRD changes, this happens when upgrading from v0.36 to v0.40.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fixes upgrades from KubeVirt v0.36
```
