### PR TITLE
virt-launcher, Fix flaky VMI report (random missing Guest Agent data)

### DIFF
--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -213,6 +213,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -238,6 +240,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			err := AddGhostRecord("test1-namespace", "test1", "somefile1", "1234-1")
 			Expect(err).ToNot(HaveOccurred())
@@ -266,6 +270,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -284,12 +290,16 @@ var _ = Describe("Domain informer", func() {
 
 			domain := api.NewMinimalDomain("test")
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{domain}, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(domain.Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 			// now prove if we make a change, like adding a label, that the resync
 			// will pick that change up automatically
 			newDomain := domain.DeepCopy()
 			newDomain.ObjectMeta.Labels = make(map[string]string)
 			newDomain.ObjectMeta.Labels["some-label"] = "some-value"
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{newDomain}, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(nil)
+			domainManager.EXPECT().InterfacesStatus(newDomain.Spec.Devices.Interfaces).Return(nil)
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -436,6 +446,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			// This file doesn't have a unix sock server behind it
 			// verify list still completes regardless

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-launcher/virtwrap/agent-poller:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -130,6 +130,27 @@ func (s *AsyncAgentStore) GetSysInfo() api.DomainSysInfo {
 	}
 }
 
+// GetInterfaceStatus returns the interfaces Guest Agent reported
+func (s *AsyncAgentStore) GetInterfaceStatus() []api.InterfaceStatus {
+	data, ok := s.store.Load(GET_INTERFACES)
+	if ok {
+		return data.([]api.InterfaceStatus)
+	}
+
+	return nil
+}
+
+// GetGuestOSInfo returns the Guest OS version and architecture
+func (s *AsyncAgentStore) GetGuestOSInfo() *api.GuestOSInfo {
+	data, ok := s.store.Load(GET_OSINFO)
+	if ok {
+		osInfo := data.(api.GuestOSInfo)
+		return &osInfo
+	}
+
+	return nil
+}
+
 // GetGA returns guest agent record with its version if present
 func (s *AsyncAgentStore) GetGA() AgentInfo {
 	data, ok := s.store.Load(GET_AGENT)

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -83,6 +83,54 @@ var _ = Describe("Qemu agent poller", func() {
 			agentStore.Store(GET_OSINFO, fakeInfo)
 			Expect(agentStore.AgentUpdated).ToNot(Receive())
 		})
+
+		It("should report nil slice when no interfaces exists", func() {
+			var agentStore = NewAsyncAgentStore()
+			interfacesStatus := agentStore.GetInterfaceStatus()
+
+			Expect(interfacesStatus).To(BeNil())
+		})
+
+		It("should report interfaces info when interfaces exists", func() {
+			var agentStore = NewAsyncAgentStore()
+
+			fakeInterfaces := []api.InterfaceStatus{
+				{
+					Name: "eth1",
+					Mac:  "00:00:00:00:00:01",
+				},
+			}
+			agentStore.Store(GET_INTERFACES, fakeInterfaces)
+			interfacesStatus := agentStore.GetInterfaceStatus()
+
+			Expect(interfacesStatus).To(Equal(fakeInterfaces))
+		})
+
+		It("should report nil when no osInfo exists", func() {
+			var agentStore = NewAsyncAgentStore()
+			osInfo := agentStore.GetGuestOSInfo()
+
+			Expect(osInfo).To(BeNil())
+		})
+
+		It("should report osInfo when osInfo exists", func() {
+			var agentStore = NewAsyncAgentStore()
+			fakeInfo := api.GuestOSInfo{
+				Name:          "TestGuestOSName",
+				KernelRelease: "1.1.0-Generic",
+				Version:       "1.0.0",
+				PrettyName:    "TestGuestOSName 1.0.0",
+				VersionId:     "1.0.0",
+				KernelVersion: "1.1.0",
+				Machine:       "x86_64",
+				Id:            "testguestos",
+			}
+
+			agentStore.Store(GET_OSINFO, fakeInfo)
+			osInfo := agentStore.GetGuestOSInfo()
+
+			Expect(*osInfo).To(Equal(fakeInfo))
+		})
 	})
 
 	Context("PollerWorker", func() {

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -308,7 +308,14 @@ func (l *Launcher) GetDomain(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.D
 	}
 
 	if len(list) > 0 {
-		if domain, err := json.Marshal(list[0]); err != nil {
+		domainObj := list[0]
+		if osInfo := l.domainManager.GetGuestOSInfo(); osInfo != nil {
+			domainObj.Status.OSInfo = *osInfo
+		}
+		if interfaces := l.domainManager.InterfacesStatus(domainObj.Spec.Devices.Interfaces); interfaces != nil {
+			domainObj.Status.Interfaces = interfaces
+		}
+		if domain, err := json.Marshal(domainObj); err != nil {
 			log.Log.Reason(err).Errorf("Failed to marshal domain")
 			response.Response.Success = false
 			response.Response.Message = getErrorMessage(err)

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -199,3 +199,23 @@ func (_m *MockDomainManager) FinalizeVirtualMachineMigration(_param0 *v1.Virtual
 func (_mr *_MockDomainManagerRecorder) FinalizeVirtualMachineMigration(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FinalizeVirtualMachineMigration", arg0)
 }
+
+func (_m *MockDomainManager) InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus {
+	ret := _m.ctrl.Call(_m, "InterfacesStatus", domainInterfaces)
+	ret0, _ := ret[0].([]api.InterfaceStatus)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) InterfacesStatus(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InterfacesStatus", arg0)
+}
+
+func (_m *MockDomainManager) GetGuestOSInfo() *api.GuestOSInfo {
+	ret := _m.ctrl.Call(_m, "GetGuestOSInfo")
+	ret0, _ := ret[0].(*api.GuestOSInfo)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) GetGuestOSInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGuestOSInfo")
+}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -100,6 +100,8 @@ type DomainManager interface {
 	GetUsers() ([]v1.VirtualMachineInstanceGuestOSUser, error)
 	GetFilesystems() ([]v1.VirtualMachineInstanceFileSystem, error)
 	FinalizeVirtualMachineMigration(*v1.VirtualMachineInstance) error
+	InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus
+	GetGuestOSInfo() *api.GuestOSInfo
 }
 
 type LibvirtDomainManager struct {
@@ -1370,6 +1372,20 @@ func (l *LibvirtDomainManager) GetGuestInfo() (v1.VirtualMachineInstanceGuestAge
 	}
 
 	return guestInfo, nil
+}
+
+// InterfacesStatus returns the interfaces Guest Agent reported
+func (l *LibvirtDomainManager) InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus {
+	if interfaces := l.agentData.GetInterfaceStatus(); interfaces != nil {
+		return agentpoller.MergeAgentStatusesWithDomainData(domainInterfaces, interfaces)
+	}
+
+	return nil
+}
+
+// GetGuestOSInfo returns the Guest OS version and architecture
+func (l *LibvirtDomainManager) GetGuestOSInfo() *api.GuestOSInfo {
+	return l.agentData.GetGuestOSInfo()
 }
 
 // GetUsers return the full list of users on the guest machine

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	libvirt "libvirt.org/libvirt-go"
 
+	agentpoller "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent-poller"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -1621,6 +1622,92 @@ var _ = Describe("Manager", func() {
 			domSpec, err := libvirtmanager.getDomainSpec(mockDomain)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domSpec).ToNot(BeNil())
+		})
+
+		Context("on call to GetGuestOSInfo", func() {
+			var libvirtmanager DomainManager
+			var agentStore agentpoller.AsyncAgentStore
+
+			BeforeEach(func() {
+				agentStore = agentpoller.NewAsyncAgentStore()
+				libvirtmanager, _ = NewLibvirtDomainManager(mockConn, testVirtShareDir, nil, 0, &agentStore, "/usr/share/OVMF")
+			})
+
+			It("should report nil when no OS info exists in the cache", func() {
+				Expect(libvirtmanager.GetGuestOSInfo()).To(BeNil())
+			})
+
+			It("should report OS info when it exists in the cache", func() {
+				fakeInfo := api.GuestOSInfo{
+					Name: "TestGuestOSName",
+				}
+				agentStore.Store(agentpoller.GET_OSINFO, fakeInfo)
+
+				osInfo := libvirtmanager.GetGuestOSInfo()
+				Expect(*osInfo).To(Equal(fakeInfo))
+			})
+		})
+
+		Context("on call to InterfacesStatus", func() {
+			var libvirtmanager DomainManager
+			var agentStore agentpoller.AsyncAgentStore
+			fakeDomInterfaces := []api.Interface{
+				{
+					MAC: &api.MAC{
+						MAC: "00:00:00:00:00:01",
+					},
+					Alias: api.NewUserDefinedAlias("eth1"),
+				},
+			}
+			fakeInterfaces := []api.InterfaceStatus{
+				{
+					Name: "eth2",
+					Mac:  "00:00:00:00:00:02",
+				},
+			}
+
+			BeforeEach(func() {
+				agentStore = agentpoller.NewAsyncAgentStore()
+				libvirtmanager, _ = NewLibvirtDomainManager(mockConn, testVirtShareDir, nil, 0, &agentStore, "/usr/share/OVMF")
+			})
+
+			It("should return nil when no interfaces exists in the cache, nor as argument", func() {
+				Expect(libvirtmanager.InterfacesStatus(nil)).To(BeNil())
+			})
+
+			It("should return nil when no interfaces exists in the cache", func() {
+				Expect(libvirtmanager.InterfacesStatus(fakeDomInterfaces)).To(BeNil())
+			})
+
+			It("should return merged list when interfaces exists on both the cache and argument", func() {
+				expectedResult := []api.InterfaceStatus{
+					{
+						Name: fakeInterfaces[0].Name,
+						Mac:  fakeInterfaces[0].Mac,
+					},
+					{
+						Name: fakeDomInterfaces[0].Alias.GetName(),
+						Mac:  fakeDomInterfaces[0].MAC.MAC,
+					},
+				}
+				agentStore.Store(agentpoller.GET_INTERFACES, fakeInterfaces)
+
+				interfaces := libvirtmanager.InterfacesStatus(fakeDomInterfaces)
+				Expect(interfaces).To(Equal(expectedResult))
+			})
+
+			It("should return merged list when interfaces exists on the cache only", func() {
+				expectedResult := []api.InterfaceStatus{
+					{
+						Name: fakeInterfaces[0].Name,
+						Mac:  fakeInterfaces[0].Mac,
+					},
+				}
+				agentStore.Store(agentpoller.GET_INTERFACES, fakeInterfaces)
+
+				interfaces := libvirtmanager.InterfacesStatus(nil)
+				Expect(interfaces).To(Equal(expectedResult))
+			})
 		})
 	})
 


### PR DESCRIPTION
`virt-handler` refreshes the VMI domain information,
each 300 seconds by `handleResync` function.
    
The information it got doesn't include
Guest Agent information such as Guest OS Info,
and interfaces status.
   
This will cause flakiness in the VMI status,
each time that the report is fetched,
until the next update of Guest Agent will be sent
by the `virt-launcher` to the `virt-handler`,
as this report does include the Guest Agent data.
   
This PR fix it by decorating the resync
domain info, with the Guest Agent information,
as the `virt-launcher` itself does before sending
the domain info to the `virt-handler`.

Replaces reverted https://github.com/kubevirt/kubevirt/pull/5428
see https://github.com/kubevirt/kubevirt/pull/5557 for more info.

Fixes:
*  https://bugzilla.redhat.com/show_bug.cgi?id=1907707
*  https://bugzilla.redhat.com/show_bug.cgi?id=1924479

```release-note
virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs. 
```
Signed-off-by: Or Shoval <oshoval@redhat.com>