### PR TITLE
Fix hostpath not working on RHCOS host

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -35,6 +35,11 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
+const (
+	// rhcosOsTreePath is the readonly file system mount that shows up as a prefix in mount info on running containers.
+	rhcosOstreePath = "/ostree/deploy/rhcos"
+)
+
 var (
 	deviceBasePath = func(podUID types.UID) string {
 		return fmt.Sprintf("/proc/1/root/var/lib/kubelet/pods/%s/volumeDevices", string(podUID))
@@ -606,10 +611,12 @@ func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.Virtua
 		}
 		for _, mount := range mounts {
 			if mount.MountPoint == "/pvc" {
-				for _, prefix := range m.stripPaths() {
-					if strings.HasPrefix(mount.Root, prefix) {
-						return strings.TrimPrefix(mount.Root, prefix), nil
-					}
+				// In Open Shift on an RHCOS node, the way ostree and ostree-rpm works the mount.Root returned in
+				// the mountInfo has a prefix. If we try to bind mount the path that includes the prefix, the bind mount
+				// will be readonly, and attempting to access the disk.img will fail. This check verifies that we have the
+				// prefix, and if so, we strip it, so the R/W version is bind mounted instead.
+				if strings.HasPrefix(mount.Root, rhcosOstreePath) {
+					return strings.TrimPrefix(mount.Root, rhcosOstreePath), nil
 				}
 				return mount.Root, nil
 			}
@@ -620,15 +627,6 @@ func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.Virtua
 		return diskPath, fmt.Errorf("Unable to find source disk image path for pod %s", sourceUID)
 	}
 	return diskPath, nil
-}
-
-func (m *volumeMounter) stripPaths() []string {
-	res := make([]string, 0)
-	// In CRC, and possibly Open Shift, the mount info returns the readonly version of the hostpath path
-	// and we need to strip it so we can return the R/W version so we can attach it to the VM.
-	res = append(res, "/ostree/deploy/rhcos")
-	// TODO: Determine if we need some env variables or something to increase this list.
-	return res
 }
 
 // Unmount unmounts all hotplug disk that are no longer part of the VMI

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -677,7 +677,7 @@ var _ = Describe("HotplugVolume filesystem volumes", func() {
 		Expect(err.Error()).To(ContainSubstring("mount detection error"))
 	})
 
-	It("getSourcePodFile should return the mountinfo value", func() {
+	table.DescribeTable("getSourcePodFile should return the mountinfo value", func(root, expectedRes string) {
 		expectedPath := filepath.Join(tempDir, "ghfjk", "volumes")
 		err = os.MkdirAll(expectedPath, 0755)
 		sourcePodBasePath = func(podUID types.UID) string {
@@ -692,7 +692,7 @@ var _ = Describe("HotplugVolume filesystem volumes", func() {
 			Expect(pid).To(Equal(1))
 			res := make([]*procfs.MountInfo, 0)
 			res = append(res, &procfs.MountInfo{
-				Root:       "/test/result",
+				Root:       root,
 				MountPoint: "/pvc",
 			})
 			return res, nil
@@ -701,8 +701,10 @@ var _ = Describe("HotplugVolume filesystem volumes", func() {
 		Expect(err).ToNot(HaveOccurred())
 		res, err := m.getSourcePodFilePath("ghfjk", vmi, "")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(Equal("/test/result"))
-	})
+		Expect(res).To(Equal(expectedRes))
+	}, table.Entry("normal mount info", "/test/result", "/test/result"),
+		table.Entry("ostree normal mount info", "/ostree/deploy/rhcos/test/result", "/test/result"),
+	)
 
 	It("should properly mount and unmount filesystem", func() {
 		sourcePodUID := "ghfjk"

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -882,7 +882,7 @@ func checkIfDiskReadyToUseFunc(filename string) (bool, error) {
 	// Before attempting to attach, ensure we can open the file
 	file, err := os.OpenFile(filename, os.O_RDWR, 0600)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	if err := file.Close(); err != nil {
 		return false, fmt.Errorf("Unable to close file: %s", file.Name())


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
RHCOS mountinfo was returning a path on a readonly mount and that was causing
the hotplug to fail. This strips the /ostree part of so we get the regular
mount path that is R/W so hotplug succeeds.
Also return error when checking if the disk.img file is able to be opened, to help debug any future issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: hotplug hostpath on RHCOS host not getting right path.
```
