### PR TITLE
fix test by changing the expect to be a single word to make the check more accurate

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -732,7 +732,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 
-			It("[QUARANTINE][test_id:6053]should restore a vm from an online snapshot", func() {
+			It("[test_id:6053]should restore a vm from an online snapshot", func() {
 				vm, vmi = createAndStartVM(tests.NewRandomVMWithBlockDataVolumeAndUserDataInStorageClass(
 					tests.GetUrl(tests.CirrosHttpUrl),
 					tests.NamespaceTestDefault,
@@ -745,8 +745,10 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 				}, 360, 10).Should(Succeed())
 
 				b := append([]expect.Batcher{
-					&expect.BSnd{S: "cat /var/run/resize.rootfs | grep resized\n"},
-					&expect.BExp{R: "resized successfully"},
+					&expect.BSnd{S: "grep -q resized /var/run/resize.rootfs \n"},
+					&expect.BExp{R: console.PromptExpression},
+					&expect.BSnd{S: expectReturn},
+					&expect.BExp{R: console.RetValue("0")},
 				})
 				Eventually(func() error {
 					return console.SafeExpectBatch(vmi, b, 10)


### PR DESCRIPTION
Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR is a possible fix to the problematic test which is currently in quarantine

**Special notes for your reviewer**:
**_I remove the quarantine label to try and test and retest the fix several time in the PR, will return the quarantine label before the merge_**

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
