### PR TITLE
Leave virt-launcher container up for failed VMI for improved debuggab…

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1036,6 +1036,10 @@ func (t *templateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, t
 		resources.Limits[KvmDevice] = resource.MustParse("1")
 	}
 
+	if checkForKeepLauncherAfterFailure(vmi) {
+		command = append(command, "--keep-after-failure")
+	}
+
 	// Add ports from interfaces to the pod manifest
 	ports := getPortsFromVMI(vmi)
 
@@ -2104,4 +2108,17 @@ func filterVMIAnnotationsForPod(vmiAnnotations map[string]string) map[string]str
 		annotationsList[k] = v
 	}
 	return annotationsList
+}
+
+func checkForKeepLauncherAfterFailure(vmi *v1.VirtualMachineInstance) bool {
+	keepLauncherAfterFailure := false
+	for k, v := range vmi.Annotations {
+		if strings.HasPrefix(k, v1.KeepLauncherAfterFailureAnnotation) {
+			if v == "" || strings.HasPrefix(v, "true") {
+				keepLauncherAfterFailure = true
+				break
+			}
+		}
+	}
+	return keepLauncherAfterFailure
 }

--- a/staging/src/kubevirt.io/client-go/api/v1/types.go
+++ b/staging/src/kubevirt.io/client-go/api/v1/types.go
@@ -726,6 +726,9 @@ const (
 
 	// This annotation represents vmi running nonroot implementation
 	NonRootVMIAnnotation = "kubevirt.io/nonroot"
+
+	// This annotation is to keep virt launcher container alive when an VMI encounters a failure for debugging purpose
+	KeepLauncherAfterFailureAnnotation string = "kubevirt.io/keep-launcher-alive-after-failure"
 )
 
 func NewVMI(name string, uid types.UID) *VirtualMachineInstance {


### PR DESCRIPTION
…ility

Signed-off-by: Hao Yu <yuh@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The goal of this PR is to keep the VMI environment up for inspection or debugging when a VMI fails.

Currently the `virt-launcher` container will exit when the corresponding VMI reached the `Failed` phase. The specific goal of the PR is to provide user a mean to have the VMI defined in a VM to pertain its environment on failure. To have a failed VMI to leave its virt-launcher container alive, user needs to

1. Specify the VM's `RunStrategy` as `Manual`
2. Define an annotation `kubevirt.io/leave-launcher-pod-after-qemu-exit` in the VM's VMI Template and assign a "`true`" value.

Then user can create the VM, start the VMI manually, then the VMI environment (the corresponding `virt-launcher` container) will stay alive. 

In addition, this PR does not change the behavior or a VMI with its VM's `RunStrategy` not defined as `Manual`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improved debuggability by keeping the environment of a failed VMI alive.
```
