### PR TITLE
Terminate Istio Proxy at VM Cleanup

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/cmd-server:go_default_library",
+        "//pkg/virt-launcher/virtwrap/network:go_default_library",
         "//pkg/virt-launcher/virtwrap/util:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -163,7 +163,7 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 					return migrationCompleted(migration)
 				}, tests.MigrationWaitTime, time.Second).Should(Succeed(), fmt.Sprintf(" migration should succeed"))
 			})
-			PIt("All containers should complete in source virt-launcher pod after migration", func() {
+			It("All containers should complete in source virt-launcher pod after migration", func() {
 				Eventually(func() error {
 					return allContainersCompleted(sourcePodName)
 				}, tests.ContainerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod"))

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -125,6 +125,50 @@ var _ = SIGDescribe("[Serial] Istio", func() {
 			By("Waiting for VMI to be ready")
 			tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 		})
+		Describe("Live Migration", func() {
+			var (
+				sourcePodName string
+			)
+			migrationCompleted := func(migration *v1.VirtualMachineInstanceMigration) error {
+				migration, err := virtClient.VirtualMachineInstanceMigration(migration.Namespace).Get(migration.Name, &metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				if migration.Status.Phase == v1.MigrationSucceeded {
+					return nil
+				}
+				return fmt.Errorf("migration is in phase %s", migration.Status.Phase)
+			}
+			allContainersCompleted := func(podName string) error {
+				pod, err := virtClient.CoreV1().Pods(vmi.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				for _, containerStatus := range pod.Status.ContainerStatuses {
+					if containerStatus.State.Terminated == nil {
+						return fmt.Errorf("container %s is not terminated, state: %s", containerStatus.Name, containerStatus.State.String())
+					}
+				}
+				return nil
+			}
+			BeforeEach(func() {
+				tests.SkipIfMigrationIsNotPossible()
+			})
+			JustBeforeEach(func() {
+				sourcePodName = tests.GetVmPodName(virtClient, vmi)
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migration, err = virtClient.VirtualMachineInstanceMigration(migration.Namespace).Create(migration)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					return migrationCompleted(migration)
+				}, tests.MigrationWaitTime, time.Second).Should(Succeed(), fmt.Sprintf(" migration should succeed"))
+			})
+			PIt("All containers should complete in source virt-launcher pod after migration", func() {
+				Eventually(func() error {
+					return allContainersCompleted(sourcePodName)
+				}, tests.ContainerCompletionWaitTime, time.Second).Should(Succeed(), fmt.Sprintf("all containers should complete in source virt-launcher pod"))
+			})
+		})
 		Describe("Inbound traffic", func() {
 			checkVMIReachability := func(vmi *v1.VirtualMachineInstance, targetPort int) error {
 				job, err := createJobCheckingVMIReachability(vmi, targetPort)

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -228,6 +228,7 @@ const (
 )
 
 const MigrationWaitTime = 240
+const ContainerCompletionWaitTime = 60
 
 type ProcessFunc func(event *k8sv1.Event) (done bool)
 


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
When VMI has Istio Proxy sidecar, then after migration the proxy keeps running in the original virt-launcher pod indefinitely.
This PR terminates the proxy, so that the original virt-launcher pod can get to `completed` state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5657

**Special notes for your reviewer**:

The solution introduced in this PR is best-effort, if for some reason the curl request fails, then the proxy is not terminated.

I tried to look into how virt-handler could deal with the `istio-agent` process in a "no questions asked" manner, but I couldn't figure out how to identify which `istio-agent` to terminate.
QUESTION: Maybe it would be possible to cache the PID of the proxy process when it's created? And then use it to kill the proxy when cleaning the VM after migration?

To decide whether or not to send the termination request, I use the output of `ss` to see if there is a `istio/proxy` socket.
If there are better ways to tell if the istio-proxy container is present from our compute container, I'd be happy for suggestions.

**Release note**:
```release-note
Fix issue with virt-launcher becoming `NotReady` after migration when Istio is used.
```
