### PR TITLE
Fix duplicate unittest descriptions and enforce unique descriptions

### DIFF
--- a/cmd/container-disk-v2alpha/BUILD.bazel
+++ b/cmd/container-disk-v2alpha/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     ],
     data = ["//cmd/container-disk-v2alpha:container-disk"],
     deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/cmd/container-disk-v2alpha/container_disk_v2alpha_suite_test.go
+++ b/cmd/container-disk-v2alpha/container_disk_v2alpha_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestContainerDiskV2alpha(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/cmd/container-disk-v2alpha/container_disk_v2alpha_suite_test.go
+++ b/cmd/container-disk-v2alpha/container_disk_v2alpha_suite_test.go
@@ -1,13 +1,11 @@
 package container_disk_v2alpha_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 
 	"testing"
 )
 
 func TestContainerDiskV2alpha(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "ContainerDiskV2alpha Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
 }

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -13,11 +13,9 @@ rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 function collect_results() {
     cd ${KUBEVIRT_DIR}
-    for f in $(find bazel-testlogs/ -name 'test.xml'); do
-        dir=${ARTIFACTS}/junit/$(dirname $f)
-        mkdir -p ${dir}
-        cp -f ${f} ${dir}/junit.xml
-    done
+    mkdir -p ${ARTIFACTS}/junit/
+    bazel run //tools/junit-merger:junit-merger -- -o ${ARTIFACTS}/junit/junit.unittests.xml $(find bazel-testlogs/ -name 'test.xml' -printf "%p ")
+
     for f in $(find bazel-out/ -name 'test.log'); do
         dir=${ARTIFACTS}/testlogs/$(dirname $f)
         mkdir -p ${dir}

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -3,27 +3,26 @@ set -e
 source hack/common.sh
 source hack/config.sh
 
+rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
+
 if [ "${CI}" == "true" ]; then
     cat >>ci.bazelrc <<EOF
 test --cache_test_results=no --runs_per_test=1
 EOF
+
+    function collect_results() {
+        cd ${KUBEVIRT_DIR}
+        mkdir -p ${ARTIFACTS}/junit/
+        bazel run //tools/junit-merger:junit-merger -- -o ${ARTIFACTS}/junit/junit.unittests.xml $(find bazel-testlogs/ -name 'test.xml' -printf "%p ")
+
+        for f in $(find bazel-out/ -name 'test.log'); do
+            dir=${ARTIFACTS}/testlogs/$(dirname $f)
+            mkdir -p ${dir}
+            cp -f ${f} ${dir}/test.log
+        done
+    }
+    trap collect_results EXIT
 fi
-
-rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
-
-function collect_results() {
-    cd ${KUBEVIRT_DIR}
-    mkdir -p ${ARTIFACTS}/junit/
-    bazel run //tools/junit-merger:junit-merger -- -o ${ARTIFACTS}/junit/junit.unittests.xml $(find bazel-testlogs/ -name 'test.xml' -printf "%p ")
-
-    for f in $(find bazel-out/ -name 'test.log'); do
-        dir=${ARTIFACTS}/testlogs/$(dirname $f)
-        mkdir -p ${dir}
-        cp -f ${f} ${dir}/test.log
-    done
-}
-
-trap collect_results EXIT
 
 bazel test \
     --config=${ARCHITECTURE} \

--- a/pkg/certificates/bootstrap/bootstrap_suite_test.go
+++ b/pkg/certificates/bootstrap/bootstrap_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestBootstrap(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Bootstrap Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/certificates/certificates_suite_test.go
+++ b/pkg/certificates/certificates_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCertificates(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Certificates Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/cloud-init/cloudinit_suite_test.go
+++ b/pkg/cloud-init/cloudinit_suite_test.go
@@ -28,5 +28,5 @@ import (
 
 func TestCloudInit(t *testing.T) {
 	ephemeraldiskutils.MockDefaultOwnershipManager()
-	testutils.KubeVirtTestSuiteSetup(t, "CloudInit Test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestConfig(t *testing.T) {
 	ephemeraldiskutils.MockDefaultOwnershipManager()
-	testutils.KubeVirtTestSuiteSetup(t, "Config Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/container-disk/container-disk_suite_test.go
+++ b/pkg/container-disk/container-disk_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestContainerDisk(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "ContainerDisk Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestController(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Controller Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/downwardmetrics/vhostmd/metrics/metrics_suite_test.go
+++ b/pkg/downwardmetrics/vhostmd/metrics/metrics_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestSelinux(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "metrics Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/downwardmetrics/vhostmd/vhostmd_suite_test.go
+++ b/pkg/downwardmetrics/vhostmd/vhostmd_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestSelinux(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "vhostmd Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/emptydisk/emptydisk_suite_test.go
+++ b/pkg/emptydisk/emptydisk_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestEmptydisk(t *testing.T) {
 	ephemeraldiskutils.MockDefaultOwnershipManager()
-	testutils.KubeVirtTestSuiteSetup(t, "Emptydisk Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/ephemeral-disk-utils/utils_suite_test.go
+++ b/pkg/ephemeral-disk-utils/utils_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestEphemeralDiskUtils(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "EphemeralDiskUtils Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
+++ b/pkg/ephemeral-disk/ephemeral-disk_suite_test.go
@@ -28,5 +28,5 @@ import (
 
 func TestContainerDisk(t *testing.T) {
 	ephemeraldiskutils.MockDefaultOwnershipManager()
-	testutils.KubeVirtTestSuiteSetup(t, "EphemeralDisk Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/healthz/BUILD.bazel
+++ b/pkg/healthz/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/pkg/healthz/healthz_suite_test.go
+++ b/pkg/healthz/healthz_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestHealthz(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Healthz Suite")
 }

--- a/pkg/healthz/healthz_suite_test.go
+++ b/pkg/healthz/healthz_suite_test.go
@@ -1,13 +1,11 @@
 package healthz
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 
 	"testing"
 )
 
 func TestHealthz(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Healthz Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
 }

--- a/pkg/healthz/healthz_suite_test.go
+++ b/pkg/healthz/healthz_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestHealthz(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Healthz Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/hooks/hooks_suite_test.go
+++ b/pkg/hooks/hooks_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestHooks(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/host-disk/host_disk_suite_test.go
+++ b/pkg/host-disk/host_disk_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestHostDisk(t *testing.T) {
 	ephemeraldiskutils.MockDefaultOwnershipManager()
-	testutils.KubeVirtTestSuiteSetup(t, "HostDisk Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/hotplug-disk/hotplug-disk_suite_test.go
+++ b/pkg/hotplug-disk/hotplug-disk_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestHostDisk(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "HotplugDisk Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/ignition/ignition_suite_test.go
+++ b/pkg/ignition/ignition_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestIgnition(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Ignition Test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/inotify-informer/inotify_suite_test.go
+++ b/pkg/inotify-informer/inotify_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestInotifyInformer(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "InotifyInformer Test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/middleware/middleware_suite_test.go
+++ b/pkg/middleware/middleware_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestEndpoints(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Endpoints Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/monitoring/domainstats/collector_suite_test.go
+++ b/pkg/monitoring/domainstats/collector_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestPrometheus(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Collector Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/monitoring/domainstats/downwardmetrics/downwardmetrics_suite_test.go
+++ b/pkg/monitoring/domainstats/downwardmetrics/downwardmetrics_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestPrometheus(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Downwardmetrics Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/monitoring/domainstats/prometheus/prometheus_suite_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestPrometheus(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Prometheus Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/monitoring/domainstats/prometheus/prometheus_test.go
+++ b/pkg/monitoring/domainstats/prometheus/prometheus_test.go
@@ -840,7 +840,7 @@ var _ = Describe("Prometheus", func() {
 			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_receive_packets_total"))
 		})
 
-		It("should handle network tx traffic bytes metrics", func() {
+		It("should handle network tx traffic packets metrics", func() {
 			ch := make(chan prometheus.Metric, 1)
 			defer close(ch)
 
@@ -894,7 +894,7 @@ var _ = Describe("Prometheus", func() {
 			Expect(result.Desc().String()).To(ContainSubstring("kubevirt_vmi_network_receive_errors_total"))
 		})
 
-		It("should handle network tx traffic bytes metrics", func() {
+		It("should handle network tx traffic error metrics", func() {
 			ch := make(chan prometheus.Metric, 1)
 			defer close(ch)
 

--- a/pkg/monitoring/vmistats/BUILD.bazel
+++ b/pkg/monitoring/vmistats/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/monitoring/vmistats/vmistats_suite_test.go
+++ b/pkg/monitoring/vmistats/vmistats_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestVmistats(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Vmistats Suite")
 }

--- a/pkg/monitoring/vmistats/vmistats_suite_test.go
+++ b/pkg/monitoring/vmistats/vmistats_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestVmistats(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Vmistats Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/monitoring/vmistats/vmistats_suite_test.go
+++ b/pkg/monitoring/vmistats/vmistats_suite_test.go
@@ -3,11 +3,9 @@ package vmistats_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestVmistats(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Vmistats Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
 }

--- a/pkg/network/cache/cache_suite_test.go
+++ b/pkg/network/cache/cache_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Cache Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/network/dhcp/BUILD.bazel
+++ b/pkg/network/dhcp/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         "//pkg/network/cache/fake:go_default_library",
         "//pkg/network/driver:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",

--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -105,16 +105,6 @@ var _ = Describe("DHCP configurator", func() {
 			table.Entry("without client filtering", newConfigurator(launcherPID, bridgeName)),
 		)
 
-		table.DescribeTable("should succeed when DHCP server started", func(configurator *Configurator) {
-			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil)
-
-			Expect(configurator.EnsureDhcpServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-			Expect(configurator.EnsureDhcpServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-		},
-			table.Entry("with active client filtering", newConfiguratorWithClientFilter(launcherPID, bridgeName)),
-			table.Entry("without client filtering", newConfigurator(launcherPID, bridgeName)),
-		)
-
 		table.DescribeTable("should succeed when DHCP server is started multiple times", func(configurator *Configurator) {
 			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil)
 

--- a/pkg/network/dhcp/dhcp_suite_test.go
+++ b/pkg/network/dhcp/dhcp_suite_test.go
@@ -3,11 +3,9 @@ package dhcp_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestDhcpConfigurator(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "DHCP Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
 }

--- a/pkg/network/dhcp/dhcp_suite_test.go
+++ b/pkg/network/dhcp/dhcp_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDhcpConfigurator(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "DHCP Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/network/dhcp/dhcp_suite_test.go
+++ b/pkg/network/dhcp/dhcp_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDhcpConfigurator(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "DHCP Suite")
 }

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",

--- a/pkg/network/driver/driver_suite_test.go
+++ b/pkg/network/driver/driver_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDriver(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Driver Suite")
 }

--- a/pkg/network/driver/driver_suite_test.go
+++ b/pkg/network/driver/driver_suite_test.go
@@ -3,11 +3,9 @@ package driver_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestDriver(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Network Driver Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
 }

--- a/pkg/network/driver/driver_suite_test.go
+++ b/pkg/network/driver/driver_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDriver(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Driver Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/testutils/testutils_suite_test.go
+++ b/pkg/testutils/testutils_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestVirtHandler(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/cluster/cluster_suite_test.go
+++ b/pkg/util/cluster/cluster_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCluster(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Cluster Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/hardware/hw_utils_suite_test.go
+++ b/pkg/util/hardware/hw_utils_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestHardwareUtils(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hardware Utils Test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/lookup/lookup_suite_test.go
+++ b/pkg/util/lookup/lookup_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestOpenapi(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Lookup Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/lookup/lookup_test.go
+++ b/pkg/util/lookup/lookup_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Lookup", func() {
 		virtClient.EXPECT().VirtualMachineInstance(gomock.Any()).Return(vmiInterface).AnyTimes()
 	})
 
-	It("should return vmis", func() {
+	It("should return all vmis on a node", func() {
 		vmi1 := createVirtualMachineInstance("vmi1", "node01", virtv1.Running)
 		vmi2 := createVirtualMachineInstance("vmi2", "node01", virtv1.Failed)
 		vmis := []virtv1.VirtualMachineInstance{*vmi1, *vmi2}
@@ -53,7 +53,7 @@ var _ = Describe("Lookup", func() {
 		Expect(len(returnedVMIs)).To(Equal(2))
 	})
 
-	It("should return vmis", func() {
+	It("should return active vmis on a node", func() {
 		vmi1 := createVirtualMachineInstance("vmi1", "node01", virtv1.Running)
 		vmi2 := createVirtualMachineInstance("vmi2", "node01", virtv1.Failed)
 		vmis := []virtv1.VirtualMachineInstance{*vmi1, *vmi2}
@@ -83,6 +83,6 @@ var _ = Describe("Lookup", func() {
 		table.Entry("pending state", virtv1.Pending),
 		table.Entry("scheduling state", virtv1.Scheduling),
 		table.Entry("failed state", virtv1.Failed),
-		table.Entry("failed state", virtv1.Succeeded),
+		table.Entry("succeeded state", virtv1.Succeeded),
 	)
 })

--- a/pkg/util/net/dns/dns_suite_test.go
+++ b/pkg/util/net/dns/dns_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDns(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Dns Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/net/ip/ip_suite_test.go
+++ b/pkg/util/net/ip/ip_suite_test.go
@@ -25,5 +25,5 @@ import (
 )
 
 func TestIp(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Ip Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/openapi/openapi_suite_test.go
+++ b/pkg/util/openapi/openapi_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestOpenapi(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Openapi Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/status/status_suite_test.go
+++ b/pkg/util/status/status_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestStatus(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Status Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/types/types_suite_test.go
+++ b/pkg/util/types/types_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestTypeUtils(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Type Utils Test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/util/webhooks/webhooks_suite_test.go
+++ b/pkg/util/webhooks/webhooks_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestWebhooks(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Webhooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-api/rest/rest_suite_test.go
+++ b/pkg/virt-api/rest/rest_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestRest(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Rest Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-api/virt-api_suite_test.go
+++ b/pkg/virt-api/virt-api_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestVirtApi(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Virt_Api Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/mutators_suite_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/mutators_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMutatingWebhook(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Mutators Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/admitters_suite_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/admitters_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestValidatingWebhook(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Admitters Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1011,25 +1011,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.networks "+
 				"list exceeds the %d element limit in length", arrayLenMax)))
 		})
-		It("should reject volume lists greater than max element length", func() {
-			vmi := v1.NewMinimalVMI("testvmi")
-
-			for i := 0; i <= arrayLenMax; i++ {
-				volumeName := "testVolume"
-				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-					Name: volumeName,
-					VolumeSource: v1.VolumeSource{
-						ContainerDisk: testutils.NewFakeContainerDiskSource(),
-					},
-				})
-			}
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			// if this is processed correctly, it should result in a single error
-			// If multiple causes occurred, then the spec was processed too far.
-			Expect(len(causes)).To(Equal(1))
-			Expect(causes[0].Field).To(Equal("fake.volumes"))
-		})
 		It("should reject disks with the same boot order", func() {
 			vmi := v1.NewMinimalVMI("testvmi")
 			order := uint(1)
@@ -3712,7 +3693,7 @@ var _ = Describe("Function getNumberOfPodInterfaces()", func() {
 		Expect(len(causes)).To(Equal(0))
 	})
 
-	It("Should validate VMIs with hyperv EVMCS configuration without deps", func() {
+	It("Should validate VMIs with hyperv EVMCS configuration without deps and detect multiple issues", func() {
 		_true := true
 		vmi := v1.NewMinimalVMI("testvmi")
 		vmi.Spec.Domain.Features = &v1.Features{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -390,8 +390,8 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		Expect(reflect.DeepEqual(result, expected)).To(BeTrue(), "result: %v and expected: %v do not match", result, expected)
 	},
 		table.Entry("Should be empty if statuses is empty", makeVolumes(), makeStatus(0, 0), emptyResult()),
-		table.Entry("Should be empty if statuses is not empty, but no hotplug", makeVolumes(), makeStatus(2, 0), emptyResult()),
-		table.Entry("Should be empty if statuses is not empty, but no hotplug", makeVolumes(), makeStatus(1, 0), emptyResult()),
+		table.Entry("Should be empty if statuses has multiple entries, but no hotplug", makeVolumes(), makeStatus(2, 0), emptyResult()),
+		table.Entry("Should be empty if statuses has one entry, but no hotplug", makeVolumes(), makeStatus(1, 0), emptyResult()),
 		table.Entry("Should have a single hotplug if status has one hotplug", makeVolumes(0, 1), makeStatus(2, 1), makeResult(1)),
 		table.Entry("Should have a multiple hotplug if status has multiple hotplug", makeVolumes(0, 1, 2, 3), makeStatus(4, 2), makeResult(2, 3)),
 	)
@@ -402,8 +402,8 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 	},
 		table.Entry("Should be empty if volume is empty", makeVolumes(), makeStatus(0, 0), emptyResult()),
 		table.Entry("Should be empty if all volumes are hotplugged", makeVolumes(0, 1, 2, 3), makeStatus(4, 4), emptyResult()),
-		table.Entry("Should return all volumes if hotplugged is empty", makeVolumes(0, 1, 2, 3), makeStatus(4, 0), makeResult(0, 1, 2, 3)),
-		table.Entry("Should return all volumes if hotplugged is empty", makeVolumes(0), makeStatus(1, 0), makeResult(0)),
+		table.Entry("Should return all volumes if hotplugged is empty with multiple volumes", makeVolumes(0, 1, 2, 3), makeStatus(4, 0), makeResult(0, 1, 2, 3)),
+		table.Entry("Should return all volumes if hotplugged is empty with a single volume", makeVolumes(0), makeStatus(1, 0), makeResult(0)),
 		table.Entry("Should return 3 volumes if  1 hotplugged volume", makeVolumes(0, 1, 2, 3), makeStatus(4, 1), makeResult(0, 1, 2)),
 	)
 
@@ -450,7 +450,7 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			makeDisks(0, 1),
 			makeStatus(1, 0),
 			makeExpected("permanent disk volume-name-0, changed", "")),
-		table.Entry("Should reject if we add volumes that are not PVC or DV",
+		table.Entry("Should reject if a hotplug volume changed",
 			makeInvalidVolumes(2, 1),
 			makeVolumes(0, 1),
 			makeDisks(0, 1),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1112,10 +1112,9 @@ var _ = Describe("Validating VM Admitter", func() {
 		},
 			table.Entry("when source namespace suppied", "ns1", "", "ns3", "", "ns3", "ns1", "default"),
 			table.Entry("when vm namespace suppied and source not", "ns1", "ns2", "", "", "ns2", "ns2", "default"),
-			table.Entry("when source namespace suppied", "ns1", "", "ns3", "", "ns3", "ns1", "default"),
 			table.Entry("when ar namespace suppied and vm/source not", "ns1", "", "", "", "ns1", "ns1", "default"),
-			table.Entry("when everything suppied", "ns1", "ns2", "ns3", "", "ns3", "ns2", "default"),
-			table.Entry("when everything suppied", "ns1", "ns2", "ns3", "sa", "ns3", "ns2", "sa"),
+			table.Entry("when everything suppied with default service account", "ns1", "ns2", "ns3", "", "ns3", "ns2", "default"),
+			table.Entry("when everything suppied with 'sa' service account", "ns1", "ns2", "ns3", "sa", "ns3", "ns2", "sa"),
 		)
 
 		table.DescribeTable("should deny clone", func(sourceNamespace, sourceName, failMessage string, failErr error, expectedMessage string) {

--- a/pkg/virt-api/webhooks/webhooks_suite_test.go
+++ b/pkg/virt-api/webhooks/webhooks_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestWebhooks(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Webhooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-config/config_suite_test.go
+++ b/pkg/virt-config/config_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Config Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/services/services_suite_test.go
+++ b/pkg/virt-controller/services/services_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestServices(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Services Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2888,5 +2888,5 @@ func False() *bool {
 }
 
 func TestTemplate(t *testing.T) {
-	testutils2.KubeVirtTestSuiteSetup(t, "Template")
+	testutils2.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -154,12 +154,7 @@ var _ = Describe("Template", func() {
 				),
 				table.Entry("and don't contain kubevirt annotation added by apiserver",
 					map[string]string{
-						"kubevirt.io/latest-observed-api-version": "source",
-					},
-					map[string]string{"kubevirt.io/domain": "testvmi"},
-				),
-				table.Entry("and don't contain kubevirt annotation added by apiserver",
-					map[string]string{
+						"kubevirt.io/latest-observed-api-version":  "source",
 						"kubevirt.io/storage-observed-api-version": ".com",
 					},
 					map[string]string{"kubevirt.io/domain": "testvmi"},
@@ -402,8 +397,8 @@ var _ = Describe("Template", func() {
 				Expect(exceptedValues).To(ContainElements(debugLogsValue))
 
 			},
-			table.Entry("defined when debug annotation is on", "true", []string{"1"}),
-			table.Entry("defined when debug annotation is on", "TRuE", []string{"1"}),
+			table.Entry("defined when debug annotation is on with lowercase true", "true", []string{"1"}),
+			table.Entry("defined when debug annotation is on with mixed case true", "TRuE", []string{"1"}),
 			table.Entry("not defined when debug annotation is off", "false", []string{"0", ""}),
 		)
 

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_suite_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDisruptionbudget(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Disruptionbudget Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_suite_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestEvacuation(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Evacuation Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/watch/snapshot/snapshot_suite_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Snapshot Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/watch/watch_suite_test.go
+++ b/pkg/virt-controller/watch/watch_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestWatch(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Watch Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_suite_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestWorkloadUpdater(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Workload Updater Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/cache/cache_suite_test.go
+++ b/pkg/virt-handler/cache/cache_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Cache Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/cgroup/cgroup_suite_test.go
+++ b/pkg/virt-handler/cgroup/cgroup_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestCgroup(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Cgroup Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/cmd-client/cmd_client_suite_test.go
+++ b/pkg/virt-handler/cmd-client/cmd_client_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCmdClient(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "CmdClient Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/container-disk/container_disk_suite_test.go
+++ b/pkg/virt-handler/container-disk/container_disk_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestContainerDisk(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "ContainerDisk Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/device-manager/device_manager_suite_test.go
+++ b/pkg/virt-handler/device-manager/device_manager_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestDeviceManager(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "DeviceManager Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/heartbeat/heartbeat_suite_test.go
+++ b/pkg/virt-handler/heartbeat/heartbeat_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestHeartbeat(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Heartbeat Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/hotplug-disk/hotplug-disk_suite_test.go
+++ b/pkg/virt-handler/hotplug-disk/hotplug-disk_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestHostDisk(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "HotplugDisk Mount Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -372,9 +372,6 @@ var _ = Describe("HotplugVolume block devices", func() {
 		table.Entry("Should not return values if stat command doesn't return block special file", func(fileName string) ([]byte, error) {
 			return []byte("245,32,0664, block file"), nil
 		}, -1, -1, "", true),
-		table.Entry("Should not return values if stat command doesn't return block special file", func(fileName string) ([]byte, error) {
-			return []byte("245,32,0664, block file"), nil
-		}, -1, -1, "", true),
 		table.Entry("Should not return values if stat command doesn't int major", func(fileName string) ([]byte, error) {
 			return []byte("kk,32,0664,block special file"), nil
 		}, -1, -1, "", true),
@@ -417,7 +414,7 @@ var _ = Describe("HotplugVolume block devices", func() {
 		Expect(err.Error()).To(ContainSubstring("no such file or directory"))
 	})
 
-	It("getTargetCgroupPath should return cgroup path", func() {
+	It("getTargetCgroupPath should return cgroup path and detect if it is not a directory", func() {
 		slicePath := "slice"
 		expectedCgroupPath := filepath.Join(tempDir, slicePath)
 		m.podIsolationDetector = &mockIsolationDetector{

--- a/pkg/virt-handler/isolation/isolation_suite_test.go
+++ b/pkg/virt-handler/isolation/isolation_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestIsolation(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Isolation Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/migration-proxy/migration_proxy_suite_test.go
+++ b/pkg/virt-handler/migration-proxy/migration_proxy_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMigrationProxy(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "MigrationProxy Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/node-labeller/node_labeller_suite_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_suite_test.go
@@ -28,5 +28,5 @@ import (
 )
 
 func TestNodeLabeller(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "NodeLabeller Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/selinux/selinux_suite_test.go
+++ b/pkg/virt-handler/selinux/selinux_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestSelinux(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Selinux Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-handler/virt_handler_suite_test.go
+++ b/pkg/virt-handler/virt_handler_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestVirtHandler(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "VirtHandler Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/notify-client/client_suite_test.go
+++ b/pkg/virt-launcher/notify-client/client_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestClient(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Client Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -122,8 +122,8 @@ var _ = Describe("Notify", func() {
 				Expect(timedOut).To(BeFalse(), "should not time out")
 			},
 				table.Entry("modified for crashed VMIs", libvirt.DOMAIN_CRASHED, libvirt.DOMAIN_EVENT_CRASHED, api.Crashed, watch.Modified),
-				table.Entry("modified for stopped VMIs", libvirt.DOMAIN_SHUTOFF, libvirt.DOMAIN_EVENT_SHUTDOWN, api.Shutoff, watch.Modified),
-				table.Entry("modified for stopped VMIs", libvirt.DOMAIN_SHUTOFF, libvirt.DOMAIN_EVENT_STOPPED, api.Shutoff, watch.Modified),
+				table.Entry("modified for stopped VMIs with shutoff reason", libvirt.DOMAIN_SHUTOFF, libvirt.DOMAIN_EVENT_SHUTDOWN, api.Shutoff, watch.Modified),
+				table.Entry("modified for stopped VMIs with stopped reason", libvirt.DOMAIN_SHUTOFF, libvirt.DOMAIN_EVENT_STOPPED, api.Shutoff, watch.Modified),
 				table.Entry("modified for running VMIs", libvirt.DOMAIN_RUNNING, libvirt.DOMAIN_EVENT_STARTED, api.Running, watch.Modified),
 				table.Entry("added for defined VMIs", libvirt.DOMAIN_SHUTOFF, libvirt.DOMAIN_EVENT_DEFINED, api.Shutoff, watch.Added),
 			)

--- a/pkg/virt-launcher/virt_launcher_suite_test.go
+++ b/pkg/virt-launcher/virt_launcher_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestVirtLauncher(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "VirtLauncher Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestAccessCredentials(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "AccessCredentials Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_suite_test.go
@@ -25,5 +25,5 @@ import (
 )
 
 func TestAgentPoller(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "AgentPoller Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/api/api_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/api/api_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestApi(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Api Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/cli/cli_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/cli/cli_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCli(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Cli Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/cmd-server/cmd_server_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/cmd_server_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestCmdServer(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "CmdServer Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestConverter(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Converter Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/device/device_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/device/device_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestNetwork(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Device Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/device/sriov/sriov_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/device/sriov/sriov_suite_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestNetwork(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Network SRIOV Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }
 
 func newSRIOVInterface(name string) v1.Interface {

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestNetwork(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "DHCP test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/network/dhcpv6/dhcpv6_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcpv6/dhcpv6_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestDhcpv6(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "DHCPv6 test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/network/network_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestNetwork(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Network Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/statsconv/stats_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/stats_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestStats(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Stats Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/util/util_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/util/util_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestUtil(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Util Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/virtwrap/virtwrap_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/virtwrap_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestVirtwrap(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Virtwrap Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-operator/resource/apply/install_strategy_suite_test.go
+++ b/pkg/virt-operator/resource/apply/install_strategy_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestInstallStrategy(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "InstallStrategy Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-operator/resource/generate/components/components_suite_test.go
+++ b/pkg/virt-operator/resource/generate/components/components_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestComponents(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Components Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-operator/resource/generate/install/install_suite_test.go
+++ b/pkg/virt-operator/resource/generate/install/install_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestInstall(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Install Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Operator Config", func() {
 			getConfigWithShas("sha256:api", "sha256:controller", "sha256:handler", "sha256:launcher", "v234"),
 			getFullConfig("kubevirt", "sha256:operator", "sha256:api", "sha256:controller", "sha256:handler", "sha256:launcher", "v234"),
 			true, true),
-		table.Entry("with all shasums given", "kubevirt/virt-operator:v123",
+		table.Entry("with shasums given should fail if not all are provided", "kubevirt/virt-operator:v123",
 			getConfigWithShas("sha256:api", "sha256:controller", "", "", ""),
 			getConfig("kubevirt", "v123"),
 			false, false),

--- a/pkg/virt-operator/util/util_suite_test.go
+++ b/pkg/virt-operator/util/util_suite_test.go
@@ -25,5 +25,5 @@ import (
 )
 
 func TestController(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Operator Util Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-operator/virt_operator_suite_test.go
+++ b/pkg/virt-operator/virt_operator_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestVirtOperator(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "VirtOperator Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 		causes := validateCustomizeComponents(cc)
 		Expect(len(causes)).To(Equal(expectedCauses))
 	},
-		table.Entry("valid values accepted", v1.CustomizeComponents{
+		table.Entry("invalid values rejected", v1.CustomizeComponents{
 			Patches: []v1.CustomizeComponentsPatch{
 				{
 					ResourceName: "virt-api",

--- a/pkg/virt-operator/webhooks/webhooks_suite_test.go
+++ b/pkg/virt-operator/webhooks/webhooks_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestWebhooks(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Webhooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virtctl/expose/expose_suite_test.go
+++ b/pkg/virtctl/expose/expose_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestExpose(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Expose Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virtctl/expose/expose_test.go
+++ b/pkg/virtctl/expose/expose_test.go
@@ -216,8 +216,13 @@ var _ = Describe("Expose", func() {
 				})
 			})
 			Context("With cluster-ip on an unknown vm", func() {
-				It("should fail", func() {
+				It("should fail on a vmi", func() {
 					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vmi", unknownVM, "--name", "my-service",
+						"--port", "9999")
+					Expect(cmd()).NotTo(BeNil())
+				})
+				It("should fail on a vm", func() {
+					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", unknownVM, "--name", "my-service",
 						"--port", "9999")
 					Expect(cmd()).NotTo(BeNil())
 				})
@@ -234,13 +239,6 @@ var _ = Describe("Expose", func() {
 					err := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", vmName, "--name", "my-service",
 						"--port", "9999")
 					Expect(err()).To(BeNil())
-				})
-			})
-			Context("With cluster-ip on an unknown vm", func() {
-				It("should fail", func() {
-					cmd := tests.NewRepeatableVirtctlCommand(expose.COMMAND_EXPOSE, "vm", unknownVM, "--name", "my-service",
-						"--port", "9999")
-					Expect(cmd()).NotTo(BeNil())
 				})
 			})
 			Context("With cluster-ip on an vm replica set", func() {

--- a/pkg/virtctl/imageupload/imageupload_suite_test.go
+++ b/pkg/virtctl/imageupload/imageupload_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestImageUpload(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "ImageUpload Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virtctl/pause/pause_suite_test.go
+++ b/pkg/virtctl/pause/pause_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestPauseUnpause(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Pausing Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virtctl/root_suite_test.go
+++ b/pkg/virtctl/root_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestRoot(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "root Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virtctl/vm/vm_suite_test.go
+++ b/pkg/virtctl/vm/vm_suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestVm(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "vm Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virtctl/vm/vm_test.go
+++ b/pkg/virtctl/vm/vm_test.go
@@ -46,28 +46,19 @@ var _ = Describe("VirtualMachine", func() {
 	})
 
 	Context("With missing input parameters", func() {
-		It("should fail", func() {
+		It("should fail a start", func() {
 			cmd := tests.NewRepeatableVirtctlCommand("start")
 			Expect(cmd()).NotTo(BeNil())
 		})
-	})
-
-	Context("With missing input parameters", func() {
-		It("should fail", func() {
+		It("should fail a stop", func() {
 			cmd := tests.NewRepeatableVirtctlCommand("stop")
 			Expect(cmd()).NotTo(BeNil())
 		})
-	})
-
-	Context("With missing input parameters", func() {
-		It("should fail", func() {
+		It("should fail a restart", func() {
 			cmd := tests.NewRepeatableVirtctlCommand("restart")
 			Expect(cmd()).NotTo(BeNil())
 		})
-	})
-
-	Context("With missing input parameters", func() {
-		It("should fail", func() {
+		It("should fail a migrate", func() {
 			cmd := tests.NewRepeatableVirtctlCommand("migrate")
 			Expect(cmd()).NotTo(BeNil())
 		})

--- a/pkg/watchdog/watchdog_suite_test.go
+++ b/pkg/watchdog/watchdog_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestWatchdog(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Watchdog Test Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/v1_suite_test.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/v1_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestV1(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "V1 Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/kubecli_suite_test.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubecli_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestKubecli(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "kubecli Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/staging/src/kubevirt.io/client-go/log/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/log/BUILD.bazel
@@ -26,6 +26,8 @@ go_test(
     deps = [
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/config:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/reporters:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/kubevirt.io/client-go/log/log_suite_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_suite_test.go
@@ -1,14 +1,43 @@
 package log
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/gomega"
 )
 
 func TestLogging(t *testing.T) {
-	Log.SetIOWriter(GinkgoWriter)
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Logging Suite")
+	Log.SetIOWriter(ginkgo.GinkgoWriter)
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	testsWrapped := os.Getenv("GO_TEST_WRAP")
+	outputFile := os.Getenv("XML_OUTPUT_FILE")
+	description := "log"
+
+	// if run on bazel (XML_OUTPUT_FILE is not empty)
+	// and rules_go is configured to not produce the junit xml
+	// produce it here. Otherwise just run the default RunSpec
+	if testsWrapped == "0" && outputFile != "" {
+		testTarget := os.Getenv("TEST_TARGET")
+		if testTarget != "" {
+			description = testTarget
+		}
+		if config.GinkgoConfig.ParallelTotal > 1 {
+			outputFile = fmt.Sprintf("%s-%d", outputFile, config.GinkgoConfig.ParallelNode)
+		}
+
+		ginkgo.RunSpecsWithDefaultAndCustomReporters(
+			t,
+			description,
+			[]ginkgo.Reporter{
+				reporters.NewJUnitReporter(outputFile),
+			},
+		)
+	} else {
+		ginkgo.RunSpecs(t, description)
+	}
 }

--- a/staging/src/kubevirt.io/client-go/testutils/setup.go
+++ b/staging/src/kubevirt.io/client-go/testutils/setup.go
@@ -3,6 +3,9 @@ package testutils
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/onsi/ginkgo"
@@ -17,7 +20,10 @@ import (
 // If tests are executed through bazel, the provided description is ignored. Instead
 // the TEST_TARGET environment variable will be used to synchronize the output
 // with bazels test output and make test navigation and detection consistent.
-func KubeVirtTestSuiteSetup(t *testing.T, description string) {
+func KubeVirtTestSuiteSetup(t *testing.T) {
+	_, description, _, _ := runtime.Caller(1)
+	projectRoot := findRoot()
+	description = strings.TrimPrefix(description, projectRoot)
 	// Redirect writes to ginkgo writer to keep tests quiet when
 	// they succeed
 	log.Log.SetIOWriter(ginkgo.GinkgoWriter)
@@ -34,21 +40,36 @@ func KubeVirtTestSuiteSetup(t *testing.T, description string) {
 	// produce it here. Otherwise just run the default RunSpec
 	if testsWrapped == "0" && outputFile != "" {
 		testTarget := os.Getenv("TEST_TARGET")
-		if testTarget != "" {
-			description = testTarget
-		}
 		if config.GinkgoConfig.ParallelTotal > 1 {
 			outputFile = fmt.Sprintf("%s-%d", outputFile, config.GinkgoConfig.ParallelNode)
 		}
 
 		ginkgo.RunSpecsWithDefaultAndCustomReporters(
 			t,
-			description,
+			testTarget,
 			[]ginkgo.Reporter{
 				reporters.NewJUnitReporter(outputFile),
 			},
 		)
 	} else {
+		// Use the current filename as description for ginkgo
 		ginkgo.RunSpecs(t, description)
+	}
+}
+
+func findRoot() string {
+	_, current, _, _ := runtime.Caller(0)
+	for {
+		current = filepath.Dir(current)
+		if current == "/" || current == "." {
+			return current
+		}
+		if _, err := os.Stat(filepath.Join(current, "WORKSPACE")); err == nil {
+			return strings.TrimSuffix(current, "/") + "/"
+		} else if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			panic(err)
+		}
 	}
 }

--- a/tests/framework/matcher/BUILD.bazel
+++ b/tests/framework/matcher/BUILD.bazel
@@ -31,7 +31,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/framework/matcher/matcher_suite_test.go
+++ b/tests/framework/matcher/matcher_suite_test.go
@@ -26,5 +26,5 @@ import (
 )
 
 func TestEndpoints(t *testing.T) {
-	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/tests/framework/matcher/matcher_suite_test.go
+++ b/tests/framework/matcher/matcher_suite_test.go
@@ -22,14 +22,9 @@ package matcher
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"kubevirt.io/client-go/log"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestEndpoints(t *testing.T) {
-	log.Log.SetIOWriter(GinkgoWriter)
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Endpoints Suite")
+	testutils.KubeVirtTestSuiteSetup(t, "Hooks Suite")
 }

--- a/tools/junit-merger/junit-merger.go
+++ b/tools/junit-merger/junit-merger.go
@@ -15,6 +15,12 @@ import (
 
 func main() {
 
+	if path := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); path != "" {
+		if err := os.Chdir(path); err != nil {
+			panic(err)
+		}
+	}
+
 	var output string
 	flag.StringVarP(&output, "output", "o", "-", "File to write the resulting junit file to, defaults to stdout (-)")
 	flag.Parse()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will now pre-merge all junit files as buildstep. This fixes a render-issue on the junit lense as well as enforcing from now on unique test-descriptions.

The change helped already here identifying a few duplicate identical tests as well as wrong test descriptions. In both cases the sources of the mistakes were probably auto-merges as well as copy-pase errors when adding new test descriptions.

If duplicate test descriptions are detected, errors like this are printed:

```
{"component":"","level":"fatal","msg":"Could not merge JUnit files","pos":"junit-merger.go:40","reason":"test 'VirtualMachineInstance watcher On valid VirtualMachineInstance given with DataVolume source should create a corresponding Pod on VMI creation when DataVolume is ready' was executed multiple times","timestamp":"2021-06-03T12:12:10.893921Z"}
panic: Could not merge JUnit files
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
