### PR TITLE
Enable live migration of VMs with hotplug volumes

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12200,6 +12200,10 @@
       "description": "The time the migration action began",
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
      },
+     "targetAttachmentPodUID": {
+      "description": "The UID of the target attachment pod for hotplug volumes",
+      "type": "string"
+     },
      "targetDirectMigrationNodePorts": {
       "description": "The list of ports opened for live migration on the destination node",
       "type": "object",

--- a/docs/hotplug.md
+++ b/docs/hotplug.md
@@ -126,4 +126,4 @@ Vda is the container disk that contains the Fedora OS, vdb is the cloudinit disk
 The hotplugVolume has some extra information that regular volume statuses do not have. The attachPodName is the name of the pod that was used to attach the volume to the node the VMI is running on. If this pod is deleted it will also stop the VMI as we cannot guarantee the volume will remain attached to the node. The other fields are similar to conditions and indicate the status of the hot plug process. Once a Volume is ready it can be used by the VM.
 
 ## Live Migration
-Currently Live Migration is disabled for any VMI that has volumes hotplugged into it. This limitation will be removed in a future release.
+Currently Live Migration is enabled for any VMI that has volumes hotplugged into it. However there is a known issue that the migration may fail for VMIs with hotplugged block volumes if the target node uses CPU manager with static policy and `runc` prior to version `v1.0.0`.

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/hooks:go_default_library",
         "//pkg/network:go_default_library",
         "//pkg/util/hardware:go_default_library",
+        "//pkg/util/migrations:go_default_library",
         "//pkg/util/types:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -421,6 +421,13 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		},
 	})
 
