### PR TITLE
Add severity to KubeVirt alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -68,16 +68,22 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "All virt-api servers are down."
+            exp_labels:
+              severity: "critical"
       - eval_time: 5m
         alertname: VirtControllerDown
         exp_alerts:
           - exp_annotations:
               summary: "No running virt-controller was detected for the last 5 min."
+            exp_labels:
+              severity: "critical"
       - eval_time: 5m
         alertname: VirtOperatorDown
         exp_alerts:
           - exp_annotations:
               summary: "All virt-operator servers are down."
+            exp_labels:
+              severity: "critical"
 
     # vmi running on a node without a virt-handler pod
   - interval: 1m
@@ -122,6 +128,8 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "Some virt controllers are running but not ready."
+            exp_labels:
+              severity: "warning"
 
   # All virt controllers are not ready
   - interval: 1m
@@ -135,6 +143,8 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No ready virt-controller was detected for the last 5 min."
+            exp_labels:
+              severity: "critical"
 
   - interval: 1m
     input_series:
@@ -147,6 +157,8 @@ tests:
         exp_alerts:
           - exp_annotations:
               summary: "No ready virt-controller was detected for the last 5 min."
+            exp_labels:
+              severity: "critical"
 
   # High REST errors
   - interval: 1m
@@ -172,6 +184,7 @@ tests:
               summary: "More than 5% of the rest calls failed in virt-controller for the last hour"
             exp_labels:
               pod: "virt-controller-1"
+              severity: "warning"
       - eval_time: 5m
         alertname: VirtControllerRESTErrorsBurst
         exp_alerts:
@@ -179,6 +192,7 @@ tests:
               summary: "More than 80% of the rest calls failed in virt-controller for the last 5 minutes"
             exp_labels:
               pod: "virt-controller-1"
+              severity: "critical"
       - eval_time: 5m
         alertname: VirtOperatorRESTErrorsHigh
         exp_alerts:
@@ -186,6 +200,7 @@ tests:
               summary: "More than 5% of the rest calls failed in virt-operator for the last hour"
             exp_labels:
               pod: "virt-operator-1"
+              severity: "warning"
       - eval_time: 5m
         alertname: VirtOperatorRESTErrorsBurst
         exp_alerts:
@@ -193,6 +208,7 @@ tests:
               summary: "More than 80% of the rest calls failed in virt-operator for the last 5 minutes"
             exp_labels:
               pod: "virt-operator-1"
+              severity: "critical"
       - eval_time: 5m
         alertname: VirtHandlerRESTErrorsHigh
         exp_alerts:
@@ -200,6 +216,7 @@ tests:
               summary: "More than 5% of the rest calls failed in virt-handler for the last hour"
             exp_labels:
               pod: "virt-handler-1"
+              severity: "warning"
       - eval_time: 5m
         alertname: VirtHandlerRESTErrorsBurst
         exp_alerts:
@@ -207,6 +224,7 @@ tests:
               summary: "More than 80% of the rest calls failed in virt-handler for the last 5 minutes"
             exp_labels:
               pod: "virt-handler-1"
+              severity: "critical"
 
   # Some nodes without KVM resources
   - interval: 1m

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -567,6 +567,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "All virt-api servers are down.",
 						},
+						Labels: map[string]string{
+							"severity": "critical",
+						},
 					},
 					{
 						Record: "num_of_allocatable_nodes",
@@ -578,6 +581,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-api should be running if more than one worker nodes exist.",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
 						},
 					},
 					{
@@ -615,6 +621,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "Some virt controllers are running but not ready.",
 						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
 					},
 					{
 						Alert: "NoReadyVirtController",
@@ -622,6 +631,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No ready virt-controller was detected for the last 5 min.",
+						},
+						Labels: map[string]string{
+							"severity": "critical",
 						},
 					},
 					{
@@ -631,6 +643,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "No running virt-controller was detected for the last 5 min.",
 						},
+						Labels: map[string]string{
+							"severity": "critical",
+						},
 					},
 					{
 						Alert: "LowVirtControllersCount",
@@ -638,6 +653,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-controller should be ready if more than one worker node.",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
 						},
 					},
 					{
@@ -671,6 +689,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "More than 5% of the rest calls failed in virt-controller for the last hour",
 						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
 					},
 					{
 						Alert: "VirtControllerRESTErrorsBurst",
@@ -678,6 +699,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "More than 80% of the rest calls failed in virt-controller for the last 5 minutes",
+						},
+						Labels: map[string]string{
+							"severity": "critical",
 						},
 					},
 					{
@@ -693,6 +717,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "All virt-operator servers are down.",
 						},
+						Labels: map[string]string{
+							"severity": "critical",
+						},
 					},
 					{
 						Alert: "LowVirtOperatorCount",
@@ -700,6 +727,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "60m",
 						Annotations: map[string]string{
 							"summary": "More than one virt-operator should be running if more than one worker nodes exist.",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
 						},
 					},
 					{
@@ -733,6 +763,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "More than 5% of the rest calls failed in virt-operator for the last hour",
 						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
 					},
 					{
 						Alert: "VirtOperatorRESTErrorsBurst",
@@ -740,6 +773,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "More than 80% of the rest calls failed in virt-operator for the last 5 minutes",
+						},
+						Labels: map[string]string{
+							"severity": "critical",
 						},
 					},
 					{
@@ -761,6 +797,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "Some virt-operators are running but not ready.",
 						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
 					},
 					{
 						Alert: "NoReadyVirtOperator",
@@ -769,6 +808,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "No ready virt-operator was detected for the last 5 min.",
 						},
+						Labels: map[string]string{
+							"severity": "critical",
+						},
 					},
 					{
 						Alert: "NoLeadingVirtOperator",
@@ -776,6 +818,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "No leading virt-operator was detected for the last 5 min.",
+						},
+						Labels: map[string]string{
+							"severity": "critical",
 						},
 					},
 					{
@@ -791,6 +836,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For: "15m",
 						Annotations: map[string]string{
 							"summary": "Some virt-handlers failed to roll out",
+						},
+						Labels: map[string]string{
+							"severity": "warning",
 						},
 					},
 					{
@@ -824,6 +872,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						Annotations: map[string]string{
 							"summary": "More than 5% of the rest calls failed in virt-handler for the last hour",
 						},
+						Labels: map[string]string{
+							"severity": "warning",
+						},
 					},
 					{
 						Alert: "VirtHandlerRESTErrorsBurst",
@@ -831,6 +882,9 @@ func NewPrometheusRuleSpec(ns string, workloadUpdatesEnabled bool) *promv1.Prome
 						For:   "5m",
 						Annotations: map[string]string{
 							"summary": "More than 80% of the rest calls failed in virt-handler for the last 5 minutes",
+						},
+						Labels: map[string]string{
+							"severity": "critical",
 						},
 					},
 					{


### PR DESCRIPTION
Signed-off-by: Shirly Radco <sradco@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adding severity label to each KubeVirt alert rule.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
