### PR TITLE
[release-0.34] Fix virt-controller clobbering in progress vmi migration state

### DIFF
--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -516,6 +516,11 @@ func (c *MigrationController) sync(key string, migration *virtv1.VirtualMachineI
 			return nil
 		}()
 	case virtv1.MigrationScheduled:
+		if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.MigrationUID == migration.UID {
+			// already handed off
+			return nil
+		}
+
 		// once target pod is scheduled, alert the VMI of the migration by
 		// setting the target and source nodes. This kicks off the preparation stage.
 		if podExists && !podIsDown(pod) {

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -601,6 +601,25 @@ var _ = Describe("Migration watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulHandOverPodReason)
 		})
 
+		It("should not hand pod over target pod that's already handed over", func() {
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			vmi.Status.NodeName = "node02"
+			migration := newMigration("testmigration", vmi.Name, v1.MigrationScheduled)
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				MigrationUID: migration.UID,
+			}
+			pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
+			pod.Spec.NodeName = "node01"
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(pod)
+
+			controller.Execute()
+
+			// expect nothing to occur
+		})
+
 		It("should transition to preparing target phase", func() {
 			vmi := newVirtualMachine("testvmi", v1.Running)
 			vmi.Status.NodeName = "node02"


### PR DESCRIPTION
related to: https://bugzilla.redhat.com/show_bug.cgi?id=1945532
Pulls targeted fix from enhancement PR: #5593
Pulls unit test from PR: #5703

When virt-controller hands off a target pod to virt-handler, that hand off occurs by initializing the vmi.Status.MigrationState object. During this initialization, any previous completed migration is overwritten with the new migration data.

There's a bug in this logic...

Under a rare sequence of events, it's possible to re-initialize this vmi.Status.MigrationState object for an active migration that has already been handed off. This is caused by a race condition between the virt-controller's migration controller reconcile loop, and how quickly the informer cache is updated. As a result this is most likely to occur when the system is under load which increases the chances that the virt-controller informer cache is further behind. 

This issue was already addressed in an enhancement PR #5593 during a refactor, however since we didn't have evidence that the double hand off was possible in the wild, this change was never backported. We now have evidence that takes makes this double hand off no longer theoretical. 

```release-note
Fix virt-controller clobbering in progress vmi migration state during virt handler handoff
```