### PR TITLE
Remove now-stable test from quarantine

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -395,7 +395,7 @@ var _ = SIGDescribe("Hotplug", func() {
 
 			verifyVolumeAndDiskVMRemoved(vm, "some-new-volume1", "some-new-volume2")
 		},
-			table.Entry("[QUARANTINE]with DataVolume", addDVVolumeVM, removeVolumeVM),
+			table.Entry("with DataVolume", addDVVolumeVM, removeVolumeVM),
 			table.Entry("[QUARANTINE]with PersistentVolume", addPVCVolumeVM, removeVolumeVM),
 		)
 	})


### PR DESCRIPTION
This one has not failed in 13 days after #5445 was merged.
the PV test seems stable too, but I would like to wait longer to
be sure.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
