### PR TITLE
Fix flaky unit tests

### DIFF
--- a/pkg/testutils/mock_queue.go
+++ b/pkg/testutils/mock_queue.go
@@ -79,9 +79,14 @@ func (q *MockWorkQueue) ExpectAdds(diff int) {
 // Wait waits until the expected amount of ExpectedAdds has happened.
 // It will not block if there were no expectations set.
 func (q *MockWorkQueue) Wait() {
-	if q.addWG != nil {
-		q.addWG.Wait()
+	q.wgLock.Lock()
+	wg := q.addWG
+	q.wgLock.Unlock()
+	if wg != nil {
+		wg.Wait()
+		q.wgLock.Lock()
 		q.addWG = nil
+		q.wgLock.Unlock()
 	}
 }
 

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    timeout = "long",
     srcs = [
         "virt_handler_suite_test.go",
         "vm_test.go",

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -249,6 +249,8 @@ func (c *DeviceController) Run(stop chan struct{}) error {
 }
 
 func (c *DeviceController) Initialized() bool {
+	c.devicePluginsMutex.Lock()
+	defer c.devicePluginsMutex.Unlock()
 	for _, dev := range c.devicePlugins {
 		if !dev.devicePlugin.GetInitialized() {
 			return false

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    timeout = "long",
     srcs = [
         "kubevirt_test.go",
         "virt_operator_suite_test.go",

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1465,7 +1465,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// Now when the controller runs, if the namespace will be patched, the test will fail
 			// because the patch is not expected here.
 			kvTestData.controller.Execute()
-		}, 30)
+		}, 60)
 
 		It("should delete install strategy configmap once kubevirt install is deleted", func(done Done) {
 			defer close(done)
@@ -1543,7 +1543,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kv = kvTestData.getLatestKubeVirt(kv)
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 
-		}, 30)
+		}, 60)
 
 		It("delete temporary validation webhook once virt-api is deployed", func(done Done) {
 			defer close(done)
@@ -1589,7 +1589,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 			Expect(kvTestData.totalDeletions).To(Equal(1))
 
-		}, 30)
+		}, 60)
 
 		It("should do nothing if KubeVirt object is deployed", func(done Done) {
 			defer close(done)
@@ -1631,7 +1631,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.controller.Execute()
 
-		}, 30)
+		}, 60)
 
 		It("should update KubeVirt object if generation IDs do not match", func(done Done) {
 			defer close(done)
@@ -1693,7 +1693,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.resourceChanges["validatingwebhookconfigurations"][Patched]).To(Equal(kvTestData.resourceChanges["validatingwebhookconfigurations"][Added]))
 			Expect(kvTestData.resourceChanges["deployements"][Patched]).To(Equal(kvTestData.resourceChanges["deployements"][Added]))
 			Expect(kvTestData.resourceChanges["daemonsets"][Patched]).To(Equal(kvTestData.resourceChanges["daemonsets"][Added]))
-		}, 30)
+		}, 60)
 
 		It("should delete operator managed resources not in the deployed installstrategy", func() {
 			kvTestData := KubeVirtTestData{}
@@ -1739,7 +1739,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.controller.Execute()
 			Expect(kvTestData.totalDeletions).To(Equal(numResources))
-		}, 30)
+		}, 60)
 
 		It("should fail if KubeVirt object already exists", func() {
 
@@ -2060,7 +2060,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Added]).To(Equal(1))
 
-		}, 30)
+		}, 60)
 
 		Context("when the monitor namespace does not exist", func() {
 			It("should not create ServiceMonitor resources", func() {
@@ -2172,7 +2172,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1))
-		}, 30)
+		}, 60)
 
 		It("should pause update after daemonsets are rolled over", func(done Done) {
 			defer close(done)
@@ -2240,7 +2240,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.resourceChanges["deployments"][Patched]).To(Equal(0))          // virt-controller and virt-api unpatched
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(0)) // PDBs unpatched
 			Expect(kvTestData.resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
-		}, 30)
+		}, 60)
 
 		It("should pause update after controllers are rolled over", func(done Done) {
 			defer close(done)
@@ -2308,7 +2308,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kvTestData.resourceChanges["deployments"][Patched]).To(Equal(1))          // virt-operator patched, virt-api unpatched
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1)) // 1 of 2 PDBs patched
 			Expect(kvTestData.resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
-		}, 30)
+		}, 60)
 
 		It("should update kubevirt resources when Operator version changes if no imageTag and imageRegistry is explicitly set.", func() {
 			os.Setenv(util.OperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "otherregistry", "1.1.1"))
@@ -2372,7 +2372,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(2))
 
-		}, 30)
+		}, 60)
 
 		It("should update resources when changing KubeVirt version.", func() {
 			updatedConfig := getConfig("otherregistry", "1.1.1")
@@ -2436,7 +2436,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// + 1 is for the namespace patch which we don't consider as a resource we own.
 			Expect(kvTestData.totalUpdates + kvTestData.totalPatches).To(Equal(resourceCount + 1))
 
-		}, 30)
+		}, 60)
 
 		It("should patch poddisruptionbudgets when changing KubeVirt version.", func() {
 			updatedConfig := getConfig("otherregistry", "1.1.1")
@@ -2501,7 +2501,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(2))
 
-		}, 30)
+		}, 60)
 
 		It("should remove resources on deletion", func() {
 
@@ -2538,7 +2538,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeleted))
 			Expect(len(kv.Status.Conditions)).To(Equal(3))
 			shouldExpectHCOConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionFalse, k8sv1.ConditionTrue)
-		}, 30)
+		}, 60)
 
 		It("should remove poddisruptionbudgets on deletion", func() {
 
@@ -2567,7 +2567,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 
 			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Deleted]).To(Equal(2))
