### PR TITLE
fix quarantine test by changing it to run without block mode

### DIFF
--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -733,24 +733,12 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 			})
 
 			It("[QUARANTINE][test_id:6053]should restore a vm from an online snapshot", func() {
-				vm, vmi = createAndStartVM(tests.NewRandomVMWithBlockDataVolumeAndUserDataInStorageClass(
+				vm, vmi = createAndStartVM(tests.NewRandomVMWithDataVolumeAndUserDataInStorageClass(
 					tests.GetUrl(tests.CirrosHttpUrl),
 					tests.NamespaceTestDefault,
 					"#!/bin/bash\necho 'hello'\n",
 					snapshotStorageClass,
 				))
-
-				Eventually(func() error {
-					return libnet.WithIPv6(console.LoginToCirros)(vmi)
-				}, 360, 10).Should(Succeed())
-
-				b := append([]expect.Batcher{
-					&expect.BSnd{S: "cat /var/run/resize.rootfs | grep resized\n"},
-					&expect.BExp{R: "resized successfully"},
-				})
-				Eventually(func() error {
-					return console.SafeExpectBatch(vmi, b, 10)
-				}, 60, 20).Should(Succeed())
 
 				doRestore("", true)
 


### PR DESCRIPTION
The test keeps failing due to different problems
with a print "resized successfully" being printed
unexpectedly (which is due the fact that the test is with block mode).
The origin fix was trying to expect for that print -
make sure the action occurred and only then continue
to the actual test, this doesn't seem to work by weird
logging behavior in the CI only.
The block mode was added because previously the default PVC fs was xfs,
Now the default fs is ext4 so no need for the block mode
which causes the problematic print.

Signed-off-by: Shelly Kagan <skagan@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
*removed the quarantine label to run the test several times in the CI env

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
