### PR TITLE
network, phases: Return error from getnic

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/network.go
+++ b/pkg/virt-launcher/virtwrap/network/network.go
@@ -74,7 +74,7 @@ func (v VMNetworkConfigurator) getNICsWithLauncherPID(launcherPID *int) ([]podNI
 func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(pid int) error {
 	nics, err := n.getNICsWithLauncherPID(&pid)
 	if err != nil {
-		return nil
+		return err
 	}
 	for _, nic := range nics {
 		if err := nic.PlugPhase1(); err != nil {
@@ -87,7 +87,7 @@ func (n *VMNetworkConfigurator) SetupPodNetworkPhase1(pid int) error {
 func (n *VMNetworkConfigurator) SetupPodNetworkPhase2(domain *api.Domain) error {
 	nics, err := n.getNICs()
 	if err != nil {
-		return nil
+		return err
 	}
 	for _, nic := range nics {
 		if err := nic.PlugPhase2(domain); err != nil {

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -26,160 +26,187 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/network/cache/fake"
 	"kubevirt.io/kubevirt/pkg/network/dhcp"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 var _ = Describe("VMNetworkConfigurator", func() {
 	Context("interface configuration", func() {
-		var launcherPID *int
 
-		It("should configure bridged pod networking by default", func() {
-			vm := newVMIBridgeInterface("testnamespace", "testVmName")
+		Context("when vm has no network source", func() {
+			var (
+				vmi                   *v1.VirtualMachineInstance
+				vmNetworkConfigurator *VMNetworkConfigurator
+			)
+			BeforeEach(func() {
+				vmi = newVMIBridgeInterface("testnamespace", "testVmName")
+				vmi.Spec.Networks = []v1.Network{{
+					Name:          "default",
+					NetworkSource: v1.NetworkSource{},
+				}}
+				vmNetworkConfigurator = NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
+			})
+			It("should propagate errors when phase1 is called", func() {
+				launcherPID := 0
+				err := vmNetworkConfigurator.SetupPodNetworkPhase1(launcherPID)
+				Expect(err).To(MatchError("Network not implemented"))
+			})
+			It("should propagate errors when phase2 is called", func() {
+				var domain *api.Domain
+				err := vmNetworkConfigurator.SetupPodNetworkPhase2(domain)
+				Expect(err).To(MatchError("Network not implemented"))
+			})
+		})
+		Context("when calling []podNIC factory functions", func() {
+			var launcherPID *int
+			It("should configure bridged pod networking by default", func() {
+				vm := newVMIBridgeInterface("testnamespace", "testVmName")
 
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
-			iface := v1.DefaultBridgeNetworkInterface()
-			defaultNet := v1.DefaultPodNetwork()
-			nics, err := vmNetworkConfigurator.getNICs()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nics).To(ConsistOf([]podNIC{{
-				vmi:              vm,
-				podInterfaceName: primaryPodInterfaceName,
-				iface:            iface,
-				network:          defaultNet,
-				handler:          vmNetworkConfigurator.handler,
-				cacheFactory:     vmNetworkConfigurator.cacheFactory,
-				dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
-					vmNetworkConfigurator.cacheFactory,
-					getPIDString(launcherPID),
-					generateInPodBridgeInterfaceName(primaryPodInterfaceName),
-					vmNetworkConfigurator.handler),
-			}}))
-		})
-		It("should accept empty network list", func() {
-			vmi := newVMI("testnamespace", "testVmName")
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
-			nics, err := vmNetworkConfigurator.getNICs()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nics).To(BeEmpty())
-		})
-		It("should configure networking with multus", func() {
-			const multusInterfaceName = "net1"
-			vmi := newVMIBridgeInterface("testnamespace", "testVmName")
-			iface := v1.DefaultBridgeNetworkInterface()
-			cniNet := &v1.Network{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "default"},
-				},
-			}
-			vmi.Spec.Networks = []v1.Network{*cniNet}
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
-			nics, err := vmNetworkConfigurator.getNICs()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nics).To(ConsistOf([]podNIC{{
-				vmi:              vmi,
-				iface:            iface,
-				network:          cniNet,
-				podInterfaceName: multusInterfaceName,
-				handler:          vmNetworkConfigurator.handler,
-				cacheFactory:     vmNetworkConfigurator.cacheFactory,
-				dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
-					vmNetworkConfigurator.cacheFactory,
-					getPIDString(launcherPID),
-					generateInPodBridgeInterfaceName(multusInterfaceName),
-					vmNetworkConfigurator.handler),
-			}}))
-		})
-		It("should configure networking with multus and a default multus network", func() {
-			vm := newVMIBridgeInterface("testnamespace", "testVmName")
-
-			// We plug three multus interfaces in, with the default being second, to ensure the netN
-			// interfaces are numbered correctly
-			vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{
-					Name: "additional1",
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Bridge: &v1.InterfaceBridge{},
-					},
-				},
-				{
+				vmNetworkConfigurator := NewVMNetworkConfigurator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
+				iface := v1.DefaultBridgeNetworkInterface()
+				defaultNet := v1.DefaultPodNetwork()
+				nics, err := vmNetworkConfigurator.getNICs()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nics).To(ConsistOf([]podNIC{{
+					vmi:              vm,
+					podInterfaceName: primaryPodInterfaceName,
+					iface:            iface,
+					network:          defaultNet,
+					handler:          vmNetworkConfigurator.handler,
+					cacheFactory:     vmNetworkConfigurator.cacheFactory,
+					dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
+						vmNetworkConfigurator.cacheFactory,
+						getPIDString(launcherPID),
+						generateInPodBridgeInterfaceName(primaryPodInterfaceName),
+						vmNetworkConfigurator.handler),
+				}}))
+			})
+			It("should accept empty network list", func() {
+				vmi := newVMI("testnamespace", "testVmName")
+				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
+				nics, err := vmNetworkConfigurator.getNICs()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nics).To(BeEmpty())
+			})
+			It("should configure networking with multus", func() {
+				const multusInterfaceName = "net1"
+				vmi := newVMIBridgeInterface("testnamespace", "testVmName")
+				iface := v1.DefaultBridgeNetworkInterface()
+				cniNet := &v1.Network{
 					Name: "default",
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Bridge: &v1.InterfaceBridge{},
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.MultusNetwork{NetworkName: "default"},
 					},
-				},
-				{
-					Name: "additional2",
-					InterfaceBindingMethod: v1.InterfaceBindingMethod{
-						Bridge: &v1.InterfaceBridge{},
-					},
-				},
-			}
-
-			cniNet := &v1.Network{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "default", Default: true},
-				},
-			}
-			additionalCNINet1 := &v1.Network{
-				Name: "additional1",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "additional1"},
-				},
-			}
-			additionalCNINet2 := &v1.Network{
-				Name: "additional2",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "additional2"},
-				},
-			}
-
-			vm.Spec.Networks = []v1.Network{*additionalCNINet1, *cniNet, *additionalCNINet2}
-
-			vmNetworkConfigurator := NewVMNetworkConfigurator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
-			nics, err := vmNetworkConfigurator.getNICs()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(nics).To(ContainElements([]podNIC{
-				{
-					vmi:              vm,
-					iface:            &vm.Spec.Domain.Devices.Interfaces[0],
-					network:          additionalCNINet1,
-					podInterfaceName: "net1",
-					handler:          vmNetworkConfigurator.handler,
-					cacheFactory:     vmNetworkConfigurator.cacheFactory,
-					dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
-						vmNetworkConfigurator.cacheFactory,
-						getPIDString(launcherPID),
-						generateInPodBridgeInterfaceName("net1"),
-						vmNetworkConfigurator.handler),
-				},
-				{
-					vmi:              vm,
-					iface:            &vm.Spec.Domain.Devices.Interfaces[1],
+				}
+				vmi.Spec.Networks = []v1.Network{*cniNet}
+				vmNetworkConfigurator := NewVMNetworkConfigurator(vmi, fake.NewFakeInMemoryNetworkCacheFactory())
+				nics, err := vmNetworkConfigurator.getNICs()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nics).To(ConsistOf([]podNIC{{
+					vmi:              vmi,
+					iface:            iface,
 					network:          cniNet,
-					podInterfaceName: "eth0",
+					podInterfaceName: multusInterfaceName,
 					handler:          vmNetworkConfigurator.handler,
 					cacheFactory:     vmNetworkConfigurator.cacheFactory,
 					dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
 						vmNetworkConfigurator.cacheFactory,
 						getPIDString(launcherPID),
-						generateInPodBridgeInterfaceName("eth0"),
+						generateInPodBridgeInterfaceName(multusInterfaceName),
 						vmNetworkConfigurator.handler),
-				},
-				{
-					vmi:              vm,
-					iface:            &vm.Spec.Domain.Devices.Interfaces[2],
-					network:          additionalCNINet2,
-					podInterfaceName: "net2",
-					handler:          vmNetworkConfigurator.handler,
-					cacheFactory:     vmNetworkConfigurator.cacheFactory,
-					dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
-						vmNetworkConfigurator.cacheFactory,
-						getPIDString(launcherPID),
-						generateInPodBridgeInterfaceName("net2"),
-						vmNetworkConfigurator.handler),
-				},
-			}))
+				}}))
+			})
+			It("should configure networking with multus and a default multus network", func() {
+				vm := newVMIBridgeInterface("testnamespace", "testVmName")
+
+				// We plug three multus interfaces in, with the default being second, to ensure the netN
+				// interfaces are numbered correctly
+				vm.Spec.Domain.Devices.Interfaces = []v1.Interface{
+					{
+						Name: "additional1",
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{},
+						},
+					},
+					{
+						Name: "default",
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{},
+						},
+					},
+					{
+						Name: "additional2",
+						InterfaceBindingMethod: v1.InterfaceBindingMethod{
+							Bridge: &v1.InterfaceBridge{},
+						},
+					},
+				}
+
+				cniNet := &v1.Network{
+					Name: "default",
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.MultusNetwork{NetworkName: "default", Default: true},
+					},
+				}
+				additionalCNINet1 := &v1.Network{
+					Name: "additional1",
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.MultusNetwork{NetworkName: "additional1"},
+					},
+				}
+				additionalCNINet2 := &v1.Network{
+					Name: "additional2",
+					NetworkSource: v1.NetworkSource{
+						Multus: &v1.MultusNetwork{NetworkName: "additional2"},
+					},
+				}
+
+				vm.Spec.Networks = []v1.Network{*additionalCNINet1, *cniNet, *additionalCNINet2}
+
+				vmNetworkConfigurator := NewVMNetworkConfigurator(vm, fake.NewFakeInMemoryNetworkCacheFactory())
+				nics, err := vmNetworkConfigurator.getNICs()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nics).To(ContainElements([]podNIC{
+					{
+						vmi:              vm,
+						iface:            &vm.Spec.Domain.Devices.Interfaces[0],
+						network:          additionalCNINet1,
+						podInterfaceName: "net1",
+						handler:          vmNetworkConfigurator.handler,
+						cacheFactory:     vmNetworkConfigurator.cacheFactory,
+						dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
+							vmNetworkConfigurator.cacheFactory,
+							getPIDString(launcherPID),
+							generateInPodBridgeInterfaceName("net1"),
+							vmNetworkConfigurator.handler),
+					},
+					{
+						vmi:              vm,
+						iface:            &vm.Spec.Domain.Devices.Interfaces[1],
+						network:          cniNet,
+						podInterfaceName: "eth0",
+						handler:          vmNetworkConfigurator.handler,
+						cacheFactory:     vmNetworkConfigurator.cacheFactory,
+						dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
+							vmNetworkConfigurator.cacheFactory,
+							getPIDString(launcherPID),
+							generateInPodBridgeInterfaceName("eth0"),
+							vmNetworkConfigurator.handler),
+					},
+					{
+						vmi:              vm,
+						iface:            &vm.Spec.Domain.Devices.Interfaces[2],
+						network:          additionalCNINet2,
+						podInterfaceName: "net2",
+						handler:          vmNetworkConfigurator.handler,
+						cacheFactory:     vmNetworkConfigurator.cacheFactory,
+						dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
+							vmNetworkConfigurator.cacheFactory,
+							getPIDString(launcherPID),
+							generateInPodBridgeInterfaceName("net2"),
+							vmNetworkConfigurator.handler),
+					},
+				}))
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currectly the errors from getNICs and getNICsWithLauncherPID are not
being propagated at Phase1 and Phase2. This change propagate them in
case they are not nil.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
