### PR TITLE
network, bind mechs: make create tap device function a method

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -542,8 +542,7 @@ func (b *BridgeBindMechanism) preparePodNetworkInterface() error {
 		return err
 	}
 
-	err := createAndBindTapToBridge(b.handler, b.tapDeviceName, b.bridgeInterfaceName, b.queueCount, *b.launcherPID, int(b.vif.Mtu), netdriver.LibvirtUserAndGroupId)
-	if err != nil {
+	if err := b.createAndBindTapToBridge(); err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", b.tapDeviceName)
 		return err
 	}
@@ -590,6 +589,17 @@ func (b *BridgeBindMechanism) decorateConfig(domainIface api.Interface) error {
 		}
 	}
 	return nil
+}
+
+func (b BridgeBindMechanism) createAndBindTapToBridge() error {
+	return createAndBindTapToBridge(
+		b.handler,
+		b.tapDeviceName,
+		b.bridgeInterfaceName,
+		b.queueCount,
+		*b.launcherPID,
+		int(b.vif.Mtu),
+		netdriver.LibvirtUserAndGroupId)
 }
 
 func getPIDString(pid *int) string {
@@ -878,8 +888,7 @@ func (b *MasqueradeBindMechanism) preparePodNetworkInterface() error {
 	}
 
 	tapDeviceName := generateTapDeviceName(b.podInterfaceName)
-	err = createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.queueCount, *b.launcherPID, int(b.vif.Mtu), netdriver.LibvirtUserAndGroupId)
-	if err != nil {
+	if err := b.createAndBindTapToBridge(); err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err
 	}
@@ -931,6 +940,17 @@ func (b *MasqueradeBindMechanism) decorateConfig(domainIface api.Interface) erro
 		}
 	}
 	return nil
+}
+
+func (b MasqueradeBindMechanism) createAndBindTapToBridge() error {
+	return createAndBindTapToBridge(
+		b.handler,
+		generateTapDeviceName(b.podInterfaceName),
+		b.bridgeInterfaceName,
+		b.queueCount,
+		*b.launcherPID,
+		int(b.vif.Mtu),
+		netdriver.LibvirtUserAndGroupId)
 }
 
 func (b *MasqueradeBindMechanism) loadCachedVIF(pid string) error {


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This helps the reader focus on what's important, by explicitly indicating that all inputs are available within the `BindMechanism` implementations.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
