### PR TITLE
Improved debuggability by leaving virt-launcher container up for failed VMI

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -999,6 +999,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		resources.Limits[KvmDevice] = resource.MustParse("1")
 	}
 
+	if checkForKeepLauncherAfterQemu(vmi) {
+		command = append(command, "--keep-after-qemu")
+	}
+
 	// Add ports from interfaces to the pod manifest
 	ports := getPortsFromVMI(vmi)
 
@@ -1814,6 +1818,19 @@ func lookupMultusDefaultNetworkName(networks []v1.Network) string {
 		}
 	}
 	return ""
+}
+
+func checkForKeepLauncherAfterQemu(vmi *v1.VirtualMachineInstance) bool {
+	keepLauncherAfterQemu := false
+	for k, v := range vmi.Annotations {
+		if strings.HasPrefix(k, v1.KeepLauncherAfterQemuAnnotation) {
+			if v == "" || strings.HasPrefix(v, "true") {
+				keepLauncherAfterQemu = true
+				break
+			}
+		}
+	}
+	return keepLauncherAfterQemu
 }
 
 func filterVMIAnnotationsForPod(vmiAnnotations map[string]string) map[string]string {

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -672,7 +672,8 @@ const (
 	VirtualMachineLabel               = AppLabel + "/vm"
 	MemfdMemoryBackend         string = "kubevirt.io/memfd"
 
-	MigrationSelectorLabel = "kubevirt.io/vmi-name"
+	MigrationSelectorLabel                 = "kubevirt.io/vmi-name"
+	KeepLauncherAfterQemuAnnotation string = "kubevirt.io/leave-launcher-pod-after-qemu-exit"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -52,6 +52,8 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libvmi"
+	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
 
 var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute]VirtualMachine", func() {
@@ -1131,6 +1133,63 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			})
 
 			Context("Using RunStrategyManual", func() {
+				table.DescribeTable("with a failing VMI and the kubevirt.io/leave-launcher-pod-after-qemu-exit annotation", func(keepLauncher string, podPhase k8sv1.PodPhase) {
+					// The estimated execution time of one test is 400 seconds.
+					By("creating a Kernel Boot VMI with a mismatched disk")
+					vmi := utils.GetVMIKernelBoot()
+					vmi.Spec.Domain.Firmware.KernelBoot.Container.Image = cd.ContainerDiskFor(cd.ContainerDiskCirros)
+
+					By("Creating a VM with RunStrategyManual")
+					newVM := NewRandomVirtualMachineWithRunStrategy(vmi, v1.RunStrategyManual)
+
+					By("Annotate the VM with regard for leaving launcher pod after qemu exit")
+					newVM.Spec.Template.ObjectMeta.Annotations = map[string]string{
+						v1.KeepLauncherAfterQemuAnnotation: keepLauncher,
+					}
+					newVM, err := virtClient.VirtualMachine(tests.NamespaceTestDefault).Create(newVM)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Starting the VMI with virtctl")
+					startCommand := tests.NewRepeatableVirtctlCommand(vm.COMMAND_START, "--namespace", newVM.Namespace, newVM.Name)
+					err = startCommand()
+					Expect(err).ToNot(HaveOccurred())
+
+					By("Waiting for VM to be in Starting status")
+					Eventually(func() bool {
+						newVM, err = virtClient.VirtualMachine(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return newVM.Status.PrintableStatus == v1.VirtualMachineStatusStarting
+					}, 160*time.Second, 1*time.Second).Should(BeTrue())
+
+					By("Check Virt Launcher log message")
+					time.Sleep(20 * time.Second)
+					var newVMI *v1.VirtualMachineInstance
+					newVMI, err = virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					logs := func() string { return getVirtLauncherLogs(virtClient, newVMI) }
+					Eventually(logs,
+						100*time.Second,
+						1*time.Second).
+						Should(ContainSubstring(fmt.Sprintf("keepAfterQemu %s", keepLauncher)))
+
+					By("Waiting for VMI to fail")
+					Eventually(func() bool {
+						newVMI, err := virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						return newVMI.Status.Phase == v1.Failed
+					}, 400*time.Second, 1*time.Second).Should(BeTrue())
+
+					By("Check Virt Launcher status")
+					// Virt launcher should be in the Running phase if the Annotation v1.KeepLauncherAfterQemuAnnotation is set to true
+					time.Sleep(10 * time.Second)
+					By(fmt.Sprintf("Verify that the VMI VirtLauncher Pod is in the expected state as %v", podPhase))
+					newVMI, _ = virtClient.VirtualMachineInstance(newVM.Namespace).Get(newVM.Name, &k8smetav1.GetOptions{})
+					launcherPod := libvmi.GetPodByVirtualMachineInstance(newVMI, newVM.Namespace)
+					Expect(launcherPod.Status.Phase).To(Equal(podPhase))
+				},
+					table.Entry("VMI launcher pod should fail", "false", k8sv1.PodFailed),
+					table.Entry("VMI launcher pod should keep running", "true", k8sv1.PodRunning),
+				)
 				It("[test_id:2036] should start", func() {
 					By("creating a VM with RunStrategyManual")
 					virtualMachine := newVirtualMachineWithRunStrategy(v1.RunStrategyManual)


### PR DESCRIPTION
Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The goal of this PR is to pertain the VMI environment up for inspection or debugging when a VMI fails. 

Currently the `virt-launcher` container will exit when the corresponding VMI reached the `Failed`. The specific goal of the PR is to provide user a mean to have the VMI defined in a VM to pertain its environment on failure. In order to have a failed VMI to keep its virt-launcher container alive, user needs to 

1. Specify the VM's `RunStrategy` as `Manual`
2. Define an annotation `kubevirt.io/leave-launcher-pod-after-qemu-exit` in the VM's VMI Template and assign a `"true"` value. 

Then user can create the VM, start the VMI manually, then the VMI environment (the corresponding virt-launcher container) will stay alive. Given the VMI is in the `Failed` phase, it will not respond to `virtctl stop` but will respond to `virtctl restart`. 

In addition, this PR does not change the behavior or a VMI with its VM's `RunStrategy` not defined as `Manual`.     

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improved debuggability by keeping the environment of a failed VMI alive.
```
