### PR TITLE
Fixes Event recording segfault

### DIFF
--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Application", func() {
 		migrationInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
 		nodeInformer, _ := testutils.NewFakeInformerFor(&kubev1.Node{})
 		recorder := record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
 		config, _, _, _ := testutils.NewFakeClusterConfig(&kubev1.ConfigMap{})
 		pdbInformer, _ := testutils.NewFakeInformerFor(&v1beta1.PodDisruptionBudget{})
 		podInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Pod{})

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Evacuation", func() {
 		nodeInformer, nodeSource = testutils.NewFakeInformerFor(&v12.Node{})
 		podInformer, podSource = testutils.NewFakeInformerFor(&v12.Pod{})
 		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
 		config, _, _, _ := testutils.NewFakeClusterConfig(&v12.ConfigMap{})
 
 		controller = evacuation.NewEvacuationController(vmiInformer, migrationInformer, nodeInformer, podInformer, recorder, virtClient, config)

--- a/pkg/virt-controller/watch/migration_test.go
+++ b/pkg/virt-controller/watch/migration_test.go
@@ -174,6 +174,7 @@ var _ = Describe("Migration watcher", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
 		nodeInformer, _ = testutils.NewFakeInformerFor(&k8sv1.Node{})
 
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})

--- a/pkg/virt-controller/watch/node_test.go
+++ b/pkg/virt-controller/watch/node_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Node controller with", func() {
 		nodeInformer, nodeSource = testutils.NewFakeInformerFor(&k8sv1.Node{})
 		vmiInformer, vmiSource = testutils.NewFakeInformerFor(&virtv1.VirtualMachineInstance{})
 		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
 
 		controller = NewNodeController(virtClient, nodeInformer, vmiInformer, recorder)
 		// Wrap our workqueue to have a way to detect when we are done processing updates

