### PR TITLE
Introduce KUBEVIRT_E2E_RUN_ALL_SUITES to continue serial tests

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -78,9 +78,7 @@ if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
     fi
     extra_args="-junit-output ${ARTIFACTS}/partial.junit.functest.xml"
     functest ${serial_test_args} ${FUNC_TEST_ARGS}
-    if [ "$return_value" -ne 0 ]; then
-        exit "$return_value"
-    fi
+    exit "$return_value"
 else
     additional_test_args=""
     if [ -n "$KUBEVIRT_E2E_SKIP" ]; then

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -68,9 +68,19 @@ if [ "$KUBEVIRT_E2E_PARALLEL" == "true" ]; then
         serial_test_args="${serial_test_args} --focus=\\[Serial\\]"
     fi
 
+    return_value=0
+    set +e
     functest --nodes=${KUBEVIRT_E2E_PARALLEL_NODES} ${parallel_test_args} ${FUNC_TEST_ARGS}
+    return_value="$?"
+    set -e
+    if [ "$return_value" -ne 0 ] && ! [ "$KUBEVIRT_E2E_RUN_ALL_SUITES" == "true" ]; then
+        exit "$return_value"
+    fi
     extra_args="-junit-output ${ARTIFACTS}/partial.junit.functest.xml"
     functest ${serial_test_args} ${FUNC_TEST_ARGS}
+    if [ "$return_value" -ne 0 ]; then
+        exit "$return_value"
+    fi
 else
     additional_test_args=""
     if [ -n "$KUBEVIRT_E2E_SKIP" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently the e2e tests run in two phases:

1. [the parallel tests run](https://github.com/kubevirt/kubevirt/blob/main/hack/functests.sh#L71)
2. [the serial tests run](https://github.com/kubevirt/kubevirt/blob/main/hack/functests.sh#L73)

Now, whenever the parallel tests have failures, the serial tests are not executed. This is especially more likely when run with QUARANTINE flag set, as those tests are more likely to fail (otherwise they wouldn't be in quarantine).

As an example please compare these two runs of the same job:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-sig-storage/1409743611955777536 (103 tests executed in total)
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-sig-storage/1409502011921010688 (49 tests executed in total)

For periodic test jobs to have comparable results we clearly want to run all the tests **in both suites** in order to see whether i.e. quarantined tests that are part of the serial test suite have improved. This we don't see whenever one or more of the parallel tests fails. As a further result the number of test results greatly varies whenever none of the parallel tests fails, and directly after one of them fails. 

This PR introduces the `KUBEVIRT_E2E_RUN_ALL_SUITES` test flag. If `KUBEVIRT_E2E_RUN_ALL_SUITES` is set to `true` we do not exit, instead we run the other test suite and exit with the return code of the first test suite.

This flag will be used for periodic jobs where we want to run the serial tests even when the parallel tests (likely due to QUARANTINE jobs being run) fail. 

See https://github.com/kubevirt/project-infra/pull/1369

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fgimenez 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
