### PR TITLE
cache `virtIface` as `setupPodNetworking` last operation

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -207,13 +207,13 @@ func (l *podNICImpl) PlugPhase1(vmi *v1.VirtualMachineInstance, iface *v1.Interf
 			return createCriticalNetworkError(err)
 		}
 
-		if err := bindMechanism.setCachedInterface(); err != nil {
-			log.Log.Reason(err).Error("failed to save interface configuration")
+		if err := bindMechanism.setCachedVIF(getPIDString(&pid)); err != nil {
+			log.Log.Reason(err).Error("failed to save vif configuration")
 			return createCriticalNetworkError(err)
 		}
 
-		if err := bindMechanism.setCachedVIF(getPIDString(&pid)); err != nil {
-			log.Log.Reason(err).Error("failed to save vif configuration")
+		if err := bindMechanism.setCachedInterface(); err != nil {
+			log.Log.Reason(err).Error("failed to save interface configuration")
 			return createCriticalNetworkError(err)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR switches the order of the caching operations (first cache VIF, only then the iface) since the criteria for knowing if the infrastructure is to be created is based on the cached iface existing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
