### PR TITLE
Fix flaky heartbeat test: increase device plugin wait timeout

### DIFF
--- a/pkg/virt-handler/heartbeat/heartbeat_test.go
+++ b/pkg/virt-handler/heartbeat/heartbeat_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Heartbeat", func() {
 
 	table.DescribeTable("without deviceplugin and", func(deviceController device_manager.DeviceControllerInterface, initiallySchedulable string, finallySchedulable string) {
 		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode")
-		heartbeat.devicePluginWaitTimeout = 1 * time.Second
+		heartbeat.devicePluginWaitTimeout = 2 * time.Second
 		heartbeat.devicePluginPollIntervall = 10 * time.Millisecond
 		stopChan := make(chan struct{})
 		done := heartbeat.Run(100*time.Second, stopChan)


### PR DESCRIPTION
When the system is under load the initially chosen timeout of 1s may not be enough to hit 100 probes (having 1 probe per each 10ms).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The PR should fix the flaky heartbeat unit-test `Heartbeat without deviceplugin and becoming ready after a few probes, node should be set to unschedulable immediately and switch earlier than one minute`

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5914/pull-kubevirt-unit-test/1407998911380983808

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5753, fixes #5930

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
