### PR TITLE
PodNetworkInfraConfigurator params renaming and redundantcy removal

### DIFF
--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -31,14 +31,13 @@ type BridgePodNetworkConfigurator struct {
 	vmi                 *v1.VirtualMachineInstance
 }
 
-func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmMac *net.HardwareAddr, cacheFactory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *BridgePodNetworkConfigurator {
+func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, cacheFactory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *BridgePodNetworkConfigurator {
 	return &BridgePodNetworkConfigurator{
 		vmi:                 vmi,
 		vmiSpecIface:        vmiSpecIface,
 		bridgeInterfaceName: bridgeIfaceName,
 		storeFactory:        cacheFactory,
 		launcherPID:         launcherPID,
-		vmMac:               vmMac,
 		handler:             handler,
 	}
 }
@@ -67,6 +66,11 @@ func (b *BridgePodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceName 
 	}
 
 	b.tapDeviceName = generateTapDeviceName(podIfaceName)
+
+	b.vmMac, err = retrieveMacAddressFromVMISpecIface(b.vmiSpecIface)
+	if err != nil {
+		return err
+	}
 	if b.vmMac == nil {
 		b.vmMac = &b.podNicLink.Attrs().HardwareAddr
 	}

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -26,7 +26,6 @@ type BridgePodNetworkConfigurator struct {
 	vmMac               *net.HardwareAddr
 	podIfaceIP          netlink.Addr
 	podNicLink          netlink.Link
-	queueCount          uint32
 	podIfaceRoutes      []netlink.Route
 	storeFactory        cache.InterfaceCacheFactory
 	tapDeviceName       string
@@ -40,7 +39,6 @@ func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIfac
 		bridgeInterfaceName: bridgeIfaceName,
 		storeFactory:        cacheFactory,
 		launcherPID:         launcherPID,
-		queueCount:          calculateNetworkQueues(vmi),
 		vmMac:               vmMac,
 		handler:             handler,
 	}
@@ -147,7 +145,7 @@ func (b *BridgePodNetworkConfigurator) PreparePodNetworkInterface() error {
 		return err
 	}
 
-	err := createAndBindTapToBridge(b.handler, b.tapDeviceName, b.bridgeInterfaceName, b.queueCount, b.launcherPID, b.podNicLink.Attrs().MTU, netdriver.LibvirtUserAndGroupId)
+	err := createAndBindTapToBridge(b.handler, b.tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, netdriver.LibvirtUserAndGroupId, b.vmi)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", b.tapDeviceName)
 		return err

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -26,17 +26,15 @@ type BridgePodNetworkConfigurator struct {
 	podIfaceIP          netlink.Addr
 	podNicLink          netlink.Link
 	podIfaceRoutes      []netlink.Route
-	storeFactory        cache.InterfaceCacheFactory
 	tapDeviceName       string
 	vmi                 *v1.VirtualMachineInstance
 }
 
-func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, cacheFactory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *BridgePodNetworkConfigurator {
+func NewBridgePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, launcherPID int, handler netdriver.NetworkHandler) *BridgePodNetworkConfigurator {
 	return &BridgePodNetworkConfigurator{
 		vmi:                 vmi,
 		vmiSpecIface:        vmiSpecIface,
 		bridgeInterfaceName: bridgeIfaceName,
-		storeFactory:        cacheFactory,
 		launcherPID:         launcherPID,
 		handler:             handler,
 	}

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -2,6 +2,7 @@ package infraconfigurators
 
 import (
 	"fmt"
+	"net"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
@@ -47,4 +48,15 @@ func calculateNetworkQueues(vmi *v1.VirtualMachineInstance) uint32 {
 func isMultiqueue(vmi *v1.VirtualMachineInstance) bool {
 	return (vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue != nil) &&
 		(*vmi.Spec.Domain.Devices.NetworkInterfaceMultiQueue)
+}
+
+func retrieveMacAddressFromVMISpecIface(vmiSpecIface *v1.Interface) (*net.HardwareAddr, error) {
+	if vmiSpecIface.MacAddress != "" {
+		macAddress, err := net.ParseMAC(vmiSpecIface.MacAddress)
+		if err != nil {
+			return nil, err
+		}
+		return &macAddress, nil
+	}
+	return nil, nil
 }

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -18,8 +18,8 @@ type PodNetworkInfraConfigurator interface {
 	GenerateDHCPConfig() *cache.DHCPConfig
 }
 
-func createAndBindTapToBridge(handler netdriver.NetworkHandler, deviceName string, bridgeIfaceName string, queueNumber uint32, launcherPID int, mtu int, tapOwner string) error {
-	err := handler.CreateTapDevice(deviceName, queueNumber, launcherPID, mtu, tapOwner)
+func createAndBindTapToBridge(handler netdriver.NetworkHandler, deviceName string, bridgeIfaceName string, launcherPID int, mtu int, tapOwner string, vmi *v1.VirtualMachineInstance) error {
+	err := handler.CreateTapDevice(deviceName, calculateNetworkQueues(vmi), launcherPID, mtu, tapOwner)
 	if err != nil {
 		return err
 	}

--- a/pkg/network/infraconfigurators/macvtap.go
+++ b/pkg/network/infraconfigurators/macvtap.go
@@ -30,31 +30,6 @@ func NewMacvtapPodNetworkConfigurator(podIfaceName string, vmiSpecIface *v1.Inte
 	}
 }
 
-func (b *MacvtapPodNetworkConfigurator) discoverPodNetworkInterface(podIfaceName string) error {
-	link, err := b.handler.LinkByName(b.podInterfaceName)
-	if err != nil {
-		log.Log.Reason(err).Errorf("failed to get a link for interface: %s", podIfaceName)
-		return err
-	}
-	b.podNicLink = link
-
-	return nil
-}
-
-func (b *MacvtapPodNetworkConfigurator) preparePodNetworkInterface() error {
-	return nil
-}
-
-func (b *MacvtapPodNetworkConfigurator) generateDomainIfaceSpec() api.Interface {
-	return api.Interface{
-		MAC: &api.MAC{MAC: b.vmMac},
-		MTU: &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)},
-		Target: &api.InterfaceTarget{
-			Device:  b.podNicLink.Attrs().Name,
-			Managed: "no",
-		},
-	}
-}
 func (b *MacvtapPodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceName string) error {
 	link, err := b.handler.LinkByName(b.podInterfaceName)
 	if err != nil {

--- a/pkg/network/infraconfigurators/macvtap.go
+++ b/pkg/network/infraconfigurators/macvtap.go
@@ -15,22 +15,21 @@ import (
 
 type MacvtapPodNetworkConfigurator struct {
 	vmi              *v1.VirtualMachineInstance
-	iface            *v1.Interface
-	virtIface        *api.Interface
+	vmiSpecIface     *v1.Interface
 	podInterfaceName string
 	podNicLink       netlink.Link
-	mac              *net.HardwareAddr
+	vmMac            *net.HardwareAddr
 	storeFactory     cache.InterfaceCacheFactory
 	launcherPID      int
 	handler          netdriver.NetworkHandler
 }
 
-func NewMacvtapPodNetworkConfigurator(vmi *v1.VirtualMachineInstance, iface *v1.Interface, podIfaceName string, mac *net.HardwareAddr, cacheFactory cache.InterfaceCacheFactory, launcherPID *int, handler netdriver.NetworkHandler) *MacvtapPodNetworkConfigurator {
+func NewMacvtapPodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, podIfaceName string, vmMac *net.HardwareAddr, cacheFactory cache.InterfaceCacheFactory, launcherPID *int, handler netdriver.NetworkHandler) *MacvtapPodNetworkConfigurator {
 	return &MacvtapPodNetworkConfigurator{
 		vmi:              vmi,
-		iface:            iface,
+		vmiSpecIface:     vmiSpecIface,
 		podInterfaceName: podIfaceName,
-		mac:              mac,
+		vmMac:            vmMac,
 		storeFactory:     cacheFactory,
 		launcherPID:      *launcherPID,
 		handler:          handler,
@@ -74,8 +73,8 @@ func (b *MacvtapPodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceName
 }
 
 func (b *MacvtapPodNetworkConfigurator) podIfaceMAC() string {
-	if b.mac != nil {
-		return b.mac.String()
+	if b.vmMac != nil {
+		return b.vmMac.String()
 	} else {
 		return b.podNicLink.Attrs().HardwareAddr.String()
 	}

--- a/pkg/network/infraconfigurators/macvtap.go
+++ b/pkg/network/infraconfigurators/macvtap.go
@@ -80,7 +80,7 @@ func (b *MacvtapPodNetworkConfigurator) PreparePodNetworkInterface() error {
 
 func (b *MacvtapPodNetworkConfigurator) GenerateDomainIfaceSpec() api.Interface {
 	return api.Interface{
-		MAC: &api.MAC{MAC: b.vmMac},
+		MAC: &api.MAC{MAC: b.vmMac.String()},
 		MTU: &api.MTU{Size: strconv.Itoa(b.podNicLink.Attrs().MTU)},
 		Target: &api.InterfaceTarget{
 			Device:  b.podNicLink.Attrs().Name,

--- a/pkg/network/infraconfigurators/macvtap.go
+++ b/pkg/network/infraconfigurators/macvtap.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/log"
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
@@ -14,24 +13,17 @@ import (
 )
 
 type MacvtapPodNetworkConfigurator struct {
-	vmi              *v1.VirtualMachineInstance
-	vmiSpecIface     *v1.Interface
 	podInterfaceName string
 	podNicLink       netlink.Link
 	vmMac            *net.HardwareAddr
-	storeFactory     cache.InterfaceCacheFactory
 	launcherPID      int
 	handler          netdriver.NetworkHandler
 }
 
-func NewMacvtapPodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, podIfaceName string, vmMac *net.HardwareAddr, cacheFactory cache.InterfaceCacheFactory, launcherPID *int, handler netdriver.NetworkHandler) *MacvtapPodNetworkConfigurator {
+func NewMacvtapPodNetworkConfigurator(podIfaceName string, vmMac *net.HardwareAddr, handler netdriver.NetworkHandler) *MacvtapPodNetworkConfigurator {
 	return &MacvtapPodNetworkConfigurator{
-		vmi:              vmi,
-		vmiSpecIface:     vmiSpecIface,
 		podInterfaceName: podIfaceName,
 		vmMac:            vmMac,
-		storeFactory:     cacheFactory,
-		launcherPID:      *launcherPID,
 		handler:          handler,
 	}
 }

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -48,7 +48,7 @@ type MasqueradePodNetworkConfigurator struct {
 	vmMac               *net.HardwareAddr
 }
 
-func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmMac *net.HardwareAddr, vmNetworkCIDR string, vmIPv6NetworkCIDR string, factory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
+func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmNetworkCIDR string, vmIPv6NetworkCIDR string, factory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
 	return &MasqueradePodNetworkConfigurator{
 		vmi:                 vmi,
 		vmiSpecIface:        vmiSpecIface,
@@ -57,7 +57,6 @@ func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpec
 		bridgeInterfaceName: bridgeIfaceName,
 		cacheFactory:        factory,
 		launcherPID:         launcherPID,
-		vmMac:               vmMac,
 		handler:             handler,
 	}
 }
@@ -87,6 +86,11 @@ func (b *MasqueradePodNetworkConfigurator) DiscoverPodNetworkInterface(podIfaceN
 		if err := b.configureIPv6Addresses(); err != nil {
 			return err
 		}
+	}
+
+	b.vmMac, err = retrieveMacAddressFromVMISpecIface(b.vmiSpecIface)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -33,34 +33,33 @@ const (
 
 type MasqueradePodNetworkConfigurator struct {
 	vmi                 *v1.VirtualMachineInstance
-	iface               *v1.Interface
+	vmiSpecIface        *v1.Interface
 	podNicLink          netlink.Link
-	domain              *api.Domain
 	bridgeInterfaceName string
 	vmNetworkCIDR       string
 	vmIPv6NetworkCIDR   string
-	gatewayAddr         *netlink.Addr
-	gatewayIpv6Addr     *netlink.Addr
+	vmGatewayAddr       *netlink.Addr
+	vmGatewayIpv6Addr   *netlink.Addr
 	cacheFactory        cache.InterfaceCacheFactory
 	launcherPID         int
 	queueCount          uint32
 	handler             netdriver.NetworkHandler
-	podIfaceIPv4Addr    netlink.Addr
-	podIfaceIPv6Addr    netlink.Addr
-	mac                 *net.HardwareAddr
+	vmIPv4Addr          netlink.Addr
+	vmIPv6Addr          netlink.Addr
+	vmMac               *net.HardwareAddr
 }
 
-func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, iface *v1.Interface, bridgeIfaceName string, mac *net.HardwareAddr, vmNetworkCIDR string, vmIPv6NetworkCIDR string, factory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
+func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmMac *net.HardwareAddr, vmNetworkCIDR string, vmIPv6NetworkCIDR string, factory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
 	return &MasqueradePodNetworkConfigurator{
 		vmi:                 vmi,
-		iface:               iface,
+		vmiSpecIface:        vmiSpecIface,
 		vmNetworkCIDR:       vmNetworkCIDR,
 		vmIPv6NetworkCIDR:   vmIPv6NetworkCIDR,
 		bridgeInterfaceName: bridgeIfaceName,
 		cacheFactory:        factory,
 		launcherPID:         launcherPID,
 		queueCount:          calculateNetworkQueues(vmi),
-		mac:                 mac,
+		vmMac:               vmMac,
 		handler:             handler,
 	}
 }
@@ -101,8 +100,8 @@ func (b *MasqueradePodNetworkConfigurator) configureIPv4Addresses() error {
 	if err != nil {
 		return err
 	}
-	b.podIfaceIPv4Addr = *vmIPv4Addr
-	b.gatewayAddr = gatewayIPv4
+	b.vmIPv4Addr = *vmIPv4Addr
+	b.vmGatewayAddr = gatewayIPv4
 	return nil
 }
 
@@ -112,8 +111,8 @@ func (b *MasqueradePodNetworkConfigurator) configureIPv6Addresses() error {
 	if err != nil {
 		return err
 	}
-	b.podIfaceIPv6Addr = *vmIPv6Addr
-	b.gatewayIpv6Addr = gatewayIPv6
+	b.vmIPv6Addr = *vmIPv6Addr
+	b.vmGatewayIpv6Addr = gatewayIPv6
 	return nil
 
 }
@@ -156,21 +155,21 @@ func (b *MasqueradePodNetworkConfigurator) generateGatewayAndVmIPAddrs(protocol 
 func (b *MasqueradePodNetworkConfigurator) GenerateDHCPConfig() *cache.DHCPConfig {
 	dhcpConfig := &cache.DHCPConfig{
 		Name: b.podNicLink.Attrs().Name,
-		IP:   b.podIfaceIPv4Addr,
-		IPv6: b.podIfaceIPv6Addr,
+		IP:   b.vmIPv4Addr,
+		IPv6: b.vmIPv6Addr,
 	}
-	if b.mac != nil {
-		dhcpConfig.MAC = *b.mac
+	if b.vmMac != nil {
+		dhcpConfig.MAC = *b.vmMac
 	}
 	if b.podNicLink != nil {
 		dhcpConfig.Mtu = uint16(b.podNicLink.Attrs().MTU)
 	}
-	if b.gatewayAddr != nil {
-		dhcpConfig.AdvertisingIPAddr = b.gatewayAddr.IP.To4()
-		dhcpConfig.Gateway = b.gatewayAddr.IP.To4()
+	if b.vmGatewayAddr != nil {
+		dhcpConfig.AdvertisingIPAddr = b.vmGatewayAddr.IP.To4()
+		dhcpConfig.Gateway = b.vmGatewayAddr.IP.To4()
 	}
-	if b.gatewayIpv6Addr != nil {
-		dhcpConfig.AdvertisingIPv6Addr = b.gatewayIpv6Addr.IP.To16()
+	if b.vmGatewayIpv6Addr != nil {
+		dhcpConfig.AdvertisingIPv6Addr = b.vmGatewayIpv6Addr.IP.To16()
 	}
 
 	return dhcpConfig
@@ -218,8 +217,8 @@ func (b *MasqueradePodNetworkConfigurator) GenerateDomainIfaceSpec() api.Interfa
 			Managed: "no",
 		},
 	}
-	if b.mac != nil {
-		domainIface.MAC = &api.MAC{MAC: b.mac.String()}
+	if b.vmMac != nil {
+		domainIface.MAC = &api.MAC{MAC: b.vmMac.String()}
 	}
 	return domainIface
 }
@@ -248,7 +247,7 @@ func (b *MasqueradePodNetworkConfigurator) createBridge() error {
 		return err
 	}
 
-	if err := b.handler.AddrAdd(bridge, b.gatewayAddr); err != nil {
+	if err := b.handler.AddrAdd(bridge, b.vmGatewayAddr); err != nil {
 		log.Log.Reason(err).Errorf("failed to set bridge IP")
 		return err
 	}
@@ -258,7 +257,7 @@ func (b *MasqueradePodNetworkConfigurator) createBridge() error {
 		return err
 	}
 	if ipv6Enabled {
-		if err := b.handler.AddrAdd(bridge, b.gatewayIpv6Addr); err != nil {
+		if err := b.handler.AddrAdd(bridge, b.vmGatewayIpv6Addr); err != nil {
 			log.Log.Reason(err).Errorf("failed to set bridge IPv6")
 			return err
 		}
@@ -359,7 +358,7 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingIptables(protocol 
 		return err
 	}
 
-	if len(b.iface.Ports) == 0 {
+	if len(b.vmiSpecIface.Ports) == 0 {
 		err = b.handler.IptablesAppendRule(protocol, "nat", "KUBEVIRT_PREINBOUND",
 			"-j",
 			"DNAT",
@@ -389,7 +388,7 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingIptables(protocol 
 		return nil
 	}
 
-	for _, port := range b.iface.Ports {
+	for _, port := range b.vmiSpecIface.Ports {
 		if port.Protocol == "" {
 			port.Protocol = "tcp"
 		}
@@ -488,7 +487,7 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingNftables(proto ipt
 		return err
 	}
 
-	if len(b.iface.Ports) == 0 {
+	if len(b.vmiSpecIface.Ports) == 0 {
 		if hasIstioSidecarInjectionEnabled(b.vmi) {
 			err = b.skipForwardingForPortsUsingNftables(proto, PortsUsedByIstio())
 			if err != nil {
@@ -521,7 +520,7 @@ func (b *MasqueradePodNetworkConfigurator) createNatRulesUsingNftables(proto ipt
 		return nil
 	}
 
-	for _, port := range b.iface.Ports {
+	for _, port := range b.vmiSpecIface.Ports {
 		if port.Protocol == "" {
 			port.Protocol = "tcp"
 		}
@@ -578,17 +577,17 @@ func (b *MasqueradePodNetworkConfigurator) skipForwardingForPortsUsingNftables(p
 
 func (b *MasqueradePodNetworkConfigurator) getGatewayByProtocol(proto iptables.Protocol) string {
 	if proto == iptables.ProtocolIPv4 {
-		return b.gatewayAddr.IP.String()
+		return b.vmGatewayAddr.IP.String()
 	} else {
-		return b.gatewayIpv6Addr.IP.String()
+		return b.vmGatewayIpv6Addr.IP.String()
 	}
 }
 
 func (b *MasqueradePodNetworkConfigurator) geVmIfaceIpByProtocol(proto iptables.Protocol) string {
 	if proto == iptables.ProtocolIPv4 {
-		return b.podIfaceIPv4Addr.IP.String()
+		return b.vmIPv4Addr.IP.String()
 	} else {
-		return b.podIfaceIPv6Addr.IP.String()
+		return b.vmIPv6Addr.IP.String()
 	}
 }
 

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -40,7 +40,6 @@ type MasqueradePodNetworkConfigurator struct {
 	vmIPv6NetworkCIDR   string
 	vmGatewayAddr       *netlink.Addr
 	vmGatewayIpv6Addr   *netlink.Addr
-	cacheFactory        cache.InterfaceCacheFactory
 	launcherPID         int
 	handler             netdriver.NetworkHandler
 	vmIPv4Addr          netlink.Addr
@@ -48,14 +47,13 @@ type MasqueradePodNetworkConfigurator struct {
 	vmMac               *net.HardwareAddr
 }
 
-func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmNetworkCIDR string, vmIPv6NetworkCIDR string, factory cache.InterfaceCacheFactory, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
+func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpecIface *v1.Interface, bridgeIfaceName string, vmNetworkCIDR string, vmIPv6NetworkCIDR string, launcherPID int, handler netdriver.NetworkHandler) *MasqueradePodNetworkConfigurator {
 	return &MasqueradePodNetworkConfigurator{
 		vmi:                 vmi,
 		vmiSpecIface:        vmiSpecIface,
 		vmNetworkCIDR:       vmNetworkCIDR,
 		vmIPv6NetworkCIDR:   vmIPv6NetworkCIDR,
 		bridgeInterfaceName: bridgeIfaceName,
-		cacheFactory:        factory,
 		launcherPID:         launcherPID,
 		handler:             handler,
 	}

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -42,7 +42,6 @@ type MasqueradePodNetworkConfigurator struct {
 	vmGatewayIpv6Addr   *netlink.Addr
 	cacheFactory        cache.InterfaceCacheFactory
 	launcherPID         int
-	queueCount          uint32
 	handler             netdriver.NetworkHandler
 	vmIPv4Addr          netlink.Addr
 	vmIPv6Addr          netlink.Addr
@@ -58,7 +57,6 @@ func NewMasqueradePodNetworkConfigurator(vmi *v1.VirtualMachineInstance, vmiSpec
 		bridgeInterfaceName: bridgeIfaceName,
 		cacheFactory:        factory,
 		launcherPID:         launcherPID,
-		queueCount:          calculateNetworkQueues(vmi),
 		vmMac:               vmMac,
 		handler:             handler,
 	}
@@ -181,7 +179,7 @@ func (b *MasqueradePodNetworkConfigurator) PreparePodNetworkInterface() error {
 	}
 
 	tapDeviceName := generateTapDeviceName(b.podNicLink.Attrs().Name)
-	err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.queueCount, b.launcherPID, b.podNicLink.Attrs().MTU, netdriver.LibvirtUserAndGroupId)
+	err := createAndBindTapToBridge(b.handler, tapDeviceName, b.bridgeInterfaceName, b.launcherPID, b.podNicLink.Attrs().MTU, netdriver.LibvirtUserAndGroupId, b.vmi)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to create tap device named %s", tapDeviceName)
 		return err

--- a/pkg/virt-launcher/virtwrap/network/network_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_test.go
@@ -69,8 +69,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(nics).To(ConsistOf([]podNIC{{
 					vmi:              vm,
 					podInterfaceName: primaryPodInterfaceName,
-					iface:            iface,
-					network:          defaultNet,
+					vmiSpecIface:     iface,
+					vmiSpecNetwork:   defaultNet,
 					handler:          vmNetworkConfigurator.handler,
 					cacheFactory:     vmNetworkConfigurator.cacheFactory,
 					dhcpConfigurator: dhcp.NewConfiguratorWithClientFilter(
@@ -103,8 +103,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(nics).To(ConsistOf([]podNIC{{
 					vmi:              vmi,
-					iface:            iface,
-					network:          cniNet,
+					vmiSpecIface:     iface,
+					vmiSpecNetwork:   cniNet,
 					podInterfaceName: multusInterfaceName,
 					handler:          vmNetworkConfigurator.handler,
 					cacheFactory:     vmNetworkConfigurator.cacheFactory,
@@ -168,8 +168,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 				Expect(nics).To(ContainElements([]podNIC{
 					{
 						vmi:              vm,
-						iface:            &vm.Spec.Domain.Devices.Interfaces[0],
-						network:          additionalCNINet1,
+						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[0],
+						vmiSpecNetwork:   additionalCNINet1,
 						podInterfaceName: "net1",
 						handler:          vmNetworkConfigurator.handler,
 						cacheFactory:     vmNetworkConfigurator.cacheFactory,
@@ -181,8 +181,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 					},
 					{
 						vmi:              vm,
-						iface:            &vm.Spec.Domain.Devices.Interfaces[1],
-						network:          cniNet,
+						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[1],
+						vmiSpecNetwork:   cniNet,
 						podInterfaceName: "eth0",
 						handler:          vmNetworkConfigurator.handler,
 						cacheFactory:     vmNetworkConfigurator.cacheFactory,
@@ -194,8 +194,8 @@ var _ = Describe("VMNetworkConfigurator", func() {
 					},
 					{
 						vmi:              vm,
-						iface:            &vm.Spec.Domain.Devices.Interfaces[2],
-						network:          additionalCNINet2,
+						vmiSpecIface:     &vm.Spec.Domain.Devices.Interfaces[2],
+						vmiSpecNetwork:   additionalCNINet2,
 						podInterfaceName: "net2",
 						handler:          vmNetworkConfigurator.handler,
 						cacheFactory:     vmNetworkConfigurator.cacheFactory,

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -364,12 +364,8 @@ func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfra
 	}
 	if l.vmiSpecIface.Macvtap != nil {
 		return infraconfigurators.NewMacvtapPodNetworkConfigurator(
-			l.vmi,
-			l.vmiSpecIface,
 			l.podInterfaceName,
 			mac,
-			l.cacheFactory,
-			l.launcherPID,
 			l.handler), nil
 	}
 	return nil, fmt.Errorf("Not implemented")

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -333,7 +333,6 @@ func newBridgeLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *Bri
 }
 
 func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfraConfigurator, error) {
-	mac, err := retrieveMacAddressFromVMISpecIface(l.vmiSpecIface)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +341,6 @@ func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfra
 			l.vmi,
 			l.vmiSpecIface,
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
-			mac,
 			l.cacheFactory,
 			*l.launcherPID,
 			l.handler), nil
@@ -352,7 +350,6 @@ func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfra
 			l.vmi,
 			l.vmiSpecIface,
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
-			mac,
 			l.vmiSpecNetwork.Pod.VMNetworkCIDR,
 			l.vmiSpecNetwork.Pod.VMIPv6NetworkCIDR,
 			l.cacheFactory,
@@ -365,21 +362,10 @@ func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfra
 	if l.vmiSpecIface.Macvtap != nil {
 		return infraconfigurators.NewMacvtapPodNetworkConfigurator(
 			l.podInterfaceName,
-			mac,
+			l.vmiSpecIface,
 			l.handler), nil
 	}
 	return nil, fmt.Errorf("Not implemented")
-}
-
-func retrieveMacAddressFromVMISpecIface(vmiSpecIface *v1.Interface) (*net.HardwareAddr, error) {
-	if vmiSpecIface.MacAddress != "" {
-		macAddress, err := net.ParseMAC(vmiSpecIface.MacAddress)
-		if err != nil {
-			return nil, err
-		}
-		return &macAddress, nil
-	}
-	return nil, nil
 }
 
 type BridgeLibvirtSpecGenerator struct {

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -21,7 +21,6 @@ package network
 
 import (
 	"fmt"
-	"net"
 	"os"
 
 	v1 "kubevirt.io/client-go/api/v1"
@@ -333,15 +332,11 @@ func newBridgeLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *Bri
 }
 
 func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfraConfigurator, error) {
-	if err != nil {
-		return nil, err
-	}
 	if l.vmiSpecIface.Bridge != nil {
 		return infraconfigurators.NewBridgePodNetworkConfigurator(
 			l.vmi,
 			l.vmiSpecIface,
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
-			l.cacheFactory,
 			*l.launcherPID,
 			l.handler), nil
 	}
@@ -352,7 +347,6 @@ func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfra
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
 			l.vmiSpecNetwork.Pod.VMNetworkCIDR,
 			l.vmiSpecNetwork.Pod.VMIPv6NetworkCIDR,
-			l.cacheFactory,
 			*l.launcherPID,
 			l.handler), nil
 	}

--- a/pkg/virt-launcher/virtwrap/network/podinterface.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface.go
@@ -43,8 +43,8 @@ type podNIC struct {
 	vmi              *v1.VirtualMachineInstance
 	podInterfaceName string
 	launcherPID      *int
-	iface            *v1.Interface
-	network          *v1.Network
+	vmiSpecIface     *v1.Interface
+	vmiSpecNetwork   *v1.Network
 	handler          netdriver.NetworkHandler
 	cacheFactory     cache.InterfaceCacheFactory
 	dhcpConfigurator *dhcpconfigurator.Configurator
@@ -83,9 +83,9 @@ func newPodNIC(vmi *v1.VirtualMachineInstance, network *v1.Network, handler netd
 		cacheFactory:     cacheFactory,
 		handler:          handler,
 		vmi:              vmi,
-		network:          network,
+		vmiSpecNetwork:   network,
 		podInterfaceName: podInterfaceName,
-		iface:            correspondingNetworkIface,
+		vmiSpecIface:     correspondingNetworkIface,
 		launcherPID:      launcherPID,
 		dhcpConfigurator: dhcpConfigurator,
 	}, nil
@@ -130,7 +130,7 @@ func isSecondaryMultusNetwork(net v1.Network) bool {
 }
 
 func (l *podNIC) setPodInterfaceCache() error {
-	ifCache := &cache.PodCacheInterface{Iface: l.iface}
+	ifCache := &cache.PodCacheInterface{Iface: l.vmiSpecIface}
 
 	ipv4, ipv6, err := l.handler.ReadIPAddressesFromLink(l.podInterfaceName)
 	if err != nil {
@@ -152,7 +152,7 @@ func (l *podNIC) setPodInterfaceCache() error {
 	}
 
 	ifCache.PodIP = ifCache.PodIPs[0]
-	err = l.cacheFactory.CacheForVMI(l.vmi).Write(l.iface.Name, ifCache)
+	err = l.cacheFactory.CacheForVMI(l.vmi).Write(l.vmiSpecIface.Name, ifCache)
 	if err != nil {
 		log.Log.Reason(err).Errorf("failed to write pod Interface to ifCache, %s", err.Error())
 		return err
@@ -179,7 +179,7 @@ func (l *podNIC) sortIPsBasedOnPrimaryIP(ipv4, ipv6 string) ([]string, error) {
 func (l *podNIC) PlugPhase1() error {
 
 	// There is nothing to plug for SR-IOV devices
-	if l.iface.SRIOV != nil {
+	if l.vmiSpecIface.SRIOV != nil {
 		return nil
 	}
 
@@ -196,7 +196,7 @@ func (l *podNIC) PlugPhase1() error {
 		}
 	}
 
-	isSlirpIface := l.iface.Slirp != nil
+	isSlirpIface := l.vmiSpecIface.Slirp != nil
 	if isSlirpIface {
 		return nil
 	}
@@ -246,7 +246,7 @@ func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 	precond.MustNotBeNil(domain)
 
 	// There is nothing to plug for SR-IOV devices
-	if l.iface.SRIOV != nil {
+	if l.vmiSpecIface.SRIOV != nil {
 		return nil
 	}
 
@@ -265,7 +265,7 @@ func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 			log.Log.Reason(err).Critical("failed to load cached dhcpConfig configuration")
 		}
 		log.Log.V(4).Infof("The imported dhcpConfig: %s", dhcpConfig.String())
-		if err := l.dhcpConfigurator.EnsureDHCPServerStarted(l.podInterfaceName, *dhcpConfig, l.iface.DHCPOptions); err != nil {
+		if err := l.dhcpConfigurator.EnsureDHCPServerStarted(l.podInterfaceName, *dhcpConfig, l.vmiSpecIface.DHCPOptions); err != nil {
 			log.Log.Reason(err).Criticalf("failed to ensure dhcp service running for: %s", l.podInterfaceName)
 			panic(err)
 		}
@@ -275,7 +275,7 @@ func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 }
 
 func (l *podNIC) getInfoForLibvirtDomainInterface() api.Interface {
-	if l.iface.Slirp == nil {
+	if l.vmiSpecIface.Slirp == nil {
 		domainIface, err := l.cachedDomainInterface()
 		if err != nil {
 			log.Log.Reason(err).Critical("failed to load cached interface configuration")
@@ -289,83 +289,83 @@ func (l *podNIC) getInfoForLibvirtDomainInterface() api.Interface {
 }
 
 func (l *podNIC) newLibvirtSpecGenerator(domain *api.Domain) (LibvirtSpecGenerator, error) {
-	if l.iface.Bridge != nil {
-		return newBridgeLibvirtSpecGenerator(l.iface, domain), nil
+	if l.vmiSpecIface.Bridge != nil {
+		return newBridgeLibvirtSpecGenerator(l.vmiSpecIface, domain), nil
 	}
-	if l.iface.Masquerade != nil {
-		return newMasqueradeLibvirtSpecGenerator(l.iface, domain), nil
+	if l.vmiSpecIface.Masquerade != nil {
+		return newMasqueradeLibvirtSpecGenerator(l.vmiSpecIface, domain), nil
 	}
-	if l.iface.Slirp != nil {
-		return newSlirpLibvirtSpecGenerator(l.iface, domain), nil
+	if l.vmiSpecIface.Slirp != nil {
+		return newSlirpLibvirtSpecGenerator(l.vmiSpecIface, domain), nil
 	}
-	if l.iface.Macvtap != nil {
-		return newMacvtapLibvirtSpecGenerator(l.iface, domain), nil
+	if l.vmiSpecIface.Macvtap != nil {
+		return newMacvtapLibvirtSpecGenerator(l.vmiSpecIface, domain), nil
 	}
 	return nil, fmt.Errorf("Not implemented")
 }
 
 func newMacvtapLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *MacvtapLibvirtSpecGenerator {
 	return &MacvtapLibvirtSpecGenerator{
-		iface:  iface,
-		domain: domain,
+		vmiSpecIface: iface,
+		domain:       domain,
 	}
 }
 
 func newMasqueradeLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *MasqueradeLibvirtSpecGenerator {
 	return &MasqueradeLibvirtSpecGenerator{
-		iface:  iface,
-		domain: domain,
+		vmiSpecIface: iface,
+		domain:       domain,
 	}
 }
 
 func newSlirpLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *SlirpLibvirtSpecGenerator {
 	return &SlirpLibvirtSpecGenerator{
-		iface:  iface,
-		domain: domain,
+		vmiSpecIface: iface,
+		domain:       domain,
 	}
 }
 
 func newBridgeLibvirtSpecGenerator(iface *v1.Interface, domain *api.Domain) *BridgeLibvirtSpecGenerator {
 	return &BridgeLibvirtSpecGenerator{
-		iface:  iface,
-		domain: domain,
+		vmiSpecIface: iface,
+		domain:       domain,
 	}
 }
 
 func (l *podNIC) newPodNetworkConfigurator() (infraconfigurators.PodNetworkInfraConfigurator, error) {
-	mac, err := retrieveMacAddressFromVMISpecIface(l.iface)
+	mac, err := retrieveMacAddressFromVMISpecIface(l.vmiSpecIface)
 	if err != nil {
 		return nil, err
 	}
-	if l.iface.Bridge != nil {
+	if l.vmiSpecIface.Bridge != nil {
 		return infraconfigurators.NewBridgePodNetworkConfigurator(
 			l.vmi,
-			l.iface,
+			l.vmiSpecIface,
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
 			mac,
 			l.cacheFactory,
 			*l.launcherPID,
 			l.handler), nil
 	}
-	if l.iface.Masquerade != nil {
+	if l.vmiSpecIface.Masquerade != nil {
 		return infraconfigurators.NewMasqueradePodNetworkConfigurator(
 			l.vmi,
-			l.iface,
+			l.vmiSpecIface,
 			generateInPodBridgeInterfaceName(l.podInterfaceName),
 			mac,
-			l.network.Pod.VMNetworkCIDR,
-			l.network.Pod.VMIPv6NetworkCIDR,
+			l.vmiSpecNetwork.Pod.VMNetworkCIDR,
+			l.vmiSpecNetwork.Pod.VMIPv6NetworkCIDR,
 			l.cacheFactory,
 			*l.launcherPID,
 			l.handler), nil
 	}
-	if l.iface.Slirp != nil {
+	if l.vmiSpecIface.Slirp != nil {
 		return nil, nil
 	}
-	if l.iface.Macvtap != nil {
+	if l.vmiSpecIface.Macvtap != nil {
 		return infraconfigurators.NewMacvtapPodNetworkConfigurator(
 			l.vmi,
-			l.iface,
+			l.vmiSpecIface,
 			l.podInterfaceName,
 			mac,
 			l.cacheFactory,
@@ -387,14 +387,14 @@ func retrieveMacAddressFromVMISpecIface(vmiSpecIface *v1.Interface) (*net.Hardwa
 }
 
 type BridgeLibvirtSpecGenerator struct {
-	iface  *v1.Interface
-	domain *api.Domain
+	vmiSpecIface *v1.Interface
+	domain       *api.Domain
 }
 
 func (b *BridgeLibvirtSpecGenerator) generate(domainIface api.Interface) error {
 	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
-		if iface.Alias.GetName() == b.iface.Name {
+		if iface.Alias.GetName() == b.vmiSpecIface.Name {
 			ifaces[i].MTU = domainIface.MTU
 			ifaces[i].MAC = domainIface.MAC
 			ifaces[i].Target = domainIface.Target
@@ -412,7 +412,7 @@ func getPIDString(pid *int) string {
 }
 
 func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
-	ifaceConfig, err := l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Read(l.iface.Name)
+	ifaceConfig, err := l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Read(l.vmiSpecIface.Name)
 
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -426,18 +426,18 @@ func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
 }
 
 func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
-	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.iface.Name, &domainIface)
+	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.vmiSpecIface.Name, &domainIface)
 }
 
 type MasqueradeLibvirtSpecGenerator struct {
-	iface  *v1.Interface
-	domain *api.Domain
+	vmiSpecIface *v1.Interface
+	domain       *api.Domain
 }
 
 func (b *MasqueradeLibvirtSpecGenerator) generate(domainIface api.Interface) error {
 	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
-		if iface.Alias.GetName() == b.iface.Name {
+		if iface.Alias.GetName() == b.vmiSpecIface.Name {
 			ifaces[i].MTU = domainIface.MTU
 			ifaces[i].MAC = domainIface.MAC
 			ifaces[i].Target = domainIface.Target
@@ -448,8 +448,8 @@ func (b *MasqueradeLibvirtSpecGenerator) generate(domainIface api.Interface) err
 }
 
 type SlirpLibvirtSpecGenerator struct {
-	iface  *v1.Interface
-	domain *api.Domain
+	vmiSpecIface *v1.Interface
+	domain       *api.Domain
 }
 
 func (b *SlirpLibvirtSpecGenerator) generate(api.Interface) error {
@@ -457,7 +457,7 @@ func (b *SlirpLibvirtSpecGenerator) generate(api.Interface) error {
 	var foundIfaceModelType string
 	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
-		if iface.Alias.GetName() == b.iface.Name {
+		if iface.Alias.GetName() == b.vmiSpecIface.Name {
 			b.domain.Spec.Devices.Interfaces = append(ifaces[:i], ifaces[i+1:]...)
 			foundIfaceModelType = iface.Model.Type
 			break
@@ -465,13 +465,13 @@ func (b *SlirpLibvirtSpecGenerator) generate(api.Interface) error {
 	}
 
 	if foundIfaceModelType == "" {
-		return fmt.Errorf("failed to find interface %s in vmi spec", b.iface.Name)
+		return fmt.Errorf("failed to find interface %s in vmi spec", b.vmiSpecIface.Name)
 	}
 
-	qemuArg := fmt.Sprintf("%s,netdev=%s,id=%s", foundIfaceModelType, b.iface.Name, b.iface.Name)
-	if b.iface.MacAddress != "" {
+	qemuArg := fmt.Sprintf("%s,netdev=%s,id=%s", foundIfaceModelType, b.vmiSpecIface.Name, b.vmiSpecIface.Name)
+	if b.vmiSpecIface.MacAddress != "" {
 		// We assume address was already validated in API layer so just pass it to libvirt as-is.
-		qemuArg += fmt.Sprintf(",mac=%s", b.iface.MacAddress)
+		qemuArg += fmt.Sprintf(",mac=%s", b.vmiSpecIface.MacAddress)
 	}
 	// Add interface configuration to qemuArgs
 	b.domain.Spec.QEMUCmd.QEMUArg = append(b.domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: "-device"})
@@ -481,14 +481,14 @@ func (b *SlirpLibvirtSpecGenerator) generate(api.Interface) error {
 }
 
 type MacvtapLibvirtSpecGenerator struct {
-	iface  *v1.Interface
-	domain *api.Domain
+	vmiSpecIface *v1.Interface
+	domain       *api.Domain
 }
 
 func (b *MacvtapLibvirtSpecGenerator) generate(domainIface api.Interface) error {
 	ifaces := b.domain.Spec.Devices.Interfaces
 	for i, iface := range ifaces {
-		if iface.Alias.GetName() == b.iface.Name {
+		if iface.Alias.GetName() == b.vmiSpecIface.Name {
 			ifaces[i].MTU = domainIface.MTU
 			ifaces[i].MAC = domainIface.MAC
 			ifaces[i].Target = domainIface.Target

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -99,8 +99,8 @@ var _ = Describe("Pod Network", func() {
 	}
 	var createDefaultPodNIC = func(vmi *v1.VirtualMachineInstance) podNIC {
 		podnic := newPodNIC(vmi)
-		podnic.iface = &vmi.Spec.Domain.Devices.Interfaces[0]
-		podnic.network = &vmi.Spec.Networks[0]
+		podnic.vmiSpecIface = &vmi.Spec.Domain.Devices.Interfaces[0]
+		podnic.vmiSpecNetwork = &vmi.Spec.Networks[0]
 		podnic.podInterfaceName = primaryPodInterfaceName
 		return podnic
 	}
@@ -476,8 +476,8 @@ var _ = Describe("Pod Network", func() {
 				}
 				vmi := newVMI("testnamespace", "testVmName")
 				podnic := newPodNIC(vmi)
-				podnic.iface = iface
-				podnic.network = net
+				podnic.vmiSpecIface = iface
+				podnic.vmiSpecNetwork = net
 				podnic.podInterfaceName = "fakeiface"
 				podnic.launcherPID = &pid
 				err := podnic.PlugPhase1()
@@ -781,7 +781,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().AddrList(primaryPodInterface, netlink.FAMILY_ALL).Return(addrList, nil)
 		mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
 		podnic := newPodNIC(vmi)
-		podnic.iface = iface
+		podnic.vmiSpecIface = iface
 		podnic.podInterfaceName = primaryPodInterfaceName
 		err := podnic.setPodInterfaceCache()
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR renames some of the different `PodNetworkInfraConfigurator` implementing structs parameters to less generic names.
For example - `iface` -> `vmiSpecIface`.
It also removes from the struct parameters that are never used or can be calculated next to their usage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Rebased on top of https://github.com/kubevirt/kubevirt/pull/5630

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
