### PR TITLE
Increase timeout when restoring the kubevirt object during func tests

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -560,6 +560,8 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 					}
 					deleteCount++
 					if kv.DeletionTimestamp == nil {
+
+						By("deleting the kv object")
 						err := virtClient.KubeVirt(kv.Namespace).Delete(kv.Name, &metav1.DeleteOptions{})
 						if err != nil {
 							return err
@@ -851,6 +853,7 @@ spec:
 
 		kvs := tests.GetKvList(virtClient)
 		if len(kvs) == 0 {
+			By("Re-creating the original KV to stabilize")
 			createKv(copyOriginalKv())
 		}
 
@@ -860,7 +863,8 @@ spec:
 			waitForUpdateCondition(originalKv)
 		}
 
-		waitForKv(originalKv)
+		By("Waiting for original KV to stabilize")
+		waitForKvWithTimeout(originalKv, 420)
 		allPodsAreReady(originalKv)
 
 		if workDir != "" {


### PR DESCRIPTION
https://search.ci.kubevirt.io/?search=test_id%3A3145&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

The update test is timing out occasionally in the AFterEach function when restoring the orignal KV object. Lets see if increasing the timeout helps. 


```release-note
NONE
```
