### PR TITLE
PoC recovering reconcile panics as errors

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -219,7 +219,7 @@ func (c *VMIController) Execute() bool {
 		return false
 	}
 	defer c.Queue.Done(key)
-	err := c.execute(key.(string))
+	err := controller.RecoverExecutePanicAsError(c.execute, key.(string))
 
 	if err != nil {
 		log.Log.Reason(err).Infof("reenqueuing VirtualMachineInstance %v", key)


### PR DESCRIPTION
We've encountered two recent virt-controller crashes (#5849 and #5694) that were caused by resources entering into unexpected states. The result is that a crash in one of our reconcile loops crashes all of virt-controller, which can cause the entire virt-controller process to enter into a crash loop.

Using the built in golang `recover()` function, we can catch and handle panics that occur during our reconcile loops and simply treat them as errors which then get rate limited.

This PR exists to illustrate how this can be done for the sake of discussion.

```release-note
NONE
```
