### PR TITLE
Expose VM/VMI readiness via a dedicated CLI column

### DIFF
--- a/pkg/controller/conditions.go
+++ b/pkg/controller/conditions.go
@@ -62,6 +62,23 @@ func (d *VirtualMachineConditionManager) RemoveCondition(vm *v1.VirtualMachine, 
 type VirtualMachineInstanceConditionManager struct {
 }
 
+// UpdateCondition updates the given VirtualMachineCondition, unless it is already set with the same status and reason.
+func (d *VirtualMachineConditionManager) UpdateCondition(vm *v1.VirtualMachine, cond *v1.VirtualMachineCondition) {
+	for i, c := range vm.Status.Conditions {
+		if c.Type != cond.Type {
+			continue
+		}
+
+		if c.Status != cond.Status || c.Reason != cond.Reason {
+			vm.Status.Conditions[i] = *cond
+		}
+
+		return
+	}
+
+	vm.Status.Conditions = append(vm.Status.Conditions, *cond)
+}
+
 func (d *VirtualMachineInstanceConditionManager) CheckFailure(vmi *v1.VirtualMachineInstance, syncErr error, reason string) (changed bool) {
 	if syncErr != nil && !d.HasCondition(vmi, v1.VirtualMachineInstanceSynchronized) {
 		vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
@@ -114,6 +131,23 @@ func (d *VirtualMachineInstanceConditionManager) RemoveCondition(vmi *v1.Virtual
 		conds = append(conds, c)
 	}
 	vmi.Status.Conditions = conds
+}
+
+// UpdateCondition updates the given VirtualMachineInstanceCondition, unless it is already set with the same status and reason.
+func (d *VirtualMachineInstanceConditionManager) UpdateCondition(vmi *v1.VirtualMachineInstance, cond *v1.VirtualMachineInstanceCondition) {
+	for i, c := range vmi.Status.Conditions {
+		if c.Type != cond.Type {
+			continue
+		}
+
+		if c.Status != cond.Status || c.Reason != cond.Reason {
+			vmi.Status.Conditions[i] = *cond
+		}
+
+		return
+	}
+
+	vmi.Status.Conditions = append(vmi.Status.Conditions, *cond)
 }
 
 // AddPodCondition add pod condition to the VM.

--- a/pkg/controller/conditions_test.go
+++ b/pkg/controller/conditions_test.go
@@ -76,4 +76,56 @@ var _ = Describe("VirtualMachineInstance ConditionManager", func() {
 			Expect(cm.HasCondition(vmi2, v1.VirtualMachineInstanceConditionType(pc1.Type))).To(BeFalse())
 		})
 	})
