### PR TITLE
Add ./hack/patch.sh to patch kubevirt

### DIFF
--- a/hack/patch.sh
+++ b/hack/patch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -xe
+
+source hack/common.sh
+source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
+source hack/config.sh
+
+function wait_for_rollout() {
+    _kubectl rollout status $1 -n $namespace $2 --timeout=240s
+}
+
+function wait_for_digest() {
+    for digest in $3; do
+        while ! _kubectl get -n $namespace $1 $2 -o yaml | grep $digest; do
+            sleep 5
+        done
+    done
+}
+
+function wait_for() {
+    wait_for_digest $1 $2 "$3"
+    wait_for_rollout $1 $2
+}
+
+PUSH_TARGETS="virt-api virt-controller virt-handler virt-launcher" ./hack/bazel-push-images.sh
+
+source ./hack/parse-shasums.sh
+
+_kubectl set env deployment -n $namespace virt-operator \
+    VIRT_HANDLER_SHASUM=$VIRT_HANDLER_SHA \
+    VIRT_LAUNCHER_SHASUM=$VIRT_LAUNCHER_SHA \
+    VIRT_CONTROLLER_SHASUM=$VIRT_CONTROLLER_SHA \
+    VIRT_API_SHASUM=$VIRT_API_SHA
+
+wait_for ds virt-handler "$VIRT_LAUNCHER_SHA $VIRT_HANDLER_SHA"
+wait_for deployment virt-controller "$VIRT_LAUNCHER_SHA $VIRT_CONTROLLER_SHA"
+wait_for deployment virt-api $VIRT_API_SHA


### PR DESCRIPTION
**What this PR does / why we need it**:
Currenctly iterating on kubevirt take a lot of time on redploying the
changes. This change creates a hacky script that will patch
controller/handler/launcher to speed things up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
