### PR TITLE
generate rest coverage report after functional tests execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ cluster/local/certs
 *.crt
 *.csr
 _out
+exported-artifacts
 vendor/**/*_test.go
 **/polarion.xml
 .coverprofile*

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -157,6 +157,7 @@ if [[ $TARGET =~ windows.* ]]; then
 fi
 
 kubectl() { cluster-up/kubectl.sh "$@"; }
+cli() { cluster-up/cli.sh "$@"; }
 
 collect_debug_logs() {
     local containers
@@ -363,3 +364,19 @@ fi
 
 # Run functional tests
 FUNC_TEST_ARGS=$ginko_params make functest
+
+# Run REST API coverage based on k8s audit log and openapi spec
+if [ -n "$RUN_REST_COVERAGE" ]; then
+  echo "Generating REST API coverage report"
+  wget https://github.com/mfranczy/crd-rest-coverage/releases/download/v0.1.3/rest-coverage -O "$WORKSPACE/_out/rest-coverage"
+  chmod +x "$WORKSPACE/_out/rest-coverage"
+  AUDIT_LOG_PATH=${AUDIT_LOG_PATH-/var/log/k8s-audit/k8s-audit.log}
+  log_dest="$ARTIFACTS_PATH/cluster-audit.log"
+  cli scp "$AUDIT_LOG_PATH" - > $log_dest
+  "$WORKSPACE/_out/rest-coverage" \
+    --swagger-path "$WORKSPACE/api/openapi-spec/swagger.json" \
+    --audit-log-path $log_dest \
+    --output-path "$ARTIFACTS_PATH/rest-coverage.json" \
+    --ignore-resource-version
+  echo "REST API coverage report generated"
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Generate rest coverage report after functional tests, this gives some insights about used endpoints and fields during tests execution.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4768 

**Special notes for your reviewer**:
Currently the coverage tool ignores version of KubeVirt resources. For KubeVirt the openapi spec is generated for `v1` but all are sent to `v1alpha3` endpoint, because of that, I am not able to match audit log with openapi spec thus I ignore version.
I think in that case it's fine since the API structures are the same for v1alpha3 and v1.

Next step will be to add a test prow job that runs the coverage report tool to check if something should be improved and eliminate potential misbehaviours.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Generate REST API coverage report after functional tests
```
