### PR TITLE
Fix a race in the operator unittests

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1217,7 +1217,9 @@ func (k *KubeVirtTestData) makeApiAndControllerReady() {
 		}
 		deplNew.Status.Replicas = replicas
 		deplNew.Status.ReadyReplicas = replicas
+		k.mockQueue.ExpectAdds(1)
 		k.deploymentSource.Modify(deplNew)
+		k.mockQueue.Wait()
 	}
 
 	for _, name := range []string{"/virt-api", "/virt-controller"} {
@@ -1259,7 +1261,9 @@ func (k *KubeVirtTestData) makeHandlerReady() {
 			handlerNew := handler.DeepCopy()
 			handlerNew.Status.DesiredNumberScheduled = 1
 			handlerNew.Status.NumberReady = 1
+			k.mockQueue.ExpectAdds(1)
 			k.daemonSetSource.Modify(handlerNew)
+			k.mockQueue.Wait()
 		}
 	}
 }
@@ -1463,7 +1467,6 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
-			kvTestData.makeHandlerReady()
 			kvTestData.makeApiAndControllerReady()
 			kvTestData.makeHandlerReady()
 			kvTestData.shouldExpectPatchesAndUpdates()


### PR DESCRIPTION
**What this PR does / why we need it**:

In #5684 I removed some `time.Sleep` which revealed a sync race in operator tests.
The races can be fixed by expecting the corresponding enqueues into the workqueue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
