### PR TITLE
Add test_id to daemonset and service reconcile tests

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -1054,7 +1054,7 @@ spec:
 
 					return pdb.Spec.Selector.MatchLabels["kubevirt.io"] != "dne"
 				}),
-			table.Entry("daemonsets",
+			table.Entry("[test_id:6308] daemonsets",
 				func() {
 					vc, err := virtClient.AppsV1().DaemonSets(originalKv.Namespace).Get(context.Background(), daemonSetName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -1091,7 +1091,7 @@ spec:
 				}),
 		)
 
-		It("checking updating service is reverted to original state", func() {
+		It("[test_id:6309] checking updating service is reverted to original state", func() {
 			service, err := virtClient.CoreV1().Services(originalKv.Namespace).Get(context.Background(), "virt-api", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: Kedar Bidarkar <kbidarka@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: `Add test_id to daemonset and service reconcile tests`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
