### PR TITLE
watch for early clean up env when monitoring qemu

### DIFF
--- a/pkg/virt-launcher/BUILD.bazel
+++ b/pkg/virt-launcher/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/virt-launcher/virtwrap/cmd-server:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/monitor.go
+++ b/pkg/virt-launcher/monitor.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/client-go/log"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/util"
+	cmdserver "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cmd-server"
 )
 
 type OnShutdownCallback func(pid int)
@@ -182,6 +183,11 @@ func (mon *monitor) monitorLoop(startTimeout time.Duration, signalStopChan chan 
 
 			mon.gracefulShutdownCallback()
 			mon.gracePeriodStartTime = time.Now().UTC().Unix()
+		default:
+			if cmdserver.ReceivedEarlyExitSignal() {
+				log.Log.Infof("received early exit signal")
+				mon.isDone = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Right now we only watch for the early exit signal in `waitForDomainUUID` but if we want to exit and qemu hasn't died nothing happens. `virt-launcher` receives the cleanup event but has nothing to do to clean its self up. This edge case was experienced in bug https://bugzilla.redhat.com/show_bug.cgi?id=1957940# . The migration started the destination thought it was healthy and kept running but the source said it failed. The destination was unable to clean itself up thought since qemu was still running. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
