### PR TITLE
Istio, automount serviceAccountToken when Istio enabled in VMI annotations

### DIFF
--- a/pkg/network/consts/BUILD.bazel
+++ b/pkg/network/consts/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["annotations.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/network/consts",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/network/consts/annotations.go
+++ b/pkg/network/consts/annotations.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	ISTIO_INJECT_ANNOTATION = "sidecar.istio.io/inject"
+)

--- a/pkg/virt-controller/services/BUILD.bazel
+++ b/pkg/virt-controller/services/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/downwardmetrics:go_default_library",
         "//pkg/hooks:go_default_library",
         "//pkg/host-disk:go_default_library",
+        "//pkg/network/consts:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
@@ -44,6 +45,7 @@ go_test(
     deps = [
         "//pkg/config:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/network/consts:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/config"
 	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/hooks"
+	"kubevirt.io/kubevirt/pkg/network/consts"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
@@ -1313,6 +1314,9 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 
 	if len(serviceAccountName) > 0 {
 		pod.Spec.ServiceAccountName = serviceAccountName
+		automount := true
+		pod.Spec.AutomountServiceAccountToken = &automount
+	} else if val, ok := vmi.GetAnnotations()[consts.ISTIO_INJECT_ANNOTATION]; ok && strings.ToLower(val) == "true" {
 		automount := true
 		pod.Spec.AutomountServiceAccountToken = &automount
 	} else {

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/network:go_default_library",
         "//pkg/network/cache:go_default_library",
+        "//pkg/network/consts:go_default_library",
         "//pkg/network/dhcp:go_default_library",
         "//pkg/network/driver:go_default_library",
         "//pkg/network/errors:go_default_library",
@@ -36,6 +37,7 @@ go_test(
         "//pkg/network:go_default_library",
         "//pkg/network/cache:go_default_library",
         "//pkg/network/cache/fake:go_default_library",
+        "//pkg/network/consts:go_default_library",
         "//pkg/network/dhcp:go_default_library",
         "//pkg/network/driver:go_default_library",
         "//pkg/network/errors:go_default_library",

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -34,6 +34,7 @@ import (
 	"kubevirt.io/client-go/precond"
 	"kubevirt.io/kubevirt/pkg/network"
 	"kubevirt.io/kubevirt/pkg/network/cache"
+	"kubevirt.io/kubevirt/pkg/network/consts"
 	dhcpconfigurator "kubevirt.io/kubevirt/pkg/network/dhcp"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 	"kubevirt.io/kubevirt/pkg/network/errors"
@@ -54,10 +55,6 @@ const (
 	EnvoyMergedPrometheusTelemetryPort = 15020
 	EnvoyHealthCheckPort               = 15021
 	EnvoyPrometheusTelemetryPort       = 15090
-)
-
-const (
-	IstioInjectAnnotation = "sidecar.istio.io/inject"
 )
 
 type BindMechanism interface {
@@ -1235,7 +1232,7 @@ func (b *MasqueradeBindMechanism) getDstAddressesToDnat(proto iptables.Protocol)
 }
 
 func hasIstioSidecarInjectionEnabled(vmi *v1.VirtualMachineInstance) bool {
-	if val, ok := vmi.GetAnnotations()[IstioInjectAnnotation]; ok {
+	if val, ok := vmi.GetAnnotations()[consts.ISTIO_INJECT_ANNOTATION]; ok {
 		return strings.ToLower(val) == "true"
 	}
 	return false

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -27,6 +27,8 @@ import (
 	"runtime"
 	"strings"
 
+	"kubevirt.io/kubevirt/pkg/network/consts"
+
 	"github.com/coreos/go-iptables/iptables"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -618,7 +620,7 @@ var _ = Describe("Pod Network", func() {
 				domain := NewDomainWithBridgeInterface()
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
 				vm.Annotations = map[string]string{
-					IstioInjectAnnotation: "true",
+					consts.ISTIO_INJECT_ANNOTATION: "true",
 				}
 
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)
@@ -660,7 +662,7 @@ var _ = Describe("Pod Network", func() {
 				vm := newVMIMasqueradeInterface("testnamespace", "testVmName")
 				vm.Spec.Domain.Devices.Interfaces[0].Ports = []v1.Port{{Name: "test", Port: 80, Protocol: "TCP"}}
 				vm.Annotations = map[string]string{
-					IstioInjectAnnotation: "true",
+					consts.ISTIO_INJECT_ANNOTATION: "true",
 				}
 
 				api.NewDefaulter(runtime.GOARCH).SetObjectDefaults_Domain(domain)

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/network",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/consts:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -332,8 +332,6 @@ func newVMIWithIstioSidecar(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithLabel("app", vmiAppSelector),
 		libvmi.WithAnnotation(consts.ISTIO_INJECT_ANNOTATION, "true"),
 	)
-	// Istio-proxy requires service account token to be mounted
-	tests.AddServiceAccountDisk(vmi, "default")
 	return vmi
 }
 

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -40,6 +40,7 @@ import (
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/pkg/network/consts"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
 	"kubevirt.io/kubevirt/tests"
 	"kubevirt.io/kubevirt/tests/console"
@@ -48,11 +49,10 @@ import (
 )
 
 const (
-	istioInjectSidecarAnnotation = "sidecar.istio.io/inject"
-	istioDeployedEnvVariable     = "KUBEVIRT_DEPLOY_ISTIO"
-	vmiAppSelector               = "istio-vmi-app"
-	svcDeclaredTestPort          = 1500
-	svcUndeclaredTestPort        = 1501
+	istioDeployedEnvVariable = "KUBEVIRT_DEPLOY_ISTIO"
+	vmiAppSelector           = "istio-vmi-app"
+	svcDeclaredTestPort      = 1500
+	svcUndeclaredTestPort    = 1501
 	// Istio uses certain ports for it's own purposes, this port server to verify that traffic is not routed
 	// into the VMI for these ports. https://istio.io/latest/docs/ops/deployment/requirements/
 	istioRestrictedPort = network.EnvoyTunnelPort
@@ -330,7 +330,7 @@ func newVMIWithIstioSidecar(ports []v1.Port) *v1.VirtualMachineInstance {
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
 		libvmi.WithLabel("app", vmiAppSelector),
-		libvmi.WithAnnotation(istioInjectSidecarAnnotation, "true"),
+		libvmi.WithAnnotation(consts.ISTIO_INJECT_ANNOTATION, "true"),
 	)
 	// Istio-proxy requires service account token to be mounted
 	tests.AddServiceAccountDisk(vmi, "default")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds default serviceAccountToken automatically when
sidecar.istio.io/inject annotation is added in the VMI.

This improves user experience, bacause users don't need to add a serviceAccountDisk manually.
Adding the annotation becomes the only requirement for Istio service mesh to work properly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
Add serviceAccountDisk automatically when Istio is enabled in VMI annotations
```
