### PR TITLE
Prevent phase1 networking setup to run twice without using libvirt domain interface cache file

### DIFF
--- a/pkg/network/cache/types.go
+++ b/pkg/network/cache/types.go
@@ -9,10 +9,19 @@ import (
 	v1 "kubevirt.io/client-go/api/v1"
 )
 
+type PodIfaceState int
+
+const (
+	PodIfaceNetworkPreparationPending PodIfaceState = iota
+	PodIfaceNetworkPreparationStarted
+	PodIfaceNetworkPreparationFinished
+)
+
 type PodCacheInterface struct {
 	Iface  *v1.Interface `json:"iface,omitempty"`
 	PodIP  string        `json:"podIP,omitempty"`
 	PodIPs []string      `json:"podIPs,omitempty"`
+	State  PodIfaceState `json:"networkState,omitempty"`
 }
 
 type DHCPConfig struct {

--- a/pkg/network/infraconfigurators/bridge.go
+++ b/pkg/network/infraconfigurators/bridge.go
@@ -156,8 +156,8 @@ func (b *BridgePodNetworkConfigurator) PreparePodNetworkInterface() error {
 	return nil
 }
 
-func (b *BridgePodNetworkConfigurator) GenerateDomainIfaceSpec() api.Interface {
-	return api.Interface{
+func (b *BridgePodNetworkConfigurator) GenerateNonRecoverableDomainIfaceSpec() *api.Interface {
+	return &api.Interface{
 		MAC: &api.MAC{MAC: b.vmMac.String()},
 	}
 }

--- a/pkg/network/infraconfigurators/common.go
+++ b/pkg/network/infraconfigurators/common.go
@@ -35,7 +35,7 @@ import (
 type PodNetworkInfraConfigurator interface {
 	DiscoverPodNetworkInterface(podIfaceName string) error
 	PreparePodNetworkInterface() error
-	GenerateDomainIfaceSpec() api.Interface
+	GenerateNonRecoverableDomainIfaceSpec() *api.Interface
 	// The method should return dhcp configuration that cannot be calculated in virt-launcher's phase2
 	GenerateNonRecoverableDHCPConfig() *cache.DHCPConfig
 }

--- a/pkg/network/infraconfigurators/generated_mock_common.go
+++ b/pkg/network/infraconfigurators/generated_mock_common.go
@@ -51,14 +51,14 @@ func (_mr *_MockPodNetworkInfraConfiguratorRecorder) PreparePodNetworkInterface(
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PreparePodNetworkInterface")
 }
 
-func (_m *MockPodNetworkInfraConfigurator) GenerateDomainIfaceSpec() api.Interface {
-	ret := _m.ctrl.Call(_m, "GenerateDomainIfaceSpec")
-	ret0, _ := ret[0].(api.Interface)
+func (_m *MockPodNetworkInfraConfigurator) GenerateNonRecoverableDomainIfaceSpec() *api.Interface {
+	ret := _m.ctrl.Call(_m, "GenerateNonRecoverableDomainIfaceSpec")
+	ret0, _ := ret[0].(*api.Interface)
 	return ret0
 }
 
-func (_mr *_MockPodNetworkInfraConfiguratorRecorder) GenerateDomainIfaceSpec() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateDomainIfaceSpec")
+func (_mr *_MockPodNetworkInfraConfiguratorRecorder) GenerateNonRecoverableDomainIfaceSpec() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GenerateNonRecoverableDomainIfaceSpec")
 }
 
 func (_m *MockPodNetworkInfraConfigurator) GenerateNonRecoverableDHCPConfig() *cache.DHCPConfig {

--- a/pkg/network/infraconfigurators/masquerade.go
+++ b/pkg/network/infraconfigurators/masquerade.go
@@ -146,9 +146,8 @@ func (b *MasqueradePodNetworkConfigurator) PreparePodNetworkInterface() error {
 	return nil
 }
 
-func (b *MasqueradePodNetworkConfigurator) GenerateDomainIfaceSpec() api.Interface {
-	// The method is left here since currently the DomainIfaceSpec cache is used as a marker that phase1 was completed
-	return api.Interface{}
+func (b *MasqueradePodNetworkConfigurator) GenerateNonRecoverableDomainIfaceSpec() *api.Interface {
+	return nil
 }
 
 func (b *MasqueradePodNetworkConfigurator) createBridge() error {

--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],

--- a/pkg/virt-launcher/virtwrap/network/podnic.go
+++ b/pkg/virt-launcher/virtwrap/network/podnic.go
@@ -34,6 +34,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const defaultState = cache.PodIfaceNetworkPreparationPending
+
 type podNIC struct {
 	vmi               *v1.VirtualMachineInstance
 	podInterfaceName  string
@@ -168,13 +170,15 @@ func (l *podNIC) PlugPhase1() error {
 		return nil
 	}
 
-	cachedDomainIface, err := l.cachedDomainInterface()
+	state, err := l.state()
 	if err != nil {
 		return err
 	}
 
-	doesExist := cachedDomainIface != nil
-	if doesExist {
+	switch state {
+	case cache.PodIfaceNetworkPreparationStarted:
+		return errors.CreateCriticalNetworkError(fmt.Errorf("pod interface %s network preparation cannot be resumed", l.podInterfaceName))
+	case cache.PodIfaceNetworkPreparationFinished:
 		return nil
 	}
 
@@ -194,12 +198,22 @@ func (l *podNIC) PlugPhase1() error {
 	if dhcpConfig != nil {
 		log.Log.V(4).Infof("The generated dhcpConfig: %s", dhcpConfig.String())
 		if err := l.cacheFactory.CacheDHCPConfigForPid(getPIDString(l.launcherPID)).Write(l.podInterfaceName, dhcpConfig); err != nil {
-			log.Log.Reason(err).Error("failed to save dhcpConfig configuration")
-			return errors.CreateCriticalNetworkError(err)
+			return fmt.Errorf("failed to save DHCP configuration: %w", err)
 		}
 	}
 
-	domainIface := l.infraConfigurator.GenerateDomainIfaceSpec()
+	domainIface := l.infraConfigurator.GenerateNonRecoverableDomainIfaceSpec()
+	if domainIface != nil {
+		log.Log.V(4).Infof("The generated libvirt domain interface: %+v", *domainIface)
+		if err := l.storeCachedDomainIface(*domainIface); err != nil {
+			return fmt.Errorf("failed to save libvirt domain interface: %w", err)
+		}
+	}
+
+	if err := l.setState(cache.PodIfaceNetworkPreparationStarted); err != nil {
+		return fmt.Errorf("failed setting state to PodIfaceNetworkPreparationStarted: %w", err)
+	}
+
 	// preparePodNetworkInterface must be called *after* the generate
 	// methods since it mutates the pod interface from which those
 	// generator methods get their info from.
@@ -208,11 +222,8 @@ func (l *podNIC) PlugPhase1() error {
 		return errors.CreateCriticalNetworkError(err)
 	}
 
-	// caching the domain interface *must* be the last thing done in phase
-	// 1, since retrieving it is the criteria to configure the pod
-	// networking infrastructure.
-	if err := l.storeCachedDomainIface(domainIface); err != nil {
-		log.Log.Reason(err).Error("failed to save interface configuration")
+	if err := l.setState(cache.PodIfaceNetworkPreparationFinished); err != nil {
+		log.Log.Reason(err).Error("failed setting state to PodIfaceNetworkPreparationFinished")
 		return errors.CreateCriticalNetworkError(err)
 	}
 
@@ -308,6 +319,38 @@ func (l *podNIC) cachedDomainInterface() (*api.Interface, error) {
 
 func (l *podNIC) storeCachedDomainIface(domainIface api.Interface) error {
 	return l.cacheFactory.CacheDomainInterfaceForPID(getPIDString(l.launcherPID)).Write(l.vmiSpecIface.Name, &domainIface)
+}
+
+func (l *podNIC) setState(state cache.PodIfaceState) error {
+	podIfaceCaches := l.cacheFactory.CacheForVMI(l.vmi)
+	podIfaceCache, err := podIfaceCaches.Read(l.vmiSpecIface.Name)
+	if err != nil && !os.IsNotExist(err) {
+		log.Log.Reason(err).Errorf("failed to read pod interface network state from cache, %s", err.Error())
+		return err
+	}
+	if os.IsNotExist(err) {
+		podIfaceCache = &cache.PodCacheInterface{}
+	}
+	podIfaceCache.State = state
+	err = podIfaceCaches.Write(l.vmiSpecIface.Name, podIfaceCache)
+	if err != nil {
+		log.Log.Reason(err).Errorf("failed to write pod interface network state to cache, %s", err.Error())
+		return err
+	}
+	return nil
+}
+
+func (l *podNIC) state() (cache.PodIfaceState, error) {
+	podIfaceCaches := l.cacheFactory.CacheForVMI(l.vmi)
+	podIfaceCache, err := podIfaceCaches.Read(l.vmiSpecIface.Name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return defaultState, nil
+		}
+		log.Log.Reason(err).Errorf("failed to read pod interface network state from cache %s", err.Error())
+		return defaultState, err
+	}
+	return podIfaceCache.State, nil
 }
 
 func generateInPodBridgeInterfaceName(podInterfaceName string) string {

--- a/pkg/virt-launcher/virtwrap/network/podnic_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podnic_test.go
@@ -3,15 +3,14 @@ package network
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"runtime"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
-	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/kubevirt/pkg/network/cache"
@@ -23,6 +22,10 @@ import (
 )
 
 var _ = Describe("podNIC", func() {
+	const (
+		masqueradeCidr     = "10.0.2.0/30"
+		masqueradeIpv6Cidr = "fd10:0:2::0/120"
+	)
 	var (
 		mockNetwork                *netdriver.MockNetworkHandler
 		cacheFactory               cache.InterfaceCacheFactory
@@ -70,15 +73,17 @@ var _ = Describe("podNIC", func() {
 			vmi    *v1.VirtualMachineInstance
 		)
 		BeforeEach(func() {
-			address1 := &net.IPNet{IP: net.IPv4(1, 2, 3, 4)}
-			address2 := &net.IPNet{IP: net.IPv4(169, 254, 0, 0)}
-			fakeAddr1 := netlink.Addr{IPNet: address1}
-			fakeAddr2 := netlink.Addr{IPNet: address2}
-			mockNetwork.EXPECT().ReadIPAddressesFromLink(primaryPodInterfaceName).Return(fakeAddr1.IP.String(), fakeAddr2.IP.String(), nil)
-			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil).Times(1)
-			mockPodNetworkConfigurator.EXPECT().DiscoverPodNetworkInterface(primaryPodInterfaceName).Times(1)
-			mockPodNetworkConfigurator.EXPECT().GenerateNonRecoverableDHCPConfig().Return(&cache.DHCPConfig{}).Times(1)
-			mockPodNetworkConfigurator.EXPECT().GenerateDomainIfaceSpec().Times(1)
+			mockNetwork.EXPECT().ReadIPAddressesFromLink(primaryPodInterfaceName).Return("1.2.3.4", "169.254.0.0", nil)
+			mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil)
+		})
+
+		BeforeEach(func() {
+			mockPodNetworkConfigurator.EXPECT().DiscoverPodNetworkInterface(primaryPodInterfaceName)
+			mockPodNetworkConfigurator.EXPECT().GenerateNonRecoverableDHCPConfig().Return(&cache.DHCPConfig{})
+			mockPodNetworkConfigurator.EXPECT().GenerateNonRecoverableDomainIfaceSpec()
+		})
+
+		BeforeEach(func() {
 			domain := NewDomainWithBridgeInterface()
 			vmi = newVMIBridgeInterface("testnamespace", "testVmName")
 
@@ -91,7 +96,7 @@ var _ = Describe("podNIC", func() {
 		})
 		Context("and networking preparation fails", func() {
 			BeforeEach(func() {
-				mockPodNetworkConfigurator.EXPECT().PreparePodNetworkInterface().Return(fmt.Errorf("podnic_test: forcing prepare networking failure")).Times(1)
+				mockPodNetworkConfigurator.EXPECT().PreparePodNetworkInterface().Return(fmt.Errorf("podnic_test: forcing prepare networking failure"))
 			})
 			It("should return a CriticalNetworkError at phase1", func() {
 				err := podnic.PlugPhase1()
@@ -103,7 +108,7 @@ var _ = Describe("podNIC", func() {
 		})
 		Context("and networking preparation success", func() {
 			BeforeEach(func() {
-				mockPodNetworkConfigurator.EXPECT().PreparePodNetworkInterface().Times(1)
+				mockPodNetworkConfigurator.EXPECT().PreparePodNetworkInterface()
 			})
 			It("should return no error at phase1 and store pod interface", func() {
 				Expect(podnic.PlugPhase1()).To(Succeed())
@@ -195,6 +200,110 @@ var _ = Describe("podNIC", func() {
 			})
 			It("should not crash", func() {
 				Expect(podnic.PlugPhase2(&api.Domain{})).To(Succeed())
+			})
+		})
+	})
+
+	Context("state retrieval function", func() {
+		var (
+			podnic *podNIC
+		)
+		BeforeEach(func() {
+			vmi := newVMIMasqueradeInterface("testnamespace", "testVmName", masqueradeCidr, masqueradeIpv6Cidr)
+			var err error
+			podnic, err = newPhase1PodNICWithMocks(vmi)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		When("there is no pod interface cache stored", func() {
+			It("should should return PodIfaceNetworkPreparationPending", func() {
+				Expect(podnic.state()).To(Equal(cache.PodIfaceNetworkPreparationPending))
+			})
+		})
+		DescribeTable("when the pod interface cache is stored", func(storedState cache.PodIfaceState) {
+			Expect(podnic.setState(storedState)).To(Succeed())
+			Expect(podnic.state()).To(Equal(storedState))
+		},
+			Entry("when PodIfaceNetworkPreparationStarted is stored should return it", cache.PodIfaceNetworkPreparationStarted),
+			Entry("when PodIfaceNetworkPreparationPending is stored should return it", cache.PodIfaceNetworkPreparationPending),
+			Entry("when PodIfaceNetworkPreparationFinished is stored should return it", cache.PodIfaceNetworkPreparationFinished),
+		)
+	})
+	Context("state transition", func() {
+		When("state is PodIfaceNetworkPreparationPending", func() {
+			var (
+				podnic *podNIC
+			)
+			BeforeEach(func() {
+				var err error
+				vmi := newVMIBridgeInterface("testnamespace", "testVmName")
+				podnic, err = newPhase1PodNICWithMocks(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				pid := 1
+				podnic.launcherPID = &pid
+				podnic.setState(cache.PodIfaceNetworkPreparationPending)
+			})
+
+			BeforeEach(func() {
+				mockNetwork.EXPECT().ReadIPAddressesFromLink(primaryPodInterfaceName).Return("1.2.3.4", "169.254.0.0", nil)
+				mockNetwork.EXPECT().IsIpv4Primary().Return(true, nil)
+			})
+
+			BeforeEach(func() {
+				mockPodNetworkConfigurator.EXPECT().DiscoverPodNetworkInterface(podnic.podInterfaceName)
+				mockPodNetworkConfigurator.EXPECT().GenerateNonRecoverableDomainIfaceSpec().Return(&api.Interface{})
+				mockPodNetworkConfigurator.EXPECT().GenerateNonRecoverableDHCPConfig().Return(&cache.DHCPConfig{})
+			})
+			Context("and prepare networking is fine at phase1 calling", func() {
+				BeforeEach(func() {
+					mockPodNetworkConfigurator.EXPECT().PreparePodNetworkInterface()
+					Expect(podnic.PlugPhase1()).To(Succeed())
+				})
+				It("should transition to PodIfaceNetworkPreparationFinished state", func() {
+					Expect(podnic.state()).To(Equal(cache.PodIfaceNetworkPreparationFinished))
+				})
+			})
+			Context("and prepare networking fails at phase1 calling", func() {
+				BeforeEach(func() {
+					mockPodNetworkConfigurator.EXPECT().PreparePodNetworkInterface().Return(fmt.Errorf("podnic_test: forced PreparePodNetworkInterface failure"))
+					Expect(podnic.PlugPhase1()).ToNot(Succeed())
+				})
+				It("should set state to PodIfaceNetworkPreparationStarted", func() {
+					Expect(podnic.state()).To(Equal(cache.PodIfaceNetworkPreparationStarted))
+				})
+			})
+		})
+		When("state is PodIfaceNetworkPreparationStarted", func() {
+			var podnic *podNIC
+			BeforeEach(func() {
+				var err error
+				vmi := newVMIMasqueradeInterface("testnamespace", "testVmName", masqueradeCidr, masqueradeIpv6Cidr)
+				podnic, err = newPhase1PodNICWithMocks(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				podnic.setState(cache.PodIfaceNetworkPreparationStarted)
+			})
+			Context("and phase1 is called", func() {
+				It("should fail with CriticalNetworkError", func() {
+					err := podnic.PlugPhase1()
+					Expect(err).To(HaveOccurred(), "SetupPhase1 should return an error")
+
+					_, ok := err.(*neterrors.CriticalNetworkError)
+					Expect(ok).To(BeTrue(), "SetupPhase1 should return an error of type CriticalNetworkError")
+				})
+			})
+		})
+		When("state is PodIfaceNetworkPreparationFinished", func() {
+			var podnic *podNIC
+			BeforeEach(func() {
+				var err error
+				vmi := newVMIMasqueradeInterface("testnamespace", "testVmName", masqueradeCidr, masqueradeIpv6Cidr)
+				podnic, err = newPhase1PodNICWithMocks(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				podnic.setState(cache.PodIfaceNetworkPreparationFinished)
+			})
+			Context("and phase1 is called", func() {
+				It("should successfully return without calling infra configurator", func() {
+					Expect(podnic.PlugPhase1()).To(Succeed())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currently there are scenarios where the virt-launcher pod networking setup step can be executed multiple times, this is prevented by checking if the libvirt domain interface cache file is already stored since this happends after the networking setup step, this create a dependency between checking if the networking setup step has being executed and if the libvirt domain interfaces has being generated. To break this dependency the fact that the networking setup step has being done is reprenseted as a "state" field at pod interface yaml with the following values:

- **PodIfaceNetworkPreparationPending**: the virt-launcher networking setup has not being executed yet
- **PodIfaceNetworkPreparationFinished**: the virt-launcher networking setup has being successfully executed.
- **PodIfaceNetworkPreparationStarted**: the virt-launcher networking setup was interrupted before finished so networking state is unknown.

In case of executing the networking setup but the state is PodIfaceNetworkPreparationStarted a error is returned since this step cannot be resumed, in case the state is PodIfaceNetworkPreparationPending all the phase1 can be executed again (dhcp config, pod IPs and libvirt domain interface can be executed again), if state is PodIfaceNetworkPreparationFinished nothing is done.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
