### PR TITLE
Fix accumulating useless info in error message

### DIFF
--- a/tests/utils.go
+++ b/tests/utils.go
@@ -4584,16 +4584,17 @@ func waitForConfigToBePropagated(resourceVersion string) {
 func WaitForConfigToBePropagatedToComponent(podLabel string, resourceVersion string, compareResourceVersions compare) {
 	virtClient, err := kubecli.GetKubevirtClient()
 	PanicOnError(err)
-	errAdditionalInfo := fmt.Sprintf("component: \"%s\"", strings.TrimPrefix(podLabel, "kubevirt.io="))
+
+	errComponentInfo := fmt.Sprintf("component: \"%s\"", strings.TrimPrefix(podLabel, "kubevirt.io="))
 
 	EventuallyWithOffset(3, func() error {
 		pods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: podLabel})
 
 		if err != nil {
-			return fmt.Errorf("failed to fetch pods. %s", errAdditionalInfo)
+			return fmt.Errorf("failed to fetch pods. %s", errComponentInfo)
 		}
 		for _, pod := range pods.Items {
-			errAdditionalInfo += fmt.Sprintf(", pod: \"%s\"", pod.Name)
+			errAdditionalInfo := errComponentInfo + fmt.Sprintf(", pod: \"%s\"", pod.Name)
 
 			if pod.DeletionTimestamp != nil {
 				continue


### PR DESCRIPTION
Small fix stop accumulating useless info in error message

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
