### PR TITLE
Use precompiled protoc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,22 @@ http_archive(
 )
 
 # Additional bazel rules
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "bc12122a5ae4b517fa423ea03a8d82ea6352d5127ea48cb54bc324e8ab78493c",
+    strip_prefix = "rules_proto-af6481970a34554c6942d993e194a9aed7987780",
+    urls = [
+        "https://github.com/bazelbuild/rules_proto/archive/af6481970a34554c6942d993e194a9aed7987780.tar.gz",
+    ],
+)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 http_archive(
     name = "io_bazel_rules_go",
@@ -44,17 +60,6 @@ http_archive(
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
         "https://storage.googleapis.com/builddeps/62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
-    ],
-)
-
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "cd218dc003eacc167e51e3ce856f6c2e607857225ef86b938d95650fcbb2f8e4",
-    strip_prefix = "protobuf-6d4e7fd7966c989e38024a8ea693db83758944f1",
-    # version 3.10.0
-    urls = [
-        "https://github.com/google/protobuf/archive/6d4e7fd7966c989e38024a8ea693db83758944f1.zip",
-        "https://storage.googleapis.com/builddeps/cd218dc003eacc167e51e3ce856f6c2e607857225ef86b938d95650fcbb2f8e4",
     ],
 )
 
@@ -193,10 +198,6 @@ go_register_toolchains(
 load("@com_github_ash2k_bazel_tools//goimports:deps.bzl", "goimports_dependencies")
 
 goimports_dependencies()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
 
 load(
     "@bazel_gazelle//:deps.bzl",


### PR DESCRIPTION
**What this PR does / why we need it**:

Pull in protoc the right way, so that we can use a released binary
instead of compiling protoc ourselves on every branch switch.

This saves quite some compile time during local development.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

For more context see https://github.com/bazelbuild/rules_scala/pull/1142 and https://github.com/bazelbuild/rules_proto/pull/36

**Release note**:

```release-note
NONE
```
