### PR TITLE
network, slirp: remove unused attributes from bind mech

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -357,7 +357,7 @@ func getPhase2Binding(vmi *v1.VirtualMachineInstance, iface *v1.Interface, netwo
 		}, nil
 	}
 	if iface.Slirp != nil {
-		return &SlirpBindMechanism{vmi: vmi, iface: iface, domain: domain}, nil
+		return &SlirpBindMechanism{iface: iface, domain: domain}, nil
 	}
 	if iface.Macvtap != nil {
 		mac, err := retrieveMacAddress(iface)
@@ -1166,10 +1166,8 @@ func (b *MasqueradeBindMechanism) createNatRulesUsingNftables(proto iptables.Pro
 }
 
 type SlirpBindMechanism struct {
-	vmi       *v1.VirtualMachineInstance
-	iface     *v1.Interface
-	virtIface *api.Interface
-	domain    *api.Domain
+	iface  *v1.Interface
+	domain *api.Domain
 }
 
 func (s *SlirpBindMechanism) discoverPodNetworkInterface() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `vmi` and `virtIface` attributes on the `Slirp` bind mechanism implementation are not being used. 

This PR removes them from the code base.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
