### PR TITLE
Fix the bandwidth limitation option for migrations

### DIFF
--- a/pkg/virt-config/config_test.go
+++ b/pkg/virt-config/config_test.go
@@ -224,7 +224,7 @@ var _ = Describe("ConfigMap", func() {
 		result := clusterConfig.GetMigrationConfiguration()
 		Expect(*result.ParallelOutboundMigrationsPerNode).To(BeNumerically("==", 10))
 		Expect(*result.ParallelMigrationsPerCluster).To(BeNumerically("==", 5))
-		Expect(result.BandwidthPerMigration.String()).To(Equal("64Mi"))
+		Expect(result.BandwidthPerMigration.String()).To(Equal("0"))
 	})
 
 	It("Should update the config if a newer version is available", func() {

--- a/pkg/virt-config/virt-config.go
+++ b/pkg/virt-config/virt-config.go
@@ -33,7 +33,7 @@ import (
 const (
 	ParallelOutboundMigrationsPerNodeDefault uint32 = 2
 	ParallelMigrationsPerClusterDefault      uint32 = 5
-	BandwithPerMigrationDefault                     = "64Mi"
+	BandwithPerMigrationDefault                     = "0Mi"
 	MigrationAllowAutoConverge               bool   = false
 	MigrationAllowPostCopy                   bool   = false
 	MigrationProgressTimeout                 int64  = 150

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1679,7 +1679,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			domainFeeder.Add(domain)
 			vmiFeeder.Add(vmi)
 			options := &cmdclient.MigrationOptions{
-				Bandwidth:               resource.MustParse("64Mi"),
+				Bandwidth:               resource.MustParse("0Mi"),
 				ProgressTimeout:         150,
 				CompletionTimeoutPerGiB: 800,
 				UnsafeMigration:         false,

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1864,11 +1864,16 @@ func QuantityToByte(quantity resource.Quantity) (api.Memory, error) {
 }
 
 func QuantityToMebiByte(quantity resource.Quantity) (uint64, error) {
-	q := int64(float64(0.953674) * float64(quantity.ScaledValue(resource.Mega)))
-	if q < 0 {
-		return 0, fmt.Errorf("Quantity '%s' must be greate tan or equal to 0", quantity.String())
+	bytes, err := QuantityToByte(quantity)
+	if err != nil {
+		return 0, err
 	}
-	return uint64(q), nil
+	if bytes.Value == 0 {
+		return 0, nil
+	} else if bytes.Value < 1048576 {
+		return 1, nil
+	}
+	return uint64(float64(bytes.Value)/1048576 + 0.5), nil
 }
 
 func boolToOnOff(value *bool, defaultOn bool) string {

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1785,12 +1785,23 @@ var _ = Describe("Converter", func() {
 			})
 		})
 
-		It("should calculate mebibyte from a quantity", func() {
-			mi64, _ := resource.ParseQuantity("2G")
+		table.DescribeTable("should calculate mebibyte from a quantity", func(quantity string, mebibyte int) {
+			mi64, _ := resource.ParseQuantity(quantity)
 			q, err := QuantityToMebiByte(mi64)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(q).To(BeNumerically("==", 1907))
-		})
+			Expect(q).To(BeNumerically("==", mebibyte))
+		},
+			table.Entry("when 0M is given", "0M", 0),
+			table.Entry("when 0 is given", "0", 0),
+			table.Entry("when 1 is given", "1", 1),
+			table.Entry("when 1M is given", "1M", 1),
+			table.Entry("when 3M is given", "3M", 3),
+			table.Entry("when 100M is given", "100M", 95),
+			table.Entry("when 1Mi is given", "1Mi", 1),
+			table.Entry("when 2G are given", "2G", 1907),
+			table.Entry("when 2Gi are given", "2Gi", 2*1024),
+			table.Entry("when 2780Gi are given", "2780Gi", 2780*1024),
+		)
 
 		It("should fail calculating mebibyte if the quantity is less than 0", func() {
 			mi64, _ := resource.ParseQuantity("-2G")
@@ -1798,47 +1809,25 @@ var _ = Describe("Converter", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should calculate memory in bytes", func() {
-			By("specifying memory 64M")
-			m64, _ := resource.ParseQuantity("64M")
+		table.DescribeTable("should calculate memory in bytes", func(quantity string, bytes int) {
+			m64, _ := resource.ParseQuantity(quantity)
 			memory, err := QuantityToByte(m64)
-			Expect(memory.Value).To(Equal(uint64(64000000)))
+			Expect(memory.Value).To(BeNumerically("==", bytes))
 			Expect(memory.Unit).To(Equal("b"))
 			Expect(err).ToNot(HaveOccurred())
-
-			By("specifying memory 64Mi")
-			mi64, _ := resource.ParseQuantity("64Mi")
-			memory, err = QuantityToByte(mi64)
-			Expect(memory.Value).To(Equal(uint64(67108864)))
-			Expect(err).ToNot(HaveOccurred())
-
-			By("specifying memory 3G")
-			g3, _ := resource.ParseQuantity("3G")
-			memory, err = QuantityToByte(g3)
-			Expect(memory.Value).To(Equal(uint64(3000000000)))
-			Expect(err).ToNot(HaveOccurred())
-
-			By("specifying memory 3Gi")
-			gi3, _ := resource.ParseQuantity("3Gi")
-			memory, err = QuantityToByte(gi3)
-			Expect(memory.Value).To(Equal(uint64(3221225472)))
-			Expect(err).ToNot(HaveOccurred())
-
-			By("specifying memory 45Gi")
-			gi45, _ := resource.ParseQuantity("45Gi")
-			memory, err = QuantityToByte(gi45)
-			Expect(memory.Value).To(Equal(uint64(48318382080)))
-			Expect(err).ToNot(HaveOccurred())
-
-			By("specifying memory 451231 bytes")
-			b451231, _ := resource.ParseQuantity("451231")
-			memory, err = QuantityToByte(b451231)
-			Expect(memory.Value).To(Equal(uint64(451231)))
-			Expect(err).ToNot(HaveOccurred())
-
+		},
+			table.Entry("specifying memory 64M", "64M", 64*1000*1000),
+			table.Entry("specifying memory 64Mi", "64Mi", 64*1024*1024),
+			table.Entry("specifying memory 3G", "3G", 3*1000*1000*1000),
+			table.Entry("specifying memory 3Gi", "3Gi", 3*1024*1024*1024),
+			table.Entry("specifying memory 45Gi", "45Gi", 45*1024*1024*1024),
+			table.Entry("specifying memory 2780Gi", "2780Gi", 2780*1024*1024*1024),
+			table.Entry("specifying memory 451231 bytes", "451231", 451231),
+		)
+		It("should calculate memory in bytes", func() {
 			By("specyfing negative memory size -45Gi")
 			m45gi, _ := resource.ParseQuantity("-45Gi")
-			_, err = QuantityToByte(m45gi)
+			_, err := QuantityToByte(m45gi)
 			Expect(err).To(HaveOccurred())
 		})
 

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -787,11 +787,12 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 	}
 
 	params := &libvirt.DomainMigrateParameters{
-		Bandwidth:  bandwidth, // MiB/s
-		URI:        migrURI,
-		URISet:     true,
-		DestXML:    xmlstr,
-		DestXMLSet: true,
+		Bandwidth:    bandwidth, // MiB/s
+		BandwidthSet: bandwidth > 0,
+		URI:          migrURI,
+		URISet:       true,
+		DestXML:      xmlstr,
+		DestXMLSet:   true,
 	}
 
 	copyDisks := getDiskTargetsForMigration(dom, vmi)


### PR DESCRIPTION
**What this PR does / why we need it**:

Set the boolean which makes the bandwidth limitation for migrations effective. In order to not break assumptions on existing installations the current default limit of 64Mi is removed and replaced with "unlimited" bandwidth.

The bandwidth limitation option for migrations was completely ignored before.
Further better define the function boundaries. The old implementation was quite
fuzzy in a few aspects:

 * 0.9999 Mi was rounded to 0, while 1Mi is obviously the desired value.
 * 0.1111 Mi was rounded to 0, while 0Mi would either mean no progress
   or unlimited (was undefined).
 * 5.9999 Mi was rounde to 5 while 6Mi is much more likely the intent.

Now the behaviour for the bandwidth calculation will be like this:

 * A `0` quantity (`0` or `0Mi`, ...) means unlimited bandwidth.
 * A positive quantity < 1Mi will be rounded up to 1Mi.
 * For all other quantities mathematical rounding will be used instead
   of computer science rounding.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: The bandwidth limitation on migrations is no longer ignored. Caution: The default bandwidth limitation of 64Mi is changed to "unlimited" to not break existing installations.
```
