### PR TITLE
add operator resources to install strategy to allow reconciliation

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -78,9 +78,9 @@ const (
 
 	NAMESPACE = "kubevirt-test"
 
-	resourceCount = 53
-	patchCount    = 34
-	updateCount   = 20
+	resourceCount = 58
+	patchCount    = 35
+	updateCount   = 24
 )
 
 type KubeVirtTestData struct {
@@ -1083,6 +1083,8 @@ func (k *KubeVirtTestData) addAll(config *util.KubeVirtDeploymentConfig, kv *v1.
 	all = append(all, rbac.GetAllApiServer(NAMESPACE)...)
 	all = append(all, rbac.GetAllHandler(NAMESPACE)...)
 	all = append(all, rbac.GetAllController(NAMESPACE)...)
+	all = append(all, rbac.GetAllOperator(NAMESPACE)...)
+
 	// crds
 	functions := []func() (*extv1.CustomResourceDefinition, error){
 		components.NewVirtualMachineInstanceCrd, components.NewPresetCrd, components.NewReplicaSetCrd,
@@ -2053,11 +2055,11 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources))
 
-			Expect(len(kvTestData.controller.stores.ServiceAccountCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.ClusterRoleCache.List())).To(Equal(7))
-			Expect(len(kvTestData.controller.stores.ClusterRoleBindingCache.List())).To(Equal(5))
-			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(3))
-			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.ServiceAccountCache.List())).To(Equal(4))
+			Expect(len(kvTestData.controller.stores.ClusterRoleCache.List())).To(Equal(8))
+			Expect(len(kvTestData.controller.stores.ClusterRoleBindingCache.List())).To(Equal(6))
+			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(4))
+			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(4))
 			Expect(len(kvTestData.controller.stores.CrdCache.List())).To(Equal(8))
 			Expect(len(kvTestData.controller.stores.ServiceCache.List())).To(Equal(3))
 			Expect(len(kvTestData.controller.stores.DeploymentCache.List())).To(Equal(1))
@@ -2574,8 +2576,8 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.controller.Execute()
 
-			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(2))
-			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(2))
+			Expect(len(kvTestData.controller.stores.RoleCache.List())).To(Equal(3))
+			Expect(len(kvTestData.controller.stores.RoleBindingCache.List())).To(Equal(3))
 			Expect(len(kvTestData.controller.stores.ServiceMonitorCache.List())).To(Equal(0))
 		}, 30)
 	})

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -389,6 +389,7 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	rbaclist = append(rbaclist, rbac.GetAllApiServer(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllController(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllHandler(config.GetNamespace())...)
+	rbaclist = append(rbaclist, rbac.GetAllOperator(config.GetNamespace())...)
 
 	if monitorNamespace != "" {
 

--- a/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
@@ -35,5 +35,6 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/pkg/virt-operator/resource/generate/rbac/operator.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	virtv1 "kubevirt.io/client-go/api/v1"
 )
@@ -31,8 +32,8 @@ import (
 const OperatorServiceAccountName = "kubevirt-operator"
 
 // Used for manifest generation only, not by the operator itself
-func GetAllOperator(namespace string) []interface{} {
-	return []interface{}{
+func GetAllOperator(namespace string) []runtime.Object {
+	return []runtime.Object{
 		newOperatorServiceAccount(namespace),
 		NewOperatorRole(namespace),
 		newOperatorRoleBinding(namespace),

--- a/pkg/virt-operator/resource/generate/rbac/operator_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var _ = Describe("RBAC", func() {
@@ -86,7 +87,7 @@ var _ = Describe("RBAC", func() {
 
 })
 
-func getFirstItemOfType(items []interface{}, tp reflect.Type) interface{} {
+func getFirstItemOfType(items []runtime.Object, tp reflect.Type) runtime.Object {
 	for _, item := range items {
 		typeOf := reflect.TypeOf(item)
 		if typeOf == tp {


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add the Operator rbac resources to the install strategy. While they will have already been created at install time adding them to the bundle allows them to be reconciled if they are changed by a user. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Reconcile operator rbac resources
```
