### PR TITLE
Remove now-stable hotplug test from quarantine.

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -396,7 +396,7 @@ var _ = SIGDescribe("Hotplug", func() {
 			verifyVolumeAndDiskVMRemoved(vm, "some-new-volume1", "some-new-volume2")
 		},
 			table.Entry("with DataVolume", addDVVolumeVM, removeVolumeVM),
-			table.Entry("[QUARANTINE]with PersistentVolume", addPVCVolumeVM, removeVolumeVM),
+			table.Entry("with PersistentVolume", addPVCVolumeVM, removeVolumeVM),
 		)
 	})
 


### PR DESCRIPTION
Waited a bit longer to see that this variant is also stable.
No failures in the past 14 days.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
