### PR TITLE
Flip flop attachment pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,9 +49,9 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190725173916-b56e63a643cc
 	github.com/operator-framework/operator-marketplace v0.0.0-20190617165322-1cbd32624349
 	github.com/pborman/uuid v1.2.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/client_model v0.2.0
-	github.com/prometheus/procfs v0.2.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/subgraph/libmacouflage v0.0.1

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1446,7 +1446,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 		} else {
 			pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, k8sv1.VolumeMount{
 				Name:      volume.Name,
-				MountPath: fmt.Sprintf("/pvc-%s", volume.Name),
+				MountPath: fmt.Sprintf("/%s", volume.Name),
 			})
 		}
 	}

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1335,7 +1335,7 @@ func (c *VMIController) needsHandleHotplug(hotplugVolumes []*virtv1.Volume, hotp
 		}
 		return true
 	}
-	return len(hotplugVolumes) > 0 && true
+	return len(hotplugVolumes) > 0
 }
 
 func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod, vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod, dataVolumes []*cdiv1.DataVolume) syncError {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -1327,7 +1327,6 @@ func (c *VMIController) virtlauncherAttachmentPods(virtlauncherPod *k8sv1.Pod) (
 }
 
 func (c *VMIController) needsHandleHotplug(hotplugVolumes []*virtv1.Volume, hotplugAttachmentPods []*k8sv1.Pod) bool {
-
 	// Determine if the ready volumes have changed compared to the current pod
 	for _, attachmentPod := range hotplugAttachmentPods {
 		if c.podVolumesMatchesReadyVolumes(attachmentPod, hotplugVolumes) {
@@ -1336,7 +1335,6 @@ func (c *VMIController) needsHandleHotplug(hotplugVolumes []*virtv1.Volume, hotp
 		}
 		return true
 	}
-	log.DefaultLogger().Infof("Handle no matching attachment pod found!")
 	return len(hotplugVolumes) > 0 && true
 }
 
@@ -1367,14 +1365,6 @@ func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, ho
 		}
 		readyHotplugVolumes = append(readyHotplugVolumes, volume)
 	}
-	logger.Infof("Ready to attach to node volumes: %d", len(readyHotplugVolumes))
-	for _, volume := range readyHotplugVolumes {
-		logger.Infof("volume: %s", volume.Name)
-	}
-	logger.Infof("Number of attachment pods: %d", len(hotplugAttachmentPods))
-	for _, pod := range hotplugAttachmentPods {
-		logger.Infof("attachment pod: %s/%s", pod.Namespace, pod.Name)
-	}
 	// Determine if the ready volumes have changed compared to the current pod
 	currentPod := make([]*k8sv1.Pod, 0)
 	oldPods := make([]*k8sv1.Pod, 0)
@@ -1384,14 +1374,6 @@ func (c *VMIController) handleHotplugVolumes(hotplugVolumes []*virtv1.Volume, ho
 		} else {
 			currentPod = append(currentPod, attachmentPod)
 		}
-	}
-	logger.Infof("Number of current pods: %d", len(currentPod))
-	for _, pod := range currentPod {
-		logger.Infof("current pod: %s/%s", pod.Namespace, pod.Name)
-	}
-	logger.Infof("Number of old pods: %d", len(oldPods))
-	for _, pod := range oldPods {
-		logger.Infof("old pod: %s/%s", pod.Namespace, pod.Name)
 	}
 
 	if len(currentPod) == 0 && len(readyHotplugVolumes) > 0 {
@@ -1421,12 +1403,9 @@ func (c *VMIController) podVolumesMatchesReadyVolumes(attachmentPod *k8sv1.Pod, 
 			podVolumeMap[volume.Name] = volume
 		}
 	}
-	log.DefaultLogger().Infof("pod volume map before: [%v]", podVolumeMap)
 	for _, volume := range volumes {
-		log.DefaultLogger().Infof("Deleting: %s", volume.Name)
 		delete(podVolumeMap, volume.Name)
 	}
-	log.DefaultLogger().Infof("pod volume map after: [%v]", podVolumeMap)
 	return len(podVolumeMap) == 0
 }
 

--- a/pkg/virt-handler/hotplug-disk/BUILD.bazel
+++ b/pkg/virt-handler/hotplug-disk/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "findmnt.go",
         "generated_mock_mount.go",
         "mount.go",
     ],
@@ -21,7 +22,7 @@ go_library(
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/devices:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fscommon:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/configs:go_default_library",
-        "//vendor/github.com/prometheus/procfs:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )
@@ -29,6 +30,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "findmnt_test.go",
         "hotplug-disk_suite_test.go",
         "mount_test.go",
     ],
