### PR TITLE
[migration_test]: decrease stressLargeVMSize to 400M

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -75,7 +75,7 @@ const (
 	fedoraVMSize         = "256M"
 	secretDiskSerial     = "D23YZ9W6WA5DJ487"
 	stressDefaultVMSize  = "100"
-	stressLargeVMSize    = "800"
+	stressLargeVMSize    = "400"
 	stressDefaultTimeout = 1600
 )
 

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1245,7 +1245,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			},
 				table.Entry("[test_id:2653] with default migration configuration", nil, v1.MigrationPreCopy),
-				table.Entry("[QUARANTINE][test_id:5004] with postcopy", &v1.MigrationConfiguration{
+				table.Entry("[test_id:5004] with postcopy", &v1.MigrationConfiguration{
 					AllowPostCopy:           pointer.BoolPtr(true),
 					CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
 				}, v1.MigrationPostCopy),


### PR DESCRIPTION
This PR is a continuation of the last PR (https://github.com/kubevirt/kubevirt/pull/5714) to take test 5004 out of quarantine.
Seems that the `stress` command fails on OOM. This is probably due to the fact the fedora images are always increase in size while our memory request (which is currently `1Gi`) stays as is.

There is no reason to use this much memory. 400 Mbs should be enough in order for post-copy to appear, especially when we set our seconds per Gigabyte to `1` in the tests (which means that the total time this migration needs to hang is maximum 1-2 seconds).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
