### PR TITLE
Speed up unit tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,3 +26,10 @@ build --define gotags=selinux
 
 # let our unit tests produce our own junit reports
 test --action_env=GO_TEST_WRAP=0
+
+# speed up unit tests by enabling ginkos parallel execution
+test --test_arg=--ginkgo.parallel.total=5
+
+# for code coverage ginkos parallel execution needs to be disabled
+# since ginkgo has a forking model
+coverage --test_arg=--ginkgo.parallel.total=1

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
 )

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -59,6 +59,7 @@ const (
 type KubeVirtController struct {
 	clientset            kubecli.KubevirtClient
 	queue                workqueue.RateLimitingInterface
+	delayedQueueAdder    func(key interface{}, queue workqueue.RateLimitingInterface)
 	kubeVirtInformer     cache.SharedIndexInformer
 	recorder             record.EventRecorder
 	stores               util.Stores
@@ -119,6 +120,9 @@ func NewKubeVirtController(
 		installStrategyMap: make(map[string]*install.Strategy),
 		operatorNamespace:  operatorNamespace,
 		statusUpdater:      status.NewKubeVirtStatusUpdater(clientset),
+		delayedQueueAdder: func(key interface{}, queue workqueue.RateLimitingInterface) {
+			queue.AddAfter(key, defaultAddDelay)
+		},
 	}
 
 	c.kubeVirtInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -445,7 +449,7 @@ func (c *KubeVirtController) genericAddHandler(obj interface{}, expecter *contro
 		if expecter != nil {
 			expecter.CreationObserved(controllerKey)
 		}
-		c.queue.AddAfter(controllerKey, defaultAddDelay)
+		c.delayedQueueAdder(controllerKey, c.queue)
 	}
 }
 
@@ -467,7 +471,7 @@ func (c *KubeVirtController) genericUpdateHandler(old, cur interface{}, expecter
 
 	key, err := c.getKubeVirtKey()
 	if key != "" && err == nil {
-		c.queue.AddAfter(key, defaultAddDelay)
+		c.delayedQueueAdder(key, c.queue)
 	}
 	return
 }
@@ -528,7 +532,7 @@ func (c *KubeVirtController) enqueueKubeVirt(obj interface{}) {
 	if err != nil {
 		logger.Object(kv).Reason(err).Error("Failed to extract key from KubeVirt.")
 	}
-	c.queue.AddAfter(key, defaultAddDelay)
+	c.delayedQueueAdder(key, c.queue)
 }
 
 func (c *KubeVirtController) Run(threadiness int, stopCh <-chan struct{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the general execution speed of virt-operator from 167 seconds down to 26 seconds.
In addition the parallel ginkgo test execution is enabled which reduces the execution time to 10 seconds for the operator, and the virt-handler tests now need 50 seconds compared to more than 200 seconds.

For code coverage, parallel test execution of ginkgo is disabled to not confuse the coverage generator with the fork model which ginkgo uses for parallel runs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