+
+	When("Updating a condition", func() {
+
+		var vc1 *v1.VirtualMachineInstanceCondition
+		BeforeEach(func() {
+			vc1 = &v1.VirtualMachineInstanceCondition{
+				Type:    v1.VirtualMachineInstanceReady,
+				Status:  v12.ConditionFalse,
+				Reason:  "A reason",
+				Message: "A message",
+			}
+
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{*vc1}
+		})
+
+		It("should update the condition if status has changed", func() {
+			vc2 := &v1.VirtualMachineInstanceCondition{
+				Type:   v1.VirtualMachineInstanceReady,
+				Status: v12.ConditionTrue,
+			}
+
+			cm.UpdateCondition(vmi, vc2)
+			Expect(len(vmi.Status.Conditions)).To(Equal(1))
+			Expect(cm.GetCondition(vmi, vc1.Type)).To(Equal(vc2))
+		})
+
+		It("should update the condition if the reason has changed", func() {
+			vc2 := &v1.VirtualMachineInstanceCondition{
+				Type:    v1.VirtualMachineInstanceReady,
+				Status:  v12.ConditionFalse,
+				Reason:  "A different reason",
+				Message: "A different message",
+			}
+
+			cm.UpdateCondition(vmi, vc2)
+			Expect(len(vmi.Status.Conditions)).To(Equal(1))
+			Expect(cm.GetCondition(vmi, vc1.Type)).To(Equal(vc2))
+		})
+
+		It("shouldn't update the condition if both status and reason hasn't changed", func() {
+			vc2 := &v1.VirtualMachineInstanceCondition{
+				Type:    v1.VirtualMachineInstanceReady,
+				Status:  v12.ConditionFalse,
+				Reason:  "A reason",
+				Message: "A different message",
+			}
+
+			cm.UpdateCondition(vmi, vc2)
+			Expect(len(vmi.Status.Conditions)).To(Equal(1))
+			Expect(cm.GetCondition(vmi, vc1.Type)).To(Equal(vc1))
+		})
+	})
 })

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -106,6 +106,7 @@ go_test(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1422,7 +1422,7 @@ func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi 
 	vmReadyCond := controller.NewVirtualMachineConditionManager().
 		GetCondition(vm, virtv1.VirtualMachineReady)
 	vmiReadyCond := controller.NewVirtualMachineInstanceConditionManager().
-		GetCondition(vmi, virtv1.VirtualMachineInstanceConditionType(k8score.PodReady))
+		GetCondition(vmi, virtv1.VirtualMachineInstanceReady)
 
 	if vmReadyCond == nil {
 		newCond := virtv1.VirtualMachineCondition{Type: virtv1.VirtualMachineReady}

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1423,8 +1423,7 @@ func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi 
 		vmReadyCond := controller.NewVirtualMachineConditionManager().GetCondition(vm, virtv1.VirtualMachineReady)
 		if vmReadyCond != nil &&
 			vmReadyCond.Status == status &&
-			vmReadyCond.Reason == reason &&
-			vmReadyCond.Message == message {
+			vmReadyCond.Reason == reason {
 			return
 		}
 
@@ -1445,7 +1444,7 @@ func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi 
 	now := v1.Now()
 	if vmi == nil {
 		setVMCondition(k8score.ConditionFalse,
-			"VMIConditionMissing",
+			"VMINotExists",
 			"VMI does not exist",
 			now,
 			now)

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1419,7 +1419,7 @@ func (c *VMController) isVirtualMachineStatusMigrating(vm *virtv1.VirtualMachine
 }
 
 func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) {
-	setVMCondition := func(status k8score.ConditionStatus, reason, message string, lastProbeTime, lastTransitionTime v1.Time) {
+	setVMReadyCondition := func(status k8score.ConditionStatus, reason, message string, lastProbeTime, lastTransitionTime v1.Time) {
 		vmReadyCond := controller.NewVirtualMachineConditionManager().GetCondition(vm, virtv1.VirtualMachineReady)
 		if vmReadyCond != nil &&
 			vmReadyCond.Status == status &&
@@ -1443,14 +1443,14 @@ func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi 
 
 	now := v1.Now()
 	if vmi == nil {
-		setVMCondition(k8score.ConditionFalse,
+		setVMReadyCondition(k8score.ConditionFalse,
 			"VMINotExists",
 			"VMI does not exist",
 			now,
 			now)
 
 	} else if vmiReadyCond == nil {
-		setVMCondition(k8score.ConditionFalse,
+		setVMReadyCondition(k8score.ConditionFalse,
 			"VMIConditionMissing",
 			"VMI is missing the Ready condition",
 			now,
@@ -1459,7 +1459,7 @@ func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi 
 	} else {
 		log.Log.Object(vm).V(4).Info("Syncing VM Ready condition from VMI")
 
-		setVMCondition(vmiReadyCond.Status,
+		setVMReadyCondition(vmiReadyCond.Status,
 			vmiReadyCond.Reason,
 			vmiReadyCond.Message,
 			vmiReadyCond.LastProbeTime,

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1442,19 +1442,20 @@ func (c *VMController) syncReadyConditionFromVMI(vm *virtv1.VirtualMachine, vmi 
 		vmReadyCond.LastTransitionTime = lastTransitionTime
 	}
 
+	now := v1.Now()
 	if vmi == nil {
 		setVMCondition(k8score.ConditionFalse,
 			"VMIConditionMissing",
 			"VMI does not exist",
-			v1.Now(),
-			v1.Now())
+			now,
+			now)
 
 	} else if vmiReadyCond == nil {
 		setVMCondition(k8score.ConditionFalse,
 			"VMIConditionMissing",
 			"VMI is missing the Ready condition",
-			v1.Now(),
-			v1.Now())
+			now,
+			now)
 
 	} else {
 		log.Log.Object(vm).V(4).Info("Syncing VM Ready condition from VMI")

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -1190,7 +1190,7 @@ func (c *VMController) updateStatus(vmOrig *virtv1.VirtualMachine, vmi *virtv1.V
 
 	ready := false
 	if created {
-		ready = controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceConditionType(k8score.PodReady), k8score.ConditionTrue)
+		ready = controller.NewVirtualMachineInstanceConditionManager().HasConditionWithStatus(vmi, virtv1.VirtualMachineInstanceReady, k8score.ConditionTrue)
 	}
 	vm.Status.Ready = ready
 

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -1569,6 +1569,7 @@ func VirtualMachineFromVMI(name string, vmi *v1.VirtualMachineInstance, started 
 				{
 					Type:   v1.VirtualMachineReady,
 					Status: k8sv1.ConditionFalse,
+					Reason: "VMINotExists",
 				},
 			},
 		},

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -690,6 +690,13 @@ func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInst
 			now,
 			now)
 
+	} else if !vmi.IsRunning() {
+		setVMICondition(k8sv1.ConditionFalse,
+			virtv1.GuestNotRunningReason,
+			"Guest VM is not reported as running",
+			now,
+			now)
+
 	} else if podReadyCond := conditionManager.GetPodCondition(pod, k8sv1.PodReady); podReadyCond != nil {
 		setVMICondition(podReadyCond.Status,
 			podReadyCond.Reason,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -654,20 +654,22 @@ func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInst
 		log.Log.Object(vmi).Infof(logMessage + ":" + message)
 	}
 
+	now := v1.Now()
+
 	// Keep PodReady condition in sync with the VMI
 	if pod == nil || isTempPod(pod) {
 		setVMICondition(k8sv1.ConditionFalse,
 			virtv1.PodConditionMissingReason,
 			"virt-launcher pod does not exist",
-			v1.Now(),
-			v1.Now())
+			now,
+			now)
 
 	} else if isPodDownOrGoingDown(pod) {
 		setVMICondition(k8sv1.ConditionFalse,
 			virtv1.PodTerminatingReason,
 			"virt-launcher pod is terminating",
-			v1.Now(),
-			v1.Now())
+			now,
+			now)
 
 	} else if podReadyCond := conditionManager.GetPodCondition(pod, k8sv1.PodReady); podReadyCond != nil {
 		setVMICondition(podReadyCond.Status,
@@ -679,8 +681,8 @@ func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInst
 		setVMICondition(k8sv1.ConditionFalse,
 			virtv1.PodConditionMissingReason,
 			"virt-launcher pod is missing the Ready condition",
-			v1.Now(),
-			v1.Now())
+			now,
+			now)
 	}
 }
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -632,8 +632,7 @@ func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInst
 		vmiReadyCond := conditionManager.GetCondition(vmi, virtv1.VirtualMachineInstanceReady)
 		if vmiReadyCond != nil &&
 			vmiReadyCond.Status == status &&
-			vmiReadyCond.Reason == reason &&
-			vmiReadyCond.Message == message {
+			vmiReadyCond.Reason == reason {
 			return
 		}
 
@@ -660,7 +659,7 @@ func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInst
 	// Keep PodReady condition in sync with the VMI
 	if pod == nil || isTempPod(pod) {
 		setVMICondition(k8sv1.ConditionFalse,
-			virtv1.PodConditionMissingReason,
+			virtv1.PodNotExistsReason,
 			"virt-launcher pod has not yet been scheduled",
 			now,
 			now)

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -19,7 +19,6 @@
 package watch
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -503,7 +502,7 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		return fmt.Errorf("unknown vmi phase %v", vmi.Status.Phase)
 	}
 
-	// VMI is owned by virt-controller, so patch instead of update
+	// VMI is owned by virt-handler, so patch instead of update
 	if vmi.IsRunning() || vmi.IsScheduled() {
 		patchBytes, err := preparePatch(vmi, vmiCopy)
 		if err != nil {
@@ -630,18 +629,7 @@ func preparePatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) ([]byte, error)
 		return nil, nil
 	}
 
-	patchBuffer := bytes.Buffer{}
-	patchBuffer.WriteString("[ ")
-	for i, entry := range patchOps {
-		patchBuffer.WriteString(entry)
-		if i == len(patchOps)-1 {
-			patchBuffer.WriteString(" ]")
-		} else {
-			patchBuffer.WriteString(", ")
-		}
-	}
-
-	return patchBuffer.Bytes(), nil
+	return controller.GeneratePatchBytes(patchOps), nil
 }
 
 func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) {

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -19,6 +19,7 @@
 package watch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -480,128 +481,45 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 		}
 
 	case vmi.IsRunning():
-		patchOps := []string{}
-		if vmiPodExists {
-			c.updateVolumeStatus(vmiCopy, pod)
-		}
-		if !reflect.DeepEqual(vmiCopy.Status.VolumeStatus, vmi.Status.VolumeStatus) {
-			// VolumeStatus changed which means either removed or added volumes.
-			newVolumeStatus, err := json.Marshal(vmiCopy.Status.VolumeStatus)
-			if err != nil {
-				return err
-			}
-			oldVolumeStatus, err := json.Marshal(vmi.Status.VolumeStatus)
-			if err != nil {
-				return err
-			}
-			if string(oldVolumeStatus) == "null" {
-				patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/status/volumeStatus", "value": %s }`, string(newVolumeStatus)))
-			} else {
-				patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/volumeStatus", "value": %s }`, string(oldVolumeStatus)))
-				patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/volumeStatus", "value": %s }`, string(newVolumeStatus)))
-			}
-			log.Log.V(3).Object(vmi).Infof("Patching Volume Status")
-		}
-		// We don't own the object anymore, so patch instead of update
-		if !conditionsEqual(vmiCopy.Status.Conditions, vmi.Status.Conditions) {
-
-			newConditions, err := json.Marshal(vmiCopy.Status.Conditions)
-			if err != nil {
-				return err
-			}
-			oldConditions, err := json.Marshal(vmi.Status.Conditions)
-			if err != nil {
-				return err
-			}
-
-			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/conditions", "value": %s }`, string(oldConditions)))
-			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/conditions", "value": %s }`, string(newConditions)))
-
-			log.Log.V(3).Object(vmi).Infof("Patching VMI conditions")
+		if !vmiPodExists {
+			break
 		}
 
-		if !reflect.DeepEqual(vmiCopy.Status.ActivePods, vmi.Status.ActivePods) {
-			newPods, err := json.Marshal(vmiCopy.Status.ActivePods)
-			if err != nil {
-				return err
-			}
-			oldPods, err := json.Marshal(vmi.Status.ActivePods)
-			if err != nil {
-				return err
-			}
+		c.updateVolumeStatus(vmiCopy, pod)
 
-			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/activePods", "value": %s }`, string(oldPods)))
-			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/activePods", "value": %s }`, string(newPods)))
-
-			log.Log.V(3).Object(vmi).Infof("Patching VMI activePods")
-		}
-
-		if vmiPodExists {
-			var foundImage string
-
-			for _, container := range pod.Spec.Containers {
-				if container.Name == "compute" {
-					foundImage = container.Image
-					break
-				}
-			}
-
-			vmiCopy = c.setLauncherContainerInfo(vmiCopy, foundImage)
-
-			if vmiCopy.Status.LauncherContainerImageVersion != vmi.Status.LauncherContainerImageVersion {
-				if vmi.Status.LauncherContainerImageVersion == "" {
-					patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "%s" }`, vmiCopy.Status.LauncherContainerImageVersion))
-				} else {
-					patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/launcherContainerImageVersion", "value": "%s" }`, vmi.Status.LauncherContainerImageVersion))
-					patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/launcherContainerImageVersion", "value": "%s" }`, vmiCopy.Status.LauncherContainerImageVersion))
-				}
-			}
-
-			if !reflect.DeepEqual(vmi.Labels, vmiCopy.Labels) {
-				labelBytes, err := json.Marshal(vmiCopy.Labels)
-				if err != nil {
-					return err
-				}
-				origLabelBytes, err := json.Marshal(vmi.Labels)
-				if err != nil {
-					return err
-				}
-
-				if vmi.Labels == nil {
-					patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/metadata/labels", "value": %s }`, string(labelBytes)))
-				} else {
-					patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/metadata/labels", "value": %s }`, string(origLabelBytes)))
-					patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/metadata/labels", "value": %s }`, string(labelBytes)))
-
-				}
+		var foundImage string
+		for _, container := range pod.Spec.Containers {
+			if container.Name == "compute" {
+				foundImage = container.Image
+				break
 			}
 		}
+		vmiCopy = c.setLauncherContainerInfo(vmiCopy, foundImage)
 
-		if len(patchOps) > 0 {
-			patch := "[ "
-			for i, entry := range patchOps {
-				patch += entry
+	case vmi.IsScheduled():
+		// Nothing here
+		break
+	default:
+		return fmt.Errorf("unknown vmi phase %v", vmi.Status.Phase)
+	}
 
-				if i == len(patchOps)-1 {
-					patch += " ]"
-				} else {
-					patch += ", "
-				}
-			}
+	// VMI is owned by virt-controller, so patch instead of update
+	if vmi.IsRunning() || vmi.IsScheduled() {
+		patchBytes, err := preparePatch(vmi, vmiCopy)
+		if err != nil {
+			return fmt.Errorf("error preparing VMI patch: %v", err)
+		}
 
-			_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(vmi.Name, types.JSONPatchType, []byte(patch))
+		if len(patchBytes) > 0 {
+			_, err = c.clientset.VirtualMachineInstance(vmi.Namespace).Patch(vmi.Name, types.JSONPatchType, []byte(patchBytes))
 			// We could not retry if the "test" fails but we have no sane way to detect that right now: https://github.com/kubernetes/kubernetes/issues/68202 for details
 			// So just retry like with any other errors
 			if err != nil {
-				return fmt.Errorf("patching of vmi conditions and activePods failed: %v, %v", err, patchOps)
+				return fmt.Errorf("patching of vmi conditions and activePods failed: %v", err)
 			}
 		}
+
 		return nil
-	case vmi.IsScheduled():
-		// Don't process states where the vmi is clearly owned by virt-handler
-		return nil
-	default:
-		return fmt.Errorf("unknown vmi phase %v", vmi.Status.Phase)
 	}
 
 	reason := ""
@@ -623,6 +541,107 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 	}
 
 	return nil
+}
+
+func preparePatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) ([]byte, error) {
+	var patchOps []string
+
+	if !reflect.DeepEqual(newVMI.Status.VolumeStatus, oldVMI.Status.VolumeStatus) {
+		// VolumeStatus changed which means either removed or added volumes.
+		newVolumeStatus, err := json.Marshal(newVMI.Status.VolumeStatus)
+		if err != nil {
+			return nil, err
+		}
+		oldVolumeStatus, err := json.Marshal(oldVMI.Status.VolumeStatus)
+		if err != nil {
+			return nil, err
+		}
+		if string(oldVolumeStatus) == "null" {
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/status/volumeStatus", "value": %s }`, string(newVolumeStatus)))
+		} else {
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/volumeStatus", "value": %s }`, string(oldVolumeStatus)))
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/volumeStatus", "value": %s }`, string(newVolumeStatus)))
+		}
+		log.Log.V(3).Object(oldVMI).Infof("Patching Volume Status")
+	}
+	// We don't own the object anymore, so patch instead of update
+	if !conditionsEqual(newVMI.Status.Conditions, oldVMI.Status.Conditions) {
+
+		newConditions, err := json.Marshal(newVMI.Status.Conditions)
+		if err != nil {
+			return nil, err
+		}
+		oldConditions, err := json.Marshal(oldVMI.Status.Conditions)
+		if err != nil {
+			return nil, err
+		}
+
+		patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/conditions", "value": %s }`, string(oldConditions)))
+		patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/conditions", "value": %s }`, string(newConditions)))
+
+		log.Log.V(3).Object(oldVMI).Infof("Patching VMI conditions")
+	}
+
+	if !reflect.DeepEqual(newVMI.Status.ActivePods, oldVMI.Status.ActivePods) {
+		newPods, err := json.Marshal(newVMI.Status.ActivePods)
+		if err != nil {
+			return nil, err
+		}
+		oldPods, err := json.Marshal(oldVMI.Status.ActivePods)
+		if err != nil {
+			return nil, err
+		}
+
+		patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/activePods", "value": %s }`, string(oldPods)))
+		patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/activePods", "value": %s }`, string(newPods)))
+
+		log.Log.V(3).Object(oldVMI).Infof("Patching VMI activePods")
+	}
+
+	if newVMI.Status.LauncherContainerImageVersion != oldVMI.Status.LauncherContainerImageVersion {
+		if oldVMI.Status.LauncherContainerImageVersion == "" {
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "%s" }`, newVMI.Status.LauncherContainerImageVersion))
+		} else {
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/status/launcherContainerImageVersion", "value": "%s" }`, oldVMI.Status.LauncherContainerImageVersion))
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/status/launcherContainerImageVersion", "value": "%s" }`, newVMI.Status.LauncherContainerImageVersion))
+		}
+	}
+
+	if !reflect.DeepEqual(oldVMI.Labels, newVMI.Labels) {
+		newLabelBytes, err := json.Marshal(newVMI.Labels)
+		if err != nil {
+			return nil, err
+		}
+		oldLabelBytes, err := json.Marshal(oldVMI.Labels)
+		if err != nil {
+			return nil, err
+		}
+
+		if oldVMI.Labels == nil {
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "add", "path": "/metadata/labels", "value": %s }`, string(newLabelBytes)))
+		} else {
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "test", "path": "/metadata/labels", "value": %s }`, string(oldLabelBytes)))
+			patchOps = append(patchOps, fmt.Sprintf(`{ "op": "replace", "path": "/metadata/labels", "value": %s }`, string(newLabelBytes)))
+
+		}
+	}
+
+	if len(patchOps) == 0 {
+		return nil, nil
+	}
+
+	patchBuffer := bytes.Buffer{}
+	patchBuffer.WriteString("[ ")
+	for i, entry := range patchOps {
+		patchBuffer.WriteString(entry)
+		if i == len(patchOps)-1 {
+			patchBuffer.WriteString(" ]")
+		} else {
+			patchBuffer.WriteString(", ")
+		}
+	}
+
+	return patchBuffer.Bytes(), nil
 }
 
 func (c *VMIController) syncReadyConditionFromPod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1243,20 +1243,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			table.Entry("and in pending state", k8sv1.PodPending),
 		)
 
