### PR TITLE
Remove restore test from quarantine - hasn't failed in 14 days

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -575,7 +575,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 
-			It("[QUARANTINE][test_id:5261]should restore a vm that boots from a datavolume (not template)", func() {
+			It("[test_id:5261]should restore a vm that boots from a datavolume (not template)", func() {
 				vm = tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					tests.GetUrl(tests.CirrosHttpUrl),
 					tests.NamespaceTestDefault,


### PR DESCRIPTION
I can't point to a single commit, but it shares the bulk of its
logic with recently de-flaked tests, and it's reasonable to
suspect it is fixed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
