### PR TITLE
Fix disappearence of go_containerregistry 0.1.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -311,6 +311,17 @@ go_repository(
     importpath = "golang.org/x/crypto",
 )
 
+# override rules_docker issue with this dependency
+# rules_docker 0.16 uses 0.1.4, bit since there the checksum changed, which is very weird, going with 0.1.4.1 to
+go_repository(
+    name = "com_github_google_go_containerregistry",
+    importpath = "github.com/google/go-containerregistry",
+    sha256 = "bc0136a33f9c1e4578a700f7afcdaa1241cfff997d6bba695c710d24c5ae26bd",
+    strip_prefix = "google-go-containerregistry-efb2d62",
+    type = "tar.gz",
+    urls = ["https://api.github.com/repos/google/go-containerregistry/tarball/efb2d62d93a7705315b841d0544cb5b13565ff2a"],  # v0.1.4.1
+)
+
 # bazel docker rules
 load(
     "@io_bazel_rules_docker//container:container.bzl",


### PR DESCRIPTION
Updating it to 0.1.4.1 to fix build issues like

```
ERROR: /home/rmohr/.cache/bazel/_bazel_rmohr/d8c39dc5bdaf4508a5ddf82e95ab388c/external/io_bazel_rules_docker/container/go/pkg/oci/BUILD:18:11: @io_bazel_rules_docker//container/go/pkg/oci:go_default_library depends on @com_github_google_go_containerregistry//pkg/v1/layout:go_default_library in repository @com_github_google_go_containerregistry which failed to fetch. no such package '@com_github_google_go_containerregistry//pkg/v1/layout': java.io.IOException: Error downloading [https://api.github.com/repos/google/go-containerregistry/tarball/8a2841911ffee4f6892ca0083e89752fb46c48dd] to /home/rmohr/.cache/bazel/_bazel_rmohr/d8c39dc5bdaf4508a5ddf82e95ab388c/external/com_github_google_go_containerregistry/temp3242427000601878860/8a2841911ffee4f6892ca0083e89752fb46c48dd.tar.gz: Checksum was cadb09cb5bcbe00688c73d716d1c9e774d6e4959abec4c425a1b995faf33e964 but wanted 60b9a600affa5667bd444019a4e218b7752d8500cfa923c1ac54ce2f88f773e2
```

Signed-off-by: Roman Mohr <rmohr@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