-		It("should remove ready condition when VMI is in a finalized state", func() {
-			vmi := NewPendingVirtualMachine("testvmi")
-			vmi.Status.Phase = v1.Succeeded
-
-			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{{Type: v1.VirtualMachineInstanceReady}}
-			addVirtualMachine(vmi)
-
-			vmiInterface.EXPECT().Update(gomock.Any()).Do(func(arg interface{}) {
-				Expect(len(arg.(*v1.VirtualMachineInstance).Status.Conditions)).To(Equal(0))
-			}).Return(vmi, nil)
-
-			controller.Execute()
-		})
-
 		It("should add outdated label if pod's image is outdated and VMI is in running state", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = v1.Running

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -743,8 +743,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			shouldExpectVirtualMachineFailedState(vmi)
 
 			controller.Execute()
-
-			testutils.ExpectEvent(recorder, v1.PodTerminatingReason)
 		})
 		table.DescribeTable("should not delete the corresponding Pod if the vmi is in", func(phase v1.VirtualMachineInstancePhase) {
 			vmi := NewPendingVirtualMachine("testvmi")
@@ -1254,8 +1252,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			shouldExpectVirtualMachineFailedState(vmi)
 
 			controller.Execute()
-
-			testutils.ExpectEvent(recorder, v1.PodNotExistsReason)
 		})
 		It("should update the virtual machine to failed if compute container is terminated while still scheduling", func() {
 			vmi := NewPendingVirtualMachine("testvmi")
@@ -1388,8 +1384,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
-
-			testutils.ExpectEvent(recorder, "")
 		})
 
 		It("should indicate on the ready condition if the pod is terminating", func() {
@@ -1422,7 +1416,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				return patchedVMI, nil
 			})
 			controller.Execute()