--- a/pkg/virt-controller/watch/replicaset_test.go
+++ b/pkg/virt-controller/watch/replicaset_test.go
@@ -62,6 +62,7 @@ var _ = Describe("Replicaset", func() {
 			vmiInformer, vmiSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			rsInformer, rsSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceReplicaSet{})
 			recorder = record.NewFakeRecorder(100)
+			recorder.IncludeObject = true
 
 			controller = NewVMIReplicaSet(vmiInformer, rsInformer, recorder, virtClient, uint(10))
 			// Wrap our workqueue to have a way to detect when we are done processing updates

--- a/pkg/virt-controller/watch/snapshot/restore_test.go
+++ b/pkg/virt-controller/watch/snapshot/restore_test.go
@@ -246,6 +246,7 @@ var _ = Describe("Restore controlleer", func() {
 			storageClassInformer, storageClassSource = testutils.NewFakeInformerFor(&storagev1.StorageClass{})
 
 			recorder = record.NewFakeRecorder(100)
+			recorder.IncludeObject = true
 
 			controller = &VMRestoreController{
 				Client:                    virtClient,

--- a/pkg/virt-controller/watch/snapshot/snapshot_test.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_test.go
@@ -272,6 +272,7 @@ var _ = Describe("Snapshot controlleer", func() {
 			dvInformer, dvSource = testutils.NewFakeInformerFor(&cdiv1alpha1.DataVolume{})
 
 			recorder = record.NewFakeRecorder(100)
+			recorder.IncludeObject = true
 
 			controller = &VMSnapshotController{
 				Client:                    virtClient,

--- a/pkg/virt-controller/watch/vm_test.go
+++ b/pkg/virt-controller/watch/vm_test.go
@@ -68,6 +68,7 @@ var _ = Describe("VirtualMachine", func() {
 			vmInformer, vmSource = testutils.NewFakeInformerFor(&v1.VirtualMachine{})
 			pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})
 			recorder = record.NewFakeRecorder(100)
+			recorder.IncludeObject = true
 
 			controller = NewVMController(vmiInformer, vmInformer, dataVolumeInformer, pvcInformer, recorder, virtClient)
 			// Wrap our workqueue to have a way to detect when we are done processing updates

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -189,6 +189,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		dataVolumeInformer, dataVolumeSource = testutils.NewFakeInformerFor(&cdiv1.DataVolume{})
 		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
 
 		config, _, _, _ := testutils.NewFakeClusterConfig(&k8sv1.ConfigMap{})
 		pvcInformer, _ = testutils.NewFakeInformerFor(&k8sv1.PersistentVolumeClaim{})

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -104,6 +104,7 @@ var _ = Describe("Workload Updater", func() {
 		migrationInformer, migrationSource = testutils.NewFakeInformerFor(&v1.VirtualMachineInstanceMigration{})
 		podInformer, podSource = testutils.NewFakeInformerFor(&k8sv1.Pod{})
 		recorder = record.NewFakeRecorder(200)
+		recorder.IncludeObject = true
 		config, _, _, _ := testutils.NewFakeClusterConfig(&v12.ConfigMap{})
 
 		kubeVirtInformer, _ = testutils.NewFakeInformerFor(&v1.KubeVirt{})

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -163,6 +163,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		domainInformer, domainSource = testutils.NewFakeInformerFor(&api.Domain{})
 		gracefulShutdownInformer, _ = testutils.NewFakeInformerFor(&api.Domain{})
 		recorder = record.NewFakeRecorder(100)
+		recorder.IncludeObject = true
 
 		clientTest = fake.NewSimpleClientset()
 		ctrl = gomock.NewController(GinkgoT())
@@ -2891,6 +2892,7 @@ var _ = Describe("DomainNotifyServerRestarts", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			recorder = record.NewFakeRecorder(10)
+			recorder.IncludeObject = true
 			vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmiStore = vmiInformer.GetStore()
 
@@ -2944,7 +2946,7 @@ var _ = Describe("DomainNotifyServerRestarts", func() {
 			case <-timeout:
 				timedOut = true
 			case event := <-recorder.Events:
-				Expect(event).To(Equal(fmt.Sprintf("%s %s %s", eventType, eventReason, eventMessage)))
+				Expect(event).To(Equal(fmt.Sprintf("%s %s %s involvedObject{kind=VirtualMachineInstance,apiVersion=kubevirt.io/v1}", eventType, eventReason, eventMessage)))
 			}
 
 			Expect(timedOut).To(BeFalse(), "should not time out")
@@ -3036,7 +3038,7 @@ var _ = Describe("DomainNotifyServerRestarts", func() {
 				case <-timeout:
 					timedOut = true
 				case event := <-recorder.Events:
-					Expect(event).To(Equal(fmt.Sprintf("%s %s %s", eventType, eventReason, eventMessage)))
+					Expect(event).To(Equal(fmt.Sprintf("%s %s %s involvedObject{kind=VirtualMachineInstance,apiVersion=kubevirt.io/v1}", eventType, eventReason, eventMessage)))
 				}
 				Expect(timedOut).To(BeFalse(), "should not time out")
 			}

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -250,6 +250,7 @@ var _ = Describe("Notify", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			recorder = record.NewFakeRecorder(10)
+			recorder.IncludeObject = true
 			vmiInformer, _ := testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			vmiStore = vmiInformer.GetStore()
 
@@ -284,7 +285,7 @@ var _ = Describe("Notify", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			event := <-recorder.Events
-			Expect(event).To(Equal(fmt.Sprintf("%s %s %s", eventType, eventReason, eventMessage)))
+			Expect(event).To(Equal(fmt.Sprintf("%s %s %s involvedObject{kind=VirtualMachineInstance,apiVersion=kubevirt.io/v1}", eventType, eventReason, eventMessage)))
 			close(done)
 		}, 5)
 
@@ -319,7 +320,7 @@ var _ = Describe("Notify", func() {
 			eventMessage := "VM Paused due to not enough space on volume: "
 			eventCallback(mockCon, domain, libvirtEvent{}, client, deleteNotificationSent, nil, nil, vmi)
 			event := <-recorder.Events
-			Expect(event).To(Equal(fmt.Sprintf("%s %s %s", eventType, eventReason, eventMessage)))
+			Expect(event).To(Equal(fmt.Sprintf("%s %s %s involvedObject{kind=VirtualMachineInstance,apiVersion=kubevirt.io/v1}", eventType, eventReason, eventMessage)))
 			close(done)
 
 		}, 20)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -160,6 +160,7 @@ func (k *KubeVirtTestData) BeforeTest() {
 
 	k.kvInformer, k.kvSource = testutils.NewFakeInformerFor(&v1.KubeVirt{})
 	k.recorder = record.NewFakeRecorder(100)
+	k.recorder.IncludeObject = true
 
 	k.informers.ServiceAccount, k.serviceAccountSource = testutils.NewFakeInformerFor(&k8sv1.ServiceAccount{})
 	k.stores.ServiceAccountCache = k.informers.ServiceAccount.GetStore()


### PR DESCRIPTION
We discovered a segfault that can occur as a result of reporting an event when a VMI pod's pdb is deleted and the VMI no longer exists.

This went unnoticed in our unit tests because our mock event recorder was ignoring objects that were passed into it. By making the mock recorder take into account objects, we catch segfaults like this because the mock recorder will crash when trying to dereference a null object pointer. 

This change to the mock recorder reproduced the bug in question and the bug has now been addressed. To  prevent similar issues from occurring in the future, i've enabled all mock recorders in our unit tests to parse the involved objects. 

```release-note
Fixes event recording causing a segfault in virt-controller
```
