### PR TITLE
Fix test from quarantine - Wait for resize successfully when using block mode

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -740,6 +740,18 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 					snapshotStorageClass,
 				))
 
+				Eventually(func() error {
+					return libnet.WithIPv6(console.LoginToCirros)(vmi)
+				}, 360, 10).Should(Succeed())
+
+				b := append([]expect.Batcher{
+					&expect.BSnd{S: "cat /var/run/resize.rootfs | grep resized\n"},
+					&expect.BExp{R: "resized successfully"},
+				})
+				Eventually(func() error {
+					return console.SafeExpectBatch(vmi, b, 10)
+				}, 60, 20).Should(Succeed())
+
 				doRestore("", true)
 
 			})


### PR DESCRIPTION
    Wait for resize successfully when using block mode
    
    When creating a vm with block mode there is a resize of
    the block device, it seems that in the CI the message of the success of
    the resize might take some time to be printed and it fails the
    test which expects at the time of the late print for
    an empty prompt.
    Instead we should check that the resize completed successfully before
    continuing to the rest of the test.

Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
