### PR TITLE
fix log pkg With() function for custom arguments

### DIFF
--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -339,7 +339,7 @@ func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, serverTLSCon
 		listenErrChan:   make(chan error, 1),
 		serverTLSConfig: serverTLSConfig,
 		clientTLSConfig: clientTLSConfig,
-		logger:          log.Log.CustomField("uid", vmiUID).CustomField("listening", filepath.Base(unixSocketPath)).CustomField("outbound", tcpTargetAddress),
+		logger:          log.Log.With("uid", vmiUID).With("listening", filepath.Base(unixSocketPath)).With("outbound", tcpTargetAddress),
 	}
 }
 
@@ -356,7 +356,7 @@ func NewTargetProxy(tcpBindAddress string, tcpBindPort int, serverTLSConfig *tls
 		listenErrChan:   make(chan error, 1),
 		serverTLSConfig: serverTLSConfig,
 		clientTLSConfig: clientTLSConfig,
-		logger:          log.Log.CustomField("uid", vmiUID).CustomField("outbound", filepath.Base(libvirtdSocketPath)),
+		logger:          log.Log.With("uid", vmiUID).With("outbound", filepath.Base(libvirtdSocketPath)),
 	}
 
 }
@@ -382,7 +382,7 @@ func (m *migrationProxy) createTcpListener() error {
 		// update the random port that was selected
 		m.tcpBindPort = listener.Addr().(*net.TCPAddr).Port
 		// Add the listener to the log output once we know the port
-		m.logger = m.logger.CustomField("listening", fmt.Sprintf("%s:%d", m.tcpBindAddress, m.tcpBindPort))
+		m.logger = m.logger.With("listening", fmt.Sprintf("%s:%d", m.tcpBindAddress, m.tcpBindPort))
 	}
 
 	m.listener = listener

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -206,14 +206,6 @@ func (l FilteredLogger) log(skipFrames int, params ...interface{}) error {
 	return nil
 }
 
-func (l FilteredLogger) CustomField(key string, value string) *FilteredLogger {
-
-	logParams := make([]interface{}, 0)
-	logParams = append(logParams, key, value)
-	l.With(logParams...)
-	return &l
-}
-
 func (l FilteredLogger) Key(key string, kind string) *FilteredLogger {
 	if key == "" {
 		return &l
@@ -229,7 +221,7 @@ func (l FilteredLogger) Key(key string, kind string) *FilteredLogger {
 	}
 	logParams = append(logParams, "name", name)
 	logParams = append(logParams, "kind", kind)
-	l.With(logParams...)
+	l.with(logParams...)
 	return &l
 }
 
@@ -248,7 +240,7 @@ func (l FilteredLogger) Object(obj LoggableObject) *FilteredLogger {
 	logParams = append(logParams, "kind", kind)
 	logParams = append(logParams, "uid", uid)
 
-	l.With(logParams...)
+	l.with(logParams...)
 	return &l
 }
 
@@ -266,17 +258,17 @@ func (l FilteredLogger) ObjectRef(obj *v1.ObjectReference) *FilteredLogger {
 	logParams = append(logParams, "kind", obj.Kind)
 	logParams = append(logParams, "uid", obj.UID)
 
-	l.With(logParams...)
+	l.with(logParams...)
 	return &l
 }
 
-func (l *FilteredLogger) With(obj ...interface{}) *FilteredLogger {
+func (l FilteredLogger) With(obj ...interface{}) *FilteredLogger {
 	l.logContext = l.logContext.With(obj...)
-	return l
+	return &l
 }
 
-func (l *FilteredLogger) WithPrefix(obj ...interface{}) *FilteredLogger {
-	l.logContext = l.logContext.WithPrefix(obj...)
+func (l *FilteredLogger) with(obj ...interface{}) *FilteredLogger {
+	l.logContext = l.logContext.With(obj...)
 	return l
 }
 

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -114,6 +114,26 @@ func TestComponent(t *testing.T) {
 	tearDown()
 }
 
+func TestWith(t *testing.T) {
+	setUp()
+	log := MakeLogger(MockLogger{})
+
+	log.With("arg1", "val1").Log("foo1", "bar1")
+	log.With("arg2", "val2").Log("foo2", "bar2")
+
+	assert(t, len(logParams) == 2, "Expected 2 log lines")
+
+	logEntry := logParams[0].([]interface{})
+	assert(t, logEntry[8].(string) == "arg1", "Custom With() field was not logged")
+	assert(t, logEntry[9].(string) == "val1", "Custom With() field was not logged")
+
+	logEntry = logParams[1].([]interface{})
+	assert(t, logEntry[8].(string) == "arg2", "Custom With() was not logged")
+	assert(t, logEntry[9].(string) == "val2", "Custom With() was not logged")
+
+	tearDown()
+}
+
 func TestInfoCutoff(t *testing.T) {
 	setUp()
 	log := MakeLogger(MockLogger{})


### PR DESCRIPTION
The `With()` function was being globally cached on the default logger rather than returning a new copy of the logger. This was a subtle change with the pointer arithmetic. The result is whenever the With() function was used, that value would get printed for every log line afterwards.

Now when the With function is used, it only pertains to the logger copy.  



```release-note
NONE
```
