### PR TITLE
Resolve containerdisk after initialization in template tests

### DIFF
--- a/tests/template_test.go
+++ b/tests/template_test.go
@@ -263,7 +263,9 @@ var _ = Describe("[Serial][sig-compute]Templates", func() {
 		AfterEach(AssertTestCleanupSuccess())
 
 		Context("with Fedora Template", func() {
-			BeforeEach(AssertTemplateSetupSuccess(vmsgen.GetTemplateFedoraWithContainerDisk(cd.ContainerDiskFor(cd.ContainerDiskFedora)), nil))
+			BeforeEach(func() {
+				AssertTemplateSetupSuccess(vmsgen.GetTemplateFedoraWithContainerDisk(cd.ContainerDiskFor(cd.ContainerDiskFedora)), nil)
+			})
 
 			AssertTemplateTestSuccess()
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

BeforeEach got the containerdisk as parameter before commandline
arguments were parsed. Therefore the tag of the containerdisk was empty
in the template task.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Fixes issues like this in some test environments:

```
Failed to apply default image tag \"/fedora-cloud-container-disk-demo:\": couldn't parse image reference \"/fedora-cloud-container-disk-demo:\": invalid reference format"
```

**Release note**:

```release-note
NONE
```
