### PR TITLE
Use new way to specify race detection in rules_go

### DIFF
--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -11,5 +11,5 @@ fi
 
 bazel coverage \
     --config=${ARCHITECTURE} \
-    --features race \
-    --test_output=errors -- //staging/src/kubevirt.io/client-go/... //pkg/... //cmd/...
+    --@io_bazel_rules_go//go/config:race \
+    --test_output=errors -- //staging/src/kubevirt.io/client-go/... //pkg/... //cmd/... -//cmd/virtctl/...


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove deprecated `--feature=race` and use the new
`--@io_bazel_rules_go//go/config:race` option.

Compiling with race detection does not work for pure go applications
like virtctl. Since we don't run any tests on the actual `virtctl`
binary, we can simply ignore the `virtctl` targets.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5868

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
