### PR TITLE
Point tests to quay images by default

### DIFF
--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -30,7 +30,7 @@ var KubeVirtUtilityVersionTag = ""
 var KubeVirtVersionTag = "latest"
 var KubeVirtVersionTagAlt = ""
 var KubeVirtUtilityRepoPrefix = ""
-var KubeVirtRepoPrefix = "kubevirt"
+var KubeVirtRepoPrefix = "quay.io/kubevirt"
 var ImagePrefixAlt = ""
 var ContainerizedDataImporterNamespace = "cdi"
 var KubeVirtKubectlPath = ""
@@ -55,7 +55,7 @@ func init() {
 	flag.StringVar(&KubeVirtVersionTag, "container-tag", "latest", "Set the image tag or digest to use")
 	flag.StringVar(&KubeVirtVersionTagAlt, "container-tag-alt", "", "An alternate tag that can be used to test operator deployments")
 	flag.StringVar(&KubeVirtUtilityRepoPrefix, "utility-container-prefix", "", "Set the repository prefix for all images")
-	flag.StringVar(&KubeVirtRepoPrefix, "container-prefix", "kubevirt", "Set the repository prefix for all images")
+	flag.StringVar(&KubeVirtRepoPrefix, "container-prefix", KubeVirtRepoPrefix, "Set the repository prefix for all images")
 	flag.StringVar(&ImagePrefixAlt, "image-prefix-alt", "", "Optional prefix for virt-* image names for additional imagePrefix operator test")
 	flag.StringVar(&ContainerizedDataImporterNamespace, "cdi-namespace", "cdi", "Set the repository prefix for CDI components")
 	flag.StringVar(&KubeVirtKubectlPath, "kubectl-path", "", "Set path to kubectl binary")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When KubeVirt's e2e test are executed in a standalone mode (against an
arbitrary non-kubevirtci cluster), they fetch all the VM and utility
images from Docker Hub. That causes issues due to rate limiting.

With this change, the default registry is Quay.io, which is aligned with
the rest of the artifacts released under KubeVirt.

This issue is especially problematic in conformance testing, where there
is no option to overwrite the default --container-prefix through
Sonobuoy.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
