### PR TITLE
add special node-labeller annotations

### DIFF
--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -170,6 +170,10 @@ func (n *NodeLabeller) run() error {
 
 	node := originalNode.DeepCopy()
 
+	if skipNode(node) {
+		return nil
+	}
+
 	//prepare new labels
 	newLabels := n.prepareLabels(cpuModels, cpuFeatures)
 	//remove old labeller labels
@@ -180,6 +184,11 @@ func (n *NodeLabeller) run() error {
 	err = n.patchNode(originalNode, node)
 
 	return err
+}
+
+func skipNode(node *v1.Node) bool {
+	_, exists := node.Annotations[kubevirtv1.LabellerSkipNodeAnnotation]
+	return exists
 }
 
 func (n *NodeLabeller) patchNode(originalNode, node *v1.Node) error {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -667,9 +667,10 @@ const (
 	HypervLabel = "hyperv.node.kubevirt.io/"
 	// This label represents vendor of cpu model on the node
 	CPUModelVendorLabel = "cpu-vendor.node.kubevirt.io/"
-
-	VirtualMachineLabel        = AppLabel + "/vm"
-	MemfdMemoryBackend  string = "kubevirt.io/memfd"
+	//
+	LabellerSkipNodeAnnotation        = "node-labeller.kubevirt.io/skip-node"
+	VirtualMachineLabel               = AppLabel + "/vm"
+	MemfdMemoryBackend         string = "kubevirt.io/memfd"
 
 	MigrationSelectorLabel = "kubevirt.io/vmi-name"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
add special node-labeller annotations
this annotations causes that node-labeller will skip reconciling the
node which has this annotation

**Which issue(s) this PR fixes**:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1956792

**Special notes for your reviewer**:

**Release note**:
```
add node-labeller.kubevirt.io/skip-node annotation 
```
Signed-off-by: Karel Šimon <ksimon@redhat.com>
