### PR TITLE
network, driver: remove unused method GenerateRandomMac

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/common.go
+++ b/pkg/virt-launcher/virtwrap/network/common.go
@@ -22,7 +22,6 @@
 package network
 
 import (
-	"crypto/rand"
 	"fmt"
 	"net"
 	"os"
@@ -97,7 +96,6 @@ type NetworkHandler interface {
 	ParseAddr(s string) (*netlink.Addr, error)
 	GetHostAndGwAddressesFromCIDR(s string) (string, string, error)
 	SetRandomMac(iface string) (net.HardwareAddr, error)
-	GenerateRandomMac() (net.HardwareAddr, error)
 	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
 	StartDHCP(nic *VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error
@@ -407,18 +405,6 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *VIF, serverAddr net.IP, bridgeInter
 	}
 
 	return nil
-}
-
-// Generate a random mac for interface
-// Avoid MAC address starting with reserved value 0xFE (https://github.com/kubevirt/kubevirt/issues/1494)
-func (h *NetworkUtilsHandler) GenerateRandomMac() (net.HardwareAddr, error) {
-	prefix := []byte{0x02, 0x00, 0x00} // local unicast prefix
-	suffix := make([]byte, 3)
-	_, err := rand.Read(suffix)
-	if err != nil {
-		return nil, err
-	}
-	return net.HardwareAddr(append(prefix, suffix...)), nil
 }
 
 func (h *NetworkUtilsHandler) CreateTapDevice(tapName string, queueNumber uint32, launcherPID int, mtu int, tapOwner string) error {

--- a/pkg/virt-launcher/virtwrap/network/common_test.go
+++ b/pkg/virt-launcher/virtwrap/network/common_test.go
@@ -22,7 +22,6 @@ package network
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/onsi/ginkgo/extensions/table"
@@ -57,14 +56,6 @@ var _ = Describe("Common Methods", func() {
 			networkHandler := NetworkUtilsHandler{}
 			_, _, err := networkHandler.GetHostAndGwAddressesFromCIDR("fd10:0:2::/127")
 			Expect(err).To(HaveOccurred())
-		})
-	})
-	Context("GenerateRandomMac function", func() {
-		It("should return a valid mac address", func() {
-			networkHandler := NetworkUtilsHandler{}
-			mac, err := networkHandler.GenerateRandomMac()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.HasPrefix(mac.String(), "02:00:00")).To(BeTrue())
 		})
 	})
 	Context("composeNftablesLoad function", func() {

--- a/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
+++ b/pkg/virt-launcher/virtwrap/network/generated_mock_common.go
@@ -181,17 +181,6 @@ func (_mr *_MockNetworkHandlerRecorder) SetRandomMac(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRandomMac", arg0)
 }
 
-func (_m *MockNetworkHandler) GenerateRandomMac() (net.HardwareAddr, error) {
-	ret := _m.ctrl.Call(_m, "GenerateRandomMac")
-	ret0, _ := ret[0].(net.HardwareAddr)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockNetworkHandlerRecorder) GenerateRandomMac() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateRandomMac")
-}
-
 func (_m *MockNetworkHandler) GetMacDetails(iface string) (net.HardwareAddr, error) {
 	ret := _m.ctrl.Call(_m, "GetMacDetails", iface)
 	ret0, _ := ret[0].(net.HardwareAddr)

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -223,7 +223,6 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkAdd(masqueradeDummy).Return(nil)
 		mockNetwork.EXPECT().LinkByName(masqueradeDummyName).Return(masqueradeDummy, nil)
 		mockNetwork.EXPECT().LinkSetUp(masqueradeDummy).Return(nil)
-		mockNetwork.EXPECT().GenerateRandomMac().Return(fakeMac, nil)
 		mockNetwork.EXPECT().LinkAdd(masqueradeBridgeTest).Return(nil)
 		mockNetwork.EXPECT().LinkSetUp(masqueradeBridgeTest).Return(nil)
 		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, masqueradeBridgeTest).Return(nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR cleans up the driver interface by removing an unused method from it.

`GenerateRandomMac` was dropped in https://github.com/kubevirt/kubevirt/pull/4804/ .

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
