### PR TITLE
[release-0.36] Improve live migration proxy logging

### DIFF
--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -72,6 +72,8 @@ type migrationProxy struct {
 	listener        net.Listener
 	serverTLSConfig *tls.Config
 	clientTLSConfig *tls.Config
+
+	logger *log.FilteredLogger
 }
 
 func GetMigrationPortsList(isBlockMigration bool) (ports []int) {
@@ -123,6 +125,7 @@ func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles 
 		} else {
 			// stop the current proxy and point it somewhere new.
 			for _, curProxy := range curProxies {
+				curProxy.logger.Infof("Manager stopping proxy on target node due to new unix filepath location")
 				curProxy.StopListening()
 			}
 		}
@@ -132,7 +135,7 @@ func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles 
 	proxiesList := []*migrationProxy{}
 	for _, targetUnixFile := range targetUnixFiles {
 		// 0 means random port is used
-		proxy := NewTargetProxy(zeroAddress, 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile)
+		proxy := NewTargetProxy(zeroAddress, 0, m.serverTLSConfig, m.clientTLSConfig, targetUnixFile, key)
 
 		err := proxy.StartListening()
 		if err != nil {
@@ -144,7 +147,7 @@ func (m *migrationProxyManager) StartTargetListener(key string, targetUnixFiles 
 			return err
 		}
 		proxiesList = append(proxiesList, proxy)
-		log.Log.Infof("Proxy Target listening on port %d for key %s", proxy.tcpBindPort, key)
+		proxy.logger.Infof("Manager created proxy on target")
 	}
 	m.targetProxies[key] = proxiesList
 	return nil
@@ -205,9 +208,9 @@ func (m *migrationProxyManager) StopTargetListener(key string) {
 	curProxies, exists := m.targetProxies[key]
 	if exists {
 		for _, curProxy := range curProxies {
+			curProxy.logger.Info("Manager stopping proxy on target node")
 			curProxy.StopListening()
 			delete(m.targetProxies, key)
-			log.Log.Infof("Stopping proxy target %s listening on %d", key, curProxy.tcpBindPort)
 		}
 	}
 }
@@ -242,6 +245,7 @@ func (m *migrationProxyManager) StartSourceListener(key string, targetAddress st
 		} else {
 			// stop the current proxy and point it somewhere new.
 			for _, curProxy := range curProxies {
+				curProxy.logger.Infof("Manager is stopping proxy on source node due to new target location")
 				curProxy.StopListening()
 			}
 		}
@@ -254,7 +258,7 @@ func (m *migrationProxyManager) StartSourceListener(key string, targetAddress st
 		filePath := SourceUnixFile(baseDir, proxyKey)
 
 		os.RemoveAll(filePath)
-		proxy := NewSourceProxy(filePath, targetFullAddr, m.serverTLSConfig, m.clientTLSConfig)
+		proxy := NewSourceProxy(filePath, targetFullAddr, m.serverTLSConfig, m.clientTLSConfig, key)
 
 		err := proxy.StartListening()
 		if err != nil {
@@ -266,7 +270,7 @@ func (m *migrationProxyManager) StartSourceListener(key string, targetAddress st
 			return err
 		}
 		proxiesList = append(proxiesList, proxy)
-		log.Log.Infof("Proxy Source listening on unix file %s for key %s", filePath, key)
+		proxy.logger.Infof("Manager created proxy on source node")
 	}
 	m.sourceProxies[key] = proxiesList
 	return nil
@@ -279,6 +283,7 @@ func (m *migrationProxyManager) StopSourceListener(key string) {
 	curProxies, exists := m.sourceProxies[key]
 	if exists {
 		for _, curProxy := range curProxies {
+			curProxy.logger.Infof("Manager stopping proxy on source node")
 			curProxy.StopListening()
 			os.RemoveAll(curProxy.unixSocketPath)
 		}
@@ -289,7 +294,7 @@ func (m *migrationProxyManager) StopSourceListener(key string) {
 // SRC POD ENV(migration unix socket) <-> HOST ENV (tcp client) <-----> HOST ENV (tcp server) <-> TARGET POD ENV (libvirtd unix socket)
 
 // Source proxy exposes a unix socket server and pipes to an outbound TCP connection.
-func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, serverTLSConfig *tls.Config, clientTLSConfig *tls.Config) *migrationProxy {
+func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, serverTLSConfig *tls.Config, clientTLSConfig *tls.Config, vmiUID string) *migrationProxy {
 	return &migrationProxy{
 		unixSocketPath:  unixSocketPath,
 		targetAddress:   tcpTargetAddress,
@@ -299,11 +304,12 @@ func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, serverTLSCon
 		listenErrChan:   make(chan error, 1),
 		serverTLSConfig: serverTLSConfig,
 		clientTLSConfig: clientTLSConfig,
+		logger:          log.Log.CustomField("uid", vmiUID).CustomField("listening", filepath.Base(unixSocketPath)).CustomField("outbound", tcpTargetAddress),
 	}
 }
 
 // Target proxy listens on a tcp socket and pipes to a libvirtd unix socket
-func NewTargetProxy(tcpBindAddress string, tcpBindPort int, serverTLSConfig *tls.Config, clientTLSConfig *tls.Config, libvirtdSocketPath string) *migrationProxy {
+func NewTargetProxy(tcpBindAddress string, tcpBindPort int, serverTLSConfig *tls.Config, clientTLSConfig *tls.Config, libvirtdSocketPath string, vmiUID string) *migrationProxy {
 
 	return &migrationProxy{
 		tcpBindAddress:  tcpBindAddress,
@@ -315,6 +321,7 @@ func NewTargetProxy(tcpBindAddress string, tcpBindPort int, serverTLSConfig *tls
 		listenErrChan:   make(chan error, 1),
 		serverTLSConfig: serverTLSConfig,
 		clientTLSConfig: clientTLSConfig,
+		logger:          log.Log.CustomField("uid", vmiUID).CustomField("outbound", filepath.Base(libvirtdSocketPath)),
 	}
 
 }
@@ -332,13 +339,15 @@ func (m *migrationProxy) createTcpListener() error {
 		return fmt.Errorf("Unsecured tcp migration proxy listeners are not permitted")
 	}
 	if err != nil {
-		log.Log.Reason(err).Error("failed to create unix socket for proxy service")
+		m.logger.Reason(err).Error("failed to create unix socket for proxy service")
 		return err
 	}
 
 	if m.tcpBindPort == 0 {
 		// update the random port that was selected
 		m.tcpBindPort = listener.Addr().(*net.TCPAddr).Port
+		// Add the listener to the log output once we know the port
+		m.logger = m.logger.CustomField("listening", fmt.Sprintf("%s:%d", m.tcpBindAddress, m.tcpBindPort))
 	}
 
 	m.listener = listener
@@ -350,13 +359,13 @@ func (m *migrationProxy) createUnixListener() error {
 	os.RemoveAll(m.unixSocketPath)
 	err := os.MkdirAll(filepath.Dir(m.unixSocketPath), 0755)
 	if err != nil {
-		log.Log.Reason(err).Error("unable to create directory for unix socket")
+		m.logger.Reason(err).Error("unable to create directory for unix socket")
 		return err
 	}
 
 	listener, err := net.Listen("unix", m.unixSocketPath)
 	if err != nil {
-		log.Log.Reason(err).Error("failed to create unix socket for proxy service")
+		m.logger.Reason(err).Error("failed to create unix socket for proxy service")
 		return err
 	}
 
@@ -369,11 +378,12 @@ func (m *migrationProxy) StopListening() {
 
 	close(m.stopChan)
 	if m.listener != nil {
+		m.logger.Infof("proxy stopped listening")
 		m.listener.Close()
 	}
 }
 
-func handleConnection(fd net.Conn, targetAddress string, targetProtocol string, clientTLSConfig *tls.Config, stopChan chan struct{}) {
+func (m *migrationProxy) handleConnection(fd net.Conn) {
 	defer fd.Close()
 
 	outBoundErr := make(chan error)
@@ -381,41 +391,40 @@ func handleConnection(fd net.Conn, targetAddress string, targetProtocol string, 
 
 	var conn net.Conn
 	var err error
-	if targetProtocol == "tcp" && clientTLSConfig != nil {
-		conn, err = tls.Dial(targetProtocol, targetAddress, clientTLSConfig)
+	if m.targetProtocol == "tcp" && m.clientTLSConfig != nil {
+		conn, err = tls.Dial(m.targetProtocol, m.targetAddress, m.clientTLSConfig)
 	} else {
-		conn, err = net.Dial(targetProtocol, targetAddress)
+		conn, err = net.Dial(m.targetProtocol, m.targetAddress)
 	}
 	if err != nil {
-		log.Log.Reason(err).Errorf("unable to create outbound leg of proxy to host %s", targetAddress)
+		m.logger.Reason(err).Error("unable to create outbound leg of proxy to host")
 		return
 	}
 
 	go func() {
 		//from outbound connection to proxy
 		n, err := io.Copy(fd, conn)
-		log.Log.Infof("%d bytes read from oubound connection", n)
+		m.logger.Infof("%d bytes copied outbound to inbound", n)
 		inBoundErr <- err
 	}()
 	go func() {
 		//from proxy to outbound connection
-
 		n, err := io.Copy(conn, fd)
-		log.Log.Infof("%d bytes written oubound connection", n)
+		m.logger.Infof("%d bytes copied from inbound to outbound", n)
 		outBoundErr <- err
 	}()
 
 	select {
 	case err = <-outBoundErr:
 		if err != nil {
-			log.Log.Reason(err).Errorf("error encountered copying data to outbound proxy connection %s", targetAddress)
+			m.logger.Reason(err).Errorf("error encountered copying data to outbound connection")
 		}
 	case err = <-inBoundErr:
 		if err != nil {
-			log.Log.Reason(err).Errorf("error encountered reading data to proxy connection %s", targetAddress)
+			m.logger.Reason(err).Errorf("error encountered copying data into inbound connection")
 		}
-	case <-stopChan:
-		log.Log.Infof("stop channel terminated proxy")
+	case <-m.stopChan:
+		m.logger.Info("stop channel terminated proxy")
 	}
 }
 
@@ -433,32 +442,40 @@ func (m *migrationProxy) StartListening() error {
 		}
 	}
 
-	go func(ln net.Listener, fdChan chan net.Conn, listenErr chan error) {
+	go func(ln net.Listener, fdChan chan net.Conn, listenErr chan error, stopChan chan struct{}) {
 		for {
 			fd, err := ln.Accept()
 			if err != nil {
 				listenErr <- err
-				log.Log.Reason(err).Error("proxy unix socket listener returned error.")
+
+				select {
+				case <-stopChan:
+					// If the stopChan is closed, then this is expected. Log at a lesser debug level
+					m.logger.Reason(err).V(3).Infof("stopChan is closed. Listener exited with expected error.")
+				default:
+					m.logger.Reason(err).Error("proxy unix socket listener returned error.")
+				}
 				break
 			} else {
 				fdChan <- fd
 			}
 		}
-	}(m.listener, m.fdChan, m.listenErrChan)
+	}(m.listener, m.fdChan, m.listenErrChan, m.stopChan)
 
-	go func(targetAddress string, targetProtocol string, clientTLSConfig *tls.Config, fdChan chan net.Conn, stopChan chan struct{}, listenErrChan chan error) {
+	go func(m *migrationProxy) {
 		for {
 			select {
-			case fd := <-fdChan:
-				go handleConnection(fd, targetAddress, targetProtocol, clientTLSConfig, stopChan)
-			case <-stopChan:
+			case fd := <-m.fdChan:
+				go m.handleConnection(fd)
+			case <-m.stopChan:
 				return
-			case <-listenErrChan:
+			case <-m.listenErrChan:
 				return
 			}
 		}
 
-	}(m.targetAddress, m.targetProtocol, m.clientTLSConfig, m.fdChan, m.stopChan, m.listenErrChan)
+	}(m)
 
+	m.logger.Infof("proxy started listening")
 	return nil
 }

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -65,7 +65,7 @@ var _ = Describe("MigrationProxy", func() {
 
 				defer listener.Close()
 
-				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig)
+				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig, "123")
 				defer sourceProxy.StopListening()
 
 				err = sourceProxy.StartListening()
@@ -107,8 +107,8 @@ var _ = Describe("MigrationProxy", func() {
 
 				defer libvirtdListener.Close()
 
-				targetProxy := NewTargetProxy("0.0.0.0", 12345, tlsConfig, tlsConfig, libvirtdSock)
-				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig)
+				targetProxy := NewTargetProxy("0.0.0.0", 12345, tlsConfig, tlsConfig, libvirtdSock, "123")
+				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig, "123")
 				defer targetProxy.StopListening()
 				defer sourceProxy.StopListening()
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -848,6 +848,7 @@ func (d *VirtualMachineController) updateVMIStatus(vmi *v1.VirtualMachineInstanc
 			vmi.Status.EvacuationNodeName = ""
 			vmi.Status.MigrationState.Completed = true
 			d.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to node %s.", migrationHost))
+			log.Log.Object(vmi).Infof("migration completed to node %s", migrationHost)
 		}
 
 		if !reflect.DeepEqual(oldStatus, vmi.Status) {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -513,7 +513,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		// Create a tcp server for each direct connection proxy
 		for _, port := range migrationPortsRange {
 			key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
-			migrationProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key))
+			migrationProxy := migrationproxy.NewTargetProxy(loopbackAddress, port, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, key), string(vmi.UID))
 			defer migrationProxy.StopListening()
 			err := migrationProxy.StartListening()
 			if err != nil {
@@ -523,7 +523,7 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		}
 
 		//  proxy incoming migration requests on port 22222 to the vmi's existing libvirt connection
-		libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)))
+		libvirtConnectionProxy := migrationproxy.NewTargetProxy(loopbackAddress, LibvirtLocalConnectionPort, nil, nil, migrationproxy.SourceUnixFile(l.virtShareDir, string(vmi.UID)), string(vmi.UID))
 		defer libvirtConnectionProxy.StopListening()
 		err := libvirtConnectionProxy.StartListening()
 		if err != nil {
@@ -1038,7 +1038,7 @@ func (l *LibvirtDomainManager) PrepareMigrationTarget(vmi *v1.VirtualMachineInst
 		key := migrationproxy.ConstructProxyKey(string(vmi.UID), port)
 		curDirectAddress := net.JoinHostPort(loopbackAddress, strconv.Itoa(port))
 		unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)
-		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil)
+		migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil, string(vmi.UID))
 
 		err := migrationProxy.StartListening()
 		if err != nil {

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -205,6 +205,15 @@ func (l FilteredLogger) log(skipFrames int, params ...interface{}) error {
 	}
 	return nil
 }
+
+func (l FilteredLogger) CustomField(key string, value string) *FilteredLogger {
+
+	logParams := make([]interface{}, 0)
+	logParams = append(logParams, key, value)
+	l.With(logParams...)
+	return &l
+}
+
 func (l FilteredLogger) Key(key string, kind string) *FilteredLogger {
 	if key == "" {
 		return &l


### PR DESCRIPTION
This is a manual backport of #5496 to release-0.36. We're justifying this backport as a defect to our logging fidelity. We've encountered migration failures that are impractical to debug due to lack of information in our logs. For example, we can tell that a migration fails due to connectivity issues, but because our migration proxy code lacks detailed enough logging, we can't tell if one of the CNV components caused the connectivity issue or if the issue is external to our components.

This logging is required to support this branch. 

----

The logging in our migration proxy code has gaps that leave us without valuable information pertaining to when proxies are start, stop, and fail. As a result, it can be difficult to debug what occurs when a migration fails due to connectivity issues. Without more fidelity in our logs, it's difficult to rule out an issue within our components vs an issue occurring within the cluster network. 

With these changes, we can clearly see when proxies are created, where they are going, when they close, and why they close. 

Below is an example of the new output on the target node.. We have structured fields for the socket the proxy listens to, and the outbound connection.

```
{"component":"virt-handler","level":"info","listening":":::32813","msg":"proxy started listening","outbound":"libvirt-sock","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.632070Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"Manager created proxy on target","outbound":"libvirt-sock","pos":"migration-proxy.go:181","timestamp":"2021-04-22T15:55:13.632162Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"proxy started listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.632233Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"Manager created proxy on target","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:181","timestamp":"2021-04-22T15:55:13.632262Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"proxy started listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.632318Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"Manager created proxy on target","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:181","timestamp":"2021-04-22T15:55:13.632341Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"279 bytes copied outbound to inbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:14.922241Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"327 bytes copied from inbound to outbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:14.922435Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"0 bytes copied outbound to inbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.105970Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"74023264 bytes copied from inbound to outbound","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.106233Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"2372 bytes copied outbound to inbound","outbound":"libvirt-sock","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.340626Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"22904 bytes copied from inbound to outbound","outbound":"libvirt-sock","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.341302Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"Manager stopping proxy on target node","outbound":"libvirt-sock","pos":"migration-proxy.go:242","timestamp":"2021-04-22T15:55:15.411995Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::32813","msg":"proxy stopped listening","outbound":"libvirt-sock","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.412167Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"Manager stopping proxy on target node","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:242","timestamp":"2021-04-22T15:55:15.412371Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::33729","msg":"proxy stopped listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.412517Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"Manager stopping proxy on target node","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:242","timestamp":"2021-04-22T15:55:15.412709Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":":::38763","msg":"proxy stopped listening","outbound":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.412818Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
```


And here is output from the source node

```
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"proxy started listening","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.647202Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"Manager created proxy on source node","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:308","timestamp":"2021-04-22T15:55:13.647255Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"proxy started listening","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.647388Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"Manager created proxy on source node","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:308","timestamp":"2021-04-22T15:55:13.647418Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"proxy started listening","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:514","timestamp":"2021-04-22T15:55:13.647530Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"Manager created proxy on source node","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:308","timestamp":"2021-04-22T15:55:13.647556Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"279 bytes copied outbound to inbound","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:14.922549Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"327 bytes copied from inbound to outbound","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:14.922641Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"0 bytes copied outbound to inbound","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.106388Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"74023264 bytes copied from inbound to outbound","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.106492Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"2372 bytes copied outbound to inbound","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:442","timestamp":"2021-04-22T15:55:15.342243Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"22904 bytes copied from inbound to outbound","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:448","timestamp":"2021-04-22T15:55:15.342525Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"Manager stopping proxy on source node","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:321","timestamp":"2021-04-22T15:55:15.453983Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-source.sock","msg":"proxy stopped listening","outbound":"10.244.196.145:32813","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.454182Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"Manager stopping proxy on source node","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:321","timestamp":"2021-04-22T15:55:15.454823Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49152-source.sock","msg":"proxy stopped listening","outbound":"10.244.196.145:33729","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.454914Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"Manager stopping proxy on source node","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:321","timestamp":"2021-04-22T15:55:15.458318Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
{"component":"virt-handler","level":"info","listening":"c4c985cb-a40b-4f4f-aa72-39a946cba881-49153-source.sock","msg":"proxy stopped listening","outbound":"10.244.196.145:38763","pos":"migration-proxy.go:416","timestamp":"2021-04-22T15:55:15.458505Z","uid":"c4c985cb-a40b-4f4f-aa72-39a946cba881"}
```



```release-note
Improvements to migration proxy logging
```
