### PR TITLE
[automation] fix root owned _out directory issue

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -49,8 +49,9 @@ if [ -z "$($KUBEVIRT_CRI volume list | grep ${BUILDER})" ]; then
     $KUBEVIRT_CRI volume create ${BUILDER}
 fi
 
-# Make sure that the output directory exists
+# Make sure that the output directory exists on both sides
 $KUBEVIRT_CRI run -v "${BUILDER}:/root:rw,z" --security-opt "label=disable" --rm ${KUBEVIRT_BUILDER_IMAGE} mkdir -p /root/go/src/kubevirt.io/kubevirt/_out
+mkdir -p ${OUT_DIR}
 
 # Start an rsyncd instance and make sure it gets stopped after the script exits
 RSYNC_CID=$($KUBEVIRT_CRI run -d -v "${BUILDER}:/root:rw,z" --security-opt "label=disable" --expose 873 -P ${KUBEVIRT_BUILDER_IMAGE} /usr/bin/rsync --no-detach --daemon --verbose)


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
There is an issue with _out directory being root-owned
when building the Kubevirt project for the first time on
a clean environment.

The root cause is that we don't explicitly create the
_out directory, leaving it to be done by rsync during the
sync out procedure. Therefore rsync creates the _out directory
with incorrect ownership, thus _out become root-owned.

Proposed solution is just to explicitly create the OUT_DIR
in case SYNC_OUT is turned on.

**Release note**:
```release-note
NONE
```