-		}, 30)
+		}, 60)
 	})
 
 	Context("On install strategy dump", func() {

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -74,1441 +74,1359 @@ const (
 	Updated = "updated"
 	Patched = "patched"
 	Deleted = "deleted"
+
+	NAMESPACE = "kubevirt-test"
+
+	resourceCount = 53
+	patchCount    = 34
+	updateCount   = 20
 )
 
-var _ = Describe("KubeVirt Operator", func() {
+type KubeVirtTestData struct {
+	ctrl             *gomock.Controller
+	kvInterface      *kubecli.MockKubeVirtInterface
+	kvSource         *framework.FakeControllerSource
+	kvInformer       cache.SharedIndexInformer
+	apiServiceClient *install.MockAPIServiceInterface
 
-	var ctrl *gomock.Controller
-	var kvInterface *kubecli.MockKubeVirtInterface
-	var kvSource *framework.FakeControllerSource
-	var kvInformer cache.SharedIndexInformer
-	var apiServiceClient *install.MockAPIServiceInterface
+	serviceAccountSource           *framework.FakeControllerSource
+	clusterRoleSource              *framework.FakeControllerSource
+	clusterRoleBindingSource       *framework.FakeControllerSource
+	roleSource                     *framework.FakeControllerSource
+	roleBindingSource              *framework.FakeControllerSource
+	crdSource                      *framework.FakeControllerSource
+	serviceSource                  *framework.FakeControllerSource
+	deploymentSource               *framework.FakeControllerSource
+	daemonSetSource                *framework.FakeControllerSource
+	validatingWebhookSource        *framework.FakeControllerSource
+	mutatingWebhookSource          *framework.FakeControllerSource
+	apiserviceSource               *framework.FakeControllerSource
+	sccSource                      *framework.FakeControllerSource
+	installStrategyConfigMapSource *framework.FakeControllerSource
+	installStrategyJobSource       *framework.FakeControllerSource
+	infrastructurePodSource        *framework.FakeControllerSource
+	podDisruptionBudgetSource      *framework.FakeControllerSource
+	serviceMonitorSource           *framework.FakeControllerSource
+	namespaceSource                *framework.FakeControllerSource
+	prometheusRuleSource           *framework.FakeControllerSource
+	secretsSource                  *framework.FakeControllerSource
+	configMapSource                *framework.FakeControllerSource
 
-	var serviceAccountSource *framework.FakeControllerSource
-	var clusterRoleSource *framework.FakeControllerSource
-	var clusterRoleBindingSource *framework.FakeControllerSource
-	var roleSource *framework.FakeControllerSource
-	var roleBindingSource *framework.FakeControllerSource
-	var crdSource *framework.FakeControllerSource
-	var serviceSource *framework.FakeControllerSource
-	var deploymentSource *framework.FakeControllerSource
-	var daemonSetSource *framework.FakeControllerSource
-	var validatingWebhookSource *framework.FakeControllerSource
-	var mutatingWebhookSource *framework.FakeControllerSource
-	var apiserviceSource *framework.FakeControllerSource
-	var sccSource *framework.FakeControllerSource
-	var installStrategyConfigMapSource *framework.FakeControllerSource
-	var installStrategyJobSource *framework.FakeControllerSource
-	var infrastructurePodSource *framework.FakeControllerSource
-	var podDisruptionBudgetSource *framework.FakeControllerSource
-	var serviceMonitorSource *framework.FakeControllerSource
-	var namespaceSource *framework.FakeControllerSource
-	var prometheusRuleSource *framework.FakeControllerSource
-	var secretsSource *framework.FakeControllerSource
-	var configMapSource *framework.FakeControllerSource
+	stop       chan struct{}
+	controller *KubeVirtController
 
-	var stop chan struct{}
-	var controller *KubeVirtController
+	recorder *record.FakeRecorder
 
-	var recorder *record.FakeRecorder
+	mockQueue  *testutils.MockWorkQueue
+	virtClient *kubecli.MockKubevirtClient
+	kubeClient *fake.Clientset
+	secClient  *secv1fake.FakeSecurityV1
+	extClient  *extclientfake.Clientset
+	promClient *promclientfake.Clientset
 
-	var mockQueue *testutils.MockWorkQueue
-	var virtClient *kubecli.MockKubevirtClient
-	var kubeClient *fake.Clientset
-	var secClient *secv1fake.FakeSecurityV1
-	var extClient *extclientfake.Clientset
-	var promClient *promclientfake.Clientset
+	informers util.Informers
+	stores    util.Stores
 
-	var informers util.Informers
-	var stores util.Stores
+	totalAdds       int
+	totalUpdates    int
+	totalPatches    int
+	totalDeletions  int
+	resourceChanges map[string]map[string]int
 
-	NAMESPACE := "kubevirt-test"
+	deleteFromCache bool
+	addToCache      bool
 
-	getConfig := func(registry, version string) *util.KubeVirtDeploymentConfig {
-		return util.GetTargetConfigFromKV(&v1.KubeVirt{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: NAMESPACE,
-			},
-			Spec: v1.KubeVirtSpec{
-				ImageRegistry: registry,
-				ImageTag:      version,
+	defaultConfig *util.KubeVirtDeploymentConfig
+}
+
+func (k *KubeVirtTestData) BeforeTest() {
+
+	k.defaultConfig = getConfig("", "")
+
+	k.totalAdds = 0
+	k.totalUpdates = 0
+	k.totalPatches = 0
+	k.totalDeletions = 0
+	k.resourceChanges = make(map[string]map[string]int)
+	k.deleteFromCache = true
+	k.addToCache = true
+
+	k.stop = make(chan struct{})
+	k.ctrl = gomock.NewController(GinkgoT())
+	k.virtClient = kubecli.NewMockKubevirtClient(k.ctrl)
+	k.kvInterface = kubecli.NewMockKubeVirtInterface(k.ctrl)
+	k.apiServiceClient = install.NewMockAPIServiceInterface(k.ctrl)
+
+	k.kvInformer, k.kvSource = testutils.NewFakeInformerFor(&v1.KubeVirt{})
+	k.recorder = record.NewFakeRecorder(100)
+
+	k.informers.ServiceAccount, k.serviceAccountSource = testutils.NewFakeInformerFor(&k8sv1.ServiceAccount{})
+	k.stores.ServiceAccountCache = k.informers.ServiceAccount.GetStore()
+
+	k.informers.ClusterRole, k.clusterRoleSource = testutils.NewFakeInformerFor(&rbacv1.ClusterRole{})
+	k.stores.ClusterRoleCache = k.informers.ClusterRole.GetStore()
+
+	k.informers.ClusterRoleBinding, k.clusterRoleBindingSource = testutils.NewFakeInformerFor(&rbacv1.ClusterRoleBinding{})
+	k.stores.ClusterRoleBindingCache = k.informers.ClusterRoleBinding.GetStore()
+
+	k.informers.Role, k.roleSource = testutils.NewFakeInformerFor(&rbacv1.Role{})
+	k.stores.RoleCache = k.informers.Role.GetStore()
+
+	k.informers.RoleBinding, k.roleBindingSource = testutils.NewFakeInformerFor(&rbacv1.RoleBinding{})
+	k.stores.RoleBindingCache = k.informers.RoleBinding.GetStore()
+
+	k.informers.Crd, k.crdSource = testutils.NewFakeInformerFor(&extv1.CustomResourceDefinition{})
+	k.stores.CrdCache = k.informers.Crd.GetStore()
+
+	k.informers.Service, k.serviceSource = testutils.NewFakeInformerFor(&k8sv1.Service{})
+	k.stores.ServiceCache = k.informers.Service.GetStore()
+
+	k.informers.Deployment, k.deploymentSource = testutils.NewFakeInformerFor(&appsv1.Deployment{})
+	k.stores.DeploymentCache = k.informers.Deployment.GetStore()
+
+	k.informers.DaemonSet, k.daemonSetSource = testutils.NewFakeInformerFor(&appsv1.DaemonSet{})
+	k.stores.DaemonSetCache = k.informers.DaemonSet.GetStore()
+
+	k.informers.ValidationWebhook, k.validatingWebhookSource = testutils.NewFakeInformerFor(&admissionregistrationv1.ValidatingWebhookConfiguration{})
+	k.stores.ValidationWebhookCache = k.informers.ValidationWebhook.GetStore()
+	k.informers.MutatingWebhook, k.mutatingWebhookSource = testutils.NewFakeInformerFor(&admissionregistrationv1.MutatingWebhookConfiguration{})
+	k.stores.MutatingWebhookCache = k.informers.MutatingWebhook.GetStore()
+	k.informers.APIService, k.apiserviceSource = testutils.NewFakeInformerFor(&apiregv1.APIService{})
+	k.stores.APIServiceCache = k.informers.APIService.GetStore()
+
+	k.informers.SCC, k.sccSource = testutils.NewFakeInformerFor(&secv1.SecurityContextConstraints{})
+	k.stores.SCCCache = k.informers.SCC.GetStore()
+
+	k.informers.InstallStrategyConfigMap, k.installStrategyConfigMapSource = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
+	k.stores.InstallStrategyConfigMapCache = k.informers.InstallStrategyConfigMap.GetStore()
+
+	k.informers.InstallStrategyJob, k.installStrategyJobSource = testutils.NewFakeInformerFor(&batchv1.Job{})
+	k.stores.InstallStrategyJobCache = k.informers.InstallStrategyJob.GetStore()
+
+	k.informers.InfrastructurePod, k.infrastructurePodSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
+	k.stores.InfrastructurePodCache = k.informers.InfrastructurePod.GetStore()
+
+	k.informers.PodDisruptionBudget, k.podDisruptionBudgetSource = testutils.NewFakeInformerFor(&policyv1beta1.PodDisruptionBudget{})
+	k.stores.PodDisruptionBudgetCache = k.informers.PodDisruptionBudget.GetStore()
+
+	k.informers.Namespace, k.namespaceSource = testutils.NewFakeInformerWithIndexersFor(
+		&k8sv1.Namespace{}, cache.Indexers{
+			"namespace_name": func(obj interface{}) ([]string, error) {
+				return []string{obj.(*k8sv1.Namespace).GetName()}, nil
 			},
 		})
+	k.stores.NamespaceCache = k.informers.Namespace.GetStore()
+
+	// test OpenShift components
+	k.stores.IsOnOpenshift = true
+
+	k.informers.ServiceMonitor, k.serviceMonitorSource = testutils.NewFakeInformerFor(&promv1.ServiceMonitor{Spec: promv1.ServiceMonitorSpec{}})
+	k.stores.ServiceMonitorCache = k.informers.ServiceMonitor.GetStore()
+	k.stores.ServiceMonitorEnabled = true
+
+	k.informers.PrometheusRule, k.prometheusRuleSource = testutils.NewFakeInformerFor(&promv1.PrometheusRule{Spec: promv1.PrometheusRuleSpec{}})
+	k.stores.PrometheusRuleCache = k.informers.PrometheusRule.GetStore()
+	k.stores.PrometheusRulesEnabled = true
+
+	k.informers.Secrets, k.secretsSource = testutils.NewFakeInformerFor(&k8sv1.Secret{})
+	k.stores.SecretCache = k.informers.Secrets.GetStore()
+	k.informers.ConfigMap, k.configMapSource = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
+	k.stores.ConfigMapCache = k.informers.ConfigMap.GetStore()
+
+	k.controller = NewKubeVirtController(k.virtClient, k.apiServiceClient, k.kvInformer, k.recorder, k.stores, k.informers, NAMESPACE)
+
+	// Wrap our workqueue to have a way to detect when we are done processing updates
+	k.mockQueue = testutils.NewMockWorkQueue(k.controller.queue)
+	k.controller.queue = k.mockQueue
+
+	// Set up mock client
+	k.virtClient.EXPECT().KubeVirt(NAMESPACE).Return(k.kvInterface).AnyTimes()
+	k.kubeClient = fake.NewSimpleClientset()
+	k.secClient = &secv1fake.FakeSecurityV1{
+		Fake: &fake.NewSimpleClientset().Fake,
 	}
+	k.extClient = extclientfake.NewSimpleClientset()
 
-	var totalAdds int
-	var totalUpdates int
-	var totalPatches int
-	var totalDeletions int
-	var resourceChanges map[string]map[string]int
+	k.promClient = promclientfake.NewSimpleClientset()
 
-	resourceCount := 53
-	patchCount := 34
-	updateCount := 20
+	k.virtClient.EXPECT().AdmissionregistrationV1().Return(k.kubeClient.AdmissionregistrationV1()).AnyTimes()
+	k.virtClient.EXPECT().CoreV1().Return(k.kubeClient.CoreV1()).AnyTimes()
+	k.virtClient.EXPECT().BatchV1().Return(k.kubeClient.BatchV1()).AnyTimes()
+	k.virtClient.EXPECT().RbacV1().Return(k.kubeClient.RbacV1()).AnyTimes()
+	k.virtClient.EXPECT().AppsV1().Return(k.kubeClient.AppsV1()).AnyTimes()
+	k.virtClient.EXPECT().SecClient().Return(k.secClient).AnyTimes()
+	k.virtClient.EXPECT().ExtensionsClient().Return(k.extClient).AnyTimes()
+	k.virtClient.EXPECT().PolicyV1beta1().Return(k.kubeClient.PolicyV1beta1()).AnyTimes()
+	k.virtClient.EXPECT().PrometheusClient().Return(k.promClient).AnyTimes()
 
-	deleteFromCache := true
-	addToCache := true
-
-	syncCaches := func(stop chan struct{}) {
-		go kvInformer.Run(stop)
-		go informers.ServiceAccount.Run(stop)
-		go informers.ClusterRole.Run(stop)
-		go informers.ClusterRoleBinding.Run(stop)
-		go informers.Role.Run(stop)
-		go informers.RoleBinding.Run(stop)
-		go informers.Crd.Run(stop)
-		go informers.Service.Run(stop)
-		go informers.Deployment.Run(stop)
-		go informers.DaemonSet.Run(stop)
-		go informers.ValidationWebhook.Run(stop)
-		go informers.MutatingWebhook.Run(stop)
-		go informers.APIService.Run(stop)
-		go informers.SCC.Run(stop)
-		go informers.InstallStrategyJob.Run(stop)
-		go informers.InstallStrategyConfigMap.Run(stop)
-		go informers.InfrastructurePod.Run(stop)
-		go informers.PodDisruptionBudget.Run(stop)
-		go informers.ServiceMonitor.Run(stop)
-		go informers.Namespace.Run(stop)
-		go informers.PrometheusRule.Run(stop)
-		go informers.Secrets.Run(stop)
-		go informers.ConfigMap.Run(stop)
-
-		Expect(cache.WaitForCacheSync(stop, kvInformer.HasSynced)).To(BeTrue())
-
-		cache.WaitForCacheSync(stop, informers.ServiceAccount.HasSynced)
-		cache.WaitForCacheSync(stop, informers.ClusterRole.HasSynced)
-		cache.WaitForCacheSync(stop, informers.ClusterRoleBinding.HasSynced)
-		cache.WaitForCacheSync(stop, informers.Role.HasSynced)
-		cache.WaitForCacheSync(stop, informers.RoleBinding.HasSynced)
-		cache.WaitForCacheSync(stop, informers.Crd.HasSynced)
-		cache.WaitForCacheSync(stop, informers.Service.HasSynced)
-		cache.WaitForCacheSync(stop, informers.Deployment.HasSynced)
-		cache.WaitForCacheSync(stop, informers.DaemonSet.HasSynced)
-		cache.WaitForCacheSync(stop, informers.ValidationWebhook.HasSynced)
-		cache.WaitForCacheSync(stop, informers.MutatingWebhook.HasSynced)
-		cache.WaitForCacheSync(stop, informers.APIService.HasSynced)
-		cache.WaitForCacheSync(stop, informers.SCC.HasSynced)
-		cache.WaitForCacheSync(stop, informers.InstallStrategyJob.HasSynced)
-		cache.WaitForCacheSync(stop, informers.InstallStrategyConfigMap.HasSynced)
-		cache.WaitForCacheSync(stop, informers.InfrastructurePod.HasSynced)
-		cache.WaitForCacheSync(stop, informers.PodDisruptionBudget.HasSynced)
-		cache.WaitForCacheSync(stop, informers.ServiceMonitor.HasSynced)
-		cache.WaitForCacheSync(stop, informers.Namespace.HasSynced)
-		cache.WaitForCacheSync(stop, informers.PrometheusRule.HasSynced)
-		cache.WaitForCacheSync(stop, informers.Secrets.HasSynced)
-		cache.WaitForCacheSync(stop, informers.ConfigMap.HasSynced)
-	}
-
-	getSCC := func() secv1.SecurityContextConstraints {
-		return secv1.SecurityContextConstraints{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "privileged",
-			},
-			Users: []string{
-				"someUser",
-			},
+	// Make sure that all unexpected calls to kubeClient will fail
+	k.kubeClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "secrets" {
+			return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, "whatever")
 		}
-	}
-
-	var defaultConfig *util.KubeVirtDeploymentConfig
-	BeforeEach(func() {
-
-		err := os.Setenv(util.OperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "someregistry", "v9.9.9"))
-		Expect(err).NotTo(HaveOccurred())
-		defaultConfig = getConfig("", "")
-
-		totalAdds = 0
-		totalUpdates = 0
-		totalPatches = 0
-		totalDeletions = 0
-		resourceChanges = make(map[string]map[string]int)
-		deleteFromCache = true
-		addToCache = true
-
-		stop = make(chan struct{})
-		ctrl = gomock.NewController(GinkgoT())
-		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		kvInterface = kubecli.NewMockKubeVirtInterface(ctrl)
-		apiServiceClient = install.NewMockAPIServiceInterface(ctrl)
-
-		kvInformer, kvSource = testutils.NewFakeInformerFor(&v1.KubeVirt{})
-		recorder = record.NewFakeRecorder(100)
-
-		informers.ServiceAccount, serviceAccountSource = testutils.NewFakeInformerFor(&k8sv1.ServiceAccount{})
-		stores.ServiceAccountCache = informers.ServiceAccount.GetStore()
-
-		informers.ClusterRole, clusterRoleSource = testutils.NewFakeInformerFor(&rbacv1.ClusterRole{})
-		stores.ClusterRoleCache = informers.ClusterRole.GetStore()
-
-		informers.ClusterRoleBinding, clusterRoleBindingSource = testutils.NewFakeInformerFor(&rbacv1.ClusterRoleBinding{})
-		stores.ClusterRoleBindingCache = informers.ClusterRoleBinding.GetStore()
-
-		informers.Role, roleSource = testutils.NewFakeInformerFor(&rbacv1.Role{})
-		stores.RoleCache = informers.Role.GetStore()
-
-		informers.RoleBinding, roleBindingSource = testutils.NewFakeInformerFor(&rbacv1.RoleBinding{})
-		stores.RoleBindingCache = informers.RoleBinding.GetStore()
-
-		informers.Crd, crdSource = testutils.NewFakeInformerFor(&extv1.CustomResourceDefinition{})
-		stores.CrdCache = informers.Crd.GetStore()
-
-		informers.Service, serviceSource = testutils.NewFakeInformerFor(&k8sv1.Service{})
-		stores.ServiceCache = informers.Service.GetStore()
-
-		informers.Deployment, deploymentSource = testutils.NewFakeInformerFor(&appsv1.Deployment{})
-		stores.DeploymentCache = informers.Deployment.GetStore()
-
-		informers.DaemonSet, daemonSetSource = testutils.NewFakeInformerFor(&appsv1.DaemonSet{})
-		stores.DaemonSetCache = informers.DaemonSet.GetStore()
-
-		informers.ValidationWebhook, validatingWebhookSource = testutils.NewFakeInformerFor(&admissionregistrationv1.ValidatingWebhookConfiguration{})
-		stores.ValidationWebhookCache = informers.ValidationWebhook.GetStore()
-		informers.MutatingWebhook, mutatingWebhookSource = testutils.NewFakeInformerFor(&admissionregistrationv1.MutatingWebhookConfiguration{})
-		stores.MutatingWebhookCache = informers.MutatingWebhook.GetStore()
-		informers.APIService, apiserviceSource = testutils.NewFakeInformerFor(&apiregv1.APIService{})
-		stores.APIServiceCache = informers.APIService.GetStore()
-
-		informers.SCC, sccSource = testutils.NewFakeInformerFor(&secv1.SecurityContextConstraints{})
-		stores.SCCCache = informers.SCC.GetStore()
-
-		informers.InstallStrategyConfigMap, installStrategyConfigMapSource = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
-		stores.InstallStrategyConfigMapCache = informers.InstallStrategyConfigMap.GetStore()
-
-		informers.InstallStrategyJob, installStrategyJobSource = testutils.NewFakeInformerFor(&batchv1.Job{})
-		stores.InstallStrategyJobCache = informers.InstallStrategyJob.GetStore()
-
-		informers.InfrastructurePod, infrastructurePodSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
-		stores.InfrastructurePodCache = informers.InfrastructurePod.GetStore()
-
-		informers.PodDisruptionBudget, podDisruptionBudgetSource = testutils.NewFakeInformerFor(&policyv1beta1.PodDisruptionBudget{})
-		stores.PodDisruptionBudgetCache = informers.PodDisruptionBudget.GetStore()
-
-		informers.Namespace, namespaceSource = testutils.NewFakeInformerWithIndexersFor(
-			&k8sv1.Namespace{}, cache.Indexers{
-				"namespace_name": func(obj interface{}) ([]string, error) {
-					return []string{obj.(*k8sv1.Namespace).GetName()}, nil
-				},
-			})
-		stores.NamespaceCache = informers.Namespace.GetStore()
-
-		// test OpenShift components
-		stores.IsOnOpenshift = true
-
-		informers.ServiceMonitor, serviceMonitorSource = testutils.NewFakeInformerFor(&promv1.ServiceMonitor{Spec: promv1.ServiceMonitorSpec{}})
-		stores.ServiceMonitorCache = informers.ServiceMonitor.GetStore()
-		stores.ServiceMonitorEnabled = true
-
-		informers.PrometheusRule, prometheusRuleSource = testutils.NewFakeInformerFor(&promv1.PrometheusRule{Spec: promv1.PrometheusRuleSpec{}})
-		stores.PrometheusRuleCache = informers.PrometheusRule.GetStore()
-		stores.PrometheusRulesEnabled = true
-
-		informers.Secrets, secretsSource = testutils.NewFakeInformerFor(&k8sv1.Secret{})
-		stores.SecretCache = informers.Secrets.GetStore()
-		informers.ConfigMap, configMapSource = testutils.NewFakeInformerFor(&k8sv1.ConfigMap{})
-		stores.ConfigMapCache = informers.ConfigMap.GetStore()
-
-		controller = NewKubeVirtController(virtClient, apiServiceClient, kvInformer, recorder, stores, informers, NAMESPACE)
-
-		// Wrap our workqueue to have a way to detect when we are done processing updates
-		mockQueue = testutils.NewMockWorkQueue(controller.queue)
-		controller.queue = mockQueue
-
-		// Set up mock client
-		virtClient.EXPECT().KubeVirt(NAMESPACE).Return(kvInterface).AnyTimes()
-		kubeClient = fake.NewSimpleClientset()
-		secClient = &secv1fake.FakeSecurityV1{
-			Fake: &fake.NewSimpleClientset().Fake,
+		if action.GetVerb() == "get" && action.GetResource().Resource == "validatingwebhookconfigurations" {
+			return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "validatingwebhookconfigurations"}, "whatever")
 		}
-		extClient = extclientfake.NewSimpleClientset()
-
-		promClient = promclientfake.NewSimpleClientset()
-
-		virtClient.EXPECT().AdmissionregistrationV1().Return(kubeClient.AdmissionregistrationV1()).AnyTimes()
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
-		virtClient.EXPECT().BatchV1().Return(kubeClient.BatchV1()).AnyTimes()
-		virtClient.EXPECT().RbacV1().Return(kubeClient.RbacV1()).AnyTimes()
-		virtClient.EXPECT().AppsV1().Return(kubeClient.AppsV1()).AnyTimes()
-		virtClient.EXPECT().SecClient().Return(secClient).AnyTimes()
-		virtClient.EXPECT().ExtensionsClient().Return(extClient).AnyTimes()
-		virtClient.EXPECT().PolicyV1beta1().Return(kubeClient.PolicyV1beta1()).AnyTimes()
-		virtClient.EXPECT().PrometheusClient().Return(promClient).AnyTimes()
-
-		// Make sure that all unexpected calls to kubeClient will fail
-		kubeClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-			if action.GetVerb() == "get" && action.GetResource().Resource == "secrets" {
-				return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "secrets"}, "whatever")
-			}
-			if action.GetVerb() == "get" && action.GetResource().Resource == "validatingwebhookconfigurations" {
-				return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "validatingwebhookconfigurations"}, "whatever")
-			}
-			if action.GetVerb() == "get" && action.GetResource().Resource == "mutatingwebhookconfigurations" {
-				return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "mutatingwebhookconfigurations"}, "whatever")
-			}
-			if action.GetVerb() != "get" || action.GetResource().Resource != "namespaces" {
-				Expect(action).To(BeNil())
-			}
-			return true, nil, nil
-		})
-		apiServiceClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "apiservices"}, "whatever"))
-		secClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		if action.GetVerb() == "get" && action.GetResource().Resource == "mutatingwebhookconfigurations" {
+			return true, nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "mutatingwebhookconfigurations"}, "whatever")
+		}
+		if action.GetVerb() != "get" || action.GetResource().Resource != "namespaces" {
 			Expect(action).To(BeNil())
-			return true, nil, nil
-		})
-		extClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-			Expect(action).To(BeNil())
-			return true, nil, nil
-		})
-		promClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-			Expect(action).To(BeNil())
-			return true, nil, nil
-		})
-
-		syncCaches(stop)
-
-		// add the privileged SCC without KubeVirt accounts
-		scc := getSCC()
-		sccSource.Add(&scc)
-
-	})
-
-	AfterEach(func() {
-		close(stop)
-		// Ensure that we add checks for expected events to every test
-		Expect(recorder.Events).To(BeEmpty())
-		ctrl.Finish()
-	})
-
-	injectMetadata := func(objectMeta *metav1.ObjectMeta, config *util.KubeVirtDeploymentConfig) {
-
-		if config == nil {
-			return
 		}
-		if objectMeta.Labels == nil {
-			objectMeta.Labels = make(map[string]string)
-		}
-		objectMeta.Labels[v1.ManagedByLabel] = v1.ManagedByLabelOperatorValue
-
-		if config.GetProductVersion() != "" {
-			objectMeta.Labels[v1.AppVersionLabel] = config.GetProductVersion()
-		}
-		if config.GetProductName() != "" {
-			objectMeta.Labels[v1.AppPartOfLabel] = config.GetProductName()
-		}
-
-		if objectMeta.Annotations == nil {
-			objectMeta.Annotations = make(map[string]string)
-		}
-		objectMeta.Annotations[v1.InstallStrategyVersionAnnotation] = config.GetKubeVirtVersion()
-		objectMeta.Annotations[v1.InstallStrategyRegistryAnnotation] = config.GetImageRegistry()
-		objectMeta.Annotations[v1.InstallStrategyIdentifierAnnotation] = config.GetDeploymentID()
-		objectMeta.Annotations[v1.KubeVirtGenerationAnnotation] = "1"
-
-		objectMeta.Labels[v1.AppComponentLabel] = v1.AppComponent
-	}
-
-	addKubeVirt := func(kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		kvSource.Add(kv)
-		mockQueue.Wait()
-	}
-
-	addServiceAccount := func(sa *k8sv1.ServiceAccount) {
-		mockQueue.ExpectAdds(1)
-		serviceAccountSource.Add(sa)
-		mockQueue.Wait()
-	}
-
-	addClusterRole := func(cr *rbacv1.ClusterRole) {
-		mockQueue.ExpectAdds(1)
-		clusterRoleSource.Add(cr)
-		mockQueue.Wait()
-	}
-
-	addClusterRoleBinding := func(crb *rbacv1.ClusterRoleBinding) {
-		mockQueue.ExpectAdds(1)
-		clusterRoleBindingSource.Add(crb)
-		mockQueue.Wait()
-	}
-
-	addRole := func(role *rbacv1.Role) {
-		mockQueue.ExpectAdds(1)
-		roleSource.Add(role)
-		mockQueue.Wait()
-	}
-
-	addRoleBinding := func(rb *rbacv1.RoleBinding) {
-		mockQueue.ExpectAdds(1)
-		roleBindingSource.Add(rb)
-		mockQueue.Wait()
-	}
-
-	addCrd := func(crd *extv1.CustomResourceDefinition, kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		if kv != nil {
-			apply.SetGeneration(&kv.Status.Generations, crd)
-		}
-
-		crdSource.Add(crd)
-		mockQueue.Wait()
-	}
-
-	addService := func(svc *k8sv1.Service) {
-		mockQueue.ExpectAdds(1)
-		serviceSource.Add(svc)
-		mockQueue.Wait()
-	}
-
-	addDeployment := func(depl *appsv1.Deployment, kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		if kv != nil {
-			apply.SetGeneration(&kv.Status.Generations, depl)
-		}
-
-		deploymentSource.Add(depl)
-		mockQueue.Wait()
-	}
-
-	addDaemonset := func(ds *appsv1.DaemonSet, kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		if kv != nil {
-			apply.SetGeneration(&kv.Status.Generations, ds)
-		}
-
-		daemonSetSource.Add(ds)
-		mockQueue.Wait()
-	}
-
-	addValidatingWebhook := func(wh *admissionregistrationv1.ValidatingWebhookConfiguration, kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		if kv != nil {
-			apply.SetGeneration(&kv.Status.Generations, wh)
-		}
-
-		validatingWebhookSource.Add(wh)
-		mockQueue.Wait()
-	}
-
-	addMutatingWebhook := func(wh *admissionregistrationv1.MutatingWebhookConfiguration, kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		if kv != nil {
-			apply.SetGeneration(&kv.Status.Generations, wh)
-		}
-
-		mutatingWebhookSource.Add(wh)
-		mockQueue.Wait()
-	}
-
-	addAPIService := func(wh *apiregv1.APIService) {
-		mockQueue.ExpectAdds(1)
-		apiserviceSource.Add(wh)
-		mockQueue.Wait()
-	}
-
-	addInstallStrategyJob := func(job *batchv1.Job) {
-		mockQueue.ExpectAdds(1)
-		installStrategyJobSource.Add(job)
-		mockQueue.Wait()
-	}
-
-	addPod := func(pod *k8sv1.Pod) {
-		mockQueue.ExpectAdds(1)
-		infrastructurePodSource.Add(pod)
-		mockQueue.Wait()
-	}
-
-	addPodDisruptionBudget := func(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, kv *v1.KubeVirt) {
-		mockQueue.ExpectAdds(1)
-		if kv != nil {
-			apply.SetGeneration(&kv.Status.Generations, podDisruptionBudget)
-		}
-
-		podDisruptionBudgetSource.Add(podDisruptionBudget)
-		mockQueue.Wait()
-	}
-
-	addSecret := func(secret *k8sv1.Secret) {
-		mockQueue.ExpectAdds(1)
-		secretsSource.Add(secret)
-		mockQueue.Wait()
-	}
-
-	addConfigMap := func(configMap *k8sv1.ConfigMap) {
-		mockQueue.ExpectAdds(1)
-		if _, ok := configMap.Labels[v1.InstallStrategyLabel]; ok {
-			installStrategyConfigMapSource.Add(configMap)
-		} else {
-			configMapSource.Add(configMap)
-		}
-		mockQueue.Wait()
-	}
-
-	addSCC := func(scc *secv1.SecurityContextConstraints) {
-		mockQueue.ExpectAdds(1)
-		sccSource.Add(scc)
-		mockQueue.Wait()
-	}
-
-	addServiceMonitor := func(serviceMonitor *promv1.ServiceMonitor) {
-		mockQueue.ExpectAdds(1)
-		serviceMonitorSource.Add(serviceMonitor)
-		mockQueue.Wait()
-	}
-
-	addPrometheusRule := func(prometheusRule *promv1.PrometheusRule) {
-		mockQueue.ExpectAdds(1)
-		prometheusRuleSource.Add(prometheusRule)
-		mockQueue.Wait()
-	}
-
-	addResource := func(obj runtime.Object, config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
-		switch resource := obj.(type) {
-		case *k8sv1.ServiceAccount:
-			injectMetadata(&obj.(*k8sv1.ServiceAccount).ObjectMeta, config)
-			addServiceAccount(resource)
-		case *rbacv1.ClusterRole:
-			injectMetadata(&obj.(*rbacv1.ClusterRole).ObjectMeta, config)
-			addClusterRole(resource)
-		case *rbacv1.ClusterRoleBinding:
-			injectMetadata(&obj.(*rbacv1.ClusterRoleBinding).ObjectMeta, config)
-			addClusterRoleBinding(resource)
-		case *rbacv1.Role:
-			injectMetadata(&obj.(*rbacv1.Role).ObjectMeta, config)
-			addRole(resource)
-		case *rbacv1.RoleBinding:
-			injectMetadata(&obj.(*rbacv1.RoleBinding).ObjectMeta, config)
-			addRoleBinding(resource)
-		case *extv1.CustomResourceDefinition:
-			injectMetadata(&obj.(*extv1.CustomResourceDefinition).ObjectMeta, config)
-			addCrd(resource, kv)
-		case *k8sv1.Service:
-			injectMetadata(&obj.(*k8sv1.Service).ObjectMeta, config)
-			addService(resource)
-		case *appsv1.Deployment:
-			injectMetadata(&obj.(*appsv1.Deployment).ObjectMeta, config)
-			addDeployment(resource, kv)
-		case *appsv1.DaemonSet:
-			injectMetadata(&obj.(*appsv1.DaemonSet).ObjectMeta, config)
-			addDaemonset(resource, kv)
-		case *admissionregistrationv1.ValidatingWebhookConfiguration:
-			injectMetadata(&obj.(*admissionregistrationv1.ValidatingWebhookConfiguration).ObjectMeta, config)
-			addValidatingWebhook(resource, kv)
-		case *admissionregistrationv1.MutatingWebhookConfiguration:
-			injectMetadata(&obj.(*admissionregistrationv1.MutatingWebhookConfiguration).ObjectMeta, config)
-			addMutatingWebhook(resource, kv)
-		case *apiregv1.APIService:
-			injectMetadata(&obj.(*apiregv1.APIService).ObjectMeta, config)
-			addAPIService(resource)
-		case *batchv1.Job:
-			injectMetadata(&obj.(*batchv1.Job).ObjectMeta, config)
-			addInstallStrategyJob(resource)
-		case *k8sv1.ConfigMap:
-			injectMetadata(&obj.(*k8sv1.ConfigMap).ObjectMeta, config)
-			addConfigMap(resource)
-		case *k8sv1.Pod:
-			injectMetadata(&obj.(*k8sv1.Pod).ObjectMeta, config)
-			addPod(resource)
-		case *policyv1beta1.PodDisruptionBudget:
-			injectMetadata(&obj.(*policyv1beta1.PodDisruptionBudget).ObjectMeta, config)
-			addPodDisruptionBudget(resource, kv)
-		case *k8sv1.Secret:
-			injectMetadata(&obj.(*k8sv1.Secret).ObjectMeta, config)
-			addSecret(resource)
-		case *secv1.SecurityContextConstraints:
-			injectMetadata(&obj.(*secv1.SecurityContextConstraints).ObjectMeta, config)
-			addSCC(resource)
-		case *promv1.ServiceMonitor:
-			injectMetadata(&obj.(*promv1.ServiceMonitor).ObjectMeta, config)
-			addServiceMonitor(resource)
-		case *promv1.PrometheusRule:
-			injectMetadata(&obj.(*promv1.PrometheusRule).ObjectMeta, config)
-			addPrometheusRule(resource)
-		default:
-			Fail("unknown resource type")
-		}
-		split := strings.Split(fmt.Sprintf("%T", obj), ".")
-		resourceKey := strings.ToLower(split[len(split)-1]) + "s"
-		if _, ok := resourceChanges[resourceKey]; !ok {
-			resourceChanges[resourceKey] = make(map[string]int)
-		}
-		resourceChanges[resourceKey][Added]++
-	}
-
-	addInstallStrategy := func(config *util.KubeVirtDeploymentConfig) {
-		// install strategy config
-		resource, _ := install.NewInstallStrategyConfigMap(config, true, NAMESPACE)
-
-		resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
-
-		injectMetadata(&resource.ObjectMeta, config)
-		addConfigMap(resource)
-	}
-
-	addPodDisruptionBudgets := func(config *util.KubeVirtDeploymentConfig, apiDeployment *appsv1.Deployment, controller *appsv1.Deployment, kv *v1.KubeVirt) {
-		minAvailable := intstr.FromInt(int(1))
-		apiPodDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: apiDeployment.Namespace,
-				Name:      apiDeployment.Name + "-pdb",
-				Labels:    apiDeployment.Labels,
-			},
-			Spec: policyv1beta1.PodDisruptionBudgetSpec{
-				MinAvailable: &minAvailable,
-				Selector:     apiDeployment.Spec.Selector,
-			},
-		}
-		injectMetadata(&apiPodDisruptionBudget.ObjectMeta, config)
-		addPodDisruptionBudget(apiPodDisruptionBudget, kv)
-		controllerPodDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: controller.Namespace,
-				Name:      controller.Name + "-pdb",
-				Labels:    controller.Labels,
-			},
-			Spec: policyv1beta1.PodDisruptionBudgetSpec{
-				MinAvailable: &minAvailable,
-				Selector:     controller.Spec.Selector,
-			},
-		}
-		injectMetadata(&controllerPodDisruptionBudget.ObjectMeta, config)
-		addPodDisruptionBudget(controllerPodDisruptionBudget, kv)
-	}
-
-	addPodsWithIndividualConfigs := func(config *util.KubeVirtDeploymentConfig,
-		configController *util.KubeVirtDeploymentConfig,
-		configHandler *util.KubeVirtDeploymentConfig,
-		shouldAddPodDisruptionBudgets bool,
-		kv *v1.KubeVirt) {
-		// we need at least one active pod for
-		// virt-api
-		// virt-controller
-		// virt-handler
-		apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
-
-		pod := &k8sv1.Pod{
-			ObjectMeta: apiDeployment.Spec.Template.ObjectMeta,
-			Spec:       apiDeployment.Spec.Template.Spec,
-			Status: k8sv1.PodStatus{
-				Phase: k8sv1.PodRunning,
-				ContainerStatuses: []k8sv1.ContainerStatus{
-					{Ready: true, Name: "somecontainer"},
-				},
-			},
-		}
-		injectMetadata(&pod.ObjectMeta, config)
-		pod.Name = "virt-api-xxxx"
-		addPod(pod)
-
-		controller, _ := components.NewControllerDeployment(NAMESPACE, configController.GetImageRegistry(), configController.GetImagePrefix(), configController.GetControllerVersion(), configController.GetLauncherVersion(), "", "", configController.GetImagePullPolicy(), configController.GetVerbosity(), configController.GetExtraEnv())
-		pod = &k8sv1.Pod{
-			ObjectMeta: controller.Spec.Template.ObjectMeta,
-			Spec:       controller.Spec.Template.Spec,
-			Status: k8sv1.PodStatus{
-				Phase: k8sv1.PodRunning,
-				ContainerStatuses: []k8sv1.ContainerStatus{
-					{Ready: true, Name: "somecontainer"},
-				},
-			},
-		}
-		pod.Name = "virt-controller-xxxx"
-		injectMetadata(&pod.ObjectMeta, configController)
-		addPod(pod)
-
-		handler, _ := components.NewHandlerDaemonSet(NAMESPACE, configHandler.GetImageRegistry(), configHandler.GetImagePrefix(), configHandler.GetHandlerVersion(), "", "", configController.GetLauncherVersion(), configHandler.GetImagePullPolicy(), configHandler.GetVerbosity(), configHandler.GetExtraEnv())
-		pod = &k8sv1.Pod{
-			ObjectMeta: handler.Spec.Template.ObjectMeta,
-			Spec:       handler.Spec.Template.Spec,
-			Status: k8sv1.PodStatus{
-				Phase: k8sv1.PodRunning,
-				ContainerStatuses: []k8sv1.ContainerStatus{
-					{Ready: true, Name: "somecontainer"},
-				},
-			},
-		}
-		injectMetadata(&pod.ObjectMeta, configHandler)
-		pod.Name = "virt-handler-xxxx"
-		addPod(pod)
-
-		if shouldAddPodDisruptionBudgets {
-			addPodDisruptionBudgets(config, apiDeployment, controller, kv)
-		}
-	}
-
-	addPodsWithOptionalPodDisruptionBudgets := func(config *util.KubeVirtDeploymentConfig, shouldAddPodDisruptionBudgets bool, kv *v1.KubeVirt) {
-		addPodsWithIndividualConfigs(config, config, config, shouldAddPodDisruptionBudgets, kv)
-	}
-
-	addPodsAndPodDisruptionBudgets := func(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
-		addPodsWithOptionalPodDisruptionBudgets(config, true, kv)
-	}
-
-	generateRandomResources := func() int {
-		version := fmt.Sprintf("rand-%s", rand.String(10))
-		registry := fmt.Sprintf("rand-%s", rand.String(10))
-		config := getConfig(registry, version)
-
-		all := make([]runtime.Object, 0)
-		all = append(all, &k8sv1.ServiceAccount{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ServiceAccount",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &rbacv1.ClusterRole{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "ClusterRole",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &rbacv1.ClusterRoleBinding{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "ClusterRoleBinding",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &rbacv1.Role{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "Role",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &rbacv1.RoleBinding{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "rbac.authorization.k8s.io/v1",
-				Kind:       "RoleBinding",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &extv1.CustomResourceDefinition{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apiextensions.k8s.io/v1",
-				Kind:       "CustomResourceDefinition",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-
-		all = append(all, &k8sv1.Service{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Service",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &appsv1.DaemonSet{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
-				Kind:       "DaemonSet",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &appsv1.Deployment{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		all = append(all, &secv1.SecurityContextConstraints{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "security.openshift.io/v1",
-				Kind:       "SecurityContextConstraints",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("rand-%s", rand.String(10)),
-			},
-		})
-		for _, obj := range all {
-			addResource(obj, config, nil)
-		}
-		return len(all)
-	}
-
-	addDummyValidationWebhook := func() {
-		version := fmt.Sprintf("rand-%s", rand.String(10))
-		registry := fmt.Sprintf("rand-%s", rand.String(10))
-		config := getConfig(registry, version)
-
-		validationWebhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "virt-operator-tmp-webhook",
-			},
-		}
-
-		injectMetadata(&validationWebhook.ObjectMeta, config)
-		addValidatingWebhook(validationWebhook, nil)
-	}
-
-	addAll := func(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
-		c, _ := apply.NewCustomizer(kv.Spec.CustomizeComponents)
-
-		all := make([]runtime.Object, 0)
-
-		// rbac
-		all = append(all, rbac.GetAllCluster()...)
-		all = append(all, rbac.GetAllApiServer(NAMESPACE)...)
-		all = append(all, rbac.GetAllHandler(NAMESPACE)...)
-		all = append(all, rbac.GetAllController(NAMESPACE)...)
-		// crds
-		functions := []func() (*extv1.CustomResourceDefinition, error){
-			components.NewVirtualMachineInstanceCrd, components.NewPresetCrd, components.NewReplicaSetCrd,
-			components.NewVirtualMachineCrd, components.NewVirtualMachineInstanceMigrationCrd,
-			components.NewVirtualMachineSnapshotCrd, components.NewVirtualMachineSnapshotContentCrd,
-			components.NewVirtualMachineRestoreCrd,
-		}
-		for _, f := range functions {
-			crd, err := f()
-			if err != nil {
-				panic(fmt.Errorf("This should not happen, %v", err))
-			}
-			all = append(all, crd)
-		}
-		// cr
-		all = append(all, components.NewPrometheusRuleCR(config.GetNamespace(), config.WorkloadUpdatesEnabled()))
-		// sccs
-		all = append(all, components.NewKubeVirtControllerSCC(NAMESPACE))
-		all = append(all, components.NewKubeVirtHandlerSCC(NAMESPACE))
-		// services and deployments
-		all = append(all, components.NewOperatorWebhookService(NAMESPACE))
-		all = append(all, components.NewPrometheusService(NAMESPACE))
-		all = append(all, components.NewApiServerService(NAMESPACE))
-
-		apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
-		apiDeploymentPdb := components.NewPodDisruptionBudgetForDeployment(apiDeployment)
-		controller, _ := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
-		controllerPdb := components.NewPodDisruptionBudgetForDeployment(controller)
-		handler, _ := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), "", "", config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
-
-		all = append(all, apiDeployment, apiDeploymentPdb, controller, controllerPdb, handler)
-
-		all = append(all, rbac.GetAllServiceMonitor(NAMESPACE, config.GetMonitorNamespace(), config.GetMonitorServiceAccount())...)
-		all = append(all, components.NewServiceMonitorCR(NAMESPACE, config.GetMonitorNamespace(), true))
-
-		// ca certificate
-		caSecret := components.NewCACertSecret(NAMESPACE)
-		components.PopulateSecretWithCertificate(caSecret, nil, &metav1.Duration{Duration: apply.Duration7d})
-		caCert, _ := components.LoadCertificates(caSecret)
-		caBundle := cert.EncodeCertPEM(caCert.Leaf)
-		all = append(all, caSecret)
-
-		caConfigMap := components.NewKubeVirtCAConfigMap(NAMESPACE)
-		caConfigMap.Data = map[string]string{components.CABundleKey: string(caBundle)}
-		all = append(all, caConfigMap)
-
-		// webhooks and apiservice
-		validatingWebhook := components.NewVirtAPIValidatingWebhookConfiguration(config.GetNamespace())
-		for i := range validatingWebhook.Webhooks {
-			validatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
-		}
-		all = append(all, validatingWebhook)
-
-		mutatingWebhook := components.NewVirtAPIMutatingWebhookConfiguration(config.GetNamespace())
-		for i := range mutatingWebhook.Webhooks {
-			mutatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
-		}
-		all = append(all, mutatingWebhook)
-
-		apiServices := components.NewVirtAPIAPIServices(config.GetNamespace())
-		for _, apiService := range apiServices {
-			apiService.Spec.CABundle = caBundle
-			all = append(all, apiService)
-		}
-
-		validatingWebhook = components.NewOpertorValidatingWebhookConfiguration(NAMESPACE)
-		for i := range validatingWebhook.Webhooks {
-			validatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
-		}
-		all = append(all, validatingWebhook)
-
-		secrets := components.NewCertSecrets(NAMESPACE, config.GetNamespace())
-		for _, secret := range secrets {
-			components.PopulateSecretWithCertificate(secret, caCert, &metav1.Duration{Duration: apply.Duration1d})
-			all = append(all, secret)
-		}
-
-		for _, obj := range all {
-			m := obj.(metav1.Object)
-			a := m.GetAnnotations()
-			if len(a) == 0 {
-				a = map[string]string{}
-			}
-
-			a[v1.KubeVirtCustomizeComponentAnnotationHash] = c.Hash()
-			m.SetAnnotations(a)
-
-			addResource(obj, config, kv)
-		}
-	}
-
-	makePodDisruptionBudgetsReady := func() {
-		for _, pdbname := range []string{"/virt-api-pdb", "/virt-controller-pdb"} {
-			exists := false
-			// we need to wait until the pdb exists
-			for !exists {
-				_, exists, _ = stores.PodDisruptionBudgetCache.GetByKey(NAMESPACE + pdbname)
-				if !exists {
-					time.Sleep(time.Second)
-				}
-			}
-		}
-	}
-
-	makeApiAndControllerReady := func() {
-		makeDeploymentReady := func(item interface{}) {
-			depl, _ := item.(*appsv1.Deployment)
-			deplNew := depl.DeepCopy()
-			var replicas int32 = 1
-			if depl.Spec.Replicas != nil {
-				replicas = *depl.Spec.Replicas
-			}
-			deplNew.Status.Replicas = replicas
-			deplNew.Status.ReadyReplicas = replicas
-			deploymentSource.Modify(deplNew)
-		}
-
-		for _, name := range []string{"/virt-api", "/virt-controller"} {
-			exists := false
-			var obj interface{}
-			// we need to wait until the deployment exists
-			for !exists {
-				obj, exists, _ = controller.stores.DeploymentCache.GetByKey(NAMESPACE + name)
-				if exists {
-					makeDeploymentReady(obj)
-				}
-				time.Sleep(time.Second)
-			}
-		}
-
-		makePodDisruptionBudgetsReady()
-	}
-
-	makeHandlerReady := func() {
-		exists := false
-		var obj interface{}
-		// we need to wait until the daemonset exists
-		for !exists {
-			obj, exists, _ = controller.stores.DaemonSetCache.GetByKey(NAMESPACE + "/virt-handler")
-			if exists {
-				handler, _ := obj.(*appsv1.DaemonSet)
-				handlerNew := handler.DeepCopy()
-				handlerNew.Status.DesiredNumberScheduled = 1
-				handlerNew.Status.NumberReady = 1
-				daemonSetSource.Modify(handlerNew)
-			}
-			time.Sleep(time.Second)
-		}
-	}
-
-	deleteServiceAccount := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.ServiceAccount.GetStore().GetByKey(key); exists {
-			serviceAccountSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteClusterRole := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.ClusterRole.GetStore().GetByKey(key); exists {
-			clusterRoleSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteClusterRoleBinding := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.ClusterRoleBinding.GetStore().GetByKey(key); exists {
-			clusterRoleBindingSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteRole := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.Role.GetStore().GetByKey(key); exists {
-			roleSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteRoleBinding := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.RoleBinding.GetStore().GetByKey(key); exists {
-			roleBindingSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteCrd := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.Crd.GetStore().GetByKey(key); exists {
-			crdSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteService := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.Service.GetStore().GetByKey(key); exists {
-			serviceSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteDeployment := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.Deployment.GetStore().GetByKey(key); exists {
-			deploymentSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteDaemonset := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.DaemonSet.GetStore().GetByKey(key); exists {
-			daemonSetSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteValidationWebhook := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.ValidationWebhook.GetStore().GetByKey(key); exists {
-			validatingWebhookSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteMutatingWebhook := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.MutatingWebhook.GetStore().GetByKey(key); exists {
-			mutatingWebhookSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteAPIService := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.APIService.GetStore().GetByKey(key); exists {
-			apiserviceSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteInstallStrategyJob := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.InstallStrategyJob.GetStore().GetByKey(key); exists {
-			installStrategyJobSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deletePodDisruptionBudget := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.PodDisruptionBudget.GetStore().GetByKey(key); exists {
-			podDisruptionBudgetSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteSecret := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.Secrets.GetStore().GetByKey(key); exists {
-			secretsSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteConfigMap := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.ConfigMap.GetStore().GetByKey(key); exists {
-			configMap := obj.(*k8sv1.ConfigMap)
-			configMapSource.Delete(configMap)
-		} else if obj, exists, _ := informers.InstallStrategyConfigMap.GetStore().GetByKey(key); exists {
-			configMap := obj.(*k8sv1.ConfigMap)
-			installStrategyConfigMapSource.Delete(configMap)
-		}
-		mockQueue.Wait()
-	}
-
-	deleteSCC := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.SCC.GetStore().GetByKey(key); exists {
-			sccSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteServiceMonitor := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.ServiceMonitor.GetStore().GetByKey(key); exists {
-			serviceMonitorSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deletePrometheusRule := func(key string) {
-		mockQueue.ExpectAdds(1)
-		if obj, exists, _ := informers.PrometheusRule.GetStore().GetByKey(key); exists {
-			prometheusRuleSource.Delete(obj.(runtime.Object))
-		}
-		mockQueue.Wait()
-	}
-
-	deleteResource := func(resource string, key string) {
-		switch resource {
-		case "serviceaccounts":
-			deleteServiceAccount(key)
-		case "clusterroles":
-			deleteClusterRole(key)
-		case "clusterrolebindings":
-			deleteClusterRoleBinding(key)
-		case "roles":
-			deleteRole(key)
-		case "rolebindings":
-			deleteRoleBinding(key)
-		case "customresourcedefinitions":
-			deleteCrd(key)
-		case "services":
-			deleteService(key)
-		case "deployments":
-			deleteDeployment(key)
-		case "daemonsets":
-			deleteDaemonset(key)
-		case "validatingwebhookconfigurations":
-			deleteValidationWebhook(key)
-		case "mutatingwebhookconfigurations":
-			deleteMutatingWebhook(key)
-		case "apiservices":
-			deleteAPIService(key)
-		case "jobs":
-			deleteInstallStrategyJob(key)
-		case "configmaps":
-			deleteConfigMap(key)
-		case "poddisruptionbudgets":
-			deletePodDisruptionBudget(key)
-		case "secrets":
-			deleteSecret(key)
-		case "securitycontextconstraints":
-			deleteSCC(key)
-		case "servicemonitors":
-			deleteServiceMonitor(key)
-		case "prometheusrules":
-			deletePrometheusRule(key)
-		default:
-			Fail(fmt.Sprintf("unknown resource type %+v", resource))
-		}
-		if _, ok := resourceChanges[resource]; !ok {
-			resourceChanges[resource] = make(map[string]int)
-		}
-		resourceChanges[resource][Deleted]++
-	}
-
-	genericUpdateFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		update, ok := action.(testing.UpdateAction)
-		Expect(ok).To(BeTrue(), "genericUpdateFunction testing ok")
-		totalUpdates++
-		resource := action.GetResource().Resource
-		if _, ok := resourceChanges[resource]; !ok {
-			resourceChanges[resource] = make(map[string]int)
-		}
-		resourceChanges[resource][Updated]++
-
-		return true, update.GetObject(), nil
-	}
-
-	genericPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		_, ok := action.(testing.PatchAction)
-		Expect(ok).To(BeTrue())
-		totalPatches++
-		resource := action.GetResource().Resource
-		if _, ok := resourceChanges[resource]; !ok {
-			resourceChanges[resource] = make(map[string]int)
-		}
-		resourceChanges[resource][Patched]++
-
 		return true, nil, nil
-	}
+	})
+	k.apiServiceClient.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.NewNotFound(schema.GroupResource{Group: "", Resource: "apiservices"}, "whatever"))
+	k.secClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		Expect(action).To(BeNil())
+		return true, nil, nil
+	})
+	k.extClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		Expect(action).To(BeNil())
+		return true, nil, nil
+	})
+	k.promClient.Fake.PrependReactor("*", "*", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		Expect(action).To(BeNil())
+		return true, nil, nil
+	})
 
-	webhookValidationPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		genericPatchFunc(action)
+	syncCaches(k.stop, k.kvInformer, k.informers)
 
-		return true, &admissionregistrationv1.ValidatingWebhookConfiguration{}, nil
-	}
+	// add the privileged SCC without KubeVirt accounts
+	scc := getSCC()
+	k.sccSource.Add(&scc)
 
-	webhookMutatingPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		genericPatchFunc(action)
+	k.deleteFromCache = true
+	k.addToCache = true
+}
 
-		return true, &admissionregistrationv1.MutatingWebhookConfiguration{}, nil
-	}
+func (k *KubeVirtTestData) AfterTest() {
+	close(k.stop)
 
-	deploymentPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		genericPatchFunc(action)
+	// Ensure that we add checks for expected events to every test
+	Expect(k.recorder.Events).To(BeEmpty())
+	k.ctrl.Finish()
+}
 
-		return true, &appsv1.Deployment{}, nil
-	}
+func (k *KubeVirtTestData) shouldExpectKubeVirtUpdate(times int) {
+	update := k.kvInterface.EXPECT().Update(gomock.Any())
+	update.Do(func(kv *v1.KubeVirt) {
+		k.kvInformer.GetStore().Update(kv)
+		update.Return(kv, nil)
+	}).Times(times)
+}
 
-	daemonsetPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		genericPatchFunc(action)
+func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatus(times int) {
+	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
+	update.Do(func(kv *v1.KubeVirt) {
+		k.kvInformer.GetStore().Update(kv)
+		update.Return(kv, nil)
+	}).Times(times)
+}
 
-		return true, &appsv1.DaemonSet{}, nil
-	}
+func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusVersion(times int, config *util.KubeVirtDeploymentConfig) {
+	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
+	update.Do(func(kv *v1.KubeVirt) {
 
-	podDisruptionBudgetPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		genericPatchFunc(action)
+		Expect(kv.Status.TargetKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
+		Expect(kv.Status.ObservedKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
+		k.kvInformer.GetStore().Update(kv)
+		update.Return(kv, nil)
+	}).Times(times)
+}
 
-		return true, &policyv1beta1.PodDisruptionBudget{}, nil
-	}
+func (k *KubeVirtTestData) shouldExpectKubeVirtUpdateStatusFailureCondition(reason string) {
+	update := k.kvInterface.EXPECT().UpdateStatus(gomock.Any())
+	update.Do(func(kv *v1.KubeVirt) {
+		Expect(len(kv.Status.Conditions)).To(Equal(1))
+		Expect(kv.Status.Conditions[0].Reason).To(Equal(reason))
+		k.kvInformer.GetStore().Update(kv)
+		update.Return(kv, nil)
+	}).Times(1)
+}
 
-	crdPatchFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		genericPatchFunc(action)
+func (k *KubeVirtTestData) addKubeVirt(kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	k.kvSource.Add(kv)
+	k.mockQueue.Wait()
+}
 
-		return true, &extv1.CustomResourceDefinition{}, nil
-	}
-
-	genericCreateFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
-		create, ok := action.(testing.CreateAction)
-		Expect(ok).To(BeTrue())
-		totalAdds++
-		if addToCache {
-			addResource(create.GetObject(), nil, nil)
+func (k *KubeVirtTestData) getLatestKubeVirt(kv *v1.KubeVirt) *v1.KubeVirt {
+	if obj, exists, _ := k.kvInformer.GetStore().GetByKey(kv.GetNamespace() + "/" + kv.GetName()); exists {
+		if kvLatest, ok := obj.(*v1.KubeVirt); ok {
+			return kvLatest
 		}
-		return true, create.GetObject(), nil
 	}
+	return nil
+}
 
-	genericDeleteFunc := func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+func (k *KubeVirtTestData) shouldExpectDeletions() {
+	genericDeleteFunc := k.genericDeleteFunc()
+	k.kubeClient.Fake.PrependReactor("delete", "serviceaccounts", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "clusterroles", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "clusterrolebindings", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "roles", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "rolebindings", genericDeleteFunc)
+	k.extClient.Fake.PrependReactor("delete", "customresourcedefinitions", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "services", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "deployments", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "daemonsets", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "validatingwebhookconfigurations", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "mutatingwebhookconfigurations", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "secrets", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "configmaps", genericDeleteFunc)
+	k.kubeClient.Fake.PrependReactor("delete", "poddisruptionbudgets", genericDeleteFunc)
+	k.secClient.Fake.PrependReactor("delete", "securitycontextconstraints", genericDeleteFunc)
+	k.promClient.Fake.PrependReactor("delete", "servicemonitors", genericDeleteFunc)
+	k.promClient.Fake.PrependReactor("delete", "prometheusrules", genericDeleteFunc)
+	k.apiServiceClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, name string, options interface{}) {
+		genericDeleteFunc(&testing.DeleteActionImpl{ActionImpl: testing.ActionImpl{Resource: schema.GroupVersionResource{Resource: "apiservices"}}, Name: name})
+	})
+}
+
+func (k *KubeVirtTestData) genericDeleteFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 		deleted, ok := action.(testing.DeleteAction)
 		Expect(ok).To(BeTrue())
-		totalDeletions++
+		k.totalDeletions++
 		var key string
 		if len(deleted.GetNamespace()) > 0 {
 			key = deleted.GetNamespace() + "/"
 		}
 		key += deleted.GetName()
-		if deleteFromCache {
-			deleteResource(deleted.GetResource().Resource, key)
+		if k.deleteFromCache {
+			k.deleteResource(deleted.GetResource().Resource, key)
 		}
 		return true, nil, nil
 	}
+}
 
-	shouldExpectInstallStrategyDeletion := func() {
-		kubeClient.Fake.PrependReactor("delete", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+func (k *KubeVirtTestData) deleteResource(resource string, key string) {
+	switch resource {
+	case "serviceaccounts":
+		k.deleteServiceAccount(key)
+	case "clusterroles":
+		k.deleteClusterRole(key)
+	case "clusterrolebindings":
+		k.deleteClusterRoleBinding(key)
+	case "roles":
+		k.deleteRole(key)
+	case "rolebindings":
+		k.deleteRoleBinding(key)
+	case "customresourcedefinitions":
+		k.deleteCrd(key)
+	case "services":
+		k.deleteService(key)
+	case "deployments":
+		k.deleteDeployment(key)
+	case "daemonsets":
+		k.deleteDaemonset(key)
+	case "validatingwebhookconfigurations":
+		k.deleteValidationWebhook(key)
+	case "mutatingwebhookconfigurations":
+		k.deleteMutatingWebhook(key)
+	case "apiservices":
+		k.deleteAPIService(key)
+	case "jobs":
+		k.deleteInstallStrategyJob(key)
+	case "configmaps":
+		k.deleteConfigMap(key)
+	case "poddisruptionbudgets":
+		k.deletePodDisruptionBudget(key)
+	case "secrets":
+		k.deleteSecret(key)
+	case "securitycontextconstraints":
+		k.deleteSCC(key)
+	case "servicemonitors":
+		k.deleteServiceMonitor(key)
+	case "prometheusrules":
+		k.deletePrometheusRule(key)
+	default:
+		Fail(fmt.Sprintf("unknown resource type %+v", resource))
+	}
+	if _, ok := k.resourceChanges[resource]; !ok {
+		k.resourceChanges[resource] = make(map[string]int)
+	}
+	k.resourceChanges[resource][Deleted]++
+}
 
-			deleted, ok := action.(testing.DeleteAction)
-			Expect(ok).To(BeTrue())
-			if deleted.GetName() == "kubevirt-ca" {
-				return false, nil, nil
+func (k *KubeVirtTestData) deleteServiceAccount(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.ServiceAccount.GetStore().GetByKey(key); exists {
+		k.serviceAccountSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteClusterRole(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.ClusterRole.GetStore().GetByKey(key); exists {
+		k.clusterRoleSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteClusterRoleBinding(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.ClusterRoleBinding.GetStore().GetByKey(key); exists {
+		k.clusterRoleBindingSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteRole(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.Role.GetStore().GetByKey(key); exists {
+		k.roleSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteRoleBinding(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.RoleBinding.GetStore().GetByKey(key); exists {
+		k.roleBindingSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteCrd(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.Crd.GetStore().GetByKey(key); exists {
+		k.crdSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteService(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.Service.GetStore().GetByKey(key); exists {
+		k.serviceSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteDeployment(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.Deployment.GetStore().GetByKey(key); exists {
+		k.deploymentSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteDaemonset(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.DaemonSet.GetStore().GetByKey(key); exists {
+		k.daemonSetSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteValidationWebhook(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.ValidationWebhook.GetStore().GetByKey(key); exists {
+		k.validatingWebhookSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteMutatingWebhook(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.MutatingWebhook.GetStore().GetByKey(key); exists {
+		k.mutatingWebhookSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteAPIService(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.APIService.GetStore().GetByKey(key); exists {
+		k.apiserviceSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteInstallStrategyJob(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.InstallStrategyJob.GetStore().GetByKey(key); exists {
+		k.installStrategyJobSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deletePodDisruptionBudget(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.PodDisruptionBudget.GetStore().GetByKey(key); exists {
+		k.podDisruptionBudgetSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteSecret(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.Secrets.GetStore().GetByKey(key); exists {
+		k.secretsSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteConfigMap(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.ConfigMap.GetStore().GetByKey(key); exists {
+		configMap := obj.(*k8sv1.ConfigMap)
+		k.configMapSource.Delete(configMap)
+	} else if obj, exists, _ := k.informers.InstallStrategyConfigMap.GetStore().GetByKey(key); exists {
+		configMap := obj.(*k8sv1.ConfigMap)
+		k.installStrategyConfigMapSource.Delete(configMap)
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteSCC(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.SCC.GetStore().GetByKey(key); exists {
+		k.sccSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deleteServiceMonitor(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.ServiceMonitor.GetStore().GetByKey(key); exists {
+		k.serviceMonitorSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) deletePrometheusRule(key string) {
+	k.mockQueue.ExpectAdds(1)
+	if obj, exists, _ := k.informers.PrometheusRule.GetStore().GetByKey(key); exists {
+		k.prometheusRuleSource.Delete(obj.(runtime.Object))
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) shouldExpectPatchesAndUpdates() {
+	genericPatchFunc := k.genericPatchFunc()
+	genericUpdateFunc := k.genericUpdateFunc()
+	webhookValidationPatchFunc := k.webhookValidationPatchFunc()
+	webhookMutatingPatchFunc := k.webhookMutatingPatchFunc()
+	daemonsetPatchFunc := k.daemonsetPatchFunc()
+	deploymentPatchFunc := k.deploymentPatchFunc()
+	podDisruptionBudgetPatchFunc := k.podDisruptionBudgetPatchFunc()
+	k.extClient.Fake.PrependReactor("patch", "customresourcedefinitions", k.crdPatchFunc())
+	k.kubeClient.Fake.PrependReactor("patch", "serviceaccounts", genericPatchFunc)
+	k.kubeClient.Fake.PrependReactor("update", "clusterroles", genericUpdateFunc)
+	k.kubeClient.Fake.PrependReactor("update", "clusterrolebindings", genericUpdateFunc)
+	k.kubeClient.Fake.PrependReactor("update", "roles", genericUpdateFunc)
+	k.kubeClient.Fake.PrependReactor("update", "rolebindings", genericUpdateFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "validatingwebhookconfigurations", webhookValidationPatchFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "mutatingwebhookconfigurations", webhookMutatingPatchFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "secrets", genericPatchFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "configmaps", genericPatchFunc)
+
+	k.kubeClient.Fake.PrependReactor("patch", "services", genericPatchFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "daemonsets", daemonsetPatchFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "deployments", deploymentPatchFunc)
+	k.kubeClient.Fake.PrependReactor("patch", "poddisruptionbudgets", podDisruptionBudgetPatchFunc)
+	k.secClient.Fake.PrependReactor("update", "securitycontextconstraints", genericUpdateFunc)
+	k.promClient.Fake.PrependReactor("patch", "servicemonitors", genericPatchFunc)
+	k.promClient.Fake.PrependReactor("patch", "prometheusrules", genericPatchFunc)
+	k.apiServiceClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(args ...interface{}) {
+		genericPatchFunc(&testing.PatchActionImpl{ActionImpl: testing.ActionImpl{Resource: schema.GroupVersionResource{Resource: "apiservices"}}})
+	})
+}
+
+func (k *KubeVirtTestData) genericPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		_, ok := action.(testing.PatchAction)
+		Expect(ok).To(BeTrue())
+		k.totalPatches++
+		resource := action.GetResource().Resource
+		if _, ok := k.resourceChanges[resource]; !ok {
+			k.resourceChanges[resource] = make(map[string]int)
+		}
+		k.resourceChanges[resource][Patched]++
+
+		return true, nil, nil
+	}
+}
+
+func (k *KubeVirtTestData) genericUpdateFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		update, ok := action.(testing.UpdateAction)
+		Expect(ok).To(BeTrue(), "genericUpdateFunction testing ok")
+		k.totalUpdates++
+
+		resource := action.GetResource().Resource
+		if _, ok := k.resourceChanges[resource]; !ok {
+			k.resourceChanges[resource] = make(map[string]int)
+		}
+		k.resourceChanges[resource][Updated]++
+
+		return true, update.GetObject(), nil
+	}
+}
+
+func (k *KubeVirtTestData) webhookValidationPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		k.genericPatchFunc()(action)
+
+		return true, &admissionregistrationv1.ValidatingWebhookConfiguration{}, nil
+	}
+}
+
+func (k *KubeVirtTestData) webhookMutatingPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		k.genericPatchFunc()(action)
+
+		return true, &admissionregistrationv1.MutatingWebhookConfiguration{}, nil
+	}
+}
+
+func (k *KubeVirtTestData) deploymentPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		k.genericPatchFunc()(action)
+
+		return true, &appsv1.Deployment{}, nil
+	}
+}
+
+func (k *KubeVirtTestData) daemonsetPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		k.genericPatchFunc()(action)
+
+		return true, &appsv1.DaemonSet{}, nil
+	}
+}
+
+func (k *KubeVirtTestData) podDisruptionBudgetPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		k.genericPatchFunc()(action)
+
+		return true, &policyv1beta1.PodDisruptionBudget{}, nil
+	}
+}
+
+func (k *KubeVirtTestData) crdPatchFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		k.genericPatchFunc()(action)
+
+		return true, &extv1.CustomResourceDefinition{}, nil
+	}
+}
+
+func (k *KubeVirtTestData) shouldExpectCreations() {
+	genericCreateFunc := k.genericCreateFunc()
+	k.kubeClient.Fake.PrependReactor("create", "serviceaccounts", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "clusterroles", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "clusterrolebindings", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "roles", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "rolebindings", genericCreateFunc)
+	k.extClient.Fake.PrependReactor("create", "customresourcedefinitions", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "services", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "deployments", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "daemonsets", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "validatingwebhookconfigurations", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "mutatingwebhookconfigurations", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "secrets", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "configmaps", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "poddisruptionbudgets", genericCreateFunc)
+	k.secClient.Fake.PrependReactor("create", "securitycontextconstraints", genericCreateFunc)
+	k.promClient.Fake.PrependReactor("create", "servicemonitors", genericCreateFunc)
+	k.promClient.Fake.PrependReactor("create", "prometheusrules", genericCreateFunc)
+	k.apiServiceClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, obj runtime.Object, opts metav1.CreateOptions) {
+		genericCreateFunc(&testing.CreateActionImpl{Object: obj})
+	})
+}
+
+func (k *KubeVirtTestData) genericCreateFunc() func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+	return func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+		create, ok := action.(testing.CreateAction)
+		Expect(ok).To(BeTrue())
+		k.totalAdds++
+		if k.addToCache {
+			k.addResource(create.GetObject(), nil, nil)
+		}
+		return true, create.GetObject(), nil
+	}
+}
+
+func (k *KubeVirtTestData) addResource(obj runtime.Object, config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
+	switch resource := obj.(type) {
+	case *k8sv1.ServiceAccount:
+		injectMetadata(&obj.(*k8sv1.ServiceAccount).ObjectMeta, config)
+		k.addServiceAccount(resource)
+	case *rbacv1.ClusterRole:
+		injectMetadata(&obj.(*rbacv1.ClusterRole).ObjectMeta, config)
+		k.addClusterRole(resource)
+	case *rbacv1.ClusterRoleBinding:
+		injectMetadata(&obj.(*rbacv1.ClusterRoleBinding).ObjectMeta, config)
+		k.addClusterRoleBinding(resource)
+	case *rbacv1.Role:
+		injectMetadata(&obj.(*rbacv1.Role).ObjectMeta, config)
+		k.addRole(resource)
+	case *rbacv1.RoleBinding:
+		injectMetadata(&obj.(*rbacv1.RoleBinding).ObjectMeta, config)
+		k.addRoleBinding(resource)
+	case *extv1.CustomResourceDefinition:
+		injectMetadata(&obj.(*extv1.CustomResourceDefinition).ObjectMeta, config)
+		k.addCrd(resource, kv)
+	case *k8sv1.Service:
+		injectMetadata(&obj.(*k8sv1.Service).ObjectMeta, config)
+		k.addService(resource)
+	case *appsv1.Deployment:
+		injectMetadata(&obj.(*appsv1.Deployment).ObjectMeta, config)
+		k.addDeployment(resource, kv)
+	case *appsv1.DaemonSet:
+		injectMetadata(&obj.(*appsv1.DaemonSet).ObjectMeta, config)
+		k.addDaemonset(resource, kv)
+	case *admissionregistrationv1.ValidatingWebhookConfiguration:
+		injectMetadata(&obj.(*admissionregistrationv1.ValidatingWebhookConfiguration).ObjectMeta, config)
+		k.addValidatingWebhook(resource, kv)
+	case *admissionregistrationv1.MutatingWebhookConfiguration:
+		injectMetadata(&obj.(*admissionregistrationv1.MutatingWebhookConfiguration).ObjectMeta, config)
+		k.addMutatingWebhook(resource, kv)
+	case *apiregv1.APIService:
+		injectMetadata(&obj.(*apiregv1.APIService).ObjectMeta, config)
+		k.addAPIService(resource)
+	case *batchv1.Job:
+		injectMetadata(&obj.(*batchv1.Job).ObjectMeta, config)
+		k.addInstallStrategyJob(resource)
+	case *k8sv1.ConfigMap:
+		injectMetadata(&obj.(*k8sv1.ConfigMap).ObjectMeta, config)
+		k.addConfigMap(resource)
+	case *k8sv1.Pod:
+		injectMetadata(&obj.(*k8sv1.Pod).ObjectMeta, config)
+		k.addPod(resource)
+	case *policyv1beta1.PodDisruptionBudget:
+		injectMetadata(&obj.(*policyv1beta1.PodDisruptionBudget).ObjectMeta, config)
+		k.addPodDisruptionBudget(resource, kv)
+	case *k8sv1.Secret:
+		injectMetadata(&obj.(*k8sv1.Secret).ObjectMeta, config)
+		k.addSecret(resource)
+	case *secv1.SecurityContextConstraints:
+		injectMetadata(&obj.(*secv1.SecurityContextConstraints).ObjectMeta, config)
+		k.addSCC(resource)
+	case *promv1.ServiceMonitor:
+		injectMetadata(&obj.(*promv1.ServiceMonitor).ObjectMeta, config)
+		k.addServiceMonitor(resource)
+	case *promv1.PrometheusRule:
+		injectMetadata(&obj.(*promv1.PrometheusRule).ObjectMeta, config)
+		k.addPrometheusRule(resource)
+	default:
+		Fail("unknown resource type")
+	}
+	split := strings.Split(fmt.Sprintf("%T", obj), ".")
+	resourceKey := strings.ToLower(split[len(split)-1]) + "s"
+	if _, ok := k.resourceChanges[resourceKey]; !ok {
+		k.resourceChanges[resourceKey] = make(map[string]int)
+	}
+	k.resourceChanges[resourceKey][Added]++
+}
+
+func (k *KubeVirtTestData) addServiceAccount(sa *k8sv1.ServiceAccount) {
+	k.mockQueue.ExpectAdds(1)
+	k.serviceAccountSource.Add(sa)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addClusterRole(cr *rbacv1.ClusterRole) {
+	k.mockQueue.ExpectAdds(1)
+	k.clusterRoleSource.Add(cr)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addClusterRoleBinding(crb *rbacv1.ClusterRoleBinding) {
+	k.mockQueue.ExpectAdds(1)
+	k.clusterRoleBindingSource.Add(crb)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addRole(role *rbacv1.Role) {
+	k.mockQueue.ExpectAdds(1)
+	k.roleSource.Add(role)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addRoleBinding(rb *rbacv1.RoleBinding) {
+	k.mockQueue.ExpectAdds(1)
+	k.roleBindingSource.Add(rb)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addCrd(crd *extv1.CustomResourceDefinition, kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	if kv != nil {
+		apply.SetGeneration(&kv.Status.Generations, crd)
+	}
+	k.crdSource.Add(crd)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addService(svc *k8sv1.Service) {
+	k.mockQueue.ExpectAdds(1)
+	k.serviceSource.Add(svc)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addDeployment(depl *appsv1.Deployment, kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	if kv != nil {
+		apply.SetGeneration(&kv.Status.Generations, depl)
+	}
+
+	k.deploymentSource.Add(depl)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addDaemonset(ds *appsv1.DaemonSet, kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	if kv != nil {
+		apply.SetGeneration(&kv.Status.Generations, ds)
+	}
+
+	k.daemonSetSource.Add(ds)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addMutatingWebhook(wh *admissionregistrationv1.MutatingWebhookConfiguration, kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	if kv != nil {
+		apply.SetGeneration(&kv.Status.Generations, wh)
+	}
+
+	k.mutatingWebhookSource.Add(wh)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addAPIService(wh *apiregv1.APIService) {
+	k.mockQueue.ExpectAdds(1)
+	k.apiserviceSource.Add(wh)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addInstallStrategyJob(job *batchv1.Job) {
+	k.mockQueue.ExpectAdds(1)
+	k.installStrategyJobSource.Add(job)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addPod(pod *k8sv1.Pod) {
+	k.mockQueue.ExpectAdds(1)
+	k.infrastructurePodSource.Add(pod)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addPodDisruptionBudget(podDisruptionBudget *policyv1beta1.PodDisruptionBudget, kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	if kv != nil {
+		apply.SetGeneration(&kv.Status.Generations, podDisruptionBudget)
+	}
+
+	k.podDisruptionBudgetSource.Add(podDisruptionBudget)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addSecret(secret *k8sv1.Secret) {
+	k.mockQueue.ExpectAdds(1)
+	k.secretsSource.Add(secret)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addConfigMap(configMap *k8sv1.ConfigMap) {
+	k.mockQueue.ExpectAdds(1)
+	if _, ok := configMap.Labels[v1.InstallStrategyLabel]; ok {
+		k.installStrategyConfigMapSource.Add(configMap)
+	} else {
+		k.configMapSource.Add(configMap)
+	}
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addSCC(scc *secv1.SecurityContextConstraints) {
+	k.mockQueue.ExpectAdds(1)
+	k.sccSource.Add(scc)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addServiceMonitor(serviceMonitor *promv1.ServiceMonitor) {
+	k.mockQueue.ExpectAdds(1)
+	k.serviceMonitorSource.Add(serviceMonitor)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addPrometheusRule(prometheusRule *promv1.PrometheusRule) {
+	k.mockQueue.ExpectAdds(1)
+	k.prometheusRuleSource.Add(prometheusRule)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) generateRandomResources() int {
+	version := fmt.Sprintf("rand-%s", rand.String(10))
+	registry := fmt.Sprintf("rand-%s", rand.String(10))
+	config := getConfig(registry, version)
+
+	all := make([]runtime.Object, 0)
+	all = append(all, &k8sv1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &extv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apiextensions.k8s.io/v1",
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+
+	all = append(all, &k8sv1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	all = append(all, &secv1.SecurityContextConstraints{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "security.openshift.io/v1",
+			Kind:       "SecurityContextConstraints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("rand-%s", rand.String(10)),
+		},
+	})
+	for _, obj := range all {
+		k.addResource(obj, config, nil)
+	}
+	return len(all)
+}
+
+func (k *KubeVirtTestData) addAll(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
+	c, _ := apply.NewCustomizer(kv.Spec.CustomizeComponents)
+
+	all := make([]runtime.Object, 0)
+
+	// rbac
+	all = append(all, rbac.GetAllCluster()...)
+	all = append(all, rbac.GetAllApiServer(NAMESPACE)...)
+	all = append(all, rbac.GetAllHandler(NAMESPACE)...)
+	all = append(all, rbac.GetAllController(NAMESPACE)...)
+	// crds
+	functions := []func() (*extv1.CustomResourceDefinition, error){
+		components.NewVirtualMachineInstanceCrd, components.NewPresetCrd, components.NewReplicaSetCrd,
+		components.NewVirtualMachineCrd, components.NewVirtualMachineInstanceMigrationCrd,
+		components.NewVirtualMachineSnapshotCrd, components.NewVirtualMachineSnapshotContentCrd,
+		components.NewVirtualMachineRestoreCrd,
+	}
+	for _, f := range functions {
+		crd, err := f()
+		if err != nil {
+			panic(fmt.Errorf("This should not happen, %v", err))
+		}
+		all = append(all, crd)
+	}
+	// cr
+	all = append(all, components.NewPrometheusRuleCR(config.GetNamespace(), config.WorkloadUpdatesEnabled()))
+	// sccs
+	all = append(all, components.NewKubeVirtControllerSCC(NAMESPACE))
+	all = append(all, components.NewKubeVirtHandlerSCC(NAMESPACE))
+	// services and deployments
+	all = append(all, components.NewOperatorWebhookService(NAMESPACE))
+	all = append(all, components.NewPrometheusService(NAMESPACE))
+	all = append(all, components.NewApiServerService(NAMESPACE))
+
+	apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+	apiDeploymentPdb := components.NewPodDisruptionBudgetForDeployment(apiDeployment)
+	controller, _ := components.NewControllerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetControllerVersion(), config.GetLauncherVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+	controllerPdb := components.NewPodDisruptionBudgetForDeployment(controller)
+	handler, _ := components.NewHandlerDaemonSet(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetHandlerVersion(), "", "", config.GetLauncherVersion(), config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+
+	all = append(all, apiDeployment, apiDeploymentPdb, controller, controllerPdb, handler)
+
+	all = append(all, rbac.GetAllServiceMonitor(NAMESPACE, config.GetMonitorNamespace(), config.GetMonitorServiceAccount())...)
+	all = append(all, components.NewServiceMonitorCR(NAMESPACE, config.GetMonitorNamespace(), true))
+
+	// ca certificate
+	caSecret := components.NewCACertSecret(NAMESPACE)
+	components.PopulateSecretWithCertificate(caSecret, nil, &metav1.Duration{Duration: apply.Duration7d})
+	caCert, _ := components.LoadCertificates(caSecret)
+	caBundle := cert.EncodeCertPEM(caCert.Leaf)
+	all = append(all, caSecret)
+
+	caConfigMap := components.NewKubeVirtCAConfigMap(NAMESPACE)
+	caConfigMap.Data = map[string]string{components.CABundleKey: string(caBundle)}
+	all = append(all, caConfigMap)
+
+	// webhooks and apiservice
+	validatingWebhook := components.NewVirtAPIValidatingWebhookConfiguration(config.GetNamespace())
+	for i := range validatingWebhook.Webhooks {
+		validatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
+	}
+	all = append(all, validatingWebhook)
+
+	mutatingWebhook := components.NewVirtAPIMutatingWebhookConfiguration(config.GetNamespace())
+	for i := range mutatingWebhook.Webhooks {
+		mutatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
+	}
+	all = append(all, mutatingWebhook)
+
+	apiServices := components.NewVirtAPIAPIServices(config.GetNamespace())
+	for _, apiService := range apiServices {
+		apiService.Spec.CABundle = caBundle
+		all = append(all, apiService)
+	}
+
+	validatingWebhook = components.NewOpertorValidatingWebhookConfiguration(NAMESPACE)
+	for i := range validatingWebhook.Webhooks {
+		validatingWebhook.Webhooks[i].ClientConfig.CABundle = caBundle
+	}
+	all = append(all, validatingWebhook)
+
+	secrets := components.NewCertSecrets(NAMESPACE, config.GetNamespace())
+	for _, secret := range secrets {
+		components.PopulateSecretWithCertificate(secret, caCert, &metav1.Duration{Duration: apply.Duration1d})
+		all = append(all, secret)
+	}
+
+	for _, obj := range all {
+		m := obj.(metav1.Object)
+		a := m.GetAnnotations()
+		if len(a) == 0 {
+			a = map[string]string{}
+		}
+
+		a[v1.KubeVirtCustomizeComponentAnnotationHash] = c.Hash()
+		m.SetAnnotations(a)
+
+		k.addResource(obj, config, kv)
+	}
+}
+
+func (k *KubeVirtTestData) shouldExpectJobCreation() {
+	k.kubeClient.Fake.PrependReactor("create", "jobs", k.genericCreateFunc())
+}
+
+func (k *KubeVirtTestData) shouldExpectRbacBackupCreations() {
+	genericCreateFunc := k.genericCreateFunc()
+	k.kubeClient.Fake.PrependReactor("create", "clusterroles", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "clusterrolebindings", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "roles", genericCreateFunc)
+	k.kubeClient.Fake.PrependReactor("create", "rolebindings", genericCreateFunc)
+}
+
+func (k *KubeVirtTestData) shouldExpectJobDeletion() {
+	k.kubeClient.Fake.PrependReactor("delete", "jobs", k.genericDeleteFunc())
+}
+
+func (k *KubeVirtTestData) shouldExpectInstallStrategyDeletion() {
+	k.kubeClient.Fake.PrependReactor("delete", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+
+		deleted, ok := action.(testing.DeleteAction)
+		Expect(ok).To(BeTrue())
+		if deleted.GetName() == "kubevirt-ca" {
+			return false, nil, nil
+		}
+		var key string
+		if len(deleted.GetNamespace()) > 0 {
+			key = deleted.GetNamespace() + "/"
+		}
+		key += deleted.GetName()
+		k.deleteResource(deleted.GetResource().Resource, key)
+		return true, nil, nil
+	})
+}
+
+func (k *KubeVirtTestData) makeApiAndControllerReady() {
+	makeDeploymentReady := func(item interface{}) {
+		depl, _ := item.(*appsv1.Deployment)
+		deplNew := depl.DeepCopy()
+		var replicas int32 = 1
+		if depl.Spec.Replicas != nil {
+			replicas = *depl.Spec.Replicas
+		}
+		deplNew.Status.Replicas = replicas
+		deplNew.Status.ReadyReplicas = replicas
+		k.deploymentSource.Modify(deplNew)
+	}
+
+	for _, name := range []string{"/virt-api", "/virt-controller"} {
+		exists := false
+		var obj interface{}
+		// we need to wait until the deployment exists
+		for !exists {
+			obj, exists, _ = k.controller.stores.DeploymentCache.GetByKey(NAMESPACE + name)
+			if exists {
+				makeDeploymentReady(obj)
 			}
-			var key string
-			if len(deleted.GetNamespace()) > 0 {
-				key = deleted.GetNamespace() + "/"
-			}
-			key += deleted.GetName()
-			deleteResource(deleted.GetResource().Resource, key)
-			return true, nil, nil
-		})
+			time.Sleep(time.Second)
+		}
 	}
 
-	shouldExpectDeletions := func() {
-		kubeClient.Fake.PrependReactor("delete", "serviceaccounts", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "clusterroles", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "clusterrolebindings", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "roles", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "rolebindings", genericDeleteFunc)
-		extClient.Fake.PrependReactor("delete", "customresourcedefinitions", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "services", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "deployments", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "daemonsets", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "validatingwebhookconfigurations", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "mutatingwebhookconfigurations", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "secrets", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "configmaps", genericDeleteFunc)
-		kubeClient.Fake.PrependReactor("delete", "poddisruptionbudgets", genericDeleteFunc)
-		secClient.Fake.PrependReactor("delete", "securitycontextconstraints", genericDeleteFunc)
-		promClient.Fake.PrependReactor("delete", "servicemonitors", genericDeleteFunc)
-		promClient.Fake.PrependReactor("delete", "prometheusrules", genericDeleteFunc)
-		apiServiceClient.EXPECT().Delete(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, name string, options interface{}) {
-			genericDeleteFunc(&testing.DeleteActionImpl{ActionImpl: testing.ActionImpl{Resource: schema.GroupVersionResource{Resource: "apiservices"}}, Name: name})
-		})
-	}
+	k.makePodDisruptionBudgetsReady()
+}
 
-	shouldExpectJobDeletion := func() {
-		kubeClient.Fake.PrependReactor("delete", "jobs", genericDeleteFunc)
-	}
-
-	shouldExpectJobCreation := func() {
-		kubeClient.Fake.PrependReactor("create", "jobs", genericCreateFunc)
-	}
-
-	shouldExpectPatchesAndUpdates := func() {
-		extClient.Fake.PrependReactor("patch", "customresourcedefinitions", crdPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "serviceaccounts", genericPatchFunc)
-		kubeClient.Fake.PrependReactor("update", "clusterroles", genericUpdateFunc)
-		kubeClient.Fake.PrependReactor("update", "clusterrolebindings", genericUpdateFunc)
-		kubeClient.Fake.PrependReactor("update", "roles", genericUpdateFunc)
-		kubeClient.Fake.PrependReactor("update", "rolebindings", genericUpdateFunc)
-		kubeClient.Fake.PrependReactor("patch", "validatingwebhookconfigurations", webhookValidationPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "mutatingwebhookconfigurations", webhookMutatingPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "secrets", genericPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "configmaps", genericPatchFunc)
-
-		kubeClient.Fake.PrependReactor("patch", "services", genericPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "daemonsets", daemonsetPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "deployments", deploymentPatchFunc)
-		kubeClient.Fake.PrependReactor("patch", "poddisruptionbudgets", podDisruptionBudgetPatchFunc)
-		secClient.Fake.PrependReactor("update", "securitycontextconstraints", genericUpdateFunc)
-		promClient.Fake.PrependReactor("patch", "servicemonitors", genericPatchFunc)
-		promClient.Fake.PrependReactor("patch", "prometheusrules", genericPatchFunc)
-		apiServiceClient.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(args ...interface{}) {
-			genericPatchFunc(&testing.PatchActionImpl{ActionImpl: testing.ActionImpl{Resource: schema.GroupVersionResource{Resource: "apiservices"}}})
-		})
-	}
-
-	shouldExpectRbacBackupCreations := func() {
-		kubeClient.Fake.PrependReactor("create", "clusterroles", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "clusterrolebindings", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "roles", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "rolebindings", genericCreateFunc)
-	}
-
-	shouldExpectCreations := func() {
-		kubeClient.Fake.PrependReactor("create", "serviceaccounts", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "clusterroles", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "clusterrolebindings", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "roles", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "rolebindings", genericCreateFunc)
-		extClient.Fake.PrependReactor("create", "customresourcedefinitions", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "services", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "deployments", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "daemonsets", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "validatingwebhookconfigurations", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "mutatingwebhookconfigurations", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "secrets", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "configmaps", genericCreateFunc)
-		kubeClient.Fake.PrependReactor("create", "poddisruptionbudgets", genericCreateFunc)
-		secClient.Fake.PrependReactor("create", "securitycontextconstraints", genericCreateFunc)
-		promClient.Fake.PrependReactor("create", "servicemonitors", genericCreateFunc)
-		promClient.Fake.PrependReactor("create", "prometheusrules", genericCreateFunc)
-		apiServiceClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Do(func(ctx context.Context, obj runtime.Object, opts metav1.CreateOptions) {
-			genericCreateFunc(&testing.CreateActionImpl{Object: obj})
-		})
-	}
-
-	shouldExpectKubeVirtUpdate := func(times int) {
-		update := kvInterface.EXPECT().Update(gomock.Any())
-		update.Do(func(kv *v1.KubeVirt) {
-			kvInformer.GetStore().Update(kv)
-			update.Return(kv, nil)
-		}).Times(times)
-	}
-
-	shouldExpectKubeVirtUpdateStatus := func(times int) {
-		update := kvInterface.EXPECT().UpdateStatus(gomock.Any())
-		update.Do(func(kv *v1.KubeVirt) {
-			kvInformer.GetStore().Update(kv)
-			update.Return(kv, nil)
-		}).Times(times)
-	}
-
-	shouldExpectKubeVirtUpdateStatusVersion := func(times int, config *util.KubeVirtDeploymentConfig) {
-		update := kvInterface.EXPECT().UpdateStatus(gomock.Any())
-		update.Do(func(kv *v1.KubeVirt) {
-
-			Expect(kv.Status.TargetKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
-			Expect(kv.Status.ObservedKubeVirtVersion).To(Equal(config.GetKubeVirtVersion()))
-			kvInformer.GetStore().Update(kv)
-			update.Return(kv, nil)
-		}).Times(times)
-	}
-
-	shouldExpectKubeVirtUpdateStatusFailureCondition := func(reason string) {
-		update := kvInterface.EXPECT().UpdateStatus(gomock.Any())
-		update.Do(func(kv *v1.KubeVirt) {
-			Expect(len(kv.Status.Conditions)).To(Equal(1))
-			Expect(kv.Status.Conditions[0].Reason).To(Equal(reason))
-			kvInformer.GetStore().Update(kv)
-			update.Return(kv, nil)
-		}).Times(1)
-	}
-
-	getLatestKubeVirt := func(kv *v1.KubeVirt) *v1.KubeVirt {
-		if obj, exists, _ := kvInformer.GetStore().GetByKey(kv.GetNamespace() + "/" + kv.GetName()); exists {
-			if kvLatest, ok := obj.(*v1.KubeVirt); ok {
-				return kvLatest
+func (k *KubeVirtTestData) makePodDisruptionBudgetsReady() {
+	for _, pdbname := range []string{"/virt-api-pdb", "/virt-controller-pdb"} {
+		exists := false
+		// we need to wait until the pdb exists
+		for !exists {
+			_, exists, _ = k.stores.PodDisruptionBudgetCache.GetByKey(NAMESPACE + pdbname)
+			if !exists {
+				time.Sleep(time.Second)
 			}
 		}
-		return nil
+	}
+}
+
+func (k *KubeVirtTestData) makeHandlerReady() {
+	exists := false
+	var obj interface{}
+	// we need to wait until the daemonset exists
+	for !exists {
+		obj, exists, _ = k.controller.stores.DaemonSetCache.GetByKey(NAMESPACE + "/virt-handler")
+		if exists {
+			handler, _ := obj.(*appsv1.DaemonSet)
+			handlerNew := handler.DeepCopy()
+			handlerNew.Status.DesiredNumberScheduled = 1
+			handlerNew.Status.NumberReady = 1
+			k.daemonSetSource.Modify(handlerNew)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func (k *KubeVirtTestData) addDummyValidationWebhook() {
+	version := fmt.Sprintf("rand-%s", rand.String(10))
+	registry := fmt.Sprintf("rand-%s", rand.String(10))
+	config := getConfig(registry, version)
+
+	validationWebhook := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "virt-operator-tmp-webhook",
+		},
 	}
 
-	shouldExpectHCOConditions := func(kv *v1.KubeVirt, available k8sv1.ConditionStatus, progressing k8sv1.ConditionStatus, degraded k8sv1.ConditionStatus) {
-		getType := func(c v1.KubeVirtCondition) v1.KubeVirtConditionType { return c.Type }
-		getStatus := func(c v1.KubeVirtCondition) k8sv1.ConditionStatus { return c.Status }
-		Expect(kv.Status.Conditions).To(ContainElement(
-			And(
-				WithTransform(getType, Equal(v1.KubeVirtConditionAvailable)),
-				WithTransform(getStatus, Equal(available)),
-			),
-		))
-		Expect(kv.Status.Conditions).To(ContainElement(
-			And(
-				WithTransform(getType, Equal(v1.KubeVirtConditionProgressing)),
-				WithTransform(getStatus, Equal(progressing)),
-			),
-		))
-		Expect(kv.Status.Conditions).To(ContainElement(
-			And(
-				WithTransform(getType, Equal(v1.KubeVirtConditionDegraded)),
-				WithTransform(getStatus, Equal(degraded)),
-			),
-		))
+	injectMetadata(&validationWebhook.ObjectMeta, config)
+	k.addValidatingWebhook(validationWebhook, nil)
+}
+
+func (k *KubeVirtTestData) addValidatingWebhook(wh *admissionregistrationv1.ValidatingWebhookConfiguration, kv *v1.KubeVirt) {
+	k.mockQueue.ExpectAdds(1)
+	if kv != nil {
+		apply.SetGeneration(&kv.Status.Generations, wh)
 	}
 
-	fakeNamespaceModificationEvent := func() {
-		// Add modification event for namespace w/o the labels we need
-		mockQueue.ExpectAdds(1)
-		namespaceSource.Modify(&k8sv1.Namespace{
-			TypeMeta: metav1.TypeMeta{
-				Kind: "Namespace",
+	k.validatingWebhookSource.Add(wh)
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) addInstallStrategy(config *util.KubeVirtDeploymentConfig) {
+	// install strategy config
+	resource, _ := install.NewInstallStrategyConfigMap(config, true, NAMESPACE)
+
+	resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
+
+	injectMetadata(&resource.ObjectMeta, config)
+	k.addConfigMap(resource)
+}
+
+func (k *KubeVirtTestData) addPodDisruptionBudgets(config *util.KubeVirtDeploymentConfig, apiDeployment *appsv1.Deployment, controller *appsv1.Deployment, kv *v1.KubeVirt) {
+	minAvailable := intstr.FromInt(int(1))
+	apiPodDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: apiDeployment.Namespace,
+			Name:      apiDeployment.Name + "-pdb",
+			Labels:    apiDeployment.Labels,
+		},
+		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector:     apiDeployment.Spec.Selector,
+		},
+	}
+	injectMetadata(&apiPodDisruptionBudget.ObjectMeta, config)
+	k.addPodDisruptionBudget(apiPodDisruptionBudget, kv)
+	controllerPodDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: controller.Namespace,
+			Name:      controller.Name + "-pdb",
+			Labels:    controller.Labels,
+		},
+		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector:     controller.Spec.Selector,
+		},
+	}
+	injectMetadata(&controllerPodDisruptionBudget.ObjectMeta, config)
+	k.addPodDisruptionBudget(controllerPodDisruptionBudget, kv)
+}
+
+func (k *KubeVirtTestData) fakeNamespaceModificationEvent() {
+	// Add modification event for namespace w/o the labels we need
+	k.mockQueue.ExpectAdds(1)
+	k.namespaceSource.Modify(&k8sv1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: NAMESPACE,
+		},
+	})
+	k.mockQueue.Wait()
+}
+
+func (k *KubeVirtTestData) shouldExpectNamespacePatch() {
+	k.kubeClient.Fake.PrependReactor("patch", "namespaces", k.genericPatchFunc())
+}
+
+func (k *KubeVirtTestData) addPodsWithIndividualConfigs(config *util.KubeVirtDeploymentConfig,
+	configController *util.KubeVirtDeploymentConfig,
+	configHandler *util.KubeVirtDeploymentConfig,
+	shouldAddPodDisruptionBudgets bool,
+	kv *v1.KubeVirt) {
+	// we need at least one active pod for
+	// virt-api
+	// virt-controller
+	// virt-handler
+	apiDeployment, _ := components.NewApiServerDeployment(NAMESPACE, config.GetImageRegistry(), config.GetImagePrefix(), config.GetApiVersion(), "", "", config.GetImagePullPolicy(), config.GetVerbosity(), config.GetExtraEnv())
+
+	pod := &k8sv1.Pod{
+		ObjectMeta: apiDeployment.Spec.Template.ObjectMeta,
+		Spec:       apiDeployment.Spec.Template.Spec,
+		Status: k8sv1.PodStatus{
+			Phase: k8sv1.PodRunning,
+			ContainerStatuses: []k8sv1.ContainerStatus{
+				{Ready: true, Name: "somecontainer"},
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: NAMESPACE,
-			},
-		})
-		mockQueue.Wait()
+		},
 	}
+	injectMetadata(&pod.ObjectMeta, config)
+	pod.Name = "virt-api-xxxx"
+	k.addPod(pod)
 
-	shouldExpectNamespacePatch := func() {
-		kubeClient.Fake.PrependReactor("patch", "namespaces", genericPatchFunc)
+	controller, _ := components.NewControllerDeployment(NAMESPACE, configController.GetImageRegistry(), configController.GetImagePrefix(), configController.GetControllerVersion(), configController.GetLauncherVersion(), "", "", configController.GetImagePullPolicy(), configController.GetVerbosity(), configController.GetExtraEnv())
+	pod = &k8sv1.Pod{
+		ObjectMeta: controller.Spec.Template.ObjectMeta,
+		Spec:       controller.Spec.Template.Spec,
+		Status: k8sv1.PodStatus{
+			Phase: k8sv1.PodRunning,
+			ContainerStatuses: []k8sv1.ContainerStatus{
+				{Ready: true, Name: "somecontainer"},
+			},
+		},
 	}
+	pod.Name = "virt-controller-xxxx"
+	injectMetadata(&pod.ObjectMeta, configController)
+	k.addPod(pod)
+
+	handler, _ := components.NewHandlerDaemonSet(NAMESPACE, configHandler.GetImageRegistry(), configHandler.GetImagePrefix(), configHandler.GetHandlerVersion(), "", "", configController.GetLauncherVersion(), configHandler.GetImagePullPolicy(), configHandler.GetVerbosity(), configHandler.GetExtraEnv())
+	pod = &k8sv1.Pod{
+		ObjectMeta: handler.Spec.Template.ObjectMeta,
+		Spec:       handler.Spec.Template.Spec,
+		Status: k8sv1.PodStatus{
+			Phase: k8sv1.PodRunning,
+			ContainerStatuses: []k8sv1.ContainerStatus{
+				{Ready: true, Name: "somecontainer"},
+			},
+		},
+	}
+	injectMetadata(&pod.ObjectMeta, configHandler)
+	pod.Name = "virt-handler-xxxx"
+	k.addPod(pod)
+
+	if shouldAddPodDisruptionBudgets {
+		k.addPodDisruptionBudgets(config, apiDeployment, controller, kv)
+	}
+}
+
+func (k *KubeVirtTestData) addPodsWithOptionalPodDisruptionBudgets(config *util.KubeVirtDeploymentConfig, shouldAddPodDisruptionBudgets bool, kv *v1.KubeVirt) {
+	k.addPodsWithIndividualConfigs(config, config, config, shouldAddPodDisruptionBudgets, kv)
+}
+
+func (k *KubeVirtTestData) addPodsAndPodDisruptionBudgets(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
+	k.addPodsWithOptionalPodDisruptionBudgets(config, true, kv)
+}
+
+var _ = Describe("KubeVirt Operator", func() {
+
+	BeforeEach(func() {
+		err := os.Setenv(util.OperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "someregistry", "v9.9.9"))
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	Context("On valid KubeVirt object", func() {
 
 		It("Should not patch kubevirt namespace when labels are already defined", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			// Add fake namespace with labels predefined
-			err := informers.Namespace.GetStore().Add(&k8sv1.Namespace{
+			err := kvTestData.informers.Namespace.GetStore().Add(&k8sv1.Namespace{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Namespace",
 				},
@@ -1532,25 +1450,29 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 			}
 			// Add kubevirt deployment and mark everything as ready
-			addKubeVirt(kv)
+			kvTestData.addKubeVirt(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			shouldExpectKubeVirtUpdateStatus(1)
-			shouldExpectCreations()
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
-			makeHandlerReady()
-			makeApiAndControllerReady()
-			makeHandlerReady()
-			shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectCreations()
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
+			kvTestData.makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
+			kvTestData.shouldExpectPatchesAndUpdates()
 
 			// Now when the controller runs, if the namespace will be patched, the test will fail
 			// because the patch is not expected here.
-			controller.Execute()
-		}, 15)
+			kvTestData.controller.Execute()
+		}, 30)
 
 		It("should delete install strategy configmap once kubevirt install is deleted", func(done Done) {
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1565,20 +1487,24 @@ var _ = Describe("KubeVirt Operator", func() {
 			kv.DeletionTimestamp = now()
 			util.UpdateConditionsDeleting(kv)
 
-			shouldExpectInstallStrategyDeletion()
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			shouldExpectKubeVirtUpdate(1)
-			controller.Execute()
-			kv = getLatestKubeVirt(kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.shouldExpectKubeVirtUpdate(1)
+			kvTestData.controller.Execute()
+			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(len(kv.ObjectMeta.Finalizers)).To(Equal(0))
-		}, 15)
+		}, 30)
 
 		It("should observe custom image tag in status during deploy", func(done Done) {
 			defer close(done)
 			defer GinkgoRecover()
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1598,30 +1524,34 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			customConfig := getConfig(defaultConfig.GetImageRegistry(), "custom.tag")
+			kvTestData.addKubeVirt(kv)
+			customConfig := getConfig(kvTestData.defaultConfig.GetImageRegistry(), "custom.tag")
 
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
-			shouldExpectPatchesAndUpdates()
-			addAll(customConfig, kv)
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.addAll(customConfig, kv)
 			// install strategy config
-			addInstallStrategy(customConfig)
-			addPodsAndPodDisruptionBudgets(customConfig, kv)
+			kvTestData.addInstallStrategy(customConfig)
+			kvTestData.addPodsAndPodDisruptionBudgets(customConfig, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			shouldExpectKubeVirtUpdateStatusVersion(1, customConfig)
-			controller.Execute()
-			kv = getLatestKubeVirt(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatusVersion(1, customConfig)
+			kvTestData.controller.Execute()
+			kv = kvTestData.getLatestKubeVirt(kv)
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 
-		}, 15)
+		}, 30)
 
 		It("delete temporary validation webhook once virt-api is deployed", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install",
@@ -1634,36 +1564,40 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
-			deleteFromCache = false
+			kvTestData.deleteFromCache = false
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addDummyValidationWebhook()
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addDummyValidationWebhook()
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			shouldExpectDeletions()
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectDeletions()
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
-			Expect(totalDeletions).To(Equal(1))
+			kvTestData.controller.Execute()
+			Expect(kvTestData.totalDeletions).To(Equal(1))
 
-		}, 15)
+		}, 30)
 
 		It("should do nothing if KubeVirt object is deployed", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install",
@@ -1676,32 +1610,36 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-		}, 15)
+		}, 30)
 
 		It("should update KubeVirt object if generation IDs do not match", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install",
@@ -1714,29 +1652,29 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
 			// invalidate all lastGeneration versions
 			numGenerations := len(kv.Status.Generations)
@@ -1744,21 +1682,24 @@ var _ = Describe("KubeVirt Operator", func() {
 				kv.Status.Generations[i].LastGeneration = -1
 			}
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
 			// add one for the namespace
-			Expect(totalPatches).To(Equal(numGenerations + 1))
+			Expect(kvTestData.totalPatches).To(Equal(numGenerations + 1))
 
 			// all these resources should be tracked by there generation so everyone that has been added should now be patched
 			// since they where the `lastGeneration` was set to -1 on the KubeVirt CR
-			Expect(resourceChanges["mutatingwebhookconfigurations"][Patched]).To(Equal(resourceChanges["mutatingwebhookconfigurations"][Added]))
-			Expect(resourceChanges["validatingwebhookconfigurations"][Patched]).To(Equal(resourceChanges["validatingwebhookconfigurations"][Added]))
-			Expect(resourceChanges["deployements"][Patched]).To(Equal(resourceChanges["deployements"][Added]))
-			Expect(resourceChanges["daemonsets"][Patched]).To(Equal(resourceChanges["daemonsets"][Added]))
-			Expect(resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(resourceChanges["poddisruptionbudgets"][Added]))
-		}, 150)
+			Expect(kvTestData.resourceChanges["mutatingwebhookconfigurations"][Patched]).To(Equal(kvTestData.resourceChanges["mutatingwebhookconfigurations"][Added]))
+			Expect(kvTestData.resourceChanges["validatingwebhookconfigurations"][Patched]).To(Equal(kvTestData.resourceChanges["validatingwebhookconfigurations"][Added]))
+			Expect(kvTestData.resourceChanges["deployements"][Patched]).To(Equal(kvTestData.resourceChanges["deployements"][Added]))
+			Expect(kvTestData.resourceChanges["daemonsets"][Patched]).To(Equal(kvTestData.resourceChanges["daemonsets"][Added]))
+		}, 30)
 
 		It("should delete operator managed resources not in the deployed installstrategy", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			defer GinkgoRecover()
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1772,35 +1713,40 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsDeploying(kv)
 			util.UpdateConditionsCreated(kv)
 
-			deleteFromCache = false
+			kvTestData.deleteFromCache = false
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
-			numResources := generateRandomResources()
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			numResources := kvTestData.generateRandomResources()
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			shouldExpectDeletions()
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectDeletions()
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
-			Expect(totalDeletions).To(Equal(numResources))
-		}, 15)
+			kvTestData.controller.Execute()
+			Expect(kvTestData.totalDeletions).To(Equal(numResources))
+		}, 30)
 
 		It("should fail if KubeVirt object already exists", func() {
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv1 := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install-1",
@@ -1826,18 +1772,22 @@ var _ = Describe("KubeVirt Operator", func() {
 			kubecontroller.SetLatestApiVersionAnnotation(kv1)
 			util.UpdateConditionsCreated(kv1)
 			util.UpdateConditionsAvailable(kv1)
-			addKubeVirt(kv1)
+			kvTestData.addKubeVirt(kv1)
 			kubecontroller.SetLatestApiVersionAnnotation(kv2)
-			addKubeVirt(kv2)
+			kvTestData.addKubeVirt(kv2)
 
-			shouldExpectKubeVirtUpdateStatusFailureCondition(util.ConditionReasonDeploymentFailedExisting)
+			kvTestData.shouldExpectKubeVirtUpdateStatusFailureCondition(util.ConditionReasonDeploymentFailedExisting)
 
-			controller.execute(fmt.Sprintf("%s/%s", kv2.Namespace, kv2.Name))
+			kvTestData.controller.execute(fmt.Sprintf("%s/%s", kv2.Namespace, kv2.Name))
 
-		}, 15)
+		}, 30)
 
 		It("should generate install strategy creation job for update version", func(done Done) {
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			updatedVersion := "1.1.1"
 			updatedRegistry := "otherregistry"
@@ -1857,33 +1807,38 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 
-			shouldExpectKubeVirtUpdateStatus(1)
-			shouldExpectJobCreation()
-			controller.Execute()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectJobCreation()
+			kvTestData.controller.Execute()
 
-		}, 15)
+		}, 30)
 
 		It("should create an install strategy creation job with passthrough env vars, if provided in config", func(done Done) {
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			config := getConfig("registry", "v1.1.1")
 			envKey := rand.String(10)
 			envVal := rand.String(10)
 			config.PassthroughEnvVars = map[string]string{envKey: envVal}
-			job, err := controller.generateInstallStrategyJob(config)
+			job, err := kvTestData.controller.generateInstallStrategyJob(config)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(job.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
-		}, 15)
+		}, 30)
 
 		It("should create an api server deployment with passthrough env vars, if provided in config", func(done Done) {
 			defer close(done)
@@ -1896,7 +1851,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(apiDeployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
-		}, 15)
+		}, 30)
 
 		It("should create a controller deployment with passthrough env vars, if provided in config", func(done Done) {
 			defer close(done)
@@ -1909,7 +1864,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(controllerDeployment.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
-		}, 15)
+		}, 30)
 
 		It("should create a handler daemonset with passthrough env vars, if provided in config", func(done Done) {
 			defer close(done)
@@ -1922,10 +1877,14 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(handlerDaemonset.Spec.Template.Spec.Containers[0].Env).To(ContainElement(k8sv1.EnvVar{Name: envKey, Value: envVal}))
-		}, 15)
+		}, 30)
 
 		It("should generate install strategy creation job if no install strategy exists", func(done Done) {
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1938,16 +1897,20 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			shouldExpectKubeVirtUpdateStatus(1)
-			shouldExpectJobCreation()
-			controller.Execute()
+			kvTestData.addKubeVirt(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectJobCreation()
+			kvTestData.controller.Execute()
 
-		}, 15)
+		}, 30)
 
 		It("should label install strategy creation job", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install",
@@ -1957,15 +1920,19 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{},
 			}
 
-			job, err := controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
+			job, err := kvTestData.controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(job.Spec.Template.ObjectMeta.Labels).Should(HaveKeyWithValue(v1.AppLabel, virtOperatorJobAppLabel))
-		}, 15)
+		}, 30)
 
 		It("should delete install strategy creation job if job has failed", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install",
@@ -1975,7 +1942,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{},
 			}
 
-			job, err := controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
+			job, err := kvTestData.controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
 			Expect(err).ToNot(HaveOccurred())
 
 			// will only create a new job after 10 seconds has passed.
@@ -1986,19 +1953,23 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategyJob(job)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategyJob(job)
 
-			shouldExpectJobDeletion()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectJobDeletion()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-		}, 15)
+		}, 30)
 
 		It("should not delete completed install strategy creation job if job has failed less that 10 seconds ago", func(done Done) {
 			defer GinkgoRecover()
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2009,23 +1980,28 @@ var _ = Describe("KubeVirt Operator", func() {
 				Status: v1.KubeVirtStatus{},
 			}
 
-			job, err := controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
+			job, err := kvTestData.controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
 			Expect(err).ToNot(HaveOccurred())
 
 			job.Status.CompletionTime = now()
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategyJob(job)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategyJob(job)
 
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-		}, 15)
+		}, 30)
 
 		It("should add resources on create", func() {
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-install",
@@ -2033,26 +2009,26 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 			}
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 
-			job, err := controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
+			job, err := kvTestData.controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
 			Expect(err).ToNot(HaveOccurred())
 
 			job.Status.CompletionTime = now()
-			addInstallStrategyJob(job)
+			kvTestData.addInstallStrategyJob(job)
 
 			// ensure completed jobs are garbage collected once install strategy
 			// is loaded
-			deleteFromCache = false
-			shouldExpectJobDeletion()
-			shouldExpectKubeVirtUpdate(1)
-			shouldExpectKubeVirtUpdateStatus(1)
-			shouldExpectCreations()
+			kvTestData.deleteFromCache = false
+			kvTestData.shouldExpectJobDeletion()
+			kvTestData.shouldExpectKubeVirtUpdate(1)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectCreations()
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeploying))
 			Expect(len(kv.Status.Conditions)).To(Equal(3))
 			Expect(len(kv.ObjectMeta.Finalizers)).To(Equal(1))
@@ -2065,29 +2041,34 @@ var _ = Describe("KubeVirt Operator", func() {
 			// 1 because a temporary validation webhook is created to block new CRDs until api server is deployed
 			expectedTemporaryResources := 1
 
-			Expect(totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources))
+			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources))
 
-			Expect(len(controller.stores.ServiceAccountCache.List())).To(Equal(3))
-			Expect(len(controller.stores.ClusterRoleCache.List())).To(Equal(7))
-			Expect(len(controller.stores.ClusterRoleBindingCache.List())).To(Equal(5))
-			Expect(len(controller.stores.RoleCache.List())).To(Equal(3))
-			Expect(len(controller.stores.RoleBindingCache.List())).To(Equal(3))
-			Expect(len(controller.stores.CrdCache.List())).To(Equal(8))
-			Expect(len(controller.stores.ServiceCache.List())).To(Equal(3))
-			Expect(len(controller.stores.DeploymentCache.List())).To(Equal(1))
-			Expect(len(controller.stores.DaemonSetCache.List())).To(Equal(0))
-			Expect(len(controller.stores.ValidationWebhookCache.List())).To(Equal(3))
-			Expect(len(controller.stores.PodDisruptionBudgetCache.List())).To(Equal(1))
-			Expect(len(controller.stores.SCCCache.List())).To(Equal(3))
-			Expect(len(controller.stores.ServiceMonitorCache.List())).To(Equal(1))
-			Expect(len(controller.stores.PrometheusRuleCache.List())).To(Equal(1))
+			Expect(len(kvTestData.controller.stores.ServiceAccountCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.ClusterRoleCache.List())).To(Equal(7))
+			Expect(len(kvTestData.controller.stores.ClusterRoleBindingCache.List())).To(Equal(5))
+			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.CrdCache.List())).To(Equal(8))
+			Expect(len(kvTestData.controller.stores.ServiceCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.DeploymentCache.List())).To(Equal(1))
+			Expect(len(kvTestData.controller.stores.DaemonSetCache.List())).To(Equal(0))
+			Expect(len(kvTestData.controller.stores.ValidationWebhookCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.PodDisruptionBudgetCache.List())).To(Equal(1))
+			Expect(len(kvTestData.controller.stores.SCCCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.ServiceMonitorCache.List())).To(Equal(1))
+			Expect(len(kvTestData.controller.stores.PrometheusRuleCache.List())).To(Equal(1))
 
-			Expect(resourceChanges["poddisruptionbudgets"][Added]).To(Equal(1))
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Added]).To(Equal(1))
 
-		}, 15)
+		}, 30)
 
 		Context("when the monitor namespace does not exist", func() {
 			It("should not create ServiceMonitor resources", func() {
+
+				kvTestData := KubeVirtTestData{}
+				kvTestData.BeforeTest()
+				defer kvTestData.AfterTest()
+
 				kv := &v1.KubeVirt{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "test-install",
@@ -2096,37 +2077,41 @@ var _ = Describe("KubeVirt Operator", func() {
 					},
 				}
 				kubecontroller.SetLatestApiVersionAnnotation(kv)
-				addKubeVirt(kv)
+				kvTestData.addKubeVirt(kv)
 
 				// install strategy config
-				resource, _ := install.NewInstallStrategyConfigMap(defaultConfig, false, NAMESPACE)
+				resource, _ := install.NewInstallStrategyConfigMap(kvTestData.defaultConfig, false, NAMESPACE)
 				resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
-				addResource(resource, defaultConfig, nil)
+				kvTestData.addResource(resource, kvTestData.defaultConfig, nil)
 
-				job, err := controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
+				job, err := kvTestData.controller.generateInstallStrategyJob(util.GetTargetConfigFromKV(kv))
 				Expect(err).ToNot(HaveOccurred())
 
 				job.Status.CompletionTime = now()
-				addInstallStrategyJob(job)
+				kvTestData.addInstallStrategyJob(job)
 
 				// ensure completed jobs are garbage collected once install strategy
 				// is loaded
-				deleteFromCache = false
-				shouldExpectJobDeletion()
-				shouldExpectKubeVirtUpdateStatus(1)
-				shouldExpectCreations()
+				kvTestData.deleteFromCache = false
+				kvTestData.shouldExpectJobDeletion()
+				kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+				kvTestData.shouldExpectCreations()
 
-				controller.Execute()
+				kvTestData.controller.Execute()
 
-				Expect(len(controller.stores.RoleCache.List())).To(Equal(2))
-				Expect(len(controller.stores.RoleBindingCache.List())).To(Equal(2))
-				Expect(len(controller.stores.ServiceMonitorCache.List())).To(Equal(0))
-			}, 15)
+				Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(2))
+				Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(2))
+				Expect(len(kvTestData.controller.stores.ServiceMonitorCache.List())).To(Equal(0))
+			}, 30)
 		})
 
 		It("should pause rollback until api server is rolled over.", func(done Done) {
 			defer close(done)
 			defer GinkgoRecover()
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			rollbackConfig := getConfig("otherregistry", "9.9.7")
 
@@ -2145,31 +2130,31 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addInstallStrategy(rollbackConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addInstallStrategy(rollbackConfig)
 
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			addToCache = false
-			shouldExpectRbacBackupCreations()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.addToCache = false
+			kvTestData.shouldExpectRbacBackupCreations()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect an ongoing update
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
@@ -2182,15 +2167,19 @@ var _ = Describe("KubeVirt Operator", func() {
 			// 4 because 2 for virt-controller service and deployment,
 			// 1 because of the pdb of virt-controller
 			// and another 1 because of the namespace was not patched yet.
-			Expect(totalPatches).To(Equal(patchCount - 4))
+			Expect(kvTestData.totalPatches).To(Equal(patchCount - 4))
 			// 2 for virt-controller and pdb
-			Expect(totalUpdates).To(Equal(updateCount))
+			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
-			Expect(resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1))
-		}, 15)
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1))
+		}, 30)
 
 		It("should pause update after daemonsets are rolled over", func(done Done) {
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			updatedConfig := getConfig("otherregistry", "9.9.10")
 
@@ -2209,35 +2198,35 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addInstallStrategy(updatedConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addInstallStrategy(updatedConfig)
 
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			addToCache = false
-			shouldExpectRbacBackupCreations()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.addToCache = false
+			kvTestData.shouldExpectRbacBackupCreations()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect an ongoing update
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
-			Expect(totalUpdates).To(Equal(updateCount))
+			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
 			// daemonset, controller and apiserver pods are updated in this order.
 			// this prevents the new API from coming online until the controllers can manage it.
@@ -2245,16 +2234,20 @@ var _ = Describe("KubeVirt Operator", func() {
 			//   daemonsets and before controller and namespace
 
 			// 5 because virt-controller, virt-api, PDBs and the namespace are not patched
-			Expect(totalPatches).To(Equal(patchCount - 5))
+			Expect(kvTestData.totalPatches).To(Equal(patchCount - 5))
 
 			// Make sure the 5 unpatched are as expected
-			Expect(resourceChanges["deployments"][Patched]).To(Equal(0))          // virt-controller and virt-api unpatched
-			Expect(resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(0)) // PDBs unpatched
-			Expect(resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
-		}, 15)
+			Expect(kvTestData.resourceChanges["deployments"][Patched]).To(Equal(0))          // virt-controller and virt-api unpatched
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(0)) // PDBs unpatched
+			Expect(kvTestData.resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
+		}, 30)
 
 		It("should pause update after controllers are rolled over", func(done Done) {
 			defer close(done)
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			updatedConfig := getConfig("otherregistry", "9.9.10")
 
@@ -2273,53 +2266,57 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addInstallStrategy(updatedConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addInstallStrategy(updatedConfig)
 
-			addAll(defaultConfig, kv)
-			// Create virt-api and virt-controller under defaultConfig,
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			// Create virt-api and virt-controller under kvTestData.defaultConfig,
 			// but use updatedConfig for virt-handler (hack) to avoid pausing after daemonsets
-			addPodsWithIndividualConfigs(defaultConfig, defaultConfig, updatedConfig, true, kv)
+			kvTestData.addPodsWithIndividualConfigs(kvTestData.defaultConfig, kvTestData.defaultConfig, updatedConfig, true, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			addToCache = false
-			shouldExpectRbacBackupCreations()
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.addToCache = false
+			kvTestData.shouldExpectRbacBackupCreations()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect an ongoing update
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
-			Expect(totalUpdates).To(Equal(updateCount))
+			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
 			// The update was hacked to avoid pausing after rolling out the daemonsets (virt-handler)
 			// That will allow both daemonset and controller pods to get patched before the pause.
 
 			// 3 because virt-api, PDB and the namespace should not be patched
-			Expect(totalPatches).To(Equal(patchCount - 3))
+			Expect(kvTestData.totalPatches).To(Equal(patchCount - 3))
 
 			// Make sure the 3 unpatched are as expected
-			Expect(resourceChanges["deployments"][Patched]).To(Equal(1))          // virt-operator patched, virt-api unpatched
-			Expect(resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1)) // 1 of 2 PDBs patched
-			Expect(resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
-		}, 15)
+			Expect(kvTestData.resourceChanges["deployments"][Patched]).To(Equal(1))          // virt-operator patched, virt-api unpatched
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(1)) // 1 of 2 PDBs patched
+			Expect(kvTestData.resourceChanges["namespace"][Patched]).To(Equal(0))            // namespace unpatched
+		}, 30)
 
 		It("should update kubevirt resources when Operator version changes if no imageTag and imageRegistry is explicitly set.", func() {
 			os.Setenv(util.OperatorImageEnvName, fmt.Sprintf("%s/virt-operator:%s", "otherregistry", "1.1.1"))
 			updatedConfig := getConfig("", "")
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2333,52 +2330,56 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addInstallStrategy(updatedConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addInstallStrategy(updatedConfig)
 
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
 			// pods for the new version are added so this test won't
 			// wait for daemonsets to rollover before updating/patching
 			// all resources.
-			addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect a successful update
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 
-			Expect(totalPatches).To(Equal(patchCount))
-			Expect(totalUpdates).To(Equal(updateCount))
+			Expect(kvTestData.totalPatches).To(Equal(patchCount))
+			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
 			// ensure every resource is either patched or updated
 			// + 1 is for the namespace patch which we don't consider as a resource we own.
-			Expect(totalUpdates + totalPatches).To(Equal(resourceCount + 1))
+			Expect(kvTestData.totalUpdates + kvTestData.totalPatches).To(Equal(resourceCount + 1))
 
-			Expect(resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(2))
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(2))
 
-		}, 15)
+		}, 30)
 
 		It("should update resources when changing KubeVirt version.", func() {
 			updatedConfig := getConfig("otherregistry", "1.1.1")
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2395,50 +2396,54 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addInstallStrategy(updatedConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addInstallStrategy(updatedConfig)
 
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
 			// pods for the new version are added so this test won't
 			// wait for daemonsets to rollover before updating/patching
 			// all resources.
-			addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
-			fakeNamespaceModificationEvent()
-			shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect a successful update
 			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 
-			Expect(totalPatches).To(Equal(patchCount))
-			Expect(totalUpdates).To(Equal(updateCount))
+			Expect(kvTestData.totalPatches).To(Equal(patchCount))
+			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
 			// ensure every resource is either patched or updated
 			// + 1 is for the namespace patch which we don't consider as a resource we own.
-			Expect(totalUpdates + totalPatches).To(Equal(resourceCount + 1))
+			Expect(kvTestData.totalUpdates + kvTestData.totalPatches).To(Equal(resourceCount + 1))
 
-		}, 15)
+		}, 30)
 
 		It("should patch poddisruptionbudgets when changing KubeVirt version.", func() {
 			updatedConfig := getConfig("otherregistry", "1.1.1")
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
 
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2469,36 +2474,41 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			defaultConfig.SetTargetDeploymentConfig(kv)
-			defaultConfig.SetObservedDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
+			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
-			addInstallStrategy(defaultConfig)
-			addInstallStrategy(updatedConfig)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addInstallStrategy(updatedConfig)
 
-			addAll(defaultConfig, kv)
-			addPodsAndPodDisruptionBudgets(defaultConfig, kv)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
+			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
 			// pods for the new version are added so this test won't
 			// wait for daemonsets to rollover before updating/patching
 			// all resources.
-			addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
 
-			makeApiAndControllerReady()
-			makeHandlerReady()
+			kvTestData.makeApiAndControllerReady()
+			kvTestData.makeHandlerReady()
 
-			shouldExpectPatchesAndUpdates()
-			shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectPatchesAndUpdates()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			Expect(resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(2))
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Patched]).To(Equal(2))
 
