### PR TITLE
[release-0.41] Add default webhook timeouts

### DIFF
--- a/pkg/virt-operator/resource/generate/components/webhooks.go
+++ b/pkg/virt-operator/resource/generate/components/webhooks.go
@@ -13,6 +13,8 @@ import (
 var sideEffectNone = admissionregistrationv1.SideEffectClassNone
 var sideEffectNoneOnDryRun = admissionregistrationv1.SideEffectClassNoneOnDryRun
 
+var defaultTimeoutSeconds = int32(10)
+
 func NewOperatorWebhookService(operatorNamespace string) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -87,13 +89,15 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *admissi
 						Resources:   []string{"kubevirts"},
 					},
 				}},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 			},
 			{
 				Name:                    "kubevirt-update-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -144,6 +148,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.Create,
@@ -168,6 +173,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.Create,
@@ -192,6 +198,7 @@ func NewVirtAPIMutatingWebhookConfiguration(installNamespace string) *admissionr
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.Create,
@@ -251,8 +258,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				// We don't want to block evictions in the cluster in a case where this webhook is down.
 				// The eviction of virt-launcher will still be protected by our pdb.
-				FailurePolicy: &ignorePolicy,
-				SideEffects:   &sideEffectNoneOnDryRun,
+				FailurePolicy:  &ignorePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNoneOnDryRun,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.OperationAll,
@@ -275,6 +283,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "virtualmachineinstances-create-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -298,6 +307,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "virtualmachineinstances-update-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -321,6 +331,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "virtualmachine-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -345,6 +356,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "virtualmachinereplicaset-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -369,6 +381,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "virtualmachinepreset-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -393,6 +406,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "migration-create-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -416,6 +430,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "migration-update-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -439,6 +454,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "virtualmachinesnapshot-validator.snapshot.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
@@ -464,6 +480,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				SideEffects:             &sideEffectNone,
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{
 						admissionregistrationv1.Create,
@@ -487,6 +504,7 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *admissio
 				Name:                    "kubevirt-crd-status-validator.kubevirt.io",
 				AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &defaultTimeoutSeconds,
 				SideEffects:             &sideEffectNone,
 				Rules: []admissionregistrationv1.RuleWithOperations{{
 					Operations: []admissionregistrationv1.OperationType{


### PR DESCRIPTION
Manual cherry pick of https://github.com/kubevirt/kubevirt/pull/5661 due to merge conflict. Original PR description follows:

-----------

related to: https://bugzilla.redhat.com/show_bug.cgi?id=1957477

Previously, no default timeout was set on our validation webhook. The default timeout is usually 10 seconds on newer versions of k8s, but it has been seen to be as high as 30 seconds on older versions of k8s. So the default changed.

This has led to some unexpected results, where a Validation Webhook with a failurePolicy: Ignore actually blocks all modifications of resources due to the default 30 second webhook timeout bumping up into the api servers total request timeout period.

Since the default timeout period can be inconsistent, we should instead explicitly set our timeout value and not depend on defaulting. This gives us stronger guarantees around what timeout the api server will observe. A 10 second timeout should be plenty of time for our virt-api component to respond under normal conditions.

```release-note
Validation/Mutation webhooks now explicitly define a 10 second timeout period
```