### PR TITLE
update resource priority classes

### DIFF
--- a/hack/generate.sh
+++ b/hack/generate.sh
@@ -113,7 +113,6 @@ rm -f ${KUBEVIRT_DIR}/manifests/generated/*
 rm -f ${KUBEVIRT_DIR}/examples/*
 
 ResourceDir=${KUBEVIRT_DIR}/manifests/generated
-${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=priorityclass >${ResourceDir}/kubevirt-priority-class.yaml
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=kv >${ResourceDir}/kv-resource.yaml
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=kv-cr --namespace='{{.Namespace}}' --pullPolicy='{{.ImagePullPolicy}}' --featureGates='{{.FeatureGates}}' >${ResourceDir}/kubevirt-cr.yaml.in
 ${KUBEVIRT_DIR}/tools/resource-generator/resource-generator --type=operator-rbac --namespace='{{.Namespace}}' >${ResourceDir}/rbac-operator.authorization.k8s.yaml.in

--- a/manifests/generated/kubevirt-priority-class.yaml
+++ b/manifests/generated/kubevirt-priority-class.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: scheduling.k8s.io/v1
-description: This priority class should be used for KubeVirt core components only.
-kind: PriorityClass
-metadata:
-  name: kubevirt-cluster-critical
-value: 1000000000

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -808,8 +808,6 @@ spec:
             type: RollingUpdate
           template:
             metadata:
-              annotations:
-                scheduler.alpha.kubernetes.io/critical-pod: ""
               labels:
                 kubevirt.io: virt-operator
                 prometheus.kubevirt.io: ""
@@ -876,7 +874,7 @@ spec:
                 - mountPath: /etc/virt-operator/certificates
                   name: kubevirt-operator-certs
                   readOnly: true
-              priorityClassName: kubevirt-cluster-critical
+              priorityClassName: system-node-critical
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: kubevirt-operator

--- a/manifests/release/kubevirt-operator.yaml.in
+++ b/manifests/release/kubevirt-operator.yaml.in
@@ -7,14 +7,6 @@ metadata:
   name: {{.Namespace}}
 {{index .GeneratedManifests "kv-resource.yaml"}}
 ---
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: kubevirt-cluster-critical
-value: 1000000000
-globalDefault: false
-description: "This priority class should be used for core kubevirt components only."
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/manifests/release/olm/kubevirt-csv-preconditions.yaml.in
+++ b/manifests/release/olm/kubevirt-csv-preconditions.yaml.in
@@ -7,4 +7,3 @@ metadata:
   name: {{.Namespace}}
 {{index .GeneratedManifests "kv-resource.yaml"}}
 {{index .GeneratedManifests "rbac-operator.authorization.k8s.yaml.in"}}
-{{index .GeneratedManifests "kubevirt-cluster-critical.yaml"}}

--- a/pkg/virt-operator/resource/generate/components/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
-        "//vendor/k8s.io/api/scheduling/v1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/crds.go
+++ b/pkg/virt-operator/resource/generate/components/crds.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coreos/prometheus-operator/pkg/apis/monitoring"
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -947,22 +946,4 @@ func NewKubeVirtCR(namespace string, pullPolicy corev1.PullPolicy, featureGates 
 	}
 
 	return cr
-}
-
-// NewKubeVirtPriorityClassCR is used for manifest generation
-func NewKubeVirtPriorityClassCR() *schedulingv1.PriorityClass {
-	return &schedulingv1.PriorityClass{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "scheduling.k8s.io/v1",
-			Kind:       "PriorityClass",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kubevirt-cluster-critical",
-		},
-		// 1 billion is the highest value we can set
-		// https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-		Value:         1000000000,
-		GlobalDefault: false,
-		Description:   "This priority class should be used for KubeVirt core components only.",
-	}
 }

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -122,13 +122,10 @@ func newPodTemplateSpec(podName string, imageName string, repository string, ver
 				virtv1.AppLabel:    podName,
 				prometheusLabelKey: "",
 			},
-			Annotations: map[string]string{
-				"scheduler.alpha.kubernetes.io/critical-pod": "",
-			},
 			Name: podName,
 		},
 		Spec: corev1.PodSpec{
-			PriorityClassName: "kubevirt-cluster-critical",
+			PriorityClassName: "system-cluster-critical",
 			Affinity:          podAffinity,
 			Tolerations:       criticalAddonsToleration(),
 			Containers: []corev1.Container{
@@ -424,13 +421,10 @@ func NewOperatorDeployment(namespace string, repository string, imagePrefix stri
 						virtv1.AppLabel:    VirtOperatorName,
 						prometheusLabelKey: "",
 					},
-					Annotations: map[string]string{
-						"scheduler.alpha.kubernetes.io/critical-pod": "",
-					},
 					Name: VirtOperatorName,
 				},
 				Spec: corev1.PodSpec{
-					PriorityClassName:  "kubevirt-cluster-critical",
+					PriorityClassName:  "system-node-critical",
 					Tolerations:        criticalAddonsToleration(),
 					Affinity:           podAntiAffinity,
 					ServiceAccountName: "kubevirt-operator",

--- a/tools/manifest-templator/manifest-templator.go
+++ b/tools/manifest-templator/manifest-templator.go
@@ -64,7 +64,6 @@ type templateData struct {
 	VirtControllerSha      string
 	VirtHandlerSha         string
 	VirtLauncherSha        string
-	PriorityClassSpec      string
 	FeatureGates           []string
 	GeneratedManifests     map[string]string
 }
@@ -134,7 +133,6 @@ func main() {
 		data.CreatedAt = getTimestamp()
 		data.ReplacesCsvVersion = ""
 		data.OperatorDeploymentSpec = getOperatorDeploymentSpec(data, 2)
-		data.PriorityClassSpec = getPriorityClassSpec(2)
 		if *featureGates != "" {
 			data.FeatureGates = strings.Split(*featureGates, ",")
 		}
@@ -220,16 +218,6 @@ func getOperatorRules() string {
 		}
 	}
 	return fixResourceString(writer.String(), 14)
-}
-
-func getPriorityClassSpec(indentation int) string {
-	priorityClassSpec := components.NewKubeVirtPriorityClassCR()
-	writer := strings.Builder{}
-	err := util.MarshallObject(priorityClassSpec, &writer)
-	if err != nil {
-		panic(err)
-	}
-	return fixResourceString(writer.String(), indentation)
 }
 
 func getOperatorDeploymentSpec(data templateData, indentation int) string {

--- a/tools/resource-generator/resource-generator.go
+++ b/tools/resource-generator/resource-generator.go
@@ -32,7 +32,7 @@ import (
 )
 
 func main() {
-	resourceType := flag.String("type", "", "Type of resource to generate. kv | kv-cr | operator-rbac | priorityclass")
+	resourceType := flag.String("type", "", "Type of resource to generate. kv | kv-cr | operator-rbac")
 	namespace := flag.String("namespace", "kube-system", "Namespace to use.")
 	pullPolicy := flag.String("pullPolicy", "IfNotPresent", "ImagePullPolicy to use.")
 	featureGates := flag.String("featureGates", "", "Feature gates to enable.")
@@ -55,9 +55,6 @@ func main() {
 		for _, r := range all {
 			util.MarshallObject(r, os.Stdout)
 		}
-	case "priorityclass":
-		priorityClass := components.NewKubeVirtPriorityClassCR()
-		util.MarshallObject(priorityClass, os.Stdout)
 	default:
 		panic(fmt.Errorf("unknown resource type %s", *resourceType))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

I have removed the `scheduler.alpha.kubernetes.io/critical-pod` annotation since it was deprecated in k8s.io 1.16 so I don't think we need to support it anymore. I have also changed the priority classes to use the built in kubernetes' priority classes so that our resources behave as expected. 

More about the priority classes can be found here https://docs.openshift.com/container-platform/3.11/admin_guide/scheduling/priority_preemption.html#admin-guide-priority-preemption-priority-class 

Please let me know if you think I have chosen the correct priority classes for each resource. 

`virt-api` -> `system-cluster-critical`
`virt-handler` -> `system-cluster-critical`
`virt-controller` -> `system-cluster-critical`

`virt-operator` -> `system-node-critical`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://bugzilla.redhat.com/show_bug.cgi?id=1953479

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove custom `kubevirt-cluster-critical` priority class and use `system-cluster-critical` and  `system-node-critical` instead
```
