### PR TITLE
Configurable runtimeClassName for virt-launcher

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10353,6 +10353,9 @@
      "cpuRequest": {
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.api.resource.Quantity"
      },
+     "defaultRuntimeClass": {
+      "type": "string"
+     },
      "developerConfiguration": {
       "$ref": "#/definitions/v1.DeveloperConfiguration"
      },
@@ -10363,9 +10366,6 @@
       }
      },
      "imagePullPolicy": {
-      "type": "string"
-     },
-     "launcherRuntimeClass": {
       "type": "string"
      },
      "machineType": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10365,6 +10365,9 @@
      "imagePullPolicy": {
       "type": "string"
      },
+     "launcherRuntimeClass": {
+      "type": "string"
+     },
      "machineType": {
       "type": "string"
      },

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -98,6 +98,8 @@ spec:
                     - type: string
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  defaultRuntimeClass:
+                    type: string
                   developerConfiguration:
                     description: DeveloperConfiguration holds developer options
                     properties:
@@ -155,8 +157,6 @@ spec:
                   imagePullPolicy:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image
-                    type: string
-                  launcherRuntimeClass:
                     type: string
                   machineType:
                     type: string
@@ -1982,6 +1982,8 @@ spec:
                     - type: string
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
+                  defaultRuntimeClass:
+                    type: string
                   developerConfiguration:
                     description: DeveloperConfiguration holds developer options
                     properties:
@@ -2039,8 +2041,6 @@ spec:
                   imagePullPolicy:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image
-                    type: string
-                  launcherRuntimeClass:
                     type: string
                   machineType:
                     type: string

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -156,6 +156,8 @@ spec:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image
                     type: string
+                  launcherRuntimeClass:
+                    type: string
                   machineType:
                     type: string
                   memBalloonStatsPeriod:
@@ -2037,6 +2039,8 @@ spec:
                   imagePullPolicy:
                     description: PullPolicy describes a policy for if/when to pull
                       a container image
+                    type: string
+                  launcherRuntimeClass:
                     type: string
                   machineType:
                     type: string

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -196,6 +196,10 @@ func (c *ClusterConfig) GetSELinuxLauncherType() string {
 	return c.GetConfig().SELinuxLauncherType
 }
 
+func (c *ClusterConfig) GetLauncherRuntimeClass() string {
+	return c.GetConfig().LauncherRuntimeClass
+}
+
 func (c *ClusterConfig) GetSupportedAgentVersions() []string {
 	return c.GetConfig().SupportedGuestAgentVersions
 }

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -196,8 +196,8 @@ func (c *ClusterConfig) GetSELinuxLauncherType() string {
 	return c.GetConfig().SELinuxLauncherType
 }
 
-func (c *ClusterConfig) GetLauncherRuntimeClass() string {
-	return c.GetConfig().LauncherRuntimeClass
+func (c *ClusterConfig) GetDefaultRuntimeClass() string {
+	return c.GetConfig().DefaultRuntimeClass
 }
 
 func (c *ClusterConfig) GetSupportedAgentVersions() []string {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1304,6 +1304,12 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		alignPodMultiCategorySecurity(&pod, selinuxType)
 	}
 
+	// If we have a runtime class specified, use it, otherwise don't set a runtimeClassName
+	runtimeClassName := t.clusterConfig.GetLauncherRuntimeClass()
+	if runtimeClassName != "" {
+		pod.Spec.RuntimeClassName = &runtimeClassName
+	}
+
 	if vmi.Spec.PriorityClassName != "" {
 		pod.Spec.PriorityClassName = vmi.Spec.PriorityClassName
 	}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1305,7 +1305,7 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 	}
 
 	// If we have a runtime class specified, use it, otherwise don't set a runtimeClassName
-	runtimeClassName := t.clusterConfig.GetLauncherRuntimeClass()
+	runtimeClassName := t.clusterConfig.GetDefaultRuntimeClass()
 	if runtimeClassName != "" {
 		pod.Spec.RuntimeClassName = &runtimeClassName
 	}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2809,6 +2809,43 @@ var _ = Describe("Template", func() {
 			})
 		})
 
+		Context("Using launcherRuntimeClass", func() {
+			It("Should set a runtimeClassName on launcher pod, if configured", func() {
+				runtimeClassName := "customRuntime"
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.LauncherRuntimeClass = runtimeClassName
+				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
+
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "namespace",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*pod.Spec.RuntimeClassName).To(BeEquivalentTo(runtimeClassName))
+			})
+
+			It("Should leave runtimeClassName unset on pod, if not configured", func() {
+				vmi := v1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testvmi",
+						Namespace: "namespace",
+						UID:       "1234",
+					},
+					Spec: v1.VirtualMachineInstanceSpec{},
+				}
+
+				pod, err := svc.RenderLaunchManifest(&vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pod.Spec.RuntimeClassName).To(BeNil())
+			})
+		})
+
 	})
 
 	Describe("ServiceAccountName", func() {

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2809,11 +2809,11 @@ var _ = Describe("Template", func() {
 			})
 		})
 
