### PR TITLE
[tests] Adding SIG label for the operator e2e tests

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -73,7 +73,7 @@ type vmYamlDefinition struct {
 	yamlFile      string
 }
 
-var _ = Describe("[Serial]Operator", func() {
+var _ = Describe("[Serial][sig-operator]Operator", func() {
 	var originalKv *v1.KubeVirt
 	var originalCDI *cdiv1.CDI
 	var originalOperatorVersion string


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
More accurate filtering based on a SIG label which is unique. will be used in the CI lanes jobs.
Usage of the operator SIG label on project-infra can be observed in this [PR](https://github.com/kubevirt/project-infra/pull/1162)

**Release note**:
```release-note
NONE
```
