### PR TITLE
Support more cpu manager policies.

### DIFF
--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -132,7 +132,7 @@ func (h *HeartBeat) isCPUManagerEnabled(cpuManagerPaths []string) bool {
 		return false
 	}
 
-	if v, ok := cpuManagerOptions["policyName"]; ok && v == "static" {
+	if v, ok := cpuManagerOptions["policyName"]; ok && v != "none" {
 		log.DefaultLogger().V(4).Infof("Node has CPU Manager running")
 		return true
 	} else {


### PR DESCRIPTION
This patch enable kubervirt to support cpu manager more cpu manager
policies. CPU manager policy can be extened in k8s. Generically they
can be divided into two categories: policy without cpu pining(none)
and policies with cpu pining(static). The static cpu manager policy
can be further extended to support, eg. interleave cpu numa allocation
or worst-fit cpu numa allocation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This patch enable kubevirt to support more cpu manager policies.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

/kind feature

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
