### PR TITLE
If the hostDisk feature gate is not enabled, skip tests

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1877,20 +1877,14 @@ var _ = Describe("[sig-compute]Configurations", func() {
 	})
 
 	Context("[Serial][rfe_id:904][crit:medium][vendor:cnv-qe@redhat.com][level:component]with driver cache and io settings and PVC", func() {
-		var originalConfig v1.KubeVirtConfiguration
 
 		BeforeEach(func() {
-			kv := util.GetCurrentKv(virtClient)
-			originalConfig = kv.Spec.Configuration
-
-			tests.EnableFeatureGate(virtconfig.HostDiskGate)
+			if !checks.HasFeature(virtconfig.HostDiskGate) {
+				Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
+			}
 			// create a new PV and PVC (PVs can't be reused)
 			tests.CreateBlockVolumePvAndPvc("1Gi")
 		}, 60)
-
-		AfterEach(func() {
-			tests.UpdateKubeVirtConfigValueAndWait(originalConfig)
-		})
 
 		It("[test_id:1681]should set appropriate cache modes", func() {
 			vmi := tests.NewRandomVMI()
@@ -2062,9 +2056,9 @@ var _ = Describe("[sig-compute]Configurations", func() {
 		})
 
 		It("Should set BlockIO when set to match volume block sizes on files", func() {
-			originalConfig := util.GetCurrentKv(virtClient).Spec.Configuration
-			tests.EnableFeatureGate(virtconfig.HostDiskGate)
-			defer tests.UpdateKubeVirtConfigValueAndWait(originalConfig)
+			if !checks.HasFeature(virtconfig.HostDiskGate) {
+				Skip("Cluster has the HostDisk featuregate disabled, skipping  the tests")
+			}
 
 			By("creating a disk image")
 			var nodeName string


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of enabling the hostdisk featurgate in some tests, we should
skip them if the surrounding environment decided to disable it. Our
default test-setup enables it already, if desired.

Fixes issues in some test environments which don't want to run hostDisk based tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
