### PR TITLE
Group podNIC methods together

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -257,6 +257,24 @@ func (l *podNIC) PlugPhase1() error {
 	return nil
 }
 
+func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
+	ifaceConfig, err := l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Read(l.iface.Name)
+
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ifaceConfig, nil
+}
+
+func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
+	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.iface.Name, &domainIface)
+}
+
 func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 	precond.MustNotBeNil(domain)
 
@@ -547,24 +565,6 @@ func getPIDString(pid *int) string {
 		return fmt.Sprintf("%d", *pid)
 	}
 	return "self"
-}
-
-func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
-	ifaceConfig, err := l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Read(l.iface.Name)
-
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return ifaceConfig, nil
-}
-
-func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
-	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.iface.Name, &domainIface)
 }
 
 func (b *BridgeBindMechanism) learnInterfaceRoutes() error {


### PR DESCRIPTION
podNIC methods cachedDomainInterface and storeCachedDomainIface methods to be
defined among BridgeBindingMechanism methods by accident.
Let's move them to other podNIC methods.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
