### PR TITLE
DO NOT MERGE - Test PR with documentation change

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,4 @@
+Testing *.md update.
 
 # Frequently Asked Questions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+Testing update of documentation file.
+
 ## Technical Overview
 
 Kubernetes allows for extensions to its architecture via

--- a/docs/devel/hostpath-provisioner.yaml
+++ b/docs/devel/hostpath-provisioner.yaml
@@ -4,6 +4,7 @@ metadata:
   name: hostpath-provisioner
   labels:
     app: hostpath-provisioner
+    test: should-be-ignored
 spec:
   selector:
     matchLabels:

--- a/docs/test-file.go
+++ b/docs/test-file.go
@@ -1,0 +1,3 @@
+package docs
+
+// Empty file for testing


### PR DESCRIPTION
**What this PR does / why we need it**:
PR to test that CI will ignore documentation changes.

Related to: https://github.com/kubevirt/project-infra/pull/1244

**Release note**:
```release-note
None
```