-		Context("Using launcherRuntimeClass", func() {
+		Context("Using defaultRuntimeClass", func() {
 			It("Should set a runtimeClassName on launcher pod, if configured", func() {
 				runtimeClassName := "customRuntime"
 				kvConfig := kv.DeepCopy()
-				kvConfig.Spec.Configuration.LauncherRuntimeClass = runtimeClassName
+				kvConfig.Spec.Configuration.DefaultRuntimeClass = runtimeClassName
 				testutils.UpdateFakeKubeVirtClusterConfig(kvInformer, kvConfig)
 
 				vmi := v1.VirtualMachineInstance{

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -563,6 +563,8 @@ var CRDsValidation map[string]string = map[string]string{
               description: PullPolicy describes a policy for if/when to pull a container
                 image
               type: string
+            launcherRuntimeClass:
+              type: string
             machineType:
               type: string
             memBalloonStatsPeriod:

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -507,6 +507,8 @@ var CRDsValidation map[string]string = map[string]string{
               - type: string
               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
               x-kubernetes-int-or-string: true
+            defaultRuntimeClass:
+              type: string
             developerConfiguration:
               description: DeveloperConfiguration holds developer options
               properties:
@@ -562,8 +564,6 @@ var CRDsValidation map[string]string = map[string]string{
             imagePullPolicy:
               description: PullPolicy describes a policy for if/when to pull a container
                 image
-              type: string
-            launcherRuntimeClass:
               type: string
             machineType:
               type: string

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -21457,7 +21457,7 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							Format: "",
 						},
 					},
-					"launcherRuntimeClass": {
+					"defaultRuntimeClass": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -21457,6 +21457,12 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							Format: "",
 						},
 					},
+					"launcherRuntimeClass": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"smbios": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubevirt.io/client-go/api/v1.SMBiosConfiguration"),

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1848,6 +1848,7 @@ type KubeVirtConfiguration struct {
 	NetworkConfiguration   *NetworkConfiguration   `json:"network,omitempty"`
 	OVMFPath               string                  `json:"ovmfPath,omitempty"`
 	SELinuxLauncherType    string                  `json:"selinuxLauncherType,omitempty"`
+	LauncherRuntimeClass   string                  `json:"launcherRuntimeClass,omitempty"`
 	SMBIOSConfig           *SMBiosConfiguration    `json:"smbios,omitempty"`
 	// deprecated
 	SupportedGuestAgentVersions []string              `json:"supportedGuestAgentVersions,omitempty"`

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1848,7 +1848,7 @@ type KubeVirtConfiguration struct {
 	NetworkConfiguration   *NetworkConfiguration   `json:"network,omitempty"`
 	OVMFPath               string                  `json:"ovmfPath,omitempty"`
 	SELinuxLauncherType    string                  `json:"selinuxLauncherType,omitempty"`
-	LauncherRuntimeClass   string                  `json:"launcherRuntimeClass,omitempty"`
+	DefaultRuntimeClass    string                  `json:"defaultRuntimeClass,omitempty"`
 	SMBIOSConfig           *SMBiosConfiguration    `json:"smbios,omitempty"`
 	// deprecated
 	SupportedGuestAgentVersions []string              `json:"supportedGuestAgentVersions,omitempty"`

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -16540,7 +16540,7 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							Format: "",
 						},
 					},
-					"launcherRuntimeClass": {
+					"defaultRuntimeClass": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
 							Format: "",

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -16540,6 +16540,12 @@ func schema_kubevirtio_client_go_api_v1_KubeVirtConfiguration(ref common.Referen
 							Format: "",
 						},
 					},
+					"launcherRuntimeClass": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"smbios": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("kubevirt.io/client-go/api/v1.SMBiosConfiguration"),

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/node/v1beta1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1584,10 +1584,10 @@ func GetRunningPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, names
 
 func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
 	pods, err := getPodsByLabel(string(vmi.GetUID()), v1.CreatedByLabel, vmi.Namespace)
-	PanicOnError(err)
+	util2.PanicOnError(err)
 
 	if len(pods.Items) != 1 {
-		PanicOnError(fmt.Errorf("found wrong number of pods for VMI '%v', count: %d", vmi, len(pods.Items)))
+		util2.PanicOnError(fmt.Errorf("found wrong number of pods for VMI '%v', count: %d", vmi, len(pods.Items)))
 	}
 
 	return &pods.Items[0]

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -55,6 +55,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8sv1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	extclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -996,6 +997,31 @@ func CreatePVC(os, size, storageClass string, recycledPV bool) {
 	}
 }
 
+func CreateRuntimeClass(name, handler string) (*nodev1.RuntimeClass, error) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return virtCli.NodeV1beta1().RuntimeClasses().Create(
+		context.Background(),
+		&nodev1.RuntimeClass{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Handler:    handler,
+		},
+		metav1.CreateOptions{},
+	)
+}
+
+func DeleteRuntimeClass(name string) error {
+	virtCli, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return err
+	}
+
+	return virtCli.NodeV1beta1().RuntimeClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
+}
+
 func newPVC(os, size, storageClass string, recycledPV bool) *k8sv1.PersistentVolumeClaim {
 	quantity, err := resource.ParseQuantity(size)
 	util2.PanicOnError(err)
@@ -1554,6 +1580,35 @@ func GetRunningPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance, names
 	pod, err := getRunningPodByVirtualMachineInstance(vmi, namespace)
 	util2.PanicOnError(err)
 	return pod
+}
+
+func GetPodByVirtualMachineInstance(vmi *v1.VirtualMachineInstance) *k8sv1.Pod {
+	pods, err := getPodsByLabel(string(vmi.GetUID()), v1.CreatedByLabel, vmi.Namespace)
+	PanicOnError(err)
+
+	if len(pods.Items) != 1 {
+		PanicOnError(fmt.Errorf("found wrong number of pods for VMI '%v', count: %d", vmi, len(pods.Items)))
+	}
+
+	return &pods.Items[0]
+}
+
+func getPodsByLabel(label, labelType, namespace string) (*k8sv1.PodList, error) {
+	virtCli, err := kubecli.GetKubevirtClient()
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector := fmt.Sprintf("%s=%s", labelType, label)
+
+	pods, err := virtCli.CoreV1().Pods(namespace).List(context.Background(),
+		metav1.ListOptions{LabelSelector: labelSelector},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return pods, nil
 }
 
 func GetRunningPodByLabel(label string, labelType string, namespace string, node string) (*k8sv1.Pod, error) {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1606,7 +1606,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 			It("should apply runtimeClassName to pod when set", func() {
 				By("Configuring a default runtime class")
-				config := tests.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
+				config := util.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
 				config.DefaultRuntimeClass = runtimeClassName
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
 
@@ -1623,14 +1623,14 @@ var _ = Describe("[sig-compute]Configurations", func() {
 			It("should not apply runtimeClassName to pod when not set", func() {
 				By("Creating a VMI")
 				var vmi = tests.NewRandomVMI()
-				vmi, err = virtClient.VirtualMachineInstance(tests.NamespaceTestDefault).Create(vmi)
+				vmi, err = virtClient.VirtualMachineInstance(util.NamespaceTestDefault).Create(vmi)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Waiting for successful start of VMI")
 				tests.WaitForSuccessfulVMIStart(vmi)
 
 				By("Checking for absence of runtimeClassName")
-				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, tests.NamespaceTestDefault)
+				pod := tests.GetRunningPodByVirtualMachineInstance(vmi, util.NamespaceTestDefault)
 				Expect(pod.Spec.RuntimeClassName).To(BeNil())
 			})
 		})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1590,7 +1590,7 @@ var _ = Describe("[sig-compute]Configurations", func() {
 
 		})
 
-		Context("using defaultRuntimeClass configuration", func() {
+		Context("[Serial]using defaultRuntimeClass configuration", func() {
 			It("should apply runtimeClassName to pod when set", func() {
 				By("Configuring a default runtime class")
 				runtimeClassName := "custom-runtime-class"

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1591,10 +1591,21 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		Context("[Serial]using defaultRuntimeClass configuration", func() {
+			runtimeClassName := "custom-runtime-class"
+
+			BeforeEach(func() {
+				By("Creating a runtime class")
+				tests.CreateRuntimeClass(runtimeClassName, "custom-handler")
+			})
+
+			AfterEach(func() {
+				By("Cleaning up runtime class")
+				err = tests.DeleteRuntimeClass(runtimeClassName)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
 			It("should apply runtimeClassName to pod when set", func() {
 				By("Configuring a default runtime class")
-				runtimeClassName := "custom-runtime-class"
-				tests.CreateRuntimeClass(runtimeClassName, "custom-handler")
 				config := tests.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()
 				config.DefaultRuntimeClass = runtimeClassName
 				tests.UpdateKubeVirtConfigValueAndWait(*config)
@@ -1607,10 +1618,6 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				By("Checking for presence of runtimeClassName")
 				pod := tests.GetPodByVirtualMachineInstance(vmi)
 				Expect(*pod.Spec.RuntimeClassName).To(BeEquivalentTo(runtimeClassName))
-
-				By("Cleaning up runtime class")
-				err = tests.DeleteRuntimeClass(runtimeClassName)
-				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should not apply runtimeClassName to pod when not set", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows administrator to specify a runtimeClassName for virt-launcher pods.

**Which issue(s) this PR fixes**:
Fixes #5754 

**Release note**:
```release-note
KubeVirt CR supports specifying a runtime class for virt-launcher pods via 'launcherRuntimeClass'.
```
