### PR TITLE
Quarantine test 5004. Remove if not failing periodics for 14 days

### DIFF
--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -1252,7 +1252,7 @@ var _ = Describe("[Serial][rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][leve
 				tests.WaitForVirtualMachineToDisappearWithTimeout(vmi, 120)
 			},
 				table.Entry("[test_id:2653] with default migration configuration", nil, v1.MigrationPreCopy),
-				table.Entry("[test_id:5004] with postcopy", &v1.MigrationConfiguration{
+				table.Entry("[QUARANTINE][test_id:5004] with postcopy", &v1.MigrationConfiguration{
 					AllowPostCopy:           pointer.BoolPtr(true),
 					CompletionTimeoutPerGiB: pointer.Int64Ptr(1),
 				}, v1.MigrationPostCopy),


### PR DESCRIPTION
This PR (https://github.com/kubevirt/kubevirt/pull/5895) got merged before I got the chance to remove quarantine. Let's get the quarantine back and wait for 14 days to see that test doesn't fail in periodics.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
