### PR TITLE
allow the cache store to sync during reconciliation

### DIFF
--- a/pkg/testutils/mock_queue.go
+++ b/pkg/testutils/mock_queue.go
@@ -58,6 +58,11 @@ func (q *MockWorkQueue) AddRateLimited(item interface{}) {
 func (q *MockWorkQueue) AddAfter(item interface{}, duration time.Duration) {
 	q.RateLimitingInterface.AddAfter(item, duration)
 	atomic.AddInt32(&q.addAfterEnque, 1)
+	q.wgLock.Lock()
+	defer q.wgLock.Unlock()
+	if q.addWG != nil {
+		q.addWG.Done()
+	}
 }
 
 func (q *MockWorkQueue) GetRateLimitedEnqueueCount() int {

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -53,6 +53,7 @@ import (
 const (
 	virtOperatorJobAppLabel    = "virt-operator-strategy-dumper"
 	installStrategyKeyTemplate = "%s-%d"
+	defaultAddDelay            = 5 * time.Second
 )
 
 type KubeVirtController struct {
@@ -444,7 +445,7 @@ func (c *KubeVirtController) genericAddHandler(obj interface{}, expecter *contro
 		if expecter != nil {
 			expecter.CreationObserved(controllerKey)
 		}
-		c.queue.Add(controllerKey)
+		c.queue.AddAfter(controllerKey, defaultAddDelay)
 	}
 }
 
@@ -466,7 +467,7 @@ func (c *KubeVirtController) genericUpdateHandler(old, cur interface{}, expecter
 
 	key, err := c.getKubeVirtKey()
 	if key != "" && err == nil {
-		c.queue.Add(key)
+		c.queue.AddAfter(key, defaultAddDelay)
 	}
 	return
 }
@@ -504,7 +505,7 @@ func (c *KubeVirtController) genericDeleteHandler(obj interface{}, expecter *con
 		if expecter != nil {
 			expecter.DeletionObserved(key, k)
 		}
-		c.queue.Add(key)
+		c.queue.AddAfter(key, defaultAddDelay)
 	}
 }
 
@@ -527,7 +528,7 @@ func (c *KubeVirtController) enqueueKubeVirt(obj interface{}) {
 	if err != nil {
 		logger.Object(kv).Reason(err).Error("Failed to extract key from KubeVirt.")
 	}
-	c.queue.Add(key)
+	c.queue.AddAfter(key, defaultAddDelay)
 }
 
 func (c *KubeVirtController) Run(threadiness int, stopCh <-chan struct{}) {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -225,6 +225,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -47,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	aggregatorclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"k8s.io/utils/pointer"
@@ -1699,10 +1700,23 @@ spec:
 		})
 
 		It("[test_id:4613]should remove owner references on non-namespaces resources when updating a resource", func() {
+			By("getting existing resource to reference")
+			cm, err := virtClient.CoreV1().ConfigMaps(originalKv.Namespace).Get(context.Background(), "kubevirt-ca", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			ownerRef := []metav1.OwnerReference{
+				*metav1.NewControllerRef(&k8sv1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: cm.Name,
+						UID:  cm.UID,
+					},
+				}, schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap", Group: ""}),
+			}
+
 			By("adding an owner reference")
 			origCRD, err := virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 			crd := origCRD.DeepCopy()
-			crd.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(&v1.KubeVirt{ObjectMeta: metav1.ObjectMeta{Name: "kubevirt", UID: "a185f8c3-3f38-4b89-a8cc-80f3731f7ff9"}}, v1.KubeVirtGroupVersionKind)}
+			crd.OwnerReferences = ownerRef
 			patch := patchCRD(origCRD, crd)
 			_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -1717,12 +1731,13 @@ spec:
 			patch = patchCRD(origCRD, crd)
 			_, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Patch(context.Background(), "virtualmachineinstances.kubevirt.io", types.MergePatchType, patch, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
+
 			By("waiting until the owner reference disappears again")
 			Eventually(func() []metav1.OwnerReference {
 				crd, err = virtClient.ExtensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "virtualmachineinstances.kubevirt.io", metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				return crd.OwnerReferences
-			}, 10*time.Second, 1*time.Second).Should(BeEmpty())
+			}, 20*time.Second, 1*time.Second).Should(BeEmpty())
 			Expect(crd.ObjectMeta.OwnerReferences).To(HaveLen(0))
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Using queue.Add() adds the item immediately to be synced and does not take the rate queue limit into account. If added with `.AddRateLimitedItem()` the rate limiter will start to increase its rate limit. By using `AddAfter` we get the desired effect that the item is queued with a 5 second delay to allow the cache store to be populated and up to date. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