-		}, 15)
+		}, 30)
 
 		It("should remove resources on deletion", func() {
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-install",
@@ -2507,30 +2517,35 @@ var _ = Describe("KubeVirt Operator", func() {
 			}
 			kv.DeletionTimestamp = now()
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
+			kvTestData.addKubeVirt(kv)
 
 			// create all resources which should be deleted
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
 
-			shouldExpectKubeVirtUpdateStatus(1)
-			shouldExpectDeletions()
-			shouldExpectInstallStrategyDeletion()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectDeletions()
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
 			// Note: in real life during the first execution loop very probably only CRDs are deleted,
 			// because that takes some time (see the check that the crd store is empty before going on with deletions)
 			// But in this test the deletion succeeds immediately, so everything is deleted on first try
-			Expect(totalDeletions).To(Equal(resourceCount))
+			Expect(kvTestData.totalDeletions).To(Equal(resourceCount))
 
-			kv = getLatestKubeVirt(kv)
+			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeleted))
 			Expect(len(kv.Status.Conditions)).To(Equal(3))
 			shouldExpectHCOConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionFalse, k8sv1.ConditionTrue)
-		}, 15)
+		}, 30)
 
 		It("should remove poddisruptionbudgets on deletion", func() {
+
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-install",
@@ -2539,30 +2554,34 @@ var _ = Describe("KubeVirt Operator", func() {
 			}
 			kv.DeletionTimestamp = now()
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
-			addKubeVirt(kv)
+			kvTestData.addKubeVirt(kv)
 
 			// create all resources which should be deleted
-			addInstallStrategy(defaultConfig)
-			addAll(defaultConfig, kv)
+			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
+			kvTestData.addAll(kvTestData.defaultConfig, kv)
 
-			shouldExpectKubeVirtUpdateStatus(1)
-			shouldExpectDeletions()
-			shouldExpectInstallStrategyDeletion()
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+			kvTestData.shouldExpectDeletions()
+			kvTestData.shouldExpectInstallStrategyDeletion()
 
-			controller.Execute()
+			kvTestData.controller.Execute()
 
-			Expect(resourceChanges["poddisruptionbudgets"][Deleted]).To(Equal(2))
-		}, 15)
+			Expect(kvTestData.resourceChanges["poddisruptionbudgets"][Deleted]).To(Equal(2))
+		}, 30)
 	})
 
 	Context("On install strategy dump", func() {
 		It("should generate latest install strategy and post as config map", func(done Done) {
 			defer close(done)
 
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
 			config, err := util.GetConfigFromEnv()
 			Expect(err).ToNot(HaveOccurred())
 
-			kubeClient.Fake.PrependReactor("create", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			kvTestData.kubeClient.Fake.PrependReactor("create", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				create, ok := action.(testing.CreateAction)
 				Expect(ok).To(BeTrue())
 
@@ -2588,12 +2607,136 @@ var _ = Describe("KubeVirt Operator", func() {
 			})
 
 			// This generates and posts the install strategy config map
-			install.DumpInstallStrategyToConfigMap(virtClient, NAMESPACE)
-		}, 15)
+			install.DumpInstallStrategyToConfigMap(kvTestData.virtClient, NAMESPACE)
+		}, 30)
 	})
 })
 
 func now() *metav1.Time {
 	now := metav1.Now()
 	return &now
+}
+
+func getSCC() secv1.SecurityContextConstraints {
+	return secv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "privileged",
+		},
+		Users: []string{
+			"someUser",
+		},
+	}
+}
+
+func getConfig(registry, version string) *util.KubeVirtDeploymentConfig {
+	return util.GetTargetConfigFromKV(&v1.KubeVirt{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: NAMESPACE,
+		},
+		Spec: v1.KubeVirtSpec{
+			ImageRegistry: registry,
+			ImageTag:      version,
+		},
+	})
+}
+
+func syncCaches(stop chan struct{}, kvInformer cache.SharedIndexInformer, informers util.Informers) {
+	go kvInformer.Run(stop)
+	go informers.ServiceAccount.Run(stop)
+	go informers.ClusterRole.Run(stop)
+	go informers.ClusterRoleBinding.Run(stop)
+	go informers.Role.Run(stop)
+	go informers.RoleBinding.Run(stop)
+	go informers.Crd.Run(stop)
+	go informers.Service.Run(stop)
+	go informers.Deployment.Run(stop)
+	go informers.DaemonSet.Run(stop)
+	go informers.ValidationWebhook.Run(stop)
+	go informers.MutatingWebhook.Run(stop)
+	go informers.APIService.Run(stop)
+	go informers.SCC.Run(stop)
+	go informers.InstallStrategyJob.Run(stop)
+	go informers.InstallStrategyConfigMap.Run(stop)
+	go informers.InfrastructurePod.Run(stop)
+	go informers.PodDisruptionBudget.Run(stop)
+	go informers.ServiceMonitor.Run(stop)
+	go informers.Namespace.Run(stop)
+	go informers.PrometheusRule.Run(stop)
+	go informers.Secrets.Run(stop)
+	go informers.ConfigMap.Run(stop)
+
+	Expect(cache.WaitForCacheSync(stop, kvInformer.HasSynced)).To(BeTrue())
+
+	cache.WaitForCacheSync(stop, informers.ServiceAccount.HasSynced)
+	cache.WaitForCacheSync(stop, informers.ClusterRole.HasSynced)
+	cache.WaitForCacheSync(stop, informers.ClusterRoleBinding.HasSynced)
+	cache.WaitForCacheSync(stop, informers.Role.HasSynced)
+	cache.WaitForCacheSync(stop, informers.RoleBinding.HasSynced)
+	cache.WaitForCacheSync(stop, informers.Crd.HasSynced)
+	cache.WaitForCacheSync(stop, informers.Service.HasSynced)
+	cache.WaitForCacheSync(stop, informers.Deployment.HasSynced)
+	cache.WaitForCacheSync(stop, informers.DaemonSet.HasSynced)
+	cache.WaitForCacheSync(stop, informers.ValidationWebhook.HasSynced)
+	cache.WaitForCacheSync(stop, informers.MutatingWebhook.HasSynced)
+	cache.WaitForCacheSync(stop, informers.APIService.HasSynced)
+	cache.WaitForCacheSync(stop, informers.SCC.HasSynced)
+	cache.WaitForCacheSync(stop, informers.InstallStrategyJob.HasSynced)
+	cache.WaitForCacheSync(stop, informers.InstallStrategyConfigMap.HasSynced)
+	cache.WaitForCacheSync(stop, informers.InfrastructurePod.HasSynced)
+	cache.WaitForCacheSync(stop, informers.PodDisruptionBudget.HasSynced)
+	cache.WaitForCacheSync(stop, informers.ServiceMonitor.HasSynced)
+	cache.WaitForCacheSync(stop, informers.Namespace.HasSynced)
+	cache.WaitForCacheSync(stop, informers.PrometheusRule.HasSynced)
+	cache.WaitForCacheSync(stop, informers.Secrets.HasSynced)
+	cache.WaitForCacheSync(stop, informers.ConfigMap.HasSynced)
+}
+
+func injectMetadata(objectMeta *metav1.ObjectMeta, config *util.KubeVirtDeploymentConfig) {
+	if config == nil {
+		return
+	}
+	if objectMeta.Labels == nil {
+		objectMeta.Labels = make(map[string]string)
+	}
+	objectMeta.Labels[v1.ManagedByLabel] = v1.ManagedByLabelOperatorValue
+
+	if config.GetProductVersion() != "" {
+		objectMeta.Labels[v1.AppVersionLabel] = config.GetProductVersion()
+	}
+	if config.GetProductName() != "" {
+		objectMeta.Labels[v1.AppPartOfLabel] = config.GetProductName()
+	}
+
+	if objectMeta.Annotations == nil {
+		objectMeta.Annotations = make(map[string]string)
+	}
+	objectMeta.Annotations[v1.InstallStrategyVersionAnnotation] = config.GetKubeVirtVersion()
+	objectMeta.Annotations[v1.InstallStrategyRegistryAnnotation] = config.GetImageRegistry()
+	objectMeta.Annotations[v1.InstallStrategyIdentifierAnnotation] = config.GetDeploymentID()
+	objectMeta.Annotations[v1.KubeVirtGenerationAnnotation] = "1"
+
+	objectMeta.Labels[v1.AppComponentLabel] = v1.AppComponent
+}
+
+func shouldExpectHCOConditions(kv *v1.KubeVirt, available k8sv1.ConditionStatus, progressing k8sv1.ConditionStatus, degraded k8sv1.ConditionStatus) {
+	getType := func(c v1.KubeVirtCondition) v1.KubeVirtConditionType { return c.Type }
+	getStatus := func(c v1.KubeVirtCondition) k8sv1.ConditionStatus { return c.Status }
+	Expect(kv.Status.Conditions).To(ContainElement(
+		And(
+			WithTransform(getType, Equal(v1.KubeVirtConditionAvailable)),
+			WithTransform(getStatus, Equal(available)),
+		),
+	))
+	Expect(kv.Status.Conditions).To(ContainElement(
+		And(
+			WithTransform(getType, Equal(v1.KubeVirtConditionProgressing)),
+			WithTransform(getStatus, Equal(progressing)),
+		),
+	))
+	Expect(kv.Status.Conditions).To(ContainElement(
+		And(
+			WithTransform(getType, Equal(v1.KubeVirtConditionDegraded)),
+			WithTransform(getStatus, Equal(degraded)),
+		),
+	))
 }

