### PR TITLE
Remove bazel shutdown on automation/test.sh

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -226,8 +226,6 @@ kubectl get nodes
 
 make cluster-sync
 
-hack/dockerized bazel shutdown
-
 # OpenShift is running important containers under default namespace
 namespaces=(kubevirt default)
 if [[ $NAMESPACE != "kubevirt" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

dockerized bazel shutdown was failing on several builds:

https://search.ci.kubevirt.io/?search=Usage%3A+bazel+%3Ccommand%3E+%3Coptions%3E&maxAge=336h&context=3&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
