### PR TITLE
Bazel target to build image bundle for external processing

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -208,6 +208,18 @@ container_bundle(
     },
 )
 
+# This is for generating a bundle of the core components for external processing
+container_bundle(
+    name = "virt-components-bundle",
+    images = {
+        "$(container_prefix)/$(image_prefix)virt-api:$(container_tag)": "//cmd/virt-api:virt-api-image",
+        "$(container_prefix)/$(image_prefix)virt-controller:$(container_tag)": "//cmd/virt-controller:virt-controller-image",
+        "$(container_prefix)/$(image_prefix)virt-handler:$(container_tag)": "//cmd/virt-handler:virt-handler-image",
+        "$(container_prefix)/$(image_prefix)virt-launcher:$(container_tag)": "//cmd/virt-launcher:virt-launcher-image",
+        "$(container_prefix)/$(image_prefix)virt-operator:$(container_tag)": "//cmd/virt-operator:virt-operator-image",
+    },
+)
+
 # heads up: docker_push is loaded from contrib:push-all, while container_push is loaded earlier from container:container
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ bazel-generate:
 bazel-build:
 	hack/dockerized "export BUILD_ARCH=${BUILD_ARCH} && hack/bazel-fmt.sh && hack/bazel-build.sh"
 
+bazel-build-image-bundle:
+	hack/dockerized "export BUILD_ARCH=${BUILD_ARCH} && hack/bazel-fmt.sh && DOCKER_PREFIX=${DOCKER_PREFIX} DOCKER_TAG=${DOCKER_TAG} IMAGE_PREFIX=${IMAGE_PREFIX} hack/bazel-build-image-bundle.sh"
+
 bazel-build-verify: bazel-build
 	./hack/dockerized "hack/bazel-fmt.sh"
 	./hack/verify-generate.sh
@@ -177,6 +180,7 @@ bump-kubevirtci:
 	go-all \
 	bazel-generate \
 	bazel-build \
+	bazel-build-image-bundle \
 	bazel-build-images \
 	bazel-push-images \
 	bazel-test \

--- a/hack/bazel-build-image-bundle.sh
+++ b/hack/bazel-build-image-bundle.sh
@@ -28,3 +28,7 @@ bazel build \
     --define image_prefix=${image_prefix} \
     --define container_tag=${docker_tag} \
     //:virt-components-bundle.tar
+
+if [ -n "$OUT_DIR" ] && [ -d "$OUT_DIR" ]; then
+    mv -fv bazel-bin/virt-components-bundle.tar ${OUT_DIR}
+fi

--- a/hack/bazel-build-image-bundle.sh
+++ b/hack/bazel-build-image-bundle.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2019 Red Hat, Inc.
+#
+
+set -e
+
+source hack/common.sh
+source hack/config.sh
+
+bazel build \
+    --config=${ARCHITECTURE} \
+    --define container_prefix=${docker_prefix} \
+    --define image_prefix=${image_prefix} \
+    --define container_tag=${docker_tag} \
+    //:virt-components-bundle.tar


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a bazel target `bazel build //:virt-components-bundle.tar` that results in a tar archive of the core virt-* images. I've found having a portable bundle for the release handy for my own external CI/CD processing use case.  The Makefile target isn't strictly necessary for me, but it was added in case others find it useful.

**Release note**:
```release-note
New build target added to export virt-* images as a tar archive.
```
