### PR TITLE
build and push a virtctl container image

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -272,6 +272,15 @@ container_push(
     tag = "$(container_tag)",
 )
 
+container_push(
+    name = "push-virtctl",
+    format = "Docker",
+    image = "//cmd/virtctl:virtctl-image",
+    registry = "$(container_prefix)",
+    repository = "$(image_prefix)virtctl",
+    tag = "$(container_tag)",
+)
+
 genrule(
     name = "build-virtctl",
     srcs = [

--- a/cmd/virtctl/BUILD.bazel
+++ b/cmd/virtctl/BUILD.bazel
@@ -46,3 +46,29 @@ go_binary(
     visibility = ["//visibility:public"],
     x_defs = version_x_defs(),
 )
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+)
+
+container_image(
+    name = "version-container",
+    base = "//:passwd-image",
+    directory = "/",
+    files = ["//:get-version"],
+)
+
+container_image(
+    name = "virtctl-image",
+    architecture = select({
+        "@io_bazel_rules_go//go/platform:linux_ppc64le": "ppc64le",
+        "//conditions:default": "amd64",
+    }),
+    base = ":version-container",
+    directory = "/usr/bin/",
+    entrypoint = ["/usr/bin/virtctl"],
+    files = [":virtctl"],
+    user = "1001",
+    visibility = ["//visibility:public"],
+)

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -29,4 +29,4 @@ bazel build \
     --define image_prefix= \
     --define container_tag= \
     //:build-other-images //cmd/virt-operator:virt-operator-image //cmd/virt-api:virt-api-image \
-    //cmd/virt-controller:virt-controller-image //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //tests:conformance_image
+    //cmd/virt-controller:virt-controller-image //cmd/virt-handler:virt-handler-image //cmd/virt-launcher:virt-launcher-image //tests:conformance_image //cmd/virtctl:virtctl-image

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -22,7 +22,7 @@ set -e
 source hack/common.sh
 source hack/config.sh
 
-PUSH_TARGETS=(${PUSH_TARGETS:-other-images virt-operator virt-api virt-controller virt-handler virt-launcher conformance})
+PUSH_TARGETS=(${PUSH_TARGETS:-other-images virt-operator virt-api virt-controller virt-handler virt-launcher conformance virtctl})
 
 for tag in ${docker_tag} ${docker_tag_alt}; do
     for target in ${PUSH_TARGETS[@]}; do


### PR DESCRIPTION
**What this PR does / why we need it**:
Publishes `virtctl` as a container image to allow using it in containerized environments (like in-cluster)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Publishing `virtctl` as a container image.
```