+	hotplugVolumes := make(map[string]bool)
+	for _, volumeStatus := range vmi.Status.VolumeStatus {
+		if volumeStatus.HotplugVolume != nil {
+			hotplugVolumes[volumeStatus.Name] = true
+		}
+	}
+
 	// Need to run in privileged mode in Power or libvirt will fail to lock memory for VMI
 	if t.IsPPC64() {
 		privileged = true
@@ -470,6 +477,9 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 	serviceAccountName := ""
 
 	for _, volume := range vmi.Spec.Volumes {
+		if hotplugVolumes[volume.Name] {
+			continue
+		}
 		volumeMount := k8sv1.VolumeMount{
 			Name:      volume.Name,
 			MountPath: hostdisk.GetMountedHostDiskDir(volume.Name),
@@ -1491,13 +1501,7 @@ func (t *templateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 		}
 	}
 	for _, volume := range volumes {
-		claimName := ""
-		if volume.DataVolume != nil {
-			// TODO, look up the correct PVC name based on the datavolume, right now they match, but that will not always be true.
-			claimName = volume.DataVolume.Name
-		} else if volume.PersistentVolumeClaim != nil {
-			claimName = volume.PersistentVolumeClaim.ClaimName
-		}
+		claimName := types.PVCNameFromVirtVolume(volume)
 		if claimName == "" {
 			continue
 		}

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -484,6 +484,7 @@ func (vca *VirtControllerApp) initCommon() {
 		vca.kvPodInformer,
 		vca.migrationInformer,
 		vca.nodeInformer,
+		vca.persistentVolumeClaimInformer,
 		vca.vmiRecorder,
 		vca.clientSet,
 		vca.clusterConfig,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Application", func() {
 			podInformer,
 			migrationInformer,
 			nodeInformer,
+			pvcInformer,
 			recorder,
 			virtClient,
 			config,

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -185,6 +185,7 @@ var _ = Describe("Migration watcher", func() {
 			podInformer,
 			migrationInformer,
 			nodeInformer,
+			pvcInformer,
 			recorder,
 			virtClient,
 			config,

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/fake"
@@ -98,6 +99,21 @@ var _ = Describe("Migration watcher", func() {
 			if expectedNodeAffinityCount > 0 {
 				Expect(len(update.GetObject().(*k8sv1.Pod).Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)).To(Equal(expectedNodeAffinityCount))
 			}
+
+			return true, update.GetObject(), nil
+		})
+	}
+
+	shouldExpectAttachmentPodCreation := func(uid types.UID, migrationUid types.UID) {
+		// Expect pod creation
+		kubeClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
+			update, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			Expect(update.GetObject().(*k8sv1.Pod).Labels[v1.MigrationJobLabel]).To(Equal(string(migrationUid)))
+
+			Expect(update.GetObject().(*k8sv1.Pod).Spec.Affinity).ToNot(BeNil())
+			Expect(update.GetObject().(*k8sv1.Pod).Spec.Affinity.NodeAffinity).ToNot(BeNil())
+			Expect(len(update.GetObject().(*k8sv1.Pod).Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms)).To(Equal(1))
 
 			return true, update.GetObject(), nil
 		})
@@ -240,6 +256,82 @@ var _ = Describe("Migration watcher", func() {
 		err := nodeInformer.GetIndexer().Add(node)
 		Expect(err).ShouldNot(HaveOccurred())
 	}
+
+	Context("Migration with hotplug volumes", func() {
+		var (
+			vmi           *v1.VirtualMachineInstance
+			migration     *v1.VirtualMachineInstanceMigration
+			sourcePod     *k8sv1.Pod
+			targetPod     *k8sv1.Pod
+			attachmentPod *k8sv1.Pod
+		)
+
+		BeforeEach(func() {
+			vmi = newVirtualMachineWithHotplugVolume("testvmi", v1.Running)
+			migration = newMigration("testmigration", vmi.Name, v1.MigrationPending)
+			sourcePod = newSourcePodForVirtualMachine(vmi)
+			targetPod = newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
+			attachmentPod = newAttachmentPodForVirtualMachine(targetPod, migration, k8sv1.PodRunning)
+		})
+
+		It("should create target attachment pod", func() {
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podInformer.GetStore().Add(sourcePod)
+			podFeeder.Add(targetPod)
+			shouldExpectAttachmentPodCreation(vmi.UID, migration.UID)
+
+			controller.Execute()
+
+			testutils.ExpectEvents(recorder, SuccessfulCreatePodReason)
+		})
+
+		It("should set migration state to scheduling if attachment pod exists", func() {
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(targetPod)
+			podFeeder.Add(attachmentPod)
+
+			shouldExpectMigrationSchedulingState(migration)
+			controller.Execute()
+		})
+
+		It("should hand pod over to target virt-handler if attachment pod is ready and running", func() {
+			vmi.Status.NodeName = "node02"
+			migration.Status.Phase = v1.MigrationScheduled
+			targetPod.Spec.NodeName = "node01"
+			targetPod.Status.ContainerStatuses = []k8sv1.ContainerStatus{{
+				Name: "compute", State: k8sv1.ContainerState{Running: &k8sv1.ContainerStateRunning{}},
+			}}
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(targetPod)
+			podFeeder.Add(attachmentPod)
+
+			patch := fmt.Sprintf(`[{ "op": "add", "path": "/status/migrationState", "value": {"targetNode":"node01","targetPod":"%s","targetAttachmentPodUID":"%s","sourceNode":"node02","migrationUid":"testmigration"} }, { "op": "test", "path": "/metadata/labels", "value": {} }, { "op": "replace", "path": "/metadata/labels", "value": {"kubevirt.io/migrationTargetNodeName":"node01"} }]`, targetPod.Name, attachmentPod.UID)
+
+			shouldExpectVirtualMachineInstancePatch(vmi, patch)
+
+			controller.Execute()
+			testutils.ExpectEvent(recorder, SuccessfulHandOverPodReason)
+		})
+
+		It("should fail the migration if the attachment pod goes to final state", func() {
+			attachmentPod.Status.Phase = k8sv1.PodFailed
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			podFeeder.Add(targetPod)
+			podFeeder.Add(attachmentPod)
+
+			shouldExpectMigrationFailedState(migration)
+
+			controller.Execute()
+
+			testutils.ExpectEvent(recorder, FailedMigrationReason)
+		})
+	})
 
 	Context("Migration object in pending state", func() {
 		It("should create target pod", func() {
@@ -942,6 +1034,42 @@ func newVirtualMachine(name string, phase v1.VirtualMachineInstancePhase) *v1.Vi
 	return vmi
 }
 
+func newVirtualMachineWithHotplugVolume(name string, phase v1.VirtualMachineInstancePhase) *v1.VirtualMachineInstance {
+	vmi := newVirtualMachine(name, phase)
+	vmi.Status.VolumeStatus = []v1.VolumeStatus{
+		{
+			HotplugVolume: &v1.HotplugVolumeStatus{},
+		},
+	}
+	return vmi
+}
+
+func newSourcePodForVirtualMachine(vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
+	return &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rand.String(10),
+			Namespace: vmi.Namespace,
+			Labels: map[string]string{
+				v1.AppLabel:       "virt-launcher",
+				v1.CreatedByLabel: string(vmi.UID),
+			},
+			Annotations: map[string]string{
+				v1.DomainAnnotation: vmi.Name,
+			},
+		},
+		Status: k8sv1.PodStatus{
+			Phase: k8sv1.PodRunning,
+			ContainerStatuses: []k8sv1.ContainerStatus{
+				{Ready: true, Name: "test"},
+			},
+		},
+		Spec: k8sv1.PodSpec{
+			NodeName: vmi.Status.NodeName,
+			Volumes:  []k8sv1.Volume{},
+		},
+	}
+}
+
 func newTargetPodForVirtualMachine(vmi *v1.VirtualMachineInstance, migration *v1.VirtualMachineInstanceMigration, phase k8sv1.PodPhase) *k8sv1.Pod {
 	return &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -955,6 +1083,36 @@ func newTargetPodForVirtualMachine(vmi *v1.VirtualMachineInstance, migration *v1
 			Annotations: map[string]string{
 				v1.DomainAnnotation:           vmi.Name,
 				v1.MigrationJobNameAnnotation: migration.Name,
+			},
+		},
+		Status: k8sv1.PodStatus{
+			Phase: phase,
+			ContainerStatuses: []k8sv1.ContainerStatus{
+				{Ready: true, Name: "test"},
+			},
+		},
+	}
+}
+
+func newAttachmentPodForVirtualMachine(ownerPod *k8sv1.Pod, migration *v1.VirtualMachineInstanceMigration, phase k8sv1.PodPhase) *k8sv1.Pod {
+	return &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rand.String(10),
+			Namespace: ownerPod.Namespace,
+			UID:       "test-uid",
+			Labels: map[string]string{
+				v1.AppLabel:          "hotplug-disk",
+				v1.MigrationJobLabel: string(migration.UID),
+			},
+			Annotations: map[string]string{
+				v1.MigrationJobNameAnnotation: migration.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerPod, schema.GroupVersionKind{
+					Group:   k8sv1.SchemeGroupVersion.Group,
+					Version: k8sv1.SchemeGroupVersion.Version,
+					Kind:    "Pod",
+				}),
 			},
 		},
 		Status: k8sv1.PodStatus{

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1581,10 +1581,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{invalidVolume})
 			Expect(pod).To(BeNil())
-			Expect(err).To(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("CreateAttachmentPodTemplate should return nil if volume has PVC that doesn't exist", func() {
+		It("CreateAttachmentPodTemplate should return error if volume has PVC that doesn't exist", func() {
 			kubeClient.Fake.PrependReactor("get", "persistentvolumeclaims", func(action testing.Action) (handled bool, obj k8sruntime.Object, err error) {
 				return true, nil, k8serrors.NewNotFound(k8sv1.Resource("persistentvolumeclaim"), "noclaim")
 			})
@@ -1602,7 +1602,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{nopvcVolume})
 			Expect(pod).To(BeNil())
-			Expect(err).To(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("CreateAttachmentPodTemplate should return nil pod if only one DV exists and owning PVC doesn't exist", func() {
@@ -1630,7 +1630,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			pod, err := controller.createAttachmentPodTemplate(vmi, virtlauncherPod, []*virtv1.Volume{volume})
 			Expect(pod).To(BeNil())
-			Expect(err).To(BeNil())
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("CreateAttachmentPodTemplate should set status to pending if DV owning PVC is not ready", func() {
@@ -1979,7 +1979,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				podInformer.GetIndexer().Add(attachmentPod)
 			}
 
-			res, err := controller.virtlauncherAttachmentPods(virtlauncherPod)
+			res, err := kvcontroller.AttachmentPods(virtlauncherPod, podInformer)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(res)).To(Equal(podCount))
 		},
@@ -1995,7 +1995,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			virtlauncherPod.Spec.Volumes = virtlauncherVolumes
-			res := controller.getHotplugVolumes(vmi, virtlauncherPod)
+			res := getHotplugVolumes(vmi, virtlauncherPod)
 			Expect(len(res)).To(Equal(len(expectedIndexes)))
 			for _, index := range expectedIndexes {
 				found := false

--- a/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/hotplug-disk/generated_mock_mount.go
@@ -41,6 +41,16 @@ func (_mr *_MockVolumeMounterRecorder) Mount(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mount", arg0)
 }
 
+func (_m *MockVolumeMounter) MountFromPod(vmi *v1.VirtualMachineInstance, sourceUID types.UID) error {
+	ret := _m.ctrl.Call(_m, "MountFromPod", vmi, sourceUID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVolumeMounterRecorder) MountFromPod(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MountFromPod", arg0, arg1)
+}
+
 func (_m *MockVolumeMounter) Unmount(vmi *v1.VirtualMachineInstance) error {
 	ret := _m.ctrl.Call(_m, "Unmount", vmi)
 	ret0, _ := ret[0].(error)

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2179,7 +2179,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				},
 			}
 
-			condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi, false)
+			condition, isBlockMigration := controller.calculateLiveMigrationCondition(vmi)
 			Expect(isBlockMigration).To(BeFalse())
 			Expect(condition.Type).To(Equal(v1.VirtualMachineInstanceIsMigratable))
 			Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7930,6 +7930,9 @@ var CRDsValidation map[string]string = map[string]string{
               format: date-time
               nullable: true
               type: string
+            targetAttachmentPodUID:
+              description: The UID of the target attachment pod for hotplug volumes
+              type: string
             targetDirectMigrationNodePorts:
               additionalProperties:
                 type: integer

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -24076,6 +24076,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceMigrationState(ref
 							Format:      "",
 						},
 					},
+					"targetAttachmentPodUID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The UID of the target attachment pod for hotplug volumes",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"sourceNode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The source node that the VMI originated on",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -530,6 +530,8 @@ type VirtualMachineInstanceMigrationState struct {
 	TargetNode string `json:"targetNode,omitempty"`
 	// The target pod that the VMI is moving to
 	TargetPod string `json:"targetPod,omitempty"`
+	// The UID of the target attachment pod for hotplug volumes
+	TargetAttachmentPodUID types.UID `json:"targetAttachmentPodUID,omitempty"`
 	// The source node that the VMI originated on
 	SourceNode string `json:"sourceNode,omitempty"`
 	// Indicates the migration completed

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -147,6 +147,7 @@ func (VirtualMachineInstanceMigrationState) SwaggerDoc() map[string]string {
 		"targetDirectMigrationNodePorts": "The list of ports opened for live migration on the destination node",
 		"targetNode":                     "The target node that the VMI is moving to",
 		"targetPod":                      "The target pod that the VMI is moving to",
+		"targetAttachmentPodUID":         "The UID of the target attachment pod for hotplug volumes",
 		"sourceNode":                     "The source node that the VMI originated on",
 		"completed":                      "Indicates the migration completed",
 		"failed":                         "Indicates that the migration failed",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -19134,6 +19134,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineInstanceMigrationState(ref
 							Format:      "",
 						},
 					},
+					"targetAttachmentPodUID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The UID of the target attachment pod for hotplug volumes",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"sourceNode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The source node that the VMI originated on",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently live migation of VMs with attached hotplug volumes is not implemented and it gets rejected by validation hook. This PR adds the missing pieces to enable it.

**Special notes for your reviewer**:

The PR is based on https://github.com/kubevirt/kubevirt/pull/5649 (which refactors hotplug disks implementation to use a single attachment pod for all volumes). Also it relies on the fix https://github.com/kubevirt/kubevirt/pull/5436. The logic is implemented as follows:

- For the migration with the status `MigrationPending` after creating the `virt-launcher` target pod, `virt-controller` checks if the VMI has hotplug volumes attached. In case if it does a new target attachment pod is created (with the target `virt-launcher` pod set as owner).
- When the attachment pod is ready `virt-controller` updates the migration phase to `MigrationScheduling`.
- Once in `MigrationScheduled`, `virt-controller` adds a `MigrationTargetAttachmentPodLabel` to VMI with the UID of the attachment pod (the UID is needed for the `virt-handler` on the target node).
- During the preparation stage `virt-handler` on the target node takes the attachment pod UID and performs the bind mount of the hotplug volumes to the `virt-launcher` pod.

~Still in TODO~ Done:

- [x] merge the mentioned PRs 
- [x] cleanup the code
- [x] add test

**(!)** The PR needs a recent version of `runc` (at least `v1.0.0`) that includes the fix https://github.com/opencontainers/runc/commit/bf7492ee5d022cd99a9dbe71c5c4f965041552e9 . Otherwise the migration of VMs with block volumes to the nodes with CPU Manager and static policy may fail (the issue is raised and discussed in the mailing list: https://groups.google.com/g/kubevirt-dev/c/0UbMD2R92mQ)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Live migration of VMs with hotplug volumes is now enabled
```
