### PR TITLE
Update removevolume virtctl example.

### DIFF
--- a/pkg/virtctl/vm/vm.go
+++ b/pkg/virtctl/vm/vm.go
@@ -190,7 +190,7 @@ func NewRemoveVolumeCommand(clientConfig clientcmd.ClientConfig) *cobra.Command 
 	cmd := &cobra.Command{
 		Use:     "removevolume VMI",
 		Short:   "remove a volume from a running VM",
-		Example: usage(COMMAND_REMOVEVOLUME),
+		Example: usageRemoveVolume(),
 		Args:    templates.ExactArgs("removevolume", 1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := Command{command: COMMAND_REMOVEVOLUME, clientConfig: clientConfig}
@@ -253,6 +253,16 @@ func usageAddVolume() string {
 
   #Dynamically attach a volume to a running VM and persisting it in the VM spec. At next VM restart the volume will be attached like any other volume.
   {{ProgramName}} addvolume fedora-dv --volume-name=example-dv --persist
+  `
+	return usage
+}
+
+func usageRemoveVolume() string {
+	usage := `  #Remove volume that was dynamically attached to a running VM.
+  {{ProgramName}} removevolume fedora-dv --volume-name=example-dv
+
+  #Remove volume dynamically attached to a running VM and persisting it in the VM spec.
+  {{ProgramName}} removevolume fedora-dv --volume-name=example-dv --persist
   `
 	return usage
 }


### PR DESCRIPTION
The example didn't include all examples like addvolume does. Added an
example of removevolume and removevolume with --persist.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes [RHBZ 1954498](https://bugzilla.redhat.com/show_bug.cgi?id=1954498)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