-			testutils.ExpectEvent(recorder, v1.PodTerminatingReason)
 		})
 
 		It("should add active pods to status if VMI is in running state", func() {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -2354,6 +2354,10 @@ func markAsNonReady(vmi *v1.VirtualMachineInstance) {
 	kvcontroller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionFalse})
 }
 
+func unmarkReady(vmi *v1.VirtualMachineInstance) {
+	kvcontroller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+}
+
 func addActivePods(vmi *v1.VirtualMachineInstance, podUID types.UID, hostName string) *v1.VirtualMachineInstance {
 
 	if vmi.Status.ActivePods != nil {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -1334,7 +1334,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			podFeeder.Add(pod)
 
-			patch := `[ { "op": "add", "path": "/status/launcherContainerImageVersion", "value": "madeup" }, { "op": "add", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} } ]`
+			patch := `[{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "madeup" }, { "op": "add", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }]`
 
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
@@ -1362,7 +1362,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			podFeeder.Add(pod)
 
-			patch := `[ { "op": "add", "path": "/status/launcherContainerImageVersion", "value": "a" }, { "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }, { "op": "replace", "path": "/metadata/labels", "value": {} } ]`
+			patch := `[{ "op": "add", "path": "/status/launcherContainerImageVersion", "value": "a" }, { "op": "test", "path": "/metadata/labels", "value": {"kubevirt.io/outdatedLauncherImage":""} }, { "op": "replace", "path": "/metadata/labels", "value": {} }]`
 
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
@@ -1380,7 +1380,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addActivePods(vmi, pod.UID, "")
 			podFeeder.Add(pod)
 
-			patch := `[ { "op": "test", "path": "/status/conditions", "value": null }, { "op": "replace", "path": "/status/conditions", "value": [{"type":"Ready","status":"True","lastProbeTime":null,"lastTransitionTime":null}] } ]`
+			patch := `[{ "op": "test", "path": "/status/conditions", "value": null }, { "op": "replace", "path": "/status/conditions", "value": [{"type":"Ready","status":"True","lastProbeTime":null,"lastTransitionTime":null}] }]`
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
@@ -1429,7 +1429,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			podFeeder.Add(pod)
 
-			patch := `[ { "op": "test", "path": "/status/activePods", "value": {} }, { "op": "replace", "path": "/status/activePods", "value": {"someUID":"someHost"} } ]`
+			patch := `[{ "op": "test", "path": "/status/activePods", "value": {} }, { "op": "replace", "path": "/status/activePods", "value": {"someUID":"someHost"} }]`
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 
 			controller.Execute()
@@ -2163,7 +2163,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			podInformer.GetIndexer().Add(virtlauncherPod)
 			//Modify by adding a new hotplugged disk
-			patch := `[ { "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","phase":"Bound","reason":"PVCNotReady","message":"PVC is in phase Bound","hotplugVolume":{}}] } ]`
+			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","phase":"Bound","reason":"PVCNotReady","message":"PVC is in phase Bound","hotplugVolume":{}}] }]`
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulCreatePodReason)
@@ -2253,7 +2253,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addVirtualMachine(vmi)
 			podInformer.GetIndexer().Add(virtlauncherPod)
 			//Modify by adding a new hotplugged disk
-			patch := `[ { "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","phase":"Detaching","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] } ]`
+			patch := `[{ "op": "test", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }, { "op": "replace", "path": "/status/volumeStatus", "value": [{"name":"existing","target":""},{"name":"hotplug","target":"","phase":"Detaching","hotplugVolume":{"attachPodName":"hp-volume-hotplug","attachPodUID":"abcd"}}] }]`
 			vmiInterface.EXPECT().Patch(vmi.Name, types.JSONPatchType, []byte(patch)).Return(vmi, nil)
 			controller.Execute()
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -161,6 +161,7 @@ func NewVirtualMachineInstanceCrd() (*extv1.CustomResourceDefinition, error) {
 		{Name: "Phase", Type: "string", JSONPath: ".status.phase"},
 		{Name: "IP", Type: "string", JSONPath: ".status.interfaces[0].ipAddress"},
 		{Name: "NodeName", Type: "string", JSONPath: ".status.nodeName"},
+		{Name: "Ready", Type: "string", JSONPath: ".status.conditions[?(@.type=='Ready')].status"},
 		{Name: "Live-Migratable", Type: "string", JSONPath: ".status.conditions[?(@.type=='LiveMigratable')].status", Priority: 1},
 		{Name: "Paused", Type: "string", JSONPath: ".status.conditions[?(@.type=='Paused')].status", Priority: 1},
 	})
