### PR TITLE
Expand our backport policy to include logging and debug fixes

### DIFF
--- a/docs/release-branch-backporting.md
+++ b/docs/release-branch-backporting.md
@@ -32,6 +32,7 @@ categories.
 - Addresses a logical defect in KubeVirt
 - Fixes or improves the stability of our test suite
 - Any infrastructure change related testing or releasing
+- Logging and debug changes aimed at improving supportability of a stable release.
 
 There is purposefully some ambiguity here. These are meant to be read as
 guidelines to help reviewers make judgment calls. The intent here is to keep


### PR DESCRIPTION
When supporting stable release branches, we often need to introduce changes that improve logging and debuggability. This updates our policy to officially allow for those changes so it's no longer a grey area.


```release-note
Expand backport policy to include logging and debug fixes
```
