### PR TITLE
Re-attach SRIOV devices to target VM when live migration fails or is canceled

### DIFF
--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -860,6 +860,10 @@ func (l *LibvirtDomainManager) asyncMigrate(vmi *v1.VirtualMachineInstance, opti
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Error("Live migration failed.")
 			migrationErrorChan <- err
+
+			if err := l.hotPlugHostDevices(vmi); err != nil {
+				log.Log.Error("failed to hot-plug host-devices after migration failure")
+			}
 			return
 		}
 

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -185,12 +185,16 @@ func ConfirmVMIPostMigrationAborted(virtClient kubecli.KubevirtClient, vmi *v1.V
 	return vmi
 }
 
-func RunStressTest(vmi *v1.VirtualMachineInstance, vmsize string, stressTimeoutSeconds int) {
+func RunStressTest(vmi *v1.VirtualMachineInstance, vmsize, stressTimeoutSeconds int) {
 	By("Run a stress test to dirty some pages and slow down the migration")
 	stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %sM --vm-keep --timeout %ds&\n", vmsize, stressTimeoutSeconds)
 	Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: console.PromptExpression},
+		&expect.BSnd{S: "which stress-ng\n"},
+		&expect.BExp{R: console.PromptExpression},
+		&expect.BSnd{S: "echo $?\n"},
+		&expect.BExp{R: console.RetValue("0")},
 		&expect.BSnd{S: stressCmd},
 		&expect.BExp{R: console.PromptExpression},
 	}, 15)).To(Succeed(), "should run a stress test")

--- a/tests/migration.go
+++ b/tests/migration.go
@@ -12,6 +12,7 @@ import (
 
 	expect "github.com/google/goexpect"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"kubevirt.io/kubevirt/tests/console"
 
@@ -205,4 +206,30 @@ func RunStressTest(vmi *v1.VirtualMachineInstance, vmsize, stressTimeoutSeconds 
 	} else {
 		time.Sleep(15 * time.Second)
 	}
+}
+
+func WaitForMigrationRunning(virtClient kubecli.KubevirtClient, vmim *v1.VirtualMachineInstanceMigration, vmi *v1.VirtualMachineInstance, timeout time.Duration) error {
+	return wait.PollImmediate(1*time.Second, timeout, func() (bool, error) {
+		migration, err := virtClient.VirtualMachineInstanceMigration(vmim.Namespace).Get(vmim.Name, &metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get VirtualMachineInstanceMigration %s/%s: %v", migration.Namespace, migration.Name, err)
+		}
+
+		migrationPhase := migration.Status.Phase
+		switch migrationPhase {
+		case v1.MigrationFailed, v1.MigrationSucceeded:
+			return false, fmt.Errorf("migration is final with phase: %s instead of %s", migrationPhase, v1.MigrationRunning)
+		case v1.MigrationRunning:
+			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("failed to get VMI %s/%s: %v", vmi.Namespace, vmi.Name, err)
+			}
+
+			if vmi.Status.MigrationState != nil && !vmi.Status.MigrationState.Completed {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
 }

--- a/tests/migration_test.go
+++ b/tests/migration_test.go
@@ -77,8 +77,8 @@ import (
 const (
 	fedoraVMSize         = "256M"
 	secretDiskSerial     = "D23YZ9W6WA5DJ487"
-	stressDefaultVMSize  = "100"
-	stressLargeVMSize    = "400"
+	stressDefaultVMSize  = 100
+	stressLargeVMSize    = 400
 	stressDefaultTimeout = 1600
 )
 

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -1117,6 +1117,21 @@ var _ = Describe("[Serial]SRIOV", func() {
 					"SR-IOV VF is expected to exist in the guest after migration")
 			})
 
+			It("should re-attach sriov devices on source VMI when failed during setup", func() {
+				By("annotate the VMI with functest force migration failure annotation")
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(vmi.Name, &metav1.GetOptions{})
+				vmi.Annotations = map[string]string{v1.FuncTestForceLauncherMigrationFailureAnnotation: ""}
+				vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Update(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				migration := tests.NewRandomMigration(vmi.Name, vmi.Namespace)
+				migrationUID := tests.RunMigrationAndExpectFailure(virtClient, migration, tests.MigrationWaitTime)
+				tests.ConfirmVMIPostMigrationFailed(virtClient, vmi, migrationUID)
+
+				expectInterfaceToExistByMac(virtClient, vmi, mac, reattachSRIOVDeviceTimeout,
+					"SR-IOV VF is expected to exist on source after migration was failing during setup")
+			})
+
 			When("aborted", func() {
 				const migrationRunningTimeout = 180 * time.Second
 				const migrationCompleteTimeout = 180


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When migrating a VM with SRIOV host-devices is aborted due to failure or cancel request,
the VM will end up with no SRIOV devices connected until the next reboot.

The reason for that is the fact that we detach SRIOV host-devices just before migration starts 
due to Libvirt won't allow migrating VM’s with connected VFIO devices (e.g: SRIOV VF).

To overcome this, SRIOV host-devices will be re-attached to the VM on source when a migration fails or is canceled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Now SRIOV host-devices re-connects to VM on source when migration is aborted
```
