### PR TITLE
Improve migration proxy logging

### DIFF
--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -65,7 +65,7 @@ var _ = Describe("MigrationProxy", func() {
 
 				defer listener.Close()
 
-				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig)
+				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig, "123")
 				defer sourceProxy.Stop()
 
 				err = sourceProxy.Start()
@@ -107,8 +107,8 @@ var _ = Describe("MigrationProxy", func() {
 
 				defer libvirtdListener.Close()
 
-				targetProxy := NewTargetProxy("0.0.0.0", 12345, tlsConfig, tlsConfig, libvirtdSock)
-				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig)
+				targetProxy := NewTargetProxy("0.0.0.0", 12345, tlsConfig, tlsConfig, libvirtdSock, "123")
+				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig, "123")
 				defer targetProxy.Stop()
 				defer sourceProxy.Stop()
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -668,6 +668,7 @@ func (d *VirtualMachineController) migrationSourceUpdateVMIStatus(origVMI *v1.Vi
 		vmi.Status.EvacuationNodeName = ""
 		vmi.Status.MigrationState.Completed = true
 		d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to node %s.", migrationHost))
+		log.Log.Object(vmi).Infof("migration completed to node %s", migrationHost)
 	}
 
 	if !reflect.DeepEqual(oldStatus, vmi.Status) {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -700,7 +700,7 @@ func (l *LibvirtDomainManager) generateMigrationProxies(vmi *v1.VirtualMachineIn
 			port = 0
 		}
 		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-		newProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
+		newProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key), string(vmi.UID))
 		proxies = append(proxies, newProxy)
 	}
 
@@ -710,7 +710,7 @@ func (l *LibvirtDomainManager) generateMigrationProxies(vmi *v1.VirtualMachineIn
 		// this is only set to 0 during unit tests
 		tcpBindPort = 0
 	}
-	libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, tcpBindPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
+	libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, tcpBindPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)), string(vmi.UID))
 	proxies = append(proxies, libvirtConnectionProxy)
 
 	return proxies

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -100,7 +100,7 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(vmi *v1.VirtualMachineInst
 		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
 		curDirectAddress := net.JoinHostPort(loopbackAddress, strconv.Itoa(port))
 		unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)
-		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil)
+		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil, string(vmi.UID))
 
 		err := migrationProxy.Start()
 		if err != nil {

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -205,6 +205,15 @@ func (l FilteredLogger) log(skipFrames int, params ...interface{}) error {
 	}
 	return nil
 }
+
+func (l FilteredLogger) CustomField(key string, value string) *FilteredLogger {
+
+	logParams := make([]interface{}, 0)
+	logParams = append(logParams, key, value)
+	l.With(logParams...)
+	return &l
+}
+
 func (l FilteredLogger) Key(key string, kind string) *FilteredLogger {
 	if key == "" {
 		return &l


### PR DESCRIPTION
The logging in our migration proxy code has gaps that leave us without valuable information pertaining to when proxies are start, stop, and fail. As a result, it can be difficult to debug what occurs when a migration fails due to connectivity issues. Without more fidelity in our logs, it's difficult to rule out an issue within our components vs an issue occurring within the cluster network. 

With these changes, we can clearly see when proxies are created, where they are going, when they close, and why they close. 

Below is an example of the new output on the target node.. We have structured fields for the socket the proxy listens to, and the outbound connection.

```
{"component":"virt-handler","level":"info","listening":":::32813","msg":"proxy started listening","outbound":"libvirt-sock","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.632070Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"Manager created proxy on target","outbound":"libvirt-sock","pos":"migration-proxy.go:181","timestamp":"2021-04-22T15:55:13.632162Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"proxy started listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.632233Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"Manager created proxy on target","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:181","timestamp":"2021-04-22T15:55:13.632262Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"proxy started listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.632318Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"Manager created proxy on target","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:181","timestamp":"2021-04-22T15:55:13.632341Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"279 bytes copied outbound to inbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:14.922241Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"327 bytes copied from inbound to outbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:14.922435Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"0 bytes copied outbound to inbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.105970Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"74023264 bytes copied from inbound to outbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.106233Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"2372 bytes copied outbound to inbound","outbound":"libvirt-sock","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.340626Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"22904 bytes copied from inbound to outbound","outbound":"libvirt-sock","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.341302Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"Manager stopping proxy on target node","outbound":"libvirt-sock","pos":"migration-proxy.go:242","timestamp":"2021-04-22T15:55:15.411995Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"proxy stopped listening","outbound":"libvirt-sock","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.412167Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"Manager stopping proxy on target node","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:242","timestamp":"2021-04-22T15:55:15.412371Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"proxy stopped listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.412517Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"Manager stopping proxy on target node","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:242","timestamp":"2021-04-22T15:55:15.412709Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"proxy stopped listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.412818Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
```


And here is output from the source node

```
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"proxy started listening","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.647202Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"Manager created proxy on source node","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:308","timestamp":"2021-04-22T15:55:13.647255Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"proxy started listening","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.647388Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"Manager created proxy on source node","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:308","timestamp":"2021-04-22T15:55:13.647418Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"proxy started listening","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.647530Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"Manager created proxy on source node","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:308","timestamp":"2021-04-22T15:55:13.647556Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"279 bytes copied outbound to inbound","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:14.922549Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"327 bytes copied from inbound to outbound","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:14.922641Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"0 bytes copied outbound to inbound","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.106388Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"74023264 bytes copied from inbound to outbound","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.106492Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"2372 bytes copied outbound to inbound","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.342243Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"22904 bytes copied from inbound to outbound","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.342525Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"Manager stopping proxy on source node","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:321","timestamp":"2021-04-22T15:55:15.453983Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"proxy stopped listening","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.454182Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"Manager stopping proxy on source node","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:321","timestamp":"2021-04-22T15:55:15.454823Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"proxy stopped listening","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.454914Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"Manager stopping proxy on source node","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:321","timestamp":"2021-04-22T15:55:15.458318Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"proxy stopped listening","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.458505Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
```



```release-note
Improvements to migration proxy logging
```
