### PR TITLE
Reduce VMI Update Collisions

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -135,6 +135,7 @@ func NewVMIController(templateService services.TemplateService,
 		recorder:           recorder,
 		clientset:          clientset,
 		podExpectations:    controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
+		vmiExpectations:    controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		dataVolumeInformer: dataVolumeInformer,
 		topologyHinter:     topologyHinter,
 	}
@@ -188,6 +189,7 @@ type VMIController struct {
 	topologyHinter     topology.Hinter
 	recorder           record.EventRecorder
 	podExpectations    *controller.UIDTrackingControllerExpectations
+	vmiExpectations    *controller.UIDTrackingControllerExpectations
 	dataVolumeInformer cache.SharedIndexInformer
 }
 
@@ -243,6 +245,7 @@ func (c *VMIController) execute(key string) error {
 	// Once all finalizers are removed the vmi gets deleted and we can clean all expectations
 	if !exists {
 		c.podExpectations.DeleteExpectations(key)
+		c.vmiExpectations.DeleteExpectations(key)
 		return nil
 	}
 	vmi := obj.(*virtv1.VirtualMachineInstance)
@@ -254,8 +257,21 @@ func (c *VMIController) execute(key string) error {
 	if !controller.ObservedLatestApiVersionAnnotation(vmi) {
 		vmi := vmi.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(vmi)
+		key := controller.VirtualMachineInstanceKey(vmi)
+		c.vmiExpectations.SetExpectations(key, 1, 0)
 		_, err = c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(vmi)
-		return err
+		if err != nil {
+			c.vmiExpectations.LowerExpectations(key, 1, 0)
+			return err
+		}
+		return nil
+	}
+
+	// If needsSync is true (expectations fulfilled) we can make save assumptions if virt-handler or virt-controller owns the pod
+	needsSync := c.podExpectations.SatisfiedExpectations(key) && c.vmiExpectations.SatisfiedExpectations(key)
+
+	if !needsSync {
+		return nil
 	}
 
 	// Only consider pods which belong to this vmi
@@ -273,13 +289,8 @@ func (c *VMIController) execute(key string) error {
 		return err
 	}
 
-	// If needsSync is true (expectations fulfilled) we can make save assumptions if virt-handler or virt-controller owns the pod
-	needsSync := c.podExpectations.SatisfiedExpectations(key)
+	syncErr := c.sync(vmi, pod, dataVolumes)
 
-	var syncErr syncError = nil
-	if needsSync {
-		syncErr = c.sync(vmi, pod, dataVolumes)
-	}
 	err = c.updateStatus(vmi, pod, dataVolumes, syncErr)
 	if err != nil {
 		return err
@@ -643,8 +654,11 @@ func (c *VMIController) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8
 	// If we detect a change on the vmi we update the vmi
 	vmiChanged := !reflect.DeepEqual(vmi.Status, vmiCopy.Status) || !reflect.DeepEqual(vmi.Finalizers, vmiCopy.Finalizers) || !reflect.DeepEqual(vmi.Annotations, vmiCopy.Annotations) || !reflect.DeepEqual(vmi.Labels, vmiCopy.Labels)
 	if vmiChanged {
+		key := controller.VirtualMachineInstanceKey(vmi)
+		c.vmiExpectations.SetExpectations(key, 1, 0)
 		_, err := c.clientset.VirtualMachineInstance(vmi.Namespace).Update(vmiCopy)
 		if err != nil {
+			c.vmiExpectations.LowerExpectations(key, 1, 0)
 			return err
 		}
 	}
@@ -1034,15 +1048,26 @@ func (c *VMIController) deletePod(obj interface{}) {
 }
 
 func (c *VMIController) addVirtualMachineInstance(obj interface{}) {
+	c.lowerVMIExpectation(obj)
 	c.enqueueVirtualMachine(obj)
 }
 
 func (c *VMIController) deleteVirtualMachineInstance(obj interface{}) {
+	c.lowerVMIExpectation(obj)
 	c.enqueueVirtualMachine(obj)
 }
 
 func (c *VMIController) updateVirtualMachineInstance(_, curr interface{}) {
+	c.lowerVMIExpectation(curr)
 	c.enqueueVirtualMachine(curr)
+}
+
+func (c *VMIController) lowerVMIExpectation(curr interface{}) {
+	key, err := controller.KeyFunc(curr)
+	if err != nil {
+		return
+	}
+	c.vmiExpectations.LowerExpectations(key, 1, 0)
 }
 
 func (c *VMIController) enqueueVirtualMachine(obj interface{}) {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -852,6 +852,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			update.Do(func(vmi *v1.VirtualMachineInstance) {
 				expectConditions(vmi)
 				vmiInformer.GetStore().Update(vmi)
+				key := kvcontroller.VirtualMachineInstanceKey(vmi)
+				controller.vmiExpectations.LowerExpectations(key, 1, 0)
 				update.Return(vmi, nil)
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

During VMI startup, our control plane causes around 2-4 http 409 errors per a VMI while attempting to perform an "Update" on a VMI object that is not up to date. 

For example, here's a grafana graph capturing these errors during the startup of 15 VMIs in my dev environment

![vmi-collisions-panel](https://user-images.githubusercontent.com/683713/124660087-bd17f000-de73-11eb-963d-72d85e10b425.jpg)

The issue appears to be caused by our controllers not waiting to observe a VMI update has occurred before attempting to issue a new Update. This occurs due to other informers (like the pod and domain informers) queuing the VMI on our controllers before the VMI's informer has completely caught up.

It seems like this collision would be a rare occurrence, but the way the timing works out these collisions actually occur nearly every time a VMI is posted.

This PR addresses this collision by adding expectation logic to ensure that when a VMI is updated, that it won't be processed again until the VMI updates in the informer cache. 


```release-note
Reduce vmi Update collisions (http code 409) during startup
```
