### PR TITLE
Fix test-id 4644

### DIFF
--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -197,9 +197,10 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 					By("Deleting the DataVolume")
 					ExpectWithOffset(1, virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Delete(context.Background(), dv.Name, metav1.DeleteOptions{})).To(Succeed(), metav1.DeleteOptions{})
 				}(dv)
-				Eventually(func() (*corev1.PersistentVolumeClaim, error) {
-					return virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
-				}).Should(Not(BeNil()), 30)
+				Eventually(func() error {
+					_, err := virtClient.CoreV1().PersistentVolumeClaims(dv.Namespace).Get(context.Background(), dv.Name, metav1.GetOptions{})
+					return err
+				}, 30*time.Second, 1*time.Second).Should(BeNil())
 
 				vmi := tests.NewRandomVMI()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The timeout for the `Eventually` block was wrongfully passed to the
`Should` assertion, which causes a panic when the test fails and hides
the actual assertion error, this commit fixes this issue, and changes the assertion to show the actual error when it occures

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
