### PR TITLE
Don't send watch error when ioerror occurs

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -289,7 +289,9 @@ func eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEve
 			if err != nil {
 				log.Log.Reason(err).Error(fmt.Sprintf("Could not send k8s event"))
 			}
-			client.SendDomainEvent(newWatchEventError(fmt.Errorf(reasonError)))
+			event := watch.Event{Type: watch.Modified, Object: domain}
+			client.SendDomainEvent(event)
+			updateEvents(event, domain, events)
 		}
 	default:
 		if libvirtEvent.Event != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5859

**Special notes for your reviewer**:
We might to this also with libvirt re-connections.

**Release note**:
```release-note
Fix: ioerrors don't cause crash-looping of notify server
```