@@ -196,8 +197,7 @@ func NewVirtualMachineCrd() (*extv1.CustomResourceDefinition, error) {
 	err := addFieldsToAllVersions(crd, []extv1.CustomResourceColumnDefinition{
 		{Name: "Age", Type: "date", JSONPath: creationTimestampJSONPath},
 		{Name: "Status", Description: "Human Readable Status", Type: "string", JSONPath: ".status.printableStatus"},
-		{Name: "Volume", Description: "Primary Volume", Type: "string", JSONPath: ".spec.volumes[0].name"},
-		{Name: "Created", Type: "boolean", JSONPath: ".status.created", Priority: 1},
+		{Name: "Ready", Type: "string", JSONPath: ".status.conditions[?(@.type=='Ready')].status"},
 	}, &extv1.CustomResourceSubresources{
 		Status: &extv1.CustomResourceSubresourceStatus{}})
 	if err != nil {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -403,6 +403,9 @@ const (
 
 	// PodConditionMissingReason indicates on the Ready condition on the VMI if the underlying pod does not report a Ready condition
 	PodConditionMissingReason = "PodConditionMissing"
+
+	// GuestNotRunningReason indicates on the Ready condition on the VMI if the underlying guest VM is not running
+	GuestNotRunningReason = "GuestNotRunning"
 )
 
 // +k8s:openapi-gen=true

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -398,7 +398,10 @@ const (
 	// PodTerminatingReason indicates on the Ready condition on the VMI if the underlying pod is terminating
 	PodTerminatingReason = "PodTerminating"
 
-	// 	PodConditionMissingReason = "PodConditionMissing" indicates on the Ready condition on the VMI if the underlying pod does not exist
+	// PodNotExistsReason indicates on the Ready condition on the VMI if the underlying pod does not exist
+	PodNotExistsReason = "PodNotExists"
+
+	// PodConditionMissingReason indicates on the Ready condition on the VMI if the underlying pod does not report a Ready condition
 	PodConditionMissingReason = "PodConditionMissing"
 )
 

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -360,7 +360,7 @@ const (
 	// and some actions are taken to provision the PVCs for the DataVolumes
 	VirtualMachineInstanceProvisioning VirtualMachineInstanceConditionType = "Provisioning"
 
-	// VMIReady means the pod is able to service requests and should be added to the
+	// Ready means the VMI is able to service requests and should be added to the
 	// load balancing pools of all matching services.
 	VirtualMachineInstanceReady VirtualMachineInstanceConditionType = "Ready"
 
@@ -395,8 +395,11 @@ const (
 )
 
 const (
-	// PodTerminatingReason indicates on the PodReady condition on the VMI if the underlying pod is terminating
+	// PodTerminatingReason indicates on the Ready condition on the VMI if the underlying pod is terminating
 	PodTerminatingReason = "PodTerminating"
+
+	// 	PodConditionMissingReason = "PodConditionMissing" indicates on the Ready condition on the VMI if the underlying pod does not exist
+	PodConditionMissingReason = "PodConditionMissing"
 )
 
 // +k8s:openapi-gen=true

--- a/tests/kubectl_test.go
+++ b/tests/kubectl_test.go
@@ -109,8 +109,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			// Name will be there in all the cases, so verify name
 			Expect(resultFields[len(expectedHeader)]).To(Equal(vm.Name))
 		},
-			table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "STATUS", "VOLUME"}),
-			table.Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME"}),
+			table.Entry("[test_id:3464]virtualmachine", "get", "vm", []string{"NAME", "AGE", "STATUS", "READY"}),
+			table.Entry("[test_id:3465]virtualmachineinstance", "get", "vmi", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY"}),
 		)
 
 		table.DescribeTable("should verify set of wide columns for", func(verb, resource, option string, expectedHeader []string, verifyPos int, expectedData string) {
@@ -134,8 +134,8 @@ var _ = Describe("[sig-compute]oc/kubectl integration", func() {
 			Expect(resultFields[len(resultFields)-verifyPos]).To(Equal(expectedData))
 
 		},
-			table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "VOLUME", "CREATED"}, 1, "true"),
-			table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
+			table.Entry("[test_id:3468]virtualmachine", "get", "vm", "wide", []string{"NAME", "AGE", "STATUS", "READY"}, 1, "True"),
+			table.Entry("[test_id:3466]virtualmachineinstance", "get", "vmi", "wide", []string{"NAME", "AGE", "PHASE", "IP", "NODENAME", "READY", "LIVE-MIGRATABLE", "PAUSED"}, 1, "True"),
 		)
 
 	})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -678,7 +678,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 				return cond.Status
 			}
 
