### PR TITLE
[release-0.36] virt-launcher, Fix flaky VMI report

### DIFF
--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -213,6 +213,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -238,6 +240,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			err := AddGhostRecord("test1-namespace", "test1", "somefile1", "1234-1")
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
@@ -265,6 +269,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -283,12 +289,16 @@ var _ = Describe("Domain informer", func() {
 
 			domain := api.NewMinimalDomain("test")
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{domain}, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(domain.Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 			// now prove if we make a change, like adding a label, that the resync
 			// will pick that change up automatically
 			newDomain := domain.DeepCopy()
 			newDomain.ObjectMeta.Labels = make(map[string]string)
 			newDomain.ObjectMeta.Labels["some-label"] = "some-value"
 			domainManager.EXPECT().ListAllDomains().Return([]*api.Domain{newDomain}, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(nil)
+			domainManager.EXPECT().InterfacesStatus(newDomain.Spec.Devices.Interfaces).Return(nil)
 
 			runCMDServer(wg, socketPath, domainManager, stopChan, nil)
 
@@ -435,6 +445,8 @@ var _ = Describe("Domain informer", func() {
 			list = append(list, domain)
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{})
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return([]api.InterfaceStatus{})
 
 			// This file doesn't have a unix sock server behind it
 			// verify list still completes regardless

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/util/net/ip:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-launcher/virtwrap/agent-poller:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter:go_default_library",

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -130,6 +130,27 @@ func (s *AsyncAgentStore) GetSysInfo() api.DomainSysInfo {
 	}
 }
 
+// GetInterfaceStatus returns the interfaces Guest Agent reported
+func (s *AsyncAgentStore) GetInterfaceStatus() []api.InterfaceStatus {
+	data, ok := s.store.Load(GET_INTERFACES)
+	if ok {
+		return data.([]api.InterfaceStatus)
+	}
+
+	return nil
+}
+
+// GetGuestOSInfo returns the Guest OS version and architecture
+func (s *AsyncAgentStore) GetGuestOSInfo() *api.GuestOSInfo {
+	data, ok := s.store.Load(GET_OSINFO)
+	if ok {
+		osInfo := data.(api.GuestOSInfo)
+		return &osInfo
+	}
+
+	return nil
+}
+
 // GetGA returns guest agent record with its version if present
 func (s *AsyncAgentStore) GetGA() AgentInfo {
 	data, ok := s.store.Load(GET_AGENT)

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -83,6 +83,54 @@ var _ = Describe("Qemu agent poller", func() {
 			agentStore.Store(GET_OSINFO, fakeInfo)
 			Expect(agentStore.AgentUpdated).ToNot(Receive())
 		})
+
+		It("should report nil slice when no interfaces exists", func() {
+			var agentStore = NewAsyncAgentStore()
+			interfacesStatus := agentStore.GetInterfaceStatus()
+
+			Expect(interfacesStatus).To(BeNil())
+		})
+
+		It("should report interfaces info when interfaces exists", func() {
+			var agentStore = NewAsyncAgentStore()
+
+			fakeInterfaces := []api.InterfaceStatus{
+				{
+					Name: "eth1",
+					Mac:  "00:00:00:00:00:01",
+				},
+			}
+			agentStore.Store(GET_INTERFACES, fakeInterfaces)
+			interfacesStatus := agentStore.GetInterfaceStatus()
+
+			Expect(interfacesStatus).To(Equal(fakeInterfaces))
+		})
+
+		It("should report nil when no osInfo exists", func() {
+			var agentStore = NewAsyncAgentStore()
+			osInfo := agentStore.GetGuestOSInfo()
+
+			Expect(osInfo).To(BeNil())
+		})
+
+		It("should report osInfo when osInfo exists", func() {
+			var agentStore = NewAsyncAgentStore()
+			fakeInfo := api.GuestOSInfo{
+				Name:          "TestGuestOSName",
+				KernelRelease: "1.1.0-Generic",
+				Version:       "1.0.0",
+				PrettyName:    "TestGuestOSName 1.0.0",
+				VersionId:     "1.0.0",
+				KernelVersion: "1.1.0",
+				Machine:       "x86_64",
+				Id:            "testguestos",
+			}
+
+			agentStore.Store(GET_OSINFO, fakeInfo)
+			osInfo := agentStore.GetGuestOSInfo()
+
+			Expect(*osInfo).To(Equal(fakeInfo))
+		})
 	})
 
 	Context("PollerWorker", func() {

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -310,7 +310,14 @@ func (l *Launcher) GetDomain(ctx context.Context, request *cmdv1.EmptyRequest) (
 	}
 
 	if len(list) > 0 {
-		if domain, err := json.Marshal(list[0]); err != nil {
+		domainObj := list[0]
+		if osInfo := l.domainManager.GetGuestOSInfo(); osInfo != nil {
+			domainObj.Status.OSInfo = *osInfo
+		}
+		if interfaces := l.domainManager.InterfacesStatus(domainObj.Spec.Devices.Interfaces); interfaces != nil {
+			domainObj.Status.Interfaces = interfaces
+		}
+		if domain, err := json.Marshal(domainObj); err != nil {
 			log.Log.Reason(err).Errorf("Failed to marshal domain")
 			response.Response.Success = false
 			response.Response.Message = getErrorMessage(err)

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -120,17 +120,46 @@ var _ = Describe("Virt remote commands", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should list domains", func() {
+		It("should list domains when no guest agent info exists", func() {
 			var list []*api.Domain
 			list = append(list, api.NewMinimalDomain("testvmi1"))
 
 			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			domainManager.EXPECT().GetGuestOSInfo().Return(nil)
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return(nil)
 			domain, exists, err := client.GetDomain()
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(exists).To(BeTrue())
 			Expect(domain).ToNot(Equal(nil))
 			Expect(domain.ObjectMeta.Name).To(Equal("testvmi1"))
+			Expect(domain.Status.OSInfo).To(Equal(api.GuestOSInfo{}))
+			Expect(domain.Status.Interfaces).To(BeNil())
+		})
+
+		It("should list domains when guest agent info exists", func() {
+			const vmiName = "testvmi1"
+			list := []*api.Domain{api.NewMinimalDomain(vmiName)}
+
+			fakeInterfaces := []api.InterfaceStatus{
+				{
+					Name: "eth1",
+					Mac:  "00:00:00:00:00:01",
+				},
+			}
+			domainManager.EXPECT().InterfacesStatus(list[0].Spec.Devices.Interfaces).Return(fakeInterfaces)
+			domainManager.EXPECT().ListAllDomains().Return(list, nil)
+			const osName = "fedora"
+			domainManager.EXPECT().GetGuestOSInfo().Return(&api.GuestOSInfo{Name: osName})
+
+			domain, exists, err := client.GetDomain()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(exists).To(BeTrue())
+			Expect(domain).ToNot(BeNil())
+			Expect(domain.ObjectMeta.Name).To(Equal(vmiName))
+			Expect(domain.Status.OSInfo).To(Equal(api.GuestOSInfo{Name: osName}))
+			Expect(domain.Status.Interfaces).To(Equal(fakeInterfaces))
 		})
 
 		It("should list no domain if no domain is there yet", func() {

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -199,3 +199,23 @@ func (_m *MockDomainManager) SetGuestTime(_param0 *v1.VirtualMachineInstance) er
 func (_mr *_MockDomainManagerRecorder) SetGuestTime(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetGuestTime", arg0)
 }
+
+func (_m *MockDomainManager) InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus {
+	ret := _m.ctrl.Call(_m, "InterfacesStatus", domainInterfaces)
+	ret0, _ := ret[0].([]api.InterfaceStatus)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) InterfacesStatus(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "InterfacesStatus", arg0)
+}
+
+func (_m *MockDomainManager) GetGuestOSInfo() *api.GuestOSInfo {
+	ret := _m.ctrl.Call(_m, "GetGuestOSInfo")
+	ret0, _ := ret[0].(*api.GuestOSInfo)
+	return ret0
+}
+
+func (_mr *_MockDomainManagerRecorder) GetGuestOSInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetGuestOSInfo")
+}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -106,6 +106,8 @@ type DomainManager interface {
 	GetUsers() ([]v1.VirtualMachineInstanceGuestOSUser, error)
 	GetFilesystems() ([]v1.VirtualMachineInstanceFileSystem, error)
 	SetGuestTime(*v1.VirtualMachineInstance) error
+	InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus
+	GetGuestOSInfo() *api.GuestOSInfo
 }
 
 type LibvirtDomainManager struct {
@@ -2036,6 +2038,20 @@ func (l *LibvirtDomainManager) GetGuestInfo() (v1.VirtualMachineInstanceGuestAge
 	}
 
 	return guestInfo, nil
+}
+
+// InterfacesStatus returns the interfaces Guest Agent reported
+func (l *LibvirtDomainManager) InterfacesStatus(domainInterfaces []api.Interface) []api.InterfaceStatus {
+	if interfaces := l.agentData.GetInterfaceStatus(); interfaces != nil {
+		return agentpoller.MergeAgentStatusesWithDomainData(domainInterfaces, interfaces)
+	}
+
+	return nil
+}
+
+// GetGuestOSInfo returns the Guest OS version and architecture
+func (l *LibvirtDomainManager) GetGuestOSInfo() *api.GuestOSInfo {
+	return l.agentData.GetGuestOSInfo()
 }
 
 // GetUsers return the full list of users on the guest machine


### PR DESCRIPTION
Virt-handler refresh the VMI domain information,
each 300 seconds by handleResync function.

The information it fetched doesn't include
Guest Agent information such as Guest OS Info,
and interface status.

This will cause flakiness in the VMI status,
each time that the report is fetched,
until the next update of Guest Agent will be sent
by the virt-launcher to the virt-handler.

This commit fix it by decorating the resync
domain info, with the Guest Agent information,
as the virt-launcher itself does before sending
the domain info to the virt-handler.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1907707

Signed-off-by: Or Shoval <oshoval@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
virt-launcher now populates domain's guestOS info and interfaces status according guest agent also when doing periodic resyncs. 
```
