### PR TITLE
Fix membership guidelines link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,9 @@ and will be assigned by Prow.
 ### Becoming a member
 
 Contributors that frequently contribute to the project may ask to join the
-kubevirt organization.
+KubeVirt organization.
 
-Please have a look at our [membership guidelines](https://github.com/kubevirt/community/tree/master/member_dd).
+Please have a look at our [membership guidelines](https://github.com/kubevirt/community/blob/master/membership_policy.md).
 
 ## Projects & Communities
 


### PR DESCRIPTION
Signed-off-by: Ben Oukhanov <boukhano@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently, membership guidelines pointing to the outdated readme. We need to update it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
