### PR TITLE
Remove code to delete ownerReferences for orphan VMIs/DVs

### DIFF
--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -312,24 +312,6 @@ var _ = Describe("Replicaset", func() {
 			testutils.ExpectEvent(recorder, SuccessfulDeleteVirtualMachineReason)
 		})
 
-		It("should detect that it is orphan deleted and remove the owner reference on the remaining VirtualMachineInstance", func() {
-			rs, vmi := DefaultReplicaSet(1)
-
-			rs.Status.Replicas = 1
-
-			// Mark it as orphan deleted
-			now := metav1.Now()
-			rs.ObjectMeta.DeletionTimestamp = &now
-			rs.ObjectMeta.Finalizers = []string{metav1.FinalizerOrphanDependents}
-
-			addReplicaSet(rs)
-			vmiFeeder.Add(vmi)
-
-			vmiInterface.EXPECT().Patch(vmi.ObjectMeta.Name, gomock.Any(), gomock.Any())
-
-			controller.Execute()
-		})
-
 		It("should detect that a VirtualMachineInstance already exists and adopt it", func() {
 			rs, vmi := DefaultReplicaSet(1)
 			vmi.OwnerReferences = []metav1.OwnerReference{}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -284,16 +283,6 @@ func (c *VMController) execute(key string) error {
 		}
 	}
 
-	// If the controller is going to be deleted and the orphan finalizer is the next one, release the VMIs. Don't update the status
-	// TODO: Workaround for https://github.com/kubernetes/kubernetes/issues/56348, remove it once it is fixed
-	if vm.ObjectMeta.DeletionTimestamp != nil && controller.HasFinalizer(vm, v1.FinalizerOrphanDependents) {
-		err = c.orphan(cm, vmi)
-		if err != nil {
-			return err
-		}
-		return c.orphanDataVolumes(cm, dataVolumes)
-	}
-
 	if createErr != nil {
 		logger.Reason(err).Error("Creating the VirtualMachine failed.")
 	}
@@ -396,50 +385,6 @@ func (c *VMController) listDataVolumesForVM(vm *virtv1.VirtualMachine) ([]*cdiv1
 		dataVolumes = append(dataVolumes, obj.(*cdiv1.DataVolume))
 	}
 	return dataVolumes, nil
-}
-
-// orphan removes the owner reference of all VMIs which are owned by the controller instance.
-// Workaround for https://github.com/kubernetes/kubernetes/issues/56348 to make no-cascading deletes possible
-// We don't have to remove the finalizer. This part of the gc is not affected by the mentioned bug
-// TODO +pkotas unify with replicasets. This function can be the same
-func (c *VMController) orphan(cm *controller.VirtualMachineControllerRefManager, vmi *virtv1.VirtualMachineInstance) error {
-	if vmi == nil {
-		return nil
-	}
-
-	err := cm.ReleaseVirtualMachine(vmi)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *VMController) orphanDataVolumes(cm *controller.VirtualMachineControllerRefManager, dataVolumes []*cdiv1.DataVolume) error {
-
-	if len(dataVolumes) == 0 {
-		return nil
-	}
-
-	var wg sync.WaitGroup
-	errChan := make(chan error, len(dataVolumes))
-	wg.Add(len(dataVolumes))
-
-	for _, dataVolume := range dataVolumes {
-		go func(dataVolume *cdiv1.DataVolume) {
-			defer wg.Done()
-			err := cm.ReleaseDataVolume(dataVolume)
-			if err != nil {
-				errChan <- err
-			}
-		}(dataVolume)
-	}
-	wg.Wait()
-	select {
-	case err := <-errChan:
-		return err
-	default:
-	}
-	return nil
 }
 
 func createDataVolumeManifest(dataVolumeTemplate *virtv1.DataVolumeTemplateSpec, vm *virtv1.VirtualMachine) *cdiv1.DataVolume {

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -873,22 +873,6 @@ var _ = Describe("VirtualMachine", func() {
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineReason)
 		})
 
-		It("should detect that it is orphan deleted and remove the owner reference on the remaining VirtualMachineInstance", func() {
-			vm, vmi := DefaultVirtualMachine(true)
-
-			// Mark it as orphan deleted
-			now := metav1.Now()
-			vm.ObjectMeta.DeletionTimestamp = &now
-			vm.ObjectMeta.Finalizers = []string{metav1.FinalizerOrphanDependents}
-
-			addVirtualMachine(vm)
-			vmiFeeder.Add(vmi)
-
-			vmiInterface.EXPECT().Patch(vmi.ObjectMeta.Name, gomock.Any(), gomock.Any())
-
-			controller.Execute()
-		})
-
 		It("should detect that a VirtualMachineInstance already exists and adopt it", func() {
 			vm, vmi := DefaultVirtualMachine(true)
 			vmi.OwnerReferences = []metav1.OwnerReference{}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes obsolete code that manually deletes VMI/DV ownerReferences when the owner VM/VMRS has been deleted with the `--cascade=orphan` option.

This code was introduced as workaround for kubernetes/kubernetes#56348, which has been resolved long ago, hence the workaround is not needed anymore.

**Special notes for your reviewer:**

There's an [existing E2E test](https://github.com/kubevirt/kubevirt/blob/0ed56e62f4bac0aebc8564c99eba36eec5d342aa/tests/vm_test.go#L559) that verifies the behavior when VMs are deleted with `--cascade=orphan`.

**Release note**:
```release-note
NONE
```
