### PR TITLE
Add a target to check if our go.mod files and our vendor folder are all in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,13 @@ distclean: clean
 	rm -rf vendor/
 
 deps-update-patch:
-	SYNC_VENDOR=true hack/dockerized " ./hack/dep-update.sh -u=patch && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
+	SYNC_VENDOR=true hack/dockerized " ./hack/dep-update.sh -- -u=patch && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
 
 deps-update:
 	SYNC_VENDOR=true hack/dockerized " ./hack/dep-update.sh && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
+
+deps-sync:
+	SYNC_VENDOR=true hack/dockerized " ./hack/dep-update.sh --sync-only && ./hack/dep-prune.sh && ./hack/bazel-generate.sh"
 
 rpm-deps:
 	SYNC_VENDOR=true hack/dockerized " ./hack/rpm-deps.sh"
@@ -179,6 +182,7 @@ bump-kubevirtci:
 	test \
 	clean \
 	distclean \
+	deps-sync \
 	sync \
 	manifests \
 	functest \

--- a/hack/dep-update.sh
+++ b/hack/dep-update.sh
@@ -3,22 +3,38 @@
 set -ex
 
 export GO111MODULE=on
+export _sync_only="false"
+
+while true; do
+    case "$1" in
+    -s | --sync-only)
+        _sync_only="true"
+        shift 1
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *) break ;;
+    esac
+done
 
 (
+    echo $_sync_only
     cd staging/src/kubevirt.io/client-go
-    go get $@ ./...
+    if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
     go mod tidy
 )
 
 (
     cd staging/src/github.com/golang/glog
-    go get $@ ./...
+    if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
     go mod tidy
 )
 
 (
     cd staging/src/kubevirt.io/client-go/examples/listvms
-    go get $@ ./...
+    if [ "${_sync_only}" == "false" ]; then go get $@ ./...; fi
     go mod tidy
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When people do go.mod updates we have a blind spot in CI, regarding to how well this was done. This PR adds a `deps-sync` target which can be used in CI to check if they are in sync.

In order to avoid any go dependency fetch issues, and still fully profit from the vendor folder, we can run the CI job only when `/vendor` content or a `go.mod` file is changed on the PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
