### PR TITLE
Fix gcsweb base url for kubevirt master nightly

### DIFF
--- a/hack/ci/entrypoint.sh
+++ b/hack/ci/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+gcsweb_base_url="https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow"
+
 function test_kubevirt_release() {
     release="$(get_release_tag_for_xy "$1")"
     export DOCKER_TAG="$release"
@@ -29,7 +31,7 @@ function deploy_release() {
     curl -L "${tagged_release_url}/kubevirt-operator.yaml" | oc create -f -
     curl -L "${tagged_release_url}/kubevirt-cr.yaml" | oc create -f -
 
-    testing_infra_url="https://gcsweb.apps.ovirt.org/gcs/kubevirt-prow/devel/release/kubevirt/kubevirt/${release}/manifests/testing/"
+    testing_infra_url="$gcsweb_base_url/devel/release/kubevirt/kubevirt/${release}/manifests/testing/"
     for testinfra_file in $(curl -L "${testing_infra_url}" | grep -oE 'https://[^"]*\.yaml'); do
         curl -L ${testinfra_file} | oc create -f -
     done
@@ -73,13 +75,13 @@ function get_release_tag_for_kubevirt_nightly() {
 }
 
 function get_release_url_for_kubevirt_nightly() {
-    release_base_url="https://gcsweb.apps.ovirt.org/gcs/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt"
+    release_base_url="$gcsweb_base_url/devel/nightly/release/kubevirt/kubevirt"
     release_date="$1"
     echo "${release_base_url}/${release_date}"
 }
 
 function get_latest_release_date_for_kubevirt_nightly() {
-    release_base_url="https://gcsweb.apps.ovirt.org/gcs/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt"
+    release_base_url="$gcsweb_base_url/devel/nightly/release/kubevirt/kubevirt"
     release_date=$(curl -L "${release_base_url}/latest")
     echo "${release_date}"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

After the prow migration the gcsweb base url has changed, this needs to get fixed in the script that downloads the manifests and the test binary from there. Otherwise the tests fail like this: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-kubevirt-kubevirt-master-4.8-e2e/1391589525796425728#1:build-log.txt%3A31

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
