### PR TITLE
Remove note about one pod per disk hotplug

### DIFF
--- a/docs/hotplug.md
+++ b/docs/hotplug.md
@@ -125,7 +125,5 @@ Vda is the container disk that contains the Fedora OS, vdb is the cloudinit disk
 
 The hotplugVolume has some extra information that regular volume statuses do not have. The attachPodName is the name of the pod that was used to attach the volume to the node the VMI is running on. If this pod is deleted it will also stop the VMI as we cannot guarantee the volume will remain attached to the node. The other fields are similar to conditions and indicate the status of the hot plug process. Once a Volume is ready it can be used by the VM.
 
-Note: Currently every volume hotplugged requires an additional pod to be created.
-
 ## Live Migration
 Currently Live Migration is disabled for any VMI that has volumes hotplugged into it. This limitation will be removed in a future release.


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There is a note in the documentation indicating one pod per hotplugged disk. Now that #5649 is merged, this is no longer true, its a single pod for all disks now. This PR removes the note in the documentation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
