### PR TITLE
Drop j2 templates

### DIFF
--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -96,7 +96,7 @@ RUN set -x && \
     rm -rf /test-infra && \
     rm -rf /go && mkdir /go
 
-RUN pip3 install --upgrade j2cli operator-courier==2.1.11
+RUN pip3 install --upgrade operator-courier==2.1.11
 
 ENV SONOBUOY_VERSION=0.19.0
 RUN set -x && \


### PR DESCRIPTION
**What this PR does / why we need it**:

Drop j2 templates from the release manifests. Kustomize can be used for customiations. The templates were added a long time ago to support kubevirt-ansible roles which are no longer in use.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Stop releasing jinja2 templates of our operator. Kustomize is the preferred way for customizations.
```
