### PR TITLE
Add iptables symlink for arm64 base container

### DIFF
--- a/rpm/BUILD.bazel
+++ b/rpm/BUILD.bazel
@@ -269,6 +269,7 @@ rpmtree(
     ],
     symlinks = {
         "/var/run": "../run",
+        "/usr/sbin/iptables": "/usr/sbin/iptables-legacy",
     },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up of #5426 which does the same for arm64 containers like we do for amd64 containers.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix fallback to iptables if nftables is not used on the host on arm64
```