-			Expect(vmReadyConditionStatus()).To(BeEmpty())
+			Expect(vmReadyConditionStatus()).ToNot(Equal(k8sv1.ConditionTrue))
 
 			startVM(vm)
 
@@ -688,7 +688,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			stopVM(vm)
 
 			Eventually(vmReadyConditionStatus, 300*time.Second, 1*time.Second).
-				Should(BeEmpty())
+				Should(Equal(k8sv1.ConditionFalse))
 		})
 
 		Context("Using virtctl interface", func() {

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -116,10 +116,6 @@ func readNewStatus(rc io.ReadCloser, oldStatus []string, timeout time.Duration) 
 		}
 		newStatus := strings.Fields(statusLine)
 
-		if prevStatus == nil {
-			return newStatus, nil
-		}
-
 		prevStatusOrPhase := ""
 		if len(prevStatus) >= 3 {
 			prevStatusOrPhase = prevStatus[2]
@@ -240,7 +236,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(titles).To(Equal([]string{"NAME", "AGE", "STATUS", "READY"}),
 			"Output should have the proper columns")
 
-		vmStatus, err := readNewStatus(stdout, titles, statusChangeTimeout)
+		vmStatus, err := readNewStatus(stdout, nil, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped), readyConditionFalse),
 			"VM should be in the %s status", v12.VirtualMachineStatusStopped)
@@ -344,7 +340,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 			"Output should have the proper columns")
 
 		// Read out the guard VMI
-		vmiStatus, err := readNewStatus(stdout, titles, statusChangeTimeout)
+		vmiStatus, err := readNewStatus(stdout, nil, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Start a VMI

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -35,6 +35,9 @@ const (
 
 	// Define a buffer size to read errors into
 	bufferSize = 1024
+
+	readyConditionFalse = "False"
+	readyConditionTrue  = "True"
 )
 
 // Reads up to buffSize characters from rc
@@ -238,7 +241,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err := readNewStatus(stdout, titles, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped), readyConditionFalse),
 			"VM should be in the %s status", v12.VirtualMachineStatusStopped)
 
 		By("Starting the VM")
@@ -246,12 +249,12 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStarting)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStarting), readyConditionFalse),
 			"VM should be in the %s status", v12.VirtualMachineStatusStarting)
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), readyConditionTrue),
 			"VM should be in the %s status", v12.VirtualMachineStatusRunning)
 
 		By("Pausing the VirtualMachine")
@@ -260,7 +263,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusPaused)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusPaused), readyConditionTrue),
 			"VM should be in the %s status", v12.VirtualMachineStatusPaused)
 
 		By("Unpausing the VirtualMachine")
@@ -269,7 +272,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), readyConditionTrue),
 			"VM should be in the %s status", v12.VirtualMachineStatusRunning)
 
 		By("Migrating the VirtualMachine")
@@ -287,12 +290,12 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, vmMigrationTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusMigrating)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusMigrating), readyConditionTrue),
 			"VM should be in the %s status", v12.VirtualMachineStatusMigrating)
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), readyConditionTrue),
 			"VM should be in the %s status", v12.VirtualMachineStatusRunning)
 
 		By("Stopping the VirtualMachine")
