### PR TITLE
Convert podNIC test into DescribeTable and increase podNIC coverage

### DIFF
--- a/pkg/virt-launcher/virtwrap/network/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/network/BUILD.bazel
@@ -46,7 +46,10 @@ go_test(
         "//vendor/github.com/coreos/go-iptables/iptables:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/matchers:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/network/network_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/network/network_suite_test.go
@@ -46,6 +46,17 @@ func newVMIMacvtapInterface(namespace string, vmiName string, ifaceName string) 
 	return vmi
 }
 
+func newVMISRIOVInterface(namespce, name string) *v1.VirtualMachineInstance {
+	vmi := newVMI("testnamespace", "testVmName")
+	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
+		Name: "default",
+		InterfaceBindingMethod: v1.InterfaceBindingMethod{
+			SRIOV: &v1.InterfaceSRIOV{},
+		},
+	}}
+	v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+	return vmi
+}
 func NewDomainWithBridgeInterface() *api.Domain {
 	domain := &api.Domain{}
 	domain.Spec.Devices.Interfaces = []api.Interface{{

--- a/pkg/virt-launcher/virtwrap/network/podnic_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podnic_test.go
@@ -212,8 +212,11 @@ var _ = Describe("podNIC", func() {
 			shouldPrepareNetworking:  withSucces(),
 			should:                   Succeed(),
 		}),
-		Entry("should propagate error if network discovering fails for bridge binding", plugPhase1Case{
-			vmis:          []*v1.VirtualMachineInstance{newVMIBridgeInterface("testnamespace", "testVmName")},
+		Entry("should propagate error if network discovering fails for bridge and masquerade binding", plugPhase1Case{
+			vmis: []*v1.VirtualMachineInstance{
+				newVMIBridgeInterface("testnamespace", "testVmName"),
+				newVMIMasqueradeInterface("testnamespace", "testVmName"),
+			},
 			ipv4Addr:      "1.2.3.4",
 			ipv6Addr:      "::1234:5678",
 			isIPv4Primary: true,
@@ -225,7 +228,10 @@ var _ = Describe("podNIC", func() {
 			should:                   MatchError(withError().err),
 		}),
 		Entry("should return CriticalNetworkError if network preparation fails for bridge binding", plugPhase1Case{
-			vmis:                []*v1.VirtualMachineInstance{newVMIBridgeInterface("testnamespace", "testVmName")},
+			vmis: []*v1.VirtualMachineInstance{
+				newVMIBridgeInterface("testnamespace", "testVmName"),
+				newVMIMasqueradeInterface("testnamespace", "testVmName"),
+			},
 			ipv4Addr:            "1.2.3.4",
 			ipv6Addr:            "::1234:5678",
 			isIPv4Primary:       true,

--- a/pkg/virt-launcher/virtwrap/network/podnic_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podnic_test.go
@@ -192,6 +192,44 @@ var _ = Describe("podNIC", func() {
 			},
 			should: Succeed(),
 		}),
+		Entry("should success with pure ipv4 cluster and store pod IPs correctly", plugPhase1Case{
+			vmis:                []*v1.VirtualMachineInstance{newVMISlirpInterface("testnamespace", "testVmName")},
+			ipv4Addr:            "1.2.3.4",
+			isIPv4Primary:       true,
+			expectedDomainIface: nil,
+			expectedDHCPConfig:  nil,
+			expectedPodInterface: &cache.PodCacheInterface{
+				PodIP:  "1.2.3.4",
+				PodIPs: []string{"1.2.3.4"},
+			},
+			should: Succeed(),
+		}),
+		Entry("should success with pure ipv6 cluster and store pod IPs correctly", plugPhase1Case{
+			vmis:                []*v1.VirtualMachineInstance{newVMISlirpInterface("testnamespace", "testVmName")},
+			ipv6Addr:            "::1234:5678",
+			isIPv4Primary:       false,
+			expectedDomainIface: nil,
+			expectedDHCPConfig:  nil,
+			expectedPodInterface: &cache.PodCacheInterface{
+				PodIP:  "::1234:5678",
+				PodIPs: []string{"::1234:5678"},
+			},
+			should: Succeed(),
+		}),
+		Entry("should select ipv6 if it's the prefered on the cluster", plugPhase1Case{
+			vmis:                []*v1.VirtualMachineInstance{newVMISlirpInterface("testnamespace", "testVmName")},
+			ipv4Addr:            "1.2.3.4",
+			ipv6Addr:            "::1234:5678",
+			isIPv4Primary:       false,
+			expectedDomainIface: nil,
+			expectedDHCPConfig:  nil,
+			expectedPodInterface: &cache.PodCacheInterface{
+				PodIP:  "::1234:5678",
+				PodIPs: []string{"::1234:5678", "1.2.3.4"},
+			},
+			should: Succeed(),
+		}),
+
 		Entry("should success and write the pod interface IPs and libvirt domain interface for macvtap binding", plugPhase1Case{
 			vmis:                []*v1.VirtualMachineInstance{newVMIMacvtapInterface("testnamespace", "testVmName", "default")},
 			ipv4Addr:            "1.2.3.4",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The podNIC test coverage is quite low, being exhaustive testing
something with Ginkgo and the nested specs is not easy, this test
convert all the test into a pair of DescribeTable one for PlugPhase1 and
the other for PlugPhase2, this make easi to be more exhaustive since new
test involve new Entry with different values at the Case struct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
