### PR TITLE
[release-0.36]Increase memory for validation of container disk

### DIFF
--- a/pkg/virt-handler/isolation/validation.go
+++ b/pkg/virt-handler/isolation/validation.go
@@ -15,7 +15,7 @@ const (
 func GetImageInfo(imagePath string, context IsolationResult) (*containerdisk.DiskInfo, error) {
 	// #nosec g204 no risk to use MountNamespace()  argument as it returns a fixed string of "/proc/<pid>/ns/mnt"
 	out, err := exec.Command(
-		"/usr/bin/virt-chroot", "--user", "qemu", "--memory", "1000", "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
+		"/usr/bin/virt-chroot", "--user", "qemu", "--memory", "1200", "--cpu", "10", "--mount", context.MountNamespace(), "exec", "--",
 		QEMUIMGPath, "info", imagePath, "--output", "json",
 	).Output()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This fix is for newer versions of golang(1.14+) which seems to allocate more memory for exec.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix: Kubevirt build with golang 1.14+ will not fail on validation of container disk with memory allocation error
```
