### PR TITLE
Enable coverage for goveralls

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,7 +74,8 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/structtag:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/tests:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unreachable:go_tool_library",
-        "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
+        # Fails on a vendored dependency, disabling for now.
+        # "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,8 +74,7 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/structtag:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/tests:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unreachable:go_tool_library",
-        # Fails on a vendored dependency, disabling for now.
-        # "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,6 +31,7 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://storage.googleapis.com/builddeps/69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
     ],
 )
 
@@ -40,6 +41,7 @@ http_archive(
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://storage.googleapis.com/builddeps/62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
     ],
 )
 
@@ -3736,7 +3738,6 @@ rpm(
     urls = [
         "https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux/updates/32/Everything/aarch64/Packages/l/libgcc-10.2.1-9.fc32.aarch64.rpm",
         "https://nrt.edge.kernel.org/fedora-buffet/fedora/linux/updates/32/Everything/aarch64/Packages/l/libgcc-10.2.1-9.fc32.aarch64.rpm",
-        "https://mirrors.tuna.tsinghua.edu.cn/fedora/updates/32/Everything/aarch64/Packages/l/libgcc-10.2.1-9.fc32.aarch64.rpm",
         "https://storage.googleapis.com/builddeps/45f0ca3a98642c045da905e38f4a00ffb4b751f558dc49dfabb8459ced343e0b",
     ],
 )
@@ -4874,7 +4875,6 @@ rpm(
     urls = [
         "https://nrt.edge.kernel.org/fedora-buffet/fedora/linux/updates/32/Everything/aarch64/Packages/l/libstdc++-10.2.1-9.fc32.aarch64.rpm",
         "https://ftp.yz.yamagata-u.ac.jp/pub/linux/fedora-projects/fedora/linux/updates/32/Everything/aarch64/Packages/l/libstdc++-10.2.1-9.fc32.aarch64.rpm",
-        "https://mirrors.tuna.tsinghua.edu.cn/fedora/updates/32/Everything/aarch64/Packages/l/libstdc++-10.2.1-9.fc32.aarch64.rpm",
         "https://storage.googleapis.com/builddeps/98df12387f9f55cd1f1ef574ee2702a56d12ec374900a40ddd0b7f0f25e6904f",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,21 +27,19 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "08369b54a7cbe9348eea474e36c9bbb19d47101e8860cec75cbf1ccd4f749281",
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.0/rules_go-v0.24.0.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.0/rules_go-v0.24.0.tar.gz",
-        "https://storage.googleapis.com/builddeps/08369b54a7cbe9348eea474e36c9bbb19d47101e8860cec75cbf1ccd4f749281",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
     ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "d4113967ab451dd4d2d767c3ca5f927fec4b30f3b2c6f8135a2033b9c05a5687",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.0/bazel-gazelle-v0.22.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.0/bazel-gazelle-v0.22.0.tar.gz",
-        "https://storage.googleapis.com/builddeps/d4113967ab451dd4d2d767c3ca5f927fec4b30f3b2c6f8135a2033b9c05a5687",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
     ],
 )
 

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -9,7 +9,7 @@ test --cache_test_results=no --runs_per_test=1
 EOF
 fi
 
