### PR TITLE
Fix dhcp config string

### DIFF
--- a/pkg/network/cache/BUILD.bazel
+++ b/pkg/network/cache/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     srcs = [
         "cache_suite_test.go",
         "infocache_test.go",
+        "types_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -29,6 +30,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/network/cache/types.go
+++ b/pkg/network/cache/types.go
@@ -29,10 +29,9 @@ type DhcpConfig struct {
 
 func (vif DhcpConfig) String() string {
 	return fmt.Sprintf(
-		"DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: %t}",
+		"DhcpConfig: { Name: %s, IPv4: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: %t}",
 		vif.Name,
-		vif.IP.IP,
-		vif.IP.Mask,
+		vif.IP,
 		vif.IPv6,
 		vif.MAC,
 		vif.AdvertisingIPAddr,

--- a/pkg/network/cache/types.go
+++ b/pkg/network/cache/types.go
@@ -27,15 +27,15 @@ type DhcpConfig struct {
 	IPAMDisabled        bool
 }
 
-func (vif DhcpConfig) String() string {
+func (d DhcpConfig) String() string {
 	return fmt.Sprintf(
 		"DhcpConfig: { Name: %s, IPv4: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: %t}",
-		vif.Name,
-		vif.IP,
-		vif.IPv6,
-		vif.MAC,
-		vif.AdvertisingIPAddr,
-		vif.Mtu,
-		vif.IPAMDisabled,
+		d.Name,
+		d.IP,
+		d.IPv6,
+		d.MAC,
+		d.AdvertisingIPAddr,
+		d.Mtu,
+		d.IPAMDisabled,
 	)
 }

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -33,11 +33,9 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/network/cache:go_default_library",
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )

--- a/pkg/network/driver/common_test.go
+++ b/pkg/network/driver/common_test.go
@@ -21,16 +21,12 @@ package driver
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/onsi/ginkgo/extensions/table"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/vishvananda/netlink"
-
-	"kubevirt.io/kubevirt/pkg/network/cache"
 )
 
 var _ = Describe("Common Methods", func() {
@@ -74,55 +70,4 @@ var _ = Describe("Common Methods", func() {
 			table.Entry("ipv6", iptables.ProtocolIPv6, "6"),
 		)
 	})
-})
-
-var _ = Describe("DhcpConfig", func() {
-	const ipv4Cidr = "10.0.0.200/24"
-	const ipv4Address = "10.0.0.200"
-	const ipv6Cidr = "fd10:0:2::2/120"
-	const mac = "de:ad:00:00:be:ef"
-	const ipv4Gateway = "10.0.0.1"
-	const mtu = 1450
-	const vifName = "test-vif"
-
-	Context("String", func() {
-		It("returns correct string representation", func() {
-			dhcpConfig := createDummyDhcpConfig(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
-			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, mac, ipv4Gateway, mtu)))
-		})
-		It("returns correct string representation with ipv6", func() {
-			dhcpConfig := createDummyDhcpConfig(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
-			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, ipv6Cidr, mac, ipv4Gateway, mtu)))
-		})
-		It("returns correct string representation when an IP is not defined", func() {
-			emptyCIDR := ""
-			dhcpConfig := createDummyDhcpConfig(vifName, emptyCIDR, ipv4Gateway, emptyCIDR, mac, mtu)
-			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: <nil>, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, mac, ipv4Gateway, mtu)))
-		})
-	})
-})
-
-func createDummyDhcpConfig(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *cache.DhcpConfig {
-	mac, _ := net.ParseMAC(macStr)
-	gw := net.ParseIP(ipv4gateway)
-	dhcpConfig := &cache.DhcpConfig{
-		Name:              vifName,
-		MAC:               mac,
-		AdvertisingIPAddr: gw,
-		Mtu:               mtu,
-	}
-	if ipv4cidr != "" {
-		ipv4Addr, _ := netlink.ParseAddr(ipv4cidr)
-		dhcpConfig.IP = *ipv4Addr
-	}
-	if ipv6cidr != "" {
-		ipv6Addr, _ := netlink.ParseAddr(ipv6cidr)
-		dhcpConfig.IPv6 = *ipv6Addr
-	}
-
-	return dhcpConfig
-}
-
-var _ = Describe("infocache", func() {
-
 })

--- a/pkg/network/driver/common_test.go
+++ b/pkg/network/driver/common_test.go
@@ -95,19 +95,31 @@ var _ = Describe("DhcpConfig", func() {
 			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
 			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu)))
 		})
