### PR TITLE
Cherry pick 5269 to release 0.39

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -311,7 +311,7 @@ func (app *virtHandlerApp) Run() {
 		app.VirtShareDir,
 	)
 
-	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight)
+	promvm.SetupCollector(app.virtCli, app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight, vmiSourceInformer)
 
 	go app.clientcertmanager.Start()
 	go app.servercertmanager.Start()

--- a/pkg/monitoring/vms/prometheus/BUILD.bazel
+++ b/pkg/monitoring/vms/prometheus/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/monitoring/vms/prometheus",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/util/lookup:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",
@@ -21,6 +20,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/version:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/libvirt.org/libvirt-go:go_default_library",
     ],
 )

--- a/pkg/monitoring/vms/prometheus/prometheus.go
+++ b/pkg/monitoring/vms/prometheus/prometheus.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/client-go/tools/cache"
+
 	libvirt "libvirt.org/libvirt-go"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,7 +36,6 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/client-go/version"
-	"kubevirt.io/kubevirt/pkg/util/lookup"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
@@ -328,15 +329,17 @@ type Collector struct {
 	virtShareDir  string
 	nodeName      string
 	concCollector *concurrentCollector
+	vmiInformer   cache.SharedIndexInformer
 }
 
-func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int) *Collector {
+func SetupCollector(virtCli kubecli.KubevirtClient, virtShareDir, nodeName string, MaxRequestsInFlight int, vmiInformer cache.SharedIndexInformer) *Collector {
 	log.Log.Infof("Starting collector: node name=%v", nodeName)
 	co := &Collector{
 		virtCli:       virtCli,
 		virtShareDir:  virtShareDir,
 		nodeName:      nodeName,
 		concCollector: NewConcurrentCollector(MaxRequestsInFlight),
+		vmiInformer:   vmiInformer,
 	}
 	prometheus.MustRegister(co)
 	return co
@@ -369,15 +372,16 @@ func newvmiSocketMapFromVMIs(baseDir string, vmis []*k6tv1.VirtualMachineInstanc
 func (co *Collector) Collect(ch chan<- prometheus.Metric) {
 	updateVersion(ch)
 
-	vmis, err := lookup.VirtualMachinesOnNode(co.virtCli, co.nodeName)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to list all VMIs in '%s': %s", co.nodeName, err)
+	cachedObjs := co.vmiInformer.GetIndexer().List()
+	if len(cachedObjs) == 0 {
+		log.Log.V(4).Infof("No VMIs detected")
 		return
 	}
 
-	if len(vmis) == 0 {
-		log.Log.V(4).Infof("No VMIs detected")
-		return
+	vmis := make([]*k6tv1.VirtualMachineInstance, len(cachedObjs))
+
+	for i, obj := range cachedObjs {
+		vmis[i] = obj.(*k6tv1.VirtualMachineInstance)
 	}
 
 	socketToVMIs := newvmiSocketMapFromVMIs(co.virtShareDir, vmis)


### PR DESCRIPTION
cherry-pick of #5269

```release-note
Prometheus metrics scraped from virt-handler are now served from the VMI informer cache, rather than calling back to the Kubernetes API for VMI information.
```
