### PR TITLE
[release-0.41] virt-launcher: fix UEFI-mode without secureboot

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2493,7 +2493,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 
 	err = client.SyncVirtualMachine(vmi, options)
 	if err != nil {
-		isSecbootError := strings.Contains(err.Error(), "EFI OVMF roms missing")
+		isSecbootError := strings.Contains(err.Error(), "EFI OVMF rom missing")
 		if isSecbootError {
 			return &virtLauncherCriticalSecurebootError{fmt.Sprintf("mismatch of Secure Boot setting and bootloaders: %v", err)}
 		}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1091,41 +1091,25 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 
 		if vmi.Spec.Domain.Firmware.Bootloader != nil && vmi.Spec.Domain.Firmware.Bootloader.EFI != nil {
-			// The location of uefi boot loader on ARM64 is different from that on x86 and ppc64le
-			efiCode := ""
-			efiVars := ""
-			if isARM64(c.Architecture) {
-				efiCode = EFICodeAARCH64
-				efiVars = EFIVarsAARCH64
-			} else {
-				efiCode = EFICode
-				efiVars = EFIVars
+			secureBoot := vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
+			efiCode, _ := detectEFICodeRom(c, secureBoot)
+			efiVars, _ := detectEFIVarsRom(c, secureBoot)
+
+			secureLoader := "yes"
+			if !secureBoot {
+				secureLoader = "no"
 			}
 
-			if vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot {
-				domain.Spec.OS.BootLoader = &api.Loader{
-					Path:     filepath.Join(c.OVMFPath, EFICodeSecureBoot),
-					ReadOnly: "yes",
-					Secure:   "yes",
-					Type:     "pflash",
-				}
+			domain.Spec.OS.BootLoader = &api.Loader{
+				Path:     filepath.Join(c.OVMFPath, efiCode),
+				ReadOnly: "yes",
+				Secure:   secureLoader,
+				Type:     "pflash",
+			}
 
-				domain.Spec.OS.NVRam = &api.NVRam{
-					NVRam:    filepath.Join("/tmp", domain.Spec.Name),
-					Template: filepath.Join(c.OVMFPath, EFIVarsSecureBoot),
-				}
-			} else {
-				domain.Spec.OS.BootLoader = &api.Loader{
-					Path:     filepath.Join(c.OVMFPath, efiCode),
-					ReadOnly: "yes",
-					Secure:   "no",
-					Type:     "pflash",
-				}
-
-				domain.Spec.OS.NVRam = &api.NVRam{
-					NVRam:    filepath.Join("/tmp", domain.Spec.Name),
-					Template: filepath.Join(c.OVMFPath, efiVars),
-				}
+			domain.Spec.OS.NVRam = &api.NVRam{
+				NVRam:    filepath.Join("/tmp", domain.Spec.Name),
+				Template: filepath.Join(c.OVMFPath, efiVars),
 			}
 		}
 
@@ -1661,33 +1645,59 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	return nil
 }
 
+func detectEFICodeRom(c *ConverterContext, secureBoot bool) (string, error) {
+	efiCode := EFICode
+
+	if secureBoot {
+		efiCode = EFICodeSecureBoot
+	} else if isARM64(c.Architecture) {
+		efiCode = EFICodeAARCH64
+	}
+
+	_, err := os.Stat(filepath.Join(c.OVMFPath, efiCode))
+	if os.IsNotExist(err) && efiCode == EFICode {
+		// The combination (EFICodeSecureBoot + EFIVars) is valid
+		// for booting in EFI mode with SecureBoot disabled
+		efiCode = EFICodeSecureBoot
+		_, err = os.Stat(filepath.Join(c.OVMFPath, efiCode))
+	}
+
+	if os.IsNotExist(err) {
+		log.Log.Reason(err).Errorf("'%s' EFI OVMF rom missing for booting in EFI mode with SecureBoot=%v", efiCode, secureBoot)
+		return "", fmt.Errorf("'%s' EFI OVMF rom missing for booting in EFI mode with SecureBoot=%v", efiCode, secureBoot)
+	}
+	return efiCode, nil
+}
+
+func detectEFIVarsRom(c *ConverterContext, secureBoot bool) (string, error) {
+	efiVars := EFIVars
+
+	if secureBoot {
+		efiVars = EFIVarsSecureBoot
+	} else if isARM64(c.Architecture) {
+		efiVars = EFIVarsAARCH64
+	}
+
+	_, err := os.Stat(filepath.Join(c.OVMFPath, efiVars))
+	if os.IsNotExist(err) {
+		log.Log.Reason(err).Errorf("'%s' EFI OVMF rom missing for booting in EFI mode with SecureBoot=%v", efiVars, secureBoot)
+		return "", fmt.Errorf("'%s' EFI OVMF rom missing for booting in EFI mode with SecureBoot=%v", efiVars, secureBoot)
+	}
+	return efiVars, nil
+}
+
 func CheckEFI_OVMFRoms(vmi *v1.VirtualMachineInstance, c *ConverterContext) (err error) {
 	if vmi.Spec.Domain.Firmware != nil {
 		if vmi.Spec.Domain.Firmware.Bootloader != nil && vmi.Spec.Domain.Firmware.Bootloader.EFI != nil {
-			if vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot {
-				_, err1 := os.Stat(filepath.Join(c.OVMFPath, EFICodeSecureBoot))
-				_, err2 := os.Stat(filepath.Join(c.OVMFPath, EFIVarsSecureBoot))
-				if os.IsNotExist(err1) || os.IsNotExist(err2) {
-					log.Log.Reason(err).Error("EFI OVMF roms missing for secure boot")
-					return fmt.Errorf("EFI OVMF roms missing for secure boot")
-				}
-			} else {
-				// the EFICode and EFIVars have different path and name on Arm64
-				efiCode := ""
-				efiVars := ""
-				if isARM64(c.Architecture) {
-					efiCode = EFICodeAARCH64
-					efiVars = EFIVarsAARCH64
-				} else {
-					efiCode = EFICode
-					efiVars = EFIVars
-				}
-				_, err1 := os.Stat(filepath.Join(c.OVMFPath, efiCode))
-				_, err2 := os.Stat(filepath.Join(c.OVMFPath, efiVars))
-				if os.IsNotExist(err1) || os.IsNotExist(err2) {
-					log.Log.Reason(err).Error("EFI OVMF roms missing for insecure boot")
-					return fmt.Errorf("EFI OVMF roms missing for insecure boot")
-				}
+			secureBoot := vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot == nil || *vmi.Spec.Domain.Firmware.Bootloader.EFI.SecureBoot
+			_, errCode := detectEFICodeRom(c, secureBoot)
+			_, errVars := detectEFIVarsRom(c, secureBoot)
+
+			if errCode != nil {
+				return errCode
+			}
+			if errVars != nil {
+				return errVars
 			}
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -22,6 +22,7 @@ package converter
 import (
 	"encoding/xml"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
@@ -2798,6 +2799,18 @@ var _ = Describe("Converter", func() {
 		var vmi *v1.VirtualMachineInstance
 		var c *ConverterContext
 
+		createEFIRoms := func(createNoSBCodeROM bool) {
+			roms := []string{"OVMF_CODE.secboot.fd", "OVMF_VARS.fd", "OVMF_VARS.secboot.fd"}
+			if createNoSBCodeROM {
+				roms = append(roms, "OVMF_CODE.fd")
+			}
+
+			for i := range roms {
+				_, err := os.Create(path.Join(c.OVMFPath, roms[i]))
+				Expect(err).To(BeNil())
+			}
+		}
+
 		BeforeEach(func() {
 			vmi = &v1.VirtualMachineInstance{
 				ObjectMeta: k8smeta.ObjectMeta{
@@ -2808,10 +2821,18 @@ var _ = Describe("Converter", func() {
 
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 
+			ovmfPath, err := ioutil.TempDir("", "kubevirt-ovmf")
+			Expect(err).To(BeNil())
+
 			c = &ConverterContext{
 				VirtualMachine: vmi,
 				UseEmulation:   true,
+				OVMFPath:       ovmfPath,
 			}
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(c.OVMFPath)
 		})
 
 		Context("when bootloader is not set", func() {
@@ -2844,38 +2865,36 @@ var _ = Describe("Converter", func() {
 				Expect(domainSpec.OS.NVRam).To(BeNil())
 			})
 
-			It("should configure the EFI bootloader if EFI insecure option", func() {
+			table.DescribeTable("EFI bootloader",
+				func(secureBoot *bool, createNoSBCodeROM bool, efiCode string, efiVars string) {
+					secure := "yes"
+					if secureBoot != nil && !*secureBoot {
+						secure = "no"
+					}
 
-				vmi.Spec.Domain.Firmware = &v1.Firmware{
-					Bootloader: &v1.Bootloader{
-						EFI: &v1.EFI{
-							SecureBoot: False(),
+					createEFIRoms(createNoSBCodeROM)
+
+					vmi.Spec.Domain.Firmware = &v1.Firmware{
+						Bootloader: &v1.Bootloader{
+							EFI: &v1.EFI{
+								SecureBoot: secureBoot,
+							},
 						},
-					},
-				}
-				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
-				Expect(domainSpec.OS.BootLoader.ReadOnly).To(Equal("yes"))
-				Expect(domainSpec.OS.BootLoader.Type).To(Equal("pflash"))
-				Expect(domainSpec.OS.BootLoader.Secure).To(Equal("no"))
-				Expect(path.Base(domainSpec.OS.BootLoader.Path)).To(Equal(EFICode))
-				Expect(path.Base(domainSpec.OS.NVRam.Template)).To(Equal(EFIVars))
-				Expect(domainSpec.OS.NVRam.NVRam).To(Equal("/tmp/mynamespace_testvmi"))
-			})
-
-			It("should configure the EFI bootloader if EFI secure option", func() {
-				vmi.Spec.Domain.Firmware = &v1.Firmware{
-					Bootloader: &v1.Bootloader{
-						EFI: &v1.EFI{},
-					},
-				}
-				domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
-				Expect(domainSpec.OS.BootLoader.ReadOnly).To(Equal("yes"))
-				Expect(domainSpec.OS.BootLoader.Type).To(Equal("pflash"))
-				Expect(domainSpec.OS.BootLoader.Secure).To(Equal("yes"))
-				Expect(path.Base(domainSpec.OS.BootLoader.Path)).To(Equal(EFICodeSecureBoot))
-				Expect(path.Base(domainSpec.OS.NVRam.Template)).To(Equal(EFIVarsSecureBoot))
-				Expect(domainSpec.OS.NVRam.NVRam).To(Equal("/tmp/mynamespace_testvmi"))
-			})
+					}
+					domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
+					Expect(domainSpec.OS.BootLoader.ReadOnly).To(Equal("yes"))
+					Expect(domainSpec.OS.BootLoader.Type).To(Equal("pflash"))
+					Expect(domainSpec.OS.BootLoader.Secure).To(Equal(secure))
+					Expect(path.Base(domainSpec.OS.BootLoader.Path)).To(Equal(efiCode))
+					Expect(path.Base(domainSpec.OS.NVRam.Template)).To(Equal(efiVars))
+					Expect(domainSpec.OS.NVRam.NVRam).To(Equal("/tmp/mynamespace_testvmi"))
+				},
+				table.Entry("should use SecureBoot", True(), true, EFICodeSecureBoot, EFIVarsSecureBoot),
+				table.Entry("should use SecureBoot when SB not defined", nil, true, EFICodeSecureBoot, EFIVarsSecureBoot),
+				table.Entry("should use SecureBoot when OVMF_CODE.fd does not exist", True(), false, EFICodeSecureBoot, EFIVarsSecureBoot),
+				table.Entry("should not use SecureBoot", False(), true, EFICode, EFIVars),
+				table.Entry("should not use SecureBoot when OVMF_CODE.fd does not exist", False(), false, EFICodeSecureBoot, EFIVars),
+			)
 		})
 	})
 

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -566,17 +566,17 @@ var _ = Describe("[sig-compute]Configurations", func() {
 				Eventually(logs,
 					30*time.Second,
 					500*time.Millisecond).
-					Should(ContainSubstring("EFI OVMF roms missing"))
+					Should(ContainSubstring("EFI OVMF rom missing"))
 			default:
 				tests.WaitUntilVMIReady(vmi, loginTo)
 				By(msg)
 				domXml, err := tests.GetRunningVirtualMachineInstanceDomainXML(virtClient, vmi)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(domXml).To(ContainSubstring(fileName))
+				Expect(domXml).To(MatchRegexp(fileName))
 			}
 		},
-			table.Entry("[Serial][test_id:1668]should use EFI", tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", "OVMF_CODE.fd"),
-			table.Entry("[Serial][test_id:4437]should enable EFI secure boot", tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", "OVMF_CODE.secboot.fd"),
+			table.Entry("[Serial][test_id:1668]should use EFI without secure boot", tests.NewRandomVMIWithEFIBootloader, console.LoginToAlpine, "Checking if UEFI is enabled", `OVMF_CODE(\.secboot)?\.fd`),
+			table.Entry("[Serial][test_id:4437]should enable EFI secure boot", tests.NewRandomVMIWithSecureBoot, console.SecureBootExpecter, "Checking if SecureBoot is enabled in the libvirt XML", `OVMF_CODE\.secboot\.fd`),
 		)
 
 		Context("[rfe_id:140][crit:medium][vendor:cnv-qe@redhat.com][level:component]with diverging guest memory from requested memory", func() {


### PR DESCRIPTION
This commit fixes UEFI mode with secureboot disabled
for base images (for virt-launcher) where only `OVMF_CODE.secboot.fd`
is shipped, letting the combination `OVMF_CODE.secboot.fd` +
`OVMF_VARS.fd` to be used to correctly boot in EFI mode with
no secureboot.

Previously when disabling secureboot virt-launcher would only try
to use `OVMF_CODE.fd` + `OVMF_VARS.fd` resulting in a VMI failure
when the former firmware file was not shipped.

Signed-off-by: Antonio Cardace <acardace@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
