### PR TITLE
Revert "Enable ginkgos parallel test runner for unit tests"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,10 +26,3 @@ build --define gotags=selinux
 
 # let our unit tests produce our own junit reports
 test --action_env=GO_TEST_WRAP=0
-
-# speed up unit tests by enabling ginkos parallel execution
-test --test_arg=--ginkgo.parallel.total=5
-
-# for code coverage ginkos parallel execution needs to be disabled
-# since ginkgo has a forking model
-coverage --test_arg=--ginkgo.parallel.total=1

--- a/pkg/util/types/BUILD.bazel
+++ b/pkg/util/types/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["pvc.go"],
+    srcs = [
+        "patch.go",
+        "pvc.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/util/types",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/util/types/patch.go
+++ b/pkg/util/types/patch.go
@@ -17,9 +17,9 @@
  *
  */
 
-package mutators
+package types
 
-type patchOperation struct {
+type PatchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
 	Value interface{} `json:"value,omitempty"`

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/BUILD.bazel
@@ -6,13 +6,13 @@ go_library(
         "migration-create-mutator.go",
         "namespace-limits.go",
         "preset.go",
-        "utils.go",
         "vm-mutator.go",
         "vmi-mutator.go",
     ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-api/webhooks/mutating-webhook/mutators",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/types:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",
@@ -41,6 +41,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/testutils:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-api/webhooks:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator.go
@@ -26,6 +26,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
@@ -60,18 +61,18 @@ func (mutator *MigrationCreateMutator) Mutate(ar *admissionv1.AdmissionReview) *
 
 	// Add a finalizer
 	migration.Finalizers = append(migration.Finalizers, v1.VirtualMachineInstanceMigrationFinalizer)
-	var patch []patchOperation
+	var patch []utiltypes.PatchOperation
 	var value interface{}
 
 	value = migration.Spec
-	patch = append(patch, patchOperation{
+	patch = append(patch, utiltypes.PatchOperation{
 		Op:    "replace",
 		Path:  "/spec",
 		Value: value,
 	})
 
 	value = migration.ObjectMeta
-	patch = append(patch, patchOperation{
+	patch = append(patch, utiltypes.PatchOperation{
 		Op:    "replace",
 		Path:  "/metadata",
 		Value: value,

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/migration-create-mutator_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "kubevirt.io/client-go/api/v1"
+	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 )
 
 var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
@@ -55,7 +56,7 @@ var _ = Describe("VirtualMachineInstanceMigration Mutator", func() {
 		By("Getting the VMI spec from the response")
 		migrationSpec := &v1.VirtualMachineInstanceMigrationSpec{}
 		migrationMeta := &k8smetav1.ObjectMeta{}
-		patch := []patchOperation{
+		patch := []utiltypes.PatchOperation{
 			{Value: migrationSpec},
 			{Value: migrationMeta},
 		}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
+	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -66,17 +67,17 @@ func (mutator *VMsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1.
 	log.Log.Object(&vm).V(4).Info("Apply defaults")
 	mutator.setDefaultMachineType(&vm)
 
-	var patch []patchOperation
+	var patch []utiltypes.PatchOperation
 	var value interface{}
 	value = vm.Spec
-	patch = append(patch, patchOperation{
+	patch = append(patch, utiltypes.PatchOperation{
 		Op:    "replace",
 		Path:  "/spec",
 		Value: value,
 	})
 
 	value = vm.ObjectMeta
-	patch = append(patch, patchOperation{
+	patch = append(patch, utiltypes.PatchOperation{
 		Op:    "replace",
 		Path:  "/metadata",
 		Value: value,

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator_test.go
@@ -31,6 +31,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
@@ -61,7 +62,7 @@ var _ = Describe("VirtualMachine Mutator", func() {
 		By("Getting the VM spec from the response")
 		vmSpec := &v1.VirtualMachineSpec{}
 		vmMeta := &k8smetav1.ObjectMeta{}
-		patch := []patchOperation{
+		patch := []utiltypes.PatchOperation{
 			{Value: vmSpec},
 			{Value: vmMeta},
 		}

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
+	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -57,7 +58,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
-	var patch []patchOperation
+	var patch []utiltypes.PatchOperation
 
 	// Patch the spec, metadata and status with defaults if we deal with a create operation
 	if ar.Request.Operation == admissionv1.Create {
@@ -120,21 +121,21 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 
 		var value interface{}
 		value = newVMI.Spec
-		patch = append(patch, patchOperation{
+		patch = append(patch, utiltypes.PatchOperation{
 			Op:    "replace",
 			Path:  "/spec",
 			Value: value,
 		})
 
 		value = newVMI.ObjectMeta
-		patch = append(patch, patchOperation{
+		patch = append(patch, utiltypes.PatchOperation{
 			Op:    "replace",
 			Path:  "/metadata",
 			Value: value,
 		})
 
 		value = newVMI.Status
-		patch = append(patch, patchOperation{
+		patch = append(patch, utiltypes.PatchOperation{
 			Op:    "replace",
 			Path:  "/status",
 			Value: value,
@@ -145,7 +146,7 @@ func (mutator *VMIsMutator) Mutate(ar *admissionv1.AdmissionReview) *admissionv1
 		// the status subresource. Until then we need to update Status and Metadata labels in parallel for e.g. Migrations.
 		if !reflect.DeepEqual(newVMI.Status, oldVMI.Status) {
 			if !webhooks.IsKubeVirtServiceAccount(ar.Request.UserInfo.Username) {
-				patch = append(patch, patchOperation{
+				patch = append(patch, utiltypes.PatchOperation{
 					Op:    "replace",
 					Path:  "/status",
 					Value: oldVMI.Status,

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -38,6 +38,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	utiltypes "kubevirt.io/kubevirt/pkg/util/types"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
@@ -82,7 +83,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 		By("Getting the VMI spec from the response")
 		vmiSpec := &v1.VirtualMachineInstanceSpec{}
 		vmiMeta := &k8smetav1.ObjectMeta{}
-		patch := []patchOperation{
+		patch := []utiltypes.PatchOperation{
 			{Value: vmiSpec},
 			{Value: vmiMeta},
 		}
@@ -120,7 +121,7 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 
 		By("Getting the VMI spec from the response")
 		vmiStatus := &v1.VirtualMachineInstanceStatus{}
-		patch := []patchOperation{
+		patch := []utiltypes.PatchOperation{
 			{Value: vmiStatus},
 		}
 		err = json.Unmarshal(resp.Patch, &patch)

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/rest:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/drain/disruptionbudget:go_default_library",
         "//pkg/virt-controller/watch/drain/evacuation:go_default_library",

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -20,8 +20,10 @@
 package watch
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -801,9 +803,31 @@ var _ = Describe("Migration watcher", func() {
 			}
 
 			if initializeMigrationState {
-				patch := `[{ "op": "test", "path": "/status/migrationState", "value": {"targetNode":"node01","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "replace", "path": "/status/migrationState", "value": {"startTimestamp":"2021-05-24T14:51:47Z","endTimestamp":"2021-05-24T14:51:47Z","targetNode":"node01","sourceNode":"node02","completed":true,"failed":true,"migrationUid":"testmigration"} }]`
-				shouldExpectVirtualMachineInstancePatch(vmi, patch)
+				patch := `[{ "op": "test", "path": "/status/migrationState", "value": {"targetNode":"node01","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "replace", "path": "/status/migrationState", "value": {"startTimestamp":"%s","endTimestamp":"%s","targetNode":"node01","sourceNode":"node02","completed":true,"failed":true,"migrationUid":"testmigration"} }]`
+
+				vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, gomock.Any()).DoAndReturn(func(name interface{}, ptype interface{}, vmiStatusPatch []byte) (*v1.VirtualMachineInstance, error) {
+					type P struct {
+						Op    string                                   `json:"op,omitempty"`
+						Path  string                                   `json:"path,omitempty"`
+						Value *v1.VirtualMachineInstanceMigrationState `json:"value,omitempty"`
+					}
+
+					vmiSP := []P{}
+					err := json.Unmarshal(vmiStatusPatch, &vmiSP)
+					Expect(err).To(BeNil())
+					Expect(vmiSP).To(HaveLen(2))
+
+					newMS := vmiSP[1].Value
+					Expect(newMS.StartTimestamp).ToNot(BeNil())
+					Expect(newMS.EndTimestamp).ToNot(BeNil())
+
+					expected := fmt.Sprintf(patch, newMS.StartTimestamp.UTC().Format(time.RFC3339), newMS.EndTimestamp.UTC().Format(time.RFC3339))
+					Expect(expected).To(Equal(string(vmiStatusPatch)))
+
+					return vmi, nil
+				})
 			}
+
 			controller.Execute()
 
 			// in this case, we have two failed events. one for the VMI and one on the Migration object.

--- a/pkg/virt-handler/node-labeller/BUILD.bazel
+++ b/pkg/virt-handler/node-labeller/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/types:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/node-labeller/api:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -36,6 +36,7 @@ import (
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+	utiltype "kubevirt.io/kubevirt/pkg/util/types"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/api"
 	"kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
@@ -183,19 +184,13 @@ func (n *NodeLabeller) run() error {
 }
 
 func (n *NodeLabeller) patchNode(originalNode, node *v1.Node) error {
-	type payload struct {
-		Op    string            `json:"op"`
-		Path  string            `json:"path"`
-		Value map[string]string `json:"value"`
-	}
-
-	p := make([]payload, 0)
+	p := make([]utiltype.PatchOperation, 0)
 	if !reflect.DeepEqual(originalNode.Labels, node.Labels) {
-		p = append(p, payload{
+		p = append(p, utiltype.PatchOperation{
 			Op:    "test",
 			Path:  "/metadata/labels",
 			Value: originalNode.Labels,
-		}, payload{
+		}, utiltype.PatchOperation{
 			Op:    "replace",
 			Path:  "/metadata/labels",
 			Value: node.Labels,
@@ -203,11 +198,11 @@ func (n *NodeLabeller) patchNode(originalNode, node *v1.Node) error {
 	}
 
 	if !reflect.DeepEqual(originalNode.Annotations, node.Annotations) {
-		p = append(p, payload{
+		p = append(p, utiltype.PatchOperation{
 			Op:    "test",
 			Path:  "/metadata/annotations",
 			Value: originalNode.Annotations,
-		}, payload{
+		}, utiltype.PatchOperation{
 			Op:    "replace",
 			Path:  "/metadata/annotations",
 			Value: node.Annotations,


### PR DESCRIPTION
This reverts commit 4d2680a385368330ed59e0d17f4107a2e349e526.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

By adding `ginkgo.parallel.total=5` the unit tests seem to only run the first `Context` block under each unit tests describe.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
