### PR TITLE
Quarantine 2 flaky sig-compute tests

### DIFF
--- a/tests/kubevirt_configmap_test.go
+++ b/tests/kubevirt_configmap_test.go
@@ -62,7 +62,7 @@ var _ = Describe("[Serial][sig-compute]KubeVirtConfigmapConfiguration", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("[test_id:4670]check health check returns configmap resource version", func() {
+	It("[QUARANTINE][test_id:4670]check health check returns configmap resource version", func() {
 		cfg, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(context.Background(), virtconfig.ConfigMapName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
@@ -71,7 +71,7 @@ var _ = Describe("[Serial][sig-compute]KubeVirtConfigmapConfiguration", func() {
 		tests.WaitForConfigToBePropagatedToComponent("kubevirt.io=virt-handler", cfg.ResourceVersion, tests.ExpectResourceVersionToBeEqualConfigVersion)
 	})
 
-	It("[test_id:4671]test kubevirt config-map is used for configuration when present", func() {
+	It("[QUARANTINE][test_id:4671]test kubevirt config-map is used for configuration when present", func() {
 
 		vmi := tests.NewRandomFedoraVMIWithDmidecode()
 


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Quarantine flaky sig-compute tests:
* `[Serial][sig-compute]KubeVirtConfigmapConfiguration [test_id:4670]check health check returns configmap resource version`
  * flakefinder report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2021-05-26-168h.html#row36
  * Recent failures: 
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-latest/1397674086238261248
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-sig-compute/1397560826742706176
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5558/pull-kubevirt-e2e-k8s-1.20-sig-compute/1397594545360736256
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5715/pull-kubevirt-e2e-k8s-1.19-sig-compute/1397778084010135552
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5677/pull-kubevirt-e2e-k8s-1.19-sig-compute/1397687475782029312
* `[Serial][sig-compute]KubeVirtConfigmapConfiguration [test_id:4671]test kubevirt config-map is used for configuration when present`
  * flakefinder report https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2021-05-26-168h.html#row3
  * Recent failures:
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-cgroupsv2/1397598578217586688
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5677/pull-kubevirt-e2e-k8s-1.19-sig-compute/1397590021044703232
    *  https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5402/pull-kubevirt-e2e-k8s-1.19-sig-compute/1397579209655717888
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5723/pull-kubevirt-e2e-k8s-1.20-sig-compute/1397577007394459648
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5401/pull-kubevirt-e2e-k8s-1.20-sig-compute/1397514718779805696

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
