### PR TITLE
Extend VM watch functest to verify printableStatus transitions

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -181,6 +181,7 @@ go_test(
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/util:go_default_library",
+        "//pkg/virtctl/pause:go_default_library",
         "//pkg/virtctl/vm:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -263,7 +263,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(err).ToNot(HaveOccurred())
 
 		nodes := tests.GetAllSchedulableNodes(virtClient)
-		Expect(nodes.Items).To(BeNumerically(">=", 2),
+		Expect(len(nodes.Items)).To(BeNumerically(">=", 2),
 			"Migration requires at least 2 schedulable nodes")
 
 		migrateCommand := tests.NewRepeatableVirtctlCommand(virtctlvm.COMMAND_MIGRATE, "--namespace", vm.Namespace, vm.Name)


### PR DESCRIPTION
Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

**What this PR does / why we need it**:

This PR complements #5528 by adding a functional test to verify the correct display of VM status via the CLI, across different VM lifecycle stages.

**Release note**:
```release-note
NONE
```
