### PR TITLE
Add dedicated functions for virt-chroot execution

### DIFF
--- a/pkg/virt-handler/container-disk/BUILD.bazel
+++ b/pkg/virt-handler/container-disk/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/container-disk:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
+        "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/virt-handler/hotplug-disk/BUILD.bazel
+++ b/pkg/virt-handler/hotplug-disk/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
+        "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 
+	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
+
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/util"
@@ -59,11 +61,11 @@ var (
 	}
 
 	mountCommand = func(sourcePath, targetPath string) ([]byte, error) {
-		return exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "mount", "-o", "bind", strings.TrimPrefix(sourcePath, isolation.NodeIsolationResult().MountRoot()), targetPath).CombinedOutput()
+		return virt_chroot.MountChroot(strings.TrimPrefix(sourcePath, isolation.NodeIsolationResult().MountRoot()), targetPath, false).CombinedOutput()
 	}
 
 	unmountCommand = func(diskPath string) ([]byte, error) {
-		return exec.Command("/usr/bin/virt-chroot", "--mount", "/proc/1/ns/mnt", "umount", diskPath).CombinedOutput()
+		return virt_chroot.UmountChroot(diskPath).CombinedOutput()
 	}
 
 	isMounted = func(path string) (bool, error) {

--- a/pkg/virt-handler/isolation/BUILD.bazel
+++ b/pkg/virt-handler/isolation/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/cgroup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/containernetworking/plugins/pkg/ns:go_default_library",

--- a/pkg/virt-handler/isolation/validation.go
+++ b/pkg/virt-handler/isolation/validation.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
+
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 )
 
@@ -14,8 +16,8 @@ const (
 
 func GetImageInfo(imagePath string, context IsolationResult) (*containerdisk.DiskInfo, error) {
 	// #nosec g204 no risk to use MountNamespace()  argument as it returns a fixed string of "/proc/<pid>/ns/mnt"
-	out, err := exec.Command(
-		"/usr/bin/virt-chroot", "--user", "qemu", "--memory", "1000", "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
+	out, err := virt_chroot.ExecChroot(
+		"--user", "qemu", "--memory", "1000", "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
 		QEMUIMGPath, "info", imagePath, "--output", "json",
 	).Output()
 	if err != nil {

--- a/pkg/virt-handler/selinux/BUILD.bazel
+++ b/pkg/virt-handler/selinux/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/selinux",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",

--- a/pkg/virt-handler/selinux/labels.go
+++ b/pkg/virt-handler/selinux/labels.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
+
 	"kubevirt.io/client-go/log"
 )
 
@@ -90,12 +92,12 @@ func (se *SELinuxImpl) semodule(args ...string) (out []byte, err error) {
 		return []byte{}, fmt.Errorf("could not find 'semodule' binary")
 	}
 
-	argsArray := []string{"--mount", "/proc/1/ns/mnt", "exec", "--", path}
+	argsArray := []string{"--mount", virt_chroot.GetChrootMountNamespace(), "exec", "--", path}
 	for _, arg := range args {
 		argsArray = append(argsArray, arg)
 	}
 
-	out, err = se.execFunc("/usr/bin/virt-chroot", argsArray...)
+	out, err = se.execFunc(virt_chroot.GetChrootBinaryPath(), argsArray...)
 	if err != nil && se.isPermissive() {
 		log.DefaultLogger().Warningf("Permissive mode, ignoring 'semodule' failure: out: %q, error: %v", string(out), err)
 		return []byte{}, nil
@@ -113,12 +115,12 @@ func (se *SELinuxImpl) Mode() string {
 }
 
 func (se *SELinuxImpl) selinux(args ...string) (out []byte, err error) {
-	argsArray := []string{"--mount", "/proc/1/ns/mnt", "selinux"}
+	argsArray := []string{"--mount", virt_chroot.GetChrootMountNamespace(), "selinux"}
 	for _, arg := range args {
 		argsArray = append(argsArray, arg)
 	}
 
-	return se.execFunc("/usr/bin/virt-chroot", argsArray...)
+	return se.execFunc(virt_chroot.GetChrootBinaryPath(), argsArray...)
 }
 
 func defaultCopyPolicyFunc(policyName string, dir string) (err error) {

--- a/pkg/virt-handler/virt-chroot/BUILD.bazel
+++ b/pkg/virt-handler/virt-chroot/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["virt-chroot.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/virt-handler/virt-chroot/virt-chroot.go
+++ b/pkg/virt-handler/virt-chroot/virt-chroot.go
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package virt_chroot
+
+import "os/exec"
+
+const (
+	binaryPath     = "/usr/bin/virt-chroot"
+	mountNamespace = "/proc/1/ns/mnt"
+)
+
+func getBaseArgs() []string {
+	return []string{"--mount", mountNamespace}
+}
+
+func GetChrootBinaryPath() string {
+	return binaryPath
+}
+
+func GetChrootMountNamespace() string {
+	return mountNamespace
+}
+
+func MountChroot(sourcePath, targetPath string, ro bool) *exec.Cmd {
+	args := append(getBaseArgs(), "mount", "-o")
+	optionArgs := "bind"
+
+	if ro {
+		optionArgs = "ro," + optionArgs
+	}
+
+	args = append(args, optionArgs, sourcePath, targetPath)
+	return exec.Command(binaryPath, args...)
+}
+
+func UmountChroot(path string) *exec.Cmd {
+	args := append(getBaseArgs(), "umount", path)
+	return exec.Command(binaryPath, args...)
+}
+
+// For general purposes
+func ExecChroot(args ...string) *exec.Cmd {
+	return exec.Command(binaryPath, args...)
+}

--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/reporter",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virt-handler/virt-chroot:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/tests/reporter/kubernetes.go
+++ b/tests/reporter/kubernetes.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	virt_chroot "kubevirt.io/kubevirt/pkg/virt-handler/virt-chroot"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/types"
@@ -365,9 +367,9 @@ func (r *KubernetesReporter) logJournal(virtCli kubecli.KubevirtClient, duration
 		}
 
 		commands := []string{
-			"/usr/bin/virt-chroot",
+			virt_chroot.GetChrootBinaryPath(),
 			"--mount",
-			"/proc/1/ns/mnt",
+			virt_chroot.GetChrootMountNamespace(),
 			"exec",
 			"--",
 			"/usr/bin/journalctl",


### PR DESCRIPTION
Important values like chroot binary path, default mount namespace
and mount execution options are not defined in a single place.
Therefore, the execution of virt-chroot, especially mounting/unmounting,
is duplicated and spread arround the code.

Now dedicated methods - MountChRoot(), UnmountChRoot() and ExecChroot() -
are added to virt-chroot.go file under util package. In addition,
GetChrootBinaryPath() and GetChrootMountNamespace() are added,
returning the data which is saved in a single place inside that file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
