### PR TITLE
Fix bug 1957852 - prevent vm to start when restore is in progress

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13102,6 +13102,10 @@
       "description": "Ready indicates if the virtual machine is running and ready",
       "type": "boolean"
      },
+     "restoreInProgress": {
+      "description": "RestoreInProgress is the name of the VirtualMachineRestore currently executing",
+      "type": "string"
+     },
      "snapshotInProgress": {
       "description": "SnapshotInProgress is the name of the VirtualMachineSnapshot currently executing",
       "type": "string"

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1372,6 +1372,63 @@ var _ = Describe("Validating VM Admitter", func() {
 			return true
 		}),
 	)
+
+	table.DescribeTable("when restore is in progress, should", func(mutateFn func(*v1.VirtualMachine) bool) {
+		vmi := v1.NewMinimalVMI("testvmi")
+		vm := &v1.VirtualMachine{
+			Spec: v1.VirtualMachineSpec{
+				Running: &[]bool{false}[0],
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+			Status: v1.VirtualMachineStatus{
+				RestoreInProgress: &[]string{"testrestore"}[0],
+			},
+		}
+		oldObjectBytes, _ := json.Marshal(vm)
+
+		allow := mutateFn(vm)
+		objectBytes, _ := json.Marshal(vm)
+
+		ar := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				Resource:  webhooks.VirtualMachineGroupVersionResource,
+				OldObject: runtime.RawExtension{
+					Raw: oldObjectBytes,
+				},
+				Object: runtime.RawExtension{
+					Raw: objectBytes,
+				},
+			},
+		}
+
+		resp := vmsAdmitter.Admit(ar)
+		Expect(resp.Allowed).To(Equal(allow))
+
+		if !allow {
+			Expect(len(resp.Result.Details.Causes)).To(Equal(1))
+			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
+		}
+	},
+		table.Entry("reject update to running true", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Running = &[]bool{true}[0]
+			return false
+		}),
+		table.Entry("accept update to spec except running true", func(vm *v1.VirtualMachine) bool {
+			vm.Spec.Template = &v1.VirtualMachineInstanceTemplateSpec{}
+			return true
+		}),
+		table.Entry("accept update to metadata", func(vm *v1.VirtualMachine) bool {
+			vm.Annotations = map[string]string{"foo": "bar"}
+			return true
+		}),
+		table.Entry("accept update to status", func(vm *v1.VirtualMachine) bool {
+			vm.Status.Ready = true
+			return true
+		}),
+	)
 })
 
 func makeCloneAdmitFunc(expectedSourceNamespace, expectedPVCName, expectedTargetNamespace, expectedServiceAccount string) CloneAuthFunc {

--- a/pkg/virt-controller/watch/snapshot/restore_base.go
+++ b/pkg/virt-controller/watch/snapshot/restore_base.go
@@ -34,6 +34,7 @@ import (
 	snapshotv1 "kubevirt.io/client-go/apis/snapshot/v1alpha1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt/pkg/util/status"
 )
 
 // VMRestoreController is resonsible for restoring VMs
@@ -52,6 +53,8 @@ type VMRestoreController struct {
 	Recorder record.EventRecorder
 
 	vmRestoreQueue workqueue.RateLimitingInterface
+
+	vmStatusUpdater *status.VMStatusUpdater
 }
 
 // Init initializes the restore controller
@@ -78,6 +81,8 @@ func (ctrl *VMRestoreController) Init() {
 			UpdateFunc: func(oldObj, newObj interface{}) { ctrl.handleVM(newObj) },
 		},
 	)
+
+	ctrl.vmStatusUpdater = status.NewVMStatusUpdater(ctrl.Client)
 }
 
 // Run the controller

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -27,6 +27,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/util/status"
 )
 
 var _ = Describe("Restore controlleer", func() {
@@ -259,6 +260,7 @@ var _ = Describe("Restore controlleer", func() {
 				StorageClassInformer:      storageClassInformer,
 				DataVolumeInformer:        dataVolumeInformer,
 				Recorder:                  recorder,
+				vmStatusUpdater:           status.NewVMStatusUpdater(virtClient),
 			}
 			controller.Init()
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -5381,6 +5381,10 @@ var CRDsValidation map[string]string = map[string]string{
         ready:
           description: Ready indicates if the virtual machine is running and ready
           type: boolean
+        restoreInProgress:
+          description: RestoreInProgress is the name of the VirtualMachineRestore
+            currently executing
+          type: string
         snapshotInProgress:
           description: SnapshotInProgress is the name of the VirtualMachineSnapshot
             currently executing
@@ -15421,6 +15425,10 @@ var CRDsValidation map[string]string = map[string]string{
                       description: Ready indicates if the virtual machine is running
                         and ready
                       type: boolean
+                    restoreInProgress:
+                      description: RestoreInProgress is the name of the VirtualMachineRestore
+                        currently executing
+                      type: string
                     snapshotInProgress:
                       description: SnapshotInProgress is the name of the VirtualMachineSnapshot
                         currently executing

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -4291,6 +4291,11 @@ func (in *VirtualMachineStatus) DeepCopyInto(out *VirtualMachineStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RestoreInProgress != nil {
+		in, out := &in.RestoreInProgress, &out.RestoreInProgress
+		*out = new(string)
+		**out = **in
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]VirtualMachineCondition, len(*in))

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -25411,6 +25411,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"restoreInProgress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RestoreInProgress is the name of the VirtualMachineRestore currently executing",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"created": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Created indicates if the virtual machine is created in the cluster",

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1275,6 +1275,8 @@ type VirtualMachineStartFailure struct {
 type VirtualMachineStatus struct {
 	// SnapshotInProgress is the name of the VirtualMachineSnapshot currently executing
 	SnapshotInProgress *string `json:"snapshotInProgress,omitempty"`
+	// RestoreInProgress is the name of the VirtualMachineRestore currently executing
+	RestoreInProgress *string `json:"restoreInProgress,omitempty"`
 	// Created indicates if the virtual machine is created in the cluster
 	Created bool `json:"created,omitempty"`
 	// Ready indicates if the virtual machine is running and ready

--- a/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types_swagger_generated.go
@@ -318,6 +318,7 @@ func (VirtualMachineStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                       "VirtualMachineStatus represents the status returned by the\ncontroller to describe how the VirtualMachine is doing\n\n+k8s:openapi-gen=true",
 		"snapshotInProgress":     "SnapshotInProgress is the name of the VirtualMachineSnapshot currently executing",
+		"restoreInProgress":      "RestoreInProgress is the name of the VirtualMachineRestore currently executing",
 		"created":                "Created indicates if the virtual machine is created in the cluster",
 		"ready":                  "Ready indicates if the virtual machine is running and ready",
 		"printableStatus":        "PrintableStatus is a human readable, high-level representation of the status of the virtual machine",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -20469,6 +20469,13 @@ func schema_kubevirtio_client_go_api_v1_VirtualMachineStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"restoreInProgress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RestoreInProgress is the name of the VirtualMachineRestore currently executing",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"created": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Created indicates if the virtual machine is created in the cluster",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When vm restore in progress prevent from starting the vm until the restore is done

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://bugzilla.redhat.com/show_bug.cgi?id=1957852

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
