### PR TITLE
Try to take [test_id:2666] out of quarantine

### DIFF
--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -38,7 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/statsconv"
 )
 
-const ConnectionTimeout = 15 * time.Second
+const ConnectionTimeout = 40 * time.Second
 const ConnectionInterval = 500 * time.Millisecond
 
 // TODO: Should we handle libvirt connection errors transparent or panic?

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -144,7 +144,7 @@ var _ = Describe("[sig-compute]HookSidecars", func() {
 				tests.DisableFeatureGate(virtconfig.SidecarGate)
 			})
 
-			It("[QUARANTINE][test_id:2666]should not start with hook sidecar annotation", func() {
+			It("[test_id:2666]should not start with hook sidecar annotation", func() {
 				By("Starting a VMI")
 				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
 				Expect(err).To(HaveOccurred(), "should not create a VMI without sidecar feature gate")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Test with ID `[test_id:2666]` is getting into quarantine since it's flakie (see [this PR](https://github.com/kubevirt/kubevirt/pull/5658)). The test often fails with the following error that pops up in virt-launcher logs:
```
Connecting to libvirt daemon failed: virError(Code=38, Domain=7, Message='Failed to connect socket to '/var/run/libvirt/libvirt-sock': No such file or directory')
```
The error essentially comes from `NewConnectionWithTimeout()` in `pkg/virt-launcher/virtwrap/cli/libvirt.go`. Th timeout there is 15 seconds. 

since there's a correlation between when this test started failing more and when we [bumped libvirt](https://github.com/kubevirt/kubevirt/pull/5328) it could be that 15 seconds timeout is not enough anymore.

**Special notes for your reviewer**:
After talking to @fgimenez we agreed to issue this PR and wait for the periodic tests' results to see if a larger timeout can stabilize the test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
