### PR TITLE
network, masquerade: remove dummy

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -990,10 +990,6 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 
 				Expect(bridgeMtu).To(Equal(primaryIfaceMtu), "k6t-eth0 bridge mtu should equal eth0 interface mtu")
 
-				By("checking k6t-eth0-nic MTU inside the pod")
-				bridgePrimaryNicMtu := getMtu(vmiPod, "k6t-eth0-nic")
-				Expect(bridgePrimaryNicMtu).To(Equal(primaryIfaceMtu), "k6t-eth0-nic mtu should equal eth0 interface mtu")
-
 				By("checking the tap device - tap0 - MTU inside the pod")
 				tapDeviceMTU := getMtu(vmiPod, "tap0")
 				Expect(tapDeviceMTU).To(Equal(primaryIfaceMtu), "tap0 mtu should equal eth0 interface mtu")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
A linux bridge MAC is set to the lowest mac address of any of the ports on it; the dummy is in place to
help keep the mac address of the bridge stable. 

Since we have started to use the same MAC address on all bridges masquerade binding bridges, plus
there's a single VM connected (hence a single tap) to the bridge, the dummy is redundant (the pod lives
as long as the VM).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