--- a/pkg/virtctl/imageupload/imageupload_test.go
+++ b/pkg/virtctl/imageupload/imageupload_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -51,9 +52,9 @@ var _ = Describe("ImageUpload", func() {
 		cdiClient  *fakecdiclient.Clientset
 		server     *httptest.Server
 
-		dvCreateCalled  bool
-		pvcCreateCalled bool
-		updateCalled    bool
+		dvCreateCalled  = &atomicBool{lock: &sync.Mutex{}}
+		pvcCreateCalled = &atomicBool{lock: &sync.Mutex{}}
+		updateCalled    = &atomicBool{lock: &sync.Mutex{}}
 
 		imagePath string
 	)
@@ -205,8 +206,8 @@ var _ = Describe("ImageUpload", func() {
 			Expect(ok).To(BeTrue())
 			Expect(dv.Name).To(Equal(targetName))
 
-			Expect(dvCreateCalled).To(BeFalse())
-			dvCreateCalled = true
+			Expect(dvCreateCalled.IsTrue()).To(BeFalse())
+			dvCreateCalled.True()
 
 			go createPVC(dv)
 			go addDvPhase()
@@ -222,10 +223,10 @@ var _ = Describe("ImageUpload", func() {
 			Expect(ok).To(BeTrue())
 			Expect(pvc.Name).To(Equal(targetName))
 
-			Expect(pvcCreateCalled).To(BeFalse())
-			pvcCreateCalled = true
+			Expect(pvcCreateCalled.IsTrue()).To(BeFalse())
+			pvcCreateCalled.True()
 
-			if !dvCreateCalled {
+			if !dvCreateCalled.IsTrue() {
 				go addPodPhaseAnnotation()
 			}
 
@@ -240,11 +241,11 @@ var _ = Describe("ImageUpload", func() {
 			Expect(ok).To(BeTrue())
 			Expect(pvc.Name).To(Equal(targetName))
 
-			if !dvCreateCalled && !pvcCreateCalled && !updateCalled {
+			if !dvCreateCalled.IsTrue() && !pvcCreateCalled.IsTrue() && !updateCalled.IsTrue() {
 				go addPodPhaseAnnotation()
 			}
 
-			updateCalled = true
+			updateCalled.True()
 
 			return false, nil, nil
 		})
@@ -331,9 +332,9 @@ var _ = Describe("ImageUpload", func() {
 	}
 
 	testInitAsyncWithCdiObjects := func(statusCode int, async bool, kubeobjects []runtime.Object, cdiobjects []runtime.Object) {
-		dvCreateCalled = false
-		pvcCreateCalled = false
-		updateCalled = false
+		dvCreateCalled.False()
+		pvcCreateCalled.False()
+		updateCalled.False()
 
 		config := createCDIConfig()
 		cdiobjects = append(cdiobjects, config)
@@ -386,7 +387,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", targetName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(pvcCreateCalled).To(BeTrue())
+			Expect(pvcCreateCalled.IsTrue()).To(BeTrue())
 			validatePVC()
 		})
 
@@ -395,7 +396,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "--pvc-name", targetName, "--no-create",
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(pvcCreateCalled).To(BeFalse())
+			Expect(pvcCreateCalled.IsTrue()).To(BeFalse())
 			validatePVC()
 		})
 
@@ -404,7 +405,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
 			validatePVC()
 			validateDataVolume()
 		},
@@ -417,7 +418,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--pvc-size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
 			validatePVC()
 			validateDataVolume()
 		})
@@ -429,7 +430,7 @@ var _ = Describe("ImageUpload", func() {
 			err := cmd()
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(Equal(fmt.Sprintf("persistentvolumeclaims %q not found", targetName)))
-			Expect(dvCreateCalled).To(BeFalse())
+			Expect(dvCreateCalled.IsTrue()).To(BeFalse())
 		})
 
 		It("Use CDI Config UploadProxyURL", func() {
@@ -437,7 +438,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
 			validatePVC()
 			validateDataVolume()
 		})
@@ -447,7 +448,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath, "--block-volume")
 			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
 			validateBlockPVC()
 			validateBlockDataVolume()
 		})
