### PR TITLE
Introduce VirtualMachine status field and CLI column

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12132,6 +12132,10 @@
       "description": "Created indicates if the virtual machine is created in the cluster",
       "type": "boolean"
      },
+     "printableStatus": {
+      "description": "PrintableStatus is a human readable, high-level representation of the status of the virtual machine",
+      "type": "string"
+     },
      "ready": {
       "description": "Ready indicates if the virtual machine is running and ready",
       "type": "boolean"

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -25,6 +25,8 @@ import (
 	"reflect"
 	"time"
 
+	"kubevirt.io/kubevirt/pkg/util/migrations"
+
 	"github.com/pborman/uuid"
 	authv1 "k8s.io/api/authorization/v1"
 	k8score "k8s.io/api/core/v1"
@@ -615,6 +617,40 @@ func (c *VMController) startStop(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualM
 	}
 }
 
+// isVMIStartExpected determines whether a VMI is expected to be started for this VM.
+func (c *VMController) isVMIStartExpected(vm *virtv1.VirtualMachine) bool {
+	vmKey, err := controller.KeyFunc(vm)
+	if err != nil {
+		log.Log.Object(vm).Errorf("Error fetching vmKey: %v", err)
+		return false
+	}
+
+	expectations, exists, _ := c.expectations.GetExpectations(vmKey)
+	if !exists || expectations == nil {
+		return false
+	}
+
+	adds, _ := expectations.GetExpectations()
+	return adds > 0
+}
+
+// isVMIStopExpected determines whether a VMI is expected to be stopped for this VM.
+func (c *VMController) isVMIStopExpected(vm *virtv1.VirtualMachine) bool {
+	vmKey, err := controller.KeyFunc(vm)
+	if err != nil {
+		log.Log.Object(vm).Errorf("Error fetching vmKey: %v", err)
+		return false
+	}
+
+	expectations, exists, _ := c.expectations.GetExpectations(vmKey)
+	if !exists || expectations == nil {
+		return false
+	}
+
+	_, dels := expectations.GetExpectations()
+	return dels > 0
+}
+
 func (c *VMController) startVMI(vm *virtv1.VirtualMachine) error {
 	// TODO add check for existence
 	vmKey, err := controller.KeyFunc(vm)
@@ -1193,6 +1229,8 @@ func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.V
 		vmCondManager.RemoveCondition(vm, virtv1.VirtualMachinePaused)
 	}
 
+	c.setPrintableStatus(vm, vmi)
+
 	// only update if necessary
 	err = nil
 	if !reflect.DeepEqual(vm.Status, vmOrig.Status) {
@@ -1200,6 +1238,114 @@ func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.V
 	}
 
 	return err
+}
+
+func (c *VMController) setPrintableStatus(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {
+	// For each status, there's a separate function that evaluates
+	// whether the status is "true" for the given VM.
+	//
+	// Note that these statuses aren't mutually exclusive,
+	// and several of them can be "true" at the same time
+	// (e.g., Running && Migrating, or Paused && Terminating).
+	//
+	// The actual precedence of these statuses are determined by the order
+	// of evaluation - first match wins.
+	statuses := []struct {
+		statusType virtv1.VirtualMachinePrintableStatus
+		statusFunc func(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool
+	}{
+		{virtv1.VirtualMachineStatusTerminating, c.isVirtualMachineStatusTerminating},
+		{virtv1.VirtualMachineStatusStopping, c.isVirtualMachineStatusStopping},
+		{virtv1.VirtualMachineStatusMigrating, c.isVirtualMachineStatusMigrating},
+		{virtv1.VirtualMachineStatusStopped, c.isVirtualMachineStatusStopped},
+		{virtv1.VirtualMachineStatusProvisioning, c.isVirtualMachineStatusProvisioning},
+		{virtv1.VirtualMachineStatusStarting, c.isVirtualMachineStatusStarting},
+		{virtv1.VirtualMachineStatusPaused, c.isVirtualMachineStatusPaused},
+		{virtv1.VirtualMachineStatusRunning, c.isVirtualMachineStatusRunning},
+	}
+
+	for _, status := range statuses {
+		if status.statusFunc(vm, vmi) {
+			vm.Status.PrintableStatus = status.statusType
+			return
+		}
+	}
+
+	vm.Status.PrintableStatus = virtv1.VirtualMachineStatusUnknown
+}
+
+// isVirtualMachineStatusStopped determines whether the VM status field should be set to "Stopped".
+func (c *VMController) isVirtualMachineStatusStopped(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	if vmi != nil {
+		return vmi.IsFinal()
+	}
+
+	return !c.isVMIStartExpected(vm)
+}
+
+// isVirtualMachineStatusStopped determines whether the VM status field should be set to "Provisioning".
+func (c *VMController) isVirtualMachineStatusProvisioning(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return c.isVMIStartExpected(vm)
+	}
+
+	hasProvisioningCondition := controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi,
+		virtv1.VirtualMachineInstanceProvisioning, k8score.ConditionTrue)
+
+	return (vmi.IsUnprocessed() || hasProvisioningCondition)
+}
+
+// isVirtualMachineStatusStarting determines whether the VM status field should be set to "Starting".
+func (c *VMController) isVirtualMachineStatusStarting(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	hasProvisioningCondition := controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi,
+		virtv1.VirtualMachineInstanceProvisioning, k8score.ConditionTrue)
+
+	return (vmi.IsScheduling() || vmi.IsScheduled()) && !hasProvisioningCondition
+}
+
+// isVirtualMachineStatusRunning determines whether the VM status field should be set to "Running".
+func (c *VMController) isVirtualMachineStatusRunning(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	hasPausedCondition := controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi,
+		virtv1.VirtualMachineInstancePaused, k8score.ConditionTrue)
+
+	return vmi.IsRunning() && !hasPausedCondition
+}
+
+// isVirtualMachineStatusPaused determines whether the VM status field should be set to "Paused".
+func (c *VMController) isVirtualMachineStatusPaused(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	if vmi == nil {
+		return false
+	}
+
+	isRunningPhase := vmi.Status.Phase == virtv1.Running
+	hasPausedCondition := controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi,
+		virtv1.VirtualMachineInstancePaused, k8score.ConditionTrue)
+
+	return isRunningPhase && hasPausedCondition
+}
+
+// isVirtualMachineStatusPaused determines whether the VM status field should be set to "Paused".
+func (c *VMController) isVirtualMachineStatusStopping(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	return vmi != nil && !vmi.IsFinal() &&
+		(vmi.IsMarkedForDeletion() || c.isVMIStopExpected(vm))
+}
+
+// isVirtualMachineStatusPaused determines whether the VM status field should be set to "Paused".
+func (c *VMController) isVirtualMachineStatusTerminating(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	return vm.ObjectMeta.DeletionTimestamp != nil
+}
+
+// isVirtualMachineStatusPaused determines whether the VM status field should be set to "Paused".
+func (c *VMController) isVirtualMachineStatusMigrating(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
+	return vmi != nil && migrations.IsMigrating(vmi)
 }
 
 func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -155,8 +155,12 @@ var _ = Describe("VirtualMachine", func() {
 			existingDataVolume := createDataVolumeManifest(&vm.Spec.DataVolumeTemplates[1], vm)
 			existingDataVolume.Namespace = "default"
 			dataVolumeFeeder.Add(existingDataVolume)
+
 			createCount := 0
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": "", "my": "label"}, map[string]string{"my": "annotation"}, &createCount)
+
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
+
 			controller.Execute()
 			Expect(createCount).To(Equal(1))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
@@ -618,6 +622,9 @@ var _ = Describe("VirtualMachine", func() {
 
 			createCount := 0
 			shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": ""}, map[string]string{}, &createCount)
+
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
+
 			controller.Execute()
 			Expect(createCount).To(Equal(2))
 			testutils.ExpectEvent(recorder, SuccessfulDataVolumeCreateReason)
@@ -684,9 +691,7 @@ var _ = Describe("VirtualMachine", func() {
 				createCount := 0
 				shouldExpectDataVolumeCreation(vm.UID, map[string]string{"kubevirt.io/created-by": ""}, map[string]string{}, &createCount)
 
-				if fail {
-					vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
-				}
+				vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
 
 				controller.cloneAuthFunc = func(pvcNamespace, pvcName, saNamespace, saName string) (bool, string, error) {
 					if dv.Spec.Source.PVC.Namespace != "" {
@@ -1085,6 +1090,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(obj interface{}) {
 				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
 
 			controller.Execute()
 		})
@@ -1099,6 +1105,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(obj interface{}) {
 				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
 
 			controller.Execute()
 		})
@@ -1113,6 +1120,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmiInterface.EXPECT().Create(gomock.Any()).Do(func(obj interface{}) {
 				Expect(obj.(*v1.VirtualMachineInstance).ObjectMeta.Annotations).To(Equal(annotations))
 			}).Return(vmi, nil)
+			vmInterface.EXPECT().UpdateStatus(gomock.Any()).Times(1).Return(vm, nil)
 
 			controller.Execute()
 		})

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -195,8 +195,10 @@ func NewVirtualMachineCrd() (*extv1.CustomResourceDefinition, error) {
 	}
 	err := addFieldsToAllVersions(crd, []extv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", JSONPath: creationTimestampJSONPath},
+		{Name: "Status", Description: "Human Readable Status", Type: "string", JSONPath: ".status.printableStatus"},
 		{Name: "Volume", Description: "Primary Volume", Type: "string", JSONPath: ".spec.volumes[0].name"},
-		{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1}}, &extv1.CustomResourceSubresources{
+		{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1},
+	}, &extv1.CustomResourceSubresources{
 		Status: &extv1.CustomResourceSubresourceStatus{}})
 	if err != nil {
 		return nil, err

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -3307,6 +3307,9 @@ var CRDsValidation map[string]string = map[string]string{
         created:
           description: Created indicates if the virtual machine is created in the cluster
           type: boolean
+        printableStatus:
+          description: PrintableStatus is a human readable, high-level representation of the status of the virtual machine
+          type: string
         ready:
           description: Ready indicates if the virtual machine is running and ready
           type: boolean
@@ -9940,6 +9943,9 @@ var CRDsValidation map[string]string = map[string]string{
                     created:
                       description: Created indicates if the virtual machine is created in the cluster
                       type: boolean
+                    printableStatus:
+                      description: PrintableStatus is a human readable, high-level representation of the status of the virtual machine
+                      type: string
                     ready:
                       description: Ready indicates if the virtual machine is running and ready
                       type: boolean

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -24653,6 +24653,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"printableStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PrintableStatus is a human readable, high-level representation of the status of the virtual machine",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Hold the state information of the VirtualMachine and its VirtualMachineInstance",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1122,6 +1122,41 @@ const (
 	StopRequest  StateChangeRequestAction = "Stop"
 )
 
+// VirtualMachinePrintableStatus is a human readable, high-level representation of the status of the virtual machine.
+//
+// +k8s:openapi-gen=true
+type VirtualMachinePrintableStatus string
+
+// A list of statuses defined for virtual machines
+const (
+	// VirtualMachineStatusStopped indicates that a VirtualMachineInstance does not exist and is not expected to.
+	VirtualMachineStatusStopped VirtualMachinePrintableStatus = "Stopped"
+	// VirtualMachineStatusProvisioning indicates that a VirtualMachineInstance exists,
+	// but associated cluster resources (e.g., DataVolumes) are still being prepared.
+	VirtualMachineStatusProvisioning VirtualMachinePrintableStatus = "Provisioning"
+	// VirtualMachineStatusStarting indicates that a VirtualMachineInstance exists,
+	//associated cluster resources have been acquired, and the guest virtual machine is being prepared for running.
+	VirtualMachineStatusStarting VirtualMachinePrintableStatus = "Starting"
+	// VirtualMachineStatusRunning indicates that a VirtualMachineInstance exists,
+	// and the guest virtual machine is in running state.
+	VirtualMachineStatusRunning VirtualMachinePrintableStatus = "Running"
+	// VirtualMachineStatusPaused indicates that a VirtualMachineInstance exists,
+	// and the guest virtual machine is in paused state.
+	VirtualMachineStatusPaused VirtualMachinePrintableStatus = "Paused"
+	// VirtualMachineStatusStopping indicates that a VirtualMachineInstance exists,
+	// with a non-null deletionTimestamp.
+	VirtualMachineStatusStopping VirtualMachinePrintableStatus = "Stopping"
+	// VirtualMachineStatusTerminating indicates that the VirtualMachine has a non-null deletionTimestamp
+	// and its associated resources (VirtualMachineInstance, volumes, …) are in the process of tear down.
+	VirtualMachineStatusTerminating VirtualMachinePrintableStatus = "Terminating"
+	// VirtualMachineStatusMigrating indicates that a VirtualMachineInstance exists,
+	// and is in the process of being migrated to another host.
+	VirtualMachineStatusMigrating VirtualMachinePrintableStatus = "Migrating"
+	// VirtualMachineStatusUnknown indicates that for some reason the state of the VirtualMachine could not be obtained,
+	// typically due to an error in communicating with the host of the VirtualMachineInstance.
+	VirtualMachineStatusUnknown VirtualMachinePrintableStatus = "Unknown"
+)
+
 // VirtualMachineStatus represents the status returned by the
 // controller to describe how the VirtualMachine is doing
 //
@@ -1133,6 +1168,8 @@ type VirtualMachineStatus struct {
 	Created bool `json:"created,omitempty"`
 	// Ready indicates if the virtual machine is running and ready
 	Ready bool `json:"ready,omitempty"`
+	// PrintableStatus is a human readable, high-level representation of the status of the virtual machine
+	PrintableStatus VirtualMachinePrintableStatus `json:"printableStatus,omitempty"`
 	// Hold the state information of the VirtualMachine and its VirtualMachineInstance
 	Conditions []VirtualMachineCondition `json:"conditions,omitempty" optional:"true"`
 	// StateChangeRequests indicates a list of actions that should be taken on a VMI

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1133,31 +1133,27 @@ type VirtualMachinePrintableStatus string
 
 // A list of statuses defined for virtual machines
 const (
-	// VirtualMachineStatusStopped indicates that a VirtualMachineInstance does not exist and is not expected to.
+	// VirtualMachineStatusStopped indicates that the virtual machine is currently stopped and isn't expected to start.
 	VirtualMachineStatusStopped VirtualMachinePrintableStatus = "Stopped"
-	// VirtualMachineStatusProvisioning indicates that a VirtualMachineInstance exists,
-	// but associated cluster resources (e.g., DataVolumes) are still being prepared.
+	// VirtualMachineStatusProvisioning indicates that cluster resources associated with the virtual machine
+	// (e.g., DataVolumes) are being provisioned and prepared.
 	VirtualMachineStatusProvisioning VirtualMachinePrintableStatus = "Provisioning"
-	// VirtualMachineStatusStarting indicates that a VirtualMachineInstance exists,
-	//associated cluster resources have been acquired, and the guest virtual machine is being prepared for running.
+	// VirtualMachineStatusStarting indicates that the virtual machine is being prepared for running.
 	VirtualMachineStatusStarting VirtualMachinePrintableStatus = "Starting"
-	// VirtualMachineStatusRunning indicates that a VirtualMachineInstance exists,
-	// and the guest virtual machine is in running state.
+	// VirtualMachineStatusRunning indicates that the virtual machine is running.
 	VirtualMachineStatusRunning VirtualMachinePrintableStatus = "Running"
-	// VirtualMachineStatusPaused indicates that a VirtualMachineInstance exists,
-	// and the guest virtual machine is in paused state.
+	// VirtualMachineStatusPaused indicates that the virtual machine is paused.
 	VirtualMachineStatusPaused VirtualMachinePrintableStatus = "Paused"
-	// VirtualMachineStatusStopping indicates that a VirtualMachineInstance exists,
-	// with a non-null deletionTimestamp.
+	// VirtualMachineStatusStopping indicates that the virtual machine is in the process of being stopped.
 	VirtualMachineStatusStopping VirtualMachinePrintableStatus = "Stopping"
-	// VirtualMachineStatusTerminating indicates that the VirtualMachine has a non-null deletionTimestamp
-	// and its associated resources (VirtualMachineInstance, volumes, …) are in the process of tear down.
+	// VirtualMachineStatusTerminating indicates that the virtual machine is in the process of deletion,
+	// as well as its associated resources (VirtualMachineInstance, DataVolumes, …).
 	VirtualMachineStatusTerminating VirtualMachinePrintableStatus = "Terminating"
-	// VirtualMachineStatusMigrating indicates that a VirtualMachineInstance exists,
-	// and is in the process of being migrated to another host.
+	// VirtualMachineStatusMigrating indicates that the virtual machine is in the process of being migrated
+	// to another host.
 	VirtualMachineStatusMigrating VirtualMachinePrintableStatus = "Migrating"
-	// VirtualMachineStatusUnknown indicates that for some reason the state of the VirtualMachine could not be obtained,
-	// typically due to an error in communicating with the host of the VirtualMachineInstance.
+	// VirtualMachineStatusUnknown indicates that the state of the virtual machine could not be obtained,
+	// typically due to an error in communicating with the host on which it's running.
 	VirtualMachineStatusUnknown VirtualMachinePrintableStatus = "Unknown"
 )
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -295,6 +295,10 @@ func (v *VirtualMachineInstance) IsFinal() bool {
 	return v.Status.Phase == Failed || v.Status.Phase == Succeeded
 }
 
+func (v *VirtualMachineInstance) IsMarkedForDeletion() bool {
+	return v.ObjectMeta.DeletionTimestamp != nil
+}
+
 func (v *VirtualMachineInstance) IsUnknown() bool {
 	return v.Status.Phase == Unknown
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -285,6 +285,7 @@ func (VirtualMachineStatus) SwaggerDoc() map[string]string {
 		"snapshotInProgress":     "SnapshotInProgress is the name of the VirtualMachineSnapshot currently executing",
 		"created":                "Created indicates if the virtual machine is created in the cluster",
 		"ready":                  "Ready indicates if the virtual machine is running and ready",
+		"printableStatus":        "PrintableStatus is a human readable, high-level representation of the status of the virtual machine",
 		"conditions":             "Hold the state information of the VirtualMachine and its VirtualMachineInstance",
 		"stateChangeRequests":    "StateChangeRequests indicates a list of actions that should be taken on a VMI\ne.g. stop a specific VMI then start a new one.",
 		"volumeRequests":         "VolumeRequests indicates a list of volumes add or remove from the VMI template and\nhotplug on an active running VMI.\n+listType=atomic",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -19737,6 +19737,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"printableStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PrintableStatus is a human readable, high-level representation of the status of the virtual machine",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Hold the state information of the VirtualMachine and its VirtualMachineInstance",

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -107,7 +107,7 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			// Name will be there in all the cases, so verify name
 			Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 		},
-			table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "VOLUME"}),
+			table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "STATUS", "VOLUME"}),
 			table.Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
 		)
 
@@ -130,34 +130,12 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 			// Verify one of the wide column output field
 			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
+
 		},
-			table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED"}, 1, "true"),
+			table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "VOLUME", "CREATED"}, 1, "true"),
 			table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 