+		It("returns correct string representation when an IP is not defined", func() {
+			emptyCIDR := ""
+			dhcpConfig := createDummyVIF(vifName, emptyCIDR, ipv4Gateway, emptyCIDR, mac, mtu)
+			// there's a bug.
+			defer func() {
+				if recover() == nil {
+				}
+			}()
+			Expect(dhcpConfig.String()).To(Panic())
+		})
 	})
 })
 
 func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *cache.DhcpConfig {
-	addr, _ := netlink.ParseAddr(ipv4cidr)
 	mac, _ := net.ParseMAC(macStr)
 	gw := net.ParseIP(ipv4gateway)
 	vif := &cache.DhcpConfig{
 		Name:              vifName,
-		IP:                *addr,
 		MAC:               mac,
 		AdvertisingIPAddr: gw,
 		Mtu:               mtu,
+	}
+	if ipv4cidr != "" {
+		ipv4Addr, _ := netlink.ParseAddr(ipv4cidr)
+		vif.IP = *ipv4Addr
 	}
 	if ipv6cidr != "" {
 		ipv6Addr, _ := netlink.ParseAddr(ipv6cidr)

--- a/pkg/network/driver/common_test.go
+++ b/pkg/network/driver/common_test.go
@@ -87,25 +87,25 @@ var _ = Describe("DhcpConfig", func() {
 
 	Context("String", func() {
 		It("returns correct string representation", func() {
-			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, mac, ipv4Gateway, mtu)))
+			dhcpConfig := createDummyDhcpConfig(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
+			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, mac, ipv4Gateway, mtu)))
 		})
 		It("returns correct string representation with ipv6", func() {
-			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, ipv6Cidr, mac, ipv4Gateway, mtu)))
+			dhcpConfig := createDummyDhcpConfig(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
+			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, ipv6Cidr, mac, ipv4Gateway, mtu)))
 		})
 		It("returns correct string representation when an IP is not defined", func() {
 			emptyCIDR := ""
-			dhcpConfig := createDummyVIF(vifName, emptyCIDR, ipv4Gateway, emptyCIDR, mac, mtu)
+			dhcpConfig := createDummyDhcpConfig(vifName, emptyCIDR, ipv4Gateway, emptyCIDR, mac, mtu)
 			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: <nil>, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, mac, ipv4Gateway, mtu)))
 		})
 	})
 })
 
-func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *cache.DhcpConfig {
+func createDummyDhcpConfig(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu uint16) *cache.DhcpConfig {
 	mac, _ := net.ParseMAC(macStr)
 	gw := net.ParseIP(ipv4gateway)
-	vif := &cache.DhcpConfig{
+	dhcpConfig := &cache.DhcpConfig{
 		Name:              vifName,
 		MAC:               mac,
 		AdvertisingIPAddr: gw,
@@ -113,14 +113,14 @@ func createDummyVIF(vifName, ipv4cidr, ipv4gateway, ipv6cidr, macStr string, mtu
 	}
 	if ipv4cidr != "" {
 		ipv4Addr, _ := netlink.ParseAddr(ipv4cidr)
-		vif.IP = *ipv4Addr
+		dhcpConfig.IP = *ipv4Addr
 	}
 	if ipv6cidr != "" {
 		ipv6Addr, _ := netlink.ParseAddr(ipv6cidr)
-		vif.IPv6 = *ipv6Addr
+		dhcpConfig.IPv6 = *ipv6Addr
 	}
 
-	return vif
+	return dhcpConfig
 }
 
 var _ = Describe("infocache", func() {

--- a/pkg/network/driver/common_test.go
+++ b/pkg/network/driver/common_test.go
@@ -79,7 +79,6 @@ var _ = Describe("Common Methods", func() {
 var _ = Describe("DhcpConfig", func() {
 	const ipv4Cidr = "10.0.0.200/24"
 	const ipv4Address = "10.0.0.200"
-	const ipv4Mask = "ffffff00"
 	const ipv6Cidr = "fd10:0:2::2/120"
 	const mac = "de:ad:00:00:be:ef"
 	const ipv4Gateway = "10.0.0.1"
@@ -89,21 +88,16 @@ var _ = Describe("DhcpConfig", func() {
 	Context("String", func() {
 		It("returns correct string representation", func() {
 			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, "", mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, mac, ipv4Gateway, mtu)))
+			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, mac, ipv4Gateway, mtu)))
 		})
 		It("returns correct string representation with ipv6", func() {
 			vif := createDummyVIF(vifName, ipv4Cidr, ipv4Gateway, ipv6Cidr, mac, mtu)
-			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IP: %s, Mask: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Address, ipv4Mask, ipv6Cidr, mac, ipv4Gateway, mtu)))
+			Expect(vif.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: %s, IPv6: %s, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, ipv4Cidr, ipv6Cidr, mac, ipv4Gateway, mtu)))
 		})
 		It("returns correct string representation when an IP is not defined", func() {
 			emptyCIDR := ""
 			dhcpConfig := createDummyVIF(vifName, emptyCIDR, ipv4Gateway, emptyCIDR, mac, mtu)
-			// there's a bug.
-			defer func() {
-				if recover() == nil {
-				}
-			}()
-			Expect(dhcpConfig.String()).To(Panic())
+			Expect(dhcpConfig.String()).To(Equal(fmt.Sprintf("DhcpConfig: { Name: %s, IPv4: <nil>, IPv6: <nil>, MAC: %s, AdvertisingIPAddr: %s, MTU: %d, IPAMDisabled: false}", vifName, mac, ipv4Gateway, mtu)))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently, the `DhcpConfig.String()` method (which is not being used in the code) panics when the IP parameter is not set. Furthermore, its output for IPv4 and IPv6 addresses differed, by considering the IPv4 mask an entity in itself.

This PR addresses that, by aligning the ipv4 implementation w/ the ipv6 one - which handles nil.

I threw in renaming some vestigial `vif` references I've seen in the code to the new type, `DhcpConfig` . I'm aware this should have been done in a different PR, but, I felt silly pushing just that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Depends-on: #5711 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