@@ -458,7 +459,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "dv", targetName, "--size", pvcSize,
 				"--insecure", "--image-path", imagePath, "--storage-class", expectedStorageClass)
 			Expect(cmd()).To(BeNil())
-			Expect(dvCreateCalled).To(BeTrue())
+			Expect(dvCreateCalled.IsTrue()).To(BeTrue())
 			expectedStorageClassMatchesActual(expectedStorageClass)
 		})
 
@@ -467,7 +468,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName, "--size", pvcSize,
 				"--uploadproxy-url", server.URL, "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(pvcCreateCalled).To(BeTrue())
+			Expect(pvcCreateCalled.IsTrue()).To(BeTrue())
 			validatePVC()
 		},
 			Entry("PVC does not exist, async", true),
@@ -479,7 +480,7 @@ var _ = Describe("ImageUpload", func() {
 			cmd := tests.NewRepeatableVirtctlCommand(commandName, "pvc", targetName,
 				"--uploadproxy-url", server.URL, "--no-create", "--insecure", "--image-path", imagePath)
 			Expect(cmd()).To(BeNil())
-			Expect(pvcCreateCalled).To(BeFalse())
+			Expect(pvcCreateCalled.IsTrue()).To(BeFalse())
 			validatePVC()
 		},
 			Entry("PVC with upload annotation", pvcSpecWithUploadAnnotation()),
@@ -494,7 +495,7 @@ var _ = Describe("ImageUpload", func() {
 			err := cmd()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("cannot upload to a readonly volume, use either ReadWriteOnce or ReadWriteMany if supported"))
-			Expect(dvCreateCalled).To(BeFalse())
+			Expect(dvCreateCalled.IsTrue()).To(BeFalse())
 		})
 
 		AfterEach(func() {
@@ -589,3 +590,26 @@ var _ = Describe("ImageUpload", func() {
 		)
 	})
 })
+
+type atomicBool struct {
+	lock  *sync.Mutex
+	value bool
+}
+
+func (b *atomicBool) IsTrue() bool {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return b.value
+}
+
+func (b *atomicBool) True() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	b.value = true
+}
+
+func (b *atomicBool) False() {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	b.value = false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR fixes flaky unit tests by eliminating data races that occur during using go `-race` flag. Based on initial changes from rmohrs PR they isolate test data and synchronize go routines to avoid concurrency issues. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5313

**Special notes for your reviewer**:

This is a spinoff from https://github.com/kubevirt/kubevirt/pull/5262 in order to get the test changes in and help fixing test flake issues.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix flaky unit tests
```