@@ -42,7 +44,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/github.com/prometheus/procfs:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/virt-handler/hotplug-disk/findmnt.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt.go
@@ -1,3 +1,21 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
 package hotplug_volume
 
 import (

--- a/pkg/virt-handler/hotplug-disk/findmnt.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt.go
@@ -1,0 +1,75 @@
+package hotplug_volume
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	rhcosPrefix = "/ostree/deploy/rhcos"
+)
+
+var (
+	sourceRgx = regexp.MustCompile(`\[(.+)\]`)
+
+	findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
+		return exec.Command("/usr/bin/findmnt", "-T", fmt.Sprintf("/%s", volumeName), "-N", strconv.Itoa(pid), "-J").CombinedOutput()
+	}
+
+	findMntByDevice = func(deviceName string) ([]byte, error) {
+		return exec.Command("/usr/bin/findmnt", "-S", deviceName, "-N", "1", "-J").CombinedOutput()
+	}
+)
+
+type FindmntInfo struct {
+	Target  string `json:"target"`
+	Source  string `json:"source"`
+	Fstype  string `json:"fstype"`
+	Options string `json:"options"`
+}
+
+type FileSystems struct {
+	Filesystems []FindmntInfo `json:"filesystems"`
+}
+
+func LookupFindmntInfoByVolume(volumeName string, pid int) ([]FindmntInfo, error) {
+	mntInfoJson, err := findMntByVolume(volumeName, pid)
+	if err != nil {
+		return make([]FindmntInfo, 0), errors.Wrapf(err, "Error running findmnt for volume %s", volumeName)
+	}
+	return parseMntInfoJson(mntInfoJson)
+}
+
+func LookupFindmntInfoByDevice(deviceName string) ([]FindmntInfo, error) {
+	mntInfoJson, err := findMntByDevice(deviceName)
+	if err != nil {
+		return make([]FindmntInfo, 0), errors.Wrapf(err, "Error running findmnt for device %s", deviceName)
+	}
+	return parseMntInfoJson(mntInfoJson)
+}
+
+func parseMntInfoJson(mntInfoJson []byte) ([]FindmntInfo, error) {
+	mntinfo := FileSystems{}
+	if err := json.Unmarshal(mntInfoJson, &mntinfo); err != nil {
+		return mntinfo.Filesystems, errors.Wrapf(err, "unable to unmarshal [%v]", mntInfoJson)
+	}
+	return mntinfo.Filesystems, nil
+}
+
+func (f *FindmntInfo) GetSource() string {
+	match := sourceRgx.FindStringSubmatch(f.Source)
+	if len(match) != 2 {
+		return strings.TrimPrefix(f.Source, rhcosPrefix)
+	}
+	return strings.TrimPrefix(match[1], rhcosPrefix)
+}
+
+func (f *FindmntInfo) GetOptions() []string {
+	return strings.Split(f.Options, ",")
+}

--- a/pkg/virt-handler/hotplug-disk/findmnt_test.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt_test.go
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Copyright 2020 Red Hat, Inc.
+ * Copyright 2021 Red Hat, Inc.
  *
  */
 

