### PR TITLE
[tests] assign sig labels to the unlabelled tests

### DIFF
--- a/tests/events_test.go
+++ b/tests/events_test.go
@@ -26,7 +26,7 @@ const (
 	diskName   = "disk0"
 )
 
-var _ = Describe("[Serial] K8s IO events", func() {
+var _ = Describe("[Serial][sig-storage]K8s IO events", func() {
 	var (
 		ns         string
 		node       string

--- a/tests/vmi_iothreads_test.go
+++ b/tests/vmi_iothreads_test.go
@@ -39,7 +39,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 )
 
-var _ = Describe("[Serial]IOThreads", func() {
+var _ = Describe("[Serial][sig-compute]IOThreads", func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/vmi_kernel_boot_test.go
+++ b/tests/vmi_kernel_boot_test.go
@@ -28,7 +28,7 @@ import (
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
 
-var _ = Describe("VMI with external kernel boot", func() {
+var _ = Describe("[sig-compute]VMI with external kernel boot", func() {
 
 	var virtClient kubecli.KubevirtClient
 


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
For a proper distribution of tests among the CI lanes

**Release note**:
```release-note
NONE
```
