### PR TITLE
Quarantine sig-compute and sig-storage flaky tests

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -1033,7 +1033,7 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 			Expect(err).To(BeNil())
 		},
 			table.Entry("[test_id:5894]by default, fstrim will make the image smaller", noop, true, false),
-			table.Entry("[test_id:5898]with preallocation true, fstrim has no effect", addPreallocationTrue, false, false),
+			table.Entry("[QUARANTINE][test_id:5898]with preallocation true, fstrim has no effect", addPreallocationTrue, false, false),
 			table.Entry("[test_id:5897]with preallocation false, fstrim will make the image smaller", addPreallocationFalse, true, false),
 			table.Entry("[test_id:5899]with thick provision true, fstrim has no effect", addThickProvisionedTrueAnnotation, false, false),
 			table.Entry("[test_id:5896]with thick provision false, fstrim will make the image smaller", addThickProvisionedFalseAnnotation, true, false),

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -156,7 +156,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			Expect(createdVM.Spec.Template.Spec.Domain.Machine.Type).To(Equal(testingMachineType))
 		})
 
-		It("[test_id:3311]should keep the supplied MachineType when created", func() {
+		It("[QUARANTINE][test_id:3311]should keep the supplied MachineType when created", func() {
 			By("Creating VirtualMachine")
 			explicitMachineType := "pc-q35-3.0"
 			template, _ := newVirtualMachineInstanceWithContainerDisk()

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -144,7 +144,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			return newVM
 		}
 
-		It("[test_id:3312]should set the default MachineType when created without explicit value", func() {
+		It("[QUARANTINE][test_id:3312]should set the default MachineType when created without explicit value", func() {
 			By("Creating VirtualMachine")
 			template, _ := newVirtualMachineInstanceWithContainerDisk()
 			template.Spec.Domain.Machine = nil


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Quarantine flaky tests:
* `[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachine [Serial]A mutated VirtualMachine given [test_id:3312]should set the default MachineType when created without explicit value`
  * flakefinder report https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2021-06-07-168h.html#row6
  * Recent failures:
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5402/pull-kubevirt-e2e-k8s-1.20-sig-compute/1402232004669345792
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5752/pull-kubevirt-e2e-k8s-1.20-sig-compute/1402221595346341888
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5782/pull-kubevirt-e2e-k8s-1.19-sig-compute/1402230456899866624
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5752/pull-kubevirt-e2e-k8s-1.19-sig-compute/1402221606809374720
    * https://prow.apps.ovirt.org/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-sig-compute/1402030280084033536

When `test_id:3312` it is set to quarantine, `test_id:3311` starts failing too, they seem to be coupled, this PR will quarantine both. 

* `[sig-storage] [Serial]DataVolume Integration Fedora VMI tests [rfe_id:5070][crit:medium][vendor:cnv-qe@redhat.com][level:component]fstrim from the VM influences disk.img [test_id:5898]with preallocation true, fstrim has no effect`
  * flakefinder report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2021-06-07-168h.html#row3
  * Recent failures:
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-storage/1400397033348534272
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5778/pull-kubevirt-e2e-k8s-1.20-sig-storage/1402208304163196928
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5169/pull-kubevirt-e2e-k8s-1.20-sig-storage/1401805941208256512
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5402/pull-kubevirt-e2e-k8s-1.19-sig-storage/1402144052798820352
    * https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5778/pull-kubevirt-e2e-k8s-1.19-sig-storage/1401854765683445760

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