@@ -300,12 +303,12 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopping)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopping), readyConditionTrue),
 			"VM should be in the %s status", v12.VirtualMachineStatusStopping)
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped)),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped), readyConditionFalse),
 			"VM should be in the %s status", v12.VirtualMachineStatusStopped)
 	})
 
@@ -374,7 +377,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Scheduling)),
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Scheduling), readyConditionFalse),
 			"VMI should be in the Scheduling phase")
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
@@ -387,13 +390,10 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		// running VM may or may not be reported as ready just yet
-		Expect(len(vmiStatus)).To(BeNumerically(">=", 5), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
-		Expect(vmiStatus[0]).To(Equal(vmi.Name))
-		Expect(vmiStatus[1]).To(MatchRegexp(vmAgeRegex))
-		Expect(vmiStatus[2]).To(Equal(string(v12.Running)), "VMI should be in the Running phase")
+		Expect(len(vmiStatus)).To(Equal(6), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
 		Expect(net.ParseIP(vmiStatus[3])).ToNot(BeNil())
-		Expect(vmiStatus[4]).To(Equal(vmi.Status.NodeName))
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Running), vmiStatus[3], vmi.Status.NodeName, readyConditionTrue),
+			"VMI should be in the Running phase")
 
 		// Restart the VMI
 		err = virtCli.VirtualMachine(vm.ObjectMeta.Namespace).Restart(vm.ObjectMeta.Name)
@@ -401,12 +401,10 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(vmiStatus)).To(BeNumerically(">=", 5), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
-		Expect(vmiStatus[0]).To(Equal(vmi.Name))
-		Expect(vmiStatus[1]).To(MatchRegexp(vmAgeRegex))
-		Expect(vmiStatus[2]).To(Equal(string(v12.Succeeded)), "VMI should be in the Succeeded phase")
+		Expect(len(vmiStatus)).To(Equal(6), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
 		Expect(net.ParseIP(vmiStatus[3])).ToNot(BeNil())
-		Expect(vmiStatus[4]).To(Equal(vmi.Status.NodeName))
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Succeeded), vmiStatus[3], vmi.Status.NodeName, readyConditionFalse),
+			"VMI should be in the Succeeded phase")
 
 		By("Waiting for the second VMI to be created")
 		Eventually(func() bool {
@@ -434,7 +432,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Scheduling)),
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Scheduling), readyConditionFalse),
 			"VMI should be in the Scheduling phase")
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
@@ -446,11 +444,9 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmiStatus, err = readNewStatus(stdout, vmiStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(vmiStatus)).To(BeNumerically(">=", 5), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
-		Expect(vmiStatus[0]).To(Equal(vmi.Name))
-		Expect(vmiStatus[1]).To(MatchRegexp(vmAgeRegex))
-		Expect(vmiStatus[2]).To(Equal(string(v12.Running)), "VMI should be in the Running phase")
+		Expect(len(vmiStatus)).To(Equal(6), fmt.Sprintf("vmiStatus is missing expected propertiesL %v", vmiStatus))
 		Expect(net.ParseIP(vmiStatus[3])).ToNot(BeNil())
-		Expect(vmiStatus[4]).To(Equal(vmi.Status.NodeName))
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Running), vmiStatus[3], vmi.Status.NodeName, readyConditionTrue),
+			"VMI should be in the Running phase")
 	})
 })

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -131,7 +131,7 @@ func readNewStatus(rc io.ReadCloser, oldStatus []string, timeout time.Duration) 
 		if prevStatusOrPhase != newStatusOrPhase {
 			return newStatus, nil
 		}
-		
+
 		prevStatus = newStatus
 		remainingTimeout -= time.Now().Sub(start)
 		if remainingTimeout <= 0 {

--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -31,7 +31,8 @@ const (
 	vmCreationTimeout   = 1 * time.Minute
 	vmMigrationTimeout  = 5 * time.Minute
 
-	vmAgeRegex = "^[0-9]+[sm]$"
+	vmAgeRegex   = "^[0-9]+[sm]$"
+	vmReadyRegex = "False|True"
 
 	// Define a buffer size to read errors into
 	bufferSize = 1024
@@ -254,7 +255,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), readyConditionTrue),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusRunning), MatchRegexp(vmReadyRegex)),
 			"VM should be in the %s status", v12.VirtualMachineStatusRunning)
 
 		By("Pausing the VirtualMachine")
@@ -303,12 +304,12 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopping), readyConditionTrue),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopping), MatchRegexp(vmReadyRegex)),
 			"VM should be in the %s status", v12.VirtualMachineStatusStopping)
 
 		vmStatus, err = readNewStatus(stdout, vmStatus, statusChangeTimeout)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped), readyConditionFalse),
+		Expect(vmStatus).To(ConsistOf(vm.Name, MatchRegexp(vmAgeRegex), string(v12.VirtualMachineStatusStopped), MatchRegexp(vmReadyRegex)),
 			"VM should be in the %s status", v12.VirtualMachineStatusStopped)
 	})
 
@@ -392,7 +393,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(vmiStatus)).To(Equal(6), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
 		Expect(net.ParseIP(vmiStatus[3])).ToNot(BeNil())
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Running), vmiStatus[3], vmi.Status.NodeName, readyConditionTrue),
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Running), vmiStatus[3], vmi.Status.NodeName, MatchRegexp(vmReadyRegex)),
 			"VMI should be in the Running phase")
 
 		// Restart the VMI
@@ -403,7 +404,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(vmiStatus)).To(Equal(6), fmt.Sprintf("vmiStatus is missing expected properties %v", vmiStatus))
 		Expect(net.ParseIP(vmiStatus[3])).ToNot(BeNil())
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Succeeded), vmiStatus[3], vmi.Status.NodeName, readyConditionFalse),
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Succeeded), vmiStatus[3], vmi.Status.NodeName, MatchRegexp(vmReadyRegex)),
 			"VMI should be in the Succeeded phase")
 
 		By("Waiting for the second VMI to be created")
