### PR TITLE
[tests] remove unused functions from utils.go

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/golang.org/x/crypto/ssh:go_default_library",
-        "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/node/v1beta1:go_default_library",

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -53,7 +53,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -436,41 +435,6 @@ func (w *ObjectEventWatcher) WaitNotFor(ctx context.Context, eventType EventType
 		return false
 	}, fmt.Sprintf("not happen event type %s, reason = %s", string(eventType), reflect.ValueOf(reason).String()))
 	return
-}
-
-// Do scale and returns error, replicas-before.
-func DoScaleDeployment(namespace string, name string, desired int32) (error, int32) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util2.PanicOnError(err)
-
-	deployment, err := virtCli.AppsV1().Deployments(namespace).Get(context.Background(), name, metav1.GetOptions{})
-	if err != nil {
-		return err, -1
-	}
-	scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: desired}, ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
-	_, err = virtCli.AppsV1().Deployments(namespace).UpdateScale(context.Background(), name, scale, metav1.UpdateOptions{})
-	if err != nil {
-		return err, -1
-	}
-	return nil, *deployment.Spec.Replicas
-}
-
-func DoScaleVirtHandler(namespace string, name string, selector map[string]string) (int32, map[string]string, int64, error) {
-	virtCli, err := kubecli.GetKubevirtClient()
-	util2.PanicOnError(err)
-
-	d, err := virtCli.AppsV1().DaemonSets(namespace).Get(context.Background(), name, metav1.GetOptions{})
-	if err != nil {
-		return 0, nil, 0, err
-	}
-	sel := d.Spec.Template.Spec.NodeSelector
-	ready := d.Status.DesiredNumberScheduled
-	d.Spec.Template.Spec.NodeSelector = selector
-	d, err = virtCli.AppsV1().DaemonSets(namespace).Update(context.Background(), d, metav1.UpdateOptions{})
-	if err != nil {
-		return 0, nil, 0, err
-	}
-	return ready, sel, d.ObjectMeta.Generation, nil
 }
 
 func WaitForAllPodsReady(timeout time.Duration, listOptions metav1.ListOptions) {


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
It turns out that `DoScaleDeployment` and `DoScaleVirthandler` functions aren't consumed anymore, thus
cleaning them up from `tests/utils.go`

```release-note
NONE
```
