### PR TITLE
Increase timeouts for operator tests

### DIFF
--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -191,7 +191,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 					}
 				}
 				return nil
-			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			}, 15*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
 
 		sanityCheckDeploymentsExist = func() {
@@ -208,7 +208,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 					}
 				}
 				return nil
-			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			}, 15*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		}
 
 		allPodsAreTerminated = func(kv *v1.KubeVirt) {
@@ -542,7 +542,7 @@ var _ = Describe("[Serial][sig-operator]Operator", func() {
 				_, err = virtClient.AppsV1().Deployments(flags.KubeVirtInstallNamespace).Patch(context.Background(), "virt-operator", types.JSONPatchType, []byte(op), metav1.PatchOptions{})
 
 				return err
-			}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+			}, 15*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 
 			return modified
 		}


### PR DESCRIPTION
Signed-off-by: Simone Tiraboschi stirabos@redhat.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
On operator tests executed on periodics lanes
we sporadically still see some flakiness while
patching deployments or other objects.
We are not able to identify a reasonable
cause and we think it's just a matter of
short timings.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes: test 3150 was still in quarantine

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
