### PR TITLE
Generate cloud-init paths without creating directories

### DIFF
--- a/pkg/cloud-init/cloud-init.go
+++ b/pkg/cloud-init/cloud-init.go
@@ -428,8 +428,14 @@ func SetLocalDirectory(dir string) error {
 		return fmt.Errorf("CloudInit local cache directory (%s) does not exist or is inaccessible", dir)
 	}
 
-	cloudInitLocalDir = dir
+	SetLocalDirectoryOnly(dir)
 	return nil
+}
+
+// XXX refactor this whole package
+// This is just a cheap workaround to make e2e tests pass
+func SetLocalDirectoryOnly(dir string) {
+	cloudInitLocalDir = dir
 }
 
 func getDomainBasePath(domain string, namespace string) string {

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -77,7 +77,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		util.PanicOnError(err)
 
 		// from default virt-launcher flag: do we need to make this configurable in some cases?
-		cloudinit.SetLocalDirectory("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
+		cloudinit.SetLocalDirectoryOnly("/var/run/kubevirt-ephemeral-disks/cloud-init-data")
 
 		LaunchVMI = func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 			By("Starting a VirtualMachineInstance")


### PR DESCRIPTION
**What this PR does / why we need it**:

For e2e tests we generate the path where we can find the cloud-init iso.

Only set the expected path on the cloud-init package without trying to
create the path structure.

We don't see this in our CI tests because in the CI cluster, the test binary has the right to execute the path in question.
On other CI systems where the permission is not given, we just got an error which we ignored which lead to wrongly constructed paths.

This is a test-only issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #5973 

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
