### PR TITLE
Run imageupload unit-tests in parallel

### DIFF
--- a/pkg/virtctl/imageupload/BUILD.bazel
+++ b/pkg/virtctl/imageupload/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@kubevirt//tools/ginkgo:ginkgo.bzl", "ginkgo_test")
 
 go_library(
     name = "go_default_library",
@@ -30,6 +31,7 @@ go_test(
         "imageupload_suite_test.go",
         "imageupload_test.go",
     ],
+    tags = ["cov"],
     deps = [
         ":go_default_library",
         "//staging/src/kubevirt.io/client-go/generated/containerized-data-importer/clientset/versioned/fake:go_default_library",
@@ -49,4 +51,11 @@ go_test(
         "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1:go_default_library",
     ],
+)
+
+ginkgo_test(
+    name = "go_parallel_test",
+    ginkgo_args = ["-p"],
+    go_test = ":go_default_test",
+    tags = ["nocov"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Run the imageupload unittests in 4 seconds instead of 30 seconds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
