### PR TITLE
virt-launcher: fix guestOS info reporting in VMI status

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -99,19 +99,24 @@ func (s *AsyncAgentStore) Store(key AgentCommand, value interface{}) {
 	}
 }
 
+func (s *AsyncAgentStore) GetOSInfo() api.GuestOSInfo {
+	data, ok := s.store.Load(GET_OSINFO)
+	osinfo := api.GuestOSInfo{}
+	if ok {
+		osinfo = data.(api.GuestOSInfo)
+	}
+	return osinfo
+}
+
 // GetSysInfo returns the sysInfo information packed together.
 // Sysinfo comprises of:
 //  * Guest Hostname
 //  * Guest OS version and architecture
 //  * Guest Timezone
 func (s *AsyncAgentStore) GetSysInfo() api.DomainSysInfo {
-	data, ok := s.store.Load(GET_OSINFO)
-	osinfo := api.GuestOSInfo{}
-	if ok {
-		osinfo = data.(api.GuestOSInfo)
-	}
+	osinfo := s.GetOSInfo()
 
-	data, ok = s.store.Load(GET_HOSTNAME)
+	data, ok := s.store.Load(GET_HOSTNAME)
 	hostname := ""
 	if ok {
 		hostname = data.(string)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1258,6 +1258,7 @@ func (l *LibvirtDomainManager) ListAllDomains() ([]*api.Domain, error) {
 			return list, err
 		}
 		domain.Spec = *spec
+		domain.Status.OSInfo = l.agentData.GetOSInfo()
 		status, reason, err := dom.GetState()
 		if err != nil {
 			if domainerrors.IsNotFound(err) {


### PR DESCRIPTION
The guestOS info in the VMI resource would stop getting populated
after 5 minutes (`--qemu-agent-version-interval` default) and until
a new Domain notification would get delivered to virt-handler because
the code which does the periodic resyncing uses the `GetDomain()`
virt-launcher API which does not populate guestOS info when retrieving a
Domain leading to virt-handler updating the VMI status with a blank guestOS info.

This commit makes `ListAllDomains()` (which is used by `GetDomain()`)
populate GuestOS info (when available).

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1924479

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher now populates domain's guestOS info also when doing periodic resyncs. 
```
