### PR TITLE
network, dhcp: Check for empty DHCP Routers and static routes options

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -108,15 +108,20 @@ func prepareDHCPOptions(
 	binary.BigEndian.PutUint16(mtuArray, mtu)
 
 	dhcpOptions := dhcp.Options{
-		dhcp.OptionSubnetMask:       []byte(clientMask),
-		dhcp.OptionRouter:           []byte(routerIP),
 		dhcp.OptionDomainNameServer: bytes.Join(dnsIPs, nil),
 		dhcp.OptionInterfaceMTU:     mtuArray,
 	}
 
+	if len(clientMask) != 0 {
+		dhcpOptions[dhcp.OptionSubnetMask] = clientMask
+	}
+	if len(routerIP) != 0 {
+		dhcpOptions[dhcp.OptionRouter] = routerIP
+	}
+
 	netRoutes := formClasslessRoutes(routes)
 
-	if netRoutes != nil {
+	if len(netRoutes) != 0 {
 		dhcpOptions[dhcp.OptionClasslessRouteFormat] = netRoutes
 	}
 

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp_test.go
@@ -244,5 +244,35 @@ var _ = Describe("DHCP", func() {
 			}))
 			Expect(options[240]).To(Equal([]byte("private.options.kubevirt.io")))
 		})
+
+		Context("Options set to invalid value", func() {
+			var (
+				err           error
+				clientMask    []byte
+				routerIP      net.IP
+				dnsIPs        [][]byte
+				routes        *[]netlink.Route
+				hostname      string
+				searchDomains []string
+				dhcpOptions   *v1.DHCPOptions
+				options       dhcp4.Options
+			)
+			BeforeEach(func() {
+				options, err = prepareDHCPOptions(clientMask, routerIP, dnsIPs, routes, searchDomains, 1500, hostname, dhcpOptions)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("should omit RouterIP Option", func() {
+				_, ok := options[dhcp4.OptionRouter]
+				Expect(ok).To(BeFalse())
+			})
+			It("should omit Classless Static Route Option", func() {
+				_, ok := options[dhcp4.OptionClasslessRouteFormat]
+				Expect(ok).To(BeFalse())
+			})
+			It("should omit Subnet Mask Option", func() {
+				_, ok := options[dhcp4.OptionSubnetMask]
+				Expect(ok).To(BeFalse())
+			})
+		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
Router Option must be at least 4 octect long [0]
Classless Route Option has minimum length 5 bytes [1]

Setting these options with empty zero length values leads to sending
currupted DHCP Offer, which is rejected by Windows DHCP clients.

This commit adds checks for non-zere length of these option values so
that DHCP server doesn't produce invalid data.

[0] https://datatracker.ietf.org/doc/html/rfc2132#section-3.5
[1] https://datatracker.ietf.org/doc/html/rfc3442

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix issue with Windows VMs not being assigned IP address configured in network-attachment-definition IPAM.
```
