### PR TITLE
migration: only remove migration-specific metadata from libvirt XML

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2035,39 +2035,56 @@ var _ = Describe("migratableDomXML", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockDomain = cli.NewMockVirDomain(ctrl)
 	})
-	It("should remove only the kubevirt metadata", func() {
+	It("should remove only the kubevirt migration metadata", func() {
 		domXML := `<domain type="kvm" id="1">
   <name>kubevirt</name>
   <metadata>
     <kubevirt xmlns="http://kubevirt.io">
       <metadata>
-         <kubevirt>nested</kubevirt>
+         <kubevirt>
+            <migration>nested</migration>
+         </kubevirt>
       </metadata>
       <uid>d38cac9c-435b-42d5-960e-06e8d41146e8</uid>
+      <migration>
+         <uid>d38cac9c-435b-42d5-960e-06e8d41146e8</uid>
+         <failed>false</failed>
+      </migration>
       <graceperiod>
         <deletionGracePeriodSeconds>0</deletionGracePeriodSeconds>
       </graceperiod>
     </kubevirt>
     <othermetadata>
       <kubevirt>
-         <keepme>42</keepme>
+         <migration>42</migration>
       </kubevirt>
     </othermetadata>
   </metadata>
-  <kubevirt>this should stay</kubevirt>
+  <kubevirt><migration>this should stay</migration></kubevirt>
 </domain>`
-		// migratableDomXML() removes the kubevirt block but not its ident, which is its own token, hence the blank line below
+		// migratableDomXML() removes the migration block but not its ident, which is its own token, hence the blank line below
 		expectedXML := `<domain type="kvm" id="1">
   <name>kubevirt</name>
   <metadata>
-    
+    <kubevirt xmlns="http://kubevirt.io">
+      <metadata>
+         <kubevirt>
+            <migration>nested</migration>
+         </kubevirt>
+      </metadata>
+      <uid>d38cac9c-435b-42d5-960e-06e8d41146e8</uid>
+      
+      <graceperiod>
+        <deletionGracePeriodSeconds>0</deletionGracePeriodSeconds>
+      </graceperiod>
+    </kubevirt>
     <othermetadata>
       <kubevirt>
-         <keepme>42</keepme>
+         <migration>42</migration>
       </kubevirt>
     </othermetadata>
   </metadata>
-  <kubevirt>this should stay</kubevirt>
+  <kubevirt><migration>this should stay</migration></kubevirt>
 </domain>`
 		mockDomain.EXPECT().Free()
 		vmi := newVMI("testns", "kubevirt")


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing the whole kubevirt metadata bloc on migration can cause issues with existing code.
This PR limits the removal to only the migration section.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1966903

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
