### PR TITLE
allow multiple calls to graceful shutdown in case acpi did not recieve call

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1155,14 +1155,14 @@ func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance)
 			return err
 		}
 
-		if domSpec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp == nil {
-			err = dom.ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN)
-			if err != nil {
-				log.Log.Object(vmi).Reason(err).Error("Signalling graceful shutdown failed.")
-				return err
-			}
-			log.Log.Object(vmi).Infof("Signaled graceful shutdown for %s", vmi.GetObjectMeta().GetName())
+		err = dom.ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN)
+		if err != nil {
+			log.Log.Object(vmi).Reason(err).Error("Signalling graceful shutdown failed.")
+			return err
+		}
+		log.Log.Object(vmi).Infof("Signaled graceful shutdown for %s", vmi.GetObjectMeta().GetName())
 
+		if domSpec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp == nil {
 			now := metav1.Now()
 			domSpec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp = &now
 			d, err := l.setDomainSpecWithHooks(vmi, domSpec)
@@ -1213,7 +1213,7 @@ func (l *LibvirtDomainManager) KillVMI(vmi *v1.VirtualMachineInstance) error {
 		return nil
 	}
 
-	log.Log.Object(vmi).Info("Domain not running or paused, nothing to do.")
+	log.Log.Object(vmi).Info("Domain not running, paused or shut down, nothing to do.")
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Right now if graceful shut down is called before acpi is able to receive events it will never reach acpi. According to https://github.com/kubevirt/kubevirt/blob/master/pkg/virt-handler/vm.go#L1992 this should not be the case, but we should instead keep trying to send this event. 

This was verified by @xpivarc 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Bug https://bugzilla.redhat.com/show_bug.cgi?id=1933043 



**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow multiple shutdown events to ensure the event is received by ACPI
```
