### PR TITLE
Fix flaky secrets certificate test

### DIFF
--- a/pkg/virt-operator/resource/generate/components/secrets_test.go
+++ b/pkg/virt-operator/resource/generate/components/secrets_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Certificate Management", func() {
 			crt, err := LoadCertificates(crtSecret)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(crt.Leaf.NotAfter.Unix()).To(BeNumerically("==", now.Add(crtDuration.Duration).Unix(), 3))
+			Expect(crt.Leaf.NotAfter.Unix()).To(BeNumerically("==", now.Add(crtDuration.Duration).Unix(), 10))
 		},
 			table.Entry("with a long valid CA", 24*time.Hour),
 			table.Entry("with a CA which expires before the certificate rotation", 1*time.Hour),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

According to

https://search.ci.kubevirt.io/?search=should+set+the+notAfter+on+the+certificate+according+to+the+supplied+duration&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

there were a couple of failures where the specified interval on the
check was not sufficient. To give it more room we extend it to be ten
seconds now.

Failures:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5902/pull-kubevirt-unit-test/1413409469940895744
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5979/pull-kubevirt-unit-test/1413400102554308608
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5943/pull-kubevirt-unit-test/1412673268980125696
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5936/pull-kubevirt-unit-test/1412329692949647360
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5922/pull-kubevirt-unit-test/1410908223392714752
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5936/pull-kubevirt-unit-test/1410558045632598016
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5936/pull-kubevirt-unit-test/1410558045632598016
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5957/pull-kubevirt-unit-test/1410495762734780416
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4089/pull-kubevirt-unit-test/1410229173389103104
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5931/pull-kubevirt-unit-test/1409847273952645120

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fgimenez @rmohr 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
