### PR TITLE
Use sync.Map for podCacheInterface

### DIFF
--- a/pkg/virt-handler/cache/BUILD.bazel
+++ b/pkg/virt-handler/cache/BUILD.bazel
@@ -2,11 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cache.go"],
+    srcs = [
+        "cache.go",
+        "maps.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/cache",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
+        "//pkg/network/cache:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",

--- a/pkg/virt-handler/cache/maps.go
+++ b/pkg/virt-handler/cache/maps.go
@@ -53,6 +53,39 @@ func (p *PodInterfaceByVMIAndName) Size() int {
 	return syncMapLen(&p.syncMap)
 }
 
+type LauncherPIDByVMI struct {
+	syncMap sync.Map
+}
+
+func (l *LauncherPIDByVMI) Load(vmiUID types.UID) (int, bool) {
+	result, exists := l.syncMap.Load(vmiUID)
+
+	if !exists {
+		return 0, false
+	}
+	return l.cast(result), true
+}
+
+func (l *LauncherPIDByVMI) Delete(vmiUID types.UID) {
+	l.syncMap.Delete(vmiUID)
+}
+
+func (l *LauncherPIDByVMI) Store(vmiUID types.UID, launcherPID int) {
+	l.syncMap.Store(vmiUID, launcherPID)
+}
+
+func (l *LauncherPIDByVMI) Size() int {
+	return syncMapLen(&l.syncMap)
+}
+
+func (*LauncherPIDByVMI) cast(result interface{}) int {
+	launcherPid, ok := result.(int)
+	if !ok {
+		panic(fmt.Sprintf("failed casting %+v to int", result))
+	}
+	return launcherPid
+}
+
 func syncMapLen(m *sync.Map) int {
 	mapLen := 0
 	m.Range(func(k, v interface{}) bool {

--- a/pkg/virt-handler/cache/maps.go
+++ b/pkg/virt-handler/cache/maps.go
@@ -96,6 +96,34 @@ type LauncherClientInfo struct {
 	Ready               bool
 }
 
+type LauncherClientInfoByVMI struct {
+	syncMap sync.Map
+}
+
+func (l *LauncherClientInfoByVMI) Delete(vmiUID types.UID) {
+	l.syncMap.Delete(vmiUID)
+}
+
+func (l *LauncherClientInfoByVMI) Store(vmiUID types.UID, launcherClientInfo *LauncherClientInfo) {
+	l.syncMap.Store(vmiUID, launcherClientInfo)
+}
+
+func (l *LauncherClientInfoByVMI) Load(vmiUID types.UID) (*LauncherClientInfo, bool) {
+	result, exists := l.syncMap.Load(vmiUID)
+	if !exists {
+		return nil, exists
+	}
+	return l.cast(result), exists
+}
+
+func (*LauncherClientInfoByVMI) cast(result interface{}) *LauncherClientInfo {
+	launcherClientInfo, ok := result.(*LauncherClientInfo)
+	if !ok {
+		panic(fmt.Sprintf("failed casting %+v to *LauncherClientInfo", result))
+	}
+	return launcherClientInfo
+}
+
 func syncMapLen(m *sync.Map) int {
 	mapLen := 0
 	m.Range(func(k, v interface{}) bool {

--- a/pkg/virt-handler/cache/maps.go
+++ b/pkg/virt-handler/cache/maps.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 
 	netcache "kubevirt.io/kubevirt/pkg/network/cache"
+	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 )
 
 type PodInterfaceByVMIAndName struct {
@@ -84,6 +86,14 @@ func (*LauncherPIDByVMI) cast(result interface{}) int {
 		panic(fmt.Sprintf("failed casting %+v to int", result))
 	}
 	return launcherPid
+}
+
+type LauncherClientInfo struct {
+	Client              cmdclient.LauncherClient
+	SocketFile          string
+	DomainPipeStopChan  chan struct{}
+	NotInitializedSince time.Time
+	Ready               bool
 }
 
 func syncMapLen(m *sync.Map) int {

--- a/pkg/virt-handler/cache/maps.go
+++ b/pkg/virt-handler/cache/maps.go
@@ -1,0 +1,63 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	netcache "kubevirt.io/kubevirt/pkg/network/cache"
+)
+
+type PodInterfaceByVMIAndName struct {
+	syncMap sync.Map
+}
+
+func (p *PodInterfaceByVMIAndName) DeleteAllForVMI(vmiUID types.UID) {
+	// Clean Pod interface cache from map and files
+	p.syncMap.Range(func(key, value interface{}) bool {
+		if strings.Contains(key.(string), string(vmiUID)) {
+			p.syncMap.Delete(key)
+		}
+		return true
+	})
+}
+
+func (p *PodInterfaceByVMIAndName) Load(vmiUID types.UID, interfaceName string) (*netcache.PodCacheInterface, bool) {
+	result, exists := p.syncMap.Load(p.key(vmiUID, interfaceName))
+
+	if !exists {
+		return nil, false
+	}
+	return p.cast(result), true
+}
+
+func (p *PodInterfaceByVMIAndName) Store(vmiUID types.UID, interfaceName string, podCacheInterface *netcache.PodCacheInterface) {
+	p.syncMap.Store(p.key(vmiUID, interfaceName), podCacheInterface)
+}
+
+func (*PodInterfaceByVMIAndName) cast(result interface{}) *netcache.PodCacheInterface {
+	podCacheInterface, ok := result.(*netcache.PodCacheInterface)
+	if !ok {
+		panic(fmt.Sprintf("failed casting %+v to *PodCacheInterface", result))
+	}
+	return podCacheInterface
+}
+
+func (*PodInterfaceByVMIAndName) key(vmiUID types.UID, interfaceName string) string {
+	return fmt.Sprintf("%s/%s", vmiUID, interfaceName)
+}
+
+func (p *PodInterfaceByVMIAndName) Size() int {
+	return syncMapLen(&p.syncMap)
+}
+
+func syncMapLen(m *sync.Map) int {
+	mapLen := 0
+	m.Range(func(k, v interface{}) bool {
+		mapLen += 1
+		return true
+	})
+	return mapLen
+}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2354,7 +2354,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, VMIStarted)
-			Expect(len(controller.podInterfaceCache)).To(Equal(1))
+			podInterfaceCacheLen := 0
+			controller.podInterfaceCache.Range(func(k, v interface{}) bool {
+				podInterfaceCacheLen += 1
+				return true
+			})
+			Expect(podInterfaceCacheLen).To(Equal(1))
 		})
 
 		table.DescribeTable("Should update masquerade interface with the pod IP", func(podIPs ...string) {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -118,15 +118,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 	var certDir string
 
-	syncMapLen := func(m *sync.Map) int {
-		mapLen := 0
-		m.Range(func(k, v interface{}) bool {
-			mapLen += 1
-			return true
-		})
-		return mapLen
-	}
-
 	BeforeEach(func() {
 		wg = &sync.WaitGroup{}
 		stop = make(chan struct{})
@@ -544,7 +535,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 			_, err := os.Stat(mockWatchdog.File(oldVMI))
 			Expect(os.IsNotExist(err)).To(BeTrue())
-			Expect(syncMapLen(&controller.phase1NetworkSetupCache)).To(Equal(0))
+			Expect(controller.phase1NetworkSetupCache.Size()).To(Equal(0))
 		}, 3)
 
 		It("should cleanup if vmi is finalized and domain does not exist", func() {
@@ -563,7 +554,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 			_, err := os.Stat(mockWatchdog.File(vmi))
 			Expect(os.IsNotExist(err)).To(BeTrue())
-			Expect(syncMapLen(&controller.phase1NetworkSetupCache)).To(Equal(0))
+			Expect(controller.phase1NetworkSetupCache.Size()).To(Equal(0))
 		}, 3)
 
 		It("should do final cleanup if vmi is being deleted and not finalized", func() {
@@ -593,7 +584,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
 			_, err := os.Stat(mockWatchdog.File(vmi))
 			Expect(os.IsNotExist(err)).To(BeFalse())
-			Expect(syncMapLen(&controller.phase1NetworkSetupCache)).To(Equal(1))
+			Expect(controller.phase1NetworkSetupCache.Size()).To(Equal(1))
 		}, 3)
 
 		It("should attempt force terminate Domain if grace period expires", func() {
@@ -665,7 +656,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			})
 			controller.Execute()
 			testutils.ExpectEvent(recorder, VMIDefined)
-			Expect(syncMapLen(&controller.phase1NetworkSetupCache)).To(Equal(1))
+			Expect(controller.phase1NetworkSetupCache.Size()).To(Equal(1))
 		})
 
 		It("should update from Scheduled to Running, if it sees a running Domain", func() {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -237,11 +237,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 		time.Sleep(1 * time.Second)
 
 		client = cmdclient.NewMockLauncherClient(ctrl)
-		clientInfo := &launcherClientInfo{
-			client:             client,
-			socketFile:         sockFile,
-			domainPipeStopChan: make(chan struct{}),
-			ready:              true,
+		clientInfo := &virtcache.LauncherClientInfo{
+			Client:             client,
+			SocketFile:         sockFile,
+			DomainPipeStopChan: make(chan struct{}),
+			Ready:              true,
 		}
 		controller.addLauncherClient(vmiTestUUID, clientInfo)
 
@@ -317,11 +317,11 @@ var _ = Describe("VirtualMachineInstance", func() {
 			uid := "1234"
 
 			legacyMockSockFile := filepath.Join(shareDir, "sockets", uid+"_sock")
-			clientInfo := &launcherClientInfo{
-				client:             client,
-				socketFile:         legacyMockSockFile,
-				domainPipeStopChan: make(chan struct{}),
-				ready:              true,
+			clientInfo := &virtcache.LauncherClientInfo{
+				Client:             client,
+				SocketFile:         legacyMockSockFile,
+				DomainPipeStopChan: make(chan struct{}),
+				Ready:              true,
 			}
 			controller.addLauncherClient(types.UID(uid), clientInfo)
 			err := virtcache.AddGhostRecord(namespace, name, legacyMockSockFile, types.UID(uid))
@@ -474,10 +474,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			})
 
 			//Did not initialize yet
-			clientInfo := &launcherClientInfo{
-				domainPipeStopChan:  make(chan struct{}),
-				ready:               false,
-				notInitializedSince: time.Now().Add(-1 * time.Minute),
+			clientInfo := &virtcache.LauncherClientInfo{
+				DomainPipeStopChan:  make(chan struct{}),
+				Ready:               false,
+				NotInitializedSince: time.Now().Add(-1 * time.Minute),
 			}
 			controller.addLauncherClient(vmi.UID, clientInfo)
 
@@ -499,10 +499,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			})
 
 			//Did not initialize yet
-			clientInfo := &launcherClientInfo{
-				domainPipeStopChan:  make(chan struct{}),
-				ready:               false,
-				notInitializedSince: time.Now().Add(-4 * time.Minute),
+			clientInfo := &virtcache.LauncherClientInfo{
+				DomainPipeStopChan:  make(chan struct{}),
+				Ready:               false,
+				NotInitializedSince: time.Now().Add(-4 * time.Minute),
 			}
 			controller.addLauncherClient(vmi.UID, clientInfo)
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2363,7 +2363,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			controller.Execute()
 			testutils.ExpectEvent(recorder, VMIStarted)
-			Expect(syncMapLen(&controller.podInterfaceCache)).To(Equal(1))
+			Expect(controller.podInterfaceCache.Size()).To(Equal(1))
 		})
 
 		table.DescribeTable("Should update masquerade interface with the pod IP", func(podIPs ...string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Currenctly all the VMIs are serialized at a mutex once per vmi+interface
at virt-handler, this change uses a sync.Map that will not serialize on
disjoint keys.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