@@ -446,7 +447,7 @@ var _ = Describe("[rfe_id:3423][crit:high][vendor:cnv-qe@redhat.com][level:compo
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(vmiStatus)).To(Equal(6), fmt.Sprintf("vmiStatus is missing expected propertiesL %v", vmiStatus))
 		Expect(net.ParseIP(vmiStatus[3])).ToNot(BeNil())
-		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Running), vmiStatus[3], vmi.Status.NodeName, readyConditionTrue),
+		Expect(vmiStatus).To(ConsistOf(vmi.Name, MatchRegexp(vmAgeRegex), string(v12.Running), vmiStatus[3], vmi.Status.NodeName, MatchRegexp(vmReadyRegex)),
 			"VMI should be in the Running phase")
 	})
 })

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1110,7 +1110,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 						if len(vmi.Status.Conditions) > 0 {
 							for _, cond := range vmi.Status.Conditions {
 								if cond.Type == v1.VirtualMachineInstanceConditionType(kubev1.PodScheduled) && cond.Status == kubev1.ConditionFalse {
-									vmiCondition = vmi.Status.Conditions[0]
+									vmiCondition = cond
 									return true
 								}
 							}

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -22,6 +22,7 @@ package tests_test
 import (
 	"context"
 	"fmt"
+	"kubevirt.io/kubevirt/pkg/controller"
 	"net/http"
 	"os"
 	"strings"
@@ -748,11 +749,13 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Eventually(func() string {
 					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					if curVMI.Status.Conditions != nil {
-						return curVMI.Status.Conditions[0].Reason
+					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+					if scheduledCond != nil {
+						return scheduledCond.Reason
 					}
 					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal("Unschedulable"), "VMI should be unschedulable")
+				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
 			})
 		})
 
@@ -810,11 +813,13 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Eventually(func() string {
 					curVmiB, err := virtClient.VirtualMachineInstance(vmiB.Namespace).Get(vmiB.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get VMIB")
-					if curVmiB.Status.Conditions != nil {
-						return curVmiB.Status.Conditions[0].Reason
+					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+						GetCondition(curVmiB, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+					if scheduledCond != nil {
+						return scheduledCond.Reason
 					}
 					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal("Unschedulable"), "VMI should be unchedulable")
+				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
 
 			})
 
@@ -1030,11 +1035,13 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Eventually(func() string {
 					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get vmi")
-					if curVMI.Status.Conditions != nil {
-						return curVMI.Status.Conditions[0].Reason
+					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+					if scheduledCond != nil {
+						return scheduledCond.Reason
 					}
 					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal("Unschedulable"), "VMI should be unchedulable")
+				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
 			})
 
 			It("[test_id:3202]the vmi with cpu.features matching nfd labels on a node should be scheduled", func() {
@@ -1088,18 +1095,16 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
 
 				By("Waiting for the VirtualMachineInstance to be unschedulable")
-				Eventually(func() bool {
+				Eventually(func() string {
 					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get vmi")
-					if curVMI.Status.Conditions != nil {
-						for _, condition := range curVMI.Status.Conditions {
-							if condition.Reason == "Unschedulable" {
-								return true
-							}
-						}
+					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+					if scheduledCond != nil {
+						return scheduledCond.Reason
 					}
-					return false
-				}, 60*time.Second, 1*time.Second).Should(Equal(true), "VMI should be unchedulable")
+					return ""
+				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
 			})
 
 			It("[test_id:3204]the vmi with cpu.feature policy 'forbid' should not be scheduled on a node with that cpu feature label", func() {
@@ -1126,11 +1131,13 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Eventually(func() string {
 					curVMI, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred(), "Should get vmi")
-					if curVMI.Status.Conditions != nil {
-						return curVMI.Status.Conditions[0].Reason
+					scheduledCond := controller.NewVirtualMachineInstanceConditionManager().
+						GetCondition(curVMI, v1.VirtualMachineInstanceConditionType(k8sv1.PodScheduled))
+					if scheduledCond != nil {
+						return scheduledCond.Reason
 					}
 					return ""
-				}, 60*time.Second, 1*time.Second).Should(Equal("Unschedulable"), "VMI should be unschedulable")
+				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unschedulable")
 			})
 
 		})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -22,7 +22,6 @@ package tests_test
 import (
 	"context"
 	"fmt"
-	"kubevirt.io/kubevirt/pkg/controller"
 	"net/http"
 	"os"
 	"strings"
@@ -41,25 +40,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	k8sWatch "k8s.io/apimachinery/pkg/watch"
 
-	"kubevirt.io/kubevirt/tests/util"
-
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
-
-	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
-
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/controller"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch"
+	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tests/util"
 )
 
 func newCirrosVMI() *v1.VirtualMachineInstance {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a `READY` column to the tabular output of `kubectl get vm` and `kubectl get vmi`, indicating the readiness condition of the VMI.

Here's how the output looks now:
```sh
zvic@ZVICAHANA-D2LK:~$ kubectl get vm
NAME     AGE   STATUS    READY
cirros   30s   Running   True

zvic@ZVICAHANA-D2LK:~$ kubectl get vmi
NAME     AGE   PHASE     IP            NODENAME   READY
cirros   37s   Running   10.244.0.74   minikube   True

zvic@ZVICAHANA-D2LK:~$ kubectl get vmi -o wide
NAME     AGE   PHASE     IP            NODENAME   READY   LIVE-MIGRATABLE   PAUSED
cirros   39s   Running   10.244.0.74   minikube   True    True
```

**Special notes for your reviewer**:

1. ~Note the slight casing difference between the VM and VMI outputs. The VM column feeds from the `.status.ready` field which is in lowercase, whereas the VMI column feeds from the status field of the VMI's "Ready" condition~ (no longer relevant as the VM column now too feeds from the VM's "Ready" condition).
2. I've used this chance to remove the obsolete `VOLUME` column from the output of `kubectl get vm`.
  This column, added way back in #1654, was pointing to a non-existing VM field, `vm.spec.volumes[0]`, and anyway incorrectly 
  assumed that the first listed volume for the VM is the "primary" one (although a provided boot order may indicate otherwise).
3. Also removed the "CREATED" column from `kubectl get vm`. With the recent introduction of the "STATUS" column, it has became quite redundant.

**Release note**:
```release-note
Added a READY column to the tabular output of "kubectl get vm/vmi"
```
