### PR TITLE
update release policy to cut release branches the first business day of the month

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -40,7 +40,7 @@ of distribution.
 
 # Cadence and Timeline
 Both a new release branch and initial release candidate are cut on the **first
-day of each month.**
+business day of each month.**
 
 If no blocker issues are discovered the release candidate is **promoted to a full
 release after 5 business days.**


### PR DESCRIPTION
This changes our release policy to release on the first business day of the month rather than the first day of the month. This helps the team resolve issues. 


```release-note
Release branches are now cut on the first _business day_ of the month rather than the first day.
```
