### PR TITLE
remove bad make verify-deps command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,9 +109,6 @@ rpm-deps:
 verify-rpm-deps:
 	SYNC_VENDOR=true hack/dockerized " ./hack/verify-rpm-deps.sh"
 
-verify-deps:
-	SYNC_VENDOR=true hack/dockerized " ./hack/verify-deps.sh"
-
 build-verify:
 	hack/build-verify.sh
 


### PR DESCRIPTION
Signed-off-by: Ashley Schuett <aschuett@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This command does not work as there is not, and never has been a `./hack/verify-deps.sh` script. The PR that added this command did not include the script file https://github.com/kubevirt/kubevirt/pull/4703/files. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
