### PR TITLE
update configmap cabundle if it is not parseable

### DIFF
--- a/pkg/virt-operator/resource/apply/BUILD.bazel
+++ b/pkg/virt-operator/resource/apply/BUILD.bazel
@@ -78,6 +78,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/certificates/triple:go_default_library",
+        "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
@@ -113,5 +115,6 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
     ],
 )

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -332,7 +332,7 @@ func (r *Reconciler) createOrUpdateComponentsWithCertificates(queue workqueue.Ra
 	}
 
 	// create/update CA config map
-	caBundle, err := r.createOrUpdateKubeVirtCAConfigMap(queue, caCert, caRenewBefore)
+	caBundle, err := r.createOrUpdateKubeVirtCAConfigMap(queue, caCert, caRenewBefore, findRequiredCAConfigMap(r.targetStrategy.ConfigMaps()))
 	if err != nil {
 		return err
 	}
@@ -556,8 +556,7 @@ func shouldUpdateBundle(required, existing *corev1.ConfigMap, key string, queue 
 	return updateBundle, nil
 }
 
-func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.RateLimitingInterface, caCert *tls.Certificate, overlapInterval *metav1.Duration) (caBundle []byte, err error) {
-	configMap := findRequiredCAConfigMap(r.targetStrategy.ConfigMaps())
+func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.RateLimitingInterface, caCert *tls.Certificate, overlapInterval *metav1.Duration, configMap *corev1.ConfigMap) (caBundle []byte, err error) {
 	if configMap == nil {
 		return nil, nil
 	}

--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -535,10 +535,11 @@ func findRequiredCAConfigMap(configmaps []*corev1.ConfigMap) *corev1.ConfigMap {
 }
 
 func shouldUpdateBundle(required, existing *corev1.ConfigMap, key string, queue workqueue.RateLimitingInterface, caCert *tls.Certificate, overlapInterval *metav1.Duration) (bool, error) {
-	updateBundle := false
 	bundle, certCount, err := components.MergeCABundle(caCert, []byte(existing.Data[components.CABundleKey]), overlapInterval.Duration)
 	if err != nil {
-		return updateBundle, err
+		// the only error that can be returned form MergeCABundle is if the CA caBundle
+		// is unable to be parsed. If we can not parse it we should update it
+		return true, err
 	}
 
 	// ensure that we remove the old CA after the overlap period
@@ -546,6 +547,7 @@ func shouldUpdateBundle(required, existing *corev1.ConfigMap, key string, queue 
 		queue.AddAfter(key, overlapInterval.Duration)
 	}
 
+	updateBundle := false
 	required.Data = map[string]string{components.CABundleKey: string(bundle)}
 	if !reflect.DeepEqual(required.Data, existing.Data) {
 		updateBundle = true
@@ -583,7 +585,12 @@ func (r *Reconciler) createOrUpdateKubeVirtCAConfigMap(queue workqueue.RateLimit
 	existing := obj.(*corev1.ConfigMap)
 	updateBundle, err := shouldUpdateBundle(configMap, existing, r.kvKey, queue, caCert, overlapInterval)
 	if err != nil {
-		return nil, err
+		if !updateBundle {
+			return nil, err
+		}
+
+		configMap.Data = map[string]string{components.CABundleKey: string(cert.EncodeCertPEM(caCert.Leaf))}
+		log.Log.Reason(err).V(2).Infof("There was an error validating the CA bundle stored in configmap %s. We are updating the bundle.", configMap.GetName())
 	}
 
 	modified := resourcemerge.BoolPtr(false)


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Right now if the ca-bundle is updated to something that is not parseable it will never be updated. This change updates the ca-bundle value if we can not parse it. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update ca-bundle if it is unable to be parsed
```
