### PR TITLE
Add make target to protoc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ push: bazel-push-images
 bazel-test:
 	hack/dockerized "hack/bazel-fmt.sh && CI=${CI} ARTIFACTS=${ARTIFACTS} hack/bazel-test.sh"
 
+gen-proto:
+	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/gen-proto.sh"
+
 generate:
 	hack/dockerized "DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PULL_POLICY=${IMAGE_PULL_POLICY} VERBOSITY=${VERBOSITY} ./hack/generate.sh"
 	SYNC_VENDOR=true hack/dockerized "./hack/bazel-generate.sh && hack/bazel-fmt.sh"

--- a/hack/gen-proto.sh
+++ b/hack/gen-proto.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+source $(dirname "$0")/common.sh
+source $(dirname "$0")/config.sh
+
+protoc --proto_path=pkg/hooks/info --go_out=plugins=grpc,import_path=kubevirt_hooks_info:pkg/hooks/info pkg/hooks/info/api_info.proto
+protoc --proto_path=pkg/hooks/v1alpha1 --go_out=plugins=grpc,import_path=kubevirt_hooks_v1alpha1:pkg/hooks/v1alpha1 pkg/hooks/v1alpha1/api_v1alpha1.proto
+protoc --proto_path=pkg/hooks/v1alpha2 --go_out=plugins=grpc,import_path=kubevirt_hooks_v1alpha2:pkg/hooks/v1alpha2 pkg/hooks/v1alpha2/api_v1alpha2.proto
+protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/notify/v1/notify.proto
+protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/notify/info/info.proto
+protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/cmd/v1/cmd.proto
+protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/cmd/info/info.proto

--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -163,13 +163,7 @@ vms_docker_prefix=${DOCKER_PREFIX:-registry:5000/kubevirt}
 vms_docker_tag=${DOCKER_TAG:-devel}
 ${KUBEVIRT_DIR}/tools/vms-generator/vms-generator --container-prefix=${vms_docker_prefix} --container-tag=${vms_docker_tag} --generated-vms-dir=${KUBEVIRT_DIR}/examples
 
-protoc --proto_path=pkg/hooks/info --go_out=plugins=grpc,import_path=kubevirt_hooks_info:pkg/hooks/info pkg/hooks/info/api_info.proto
-protoc --proto_path=pkg/hooks/v1alpha1 --go_out=plugins=grpc,import_path=kubevirt_hooks_v1alpha1:pkg/hooks/v1alpha1 pkg/hooks/v1alpha1/api_v1alpha1.proto
-protoc --proto_path=pkg/hooks/v1alpha2 --go_out=plugins=grpc,import_path=kubevirt_hooks_v1alpha2:pkg/hooks/v1alpha2 pkg/hooks/v1alpha2/api_v1alpha2.proto
-protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/notify/v1/notify.proto
-protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/notify/info/info.proto
-protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/cmd/v1/cmd.proto
-protoc --go_out=plugins=grpc:. pkg/handler-launcher-com/cmd/info/info.proto
+${KUBEVIRT_DIR}/hack/gen-proto.sh
 
 mockgen -source pkg/handler-launcher-com/notify/info/info.pb.go -package=info -destination=pkg/handler-launcher-com/notify/info/generated_mock_info.go
 mockgen -source pkg/handler-launcher-com/cmd/info/info.pb.go -package=info -destination=pkg/handler-launcher-com/cmd/info/generated_mock_info.go


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Calling "make generate" everytime there is a change at a .proto file
takes a lot of time, this change move the protoc generation to
hack/gen-proto.sh and it's called from hack/generate.sh and from a
target at Makefile so it can be called if needed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
