### PR TITLE
reflect state of virt-launcher pod on vmi status

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -359,7 +359,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 
 	switch {
 	case vmi.IsUnprocessed():
-		if vmiPodExists {
+		if vmiPodExists && pod.Status.Phase == k8sv1.PodRunning {
 			vmiCopy.Status.Phase = virtv1.Scheduling
 		} else if vmi.DeletionTimestamp != nil || hasFailedDataVolume {
 			vmiCopy.Status.Phase = virtv1.Failed

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -871,11 +871,24 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			controller.Execute()
 		},
 			table.Entry(", not ready and in running state", k8sv1.PodRunning, false),
+			table.Entry(", ready and in running state", k8sv1.PodRunning, true),
+		)
+
+		table.DescribeTable("keep the vmi in pending state if a pod exists", func(phase k8sv1.PodPhase, isReady bool) {
+			vmi := NewPendingVirtualMachine("testvmi")
+			pod := NewPodForVirtualMachine(vmi, phase)
+			pod.Status.ContainerStatuses[0].Ready = isReady
+
+			addVirtualMachine(vmi)
+			podFeeder.Add(pod)
+			addActivePods(vmi, pod.UID, "")
+
+			controller.Execute()
+		},
 			table.Entry(", not ready and in unknown state", k8sv1.PodUnknown, false),
 			table.Entry(", not ready and in succeeded state", k8sv1.PodSucceeded, false),
 			table.Entry(", not ready and in failed state", k8sv1.PodFailed, false),
 			table.Entry(", not ready and in pending state", k8sv1.PodPending, false),
-			table.Entry(", ready and in running state", k8sv1.PodRunning, true),
 			table.Entry(", ready and in unknown state", k8sv1.PodUnknown, true),
 			table.Entry(", ready and in succeeded state", k8sv1.PodSucceeded, true),
 			table.Entry(", ready and in failed state", k8sv1.PodFailed, true),


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

I'm not sure if this is actually correct. It does seem strange to have the VMI phase in `Scheduling` when the Pod phase is `Failed` `Pending` or `Unknown`. I think it makes sense update to `Scheduling` when the Pod is running since that means  

```
	// PodRunning means the pod has been bound to a node and all of the containers have been started.
	// At least one container is still running or is in the process of being restarted.
```

which at that point is when the VMI would be `Scheduling`. But it also seems a bit confusing this way as well... interested in other peoples thoughts on how to properly reflect the state. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5195

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change VMI phase to update to Scheduling only if pod is Running
```
