### PR TITLE
Fix test binary build targets for cross-compiling

### DIFF
--- a/hack/build-func-tests.sh
+++ b/hack/build-func-tests.sh
@@ -32,7 +32,7 @@ mkdir -p "${CMD_OUT_DIR}/virtctl"
 # we have to explicitly call them as top-level targets, so that they get
 # downloaded.
 bazel build \
-    --config=${ARCHITECTURE} \
+    --config=${HOST_ARCHITECTURE} \
     //cmd/virtctl:virtctl \
     //cmd/dump:dump \
     //tools/manifest-templator:templator \
@@ -41,17 +41,17 @@ bazel build \
     //tools/junit-merger:junit-merger
 
 bazel run \
-    --config=${ARCHITECTURE} \
+    --config=${HOST_ARCHITECTURE} \
     :build-ginkgo -- ${TESTS_OUT_DIR}/ginkgo
 bazel run \
-    --config=${ARCHITECTURE} \
+    --config=${HOST_ARCHITECTURE} \
     :build-functests -- ${TESTS_OUT_DIR}/tests.test
 bazel run \
-    --config=${ARCHITECTURE} \
+    --config=${HOST_ARCHITECTURE} \
     :build-junit-merger -- ${TESTS_OUT_DIR}/junit-merger
 bazel run \
-    --config=${ARCHITECTURE} \
+    --config=${HOST_ARCHITECTURE} \
     :build-dump -- ${CMD_OUT_DIR}/dump/dump
 bazel run \
-    --config=${ARCHITECTURE} \
+    --config=${HOST_ARCHITECTURE} \
     :build-virtctl -- ${CMD_OUT_DIR}/virtctl/virtctl


### PR DESCRIPTION
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Currently the build targets in https://github.com/kubevirt/kubevirt/blob/main/hack/build-func-tests.sh create binaries for `$ARCHITECTURE`, this doesn't work when cross-compiling, we need to use instead `$HOST_ARCHITECTURE`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
