### PR TITLE
Bump bazeldnf version to v0.1.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -196,11 +196,10 @@ http_file(
 
 http_archive(
     name = "bazeldnf",
-    sha256 = "60acf03051025e6d013ac24daebefa21e4543225112b89140118f7e10e212378",
-    strip_prefix = "bazeldnf-0.0.15",
+    sha256 = "f6c9293d36914755c8fc808a2145edddcde2a26525afde1b9356bd63968b2d94",
+    strip_prefix = "bazeldnf-0.1.0",
     urls = [
-        "https://github.com/rmohr/bazeldnf/archive/v0.0.15.tar.gz",
-        "https://storage.googleapis.com/builddeps/60acf03051025e6d013ac24daebefa21e4543225112b89140118f7e10e212378",
+        "https://github.com/rmohr/bazeldnf/archive/v0.1.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump bazeldnf to fix `docker save` issues for containers created with
bazeldnf.

Fixes issues like

```
]# docker save  quay.io/kubevirt/virt-handler:v0.40.0  >image.tar
Error response from daemon: read /var/lib/docker/overlay2/7dcbf28f1c151e11c9d71d49f39ab76f0606f7efcb3fb8a909d0883ff4fbdf32/diff/lib64: is a directory
```

The background is that the RPM to Tar conversion left for symlinks the body size to the original non-zero value, since RPMs store the target link in the body, while on Tar headers there is an extra symlink header field, and the body size should be set to `0`: https://github.com/rmohr/bazeldnf/releases/tag/v0.1.0.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix `docker save` issues with kubevirt images
```
