### PR TITLE
Minor code cleanups left over from transition to VMI and VM

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -104,7 +104,7 @@ func MigrationKey(migration *v1.VirtualMachineInstanceMigration) string {
 	return fmt.Sprintf("%v/%v", migration.ObjectMeta.Namespace, migration.ObjectMeta.Name)
 }
 
-func VirtualMachineKey(vmi *v1.VirtualMachineInstance) string {
+func VirtualMachineInstanceKey(vmi *v1.VirtualMachineInstance) string {
 	return fmt.Sprintf("%v/%v", vmi.ObjectMeta.Namespace, vmi.ObjectMeta.Name)
 }
 
@@ -116,10 +116,10 @@ func DataVolumeKey(dataVolume *cdiv1.DataVolume) string {
 	return fmt.Sprintf("%v/%v", dataVolume.Namespace, dataVolume.Name)
 }
 
-func VirtualMachineKeys(vmis []*v1.VirtualMachineInstance) []string {
+func VirtualMachineInstanceKeys(vmis []*v1.VirtualMachineInstance) []string {
 	keys := []string{}
 	for _, vmi := range vmis {
-		keys = append(keys, VirtualMachineKey(vmi))
+		keys = append(keys, VirtualMachineInstanceKey(vmi))
 	}
 	return keys
 }

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -264,7 +264,7 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 		// We have to delete VMIs, use a very simple selection strategy for now
 		// TODO: Possible deletion order: not yet running VMIs < migrating VMIs < other
 		deleteCandidates := vmis[0:diff]
-		c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineKeys(deleteCandidates))
+		c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineInstanceKeys(deleteCandidates))
 		for i := 0; i < diff; i++ {
 			go func(idx int) {
 				defer wg.Done()
@@ -273,7 +273,7 @@ func (c *VMIReplicaSet) scale(rs *virtv1.VirtualMachineInstanceReplicaSet, vmis 
 				// Don't log an error if it is already deleted
 				if err != nil {
 					// We can't observe a delete if it was not accepted by the server
-					c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(deleteCandidate))
+					c.expectations.DeletionObserved(rsKey, controller.VirtualMachineInstanceKey(deleteCandidate))
 					c.recorder.Eventf(rs, k8score.EventTypeWarning, FailedDeleteVirtualMachineReason, "Error deleting virtual machine instance %s: %v", deleteCandidate.ObjectMeta.Name, err)
 					errChan <- err
 					return
@@ -553,7 +553,7 @@ func (c *VMIReplicaSet) deleteVirtualMachine(obj interface{}) {
 	if err != nil {
 		return
 	}
-	c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(vmi))
+	c.expectations.DeletionObserved(rsKey, controller.VirtualMachineInstanceKey(vmi))
 	c.enqueueReplicaSet(rs)
 }
 
@@ -796,7 +796,7 @@ func (c *VMIReplicaSet) cleanFinishedVmis(rs *virtv1.VirtualMachineInstanceRepli
 
 	log.Log.V(4).Object(rs).Info("Delete finished VM's")
 	deleteCandidates := vmis[0:diff]
-	c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineKeys(deleteCandidates))
+	c.expectations.ExpectDeletions(rsKey, controller.VirtualMachineInstanceKeys(deleteCandidates))
 	for i := 0; i < diff; i++ {
 		go func(idx int) {
 			defer wg.Done()
@@ -805,7 +805,7 @@ func (c *VMIReplicaSet) cleanFinishedVmis(rs *virtv1.VirtualMachineInstanceRepli
 			// Don't log an error if it is already deleted
 			if err != nil {
 				// We can't observe a delete if it was not accepted by the server
-				c.expectations.DeletionObserved(rsKey, controller.VirtualMachineKey(deleteCandidate))
+				c.expectations.DeletionObserved(rsKey, controller.VirtualMachineInstanceKey(deleteCandidate))
 				c.recorder.Eventf(rs, k8score.EventTypeWarning, FailedDeleteVirtualMachineReason, "Error deleting finished virtual machine %s: %v", deleteCandidate.ObjectMeta.Name, err)
 				errChan <- err
 				return

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -762,13 +762,13 @@ func (c *VMController) stopVMI(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMac
 	}
 
 	// stop it
-	c.expectations.ExpectDeletions(vmKey, []string{controller.VirtualMachineKey(vmi)})
+	c.expectations.ExpectDeletions(vmKey, []string{controller.VirtualMachineInstanceKey(vmi)})
 	err = c.clientset.VirtualMachineInstance(vm.ObjectMeta.Namespace).Delete(vmi.ObjectMeta.Name, &v1.DeleteOptions{})
 
 	// Don't log an error if it is already deleted
 	if err != nil {
 		// We can't observe a delete if it was not accepted by the server
-		c.expectations.DeletionObserved(vmKey, controller.VirtualMachineKey(vmi))
+		c.expectations.DeletionObserved(vmKey, controller.VirtualMachineInstanceKey(vmi))
 		c.recorder.Eventf(vm, k8score.EventTypeWarning, FailedDeleteVirtualMachineReason, "Error deleting virtual machine instance %s: %v", vmi.ObjectMeta.Name, err)
 		return err
 	}
@@ -1055,7 +1055,7 @@ func (c *VMController) deleteVirtualMachine(obj interface{}) {
 	if err != nil {
 		return
 	}
-	c.expectations.DeletionObserved(vmKey, controller.VirtualMachineKey(vmi))
+	c.expectations.DeletionObserved(vmKey, controller.VirtualMachineInstanceKey(vmi))
 	c.enqueueVm(vm)
 }
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -140,9 +140,9 @@ func NewVMIController(templateService services.TemplateService,
 	}
 
 	c.vmiInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.addVirtualMachine,
-		DeleteFunc: c.deleteVirtualMachine,
-		UpdateFunc: c.updateVirtualMachine,
+		AddFunc:    c.addVirtualMachineInstance,
+		DeleteFunc: c.deleteVirtualMachineInstance,
+		UpdateFunc: c.updateVirtualMachineInstance,
 	})
 
 	c.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -1033,15 +1033,15 @@ func (c *VMIController) deletePod(obj interface{}) {
 	c.enqueueVirtualMachine(vmi)
 }
 
-func (c *VMIController) addVirtualMachine(obj interface{}) {
+func (c *VMIController) addVirtualMachineInstance(obj interface{}) {
 	c.enqueueVirtualMachine(obj)
 }
 
-func (c *VMIController) deleteVirtualMachine(obj interface{}) {
+func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
 	c.enqueueVirtualMachine(obj)
 }
 
-func (c *VMIController) updateVirtualMachine(_, curr interface{}) {
+func (c *VMIController) updateVirtualMachineInstance(_, curr interface{}) {
 	c.enqueueVirtualMachine(curr)
 }
 

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -771,7 +771,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 			return &syncErrorImpl{fmt.Errorf(failedToRenderLaunchManifestErrFormat, err), FailedCreatePodReason}
 		}
 
-		vmiKey := controller.VirtualMachineKey(vmi)
+		vmiKey := controller.VirtualMachineInstanceKey(vmi)
 		c.podExpectations.ExpectCreations(vmiKey, 1)
 		pod, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.Background(), templatePod, v1.CreateOptions{})
 		if err != nil {
@@ -1176,7 +1176,7 @@ func (c *VMIController) deleteAllMatchingPods(vmi *virtv1.VirtualMachineInstance
 		return err
 	}
 
-	vmiKey := controller.VirtualMachineKey(vmi)
+	vmiKey := controller.VirtualMachineInstanceKey(vmi)
 
 	for _, pod := range pods {
 		if pod.DeletionTimestamp != nil {
@@ -1293,7 +1293,7 @@ func (c *VMIController) deleteRunningOrFinishedWFFCPods(vmi *virtv1.VirtualMachi
 func (c *VMIController) deleteRunningFinishedOrFailedPod(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) error {
 	zero := int64(0)
 	if pod.Status.Phase == k8sv1.PodRunning || pod.Status.Phase == k8sv1.PodSucceeded || pod.Status.Phase == k8sv1.PodFailed {
-		vmiKey := controller.VirtualMachineKey(vmi)
+		vmiKey := controller.VirtualMachineInstanceKey(vmi)
 		c.podExpectations.ExpectDeletions(vmiKey, []string{controller.PodKey(pod)})
 		err := c.clientset.CoreV1().Pods(pod.GetNamespace()).Delete(context.Background(), pod.Name, v1.DeleteOptions{
 			GracePeriodSeconds: &zero,
@@ -1414,7 +1414,7 @@ func (c *VMIController) createAttachmentPod(vmi *virtv1.VirtualMachineInstance, 
 	if attachmentPodTemplate == nil {
 		return nil
 	}
-	vmiKey := controller.VirtualMachineKey(vmi)
+	vmiKey := controller.VirtualMachineInstanceKey(vmi)
 	c.podExpectations.ExpectCreations(vmiKey, 1)
 
 	pod, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.Background(), attachmentPodTemplate, v1.CreateOptions{})
@@ -1433,7 +1433,7 @@ func (c *VMIController) triggerHotplugPopulation(volume *virtv1.Volume, vmi *vir
 		return &syncErrorImpl{fmt.Errorf("Error creating trigger pod template %v", err), FailedCreatePodReason}
 	}
 	if populateHotplugPodTemplate != nil { // nil means the PVC is not populated yet.
-		vmiKey := controller.VirtualMachineKey(vmi)
+		vmiKey := controller.VirtualMachineInstanceKey(vmi)
 		c.podExpectations.ExpectCreations(vmiKey, 1)
 
 		_, err := c.clientset.CoreV1().Pods(vmi.GetNamespace()).Create(context.Background(), populateHotplugPodTemplate, v1.CreateOptions{})
@@ -1525,7 +1525,7 @@ func (c *VMIController) getDeletedHotplugVolumes(hotplugPods []*k8sv1.Pod, hotpl
 }
 
 func (c *VMIController) deleteAttachmentPodForVolume(vmi *virtv1.VirtualMachineInstance, attachmentPod *k8sv1.Pod) error {
-	vmiKey := controller.VirtualMachineKey(vmi)
+	vmiKey := controller.VirtualMachineInstanceKey(vmi)
 	zero := int64(0)
 
 	if attachmentPod.DeletionTimestamp != nil {


### PR DESCRIPTION
A long time ago VMIs were called VMs, and the concept of a persistent and ephemeral virtual machine didn't exist. When we introduced the VMI object, a lot of code had to be split to account for what was essentially the rename of the existing VM object to a VMI. Some references never got updated, which I've found confusing.

This addresses those instances where we are not clearly separating a VM and VMI through our naming conventions. 

```release-note
NONE
```
