### PR TITLE
[release-0.36] Add default webhook timeouts

### DIFF
--- a/pkg/virt-operator/creation/components/webhooks.go
+++ b/pkg/virt-operator/creation/components/webhooks.go
@@ -12,6 +12,7 @@ import (
 
 var sideEffectNone = v1beta1.SideEffectClassNone
 var sideEffectNoneOnDryRun = v1beta1.SideEffectClassNoneOnDryRun
+var defaultTimeoutSeconds = int32(10)
 
 func NewOperatorWebhookService(operatorNamespace string) *corev1.Service {
 	return &corev1.Service{
@@ -86,13 +87,15 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *v1beta1
 						Resources:   []string{"kubevirts"},
 					},
 				}},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 			},
 			{
-				Name:          "kubevirt-update-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "kubevirt-update-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Update,
@@ -241,8 +244,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				Name: "virt-launcher-eviction-interceptor.kubevirt.io",
 				// We don't want to block evictions in the cluster in a case where this webhook is down.
 				// The eviction of virt-launcher will still be protected by our pdb.
-				FailurePolicy: &ignorePolicy,
-				SideEffects:   &sideEffectNoneOnDryRun,
+				FailurePolicy:  &ignorePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNoneOnDryRun,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.OperationAll,
@@ -262,9 +266,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachineinstances-create-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "virtualmachineinstances-create-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -284,9 +289,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachineinstances-update-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "virtualmachineinstances-update-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Update,
@@ -306,9 +312,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachine-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "virtualmachine-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -329,9 +336,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinereplicaset-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "virtualmachinereplicaset-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -352,9 +360,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinepreset-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "virtualmachinepreset-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -375,9 +384,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "migration-create-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "migration-create-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -397,9 +407,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "migration-update-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "migration-update-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Update,
@@ -419,9 +430,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinesnapshot-validator.snapshot.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "virtualmachinesnapshot-validator.snapshot.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -442,9 +454,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinerestore-validator.snapshot.kubevirt.io",
-				SideEffects:   &sideEffectNone,
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachinerestore-validator.snapshot.kubevirt.io",
+				SideEffects:    &sideEffectNone,
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -465,9 +478,10 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "kubevirt-crd-status-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				Name:           "kubevirt-crd-status-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,


### PR DESCRIPTION
backport of: #5661 
related to: https://bugzilla.redhat.com/show_bug.cgi?id=1957477 

Previously, no default timeout was set on our validation webhook. The default timeout is usually 10 seconds on newer versions of k8s, but it has been seen to be as high as 30 seconds on older versions of k8s. So the default changed.

This has led to some unexpected results, where a Validation Webhook with a `failurePolicy: Ignore` actually blocks all modifications of resources due to the default 30 second webhook timeout bumping up into the api servers total request timeout period. 

Since the default timeout period can be inconsistent, we should instead explicitly set our timeout value and not depend on defaulting. This gives us stronger guarantees around what timeout the api server will observe. A 10 second timeout should be plenty of time for our virt-api component to respond under normal conditions. 


```release-note
Validation/Mutation webhooks now explicitly define a 10 second timeout period
```
