### PR TITLE
network: remove (broken) dhcp idempotency mechanism

### DIFF
--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -2,7 +2,6 @@ package dhcp
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -20,31 +19,19 @@ import (
 var _ = Describe("DHCP configurator", func() {
 
 	const (
-		advertisingCIDR    = "10.10.10.0/24"
-		bridgeName         = "br0"
-		ifaceName          = "eth0"
-		launcherPID        = "self"
-		fakeDhcpStartedDir = "/tmp/dhcpStartedPath"
+		advertisingCIDR = "10.10.10.0/24"
+		bridgeName      = "br0"
+		ifaceName       = "eth0"
+		launcherPID     = "self"
 	)
-
-	BeforeEach(func() {
-		// make sure the test can write a file in the whatever dir ensure uses.
-		Expect(os.MkdirAll(fakeDhcpStartedDir, 0755)).To(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(os.RemoveAll(fakeDhcpStartedDir)).To(Succeed())
-	})
 
 	newConfiguratorWithClientFilter := func(launcherPID string, advertisingIfaceName string) *Configurator {
 		configurator := NewConfiguratorWithClientFilter(fake.NewFakeInMemoryNetworkCacheFactory(), launcherPID, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())))
-		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
 		return configurator
 	}
 
 	newConfigurator := func(launcherPID string, advertisingIfaceName string) *Configurator {
 		configurator := NewConfigurator(fake.NewFakeInMemoryNetworkCacheFactory(), launcherPID, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())))
-		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
 		return configurator
 	}
 
@@ -99,17 +86,7 @@ var _ = Describe("DHCP configurator", func() {
 		table.DescribeTable("should succeed when DHCP server started", func(configurator *Configurator) {
 			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil)
 
-			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-		},
-			table.Entry("with active client filtering", newConfiguratorWithClientFilter(launcherPID, bridgeName)),
-			table.Entry("without client filtering", newConfigurator(launcherPID, bridgeName)),
-		)
-
-		table.DescribeTable("should succeed when DHCP server is started multiple times", func(configurator *Configurator) {
-			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil)
-
-			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
+			Expect(configurator.StartDHCPServer(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
 		},
 			table.Entry("with active client filtering", newConfiguratorWithClientFilter(launcherPID, bridgeName)),
 			table.Entry("without client filtering", newConfigurator(launcherPID, bridgeName)),
@@ -118,7 +95,7 @@ var _ = Describe("DHCP configurator", func() {
 		table.DescribeTable("should fail when DHCP server failed", func(configurator *Configurator) {
 			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(fmt.Errorf("failed to start DHCP server"))
 
-			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(HaveOccurred())
+			Expect(configurator.StartDHCPServer(ifaceName, dhcpConfig, dhcpOptions)).To(HaveOccurred())
 		},
 			table.Entry("with active client filtering", newConfiguratorWithClientFilter(launcherPID, bridgeName)),
 			table.Entry("without client filtering", newConfigurator(launcherPID, bridgeName)),
@@ -138,7 +115,7 @@ var _ = Describe("DHCP configurator", func() {
 			table.DescribeTable("should fail when DHCP server failed", func(configurator *Configurator) {
 				configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil).Times(0)
 
-				Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
+				Expect(configurator.StartDHCPServer(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
 			},
 				table.Entry("with active client filtering", newConfiguratorWithClientFilter(launcherPID, bridgeName)),
 				table.Entry("without client filtering", newConfigurator(launcherPID, bridgeName)),

--- a/pkg/virt-launcher/virtwrap/network/podnic.go
+++ b/pkg/virt-launcher/virtwrap/network/podnic.go
@@ -253,7 +253,7 @@ func (l *podNIC) PlugPhase2(domain *api.Domain) error {
 			log.Log.Reason(err).Critical("failed to load cached dhcpConfig configuration")
 		}
 		log.Log.V(4).Infof("The imported dhcpConfig: %s", dhcpConfig.String())
-		if err := l.dhcpConfigurator.EnsureDHCPServerStarted(l.podInterfaceName, *dhcpConfig, l.vmiSpecIface.DHCPOptions); err != nil {
+		if err := l.dhcpConfigurator.StartDHCPServer(l.podInterfaceName, *dhcpConfig, l.vmiSpecIface.DHCPOptions); err != nil {
 			log.Log.Reason(err).Criticalf("failed to ensure dhcp service running for: %s", l.podInterfaceName)
 			panic(err)
 		}

--- a/pkg/virt-launcher/virtwrap/network/podnic_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podnic_test.go
@@ -39,7 +39,7 @@ var _ = Describe("podNIC", func() {
 		}
 		podnic.podInterfaceName = primaryPodInterfaceName
 		podnic.infraConfigurator = mockPodNetworkConfigurator
-		podnic.dhcpConfigurator = dhcpconfigurator.NewConfiguratorWithDHCPStartedDirectory(cacheFactory, getPIDString(nil), primaryPodInterfaceName, mockNetwork, tmpDir)
+		podnic.dhcpConfigurator = dhcpconfigurator.NewConfigurator(cacheFactory, getPIDString(nil), primaryPodInterfaceName, mockNetwork)
 		return podnic, nil
 	}
 	BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There currently is a mechanism to prevent the in-pod DHCP server (plugged in
the IP pod bridge) from being started twice.

It consists of creating a file in a kubevirt known path
(/var/run/kubevirt-private/dhcp_started-<pod-interface-name>), and not starting
the server if the file already exists.

This so-called "idempotency" mechanism has ~~two different issues~~ an issue:
~~- it is not possible to call the StartDHCP method twice in the life of the same
  pod since PR #5400.~~
- the file is never removed when/if the server dies. As a consequence, this does
not implement idempotency - it just ensures that you have successfully started
the dhcp server once in the life of the pod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5984 

**Special notes for your reviewer**:
I've removed the tests that indicate the `EnsureDHCPStarted` methods can be called twice, since that is not possible in the production code.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TODO
```
