### PR TITLE
[automation] adding timestamps for the repeated tests stdout

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
-
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2019 Red Hat, Inc.
+#
 set -euo pipefail
+
+export TIMESTAMP=${TIMESTAMP:-1}
 
 function usage {
     cat <<EOF


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
It will be more easy to correlate a test failure to the k8s-reporter logs.
For example, the `pull-kubevirt-check-for-flakes` CI job which uses `autmation/repeated_tests.sh` doesn't produce 
the timestamps.

**Release note**:
```release-note
NONE
```