--- a/pkg/virt-handler/hotplug-disk/findmnt_test.go
+++ b/pkg/virt-handler/hotplug-disk/findmnt_test.go
@@ -1,0 +1,147 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package hotplug_volume
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	invalidFindmntByVolume = "{\"filesystems\": [{:\"/t\", \"source\":\"/dev/testvolume\", \"fstype\":\"xfs\", \"options\":\"rw,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota\"}]}"
+)
+
+var _ = Describe("findmnt", func() {
+	callFindMntByVolume := func() ([]FindmntInfo, error) {
+		findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
+			return []byte(fmt.Sprintf(findmntByVolumeRes, "testvolume", "/test/path")), nil
+		}
+		return LookupFindmntInfoByVolume("test", 1234)
+	}
+
+	callFindMntByDevice := func() ([]FindmntInfo, error) {
+		findMntByDevice = func(volumeName string) ([]byte, error) {
+			return []byte(fmt.Sprintf(findmntByVolumeRes, "testvolume", "/test/path")), nil
+		}
+		return LookupFindmntInfoByDevice("test")
+	}
+
+	callFindMntByVolumeBrokenFindmnt := func() ([]FindmntInfo, error) {
+		findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
+			return []byte(""), fmt.Errorf("findmnt is busted")
+		}
+		return LookupFindmntInfoByVolume("test", 1234)
+	}
+
+	callFindMntByDeviceBrokenFindmnt := func() ([]FindmntInfo, error) {
+		findMntByDevice = func(volumeName string) ([]byte, error) {
+			return []byte(""), fmt.Errorf("findmnt is busted")
+		}
+		return LookupFindmntInfoByDevice("test")
+	}
+
+	callFindMntByVolumeInvalidJson := func() ([]FindmntInfo, error) {
+		findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
+			return []byte(invalidFindmntByVolume), nil
+		}
+		return LookupFindmntInfoByVolume("test", 1234)
+	}
+
+	callFindMntByDeviceInvalidJson := func() ([]FindmntInfo, error) {
+		findMntByDevice = func(volumeName string) ([]byte, error) {
+			return []byte(invalidFindmntByVolume), nil
+		}
+		return LookupFindmntInfoByDevice("test")
+	}
+
+	AfterEach(func() {
+		findMntByVolume = orgFindMntByVolume
+		findMntByDevice = orgFindMntByDevice
+	})
+
+	table.DescribeTable("Should return a list of values, with valid input", func(findMntFunc func() ([]FindmntInfo, error)) {
+		res, err := findMntFunc()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(res)).To(Equal(1))
+		Expect(res[0].GetSource()).To(Equal("/test/path"))
+		Expect(res[0].Target).To(Equal("/testvolume"))
+		Expect(res[0].Fstype).To(Equal("xfs"))
+		Expect(len(res[0].GetOptions())).To(Equal(8))
+		Expect(res[0].GetOptions()[0]).To(Equal("rw"))
+		Expect(res[0].GetOptions()[1]).To(Equal("relatime"))
+		Expect(res[0].GetOptions()[2]).To(Equal("seclabel"))
+		Expect(res[0].GetOptions()[3]).To(Equal("attr2"))
+		Expect(res[0].GetOptions()[4]).To(Equal("inode64"))
+		Expect(res[0].GetOptions()[5]).To(Equal("logbufs=8"))
+		Expect(res[0].GetOptions()[6]).To(Equal("logbsize=32k"))
+		Expect(res[0].GetOptions()[7]).To(Equal("noquota"))
+	},
+		table.Entry("for findmntbyvolume", callFindMntByVolume),
+		table.Entry("for findmntbydevice", callFindMntByDevice),
+	)
+
+	table.DescribeTable("Should return an error if findmnt fails", func(findMntFunc func() ([]FindmntInfo, error)) {
+		_, err := findMntFunc()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("findmnt is busted"))
+		Expect(err.Error()).To(ContainSubstring("test"))
+	},
+		table.Entry("for findmntbyvolume", callFindMntByVolumeBrokenFindmnt),
+		table.Entry("for findmntbydevice", callFindMntByDeviceBrokenFindmnt),
+	)
+
+	table.DescribeTable("Should return an error if unmarshalling fails", func(findMntFunc func() ([]FindmntInfo, error)) {
+		_, err := findMntFunc()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unable to unmarshal"))
+	},
+		table.Entry("for findmntbyvolume", callFindMntByVolumeInvalidJson),
+		table.Entry("for findmntbydevice", callFindMntByDeviceInvalidJson),
+	)
+
+	It("GetSource should properly match source field", func() {
+		test := FindmntInfo{
+			Source: "/dev/test",
+		}
+		Expect(test.GetSource()).To(Equal("/dev/test"))
+		test2 := FindmntInfo{
+			Source: "/dev/test[/mnt/something/else/]",
+		}
+		Expect(test2.GetSource()).To(Equal("/mnt/something/else/"))
+		test3 := FindmntInfo{
+			Source: "/dev/test[/mnt/something/else/[/more]]",
+		}
+		Expect(test3.GetSource()).To(Equal("/mnt/something/else/[/more]"))
+	})
+
+	It("GetOptions should properly return a list", func() {
+		test := FindmntInfo{
+			Options: "aa,bb,cc,dd",
+		}
+		Expect(len(test.GetOptions())).To(Equal(4))
+		Expect(test.GetOptions()[0]).To(Equal("aa"))
+		Expect(test.GetOptions()[1]).To(Equal("bb"))
+		Expect(test.GetOptions()[2]).To(Equal("cc"))
+		Expect(test.GetOptions()[3]).To(Equal("dd"))
+	})
+})

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -250,6 +250,7 @@ func (m *volumeMounter) Mount(vmi *v1.VirtualMachineInstance) error {
 	if err != nil {
 		return err
 	}
+	logger.Infof("record for: %s, %v", vmi.UID, record)
 	for _, volumeStatus := range vmi.Status.VolumeStatus {
 		if volumeStatus.HotplugVolume == nil {
 			// Skip non hotplug volumes
@@ -607,7 +608,6 @@ func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.Virtua
 				}
 				split := strings.Split(string(target), "\n")
 				if len(split) > 0 {
-					log.DefaultLogger().Infof("Target: [%s]", split[1])
 					return split[1], nil
 				}
 			} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -338,6 +338,7 @@ github.com/pborman/uuid
 # github.com/pkg/diff v0.0.0-20190930165518-531926345625
 github.com/pkg/diff
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.7.1
 ## explicit
@@ -352,7 +353,6 @@ github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
 # github.com/prometheus/procfs v0.2.0
-## explicit
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The PR modifies the hotplug code to recreate the attachment pod with the current number of hotplug volumes in it. Instead of one pod per volume. This reduces the number of extra pods used by the hotplug system to 1 instead of N.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enhancement: remove one attachment pod per disk limit
```
