### PR TITLE
spelling fix in logging output of virt-handler/device…

### DIFF
--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -222,8 +222,8 @@ func (c *DeviceController) refreshPermittedDevices() {
 	c.devicePluginsMutex.Unlock()
 
 	logger.Info("refreshed device plugins for permitted/forbidden host devices")
-	logger.Infof("enabled device-pluings for: %v", debugDevAdded)
-	logger.Infof("disabled device-pluings for: %v", debugDevRemoved)
+	logger.Infof("enabled device-plugins for: %v", debugDevAdded)
+	logger.Infof("disabled device-plugins for: %v", debugDevRemoved)
 }
 
 func (c *DeviceController) Run(stop chan struct{}) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed small spelling error found in virt-handler device_controller logging output. Changed "pluings" to "plugins". 

**Special notes for your reviewer**:
I closed out my last PR for this as I got the history of changes all messed up. This should be nice and clean, and easier to review/merge.  Thanks

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
