### PR TITLE
Compute DHCP configuration at phase2 for masquerade

### DIFF
--- a/pkg/network/cache/infocache.go
+++ b/pkg/network/cache/infocache.go
@@ -132,8 +132,17 @@ type dhcpConfigCacheStore struct {
 }
 
 func (d dhcpConfigCacheStore) Read(ifaceName string) (*DHCPConfig, error) {
+	interfaceCacheFile := d.getInterfaceCacheFile(ifaceName)
+
+	_, err := os.Stat(interfaceCacheFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
 	cachedIface := &DHCPConfig{}
-	err := readFromCachedFile(cachedIface, d.getInterfaceCacheFile(ifaceName))
+	err = readFromCachedFile(cachedIface, interfaceCacheFile)
 	return cachedIface, err
 }
 

--- a/pkg/network/dhcp/configurator.go
+++ b/pkg/network/dhcp/configurator.go
@@ -51,9 +51,11 @@ func (d Configurator) ImportConfiguration(ifaceName string) (*cache.DHCPConfig, 
 	if err != nil {
 		return nil, err
 	}
-	dhcpConfig.AdvertisingIPAddr = dhcpConfig.AdvertisingIPAddr.To4()
-	dhcpConfig.Gateway = dhcpConfig.Gateway.To4()
-	dhcpConfig.AdvertisingIPv6Addr = dhcpConfig.AdvertisingIPv6Addr.To16()
+	if dhcpConfig != nil {
+		dhcpConfig.AdvertisingIPAddr = dhcpConfig.AdvertisingIPAddr.To4()
+		dhcpConfig.Gateway = dhcpConfig.Gateway.To4()
+		dhcpConfig.AdvertisingIPv6Addr = dhcpConfig.AdvertisingIPv6Addr.To16()
+	}
 	return dhcpConfig, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
As an effort to reduce the communication between virt-handler and
virt-launcher this change compute the DHCP configuration at phase2 for
masquerade, bridge binding has the original implementation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
