### PR TITLE
Networking configurator iface

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -513,7 +513,7 @@ func (d *VirtualMachineController) setPodNetworkPhase1(vmi *v1.VirtualMachineIns
 	}
 
 	err = res.DoNetNS(func() error {
-		return network.NewVMNetworkConfigurator(vmi, d.networkCacheStoreFactory).SetupPodNetworkPhase1(pid)
+		return network.NewInfraNetworkingConfigurator(vmi, d.networkCacheStoreFactory, pid).Setup()
 	})
 	if err != nil {
 		_, critical := err.(*neterrors.CriticalNetworkError)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -447,7 +447,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		}
 	}
 
-	err = network.NewVMNetworkConfigurator(vmi, l.networkCacheStoreFactory).SetupPodNetworkPhase2(domain)
+	err = network.NewNetworkingSpecGenerator(vmi, l.networkCacheStoreFactory, *domain).Setup()
 	if err != nil {
 		return domain, fmt.Errorf("preparing the pod network failed: %v", err)
 	}

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -28,15 +28,15 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 )
 
-var _ = Describe("VMNetworkConfigurator", func() {
+var _ = Describe("NicGenerator", func() {
 	Context("interface configuration", func() {
 		It("should configure bridged pod networking by default", func() {
 			vm := newVMIBridgeInterface("testnamespace", "testVmName")
 
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
+			vmNetworkConfigurator := newNicGenerator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
 			iface := v1.DefaultBridgeNetworkInterface()
 			defaultNet := v1.DefaultPodNetwork()
-			nics, err := vmNetworkConfigurator.getNICs()
+			nics, err := vmNetworkConfigurator.getNICs(nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nics).To(ConsistOf([]podNIC{{
 				vmi:              vm,
@@ -49,8 +49,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 		})
 		It("should accept empty network list", func() {
 			vmi := newVMI("testnamespace", "testVmName")
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
-			nics, err := vmNetworkConfigurator.getNICs()
+			vmNetworkConfigurator := newNicGenerator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
+			nics, err := vmNetworkConfigurator.getNICs(nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nics).To(BeEmpty())
 		})
@@ -65,8 +65,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				},
 			}
 			vmi.Spec.Networks = []v1.Network{*cniNet}
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
-			nics, err := vmNetworkConfigurator.getNICs()
+			vmNetworkConfigurator := newNicGenerator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
+			nics, err := vmNetworkConfigurator.getNICs(nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nics).To(ConsistOf([]podNIC{{
 				vmi:              vmi,
@@ -124,8 +124,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 
 			vm.Spec.Networks = []v1.Network{*additionalCNINet1, *cniNet, *additionalCNINet2}
 
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
-			nics, err := vmNetworkConfigurator.getNICs()
+			vmNetworkConfigurator := newNicGenerator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
+			nics, err := vmNetworkConfigurator.getNICs(nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nics).To(ContainElements([]podNIC{
 				{

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -240,7 +240,9 @@ func (l *podNIC) sortIPsBasedOnPrimaryIP(ipv4, ipv6 string) ([]string, error) {
 	return []string{ipv6, ipv4}, nil
 }
 
-func (l *podNIC) PlugPhase1() error {
+// SetupNetworkInfrastructure creates and configures networking infrastructure
+// in the virt-launcher pod. Requires NET_ADMIN capability.
+func (l *podNIC) SetupNetworkInfrastructure() error {
 
 	// There is nothing to plug for SR-IOV devices
 	if l.iface.SRIOV != nil {
@@ -305,7 +307,10 @@ func ensureDHCP(bindMechanism BindMechanism, podInterfaceName string) error {
 	return nil
 }
 
-func (l *podNIC) PlugPhase2(domain *api.Domain) error {
+// UnpriviligedSetup generates the domail XML document required by libvirt
+// and starts dynamic IP address assignment protocols in the launcher's net ns
+// (dhcp). No network capabilities are required.
+func (l *podNIC) UnpriviligedSetup(domain *api.Domain) error {
 	precond.MustNotBeNil(domain)
 
 	// There is nothing to plug for SR-IOV devices

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -290,7 +290,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
 		podnic := createDefaultPodNIC(vm)
 		podnic.launcherPID = &pid
-		err := podnic.PlugPhase1()
+		err := podnic.SetupNetworkInfrastructure()
 		Expect(err).To(BeNil())
 
 		// Calling SetupPhase1 a second time should result in
@@ -298,7 +298,7 @@ var _ = Describe("Pod Network", func() {
 		// limited number of calls expected for each mocked entry point.
 		podnic = createDefaultPodNIC(vm)
 		podnic.launcherPID = &pid
-		err = podnic.PlugPhase1()
+		err = podnic.SetupNetworkInfrastructure()
 		Expect(err).To(BeNil())
 	}
 
@@ -353,7 +353,7 @@ var _ = Describe("Pod Network", func() {
 
 			podnic := createDefaultPodNIC(vm)
 			podnic.launcherPID = &pid
-			err := podnic.PlugPhase1()
+			err := podnic.SetupNetworkInfrastructure()
 			Expect(err).To(HaveOccurred(), "SetupPhase1 should return an error")
 
 			_, ok := err.(*neterrors.CriticalNetworkError)
@@ -374,7 +374,7 @@ var _ = Describe("Pod Network", func() {
 
 			podnic := createDefaultPodNIC(vm)
 			podnic.launcherPID = &pid
-			err := podnic.PlugPhase1()
+			err := podnic.SetupNetworkInfrastructure()
 			Expect(err).To(HaveOccurred())
 		})
 		Context("func filterPodNetworkRoutes()", func() {
@@ -404,7 +404,7 @@ var _ = Describe("Pod Network", func() {
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
 				mockNetwork.EXPECT().StartDHCP(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("failed to open file"))
 				podnic := createDefaultPodNIC(vm)
-				Expect(podnic.PlugPhase2(domain)).To(Succeed())
+				Expect(podnic.UnpriviligedSetup(domain)).To(Succeed())
 			}
 			Expect(testDhcpPanic).To(Panic())
 		})
@@ -442,10 +442,10 @@ var _ = Describe("Pod Network", func() {
 				podnic.network = net
 				podnic.podInterfaceName = "fakeiface"
 				podnic.launcherPID = &pid
-				err := podnic.PlugPhase1()
+				err := podnic.SetupNetworkInfrastructure()
 				Expect(err).ToNot(HaveOccurred())
 
-				err = podnic.PlugPhase2(domain)
+				err = podnic.UnpriviligedSetup(domain)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Rename the phase 1 / phase 2 network entities to a networking configurator whose name hints at what it does.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends-on: #5062 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
