### PR TITLE
Run a first set of unit tests in parallel through ginkgo

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -26,3 +26,6 @@ build --define gotags=selinux
 
 # let our unit tests produce our own junit reports
 test --action_env=GO_TEST_WRAP=0
+
+test --test_tag_filters=-cov
+coverage --test_tag_filters=-nocov

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,5 @@
+workspace(name = "kubevirt")
+
 load("//third_party:deps.bzl", "deps")
 
 deps()

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -3,6 +3,12 @@ set -e
 
 source hack/common.sh
 
+if [ "${CI}" == "true" ]; then
+    cat >>ci.bazelrc <<EOF
+coverage --cache_test_results=no --runs_per_test=1
+EOF
+fi
+
 bazel coverage \
     --config=${ARCHITECTURE} \
     --features race \

--- a/pkg/util/webhooks/BUILD.bazel
+++ b/pkg/util/webhooks/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 
 go_library(
     name = "go_default_library",
@@ -34,6 +35,7 @@ go_test(
         "webhooks_suite_test.go",
     ],
     embed = [":go_default_library"],
+    tags = ["cov"],
     deps = [
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
@@ -48,4 +50,11 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
     ],
+)
+
+ginkgo_test(
+    name = "go_parallel_test",
+    ginkgo_args = ["-p"],
+    go_test = ":go_default_test",
+    tags = ["nocov"],
 )

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 
 go_library(
     name = "go_default_library",
@@ -78,6 +79,7 @@ go_test(
         "watch_suite_test.go",
     ],
     embed = [":go_default_library"],
+    tags = ["cov"],
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/rest:go_default_library",
@@ -121,4 +123,11 @@ go_test(
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
     ],
+)
+
+ginkgo_test(
+    name = "go_parallel_test",
+    ginkgo_args = ["-p"],
+    go_test = ":go_default_test",
+    tags = ["nocov"],
 )

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Node controller with", func() {
 			controller.Execute()
 			testutils.ExpectEvent(recorder, NodeUnresponsiveReason)
 		})
