### PR TITLE
Remove get mac details

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -97,7 +97,6 @@ type NetworkHandler interface {
 	ParseAddr(s string) (*netlink.Addr, error)
 	GetHostAndGwAddressesFromCIDR(s string) (string, string, error)
 	SetRandomMac(ifaceName string) (*net.HardwareAddr, error)
-	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error
 	HasNatIptables(proto iptables.Protocol) bool
@@ -315,16 +314,6 @@ func inc(ip net.IP) {
 			break
 		}
 	}
-}
-
-// GetMacDetails from an interface
-func (h *NetworkUtilsHandler) GetMacDetails(iface string) (net.HardwareAddr, error) {
-	currentMac, err := lmf.GetCurrentMac(iface)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to get mac information for interface: %s", iface)
-		return nil, err
-	}
-	return currentMac, nil
 }
 
 // SetRandomMac changes the MAC address for a given interface to a randomly generated, preserving the vendor prefix

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -170,9 +170,9 @@ func (_mr *_MockNetworkHandlerRecorder) GetHostAndGwAddressesFromCIDR(arg0 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHostAndGwAddressesFromCIDR", arg0)
 }
 
-func (_m *MockNetworkHandler) SetRandomMac(iface string) (net.HardwareAddr, error) {
-	ret := _m.ctrl.Call(_m, "SetRandomMac", iface)
-	ret0, _ := ret[0].(net.HardwareAddr)
+func (_m *MockNetworkHandler) SetRandomMac(ifaceName string) (*net.HardwareAddr, error) {
+	ret := _m.ctrl.Call(_m, "SetRandomMac", ifaceName)
+	ret0, _ := ret[0].(*net.HardwareAddr)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -181,17 +181,6 @@ func (_mr *_MockNetworkHandlerRecorder) SetRandomMac(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRandomMac", arg0)
 }
 
-func (_m *MockNetworkHandler) GetMacDetails(iface string) (net.HardwareAddr, error) {
-	ret := _m.ctrl.Call(_m, "GetMacDetails", iface)
-	ret0, _ := ret[0].(net.HardwareAddr)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockNetworkHandlerRecorder) GetMacDetails(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetMacDetails", arg0)
-}
-
 func (_m *MockNetworkHandler) LinkSetMaster(link netlink.Link, master *netlink.Bridge) error {
 	ret := _m.ctrl.Call(_m, "LinkSetMaster", link, master)
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -474,16 +474,18 @@ func (b *BridgeBindMechanism) preparePodNetworkInterfaces() error {
 		}
 	}
 
-	if _, err := b.handler.SetRandomMac(b.podInterfaceName); err != nil {
+	currentMac := b.podNicLink.Attrs().HardwareAddr
+	newMAC, err := b.handler.SetRandomMac(b.podNicLink.Attrs().Name)
+	if err != nil {
 		return err
 	}
+	log.Log.Infof("updated MAC for %s interface: old: %s -> new: %s", b.podInterfaceName, currentMac, newMAC)
 
 	if err := b.createBridge(); err != nil {
 		return err
 	}
 
-	err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.queueCount, *b.launcherPID, int(b.vif.Mtu), libvirtUserAndGroupId)
-	if err != nil {
+	if err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.queueCount, *b.launcherPID, int(b.vif.Mtu), libvirtUserAndGroupId); err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -57,7 +57,6 @@ var _ = Describe("Pod Network", func() {
 	var routeAddr netlink.Route
 	var fakeMac net.HardwareAddr
 	var fakeAddr netlink.Addr
-	var updateFakeMac net.HardwareAddr
 	var bridgeTest *netlink.Bridge
 	var masqueradeBridgeTest *netlink.Bridge
 	var bridgeAddr *netlink.Addr
@@ -95,7 +94,6 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork = NewMockNetworkHandler(ctrl)
 		podnic = podNICImpl{cacheFactory: cacheFactory, handler: mockNetwork}
 		testMac := "12:34:56:78:9A:BC"
-		updateTestMac := "AF:B3:1F:78:2A:CA"
 		mtu = 1410
 		newPodInterfaceName = fmt.Sprintf("%s-nic", primaryPodInterfaceName)
 		dummySwap = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: primaryPodInterfaceName}}
@@ -104,7 +102,6 @@ var _ = Describe("Pod Network", func() {
 		address := &net.IPNet{IP: net.IPv4(10, 35, 0, 6), Mask: net.CIDRMask(24, 32)}
 		gw := net.IPv4(10, 35, 0, 1)
 		fakeMac, _ = net.ParseMAC(testMac)
-		updateFakeMac, _ = net.ParseMAC(updateTestMac)
 		fakeAddr = netlink.Addr{IPNet: address}
 		addrList = []netlink.Addr{fakeAddr}
 		routeAddr = netlink.Route{Gw: gw}
@@ -200,7 +197,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().RouteList(primaryPodInterface, netlink.FAMILY_V4).Return(routeList, nil)
 		mockNetwork.EXPECT().AddrDel(primaryPodInterface, &fakeAddr).Return(nil)
 		mockNetwork.EXPECT().LinkSetDown(primaryPodInterface).Return(nil)
-		mockNetwork.EXPECT().SetRandomMac(newPodInterfaceName).Return(updateFakeMac, nil)
+		mockNetwork.EXPECT().SetRandomMac(newPodInterfaceName).Return(&fakeMac, nil)
 		mockNetwork.EXPECT().LinkSetUp(primaryPodInterfaceAfterNameChange).Return(nil)
 		mockNetwork.EXPECT().LinkSetLearningOff(primaryPodInterfaceAfterNameChange).Return(nil)
 		mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
@@ -319,7 +316,7 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_ALL).Return(addrList, nil)
 			mockNetwork.EXPECT().LinkByName(primaryPodInterfaceName).Return(primaryPodInterface, nil)
 			mockNetwork.EXPECT().LinkSetDown(primaryPodInterface).Return(nil)
-			mockNetwork.EXPECT().SetRandomMac(primaryPodInterfaceName).Return(updateFakeMac, nil)
+			mockNetwork.EXPECT().SetRandomMac(primaryPodInterfaceName).Return(&fakeMac, nil)
 			mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_V4).Return(addrList, nil)
 			mockNetwork.EXPECT().LinkAdd(bridgeTest).Return(nil)
 			mockNetwork.EXPECT().LinkByName(api.DefaultBridgeName).Return(bridgeTest, nil)

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -325,7 +325,6 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().ParseAddr(fmt.Sprintf(bridgeFakeIP, 0)).Return(bridgeAddr, nil)
 			mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
 			mockNetwork.EXPECT().RouteList(primaryPodInterface, netlink.FAMILY_V4).Return(routeList, nil)
-			mockNetwork.EXPECT().GetMacDetails(primaryPodInterfaceName).Return(fakeMac, nil)
 			mockNetwork.EXPECT().LinkSetMaster(primaryPodInterface, bridgeTest).Return(nil)
 			mockNetwork.EXPECT().AddrDel(primaryPodInterface, &fakeAddr).Return(errors.New("device is busy"))
 			mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid, mtu, libvirtUser).Return(nil)
@@ -349,7 +348,6 @@ var _ = Describe("Pod Network", func() {
 			mockNetwork.EXPECT().LinkByName(primaryPodInterfaceName).Return(primaryPodInterface, nil).Times(2)
 			mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_ALL).Return(addrList, nil)
 			mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_V4).Return(addrList, nil)
-			mockNetwork.EXPECT().GetMacDetails(primaryPodInterfaceName).Return(fakeMac, nil)
 			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			err := podnic.PlugPhase1(vm, &vm.Spec.Domain.Devices.Interfaces[0], &vm.Spec.Networks[0], primaryPodInterfaceName, pid)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove the `GetMacDetails` function from the network driver.

We are already reading (and caching) the full link; we can simply return its MAC attribute, rather than using this library's function.

**Special notes for your reviewer**:
Depends-on: #5453

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
