### PR TITLE
[Sig-scale] Expose workqueue metrics to Prometheus

### DIFF
--- a/pkg/monitoring/workqueue/prometheus/prometheus.go
+++ b/pkg/monitoring/workqueue/prometheus/prometheus.go
@@ -28,13 +28,28 @@ func init() {
 	workqueue.SetProvider(prometheusMetricsProvider{})
 }
 
+// Metrics namespace, subsystem and keys used by the workqueue.
+const (
+	WorkQueueNamespace         = "kubevirt"
+	WorkQueueSubsystem         = "workqueue"
+	DepthKey                   = "depth"
+	AddsKey                    = "adds_total"
+	QueueLatencyKey            = "queue_duration_seconds"
+	WorkDurationKey            = "work_duration_seconds"
+	UnfinishedWorkKey          = "unfinished_work_seconds"
+	LongestRunningProcessorKey = "longest_running_processor_seconds"
+	RetriesKey                 = "retries_total"
+)
+
 type prometheusMetricsProvider struct{}
 
 func (_ prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
 	depth := prometheus.NewGauge(prometheus.GaugeOpts{
-		Subsystem: name,
-		Name:      "depth",
-		Help:      "Current depth of workqueue: " + name,
+		Namespace:   WorkQueueNamespace,
+		Subsystem:   WorkQueueSubsystem,
+		Name:        DepthKey,
+		Help:        "Current depth of workqueue",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 	prometheus.Register(depth)
 	return depth
@@ -42,29 +57,37 @@ func (_ prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMe
 
 func (_ prometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
 	adds := prometheus.NewCounter(prometheus.CounterOpts{
-		Subsystem: name,
-		Name:      "adds",
-		Help:      "Total number of adds handled by workqueue: " + name,
+		Namespace:   WorkQueueNamespace,
+		Subsystem:   WorkQueueSubsystem,
+		Name:        AddsKey,
+		Help:        "Total number of adds handled by workqueue",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 	prometheus.Register(adds)
 	return adds
 }
 
 func (_ prometheusMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
-	latency := prometheus.NewSummary(prometheus.SummaryOpts{
-		Subsystem: name,
-		Name:      "queue_latency",
-		Help:      "How long an item stays in workqueue" + name + " before being requested.",
+	latency := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace:   WorkQueueNamespace,
+		Subsystem:   WorkQueueSubsystem,
+		Name:        QueueLatencyKey,
+		Help:        "How long an item stays in workqueue before being requested.",
+		ConstLabels: prometheus.Labels{"name": name},
+		Buckets:     prometheus.ExponentialBuckets(10e-9, 10, 10),
 	})
 	prometheus.Register(latency)
 	return latency
 }
 
 func (_ prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
-	workDuration := prometheus.NewSummary(prometheus.SummaryOpts{
-		Subsystem: name,
-		Name:      "work_duration",
-		Help:      "How long processing an item from workqueue" + name + " takes.",
+	workDuration := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace:   WorkQueueNamespace,
+		Subsystem:   WorkQueueSubsystem,
+		Name:        WorkDurationKey,
+		Help:        "How long in seconds processing an item from workqueue takes.",
+		ConstLabels: prometheus.Labels{"name": name},
+		Buckets:     prometheus.ExponentialBuckets(10e-9, 10, 10),
 	})
 	prometheus.Register(workDuration)
 	return workDuration
@@ -72,9 +95,11 @@ func (_ prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.
 
 func (_ prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
 	retries := prometheus.NewCounter(prometheus.CounterOpts{
-		Subsystem: name,
-		Name:      "retries",
-		Help:      "Total number of retries handled by workqueue: " + name,
+		Namespace:   WorkQueueNamespace,
+		Subsystem:   WorkQueueSubsystem,
+		Name:        RetriesKey,
+		Help:        "Total number of retries handled by workqueue",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 	prometheus.Register(retries)
 	return retries
@@ -82,9 +107,12 @@ func (_ prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.Count
 
 func (_ prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	longestRunningProcessor := prometheus.NewGauge(prometheus.GaugeOpts{
-		Subsystem: name,
-		Name:      "longest_running_proceessror_seconds",
-		Help:      "The longest running processor time",
+		Namespace: WorkQueueNamespace,
+		Subsystem: WorkQueueSubsystem,
+		Name:      LongestRunningProcessorKey,
+		Help: "How many seconds has the longest running " +
+			"processor for workqueue been running.",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 	prometheus.Register(longestRunningProcessor)
 	return longestRunningProcessor
@@ -92,9 +120,14 @@ func (_ prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name 
 
 func (_ prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
 	unfinishedWork := prometheus.NewGauge(prometheus.GaugeOpts{
-		Subsystem: name,
-		Name:      "unfinished_work",
-		Help:      "The unfinished work duration",
+		Namespace: WorkQueueNamespace,
+		Subsystem: WorkQueueSubsystem,
+		Name:      UnfinishedWorkKey,
+		Help: "How many seconds of work has done that " +
+			"is in progress and hasn't been observed by work_duration. Large " +
+			"values indicate stuck threads. One can deduce the number of stuck " +
+			"threads by observing the rate at which this increases.",
+		ConstLabels: prometheus.Labels{"name": name},
 	})
 	prometheus.Register(unfinishedWork)
 	return unfinishedWork

--- a/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
+++ b/pkg/virt-controller/watch/drain/disruptionbudget/disruptionbudget.go
@@ -53,7 +53,7 @@ func NewDisruptionBudgetController(
 ) *DisruptionBudgetController {
 
 	c := &DisruptionBudgetController{
-		Queue:                           workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:                           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-disruption-budget"),
 		vmiInformer:                     vmiInformer,
 		pdbInformer:                     pdbInformer,
 		podInformer:                     podInformer,

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -53,7 +53,7 @@ func NewEvacuationController(
 ) *EvacuationController {
 
 	c := &EvacuationController{
-		Queue:                 workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-evacuation"),
 		vmiInformer:           vmiInformer,
 		migrationInformer:     migrationInformer,
 		nodeInformer:          nodeInformer,

--- a/pkg/virt-controller/watch/migration.go
+++ b/pkg/virt-controller/watch/migration.go
@@ -85,7 +85,7 @@ func NewMigrationController(templateService services.TemplateService,
 
 	c := &MigrationController{
 		templateService:    templateService,
-		Queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-migration"),
 		vmiInformer:        vmiInformer,
 		podInformer:        podInformer,
 		migrationInformer:  migrationInformer,

--- a/pkg/virt-controller/watch/node.go
+++ b/pkg/virt-controller/watch/node.go
@@ -44,7 +44,7 @@ type NodeController struct {
 func NewNodeController(clientset kubecli.KubevirtClient, nodeInformer cache.SharedIndexInformer, vmiInformer cache.SharedIndexInformer, recorder record.EventRecorder) *NodeController {
 	c := &NodeController{
 		clientset:        clientset,
-		Queue:            workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-node"),
 		nodeInformer:     nodeInformer,
 		vmiInformer:      vmiInformer,
 		recorder:         recorder,

--- a/pkg/virt-controller/watch/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset.go
@@ -68,7 +68,7 @@ const (
 func NewVMIReplicaSet(vmiInformer cache.SharedIndexInformer, vmiRSInformer cache.SharedIndexInformer, recorder record.EventRecorder, clientset kubecli.KubevirtClient, burstReplicas uint) *VMIReplicaSet {
 
 	c := &VMIReplicaSet{
-		Queue:         workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-replicaset"),
 		vmiInformer:   vmiInformer,
 		vmiRSInformer: vmiRSInformer,
 		recorder:      recorder,

--- a/pkg/virt-controller/watch/snapshot/restore_base.go
+++ b/pkg/virt-controller/watch/snapshot/restore_base.go
@@ -56,7 +56,7 @@ type VMRestoreController struct {
 
 // Init initializes the restore controller
 func (ctrl *VMRestoreController) Init() {
-	ctrl.vmRestoreQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "restore-controller-vmrestore")
+	ctrl.vmRestoreQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-restore-vmrestore")
 
 	ctrl.VMRestoreInformer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/virt-controller/watch/snapshot/snapshot_base.go
+++ b/pkg/virt-controller/watch/snapshot/snapshot_base.go
@@ -91,12 +91,12 @@ var supportedCRDVersions = []string{"v1beta1"}
 
 // Init initializes the snapshot controller
 func (ctrl *VMSnapshotController) Init() {
-	ctrl.vmSnapshotQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "snapshot-controller-vmsnapshot")
-	ctrl.vmSnapshotContentQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "snapshot-controller-vmsnapshotcontent")
-	ctrl.crdQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "snapshot-controller-crd")
-	ctrl.vmSnapshotStatusQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "snapshot-controller-vmsnashotstatus")
-	ctrl.vmQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "snapshot-controller-vm")
-	ctrl.dvQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "snapshot-controller-dv")
+	ctrl.vmSnapshotQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vmsnapshot")
+	ctrl.vmSnapshotContentQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vmsnapshotcontent")
+	ctrl.crdQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-crd")
+	ctrl.vmSnapshotStatusQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vmsnashotstatus")
+	ctrl.vmQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-vm")
+	ctrl.dvQueue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-snapshot-dv")
 
 	ctrl.dynamicInformerMap = map[string]*dynamicInformer{
 		volumeSnapshotCRD:      {informerFunc: controller.VolumeSnapshotInformer},

--- a/pkg/virt-controller/watch/vm.go
+++ b/pkg/virt-controller/watch/vm.go
@@ -68,7 +68,7 @@ func NewVMController(vmiInformer cache.SharedIndexInformer,
 	proxy := &sarProxy{client: clientset}
 
 	c := &VMController{
-		Queue:                  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vm"),
 		vmiInformer:            vmiInformer,
 		vmInformer:             vmInformer,
 		dataVolumeInformer:     dataVolumeInformer,

--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -128,7 +128,7 @@ func NewVMIController(templateService services.TemplateService,
 
 	c := &VMIController{
 		templateService:    templateService,
-		Queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		Queue:              workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-controller-vmi"),
 		vmiInformer:        vmiInformer,
 		podInformer:        podInformer,
 		pvcInformer:        pvcInformer,

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -106,7 +106,7 @@ func NewWorkloadUpdateController(
 	)
 
 	c := &WorkloadUpdateController{
-		queue:                 workqueue.NewRateLimitingQueue(rl),
+		queue:                 workqueue.NewNamedRateLimitingQueue(rl, "virt-controller-workload-update"),
 		vmiInformer:           vmiInformer,
 		podInformer:           podInformer,
 		migrationInformer:     migrationInformer,

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -72,7 +72,7 @@ func newNodeLabeller(clusterConfig *virtconfig.ClusterConfig, clientset kubecli.
 		namespace:               namespace,
 		logger:                  log.DefaultLogger(),
 		clusterConfig:           clusterConfig,
-		queue:                   workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
+		queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-handler-node-labeller"),
 		volumePath:              volumePath,
 		domCapabilitiesFileName: "virsh_domcapabilities.xml",
 		hostCPUModel:            hostCPUModel{requiredFeatures: make(map[string]bool, 0)},

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -160,7 +160,7 @@ func NewController(
 	capabilities *nodelabellerapi.Capabilities,
 ) *VirtualMachineController {
 
-	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "virt-handler-vm")
 
 	c := &VirtualMachineController{
 		Queue:                       queue,
@@ -2514,7 +2514,7 @@ func (d *VirtualMachineController) vmUpdateHelperDefault(origVMI *v1.VirtualMach
 
 	err = client.SyncVirtualMachine(vmi, options)
 	if err != nil {
-		isSecbootError := strings.Contains(err.Error(), "EFI OVMF roms missing")
+		isSecbootError := strings.Contains(err.Error(), "EFI OVMF rom missing")
 		if isSecbootError {
 			return &virtLauncherCriticalSecurebootError{fmt.Sprintf("mismatch of Secure Boot setting and bootloaders: %v", err)}
 		}

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -90,7 +90,7 @@ func NewKubeVirtController(
 	c := KubeVirtController{
 		clientset:        clientset,
 		aggregatorClient: aggregatorClient,
-		queue:            workqueue.NewRateLimitingQueue(rl),
+		queue:            workqueue.NewNamedRateLimitingQueue(rl, "virt-operator"),
 		kubeVirtInformer: informer,
 		recorder:         recorder,
 		stores:           stores,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Today, KubeVirt has already some logic to expose the workqueue metrics to Prometheus

However, those metrics are not been exposed. It is missing some additional configurations to properly work.
- we must set the kubevirt namespace
- the name parameter of the functions that enable the metric should be used as the metric labels
- the metrics queue_duration_seconds and work_duration_seconds should be histograms
- workqueues cannot have empty names, otherwise the metrics are not exposed, see [here](https://github.com/kubernetes/client-go/blob/master/util/workqueue/metrics.go#L231).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #6012

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
