### PR TITLE
manifests: use rbac.authorization.k8s.io/v1 instead of v1beta1

### DIFF
--- a/manifests/testing/rbac-for-testing.yaml.in
+++ b/manifests/testing/rbac-for-testing.yaml.in
@@ -7,7 +7,7 @@ metadata:
   labels:
     kubevirt.io: ""
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubevirt-testing-cluster-admin


### PR DESCRIPTION
rbac.authorization.k8s.io/v1beta1 has been deprecated

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
