### PR TITLE
Attempt to fix flaky VmWatch test

### DIFF
--- a/tests/vm_watch_test.go
+++ b/tests/vm_watch_test.go
@@ -27,7 +27,7 @@ const (
 	relevantk8sVer = "1.16.2"
 
 	// Define a timeout for read operations in order to prevent test hanging
-	statusChangeTimeout = 5 * time.Minute
+	statusChangeTimeout = 10 * time.Minute
 	vmCreationTimeout   = 1 * time.Minute
 	vmMigrationTimeout  = 5 * time.Minute
 
@@ -108,7 +108,7 @@ func readNewStatus(rc io.ReadCloser, oldStatus []string, timeout time.Duration) 
 		statusLine, err := readLineWithTimeout(rc, remainingTimeout)
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error reading new status: '%v', last observed status: %v", err, prevStatus)
 		}
 		newStatus := strings.Fields(statusLine)
 


### PR DESCRIPTION
Signed-off-by: Zvi Cahana <zvic@il.ibm.com>

This PR attempts to fix the [flaky](https://search.ci.kubevirt.io/?search=VmWatch) [VmWatch test](https://github.com/zcahana/kubevirt/blob/ecaaf34277a5a4361426125ba5f371b6678ac52f/tests/vm_watch_test.go#L144) which has been intermittently failing since #5675.

The current failure message don't provide much info as to why a timeout has reached, but the flakiness of this suggests that this is a timing issue (e.g., slow machines on test cluster).
Hence, this PR will:

- Increase the timeout waiting for VM/VMI status change from 5min to 10min.
- Augments the "timeout reached" error message with some additional info for better debuggability.

```release-note
NONE
```
