### PR TITLE
virt-launcher,DHCP: Not passing MAC address to the masquerade DHCP server

### DIFF
--- a/pkg/network/dhcp/configurator.go
+++ b/pkg/network/dhcp/configurator.go
@@ -40,7 +40,6 @@ type Configurator interface {
 type configurator struct {
 	advertisingIfaceName string
 	configGenerator      ConfigGenerator
-	filterByMac          bool
 	handler              netdriver.NetworkHandler
 	dhcpStartedDirectory string
 	podInterfaceName     string
@@ -55,7 +54,6 @@ func NewBridgeConfigurator(cacheFactory cache.InterfaceCacheFactory, launcherPID
 	return &configurator{
 		podInterfaceName:     podInterfaceName,
 		advertisingIfaceName: advertisingIfaceName,
-		filterByMac:          true,
 		handler:              handler,
 		dhcpStartedDirectory: defaultDHCPStartedDirectory,
 		configGenerator:      &BridgeConfigGenerator{handler: handler, cacheFactory: cacheFactory, podInterfaceName: podInterfaceName, launcherPID: launcherPID, vmiSpecIfaces: vmiSpecIfaces, vmiSpecIface: vmiSpecIface},
@@ -67,7 +65,6 @@ func NewMasqueradeConfigurator(advertisingIfaceName string, handler netdriver.Ne
 		podInterfaceName:     podInterfaceName,
 		advertisingIfaceName: advertisingIfaceName,
 		configGenerator:      &MasqueradeConfigGenerator{handler: handler, vmiSpecIface: vmiSpecIface, vmiSpecNetwork: vmiSpecNetwork, podInterfaceName: podInterfaceName},
-		filterByMac:          false,
 		handler:              handler,
 		dhcpStartedDirectory: defaultDHCPStartedDirectory,
 	}
@@ -80,7 +77,7 @@ func (d *configurator) EnsureDHCPServerStarted(podInterfaceName string, dhcpConf
 	dhcpStartedFile := d.getDHCPStartedFilePath(podInterfaceName)
 	_, err := os.Stat(dhcpStartedFile)
 	if os.IsNotExist(err) {
-		if err := d.handler.StartDHCP(&dhcpConfig, d.advertisingIfaceName, dhcpOptions, d.filterByMac); err != nil {
+		if err := d.handler.StartDHCP(&dhcpConfig, d.advertisingIfaceName, dhcpOptions); err != nil {
 			return fmt.Errorf("failed to start DHCP server for interface %s", podInterfaceName)
 		}
 		newFile, err := os.Create(dhcpStartedFile)

--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -70,31 +70,31 @@ var _ = Describe("DHCP configurator", func() {
 		})
 
 		table.DescribeTable("should succeed when DHCP server started", func(configurator *configurator) {
-			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil)
+			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(nil)
 
 			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
 		},
-			table.Entry("with active client filtering", newBridgeConfigurator(launcherPID, bridgeName)),
-			table.Entry("without client filtering", newMasqueradeConfigurator(bridgeName)),
+			table.Entry("with bridge configurator", newBridgeConfigurator(launcherPID, bridgeName)),
+			table.Entry("with masquerade configurator", newMasqueradeConfigurator(bridgeName)),
 		)
 
 		table.DescribeTable("should succeed when DHCP server is started multiple times", func(configurator *configurator) {
-			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil)
+			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(nil)
 
 			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
 			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
 		},
-			table.Entry("with active client filtering", newBridgeConfigurator(launcherPID, bridgeName)),
-			table.Entry("without client filtering", newMasqueradeConfigurator(bridgeName)),
+			table.Entry("with bridge configurator", newBridgeConfigurator(launcherPID, bridgeName)),
+			table.Entry("with masquerade configurator", newMasqueradeConfigurator(bridgeName)),
 		)
 
 		table.DescribeTable("should fail when DHCP server failed", func(configurator *configurator) {
-			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(fmt.Errorf("failed to start DHCP server"))
+			configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(fmt.Errorf("failed to start DHCP server"))
 
 			Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(HaveOccurred())
 		},
-			table.Entry("with active client filtering", newBridgeConfigurator(launcherPID, bridgeName)),
-			table.Entry("without client filtering", newMasqueradeConfigurator(bridgeName)),
+			table.Entry("with bridge configurator", newBridgeConfigurator(launcherPID, bridgeName)),
+			table.Entry("with masquerade configurator", newMasqueradeConfigurator(bridgeName)),
 		)
 
 		When("IPAM is disabled on the DHCPConfig", func() {
@@ -109,12 +109,12 @@ var _ = Describe("DHCP configurator", func() {
 			})
 
 			table.DescribeTable("shouldn't fail when DHCP server failed", func(configurator *configurator) {
-				configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil, configurator.filterByMac).Return(nil).Times(0)
+				configurator.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(nil).Times(0)
 
 				Expect(configurator.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
 			},
-				table.Entry("with active client filtering", newBridgeConfigurator(launcherPID, bridgeName)),
-				table.Entry("without client filtering", newMasqueradeConfigurator(bridgeName)),
+				table.Entry("with bridge configurator", newBridgeConfigurator(launcherPID, bridgeName)),
+				table.Entry("with masquerade", newMasqueradeConfigurator(bridgeName)),
 			)
 		})
 	})

--- a/pkg/network/dhcp/masquerade.go
+++ b/pkg/network/dhcp/masquerade.go
@@ -42,11 +42,6 @@ func (d *MasqueradeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 		return nil, err
 	}
 
-	mac, err := virtnetlink.RetrieveMacAddressFromVMISpecIface(d.vmiSpecIface)
-	if err != nil {
-		return nil, err
-	}
-
 	dhcpConfig.Name = podNicLink.Attrs().Name
 	dhcpConfig.Mtu = uint16(podNicLink.Attrs().MTU)
 
@@ -65,8 +60,5 @@ func (d *MasqueradeConfigGenerator) Generate() (*cache.DHCPConfig, error) {
 	dhcpConfig.IPv6 = *ipv6
 	dhcpConfig.AdvertisingIPv6Addr = ipv6Gateway.IP.To16()
 
-	if mac != nil {
-		dhcpConfig.MAC = *mac
-	}
 	return dhcpConfig, nil
 }

--- a/pkg/network/dhcp/masquerade_test.go
+++ b/pkg/network/dhcp/masquerade_test.go
@@ -95,18 +95,10 @@ var _ = Describe("Masquerade DHCP configurator", func() {
 		BeforeEach(func() {
 			mockHandler.EXPECT().LinkByName(ifaceName).Return(iface, nil)
 		})
-		It("Should return the dhcp configuration without mac", func() {
+		It("Should return the dhcp configuration", func() {
 			config, err := generator.Generate()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*config).To(Equal(generateExpectedConfig(vmiSpecNetwork, nil, mtu, ifaceName)))
-		})
-		It("Should return the dhcp configuration with mac", func() {
-			macString := "de-ad-00-00-be-af"
-			vmiSpecIface.MacAddress = macString
-
-			config, err := generator.Generate()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(*config).To(Equal(generateExpectedConfig(vmiSpecNetwork, &macString, mtu, ifaceName)))
 		})
 		It("Should return an error if the config discovering fails", func() {
 			vmiSpecNetwork.Pod.VMNetworkCIDR = "abc"

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -68,7 +68,7 @@ type NetworkHandler interface {
 	SetRandomMac(iface string) (net.HardwareAddr, error)
 	GetMacDetails(iface string) (net.HardwareAddr, error)
 	LinkSetMaster(link netlink.Link, master *netlink.Bridge) error
-	StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error
+	StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
 	HasNatIptables(proto iptables.Protocol) bool
 	IsIpv6Enabled(interfaceName string) (bool, error)
 	IsIpv4Primary() (bool, error)
@@ -335,7 +335,7 @@ func (h *NetworkUtilsHandler) SetRandomMac(iface string) (net.HardwareAddr, erro
 	return currentMac, nil
 }
 
-func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
+func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
 	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
 	nameservers, searchDomains, err := converter.GetResolvConfDetailsFromPod()
 	if err != nil {
@@ -347,7 +347,6 @@ func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceNa
 	go func() {
 		if err = DHCPServer(
 			nic.MAC,
-			filterByMAC,
 			nic.IP.IP,
 			nic.IP.Mask,
 			bridgeInterfaceName,

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -203,14 +203,14 @@ func (_mr *_MockNetworkHandlerRecorder) LinkSetMaster(arg0, arg1 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LinkSetMaster", arg0, arg1)
 }
 
-func (_m *MockNetworkHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions, filterByMAC bool) error {
-	ret := _m.ctrl.Call(_m, "StartDHCP", nic, bridgeInterfaceName, dhcpOptions, filterByMAC)
+func (_m *MockNetworkHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
+	ret := _m.ctrl.Call(_m, "StartDHCP", nic, bridgeInterfaceName, dhcpOptions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2, arg3)
+func (_mr *_MockNetworkHandlerRecorder) StartDHCP(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StartDHCP", arg0, arg1, arg2)
 }
 
 func (_m *MockNetworkHandler) HasNatIptables(proto iptables.Protocol) bool {

--- a/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
+++ b/pkg/virt-launcher/virtwrap/network/dhcp/dhcp.go
@@ -49,7 +49,6 @@ var searchDomainValidationRegex = regexp.MustCompile(`^(?:[_a-z0-9](?:[_a-z0-9-]
 
 func SingleClientDHCPServer(
 	clientMAC net.HardwareAddr,
-	filterByMAC bool,
 	clientIP net.IP,
 	clientMask net.IPMask,
 	serverIface string,
@@ -76,7 +75,6 @@ func SingleClientDHCPServer(
 	handler := &DHCPHandler{
 		clientIP:      clientIP,
 		clientMAC:     clientMAC,
-		filterByMAC:   filterByMAC,
 		serverIP:      serverIP.To4(),
 		leaseDuration: infiniteLease,
 		options:       options,
@@ -184,14 +182,13 @@ type DHCPHandler struct {
 	serverIP      net.IP
 	clientIP      net.IP
 	clientMAC     net.HardwareAddr
-	filterByMAC   bool
 	leaseDuration time.Duration
 	options       dhcp.Options
 }
 
 func (h *DHCPHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, _ dhcp.Options) (d dhcp.Packet) {
 	log.Log.V(4).Info("Serving a new request")
-	if h.filterByMAC {
+	if len(h.clientMAC) != 0 {
 		if mac := p.CHAddr(); !bytes.Equal(mac, h.clientMAC) {
 			log.Log.V(4).Info("The request is not from our client")
 			return nil // Is not our client

--- a/pkg/virt-launcher/virtwrap/network/podinterface_test.go
+++ b/pkg/virt-launcher/virtwrap/network/podinterface_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().ParseAddr(fmt.Sprintf(bridgeFakeIP, 0)).Return(bridgeAddr, nil)
 		mockNetwork.EXPECT().LinkSetMaster(primaryPodInterfaceAfterNameChange, bridgeTest).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(bridgeTest, bridgeAddr).Return(nil)
-		mockNetwork.EXPECT().StartDHCP(testNic, api.DefaultBridgeName, nil, true)
+		mockNetwork.EXPECT().StartDHCP(testNic, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().CreateTapDevice(tapDeviceName, queueNumber, pid, mtu, libvirtUser).Return(nil)
 		mockNetwork.EXPECT().BindTapDeviceToBridge(tapDeviceName, "k6t-eth0").Return(nil)
 		mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
@@ -237,7 +237,7 @@ var _ = Describe("Pod Network", func() {
 		mockNetwork.EXPECT().LinkSetMaster(masqueradeDummy, masqueradeBridgeTest).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeGwAddr).Return(nil)
 		mockNetwork.EXPECT().AddrAdd(masqueradeBridgeTest, masqueradeIpv6GwAddr).Return(nil)
-		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, api.DefaultBridgeName, nil, false)
+		mockNetwork.EXPECT().StartDHCP(masqueradeTestNic, api.DefaultBridgeName, nil)
 		mockNetwork.EXPECT().DisableTXOffloadChecksum(bridgeTest.Name).Return(nil)
 		// Global nat rules using iptables
 		for _, proto := range ipProtocols() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We shouldn't not pass MAC address to the masquerade DHCP server, it is redundant since the masquerade DHCP server is not filtering by MAC and the MAC value is not used by anything else.

Also -
The DHCP server has two fields -

```
clientMAC net.HardwareAddr,
filterByMAC bool,
```
There is no need to have both of them. Empty `clientMAC` is enough to indicate if there is no need filter by the MAC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Rebased on top of https://github.com/kubevirt/kubevirt/pull/5902
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