-		table.DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
-
-			result, _, err := tests.RunCommand(k8sClient, verb, resource, vm.Name, "-o", option)
-			// due to issue of kubectl that sometimes doesn't show CRDs on the first try, retry the same command
-			if err != nil {
-				result, _, err = tests.RunCommand(k8sClient, verb, resource, vm.Name, "-o", option)
-			}
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(result)).ToNot(Equal(0))
-			resultFields := strings.Fields(result)
-			// Verify that only Header is not present
-			Expect(len(resultFields)).Should(BeNumerically(">", len(expectedHeader)))
-			columnHeaders := resultFields[:len(expectedHeader)]
-			// Verify the generated header is same as expected
-			Expect(columnHeaders).To(Equal(expectedHeader))
-			// Name will be there in all the cases, so verify name
-			Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
-			// Verify one of the wide column output field
-			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
-		},
-			table.Entry("[test_id:4423]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "VOLUME", "CREATED"}, 1, "true"),
-			table.Entry("[test_id:4422]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
-		)
 	})
 
 })

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -211,7 +211,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		// Read column titles
 		titles, err := readNewStatus(stdout, nil, readTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(titles).To(Equal([]string{"NAME", "AGE", "VOLUME"}),
+		Expect(titles).To(Equal([]string{"NAME", "AGE", "STATUS", "VOLUME"}),
 			"Output should have the proper columns")
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new `status.printableStatus` field to the VirtualMachine CRD, as well as a new `STATUS` column to the output of `kubectl get vm`.

The purpose of this field is to provide a high-level representation of the status of the virtual machine. It's designated to be consumed by human users, and not automated processes (i.e., no state machine semantics, values may be added or dropped in the future, ...).

Here's an example output:
```bash
$ kubectl get vms
NAME     AGE   STATUS    VOLUME
testvm   4s    Stopped
```

**Release note:**
```release-note
Introduced a "status.printableStatus" field in the VirtualMachine CRD. This field is now displayed in the tabular output of "kubectl get vm".
```
