### PR TITLE
[release-0.34]  Add default webhook timeouts

### DIFF
--- a/pkg/virt-operator/creation/components/webhooks.go
+++ b/pkg/virt-operator/creation/components/webhooks.go
@@ -10,6 +10,8 @@ import (
 	snapshotv1 "kubevirt.io/client-go/apis/snapshot/v1alpha1"
 )
 
+var defaultTimeoutSeconds = int32(10)
+
 func NewOperatorWebhookService(operatorNamespace string) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -83,8 +85,9 @@ func NewOpertorValidatingWebhookConfiguration(operatorNamespace string) *v1beta1
 						Resources:   []string{"kubevirts"},
 					},
 				}},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffectNone,
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
+				SideEffects:    &sideEffectNone,
 			},
 		},
 	}
@@ -214,7 +217,8 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				Name: "virt-launcher-eviction-interceptor.kubevirt.io",
 				// We don't want to block evictions in the cluster in a case where this webhook is down.
 				// The eviction of virt-launcher will still be protected by our pdb.
-				FailurePolicy: &ignorePolicy,
+				FailurePolicy:  &ignorePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.OperationAll,
@@ -234,8 +238,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachineinstances-create-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachineinstances-create-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -255,8 +260,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachineinstances-update-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachineinstances-update-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Update,
@@ -276,8 +282,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachine-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachine-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -298,8 +305,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinereplicaset-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachinereplicaset-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -320,8 +328,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinepreset-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachinepreset-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -342,8 +351,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "migration-create-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "migration-create-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -363,8 +373,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "migration-update-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "migration-update-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Update,
@@ -384,8 +395,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinesnapshot-validator.snapshot.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachinesnapshot-validator.snapshot.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -406,8 +418,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "virtualmachinerestore-validator.snapshot.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "virtualmachinerestore-validator.snapshot.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,
@@ -428,8 +441,9 @@ func NewVirtAPIValidatingWebhookConfiguration(installNamespace string) *v1beta1.
 				},
 			},
 			{
-				Name:          "kubevirt-crd-status-validator.kubevirt.io",
-				FailurePolicy: &failurePolicy,
+				Name:           "kubevirt-crd-status-validator.kubevirt.io",
+				FailurePolicy:  &failurePolicy,
+				TimeoutSeconds: &defaultTimeoutSeconds,
 				Rules: []v1beta1.RuleWithOperations{{
 					Operations: []v1beta1.OperationType{
 						v1beta1.Create,


### PR DESCRIPTION
backport of: #5661 
related to: https://bugzilla.redhat.com/show_bug.cgi?id=1957477 

Previously, no default timeout was set on our validation webhook. The default timeout is usually 10 seconds on newer versions of k8s, but it has been seen to be as high as 30 seconds on older versions of k8s. So the default changed.

This has led to some unexpected results, where a Validation Webhook with a `failurePolicy: Ignore` actually blocks all modifications of resources due to the default 30 second webhook timeout bumping up into the api servers total request timeout period. 

Since the default timeout period can be inconsistent, we should instead explicitly set our timeout value and not depend on defaulting. This gives us stronger guarantees around what timeout the api server will observe. A 10 second timeout should be plenty of time for our virt-api component to respond under normal conditions. 


```release-note
Validation/Mutation webhooks now explicitly define a 10 second timeout period
```
