### PR TITLE
Assign template and container disk tests to sig-compute

### DIFF
--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmi"
 )
 
-var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component]ContainerDisk", func() {
+var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]ContainerDisk", func() {
 
 	var virtClient kubecli.KubevirtClient
 	var err error

--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -47,7 +47,7 @@ const (
 	defaultMemory     = "2Gi"
 )
 
-var _ = Describe("[Serial]Templates", func() {
+var _ = Describe("[Serial][sig-compute]Templates", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Assigned to test files to `sig-compute`:
- tests/template_test.go
- tests/container_disk_test.go

**Release note**:
```release-note
None
```
