### PR TITLE
Fix ineffassign warning: ineffectual assignment to isBlockPVC/isBlockDV

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -650,13 +650,11 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	diskInfo := make(map[string]*containerdisk.DiskInfo)
 	for i, volume := range vmi.Spec.Volumes {
 		if volume.VolumeSource.PersistentVolumeClaim != nil {
-			isBlockPVC := false
 			if _, ok := hotplugVolumes[volume.Name]; ok {
-				isBlockPVC = isHotplugBlockDeviceVolume(volume.Name)
+				isBlockPVCMap[volume.Name] = isHotplugBlockDeviceVolume(volume.Name)
 			} else {
-				isBlockPVC, _ = isBlockDeviceVolume(volume.Name)
+				isBlockPVCMap[volume.Name], _ = isBlockDeviceVolume(volume.Name)
 			}
-			isBlockPVCMap[volume.Name] = isBlockPVC
 		} else if volume.VolumeSource.ContainerDisk != nil {
 			image, err := containerdisk.GetDiskTargetPartFromLauncherView(i)
 			if err != nil {
@@ -668,13 +666,11 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 			}
 			diskInfo[volume.Name] = info
 		} else if volume.VolumeSource.DataVolume != nil {
-			isBlockDV := false
 			if _, ok := hotplugVolumes[volume.Name]; ok {
-				isBlockDV = isHotplugBlockDeviceVolume(volume.Name)
+				isBlockDVMap[volume.Name] = isHotplugBlockDeviceVolume(volume.Name)
 			} else {
-				isBlockDV, _ = isBlockDeviceVolume(volume.Name)
+				isBlockDVMap[volume.Name], _ = isBlockDeviceVolume(volume.Name)
 			}
-			isBlockDVMap[volume.Name] = isBlockDV
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Zou Yu <zouy.fnst@cn.fujitsu.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
