### PR TITLE
Add vif cache

### DIFF
--- a/pkg/network/cache/fake/infocache.go
+++ b/pkg/network/cache/fake/infocache.go
@@ -38,7 +38,7 @@ func (f *fakeInterfaceCacheFactory) CacheForVMI(vmi *v1.VirtualMachineInstance) 
 	return f.vmiCacheStores[vmi.UID]
 }
 
-func (f *fakeInterfaceCacheFactory) CacheForPID(pid string) cache.DomainInterfaceStore {
+func (f *fakeInterfaceCacheFactory) CacheDomainInterfaceForPID(pid string) cache.DomainInterfaceStore {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if store, exists := f.domainCacheStores[pid]; exists {

--- a/pkg/network/cache/infocache.go
+++ b/pkg/network/cache/infocache.go
@@ -38,7 +38,7 @@ var virtLauncherCachedPattern = "/proc/%s/root/var/run/kubevirt-private/interfac
 
 type InterfaceCacheFactory interface {
 	CacheForVMI(vmi *v1.VirtualMachineInstance) PodInterfaceCacheStore
-	CacheForPID(pid string) DomainInterfaceStore
+	CacheDomainInterfaceForPID(pid string) DomainInterfaceStore
 }
 
 func NewInterfaceCacheFactory() *interfaceCacheFactory {
@@ -53,7 +53,7 @@ func (i *interfaceCacheFactory) CacheForVMI(vmi *v1.VirtualMachineInstance) PodI
 	return newPodInterfaceCacheStore(vmi, i.baseDir, virtHandlerCachePattern)
 }
 
-func (i *interfaceCacheFactory) CacheForPID(pid string) DomainInterfaceStore {
+func (i *interfaceCacheFactory) CacheDomainInterfaceForPID(pid string) DomainInterfaceStore {
 	return newDomainInterfaceStore(pid, i.baseDir, virtLauncherCachedPattern)
 }
 

--- a/pkg/network/cache/infocache_test.go
+++ b/pkg/network/cache/infocache_test.go
@@ -69,12 +69,12 @@ var _ = Describe("Infocache", func() {
 			Model: &api.Model{Type: "a nice model"},
 		}
 		It("should return os.ErrNotExist if no cache entry exists", func() {
-			_, err := cacheFactory.CacheForPID("123").Read("abc")
+			_, err := cacheFactory.CacheDomainInterfaceForPID("123").Read("abc")
 			Expect(os.IsNotExist(err)).To(BeTrue())
 		})
 		It("should save and restore pod interface information", func() {
-			Expect(cacheFactory.CacheForPID("123").Write("abc", obj)).To(Succeed())
-			newObj, err := cacheFactory.CacheForPID("123").Read("abc")
+			Expect(cacheFactory.CacheDomainInterfaceForPID("123").Write("abc", obj)).To(Succeed())
+			newObj, err := cacheFactory.CacheDomainInterfaceForPID("123").Read("abc")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newObj).To(Equal(obj))
 		})

--- a/pkg/network/cache/types.go
+++ b/pkg/network/cache/types.go
@@ -15,7 +15,7 @@ type PodCacheInterface struct {
 	PodIPs []string      `json:"podIPs,omitempty"`
 }
 
-type VIF struct {
+type DhcpConfig struct {
 	Name         string
 	IP           netlink.Addr
 	IPv6         netlink.Addr
@@ -27,9 +27,9 @@ type VIF struct {
 	IPAMDisabled bool
 }
 
-func (vif VIF) String() string {
+func (vif DhcpConfig) String() string {
 	return fmt.Sprintf(
-		"VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: %t}",
+		"DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: %t}",
 		vif.Name,
 		vif.IP.IP,
 		vif.IP.Mask,

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -68,7 +68,7 @@ type NetworkHandler interface {
 	SetRandomMac(iface string) (net.HardwareAddr, error)
 	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
-	StartDHCP(nic *cache.VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error
+	StartDHCP(nic *cache.DhcpConfig, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error
 	HasNatIptables(proto iptables.Protocol) bool
 	IsIpv6Enabled(interfaceName string) (bool, error)
 	IsIpv4Primary() (bool, error)
@@ -331,7 +331,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 	return currentMac, nil
 }
 
-func (h *NetworkUtilsHandler) StartDHCP(nic *cache.VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
+func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DhcpConfig, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
 	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
 	nameservers, searchDomains, err := converter.GetResolvConfDetailsFromPod()
 	if err != nil {
@@ -441,7 +441,7 @@ var DHCPServer = dhcp.SingleClientDHCPServer
 var DHCPv6Server = dhcpv6.SingleClientDHCPv6Server
 
 // filter out irrelevant routes
-func FilterPodNetworkRoutes(routes []netlink.Route, nic *cache.VIF) (filteredRoutes []netlink.Route) {
+func FilterPodNetworkRoutes(routes []netlink.Route, nic *cache.DhcpConfig) (filteredRoutes []netlink.Route) {
 	for _, route := range routes {
 		// don't create empty static routes
 		if route.Dst == nil && route.Src.Equal(nil) && route.Gw.Equal(nil) {

--- a/pkg/network/driver/common_test.go
+++ b/pkg/network/driver/common_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Common Methods", func() {
 	})
 })
 
-var _ = Describe("VIF", func() {
+var _ = Describe("DhcpConfig", func() {
 	const ipv4Cidr = "10.0.0.200/24"
 	const ipv4Address = "10.0.0.200"
 	const ipv4Mask = "ffffff00"
@@ -89,20 +89,20 @@ var _ = Describe("VIF", func() {
 	Context("String", func() {
 		It("returns correct string representation", func() {
 			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway, mtu)))
+			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway, mtu)))
 		})
 		It("returns correct string representation with ipv6", func() {
 			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("VIF: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu)))
+			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, Gateway: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu)))
 		})
 	})
 })
 
-func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *cache.VIF {
+func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *cache.DhcpConfig {
 	addr, _ := netlink.ParseAddr(ipv4cidr)
 	mac, _ := net.ParseMAC(macStr)
 	gw := net.ParseIP(ipv4gateway)
-	vif := &cache.VIF{
+	vif := &cache.DhcpConfig{
 		Name:    vifName,
 		IP:      *addr,
 		MAC:     mac,

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -203,7 +203,7 @@ func (_mr *_MockNetworkHandlerRecorder) LinkSetMaster(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetMaster", arg0, arg1)
 }
 
-func (_m *MockNetworkHandler) StartDHCP(nic *cache.VIF, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
+func (_m *MockNetworkHandler) StartDHCP(nic *cache.DhcpConfig, serverAddr net.IP, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
 	ret := _m.ctrl.Call(_m, "StartDHCP", nic, serverAddr, bridgeInterfaceName, dhcpOptions, filterByMAC)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -61,8 +61,8 @@ type BindMechanism interface {
 	// ports are rewired, meaning, routes and IP addresses configured by
 	// CNI plugin may be gone. For this matter, we use a cached DhcpConfig file to
 	// pass discovered information between phases.
-	loadCachedDhcpConfig(pid string) error
-	setCachedDhcpConfig(pid string) error
+	loadCachedDhcpConfig() error
+	setCachedDhcpConfig() error
 
 	// The following entry points require domain initialized for the
 	// binding and can be used in phase2 only.
@@ -259,7 +259,7 @@ func (l *podNIC) PlugPhase1() error {
 			return errors.CreateCriticalNetworkError(err)
 		}
 
-		if err := bindMechanism.setCachedDhcpConfig(getPIDString(l.launcherPID)); err != nil {
+		if err := bindMechanism.setCachedDhcpConfig(); err != nil {
 			log.Log.Reason(err).Error("failed to save dhcpConfig configuration")
 			return errors.CreateCriticalNetworkError(err)
 		}
@@ -310,9 +310,8 @@ func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 		return err
 	}
 
-	pid := "self"
-	if err = bindMechanism.loadCachedDhcpConfig(pid); err != nil {
-		log.Log.Reason(err).Critical("failed to load cached dhcpConfig configuration")
+	if err = bindMechanism.loadCachedDhcpConfig(); err != nil {
+		log.Log.Reason(err).Critical("failed to load cached vif configuration")
 	}
 
 	if err := bindMechanism.decorateConfig(*domainIface); err != nil {
@@ -603,8 +602,8 @@ func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
 	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.iface.Name, &domainIface)
 }
 
-func (b *BridgeBindMechanism) loadCachedDhcpConfig(pid string) error {
-	dhcpConfig, err := b.cacheFactory.CacheDhcpConfigForPid(pid).Read(b.iface.Name)
+func (b *BridgeBindMechanism) loadCachedDhcpConfig() error {
+	dhcpConfig, err := b.cacheFactory.CacheDhcpConfigForPid(getPIDString(b.launcherPID)).Read(b.iface.Name)
 	if err != nil {
 		return err
 	}
@@ -613,8 +612,8 @@ func (b *BridgeBindMechanism) loadCachedDhcpConfig(pid string) error {
 	return nil
 }
 
-func (b *BridgeBindMechanism) setCachedDhcpConfig(pid string) error {
-	return b.cacheFactory.CacheDhcpConfigForPid(pid).Write(b.iface.Name, b.dhcpConfig)
+func (b *BridgeBindMechanism) setCachedDhcpConfig() error {
+	return b.cacheFactory.CacheDhcpConfigForPid(getPIDString(b.launcherPID)).Write(b.iface.Name, b.dhcpConfig)
 }
 
 func (b *BridgeBindMechanism) setInterfaceRoutes() error {
@@ -916,8 +915,8 @@ func (b *MasqueradeBindMechanism) decorateConfig(domainIface api.Interface) erro
 	return nil
 }
 
-func (b *MasqueradeBindMechanism) loadCachedDhcpConfig(pid string) error {
-	dhcpConfig, err := b.cacheFactory.CacheDhcpConfigForPid(pid).Read(b.iface.Name)
+func (b *MasqueradeBindMechanism) loadCachedDhcpConfig() error {
+	dhcpConfig, err := b.cacheFactory.CacheDhcpConfigForPid(getPIDString(b.launcherPID)).Read(b.iface.Name)
 	if err != nil {
 		return err
 	}
@@ -927,8 +926,8 @@ func (b *MasqueradeBindMechanism) loadCachedDhcpConfig(pid string) error {
 	return nil
 }
 
-func (b *MasqueradeBindMechanism) setCachedDhcpConfig(pid string) error {
-	return b.cacheFactory.CacheDhcpConfigForPid(pid).Write(b.iface.Name, b.dhcpConfig)
+func (b *MasqueradeBindMechanism) setCachedDhcpConfig() error {
+	return b.cacheFactory.CacheDhcpConfigForPid(getPIDString(b.launcherPID)).Write(b.iface.Name, b.dhcpConfig)
 }
 
 func (b *MasqueradeBindMechanism) createBridge() error {
@@ -1280,11 +1279,11 @@ func (b *SlirpBindMechanism) decorateConfig(api.Interface) error {
 	return nil
 }
 
-func (b *SlirpBindMechanism) loadCachedDhcpConfig(string) error {
+func (b *SlirpBindMechanism) loadCachedDhcpConfig() error {
 	return nil
 }
 
-func (b *SlirpBindMechanism) setCachedDhcpConfig(string) error {
+func (b *SlirpBindMechanism) setCachedDhcpConfig() error {
 	return nil
 }
 
@@ -1351,11 +1350,11 @@ func (b *MacvtapBindMechanism) decorateConfig(domainIface api.Interface) error {
 	return nil
 }
 
-func (b *MacvtapBindMechanism) loadCachedDhcpConfig(_ string) error {
+func (b *MacvtapBindMechanism) loadCachedDhcpConfig() error {
 	return nil
 }
 
-func (b *MacvtapBindMechanism) setCachedDhcpConfig(_ string) error {
+func (b *MacvtapBindMechanism) setCachedDhcpConfig() error {
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -606,7 +606,7 @@ func getPIDString(pid *int) string {
 }
 
 func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
-	ifaceConfig, err := l.cacheFactory.CacheForPID(getPIDString(l.launcherPID)).Read(l.iface.Name)
+	ifaceConfig, err := l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Read(l.iface.Name)
 
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -620,7 +620,7 @@ func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
 }
 
 func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
-	return l.cacheFactory.CacheForPID(getPIDString(l.launcherPID)).Write(l.iface.Name, &domainIface)
+	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.iface.Name, &domainIface)
 }
 
 func (b *BridgeBindMechanism) loadCachedDhcpConfig(pid string) error {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -1287,10 +1287,6 @@ func (b *SlirpBindMechanism) setCachedDhcpConfig() error {
 	return nil
 }
 
-func (b *SlirpBindMechanism) wasCachedInterfaceLoaded() bool {
-	return true
-}
-
 type MacvtapBindMechanism struct {
 	vmi              *v1.VirtualMachineInstance
 	iface            *v1.Interface

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -22,7 +22,6 @@ package network
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"runtime"
@@ -101,8 +100,6 @@ var _ = Describe("Pod Network", func() {
 	}
 	BeforeEach(func() {
 		cacheFactory = fake.NewFakeInMemoryNetworkCacheFactory()
-		tmpDir, _ := ioutil.TempDir("", "networktest")
-		setVifCacheFile(tmpDir + "/cache-vif-%s.json")
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockNetwork = netdriver.NewMockNetworkHandler(ctrl)

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -768,7 +768,7 @@ var _ = Describe("Pod Network", func() {
 			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			Expect(bridge.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).To(HaveOccurred())
+			Expect(bridge.loadCachedDhcpConfig()).To(HaveOccurred())
 		})
 		It("should succeed when cache file present", func() {
 			vmi := newVMIBridgeInterface("testnamespace", "testVmName")
@@ -780,9 +780,8 @@ var _ = Describe("Pod Network", func() {
 			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			pidStr := fmt.Sprintf("%d", pid)
-			Expect(bridge.setCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
-			Expect(bridge.loadCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
+			Expect(bridge.setCachedDhcpConfig()).ToNot(HaveOccurred())
+			Expect(bridge.loadCachedDhcpConfig()).ToNot(HaveOccurred())
 		})
 	})
 
@@ -797,14 +796,14 @@ var _ = Describe("Pod Network", func() {
 			slirp, ok := driver.(*SlirpBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			// it doesn't fail regardless, whether called without setCachedDhcpConfig...
-			Expect(slirp.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).NotTo(HaveOccurred())
+			// it doesn't fail regardless, whether called without setCachedVIF...
+			Expect(slirp.loadCachedDhcpConfig()).NotTo(HaveOccurred())
 
 			// ...or after it
-			err = slirp.setCachedDhcpConfig(fmt.Sprintf("%d", pid))
+			err = slirp.setCachedDhcpConfig()
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(slirp.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).NotTo(HaveOccurred())
+			Expect(slirp.loadCachedDhcpConfig()).NotTo(HaveOccurred())
 		})
 	})
 
@@ -819,7 +818,7 @@ var _ = Describe("Pod Network", func() {
 			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			Expect(masq.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).To(HaveOccurred())
+			Expect(masq.loadCachedDhcpConfig()).To(HaveOccurred())
 		})
 		It("should succeed when cache file present", func() {
 			vmi := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -831,9 +830,8 @@ var _ = Describe("Pod Network", func() {
 			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			pidStr := fmt.Sprintf("%d", pid)
-			Expect(masq.setCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
-			Expect(masq.loadCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
+			Expect(masq.setCachedDhcpConfig()).ToNot(HaveOccurred())
+			Expect(masq.loadCachedDhcpConfig()).ToNot(HaveOccurred())
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -62,9 +62,9 @@ var _ = Describe("Pod Network", func() {
 	var bridgeTest *netlink.Bridge
 	var masqueradeBridgeTest *netlink.Bridge
 	var bridgeAddr *netlink.Addr
-	var testNic *cache.VIF
+	var testNic *cache.DhcpConfig
 	var tmpDir string
-	var masqueradeTestNic *cache.VIF
+	var masqueradeTestNic *cache.DhcpConfig
 	var masqueradeDummyName string
 	var masqueradeDummy *netlink.Dummy
 	var masqueradeGwStr string
@@ -141,7 +141,7 @@ var _ = Describe("Pod Network", func() {
 
 		bridgeAddr, _ = netlink.ParseAddr(fmt.Sprintf(bridgeFakeIP, 0))
 		tapDeviceName = "tap0"
-		testNic = &cache.VIF{Name: primaryPodInterfaceName,
+		testNic = &cache.DhcpConfig{Name: primaryPodInterfaceName,
 			IP:      fakeAddr,
 			MAC:     fakeMac,
 			Mtu:     uint16(mtu),
@@ -162,7 +162,7 @@ var _ = Describe("Pod Network", func() {
 		masqueradeVmIpv6 = masqueradeIpv6VmAddr.IP.String()
 		masqueradeDummyName = fmt.Sprintf("%s-nic", api.DefaultBridgeName)
 		masqueradeDummy = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: masqueradeDummyName, MTU: mtu}}
-		masqueradeTestNic = &cache.VIF{Name: primaryPodInterfaceName,
+		masqueradeTestNic = &cache.DhcpConfig{Name: primaryPodInterfaceName,
 			IP:          *masqueradeVmAddr,
 			IPv6:        *masqueradeIpv6VmAddr,
 			MAC:         fakeMac,
@@ -322,7 +322,7 @@ var _ = Describe("Pod Network", func() {
 	}
 
 	Context("on successful setup", func() {
-		It("should define a new VIF bind to a bridge", func() {
+		It("should define a new DhcpConfig bind to a bridge", func() {
 			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 
 			domain := NewDomainWithBridgeInterface()
@@ -427,7 +427,7 @@ var _ = Describe("Pod Network", func() {
 					Expect(err).ToNot(HaveOccurred())
 					bridge, ok := driver.(*BridgeBindMechanism)
 					Expect(ok).To(BeTrue())
-					Expect(bridge.vif.MAC.String()).To(Equal("de:ad:00:00:be:af"))
+					Expect(bridge.dhcpConfig.MAC.String()).To(Equal("de:ad:00:00:be:af"))
 				})
 			})
 		})
@@ -458,7 +458,7 @@ var _ = Describe("Pod Network", func() {
 			})
 		})
 		Context("Masquerade Plug", func() {
-			It("should define a new VIF bind to a bridge and create a default nat rule using iptables", func() {
+			It("should define a new DhcpConfig bind to a bridge and create a default nat rule using iptables", func() {
 
 				// forward all the traffic
 				for _, proto := range ipProtocols() {
@@ -474,7 +474,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new VIF bind to a bridge and create a specific nat rule using iptables", func() {
+			It("should define a new DhcpConfig bind to a bridge and create a specific nat rule using iptables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
 				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
@@ -512,7 +512,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new VIF bind to a bridge and create a default nat rule using nftables", func() {
+			It("should define a new DhcpConfig bind to a bridge and create a default nat rule using nftables", func() {
 				// forward all the traffic
 				for _, proto := range ipProtocols() {
 					mockNetwork.EXPECT().NftablesLoad(proto).Return(nil)
@@ -526,7 +526,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				TestPodInterfaceIPBinding(vm, domain)
 			})
-			It("should define a new VIF bind to a bridge and create a specific nat rule using nftables", func() {
+			It("should define a new DhcpConfig bind to a bridge and create a specific nat rule using nftables", func() {
 				// Forward a specific port
 				mockNetwork.EXPECT().IsIpv6Enabled(primaryPodInterfaceName).Return(true, nil).Times(3)
 				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
@@ -664,9 +664,9 @@ var _ = Describe("Pod Network", func() {
 			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			masq.vif.Gateway = masqueradeGwAddr.IP.To4()
-			masq.vif.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
-			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(nil)
+			masq.dhcpConfig.Gateway = masqueradeGwAddr.IP.To4()
+			masq.dhcpConfig.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
+			mockNetwork.EXPECT().StartDHCP(masq.dhcpConfig, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(nil)
 
 			Expect(masq.startDHCP()).To(Succeed())
 		})
@@ -682,11 +682,11 @@ var _ = Describe("Pod Network", func() {
 			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			masq.vif.Gateway = masqueradeGwAddr.IP.To4()
-			masq.vif.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
+			masq.dhcpConfig.Gateway = masqueradeGwAddr.IP.To4()
+			masq.dhcpConfig.GatewayIpv6 = masqueradeIpv6GwAddr.IP.To16()
 
 			err = fmt.Errorf("failed to start DHCP server")
-			mockNetwork.EXPECT().StartDHCP(masq.vif, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(err)
+			mockNetwork.EXPECT().StartDHCP(masq.dhcpConfig, gomock.Any(), masq.bridgeInterfaceName, nil, false).Return(err)
 
 			Expect(masq.startDHCP()).To(HaveOccurred())
 		})
@@ -704,7 +704,7 @@ var _ = Describe("Pod Network", func() {
 			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(nil)
+			mockNetwork.EXPECT().StartDHCP(bridge.dhcpConfig, gomock.Any(), api.DefaultBridgeName, nil, true).Return(nil)
 
 			Expect(bridge.startDHCP()).To(Succeed())
 		})
@@ -721,7 +721,7 @@ var _ = Describe("Pod Network", func() {
 			Expect(ok).To(BeTrue())
 
 			err = fmt.Errorf("failed to start DHCP server")
-			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
+			mockNetwork.EXPECT().StartDHCP(bridge.dhcpConfig, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
 
 			Expect(bridge.startDHCP()).To(HaveOccurred())
 		})
@@ -737,9 +737,9 @@ var _ = Describe("Pod Network", func() {
 			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			bridge.vif.IPAMDisabled = true
+			bridge.dhcpConfig.IPAMDisabled = true
 			err = fmt.Errorf("failed to start DHCP server")
-			mockNetwork.EXPECT().StartDHCP(bridge.vif, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
+			mockNetwork.EXPECT().StartDHCP(bridge.dhcpConfig, gomock.Any(), api.DefaultBridgeName, nil, true).Return(err)
 
 			Expect(bridge.startDHCP()).To(Succeed())
 		})
@@ -760,7 +760,7 @@ var _ = Describe("Pod Network", func() {
 		// slirp never fails to start DHCP because it doesn't need it at all
 	})
 
-	Context("Bridge loadCachedVIF", func() {
+	Context("Bridge loadCachedDhcpConfig", func() {
 		It("should fail when nothing to load", func() {
 			vmi := newVMIBridgeInterface("testnamespace", "testVmName")
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
@@ -771,7 +771,7 @@ var _ = Describe("Pod Network", func() {
 			bridge, ok := driver.(*BridgeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			Expect(bridge.loadCachedVIF(fmt.Sprintf("%d", pid))).To(HaveOccurred())
+			Expect(bridge.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).To(HaveOccurred())
 		})
 		It("should succeed when cache file present", func() {
 			vmi := newVMIBridgeInterface("testnamespace", "testVmName")
@@ -784,12 +784,12 @@ var _ = Describe("Pod Network", func() {
 			Expect(ok).To(BeTrue())
 
 			pidStr := fmt.Sprintf("%d", pid)
-			Expect(bridge.setCachedVIF(pidStr)).ToNot(HaveOccurred())
-			Expect(bridge.loadCachedVIF(pidStr)).ToNot(HaveOccurred())
+			Expect(bridge.setCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
+			Expect(bridge.loadCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
 		})
 	})
 
-	Context("Slirp loadCachedVIF", func() {
+	Context("Slirp loadCachedDhcpConfig", func() {
 		It("should succeed", func() {
 			vmi := newVMISlirpInterface("testnamespace", "testVmName")
 
@@ -800,18 +800,18 @@ var _ = Describe("Pod Network", func() {
 			slirp, ok := driver.(*SlirpBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			// it doesn't fail regardless, whether called without setCachedVIF...
-			Expect(slirp.loadCachedVIF(fmt.Sprintf("%d", pid))).NotTo(HaveOccurred())
+			// it doesn't fail regardless, whether called without setCachedDhcpConfig...
+			Expect(slirp.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).NotTo(HaveOccurred())
 
 			// ...or after it
-			err = slirp.setCachedVIF(fmt.Sprintf("%d", pid))
+			err = slirp.setCachedDhcpConfig(fmt.Sprintf("%d", pid))
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(slirp.loadCachedVIF(fmt.Sprintf("%d", pid))).NotTo(HaveOccurred())
+			Expect(slirp.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).NotTo(HaveOccurred())
 		})
 	})
 
-	Context("Masquerade loadCachedVIF", func() {
+	Context("Masquerade loadCachedDhcpConfig", func() {
 		It("should fail when nothing to load", func() {
 			vmi := newVMIMasqueradeInterface("testnamespace", "testVmName")
 			vmi.Spec.Domain.Devices.Interfaces[0].MacAddress = "de-ad-00-00-be-af"
@@ -822,7 +822,7 @@ var _ = Describe("Pod Network", func() {
 			masq, ok := driver.(*MasqueradeBindMechanism)
 			Expect(ok).To(BeTrue())
 
-			Expect(masq.loadCachedVIF(fmt.Sprintf("%d", pid))).To(HaveOccurred())
+			Expect(masq.loadCachedDhcpConfig(fmt.Sprintf("%d", pid))).To(HaveOccurred())
 		})
 		It("should succeed when cache file present", func() {
 			vmi := newVMIMasqueradeInterface("testnamespace", "testVmName")
@@ -835,8 +835,8 @@ var _ = Describe("Pod Network", func() {
 			Expect(ok).To(BeTrue())
 
 			pidStr := fmt.Sprintf("%d", pid)
-			Expect(masq.setCachedVIF(pidStr)).ToNot(HaveOccurred())
-			Expect(masq.loadCachedVIF(pidStr)).ToNot(HaveOccurred())
+			Expect(masq.setCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
+			Expect(masq.loadCachedDhcpConfig(pidStr)).ToNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends the existing cache mechanism to also cache the network VIFs, which will be used to pass the original pod networking information to the DHCP server running in virt-launcher.

A follow-up PR will allow the get / set cached VIF functions to be moved away from `BindMechanism` interfaces, into the podNIC structs, thus further cleaning up the interface.

**Special notes for your reviewer**:
Depends-on: #5044 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
