### PR TITLE
Allow disable tls for migrations in case getting the last bits of performance matters

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -10692,6 +10692,9 @@
       "type": "integer",
       "format": "int64"
      },
+     "disableTLS": {
+      "type": "boolean"
+     },
      "nodeDrainTaintKey": {
       "type": "string"
      },

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -289,7 +289,7 @@ func (app *virtHandlerApp) Run() {
 	// set log verbosity
 	app.clusterConfig.SetConfigModifiedCallback(app.shouldChangeLogVerbosity)
 
-	migrationProxy := migrationproxy.NewMigrationProxyManager(app.serverTLSConfig, app.clientTLSConfig)
+	migrationProxy := migrationproxy.NewMigrationProxyManager(app.serverTLSConfig, app.clientTLSConfig, app.clusterConfig)
 
 	vmController := virthandler.NewController(
 		recorder,

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -171,6 +171,8 @@ spec:
                       completionTimeoutPerGiB:
                         format: int64
                         type: integer
+                      disableTLS:
+                        type: boolean
                       nodeDrainTaintKey:
                         type: string
                       parallelMigrationsPerCluster:
@@ -2035,6 +2037,8 @@ spec:
                       completionTimeoutPerGiB:
                         format: int64
                         type: integer
+                      disableTLS:
+                        type: boolean
                       nodeDrainTaintKey:
                         type: string
                       parallelMigrationsPerCluster:

--- a/pkg/virt-config/config-map.go
+++ b/pkg/virt-config/config-map.go
@@ -257,6 +257,7 @@ type migrationConfiguration struct {
 	ProgressTimeout                   *int64             `json:"progressTimeout,string,omitempty"`
 	UnsafeMigrationOverride           *bool              `json:"unsafeMigrationOverride,string,omitempty"`
 	AllowPostCopy                     *bool              `json:"allowPostCopy,string,omitempty"`
+	DisableTLS                        *bool              `json:"disableTLS,omitempty"`
 }
 
 // setConfigFromConfigMap parses the provided config map and updates the provided config.

--- a/pkg/virt-handler/migration-proxy/BUILD.bazel
+++ b/pkg/virt-handler/migration-proxy/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/util:go_default_library",
         "//pkg/util/net/ip:go_default_library",
+        "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )
@@ -21,8 +22,12 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/certificates:go_default_library",
+        "//pkg/testutils:go_default_library",
+        "//staging/src/kubevirt.io/client-go/api/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -187,7 +187,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		mockContainerDiskMounter = container_disk.NewMockMounter(ctrl)
 		mockHotplugVolumeMounter = hotplug_volume.NewMockVolumeMounter(ctrl)
 
-		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig)
+		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 		controller = NewController(recorder,
 			virtClient,
 			host,

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -579,6 +579,8 @@ var CRDsValidation map[string]string = map[string]string{
                 completionTimeoutPerGiB:
                   format: int64
                   type: integer
+                disableTLS:
+                  type: boolean
                 nodeDrainTaintKey:
                   type: string
                 parallelMigrationsPerCluster:

--- a/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/deepcopy_generated.go
@@ -2263,6 +2263,11 @@ func (in *MigrationConfiguration) DeepCopyInto(out *MigrationConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisableTLS != nil {
+		in, out := &in.DisableTLS, &out.DisableTLS
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/openapi_generated.go
@@ -22073,6 +22073,12 @@ func schema_kubevirtio_client_go_api_v1_MigrationConfiguration(ref common.Refere
 							Format: "",
 						},
 					},
+					"disableTLS": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -1871,6 +1871,7 @@ type MigrationConfiguration struct {
 	ProgressTimeout                   *int64             `json:"progressTimeout,omitempty"`
 	UnsafeMigrationOverride           *bool              `json:"unsafeMigrationOverride,omitempty"`
 	AllowPostCopy                     *bool              `json:"allowPostCopy,omitempty"`
+	DisableTLS                        *bool              `json:"disableTLS,omitempty"`
 }
 
 // DeveloperConfiguration holds developer options

--- a/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/apis/snapshot/v1alpha1/openapi_generated.go
@@ -17156,6 +17156,12 @@ func schema_kubevirtio_client_go_api_v1_MigrationConfiguration(ref common.Refere
 							Format: "",
 						},
 					},
+					"disableTLS": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes getting the best performance is more important than encrypted migrations. For these rare cases, allow disabling migrations by setting `spec.migrations.disableTLS` to `true` to do migrations without TLS encryption.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Add `spec.migrations.disableTLS` to the KubeVirt CR to allow disabling encrypted migrations. They stay secure by default.
```