-rm -rf ${ARTIFACTS}/junit
+rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 function collect_results() {
     cd ${KUBEVIRT_DIR}
@@ -18,10 +18,16 @@ function collect_results() {
         mkdir -p ${dir}
         cp -f ${f} ${dir}/junit.xml
     done
+    for f in $(find bazel-out/ -name 'test.log'); do
+        dir=${ARTIFACTS}/testlogs/$(dirname $f)
+        mkdir -p ${dir}
+        cp -f ${f} ${dir}/test.log
+    done
 }
 
 trap collect_results EXIT
 
 bazel test \
     --config=${ARCHITECTURE} \
+    --features race \
     --test_output=errors -- //staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... //tests/framework/...

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -110,6 +110,7 @@
   "unsafeptr": {
     "exclude_files": {
       "vendor/": "vendor doesn't pass vet",
+      "rules_go_work-.*/": "necessary due to https://github.com/bazelbuild/rules_go/issues/2513",
       "external/": "externaldoesn't pass vet"
     }
   },

--- a/pkg/certificates/BUILD.bazel
+++ b/pkg/certificates/BUILD.bazel
@@ -18,8 +18,8 @@ go_test(
         "certificates_suite_test.go",
         "certificates_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/hooks/BUILD.bazel
+++ b/pkg/hooks/BUILD.bazel
@@ -28,8 +28,8 @@ go_test(
         "hooks_test.go",
         "manager_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/hooks/info:go_default_library",
         "//pkg/hooks/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",

--- a/pkg/util/openapi/BUILD.bazel
+++ b/pkg/util/openapi/BUILD.bazel
@@ -27,8 +27,8 @@ go_test(
         "openapi_suite_test.go",
         "openapi_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/virt-api/rest:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-api/webhooks/BUILD.bazel
+++ b/pkg/virt-api/webhooks/BUILD.bazel
@@ -32,8 +32,8 @@ go_test(
         "utils_test.go",
         "webhooks_suite_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/BUILD.bazel
@@ -27,8 +27,8 @@ go_test(
         "disruptionbudget_suite_test.go",
         "disruptionbudget_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/testutils:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/BUILD.bazel
@@ -17,8 +17,8 @@ go_test(
         "device_suite_test.go",
         "pciaddress_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/sriov/BUILD.bazel
@@ -26,8 +26,8 @@ go_test(
         "pcipool_test.go",
         "sriov_suite_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virtctl/BUILD.bazel
+++ b/pkg/virtctl/BUILD.bazel
@@ -30,8 +30,8 @@ go_test(
         "root_suite_test.go",
         "root_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virtctl/expose/BUILD.bazel
+++ b/pkg/virtctl/expose/BUILD.bazel
@@ -26,8 +26,8 @@ go_test(
         "expose_suite_test.go",
         "expose_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -30,8 +30,8 @@ go_test(
         "imageupload_suite_test.go",
         "imageupload_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virtctl/pause/BUILD.bazel
+++ b/pkg/virtctl/pause/BUILD.bazel
@@ -22,8 +22,8 @@ go_test(
         "pause_suite_test.go",
         "pause_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
+        ":go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virtctl/vm/BUILD.bazel
+++ b/pkg/virtctl/vm/BUILD.bazel
@@ -22,7 +22,6 @@ go_test(
         "vm_suite_test.go",
         "vm_test.go",
     ],
-    embed = [":go_default_library"],
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -154,9 +154,9 @@ go_test(
         "vnc_test.go",
         "windows_test.go",
     ],
-    embed = [":go_default_library"],
     visibility = ["//visibility:public"],
     deps = [
+        ":go_default_library",
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/cloud-init:go_default_library",

--- a/vendor/github.com/opencontainers/runc/libcontainer/configs/BUILD.bazel
+++ b/vendor/github.com/opencontainers/runc/libcontainer/configs/BUILD.bazel
@@ -59,9 +59,6 @@ go_library(
             "//vendor/github.com/coreos/go-systemd/v22/dbus:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/golang.org/x/sys/unix:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],

--- a/vendor/github.com/prometheus/client_golang/prometheus/BUILD.bazel
+++ b/vendor/github.com/prometheus/client_golang/prometheus/BUILD.bazel
@@ -68,9 +68,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/prometheus/procfs:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/github.com/prometheus/procfs:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/github.com/prometheus/procfs:go_default_library",
         ],

--- a/vendor/github.com/u-root/u-root/pkg/rand/BUILD.bazel
+++ b/vendor/github.com/u-root/u-root/pkg/rand/BUILD.bazel
@@ -34,9 +34,6 @@ go_library(
             "//vendor/github.com/u-root/u-root/pkg/cmdline:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/golang.org/x/sys/unix:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
         ],

--- a/vendor/github.com/vishvananda/netlink/BUILD.bazel
+++ b/vendor/github.com/vishvananda/netlink/BUILD.bazel
@@ -87,9 +87,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/vishvananda/netns:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:nacl": [
-            "//vendor/github.com/vishvananda/netns:go_default_library",
-        ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//vendor/github.com/vishvananda/netns:go_default_library",
         ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Based on #5262, this PR restores the ability to run goveralls again. This contains the changes to reenable bazel coverage and also enable the go -race flag in order to catch flakyness and data races.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reenable coverage
```