-		It("should set a vmi without a pod to failed state, triggered by vmi modify event", func() {
+		It("should set a vmi with an unhealthy pod to failed state, triggered by vmi modify event", func() {
 			node := NewUnhealthyNode("testnode")
 			vmi := NewRunningVirtualMachine("vmi1", node)
 

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1458,7 +1458,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("DeleteAllAttachmentPods should return success if there are no attachment pods", func() {
+		It("DeleteAllAttachmentPods should return success with existing attachment pods", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			virtlauncherPod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
 			attachmentPod1 := NewPodForVirtlauncher(virtlauncherPod, "pod1", "abcd", k8sv1.PodRunning)
@@ -1756,10 +1756,10 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			res := controller.volumeStatusContainsVolumeAndPod(volumeStatuses, volume)
 			Expect(res).To(Equal(expected))
 		},
-			table.Entry("should return if the volume with pod is in the status", makeVolumeStatuses(), &v1.Volume{
+			table.Entry("should return true if the volume with pod is in the status", makeVolumeStatuses(), &v1.Volume{
 				Name: "test-volume",
 			}, true),
-			table.Entry("should return if the volume with pod is in the status", makeVolumeStatuses(), &v1.Volume{
+			table.Entry("should return false if the volume with pod is in the status", makeVolumeStatuses(), &v1.Volume{
 				Name: "test-volume2",
 			}, false),
 		)
@@ -1997,9 +1997,9 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(res)).To(Equal(podCount))
 		},
-			table.Entry("should return number of pods passed in", 0),
-			table.Entry("should return number of pods passed in", 1),
-			table.Entry("should return number of pods passed in", 2),
+			table.Entry("should return number (0) of pods passed in", 0),
+			table.Entry("should return number (1) of pods passed in", 1),
+			table.Entry("should return number (2) of pods passed in", 2),
 		)
 
 		table.DescribeTable("getHotplugVolumes", func(virtlauncherVolumes []k8sv1.Volume, vmiVolumes []*v1.Volume, expectedIndexes ...int) {

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 
 go_library(
     name = "go_default_library",
@@ -50,6 +51,7 @@ go_test(
         "vm_test.go",
     ],
     embed = [":go_default_library"],
+    tags = ["cov"],
     deps = [
         "//pkg/certificates:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",
@@ -88,4 +90,11 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
+)
+
+ginkgo_test(
+    name = "go_parallel_test",
+    ginkgo_args = ["-p"],
+    go_test = ":go_default_test",
+    tags = ["nocov"],
 )

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1334,7 +1334,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			},
 				table.Entry("When current phase is bound", v1.VolumeBound),
 				table.Entry("When current phase is pending", v1.VolumePending),
-				table.Entry("When current phase is bound", v1.HotplugVolumeAttachedToNode),
+				table.Entry("When current phase is bound for hotplug volume", v1.HotplugVolumeAttachedToNode),
 			)
 
 			table.DescribeTable("should generate an unmount event, when able to move to unmount", func(currentPhase v1.VolumePhase) {
@@ -1370,7 +1370,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			},
 				table.Entry("When current phase is bound", v1.VolumeReady),
 				table.Entry("When current phase is pending", v1.HotplugVolumeMounted),
-				table.Entry("When current phase is bound", v1.HotplugVolumeAttachedToNode),
+				table.Entry("When current phase is bound for hotplug volume", v1.HotplugVolumeAttachedToNode),
 			)
 
 			It("Should generate a ready event when target is assigned", func() {

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -57,7 +57,7 @@ go_test(
         "virt_operator_suite_test.go",
     ],
     embed = [":go_default_library"],
-    tags = ["manual"],
+    tags = ["cov"],
     deps = [
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
@@ -106,4 +106,5 @@ ginkgo_test(
     name = "go_parallel_test",
     ginkgo_args = ["-p"],
     go_test = ":go_default_test",
+    tags = ["nocov"],
 )

--- a/pkg/virt-operator/BUILD.bazel
+++ b/pkg/virt-operator/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 
 go_library(
     name = "go_default_library",
@@ -56,6 +57,7 @@ go_test(
         "virt_operator_suite_test.go",
     ],
     embed = [":go_default_library"],
+    tags = ["manual"],
     deps = [
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
@@ -98,4 +100,10 @@ go_test(
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
     ],
+)
+
+ginkgo_test(
+    name = "go_parallel_test",
+    ginkgo_args = ["-p"],
+    go_test = ":go_default_test",
 )

--- a/staging/src/kubevirt.io/client-go/testutils/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/testutils/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/config:go_default_library",
         "//vendor/github.com/onsi/ginkgo/reporters:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/staging/src/kubevirt.io/client-go/testutils/setup.go
+++ b/staging/src/kubevirt.io/client-go/testutils/setup.go
@@ -1,10 +1,12 @@
 package testutils
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 
@@ -34,6 +36,9 @@ func KubeVirtTestSuiteSetup(t *testing.T, description string) {
 		testTarget := os.Getenv("TEST_TARGET")
 		if testTarget != "" {
 			description = testTarget
+		}
+		if config.GinkgoConfig.ParallelTotal > 1 {
+			outputFile = fmt.Sprintf("%s-%d", outputFile, config.GinkgoConfig.ParallelNode)
 		}
 
 		ginkgo.RunSpecsWithDefaultAndCustomReporters(

--- a/tools/ginkgo/ginkgo.bzl
+++ b/tools/ginkgo/ginkgo.bzl
@@ -1,0 +1,42 @@
+# Inspired by https://github.com/onsi/ginkgo/issues/800#issuecomment-829037396
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _ginkgo_test_impl(ctx):
+    wrapper = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(
+        output = wrapper,
+        content = """#!/usr/bin/env bash
+set -e
+trap "{merger} -o ${{XML_OUTPUT_FILE}} ${{XML_OUTPUT_FILE}}*" EXIT
+{ginkgo} {ginkgo_args} {go_test} -- "$@"
+""".format(
+            ginkgo = shell.quote(ctx.executable._ginkgo.short_path),
+            merger = shell.quote(ctx.executable._merger.short_path),
+            ginkgo_args = " ".join([shell.quote(arg) for arg in ctx.attr.ginkgo_args]),
+            # Ginkgo requires the precompiled binary end with ".test".
+            go_test = shell.quote(ctx.executable.go_test.short_path + ".test"),
+        ),
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = wrapper,
+        runfiles = ctx.runfiles(
+            files = ctx.files.data,
+            symlinks = {ctx.executable.go_test.short_path + ".test": ctx.executable.go_test},
+            transitive_files = depset([], transitive = [ctx.attr._ginkgo.default_runfiles.files, ctx.attr._merger.default_runfiles.files, ctx.attr.go_test.default_runfiles.files]),
+        ),
+    )]
+
+ginkgo_test = rule(
+    implementation = _ginkgo_test_impl,
+    attrs = {
+        "data": attr.label_list(allow_files = True),
+        "go_test": attr.label(executable = True, cfg = "target"),
+        "ginkgo_args": attr.string_list(),
+        "_ginkgo": attr.label(default = "//vendor/github.com/onsi/ginkgo/ginkgo", executable = True, cfg = "target"),
+        "_merger": attr.label(default = "//tools/junit-merger:junit-merger", executable = True, cfg = "target"),
+    },
+    executable = True,
+    test = True,
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the second attempt after #5712 to run unit tests in parallel through ginkgo. In the first attempt in #5684 I made a mistake which led to tests being skipped. This time it should be done properly.

A new `ginkgo_test` target is introduced. In order to make use of it, do the following:

First import `ginkgo_test` to a BUID file with the `go_test` target you want to speed up: 

```python
load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")`
```

Mark the original `go_test` target with the `cov` tag to avoid double exeuction if you do something like `bazel test //pkg/...`:

```python
go_test(
    name = "go_default_test",
    [...]
    tags = ["cov"],
   [...]
)
```

Introduce the new `ginkgo_test` target, point it to the `go_test` target and tell it to run in parallel with the `-p` flag:

```python
ginkgo_test(
    name = "go_parallel_test",
    tags = ["nocov"],    
    ginkgo_args = ["-p"],
    go_test = ":go_default_test",
)
```

Further a `nocov` tag is added to exclude it from coverage runs. There we want to still run the `go_test` target

The PR runs a first set of very slow unit tests in parallel now.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The original starlark wrapper is from here: # Inspired by https://github.com/onsi/ginkgo/issues/800#issuecomment-829037396 and is extended with junit merging.

Most tests are fast enough and don't require parallel building. Therefore I think this mental overhead is acceptable if one has to run test suites in parallel too.

**Release note**:

```release-note
NONE
```
