### PR TITLE
Run rook ceph together with sig storage

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -312,7 +312,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
   elif [[ $TARGET =~ sig-network ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
   elif [[ $TARGET =~ sig-storage ]]; then
-    export KUBEVIRT_E2E_FOCUS="\\[sig-storage\\]|rook-ceph"
+    export KUBEVIRT_E2E_FOCUS="\\[sig-storage\\]|\\[rook-ceph\\]"
     export KUBEVIRT_STORAGE="rook-ceph-default"
   elif [[ $TARGET =~ sig-compute ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-compute\\]"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -327,8 +327,10 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
     export KUBEVIRT_E2E_SKIP="Multus|SRIOV|GPU|Macvtap"
   fi
 
-  if [[ "$KUBEVIRT_STORAGE" == "rook-ceph" || "$KUBEVIRT_STORAGE" == "rook-ceph-default" ]]; then
-    export KUBEVIRT_E2E_FOCUS=rook-ceph
+  if ! [[ $TARGET =~ sig-storage ]]; then
+    if [[ "$KUBEVIRT_STORAGE" == "rook-ceph" || "$KUBEVIRT_STORAGE" == "rook-ceph-default" ]]; then
+        export KUBEVIRT_E2E_FOCUS=rook-ceph
+    fi
   fi
 fi
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -312,7 +312,8 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
   elif [[ $TARGET =~ sig-network ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
   elif [[ $TARGET =~ sig-storage ]]; then
-    export KUBEVIRT_E2E_FOCUS="\\[sig-storage\\]"
+    export KUBEVIRT_E2E_FOCUS="\\[sig-storage\\]|rook-ceph"
+    export KUBEVIRT_STORAGE="rook-ceph-default"
   elif [[ $TARGET =~ sig-compute ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-compute\\]"
     export KUBEVIRT_E2E_SKIP="GPU"

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -54,6 +54,7 @@ elif [[ $TARGET =~ sig-network ]]; then
   fi
 elif [[ $TARGET =~ sig-storage ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-storage/}
+  export KUBEVIRT_STORAGE="rook-ceph-default"
 elif [[ $TARGET =~ sig-compute ]]; then
   export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
 else
@@ -313,7 +314,6 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-network\\]"
   elif [[ $TARGET =~ sig-storage ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-storage\\]|\\[rook-ceph\\]"
-    export KUBEVIRT_STORAGE="rook-ceph-default"
   elif [[ $TARGET =~ sig-compute ]]; then
     export KUBEVIRT_E2E_FOCUS="\\[sig-compute\\]"
     export KUBEVIRT_E2E_SKIP="GPU"

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -118,7 +118,6 @@ go_test(
         "console_test.go",
         "container_disk_test.go",
         "credentials_test.go",
-        "events_test.go",
         "infra_test.go",
         "kubectl_test.go",
         "kubevirt_configmap_test.go",

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1810,7 +1810,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 			},
 				table.Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
-				table.Entry("[sig-storage][test_id:2731] rook-ceph with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
+				table.Entry("[sig-storage][rook-ceph][test_id:2731] with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
 			)
 			It("[sig-compute][test_id:3241]should be able to cancel a migration right after posting it", func() {
 				vmi := tests.NewRandomFedoraVMIWithGuestAgent()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1811,7 +1811,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 				},
 					table.Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
-					table.Entry("[sig-storage][sig-compute][test_id:2731] with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
+					table.Entry("[sig-storage][test_id:2731] with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
 				)
 				It("[sig-compute][test_id:3241]should be able to cancel a migration right after posting it", func() {
 					vmi := tests.NewRandomFedoraVMIWithGuestAgent()

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1737,114 +1737,113 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 			})
 		})
 
-		Context("rook-ceph", func() {
-			Context("live migration cancelation", func() {
-				type vmiBuilder func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume)
+		Context("live migration cancelation", func() {
+			type vmiBuilder func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume)
 
-				newVirtualMachineInstanceWithFedoraContainerDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-					return tests.NewRandomFedoraVMIWithGuestAgent(), nil
+			newVirtualMachineInstanceWithFedoraContainerDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
+				return tests.NewRandomFedoraVMIWithGuestAgent(), nil
+			}
+
+			newVirtualMachineInstanceWithFedoraOCSDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
+				// It could have been cleaner to import cd.ContainerDiskFedora from cdi-http-server but that does
+				// not work so as a temporary workaround the following imports the image from an ISCSI target pod
+				if !tests.HasCDI() {
+					Skip("Skip DataVolume tests when CDI is not present")
+				}
+				sc, exists := tests.GetCephStorageClass()
+				if !exists {
+					Skip("Skip OCS tests when Ceph is not present")
 				}
 
-				newVirtualMachineInstanceWithFedoraOCSDisk := func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) {
-					// It could have been cleaner to import cd.ContainerDiskFedora from cdi-http-server but that does
-					// not work so as a temporary workaround the following imports the image from an ISCSI target pod
-					if !tests.HasCDI() {
-						Skip("Skip DataVolume tests when CDI is not present")
-					}
-					sc, exists := tests.GetCephStorageClass()
-					if !exists {
-						Skip("Skip OCS tests when Ceph is not present")
-					}
+				quantity, err := resource.ParseQuantity("5Gi")
+				Expect(err).ToNot(HaveOccurred())
 
-					quantity, err := resource.ParseQuantity("5Gi")
-					Expect(err).ToNot(HaveOccurred())
+				volMode := k8sv1.PersistentVolumeBlock
+				url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
+				dv := tests.NewRandomDataVolumeWithRegistryImport(url, tests.NamespaceTestDefault, k8sv1.ReadWriteMany)
+				dv.Spec.PVC.StorageClassName = &sc
+				dv.Spec.PVC.Resources.Requests["storage"] = quantity
+				dv.Spec.PVC.VolumeMode = &volMode
 
-					volMode := k8sv1.PersistentVolumeBlock
-					url := "docker://" + cd.ContainerDiskFor(cd.ContainerDiskFedoraTestTooling)
-					dv := tests.NewRandomDataVolumeWithRegistryImport(url, tests.NamespaceTestDefault, k8sv1.ReadWriteMany)
-					dv.Spec.PVC.StorageClassName = &sc
-					dv.Spec.PVC.Resources.Requests["storage"] = quantity
-					dv.Spec.PVC.VolumeMode = &volMode
+				_, err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				tests.WaitForSuccessfulDataVolumeImport(dv, 600)
+				vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
+				tests.AddUserData(vmi, "disk1", tests.GetFedoraToolsGuestAgentUserData())
+				return vmi, dv
+			}
 
-					_, err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dv.Namespace).Create(context.Background(), dv, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					tests.WaitForSuccessfulDataVolumeImport(dv, 600)
-					vmi := tests.NewRandomVMIWithDataVolume(dv.Name)
-					tests.AddUserData(vmi, "disk1", tests.GetFedoraToolsGuestAgentUserData())
-					return vmi, dv
-				}
+			table.DescribeTable("should be able to cancel a migration", func(createVMI vmiBuilder) {
+				vmi, dv := createVMI()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
+				defer deleteDataVolume(dv)
 
-				table.DescribeTable("should be able to cancel a migration", func(createVMI vmiBuilder) {
-					vmi, dv := createVMI()
-					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
-					defer deleteDataVolume(dv)
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
 
-					By("Starting the VirtualMachineInstance")
-					vmi = runVMIAndExpectLaunch(vmi, 240)
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
 
-					By("Checking that the VirtualMachineInstance console has expected output")
-					Expect(libnet.WithIPv6(console.LoginToFedora)(vmi)).To(Succeed())
+				// Need to wait for cloud init to finish and start the agent inside the vmi.
+				tests.WaitAgentConnected(virtClient, vmi)
 
-					// Need to wait for cloud init to finish and start the agent inside the vmi.
-					tests.WaitAgentConnected(virtClient, vmi)
+				runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
 
-					runStressTest(vmi, stressDefaultVMSize, stressDefaultTimeout)
+				// execute a migration, wait for finalized state
+				By("Starting the Migration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 
-					// execute a migration, wait for finalized state
-					By("Starting the Migration")
-					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migration = runAndCancelMigration(migration, vmi, 180)
+				migrationUID := string(migration.UID)
 
-					migration = runAndCancelMigration(migration, vmi, 180)
-					migrationUID := string(migration.UID)
+				// check VMI, confirm migration state
+				confirmVMIPostMigrationAborted(vmi, migrationUID, 180)
 
-					// check VMI, confirm migration state
-					confirmVMIPostMigrationAborted(vmi, migrationUID, 180)
+				By("Waiting for the migration object to disappear")
+				tests.WaitForMigrationToDisappearWithTimeout(migration, 240)
 
-					By("Waiting for the migration object to disappear")
-					tests.WaitForMigrationToDisappearWithTimeout(migration, 240)
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 
-					// delete VMI
-					By("Deleting the VMI")
-					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
+			},
+				table.Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
+				table.Entry("[sig-storage][test_id:2731] rook-ceph with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
+			)
+			It("[sig-compute][test_id:3241]should be able to cancel a migration right after posting it", func() {
+				vmi := tests.NewRandomFedoraVMIWithGuestAgent()
+				vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
 
-					By("Waiting for VMI to disappear")
-					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
-				},
-					table.Entry("[sig-storage][test_id:2226] with ContainerDisk", newVirtualMachineInstanceWithFedoraContainerDisk),
-					table.Entry("[sig-storage][test_id:2731] with OCS Disk (using ISCSI IPv4 address)", newVirtualMachineInstanceWithFedoraOCSDisk),
-				)
-				It("[sig-compute][test_id:3241]should be able to cancel a migration right after posting it", func() {
-					vmi := tests.NewRandomFedoraVMIWithGuestAgent()
-					vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse(fedoraVMSize)
+				By("Starting the VirtualMachineInstance")
+				vmi = runVMIAndExpectLaunch(vmi, 240)
 
-					By("Starting the VirtualMachineInstance")
-					vmi = runVMIAndExpectLaunch(vmi, 240)
+				By("Checking that the VirtualMachineInstance console has expected output")
+				Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-					By("Checking that the VirtualMachineInstance console has expected output")
-					Expect(console.LoginToFedora(vmi)).To(Succeed())
+				// execute a migration, wait for finalized state
+				By("Starting the Migration")
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
 
-					// execute a migration, wait for finalized state
-					By("Starting the Migration")
-					migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migration = runAndImmediatelyCancelMigration(migration, vmi, 180)
 
-					migration = runAndImmediatelyCancelMigration(migration, vmi, 180)
+				// check VMI, confirm migration state
+				confirmVMIPostMigrationAborted(vmi, string(migration.UID), 180)
 
-					// check VMI, confirm migration state
-					confirmVMIPostMigrationAborted(vmi, string(migration.UID), 180)
+				By("Waiting for the migration object to disappear")
+				tests.WaitForMigrationToDisappearWithTimeout(migration, 240)
 
-					By("Waiting for the migration object to disappear")
-					tests.WaitForMigrationToDisappearWithTimeout(migration, 240)
+				// delete VMI
+				By("Deleting the VMI")
+				Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
 
-					// delete VMI
-					By("Deleting the VMI")
-					Expect(virtClient.VirtualMachineInstance(vmi.Namespace).Delete(vmi.Name, &metav1.DeleteOptions{})).To(Succeed())
+				By("Waiting for VMI to disappear")
+				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
 
-					By("Waiting for VMI to disappear")
-					tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 240)
-
-				})
 			})
 		})
+
 		Context("with a host-model cpu", func() {
 			getNodeHostModel := func(node *k8sv1.Node) (hostModel string) {
 				for key, _ := range node.Labels {

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "datavolume.go",
+        "events.go",
         "framework.go",
         "hotplug.go",
         "imageupload.go",

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -807,7 +807,7 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 				}
 			})
 
-			table.DescribeTable("deny then allow clone request on rook-ceph", func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
+			table.DescribeTable("[rook-ceph] deny then allow clone request", func(role *rbacv1.Role, allServiceAccounts, allServiceAccountsInNamespace bool) {
 				vm := tests.NewRandomVMWithCloneDataVolume(dataVolume.Namespace, dataVolume.Name, tests.NamespaceTestDefault)
 				const volumeName = "sa"
 				saVol := v1.Volume{

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -1,4 +1,23 @@
-package tests_test
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
+
+package storage
 
 import (
 	"context"
@@ -21,7 +40,7 @@ const (
 	diskName   = "disk0"
 )
 
-var _ = Describe("[Serial][sig-storage]K8s IO events", func() {
+var _ = SIGDescribe("[Serial]K8s IO events", func() {
 	var (
 		nodeName   string
 		virtClient kubecli.KubevirtClient

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -518,7 +518,7 @@ var _ = SIGDescribe("Hotplug", func() {
 		)
 	})
 
-	Context("rook-ceph", func() {
+	Context("[rook-ceph]", func() {
 		Context("Online VM", func() {
 			var (
 				vm *kubevirtv1.VirtualMachine

--- a/tests/storage/imageupload.go
+++ b/tests/storage/imageupload.go
@@ -128,7 +128,7 @@ var _ = SIGDescribe("[Serial]ImageUpload", func() {
 		Expect(*pvc.Spec.StorageClassName).To(Equal(storageClass))
 	}
 
-	Context("Upload an image and start a VMI with PVC on rook-ceph", func() {
+	Context("[rook-ceph] Upload an image and start a VMI with PVC", func() {
 		DescribeTable("[test_id:4621] Should succeed", func(resource, targetName string, validateFunc func(string, string), deleteFunc func(string), startVM bool) {
 			sc, exists := tests.GetCephStorageClass()
 			if !exists {

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -348,7 +348,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineRestore Tests", func() {
 		})
 	})
 
-	Context("rook-ceph", func() {
+	Context("[rook-ceph]", func() {
 		Context("With a more complicated VM", func() {
 			var (
 				vm                   *v1.VirtualMachine

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -151,7 +151,7 @@ var _ = SIGDescribe("[Serial]VirtualMachineSnapshot Tests", func() {
 		})
 	})
 
-	Context("rook-ceph", func() {
+	Context("[rook-ceph]", func() {
 		Context("With more complicated VM", func() {
 			BeforeEach(func() {
 				sc, err := getSnapshotStorageClass(virtClient)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR enables `rook-ceph-default` coming with kubevirtci and focusses all sig-storage **and** rook-ceph tests for the sig-storage lanes (i.e. `TARGET=k8s-1.19-sig-storage`).
It also moves a test into `tests/storage` folder and removes a duplicate sig label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
