### PR TITLE
Set DV priority class if VM priority class is set.

### DIFF
--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -349,6 +349,10 @@ func createDataVolumeManifest(dataVolumeTemplate *virtv1.DataVolumeTemplateSpec,
 	newDataVolume.ObjectMeta.OwnerReferences = []v1.OwnerReference{
 		*v1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind),
 	}
+
+	if newDataVolume.Spec.PriorityClassName == "" && vm.Spec.Template.Spec.PriorityClassName != "" {
+		newDataVolume.Spec.PriorityClassName = vm.Spec.Template.Spec.PriorityClassName
+	}
 	return newDataVolume
 }
 


### PR DESCRIPTION
Have DataVolumes follow the priority class of the VM they
are associated with. We still allow different priority class
to be defined in the datavolume templates.

Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
DataVolumes now pass PriorityClass to the transfer pods, but we want them to have the same priority class as the VMs. This PR will copy of the PriorityClassName from the VM to the created DVs if the DataVolumeTemplate does not define it, and the VM priority class is set.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
DataVolumes created by DataVolumeTemplates will follow the associated VMs priority class.
```
