### PR TITLE
add cached session affinity before comparing service resource

### DIFF
--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -413,6 +413,9 @@ func generateServicePatch(
 	// set these values in the case they are empty
 	service.Spec.ClusterIP = cachedService.Spec.ClusterIP
 	service.Spec.Type = cachedService.Spec.Type
+	if service.Spec.SessionAffinity == "" {
+		service.Spec.SessionAffinity = cachedService.Spec.SessionAffinity
+	}
 
 	// If the Specs don't equal each other, replace it
 	if !equality.Semantic.DeepEqual(cachedService.Spec, service.Spec) {


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Session affinity is a required defaulted field, since we do not set it in our required manifest the deep equal thinks the two resources are different and continuously patches. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
