### PR TITLE
[release-0.41] Manual cherry pick of #5891

### DIFF
--- a/pkg/virt-controller/watch/vmi.go
+++ b/pkg/virt-controller/watch/vmi.go
@@ -721,6 +721,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 	if syncErr != nil {
 		return syncErr
 	}
+
 	if !podExists(pod) {
 		// If we came ever that far to detect that we already created a pod, we don't create it again
 		if !vmi.IsUnprocessed() {
@@ -760,7 +761,7 @@ func (c *VMIController) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod,
 	}
 
 	if !isWaitForFirstConsumer {
-		err := c.cleanupWaitForFirstConsumerTemporaryPods(vmi)
+		err := c.cleanupWaitForFirstConsumerTemporaryPods(vmi, pod)
 		if err != nil {
 			return &syncErrorImpl{fmt.Errorf("failed to clean up temporary pods: %v", err), FailedHotplugSyncReason}
 		}
@@ -1238,17 +1239,10 @@ func (c *VMIController) getHotplugVolumes(vmi *virtv1.VirtualMachineInstance, vi
 	return hotplugVolumes
 }
 
-func (c *VMIController) cleanupWaitForFirstConsumerTemporaryPods(vmi *virtv1.VirtualMachineInstance) error {
-	// Get all pods from the namespace
-	pods, err := c.listPodsFromNamespace(vmi.Namespace)
+func (c *VMIController) cleanupWaitForFirstConsumerTemporaryPods(vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) error {
+	triggerPods, err := c.waitForFirstConsumerTemporaryPods(vmi, virtLauncherPod)
 	if err != nil {
 		return err
-	}
-	triggerPods := make([]*k8sv1.Pod, 0)
-	for _, pod := range pods {
-		if isTempPod(pod) {
-			triggerPods = append(triggerPods, pod)
-		}
 	}
 
 	return c.deleteRunningOrFinishedWFFCPods(vmi, triggerPods...)
@@ -1292,14 +1286,40 @@ func (c *VMIController) virtlauncherAttachmentPods(virtlauncherPod *k8sv1.Pod) (
 	}
 
 	for _, pod := range pods {
-		ownerRef := controller.GetControllerOf(pod)
-		if ownerRef == nil || ownerRef.UID != virtlauncherPod.UID {
+		if ownerRef := controller.GetControllerOf(pod); ownerRef == nil || ownerRef.UID != virtlauncherPod.UID {
 			continue
 		}
 		attachmentPods = append(attachmentPods, pod)
 	}
 
 	return attachmentPods, nil
+}
+
+func (c *VMIController) waitForFirstConsumerTemporaryPods(vmi *virtv1.VirtualMachineInstance, virtLauncherPod *k8sv1.Pod) ([]*k8sv1.Pod, error) {
+	var temporaryPods []*k8sv1.Pod
+
+	// Get all pods from the namespace
+	pods, err := c.listPodsFromNamespace(vmi.Namespace)
+	if err != nil {
+		return temporaryPods, err
+	}
+
+	for _, pod := range pods {
+		// Cleanup candidates are temporary pods that are either controlled by the VMI or the virt launcher pod
+		if !isTempPod(pod) {
+			continue
+		}
+
+		if controller.IsControlledBy(pod, vmi) {
+			temporaryPods = append(temporaryPods, pod)
+		}
+
+		if ownerRef := controller.GetControllerOf(pod); ownerRef != nil && ownerRef.UID == virtLauncherPod.UID {
+			temporaryPods = append(temporaryPods, pod)
+		}
+	}
+
+	return temporaryPods, nil
 }
 
 func (c *VMIController) needsHandleHotplug(hotplugVolumes []*virtv1.Volume, currentAttachmentPods []*k8sv1.Pod) bool {

--- a/pkg/virt-controller/watch/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi_test.go
@@ -380,6 +380,32 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			testutils.ExpectEvent(recorder, SuccessfulDeletePodReason)
 		})
 
+		It("should only get WFFC pods that are associated with current VMI", func() {
+			vmi := NewPendingVirtualMachine("testvmi")
+			pod := NewPodForVirtualMachine(vmi, k8sv1.PodRunning)
+			pod.Annotations[v1.EphemeralProvisioningObject] = "true"
+			podInformer.GetIndexer().Add(pod)
+
+			// Non owned pod that shouldn't be found by waitForFirstConsumerTemporaryPods
+			nonOwnedPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unowned-test-pod",
+					Namespace: vmi.Namespace,
+					Annotations: map[string]string{
+						v1.EphemeralProvisioningObject: "true",
+					},
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodRunning,
+				},
+			}
+			podInformer.GetIndexer().Add(nonOwnedPod)
+
+			res, err := controller.waitForFirstConsumerTemporaryPods(vmi, pod)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(res)).To(Equal(1))
+		})
+
 		table.DescribeTable("VMI should handle doppleganger Pod status while DV is in WaitForFirstConsumer phase",
 			func(phase k8sv1.PodPhase, conditions []k8sv1.PodCondition, expectedPhase v1.VirtualMachineInstancePhase) {
 				vmi := NewPendingVirtualMachine("testvmi")

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -72,14 +72,14 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 				cdis, err := virtClient.CdiClient().CdiV1beta1().CDIs().List(context.Background(), metav1.ListOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cdis.Items).To(HaveLen(1))
-				hasWaitForCustomerGate := false
+				hasWaitForFirstConsumerGate := false
 				for _, feature := range cdis.Items[0].Spec.Config.FeatureGates {
 					if feature == "HonorWaitForFirstConsumer" {
-						hasWaitForCustomerGate = true
+						hasWaitForFirstConsumerGate = true
 						break
 					}
 				}
-				if !hasWaitForCustomerGate {
+				if !hasWaitForFirstConsumerGate {
 					Skip("HonorWaitForFirstConsumer is disabled in CDI, skipping tests relying on it")
 				}
 			})
@@ -113,6 +113,36 @@ var _ = SIGDescribe("[Serial]DataVolume Integration", func() {
 				}
 				err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Delete(context.Background(), dataVolume.Name, metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
+			})
+
+			It("[test_id:6686]should successfully start multiple concurrent VMIs", func() {
+
+				numVmis := 5
+				vmis := make([]*v1.VirtualMachineInstance, 0, numVmis)
+				dvs := make([]*cdiv1.DataVolume, 0, numVmis)
+
+				for idx := 0; idx < numVmis; idx++ {
+					dataVolume := tests.NewRandomDataVolumeWithHttpImport(tests.GetUrl(tests.AlpineHttpUrl), tests.NamespaceTestDefault, k8sv1.ReadWriteOnce)
+					vmi := tests.NewRandomVMIWithDataVolume(dataVolume.Name)
+
+					_, err := virtClient.CdiClient().CdiV1alpha1().DataVolumes(dataVolume.Namespace).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+					Expect(err).To(BeNil())
+
+					vmi = tests.RunVMI(vmi, 60)
+					vmis = append(vmis, vmi)
+					dvs = append(dvs, dataVolume)
+				}
+
+				for idx := 0; idx < numVmis; idx++ {
+					tests.WaitForSuccessfulVMIStartWithTimeoutIgnoreWarnings(vmis[idx], 500)
+					By("Checking that the VirtualMachineInstance console has expected output")
+					Expect(console.LoginToAlpine(vmis[idx])).To(Succeed())
+
+					err := virtClient.VirtualMachineInstance(vmis[idx].Namespace).Delete(vmis[idx].Name, &metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+					err = virtClient.CdiClient().CdiV1alpha1().DataVolumes(dvs[idx].Namespace).Delete(context.Background(), dvs[idx].Name, metav1.DeleteOptions{})
+					Expect(err).To(BeNil())
+				}
 			})
 
 			It("[test_id:5252]should be successfully started when using a PVC volume owned by a DataVolume", func() {


### PR DESCRIPTION
Don't delete temp pods that aren't associated with VMI;
We do not want to delete temporary pods that are not owned by the VMI.

Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://bugzilla.redhat.com/show_bug.cgi?id=1974289
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Pending VMIs when creating concurrent bulk of VMs backed by WFFC DVs
```

