### PR TITLE
Update kernel boot container files to be owned by QEMU

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -468,7 +468,7 @@ container_pull(
 
 container_pull(
     name = "alpine-ext-kernel-boot-demo-container-base",
-    digest = "sha256:97bfbe0e3d57a45da3130dd6a63d6f83dcbc37e82b1be7ac30b6cf698d52e932",
+    digest = "sha256:a2ddb2f568bf3814e594a14bc793d5a655a61d5983f3561d60d02afa7bbc56b4",
     registry = "quay.io",
     repository = "kubevirt/alpine-ext-kernel-boot-demo",
 )


### PR DESCRIPTION
Update kernel boot container to tag 07_05_2021__1.
The new container's binaries (kernel & initrd) are owned by QEMU (UID 107).

Container image on quay:
https://quay.io/repository/kubevirt/alpine-ext-kernel-boot-demo

PR to update Dockerfile:
https://github.com/kubevirt/kubevirtci/pull/613

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
