### PR TITLE
Reconcole every RoleBinding subject, not only "User" kind

### DIFF
--- a/pkg/virt-operator/resource/apply/rbac.go
+++ b/pkg/virt-operator/resource/apply/rbac.go
@@ -221,16 +221,12 @@ func enforceAPIGroup(existing runtime.Object, required runtime.Object) {
 
 	existingRoleRef.APIGroup = rbacv1.GroupName
 	for i := range existingSubjects {
-		if existingSubjects[i].Kind == "User" {
-			existingSubjects[i].APIGroup = rbacv1.GroupName
-		}
+		existingSubjects[i].APIGroup = rbacv1.GroupName
 	}
 
 	requiredRoleRef.APIGroup = rbacv1.GroupName
 	for i := range requiredSubjects {
-		if existingSubjects[i].Kind == "User" {
-			requiredSubjects[i].APIGroup = rbacv1.GroupName
-		}
+		requiredSubjects[i].APIGroup = rbacv1.GroupName
 	}
 }
 


### PR DESCRIPTION
Today we only reconcile RoleBindings / ClusterRoleBindings
subjects which has Kind == "User". This was done intentionally
because this is what is done is OpenShift.

This change addresses this bugzilla bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1965050

According to Kubernetes documentation [1] there are 3 subject
Kinds: users, groups, and service accounts. Since we use all
three of them we need to reconcile all RoleBinding /
ClusterRoleBinding subjects unconditionally.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
