### PR TITLE
Add xz package to builder image

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -38,7 +38,8 @@ RUN dnf install -y dnf-plugins-core && \
         redhat-rpm-config \
         jq \
         wget \
-        diffutils && \
+        diffutils \
+        xz && \
     dnf -y clean all
 
 # install gradle (required for swagger)

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -22,7 +22,7 @@ if [ -z ${KUBEVIRT_CRI} ]; then
     fi
 fi
 
-KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2104200947-285ddf078"
+KUBEVIRT_BUILDER_IMAGE="quay.io/kubevirt/builder:2105310929-3310f7bdd"
 
 SYNC_OUT=${SYNC_OUT:-true}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR is a prerequisite to build the new libguestfs-tools image with bazel in #5402 using tar. The appliance has to be extracted before being copied into the container using a `genrule` and `tar xvf` with bazel. Currently. bazel doesn't extract the root filesystem correctly. Until https://github.com/bazelbuild/bazel/issues/13501 is not fixed, we fall back in using `tar` in order to properly untar the appliance

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
