### PR TITLE
network, Increase deadline for ping to 15 seconds

### DIFF
--- a/tests/libnet/ping.go
+++ b/tests/libnet/ping.go
@@ -31,8 +31,8 @@ import (
 )
 
 // PingFromVMConsole performs a ping through the provided VMI console.
-// Optional arguments for the ping command may be provided, overwirting the default ones.
-// (default ping options: "-c 5, -w 10")
+// Optional arguments for the ping command may be provided, overwriting the default ones.
+// (default ping options: "-c 5, -w 15")
 // Note: The maximum overall command timeout is 20 seconds.
 func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...string) error {
 	const maxCommandTimeout = 20 * time.Second
@@ -43,7 +43,7 @@ func PingFromVMConsole(vmi *v1.VirtualMachineInstance, ipAddr string, args ...st
 	}
 
 	if len(args) == 0 {
-		args = []string{"-c 5", "-w 10"}
+		args = []string{"-c 5", "-w 15"}
 	}
 	args = append([]string{pingString, ipAddr}, args...)
 	cmdCheck := strings.Join(args, " ")

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -760,8 +760,8 @@ var _ = SIGDescribe("[Serial][rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com]
 				vmi = tests.WaitUntilVMIReady(vmi, console.LoginToCirros)
 
 				By("Checking ping (IPv4)")
-				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
-				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, ipv4Address)).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, dns)).To(Succeed())
 			})
 
 			table.DescribeTable("IPv6", func(ports []v1.Port, tcpPort int, networkCIDR string) {


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:

This PR intents to fix flaky ping test: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5797/pull-kubevirt-e2e-k8s-1.20-sig-network/1405063916932829184
by increasing `-w deadline` to 15 seconds.

The test fails on reaching the current deadline:
```
12:22:03: Sent: "ping 192.168.66.142 -c 5 -w 10\n"
12:22:03: Match for RE: "(\\$ |\\# )" found: ["$ " "$ "] Buffer: ping 192.168.66.142 -c 5 -w 10
12:22:03: PING 192.168.66.142 (192.168.66.142): 56 data bytes
12:22:03: 64 bytes from 192.168.66.142: seq=6 ttl=64 time=1.228 ms
12:22:03: 64 bytes from 192.168.66.142: seq=7 ttl=64 time=0.926 ms
12:22:03: 64 bytes from 192.168.66.142: seq=8 ttl=64 time=0.766 ms
12:22:03: 64 bytes from 192.168.66.142: seq=9 ttl=64 time=0.972 ms
12:22:03: 
12:22:03: --- 192.168.66.142 ping statistics ---
12:22:03: 10 packets transmitted, 4 packets received, 60% packet loss
12:22:03: round-trip min/avg/max = 0.766/0.973/1.228 ms
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release Note**
```release-note
NONE
```
