### PR TITLE
[SIG-scale] Add density performance tests to evaluate the Kubevirt control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ functest-image-push: functest-image-build
 conformance:
 	hack/dockerized "export SKIP_OUTSIDE_CONN_TESTS=${SKIP_OUTSIDE_CONN_TESTS} && hack/conformance.sh"
 
+perftest: build-functests
+	hack/perftests.sh
+
 clean:
 	hack/dockerized "./hack/build-go.sh clean ${WHAT} && rm _out/* -rf"
 	hack/dockerized "bazel clean --expunge"

--- a/hack/perftests.sh
+++ b/hack/perftests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# This script should be executed through the makefile via `make perftest`.
+
+set -e
+
+DOCKER_TAG=${DOCKER_TAG:-devel}
+DOCKER_TAG_ALT=${DOCKER_TAG_ALT:-devel_alt}
+
+source hack/common.sh
+source hack/config.sh
+
+_default_previous_release_registry="quay.io/kubevirt"
+
+previous_release_registry=${PREVIOUS_RELEASE_REGISTRY:-$_default_previous_release_registry}
+
+perftest_docker_prefix=${manifest_docker_prefix-${docker_prefix}}
+
+if [[ ${KUBEVIRT_PROVIDER} == os-* ]] || [[ ${KUBEVIRT_PROVIDER} =~ (okd|ocp)-* ]]; then
+    oc=${kubectl}
+fi
+
+if [ -z "$kubeconfig" ]; then
+    kubeconfig="$KUBECONFIG"
+fi
+
+echo 'Performance testing'
+export KUBEVIRT_E2E_PERF_TEST=true
+
+echo 'Preparing directory for artifacts'
+export ARTIFACTS=${ARTIFACTS}/performance
+rm -rf $ARTIFACTS
+mkdir -p $ARTIFACTS
+
+export TESTS_OUT_DIR=${TESTS_OUT_DIR}
+mkdir -p ${TESTS_OUT_DIR}/performance
+
+echo 'ARTIFACTS ' ${ARTIFACTS}
+echo 'TESTS_OUT_DIR ' ${TESTS_OUT_DIR}
+
+function perftest() {
+    _out/tests/ginkgo -r --slowSpecThreshold 60 $@ _out/tests/tests.test -- ${extra_args} -kubeconfig=${kubeconfig} -container-tag=${docker_tag} -container-tag-alt=${docker_tag_alt} -container-prefix=${perftest_docker_prefix} -image-prefix-alt=${image_prefix_alt} -oc-path=${oc} -kubectl-path=${kubectl} -gocli-path=${gocli} -installed-namespace=${namespace} -previous-release-tag=${PREVIOUS_RELEASE_TAG} -previous-release-registry=${previous_release_registry} -deploy-testing-infra=${deploy_testing_infra} -config=${KUBEVIRT_DIR}/tests/default-config.json --artifacts=${ARTIFACTS}
+}
+
+if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+    export KUBEVIRT_E2E_FOCUS="${KUBEVIRT_E2E_FOCUS}|\\[sig-performance\\]"
+else
+    export KUBEVIRT_E2E_FOCUS="\\[sig-performance\\]"
+fi
+
+additional_test_args=""
+if [ -n "$KUBEVIRT_E2E_SKIP" ]; then
+    additional_test_args="${additional_test_args} --skip=${KUBEVIRT_E2E_SKIP}"
+fi
+
+if [ -n "$KUBEVIRT_E2E_FOCUS" ]; then
+    additional_test_args="${additional_test_args} --focus=${KUBEVIRT_E2E_FOCUS}"
+fi
+
+additional_test_args="${additional_test_args} --skipPackage test/performance"
+
+perftest ${additional_test_args} ${FUNC_TEST_ARGS}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -201,6 +201,7 @@ go_test(
         "//tests/libvmi:go_default_library",
         "//tests/network:go_default_library",
         "//tests/numa:go_default_library",
+        "//tests/performance:go_default_library",
         "//tests/reporter:go_default_library",
         "//tests/storage:go_default_library",
         "//tests/util:go_default_library",

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "density.go",
+        "framework.go",
+    ],
+    importpath = "kubevirt.io/kubevirt/tests/performance",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests:go_default_library",
+        "//tests/containerdisk:go_default_library",
+        "//tests/util:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/tests/performance/density.go
+++ b/tests/performance/density.go
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package performance
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kvv1 "kubevirt.io/client-go/api/v1"
+	cd "kubevirt.io/kubevirt/tests/containerdisk"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt/tests"
+	"kubevirt.io/kubevirt/tests/util"
+)
+
+var _ = SIGDescribe("Control Plane Performance Density Testing", func() {
+	var (
+		err        error
+		virtClient kubecli.KubevirtClient
+	)
+
+	BeforeEach(func() {
+		virtClient, err = kubecli.GetKubevirtClient()
+		util.PanicOnError(err)
+		tests.BeforeTestCleanup()
+	})
+
+	AfterEach(func() {
+		// ensure the metrics get scraped and collected  till the end
+		time.Sleep(30 * time.Second)
+	})
+
+	Describe("Density test", func() {
+		vmCount := 100
+		vmBatchStartupLimit := 300 * time.Second
+
+		Context(fmt.Sprintf("[small] create a batch of %d VMIs", vmCount), func() {
+
+			It("should sucessfully create all VMIS", func() {
+
+				By("Creating a batch of VMIs")
+				createBatchVMIWithRateControl(virtClient, vmCount)
+
+				By("Waiting a batch of VMIs")
+				waitRunningVMI(virtClient, vmCount, vmBatchStartupLimit)
+			})
+		})
+	})
+})
+
+// createBatchVMIWithRateControl creates a batch of vms concurrently, uses one goroutine for each creation.
+// between creations there is an interval for throughput control
+func createBatchVMIWithRateControl(virtClient kubecli.KubevirtClient, vmCount int) {
+	for i := 1; i <= vmCount; i++ {
+		vmi := createVMISpecWithResources(virtClient)
+		By(fmt.Sprintf("Creating VMI %s", vmi.ObjectMeta.Name))
+		_, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
+		Expect(err).ToNot(HaveOccurred())
+
+		// interval for throughput control
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func createVMISpecWithResources(virtClient kubecli.KubevirtClient) *kvv1.VirtualMachineInstance {
+	vmImage := cd.ContainerDiskFor("cirros")
+	cpuLimit := "100m"
+	memLimit := "90Mi"
+	cloudInitUserData := "#!/bin/bash\necho 'hello'\n"
+	vmi := tests.NewRandomVMIWithEphemeralDiskAndUserdata(vmImage, cloudInitUserData)
+	vmi.Spec.Domain.Resources.Limits = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: resource.MustParse(memLimit),
+		k8sv1.ResourceCPU:    resource.MustParse(cpuLimit),
+	}
+	vmi.Spec.Domain.Resources.Requests = k8sv1.ResourceList{
+		k8sv1.ResourceMemory: resource.MustParse(memLimit),
+		k8sv1.ResourceCPU:    resource.MustParse(cpuLimit),
+	}
+	return vmi
+}
+
+func waitRunningVMI(virtClient kubecli.KubevirtClient, vmiCount int, timeout time.Duration) {
+	Eventually(func() int {
+		vmis, err := virtClient.VirtualMachineInstance(util.NamespaceTestDefault).List(&metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		running := 0
+		for _, vmi := range vmis.Items {
+			if vmi.Status.Phase == kvv1.Running {
+				running++
+			}
+		}
+		return running
+	}, timeout, 10*time.Second).Should(Equal(vmiCount))
+}

--- a/tests/performance/framework.go
+++ b/tests/performance/framework.go
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package performance
+
+import (
+	"flag"
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var RunPerfTests = false
+
+func init() {
+	flag.BoolVar(&RunPerfTests, "performance-test", false, "run performance tests. If false, all performance tests will be skiped.")
+	if ptest, _ := strconv.ParseBool(os.Getenv("KUBEVIRT_E2E_PERF_TEST")); ptest {
+		RunPerfTests = true
+	}
+}
+
+func SIGDescribe(text string, body func()) bool {
+	BeforeEach(func() {
+		if !RunPerfTests {
+			Skip("Performance tests are not enabled.")
+		}
+	})
+	return Describe("[sig-performance][Serial] "+text, body)
+}
+
+func FSIGDescribe(text string, body func()) bool {
+	BeforeEach(func() {
+		if !RunPerfTests {
+			Skip("Performance tests are not enabled.")
+		}
+	})
+	return FDescribe("[sig-performance][Serial] "+text, body)
+}

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -39,6 +39,7 @@ import (
 
 	_ "kubevirt.io/kubevirt/tests/network"
 	_ "kubevirt.io/kubevirt/tests/numa"
+	_ "kubevirt.io/kubevirt/tests/performance"
 	_ "kubevirt.io/kubevirt/tests/storage"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds support for performance tests to be the basis of both performance and scalability tests. 

More specifically, It enables the creation of density tests to run (e.g., scheduling in parallel 100, 200 ... 600 VMs), measuring the VM's creation time (from submission to Running Phase) and failing when the time is higher than a given threshold. 

For further analysis, the VMI's phase transition latency, the VMI resource usage, and the Kubevirt control plane resource usage are also collected and logged into a file. Note that, resource usage is only collected when Prometheus is available.

The test configuration is defined in a YAML file so that it can be easily adapted to different environments. For rate control during the creation process, it is possible to define a step function or use a Poisson process with a given arrival rate.

The density test is inspired by the [Kubernetes density test](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/density_test.go). Even though  Kubernetes has a [new repository](https://github.com/kubernetes/perf-tests) for perf tests, the ginkgo-based tests are a good source of reference.


_why we need it_:
We would like to integrate those tests into our CI/CD system to facilitate the evaluation of the Kubevirt control plane. The motivation of such evaluation is because code changes may affect system scalability and performance. Then, with a set of performance and scalability tests, we may identify possible performance regression in the KubeVirt control plane between PRs and new Releases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The thresholds now are pessimistic since my environment has nested virtualization and I could not measure "realistic" latencies yet. I will need to adapt it accordingly...

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
