### PR TITLE
Prevent unset of manifest_docker_prefix

### DIFF
--- a/hack/parse-shasums.sh
+++ b/hack/parse-shasums.sh
@@ -20,7 +20,6 @@
 set -e
 
 source hack/common.sh
-source hack/config.sh
 
 if [[ ! -f "${DIGESTS_DIR}/bazel-bin/push-virt-operator.digest" ]]; then
     echo "digest files not found: won't use shasums, falling back to tags"


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Now `hack/build-manifests.sh` is generating manifests without docker prefix in the deployment spec image property. These changes fix it by preventing the `manifest_docker_prefix` environment variable to be overridden by a sourcing `hack/config.sh` twice during the script execution.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5950

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
/cc @rmohr @ormergi @oshoval 