### PR TITLE
[release-0.34] fix pdb controller segfault 

### DIFF
--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget_test.go
@@ -156,6 +156,17 @@ var _ = Describe("Disruptionbudget", func() {
 			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
 		})
 
+		It("should remove the pdb if VMI doesn't exist", func() {
+			vmi := newVirtualMachine("testvm")
+			vmi.Spec.EvictionStrategy = newEvictionStrategy()
+			pdb := newPodDisruptionBudget(vmi)
+			pdbFeeder.Add(pdb)
+
+			shouldExpectPDBDeletion(pdb)
+			controller.Execute()
+			testutils.ExpectEvent(recorder, disruptionbudget.SuccessfulDeletePodDisruptionBudgetReason)
+		})
+
 		It("should recreate the PDB if the VMI is recreated", func() {
 			vmi := newVirtualMachine("testvm")
 			vmi.Spec.EvictionStrategy = newEvictionStrategy()


### PR DESCRIPTION
manual backport of the primary fix and unit test for #5849

This backport focuses only on the segfault and targeted unit test and does not include the other unit test enhancements #5849 introduced.

```release-note
Fixes event recording causing a segfault in virt-controller
```
